### PR TITLE
feat: implement LoRA support and training pipeline

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+## 0.3.0
+*   **LoRA Support**: Added full support for Low-Rank Adaptation (LoRA) on all native platforms (iOS, Android, macOS, Linux, Windows).
+*   **Dynamic Adapters**: Implemented APIs to dynamically add, update scale, or remove LoRA adapters at runtime without reloading the base model.
+*   **LoRA Training Pipeline**: Added a comprehensive Jupyter Notebook for fine-tuning models and converting adapters to GGUF format.
+*   **CLI Tooling**: Updated the `basic_app` example to support testing LoRA adapters via the `--lora` flag.
+*   **API Enhancements**: Updated `ModelParams` to include initial LoRA configurations.
+
 ## 0.2.0+b7883
 
 *   **Project Rebrand**: Renamed package from `llama_dart` to `llamadart`.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -20,7 +20,7 @@ The project maps closely to the `llama.cpp` structure:
 
 -   `lib/`: Dart source code and FFI bindings.
 -   `third_party/`: `llama.cpp` core engine, dependencies (submodules), and build infrastructure.
--   `example/`: Usage examples (CLI and Flutter).
+-   `example/`: Usage examples, Flutter app, and LoRA training notebook.
 -   `hook/`: Native Assets build hook for automatic binary management.
 
 ## 🛡️ Zero-Patch Strategy

--- a/README.md
+++ b/README.md
@@ -14,6 +14,7 @@
 - ⚡ **GPU Acceleration**:
   - **Apple**: Metal (macOS/iOS)
   - **Android/Linux/Windows**: Vulkan
+- 🧠 **LoRA Support**: Apply fine-tuned adapters (GGUF) dynamically at runtime.
 - 🌐 **Web Support**: Run inference in the browser via WASM (powered by `wllama`).
 - 💎 **Dart-First API**: Streamlined FFI bindings with a clean, isolate-safe Dart interface.
 - 🔇 **Logging Control**: Granular control over native engine output (debug, info, warn, error, none).
@@ -24,12 +25,12 @@
 
 | Platform | Architecture(s) | GPU Backend | Status |
 |----------|-----------------|-------------|--------|
-| **macOS** | arm64, x86_64 | Metal | ✅ Tested (CPU, Metal) |
-| **iOS** | arm64 (Device), x86_64 (Sim) | Metal (Device), CPU (Sim) | ✅ Tested (CPU, Metal) |
-| **Android** | arm64-v8a, x86_64 | Vulkan | ✅ Tested (CPU, Vulkan) |
-| **Linux** | arm64, x86_64 | Vulkan | ⚠️ Tested (CPU Verified, Vulkan Untested) |
-| **Windows** | x64 | Vulkan | ✅ Tested (CPU, Vulkan) |
-| **Web** | WASM | CPU | ✅ Tested (WASM) |
+| **macOS** | arm64, x86_64 | Metal | ✅ Tested |
+| **iOS** | arm64 (Device), x86_64 (Sim) | Metal (Device), CPU (Sim) | ✅ Tested |
+| **Android** | arm64-v8a, x86_64 | Vulkan | ✅ Tested |
+| **Linux** | arm64, x86_64 | Vulkan | ⚠️ Expected (Vulkan Untested) |
+| **Windows** | x64 | Vulkan | ✅ Tested |
+| **Web** | WASM | CPU | ✅ Tested |
 
 ---
 
@@ -41,7 +42,7 @@ Add `llamadart` to your `pubspec.yaml`:
 
 ```yaml
 dependencies:
-  llamadart: ^0.2.0
+  llamadart: ^0.3.0
 ```
 
 ### 2. Zero Setup (Native Assets)
@@ -63,11 +64,21 @@ void main() async {
   // 1. Create the service
   final service = LlamaService();
 
-  // 2. Initialize with a GGUF model
+  // 2. Initialize with a GGUF model and optional LoRA adapters
   // This loads the model and prepares the native backend (GPU/CPU)
-  await service.init('path/to/your_model.gguf');
+  await service.init(
+    'path/to/your_model.gguf',
+    modelParams: ModelParams(
+      loras: [
+        LoraAdapterConfig(path: 'path/to/style.lora.gguf', scale: 0.8),
+      ],
+    ),
+  );
 
-  // 3. Generate text (streaming)
+  // 3. You can also update or add LoRA adapters dynamically (Native platforms)
+  await service.setLoraAdapter('path/to/emotional_shift.lora.gguf', scale: 1.2);
+
+  // 4. Generate text (streaming)
   final stream = service.generate('The capital of France is');
   
   await for (final token in stream) {
@@ -82,29 +93,28 @@ void main() async {
 
 ---
 
-## 📂 Examples
+## 🎨 Low-Rank Adaptation (LoRA)
 
-Explore the `example/` directory for full implementations:
-- **`basic_app`**: A lightweight CLI example for quick verification.
-- **`chat_app`**: A feature-rich Flutter chat application with streaming UI and model management.
+`llamadart` supports applying one or multiple LoRA adapters to your base model. This allows you to customize the model's style, persona, or domain knowledge without replacing the entire 7B+ parameter model.
+
+- **Dynamic Scaling**: Adjust the strength (`scale`) of each adapter at runtime.
+- **Isolate-Safe**: Adapters are loaded and managed in the background Isolate.
+- **Resource Efficient**: Multiple LoRAs share the memory of a single base model.
+
+### Training your own LoRA
+Check out our [LoRA Training Notebook](example/training_notebook/lora_training.ipynb) to learn how to:
+1. Fine-tune a small model (like Qwen2.5-0.5B) using Hugging Face tools.
+2. Convert the adapter to GGUF format using `llama.cpp`.
+3. Run it in your Flutter app with `llamadart`.
 
 ---
 
-## 🐳 Docker (Linux)
+## 📂 Examples
 
-You can build and run the examples using Docker on Linux. This ensures all build dependencies (like `libgtk-3-dev`, `cmake`, etc.) are correctly configured.
-
-### 1. Build and Run CLI Basic Example
-```bash
-./docker/build-docker.sh basic-run
-```
-
-### 2. Build Flutter Chat App for Linux
-```bash
-./docker/build-docker.sh chat-build
-```
-
-The Dockerfile is multi-stage and optimized to minimize context size. It handles the downloading of native assets and compilation of Flutter Linux binaries.
+Explore the `example/` directory for full implementations:
+- **`basic_app`**: A lightweight CLI example for quick verification. Supports loading LoRA adapters via `--lora`.
+- **`chat_app`**: A feature-rich Flutter chat application with streaming UI and model management.
+- **`training_notebook`**: A Jupyter Notebook demonstrating how to train your own LoRA adapters and convert them to GGUF.
 
 ---
 

--- a/dartdoc_options.yaml
+++ b/dartdoc_options.yaml
@@ -1,0 +1,4 @@
+dartdoc:
+  exclude:
+    - 'src/generated/llama_bindings.dart'
+    - 'src/generated/llama_bindings_stub.dart'

--- a/example/README.md
+++ b/example/README.md
@@ -99,7 +99,7 @@ example/
 | **macOS** | arm64, x86_64 | Metal | ✅ Tested |
 | **iOS** | arm64 (Device), x86_64 (Sim) | Metal (Device), CPU (Sim) | ✅ Tested |
 | **Android** | arm64-v8a, x86_64 | Vulkan | ✅ Tested |
-| **Linux** | arm64, x86_64 | Vulkan | ⚠️ Tested (CPU Verified, Vulkan Untested) |
+| **Linux** | arm64, x86_64 | Vulkan | 🟡 Expected (Vulkan Untested) |
 | **Windows** | x64 | Vulkan | ✅ Tested |
 | **Web** | WASM | CPU | ✅ Tested |
 

--- a/example/basic_app/bin/llamadart_basic_example.dart
+++ b/example/basic_app/bin/llamadart_basic_example.dart
@@ -1,5 +1,6 @@
 import 'dart:io';
 import 'package:args/args.dart';
+import 'package:llamadart/llamadart.dart';
 import 'package:llamadart_basic_example/services/model_service.dart';
 import 'package:llamadart_basic_example/services/llama_service.dart';
 
@@ -12,6 +13,9 @@ void main(List<String> arguments) async {
         abbr: 'm',
         help: 'Path or URL to the GGUF model file.',
         defaultsTo: defaultModelUrl)
+    ..addMultiOption('lora',
+        abbr: 'l',
+        help: 'Path to LoRA adapter(s). Can be specified multiple times.')
     ..addOption('prompt', abbr: 'p', help: 'Prompt for single response mode.')
     ..addFlag('interactive',
         abbr: 'i',
@@ -39,8 +43,11 @@ void main(List<String> arguments) async {
     print('Checking model...');
     final modelFile = await modelService.ensureModel(modelUrlOrPath);
 
+    final loraPaths = results['lora'] as List<String>;
+    final loras = loraPaths.map((p) => LoraAdapterConfig(path: p)).toList();
+
     print('Initializing engine...');
-    await llamaService.init(modelFile.path);
+    await llamaService.init(modelFile.path, loras: loras);
     print('Model loaded successfully.\n');
 
     if (singlePrompt != null) {

--- a/example/basic_app/lib/services/llama_service.dart
+++ b/example/basic_app/lib/services/llama_service.dart
@@ -7,12 +7,16 @@ class LlamaCliService {
   final List<CliMessage> _history = [];
 
   /// Initializes the engine with the given [modelPath].
-  Future<void> init(String modelPath) async {
+  Future<void> init(
+    String modelPath, {
+    List<LoraAdapterConfig> loras = const [],
+  }) async {
     await _service.init(
       modelPath,
-      modelParams: const ModelParams(
+      modelParams: ModelParams(
         gpuLayers: 99,
         logLevel: LlamaLogLevel.error,
+        loras: loras,
       ),
     );
   }

--- a/example/chat_app/README.md
+++ b/example/chat_app/README.md
@@ -13,30 +13,24 @@ A Flutter chat application demonstrating real-world usage of llamadart with UI.
 
 ## Setup
 
-### 1. Download a Model
+### 1. Run the App
 ```bash
-# For macOS/Linux
-mkdir -p /tmp/models
-curl -L https://huggingface.co/TheBloke/TinyLlama-1.1B-Chat-v1.0-GGUF/resolve/main/tinyllama-1.1b-chat-v1.0.Q4_K_M.gguf \
-  -o /tmp/models/tinyllama-1.1b-chat-v1.0.Q4_K_M.gguf
-
-# For Android
-# Download and place in /storage/emulated/0/Download/
-```
-
-### 2. Run the App
-```bash
-cd chat_app
+cd example/chat_app
 flutter pub get
 flutter run
 ```
 
-### 3. Configure
-1. Tap the settings icon (⚙️) in the app bar
-2. Set your model path
-3. Select Preferred Backend (Auto/Metal/Vulkan/CPU)
-4. Tap "Load Model"
-5. Start chatting!
+### 2. Choose and Download a Model
+1. The app will open to a **Model Selection** screen.
+2. Select one of the pre-configured models (e.g., Qwen 2.5 0.5B).
+3. Tap the **Download** icon. The app uses `Dio` to download the model directly to your device's documents directory.
+4. Once downloaded, tap **Select** to load the model.
+
+### 3. Advanced Configuration (Optional)
+1. Tap the settings icon (⚙️) in the app bar.
+2. Adjust **GPU Layers**, **Context Size**, or **Preferred Backend**.
+3. Tap **Load Model** to apply changes.
+
 
 ## Testing Scenarios
 
@@ -112,6 +106,7 @@ await service.init(
     gpuLayers: 99, // Offload all layers for best performance on GPU
     contextSize: 2048,
     preferredBackend: GpuBackend.auto,
+    loras: [], // Optional LoRA adapters
   ),
 );
 ```
@@ -135,7 +130,6 @@ await for (final token in stream) {
 ```dart
 final prefs = await SharedPreferences.getInstance();
 await prefs.setString('model_path', modelPath);
-await prefs.setString('model_path', modelPath);
 await prefs.setInt('preferred_backend', backendIndex);
 ```
 
@@ -145,19 +139,20 @@ _(Add screenshots here when complete)_
 
 ## Troubleshooting
 
-**"Failed to load library" on first run:**
-- Check console for download messages
-- Ensure GitHub releases are accessible
-- Check internet connection
+**"Failed to load library" or "Native asset not found" on first run:**
+- Ensure you have an active internet connection. The `llamadart` build hook needs to download the pre-compiled `llama.cpp` binary for your platform.
+- Check the console for download progress logs.
+- If behind a proxy, ensure Dart/Flutter can access GitHub.
 
 **"Model file not found" error:**
-- Verify model path in settings
-- Ensure model is downloaded
-- Check file permissions
+- Ensure you have successfully downloaded a model from the selection screen.
+- If you manually moved a model, verify the path in the settings sheet.
 
 **Slow generation:**
-- Ensure hardware acceleration is enabled in settings
-- Use smaller quantization model (Q4_K_M)
+- Ensure hardware acceleration is enabled (e.g., Metal on Apple, Vulkan on Android/Linux/Windows).
+- Check if `GPU Layers` is set to a high enough value (default 99 offloads all layers).
+- Use a model with a smaller quantization level (e.g., Q4_K_M).
+
 
 **App crashes on startup:**
 - Check console output for error messages
@@ -175,13 +170,15 @@ _(Add screenshots here when complete)_
 
 ## Platform Support
 
-| Platform | Status | Notes |
-|----------|--------|-------|
-| macOS    | ✅ Tested | Full support |
-| Linux    | ✅ Tested | Full support |
-| Windows  | 🟡 Expected | Should work |
-| Android  | ✅ Verified | Full Vulkan acceleration |
-| iOS      | ✅ Verified | Full Metal acceleration |
+| Platform | Status | Hardware Acceleration |
+|----------|--------|-----------------------|
+| macOS    | ✅ Tested | Metal |
+| iOS      | ✅ Tested | Metal |
+| Android  | ✅ Tested | Vulkan |
+| Linux    | 🟡 Expected | Vulkan |
+| Windows  | ✅ Tested | Vulkan |
+| Web      | ✅ Tested | CPU (Wasm) |
+
 
 ## Future Enhancements (Implemented ✅)
 

--- a/example/training_notebook/lora_training.ipynb
+++ b/example/training_notebook/lora_training.ipynb
@@ -1,0 +1,265 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Training a LoRA Adapter for llamadart\n",
+    "\n",
+    "This notebook provides a step-by-step guide to fine-tuning a Large Language Model (LLM) using **LoRA (Low-Rank Adaptation)** and preparing it for use with the `llamadart` plugin in Flutter or Dart applications.\n",
+    "\n",
+    "### Why LoRA?\n",
+    "- **Efficient**: Only a small fraction of parameters are trained.\n",
+    "- **Portable**: The resulting \"adapter\" files are small (typically 10MB - 200MB).\n",
+    "- **Dynamic**: You can swap adapters at runtime in `llamadart` without reloading the base model.\n",
+    "\n",
+    "### Resources\n",
+    "- **Model**: [Qwen/Qwen2.5-0.5B-Instruct](https://huggingface.co/Qwen/Qwen2.5-0.5B-Instruct)\n",
+    "- **Dataset**: [timdettmers/openassistant-guanaco](https://huggingface.co/datasets/timdettmers/openassistant-guanaco)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 1. Setup Environment\n",
+    "\n",
+    "We will use the Hugging Face `peft` library for LoRA and `bitsandbytes` for 4-bit quantization (QLoRA) where supported."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "%pip install -q -U transformers peft bitsandbytes datasets accelerate trl"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import torch\n",
+    "from transformers import AutoModelForCausalLM, AutoTokenizer, BitsAndBytesConfig, TrainingArguments, Trainer, DataCollatorForLanguageModeling\n",
+    "from peft import LoraConfig, get_peft_model, prepare_model_for_kbit_training\n",
+    "from datasets import load_dataset\n",
+    "import os\n",
+    "\n",
+    "# Configuration\n",
+    "model_id = \"Qwen/Qwen2.5-0.5B-Instruct\" # Small model for demonstration (Downloaded from Hugging Face)\n",
+    "dataset_id = \"timdettmers/openassistant-guanaco\" # Instruction following dataset\n",
+    "output_dir = \"./lora-adapter-output\"\n",
+    "\n",
+    "# Note: Models and datasets are cached by default in ~/.cache/huggingface/\n",
+    "\n",
+    "# Detect environment\n",
+    "has_cuda = torch.cuda.is_available()\n",
+    "is_mac = torch.backends.mps.is_available()\n",
+    "print(f\"CUDA available: {has_cuda}\")\n",
+    "print(f\"Apple Silicon (MPS) available: {is_mac}\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 2. Load Model and Tokenizer\n",
+    "\n",
+    "On NVIDIA GPUs, we use 4-bit quantization (QLoRA) to save VRAM. \n",
+    "On Mac (Apple Silicon) or CPU, we load in `bfloat16` or `float16` directly, as bitsandbytes 4-bit is currently optimized for CUDA."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "if has_cuda:\n",
+    "    # QLoRA config for NVIDIA GPUs\n",
+    "    bnb_config = BitsAndBytesConfig(\n",
+    "        load_in_4bit=True,\n",
+    "        bnb_4bit_quant_type=\"nf4\",\n",
+    "        bnb_4bit_compute_dtype=torch.bfloat16,\n",
+    "        bnb_4bit_use_double_quant=True,\n",
+    "    )\n",
+    "    model_kwargs = {\"quantization_config\": bnb_config}\n",
+    "else:\n",
+    "    # FP16/BF16 for Mac or CPU (Standard LoRA)\n",
+    "    model_kwargs = {\"torch_dtype\": torch.bfloat16 if torch.cuda.is_bf16_supported() or is_mac else torch.float16}\n",
+    "\n",
+    "model = AutoModelForCausalLM.from_pretrained(\n",
+    "    model_id,\n",
+    "    device_map=\"auto\",\n",
+    "    trust_remote_code=True,\n",
+    "    **model_kwargs\n",
+    ")\n",
+    "\n",
+    "tokenizer = AutoTokenizer.from_pretrained(model_id, trust_remote_code=True)\n",
+    "tokenizer.pad_token = tokenizer.eos_token"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 3. Prepare for LoRA\n",
+    "\n",
+    "Define the LoRA parameters. `r` is the rank (higher = more expressive but larger file)."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "if has_cuda:\n",
+    "    model = prepare_model_for_kbit_training(model)\n",
+    "\n",
+    "lora_config = LoraConfig(\n",
+    "    r=16,\n",
+    "    lora_alpha=32,\n",
+    "    target_modules=[\"q_proj\", \"v_proj\", \"k_proj\", \"o_proj\"], # Depends on architecture\n",
+    "    lora_dropout=0.05,\n",
+    "    bias=\"none\",\n",
+    "    task_type=\"CAUSAL_LM\"\n",
+    ")\n",
+    "\n",
+    "model = get_peft_model(model, lora_config)\n",
+    "model.print_trainable_parameters()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 4. Load and Tokenize Dataset\n",
+    "\n",
+    "We pre-tokenize the dataset to avoid issues with specialized trainers like SFTTrainer."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "dataset = load_dataset(dataset_id, split=\"train[:100]\")\n",
+    "\n",
+    "def tokenize_function(examples):\n",
+    "    return tokenizer(examples[\"text\"], truncation=True, max_length=512, padding=\"max_length\")\n",
+    "\n",
+    "tokenized_dataset = dataset.map(tokenize_function, batched=True, remove_columns=dataset.column_names)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 5. Training\n",
+    "\n",
+    "We use the standard `Trainer` from the `transformers` library, which is stable and avoids version conflicts."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "training_args = TrainingArguments(\n",
+    "    output_dir=output_dir,\n",
+    "    per_device_train_batch_size=4,\n",
+    "    gradient_accumulation_steps=4,\n",
+    "    learning_rate=2e-4,\n",
+    "    logging_steps=10,\n",
+    "    max_steps=50,\n",
+    "    fp16=not is_mac and not torch.cuda.is_bf16_supported(),\n",
+    "    bf16=torch.cuda.is_bf16_supported() or is_mac,\n",
+    "    save_strategy=\"no\",\n",
+    "    report_to=\"none\",\n",
+    "    remove_unused_columns=False\n",
+    ")\n",
+    "\n",
+    "trainer = Trainer(\n",
+    "    model=model,\n",
+    "    train_dataset=tokenized_dataset,\n",
+    "    args=training_args,\n",
+    "    data_collator=DataCollatorForLanguageModeling(tokenizer, mlm=False),\n",
+    ")\n",
+    "\n",
+    "trainer.train()\n",
+    "\n",
+    "# Save only the adapter\n",
+    "model.save_pretrained(output_dir)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 6. Convert to GGUF format\n",
+    "\n",
+    "After training, you have a Hugging Face LoRA adapter (several `.bin` or `.safetensors` files and a `adapter_config.json`). To use it with `llamadart`, you must convert it to the **GGUF** format.\n",
+    "\n",
+    "### Step 1: Clone llama.cpp\n",
+    "```bash\n",
+    "git clone https://github.com/ggerganov/llama.cpp\n",
+    "cd llama.cpp\n",
+    "pip install -r requirements.txt\n",
+    "```\n",
+    "\n",
+    "### Step 2: Convert\n",
+    "Run the conversion script. You need the directory where you saved the adapter.\n",
+    "\n",
+    "```bash\n",
+    "python convert_lora_to_gguf.py ../lora-adapter-output/ --out-file my_adapter.gguf\n",
+    "```\n",
+    "\n",
+    "### Step 3: Use in llamadart\n",
+    "\n",
+    "#### Option A: Load in your code\n",
+    "```dart\n",
+    "await service.init(\n",
+    "  'base_model.gguf',\n",
+    "  modelParams: ModelParams(\n",
+    "    loras: [LoraAdapterConfig(path: 'path/to/my_adapter.gguf', scale: 1.0)],\n",
+    "  ),\n",
+    ");\n",
+    "```\n",
+    "\n",
+    "#### Option B: Test with basic_app CLI\n",
+    "Navigate to the `example/basic_app` directory and run the following command. Note that the `basic_app` uses the same **Qwen2.5-0.5B** base model by default, so it will match your trained adapter perfectly.\n",
+    "\n",
+    "```bash\n",
+    "dart run bin/llamadart_basic_example.dart --lora path/to/my_adapter.gguf\n",
+    "```"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.11.14"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 4
+}

--- a/ffigen.yaml
+++ b/ffigen.yaml
@@ -17,6 +17,7 @@ preamble: |
   // ignore_for_file: always_specify_types, unused_field
   // ignore_for_file: camel_case_types
   // ignore_for_file: non_constant_identifier_names
+  /// @nodoc
 comments:
   style: any
   length: full

--- a/lib/llamadart.dart
+++ b/lib/llamadart.dart
@@ -2,7 +2,11 @@
 ///
 /// This package provides a streamlined interface for running Large Language Models (LLMs)
 /// locally using GGUF models across all major platforms with minimal setup.
-library llamadart;
+///
+/// Includes support for streaming generation, chat templates, and LoRA adapters.
+///
+/// Platforms: Android, iOS, macOS, Linux, Windows, Web.
+library;
 
 export 'src/generated/llama_bindings.dart'
     if (dart.library.js_interop) 'src/generated/llama_bindings_stub.dart';

--- a/lib/src/generated/llama_bindings.dart
+++ b/lib/src/generated/llama_bindings.dart
@@ -1,6 +1,7 @@
 // ignore_for_file: always_specify_types, unused_field
 // ignore_for_file: camel_case_types
 // ignore_for_file: non_constant_identifier_names
+/// @nodoc
 
 // AUTO GENERATED FILE, DO NOT EDIT.
 //

--- a/lib/src/llama_service_interface.dart
+++ b/lib/src/llama_service_interface.dart
@@ -40,6 +40,18 @@ enum LlamaLogLevel {
   error,
 }
 
+/// Configuration for a LoRA adapter.
+class LoraAdapterConfig {
+  /// Local file path to the LoRA adapter.
+  final String path;
+
+  /// The strength of the adapter (0.0 to 1.0+). Defaults to 1.0.
+  final double scale;
+
+  /// Creates a LoRA adapter configuration.
+  const LoraAdapterConfig({required this.path, this.scale = 1.0});
+}
+
 /// Configuration parameters for loading the model.
 class ModelParams {
   /// Context size (n_ctx). Defaults to 2048.
@@ -56,12 +68,16 @@ class ModelParams {
   /// Minimum log level to print. Defaults to [LlamaLogLevel.info].
   final LlamaLogLevel logLevel;
 
+  /// Initial LoRA adapters to load with the model.
+  final List<LoraAdapterConfig> loras;
+
   /// Creates configuration for the model.
   const ModelParams({
     this.contextSize = 0, // 0 = Auto detect from model
     this.gpuLayers = 99,
     this.preferredBackend = GpuBackend.auto,
     this.logLevel = LlamaLogLevel.info,
+    this.loras = const [],
   });
 
   /// Creates a copy of this [ModelParams] with updated fields.
@@ -70,12 +86,14 @@ class ModelParams {
     int? gpuLayers,
     GpuBackend? preferredBackend,
     LlamaLogLevel? logLevel,
+    List<LoraAdapterConfig>? loras,
   }) {
     return ModelParams(
       contextSize: contextSize ?? this.contextSize,
       gpuLayers: gpuLayers ?? this.gpuLayers,
       preferredBackend: preferredBackend ?? this.preferredBackend,
       logLevel: logLevel ?? this.logLevel,
+      loras: loras ?? this.loras,
     );
   }
 }
@@ -184,4 +202,20 @@ abstract class LlamaServiceBase {
 
   /// Returns all available metadata from the model as a map.
   Future<Map<String, String>> getAllMetadata();
+
+  /// Dynamically adds or updates a LoRA adapter's scale.
+  ///
+  /// This loads the adapter if it's not already loaded.
+  /// Note: Not supported on Web.
+  Future<void> setLoraAdapter(String path, {double scale = 1.0});
+
+  /// Removes a specific LoRA adapter from the session.
+  ///
+  /// Note: Not supported on Web.
+  Future<void> removeLoraAdapter(String path);
+
+  /// Clears all active LoRA adapters.
+  ///
+  /// Note: Not supported on Web.
+  Future<void> clearLoraAdapters();
 }

--- a/lib/src/llama_service_stub.dart
+++ b/lib/src/llama_service_stub.dart
@@ -83,4 +83,19 @@ class LlamaService implements LlamaServiceBase {
   Future<Map<String, String>> getAllMetadata() {
     throw UnimplementedError('LlamaService not supported on this platform');
   }
+
+  @override
+  Future<void> setLoraAdapter(String path, {double scale = 1.0}) {
+    throw UnimplementedError('LlamaService not supported on this platform');
+  }
+
+  @override
+  Future<void> removeLoraAdapter(String path) {
+    throw UnimplementedError('LlamaService not supported on this platform');
+  }
+
+  @override
+  Future<void> clearLoraAdapters() {
+    throw UnimplementedError('LlamaService not supported on this platform');
+  }
 }

--- a/lib/src/llama_service_web.dart
+++ b/lib/src/llama_service_web.dart
@@ -54,6 +54,11 @@ class LlamaService implements LlamaServiceBase {
   /// Initializes the service with the model at the given [modelUrl].
   @override
   Future<void> initFromUrl(String modelUrl, {ModelParams? modelParams}) async {
+    if (modelParams != null && modelParams.loras.isNotEmpty) {
+      print(
+        'Warning: LoRA adapters are not yet supported on Web (Wasm). They will be ignored.',
+      );
+    }
     if (_wllama != null) {
       // If already initialized, dispose/exit the current instance to load the new one.
       final exitPromise = _wllama!.exit();
@@ -420,4 +425,19 @@ class LlamaService implements LlamaServiceBase {
   /// Returns true if GPU acceleration is supported.
   @override
   Future<bool> isGpuSupported() async => false; // WebGPU not yet explicitly toggled
+
+  @override
+  Future<void> setLoraAdapter(String path, {double scale = 1.0}) async {
+    print('LoRA is not yet supported on Web (Wasm).');
+  }
+
+  @override
+  Future<void> removeLoraAdapter(String path) async {
+    print('LoRA is not yet supported on Web (Wasm).');
+  }
+
+  @override
+  Future<void> clearLoraAdapters() async {
+    print('LoRA is not yet supported on Web (Wasm).');
+  }
 }

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: llamadart
 description: A Dart/Flutter plugin for llama.cpp - run LLM inference on any platform using GGUF models
-version: 0.2.0
+version: 0.3.0
 homepage: https://github.com/leehack/llamadart
 repository: https://github.com/leehack/llamadart
 issue_tracker: https://github.com/leehack/llamadart/issues

--- a/test/llamadart_test.dart
+++ b/test/llamadart_test.dart
@@ -121,5 +121,12 @@ void main() async {
       final count = await service.getTokenCount(text);
       expect(count, greaterThan(0));
     });
+
+    test('LoRA non-existent file', () async {
+      await expectLater(
+        service.setLoraAdapter('non_existent.lora'),
+        throwsA(isA<Exception>()),
+      );
+    });
   });
 }


### PR DESCRIPTION
## Summary
This PR implements full **Low-Rank Adaptation (LoRA)** support for `llamadart`, enabling users to apply fine-tuned adapters to base models at runtime.

### Key Changes
- **Core Engine**: Integrated `llama_adapter_lora` APIs into the native backend.
- **Dynamic Control**: Added `setLoraAdapter`, `removeLoraAdapter`, and `clearLoraAdapters` to `LlamaService`.
- **Training Pipeline**: Added a comprehensive [Jupyter Notebook](example/training_notebook/lora_training.ipynb) for training QLoRA adapters and converting them to GGUF.
- **CLI Tooling**: Updated `basic_app` to support testing LoRA adapters via the `--lora` flag.
- **Documentation**: Updated README, CHANGELOG, and example docs to reflect version 0.3.0 changes.

### Supported Platforms
- ✅ **Native**: iOS, Android, macOS, Linux, Windows (Full Support)
- ⚠️ **Web**: API stubs provided (Awaiting `wllama` backend support)