### PR TITLE
chore: prepare 0.5.1 docs and publishing cleanup

### DIFF
--- a/.pubignore
+++ b/.pubignore
@@ -1,7 +1,39 @@
-# Local build artifacts
+# Dart / Flutter local artifacts
+.dart_tool/
+build/
+coverage/
+.pub/
+.metadata
+.flutter-plugins
+.flutter-plugins-dependencies
+
+# IDE / OS
+.idea/
+.vscode/
+*.iml
+.DS_Store
+
+# Local logs / scratch outputs
+*.log
+full_log.txt
+firebase-debug.log
+test_output.txt
+test_output_*.txt
+test_failure_details.txt
 a.out.js
 a.out.wasm
-full_log.txt
+
+# Large local model/test assets
+*.gguf
+models/
+example/basic_app/models/
+test_assets/
+
+# Native local build outputs / vendored sources
+third_party/bin/
+third_party/build-*/
+third_party/llama_cpp/
+third_party/Vulkan-Headers/
 
 # Local bridge build/fetch outputs
 webgpu_bridge/
@@ -14,3 +46,6 @@ test/unit/backends/wllama/
 
 # Local scratch docs directory
 docs/
+
+# Agent-only maintainer notes
+AGENTS.md

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
-## Unreleased
-> Upcoming release target: `0.5.0` (not published yet).
+## 0.5.1
+
+*   **Documentation fixes**:
+    *   Updated README internal links to absolute GitHub URLs so they resolve reliably on pub.dev.
+    *   Updated release/migration wording after 0.5.0 publication and refreshed installation/version snippets.
+    *   Corrected iOS simulator architecture notes and contributor prerequisites/build target docs.
+*   **Publishing hygiene**:
+    *   Expanded `.pubignore` to exclude local build outputs, large model/test artifacts, and checked-out `third_party` sources from package uploads.
+
+## 0.5.0
 
 *   **[BREAKING] Public API Changes**:
     *   Root exports were tightened; previously exposed internals such as `ToolRegistry`, `LlamaTokenizer`, and `ChatTemplateProcessor` are no longer part of the public package API.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -6,8 +6,8 @@ Thank you for your interest in contributing to `llamadart`! We welcome contribut
 
 Before you begin, ensure you have the following installed:
 
--   **Dart SDK**: >= 3.10.0
--   **Flutter SDK**: (Optional, for running UI examples)
+-   **Dart SDK**: >= 3.10.7
+-   **Flutter SDK**: >= 3.38.0 (optional, for running UI examples)
 -   **CMake**: >= 3.10
 -   **C++ Compiler**:
     -   **macOS**: Xcode Command Line Tools (`xcode-select --install`)
@@ -140,7 +140,8 @@ If you need to build binaries for a new release:
 
 2.  **Run platform scripts**:
     -   **Android**: `./build_android.sh`
-    -   **Apple (macOS/iOS)**: `./build_apple.sh macos` or `./build_apple.sh ios`
+    -   **Apple (macOS)**: `./build_apple.sh macos-arm64` or `./build_apple.sh macos-x86_64`
+    -   **Apple (iOS)**: `./build_apple.sh ios-device-arm64`, `./build_apple.sh ios-sim-arm64`, or `./build_apple.sh ios-sim-x86_64`
     -   **Linux**: `./build_linux.sh vulkan`
 
 ## Running Examples

--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -1,7 +1,6 @@
-# Migration Guide (`main` / `0.4.0` -> upcoming `0.5.0`)
+# Migration Guide (`0.4.x` -> `0.5.0`)
 
-`0.5.0` is not published yet. This document covers intentional breaking
-changes already present on this branch.
+This document covers the breaking changes introduced in `0.5.0`.
 
 ## 1) ChatSession API
 

--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ llamadart uses a modern, decoupled architecture designed for flexibility and pla
 | Platform | Architecture(s) | GPU Backend | Status |
 |----------|-----------------|-------------|--------|
 | **macOS** | arm64, x86_64 | Metal | ✅ Tested |
-| **iOS** | arm64 (Device), x86_64 (Sim) | Metal (Device), CPU (Sim) | ✅ Tested |
+| **iOS** | arm64 (Device), arm64/x86_64 (Sim) | Metal (Device), CPU (Sim) | ✅ Tested |
 | **Android** | arm64-v8a, x86_64 | Vulkan | ✅ Tested |
 | **Linux** | arm64, x86_64 | Vulkan | ✅ Tested |
 | **Windows** | x64 | Vulkan | ✅ Tested |
@@ -56,12 +56,12 @@ both WebGPU and CPU execution paths.
 Current limitations:
 
 - Web mode is currently **experimental** and depends on an external JS bridge runtime.
-- Bridge API contract: [WebGPU bridge contract](doc/webgpu_bridge.md).
+- Bridge API contract: [WebGPU bridge contract](https://github.com/leehack/llamadart/blob/main/doc/webgpu_bridge.md).
 - Prebuilt web bridge assets are published from
   [`leehack/llama-web-bridge`](https://github.com/leehack/llama-web-bridge)
   to
   [`leehack/llama-web-bridge-assets`](https://github.com/leehack/llama-web-bridge-assets).
-- [`example/chat_app`](example/chat_app) uses local bridge files first and
+- [`example/chat_app`](https://github.com/leehack/llamadart/blob/main/example/chat_app/README.md) uses local bridge files first and
   falls back to jsDelivr assets when local assets are missing.
 - Bridge model loading now uses browser Cache Storage when `useCache` is true
   (enabled by default in `llamadart` web backend), so repeat loads of the same
@@ -99,7 +99,7 @@ Add `llamadart` to your `pubspec.yaml`:
 
 ```yaml
 dependencies:
-  llamadart: ^0.4.0
+  llamadart: ^0.5.1
 ```
 
 ### Zero Setup (Native Assets)
@@ -113,14 +113,11 @@ No manual binary downloads, CMake configuration, or platform-specific project ch
 
 ---
 
-## ⚠️ Breaking Changes (Upcoming 0.5.0)
+## ⚠️ Breaking Changes in 0.5.0
 
-`0.5.0` has not been published yet. This branch includes intentional
-breaking changes while the API is still early.
+If you are upgrading from `0.4.x`, read:
 
-Before upgrading from `main` / `0.4.0`, read:
-
-- [MIGRATION.md](MIGRATION.md)
+- [MIGRATION.md](https://github.com/leehack/llamadart/blob/main/MIGRATION.md)
 
 High-impact changes:
 
@@ -402,7 +399,7 @@ void dispose() {
 - **Isolate-Safe**: Native adapters are managed in a background Isolate to prevent UI jank.
 - **Efficient**: Multiple LoRAs share the memory of a single base model.
 
-Check out our [LoRA Training Notebook](example/training_notebook/lora_training.ipynb) to learn how to train and convert your own adapters.
+Check out our [LoRA Training Notebook](https://github.com/leehack/llamadart/blob/main/example/training_notebook/lora_training.ipynb) to learn how to train and convert your own adapters.
 
 ---
 
@@ -435,8 +432,8 @@ dart run tool/testing/check_lcov_threshold.dart coverage/lcov.info 70
 
 ## 🤝 Contributing
 
-Contributions are welcome! Please see [CONTRIBUTING.md](CONTRIBUTING.md) for architecture details and maintainer instructions for building native binaries.
+Contributions are welcome! Please see [CONTRIBUTING.md](https://github.com/leehack/llamadart/blob/main/CONTRIBUTING.md) for architecture details and maintainer instructions for building native binaries.
 
 ## 📜 License
 
-This project is licensed under the MIT License - see the [LICENSE](LICENSE) file for details.
+This project is licensed under the MIT License - see the [LICENSE](https://github.com/leehack/llamadart/blob/main/LICENSE) file for details.

--- a/example/README.md
+++ b/example/README.md
@@ -116,7 +116,7 @@ example/
 | Platform | Architecture(s) | GPU Backend | Status |
 |----------|-----------------|-------------|--------|
 | **macOS** | arm64, x86_64 | Metal | ✅ Tested |
-| **iOS** | arm64 (Device), x86_64 (Sim) | Metal (Device), CPU (Sim) | ✅ Tested |
+| **iOS** | arm64 (Device), arm64/x86_64 (Sim) | Metal (Device), CPU (Sim) | ✅ Tested |
 | **Android** | arm64-v8a, x86_64 | Vulkan | ✅ Tested |
 | **Linux** | arm64, x86_64 | Vulkan | 🟡 Expected (Vulkan Untested) |
 | **Windows** | x64 | Vulkan | ✅ Tested |

--- a/example/chat_app/README.md
+++ b/example/chat_app/README.md
@@ -144,7 +144,7 @@ final messages = [
 final stream = engine.create(
   messages,
   params: GenerationParams(
-    maxTokens: 4096, // Current default in this branch
+    maxTokens: 4096, // Current default in 0.5.0
     temp: 0.7,
   ),
 );
@@ -185,7 +185,7 @@ _(Add screenshots here when complete)_
 **App crashes on startup:**
 - Check console output for error messages
 - Verify llamadart dependency is correctly configured
-- Ensure Flutter version >= 3.10.0
+- Ensure Flutter version >= 3.38.0
 
 ## Tech Stack
 

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: llamadart
 description: A Dart/Flutter plugin for llama.cpp - run LLM inference on any platform using GGUF models
-version: 0.5.0
+version: 0.5.1
 homepage: https://github.com/leehack/llamadart
 repository: https://github.com/leehack/llamadart
 issue_tracker: https://github.com/leehack/llamadart/issues


### PR DESCRIPTION
## Summary
- prepare `0.5.1` by bumping `pubspec.yaml` and adding a dedicated changelog entry
- update README/docs/examples for post-`0.5.0` accuracy and pub.dev-safe absolute documentation links
- tighten `.pubignore` to exclude local build/test/model artifacts from published archives

## Validation
- `dart pub publish --dry-run`