### PR TITLE
feat: integrate mtmd module and upgrade native build to b7898

### DIFF
--- a/hook/build.dart
+++ b/hook/build.dart
@@ -117,9 +117,20 @@ void main(List<String> args) async {
 
       // 3. Asset Acquisition (Local -> Cache -> Download)
       String? finalAssetPath;
+      final localSimpleAssetPath = path.join(
+        pkgRoot,
+        _thirdPartyDir,
+        _binDir,
+        relPath,
+        '$_libPrefix.$extension',
+      );
+
       if (File(localAssetPath).existsSync()) {
         log.info('Using local binary: $localAssetPath');
         finalAssetPath = localAssetPath;
+      } else if (File(localSimpleAssetPath).existsSync()) {
+        log.info('Using local binary (simple name): $localSimpleAssetPath');
+        finalAssetPath = localSimpleAssetPath;
       } else {
         if (!File(cacheAssetPath).existsSync()) {
           log.info('Cache miss, ensuring cached assets...');

--- a/third_party/CMakeLists.txt
+++ b/third_party/CMakeLists.txt
@@ -8,20 +8,27 @@ set(CMAKE_POSITION_INDEPENDENT_CODE ON)
 set(BUILD_SHARED_LIBS OFF CACHE BOOL "Build shared libraries" FORCE)
 
 # Add llama.cpp as a subdirectory
-add_subdirectory(llama_cpp)
+set(LLAMA_BUILD_COMMON OFF CACHE BOOL "Build llama.cpp common library" FORCE)
+set(LLAMA_BUILD_TESTS OFF CACHE BOOL "Build llama.cpp tests" FORCE)
+set(LLAMA_BUILD_EXAMPLES OFF CACHE BOOL "Build llama.cpp examples" FORCE)
+set(LLAMA_BUILD_SERVER OFF CACHE BOOL "Build llama.cpp server" FORCE)
+set(LLAMA_BUILD_TOOLS OFF CACHE BOOL "Build llama.cpp tools" FORCE)
 
-set(CONSOLIDATED_LIBS llama ggml ggml-base ggml-cpu ggml-vulkan ggml-blas ggml-metal ggml-cuda)
+add_subdirectory(llama_cpp)
+add_subdirectory(llama_cpp/tools/mtmd EXCLUDE_FROM_ALL)
+
+set(CONSOLIDATED_LIBS llama ggml ggml-base ggml-cpu ggml-vulkan ggml-blas ggml-metal ggml-cuda mtmd)
 
 if (APPLE)
     # Support both STATIC and SHARED for Apple platforms
     if (LLAMADART_SHARED)
         add_library(llamadart_lib SHARED "llamadart_empty.cpp")
         # Use -Wl,-force_load to ensure all symbols from the static 'llama' lib are included in the dylib
-        target_link_libraries(llamadart_lib PUBLIC -Wl,-force_load llama)
+        target_link_libraries(llamadart_lib PUBLIC -Wl,-force_load llama -Wl,-force_load mtmd)
     else()
         add_library(llamadart_lib STATIC "llamadart_empty.cpp")
         # Use -Wl,-all_load for static library consolidation
-        target_link_libraries(llamadart_lib PUBLIC -Wl,-all_load llama)
+        target_link_libraries(llamadart_lib PUBLIC -Wl,-all_load llama -Wl,-all_load mtmd)
     endif()
 elseif (MSVC)
     # On MSVC, we want to consolidate everything into a single DLL.


### PR DESCRIPTION
This pull request focuses on improving binary asset discovery in the Dart build script and updating the CMake build configuration to better manage dependencies and library linking, especially for the addition of the `mtmd` tool/library.

**Build script improvements:**

- Added support in `build.dart` for discovering binaries with a "simple name" (i.e., without a platform/architecture subdirectory) as a fallback if the standard local binary is not found. This enhances the robustness of local asset resolution.

**CMake build configuration updates:**

- Disabled unnecessary components of `llama.cpp` (common library, tests, examples, server, tools) to streamline the build process and reduce build time.
- Added `mtmd` as a subdirectory and included it in the consolidated library list, ensuring it is built and linked as part of the overall project.
- Updated linking commands for both static and shared libraries (especially for Apple platforms) to ensure `mtmd` is force-loaded along with `llama`, preventing missing symbols at link time.