### PR TITLE
feat(template): harden llama.cpp tool-call parity and grammar stability

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,13 @@
+## 0.5.2
+
+*   **Chat template parity hardening**:
+    *   Expanded llama.cpp parity across additional format handlers, including grammar construction, lazy-grammar triggers, preserved tokens, and parser behavior for tool-call payload extraction.
+    *   Added shared `ToolCallGrammarUtils` helpers for wrapped object/array tool-call grammar generation and root-rule wrapping.
+*   **Crash fix (grammar parsing)**:
+    *   Fixed malformed GBNF escaping in Hermes/Command-R string rules that could cause runtime `llama_grammar_init_impl` parse failures during tool-calling generations.
+*   **Test coverage expansion**:
+    *   Added and expanded handler-level parity tests (Apertus, LFM2, Nemotron V2, Magistral, Seed-OSS, Xiaomi MiMo, DeepSeek R1/V3, Hermes) and mirrored unit tests for new grammar utilities.
+
 ## 0.5.1
 
 *   **Documentation fixes**:

--- a/README.md
+++ b/README.md
@@ -99,7 +99,7 @@ Add `llamadart` to your `pubspec.yaml`:
 
 ```yaml
 dependencies:
-  llamadart: ^0.5.1
+  llamadart: ^0.5.2
 ```
 
 ### Zero Setup (Native Assets)
@@ -223,6 +223,12 @@ await for (final chunk in session.create(
   if (delta.content != null) stdout.write(delta.content);
 }
 ```
+
+Notes:
+
+- Built-in template handlers automatically select model-specific tool-call grammar and parser behavior; you usually do not need to set `GenerationParams.grammar` manually for normal tool use.
+- Some handlers use lazy grammar activation (triggered when a tool-call prefix appears) to match llama.cpp behavior.
+- If you implement a custom handler grammar, prefer Dart raw strings (`r'''...'''`) for GBNF blocks to avoid escaping bugs.
 
 ### 3.5 Custom Template Handlers and Overrides (Advanced)
 

--- a/example/chat_app/README.md
+++ b/example/chat_app/README.md
@@ -187,6 +187,18 @@ _(Add screenshots here when complete)_
 - Verify llamadart dependency is correctly configured
 - Ensure Flutter version >= 3.38.0
 
+**macOS warning: "Stale file ... located outside of the allowed root paths":**
+- This is usually a stale Flutter/Xcode build cache path after moving or renaming directories.
+- From `example/chat_app`, run:
+  - `flutter clean`
+  - `flutter pub get`
+  - `flutter run -d macos`
+
+**`llama_grammar_init_impl: failed to parse grammar` during tool calls:**
+- This indicates invalid generated GBNF (often from custom template/handler grammar escaping).
+- Update to the latest package version and retry.
+- If using custom handlers, validate grammar strings and prefer Dart raw strings (`r'''...'''`) for multiline GBNF.
+
 ## Tech Stack
 
 - **llamadart** - High-performance LLM inference

--- a/lib/src/core/models/chat/chat_template_result.dart
+++ b/lib/src/core/models/chat/chat_template_result.dart
@@ -4,7 +4,7 @@ class LlamaChatTemplateResult {
   final String prompt;
 
   /// The detected chat format code (corresponds to common_chat_format enum).
-  /// Defaults to 0 (generic format) if not specified.
+  /// Defaults to 0 (content-only format) if not specified.
   final int format;
 
   /// GBNF grammar string for constraining model output (e.g., for tool calls).

--- a/lib/src/core/models/inference/generation_params.dart
+++ b/lib/src/core/models/inference/generation_params.dart
@@ -13,6 +13,26 @@
 ///   grammar: 'root ::= "yes" | "no"', // Force binary response
 /// );
 /// ```
+/// Lazy grammar activation trigger.
+class GenerationGrammarTrigger {
+  /// Trigger type (0=word, 1=token, 2=pattern, 3=pattern_full).
+  final int type;
+
+  /// Trigger text value.
+  final String value;
+
+  /// Trigger token id for token-based triggers.
+  final int? token;
+
+  /// Creates a new grammar trigger.
+  const GenerationGrammarTrigger({
+    required this.type,
+    required this.value,
+    this.token,
+  });
+}
+
+/// Parameters controlling the token sampling and generation process.
 class GenerationParams {
   /// Maximum number of new tokens to generate.
   final int maxTokens;
@@ -44,6 +64,15 @@ class GenerationParams {
   /// GBNF grammar string for structured output (e.g., "root ::= \"hello\" | \"world\"").
   final String? grammar;
 
+  /// Whether grammar should be lazily activated by triggers.
+  final bool grammarLazy;
+
+  /// Lazy grammar activation triggers.
+  final List<GenerationGrammarTrigger> grammarTriggers;
+
+  /// Tokens to preserve during constrained decoding.
+  final List<String> preservedTokens;
+
   /// Grammar start symbol. Defaults to "root".
   final String grammarRoot;
 
@@ -57,6 +86,9 @@ class GenerationParams {
     this.seed,
     this.stopSequences = const [],
     this.grammar,
+    this.grammarLazy = false,
+    this.grammarTriggers = const [],
+    this.preservedTokens = const [],
     this.grammarRoot = 'root',
   });
 
@@ -70,6 +102,9 @@ class GenerationParams {
     int? seed,
     List<String>? stopSequences,
     String? grammar,
+    bool? grammarLazy,
+    List<GenerationGrammarTrigger>? grammarTriggers,
+    List<String>? preservedTokens,
     String? grammarRoot,
   }) {
     return GenerationParams(
@@ -81,6 +116,9 @@ class GenerationParams {
       seed: seed ?? this.seed,
       stopSequences: stopSequences ?? this.stopSequences,
       grammar: grammar ?? this.grammar,
+      grammarLazy: grammarLazy ?? this.grammarLazy,
+      grammarTriggers: grammarTriggers ?? this.grammarTriggers,
+      preservedTokens: preservedTokens ?? this.preservedTokens,
       grammarRoot: grammarRoot ?? this.grammarRoot,
     );
   }

--- a/lib/src/core/template/chat_format.dart
+++ b/lib/src/core/template/chat_format.dart
@@ -13,11 +13,20 @@ enum ChatFormat {
   /// a more specific tool call format.
   generic,
 
-  /// Hermes 2 Pro / Qwen 2.5 / Qwen 3 — `<tool_call>` XML tags.
-  hermes,
+  /// Mistral Nemo — `[TOOL_CALLS]` prefix with JSON array.
+  mistralNemo,
 
-  /// Llama 3.x — ipython role with `<|python_tag|>`.
+  /// Magistral — `[THINK]`/`[/THINK]` thinking + `[TOOL_CALLS]` prefix.
+  magistral,
+
+  /// Llama 3.x — ipython role with `<|python_tag|>` optional builtin tools.
   llama3,
+
+  /// Llama 3.x builtin-tools variant.
+  llama3BuiltinTools,
+
+  /// DeepSeek R1 — fullwidth unicode delimiters.
+  deepseekR1,
 
   /// FireFunction v2 — `functools[...]` JSON tool-call arrays.
   firefunctionV2,
@@ -28,45 +37,17 @@ enum ChatFormat {
   /// Functionary v3.1 Llama 3.1 — `<function=name>{...}</function>`.
   functionaryV31Llama31,
 
-  /// Mistral Nemo — `[TOOL_CALLS]` prefix with JSON array.
-  mistralNemo,
-
-  /// Magistral — `[THINK]`/`[/THINK]` thinking + `[TOOL_CALLS]` prefix.
-  magistral,
-
-  /// LFM2 — `<|tool_call_start|>/<|tool_call_end|>` special tokens.
-  lfm2,
-
-  /// DeepSeek R1 — fullwidth unicode delimiters.
-  deepseekR1,
-
   /// DeepSeek V3.1 — prefix-based thinking with `<tool_call>` tags.
   deepseekV3,
 
-  /// FunctionGemma — `<start_function_call>call:name{args}<end_function_call>`.
-  functionGemma,
-
-  /// Gemma 3 / Gemma 3n — `<start_of_turn>/<end_of_turn>` with
-  /// prompt-engineered tool calling and multimodal support.
-  gemma,
+  /// Hermes 2 Pro / Qwen 2.5 / Qwen 3 — `<tool_call>` XML tags.
+  hermes,
 
   /// Command R7B — `<|START_ACTION|>/<|END_ACTION|>` with thinking.
   commandR7B,
 
   /// Granite — `<|tool_call|>` + JSON array with `<think>` support.
   granite,
-
-  /// GLM 4.5 — `<|observation|>` with XML-style arg_key/arg_value.
-  glm45,
-
-  /// Kimi K2 — `<|tool_call_begin|>` with special tokens.
-  kimiK2,
-
-  /// Qwen3 Coder XML — `<function=name><parameter=key>` format.
-  qwen3CoderXml,
-
-  /// MiniMax M2 — `<minimax:tool_call>` with `<invoke>` tags.
-  minimaxM2,
 
   /// GPT-OSS assistant channel/message format.
   gptOss,
@@ -80,17 +61,48 @@ enum ChatFormat {
   /// Apertus format with `<|tools_prefix|>` and `<|tools_suffix|>`.
   apertus,
 
-  /// Xiaomi MiMo format with `<tool_call>` JSON blocks.
-  xiaomiMimo,
+  /// LFM2 — `<|tool_call_start|>/<|tool_call_end|>` special tokens.
+  lfm2,
+
+  /// GLM 4.5 — `<|observation|>` with XML-style arg_key/arg_value.
+  glm45,
+
+  /// MiniMax M2 — `<minimax:tool_call>` with `<invoke>` tags.
+  minimaxM2,
+
+  /// Kimi K2 — `<|tool_call_begin|>` with special tokens.
+  kimiK2,
+
+  /// Qwen3 Coder XML — `<function=name><parameter=key>` format.
+  qwen3CoderXml,
 
   /// Apriel 1.5 format with `<thinking>` and `<tool_calls>`.
   apriel15,
+
+  /// Xiaomi MiMo format with `<tool_call>` JSON blocks.
+  xiaomiMimo,
 
   /// Solar Open format with `<|think|>` and tool response markers.
   solarOpen,
 
   /// EXAONE MoE format with `<tool_call>` blocks and thinking tags.
   exaoneMoe,
+
+  /// PEG simple parser-backed format.
+  pegSimple,
+
+  /// PEG native parser-backed format.
+  pegNative,
+
+  /// PEG constructed parser-backed format.
+  pegConstructed,
+
+  /// FunctionGemma — `<start_function_call>call:name{args}<end_function_call>`.
+  functionGemma,
+
+  /// Gemma 3 / Gemma 3n — `<start_of_turn>/<end_of_turn>` with
+  /// prompt-engineered tool calling and multimodal support.
+  gemma,
 
   /// TranslateGemma format with language-code message content fields.
   translateGemma,

--- a/lib/src/core/template/handlers/apriel15_handler.dart
+++ b/lib/src/core/template/handlers/apriel15_handler.dart
@@ -10,6 +10,7 @@ import '../chat_format.dart';
 import '../chat_parse_result.dart';
 import '../chat_template_handler.dart';
 import '../thinking_utils.dart';
+import '../tool_call_grammar_utils.dart';
 
 /// Handler for Apriel 1.5 format.
 ///
@@ -27,6 +28,14 @@ class Apriel15Handler extends ChatTemplateHandler {
 
   @override
   List<String> get additionalStops => [];
+
+  @override
+  List<String> get preservedTokens => const [
+    '<thinking>',
+    '</thinking>',
+    '<tool_calls>',
+    '</tool_calls>',
+  ];
 
   @override
   LlamaChatTemplateResult render({
@@ -66,8 +75,9 @@ class Apriel15Handler extends ChatTemplateHandler {
         hasTools: hasTools,
         enableThinking: enableThinking,
       ),
+      preservedTokens: hasTools ? preservedTokens : const [],
       grammarTriggers: hasTools
-          ? [const GrammarTrigger(type: 0, value: '<tool_calls>[')]
+          ? [const GrammarTrigger(type: 0, value: '<tool_calls>[{"name": "')]
           : [],
     );
   }
@@ -156,6 +166,10 @@ class Apriel15Handler extends ChatTemplateHandler {
 
   @override
   String? buildGrammar(List<ToolDefinition>? tools) {
-    return null;
+    return ToolCallGrammarUtils.buildWrappedArrayGrammar(
+      tools: tools,
+      prefix: '<tool_calls>',
+      suffix: '</tool_calls>',
+    );
   }
 }

--- a/lib/src/core/template/handlers/command_r7b_handler.dart
+++ b/lib/src/core/template/handlers/command_r7b_handler.dart
@@ -212,9 +212,9 @@ class CommandR7BHandler extends ChatTemplateHandler {
   }
 
   String _commonGbnfRules() {
-    return '''
+    return r'''
 space ::= " "?
-string ::= "\\"" ([^"\\\\] | "\\\\" .)* "\\""
+string ::= "\"" ([^"\\] | "\\\\" .)* "\""
 number ::= "-"? ([0-9] | [1-9] [0-9]*) ("." [0-9]+)? ([eE] [-+]? [0-9]+)?
 boolean ::= "true" | "false"
 null ::= "null"

--- a/lib/src/core/template/handlers/hermes_handler.dart
+++ b/lib/src/core/template/handlers/hermes_handler.dart
@@ -199,9 +199,9 @@ class HermesHandler extends ChatTemplateHandler {
   }
 
   String _commonGbnfRules() {
-    return '''
+    return r'''
 space ::= " "?
-string ::= "\\\\"" ([^"\\\\] | "\\\\" .)* "\\\\""
+string ::= "\"" ([^"\\] | "\\\\" .)* "\""
 number ::= "-"? ([0-9] | [1-9] [0-9]*) ("." [0-9]+)? ([eE] [-+]? [0-9]+)?
 boolean ::= "true" | "false"
 null ::= "null"

--- a/lib/src/core/template/handlers/magistral_handler.dart
+++ b/lib/src/core/template/handlers/magistral_handler.dart
@@ -10,6 +10,7 @@ import '../chat_format.dart';
 import '../chat_parse_result.dart';
 import '../chat_template_handler.dart';
 import '../thinking_utils.dart';
+import '../tool_call_grammar_utils.dart';
 
 /// Handler for Magistral format.
 ///
@@ -27,6 +28,9 @@ class MagistralHandler extends ChatTemplateHandler {
 
   @override
   List<String> get additionalStops => ['</s>'];
+
+  @override
+  List<String> get preservedTokens => const ['[THINK]', '[/THINK]'];
 
   @override
   List<String> getStops({bool hasTools = false, bool enableThinking = true}) {
@@ -72,6 +76,9 @@ class MagistralHandler extends ChatTemplateHandler {
         hasTools: hasTools,
         enableThinking: enableThinking,
       ),
+      preservedTokens: hasTools
+          ? const ['[THINK]', '[/THINK]', '[TOOL_CALLS]']
+          : preservedTokens,
       grammarTriggers: hasTools
           ? [const GrammarTrigger(type: 0, value: '[TOOL_CALLS]')]
           : [],
@@ -151,7 +158,12 @@ class MagistralHandler extends ChatTemplateHandler {
 
   @override
   String? buildGrammar(List<ToolDefinition>? tools) {
-    // Mistral-based, native tool calling via template
-    return null;
+    return ToolCallGrammarUtils.buildWrappedArrayGrammar(
+      tools: tools,
+      prefix: '[TOOL_CALLS]',
+      suffix: '',
+      idKey: 'id',
+      idPattern: r'^[a-zA-Z0-9]{9}$',
+    );
   }
 }

--- a/lib/src/core/template/handlers/mistral_handler.dart
+++ b/lib/src/core/template/handlers/mistral_handler.dart
@@ -10,6 +10,7 @@ import '../chat_format.dart';
 import '../chat_parse_result.dart';
 import '../chat_template_handler.dart';
 import '../thinking_utils.dart';
+import '../tool_call_grammar_utils.dart';
 
 /// Handler for Mistral Nemo format.
 ///
@@ -21,6 +22,9 @@ class MistralHandler extends ChatTemplateHandler {
 
   @override
   List<String> get additionalStops => ['</s>'];
+
+  @override
+  List<String> get preservedTokens => const ['[TOOL_CALLS]'];
 
   @override
   List<String> getStops({bool hasTools = false, bool enableThinking = true}) {
@@ -55,6 +59,7 @@ class MistralHandler extends ChatTemplateHandler {
         hasTools: hasTools,
         enableThinking: enableThinking,
       ),
+      preservedTokens: hasTools ? preservedTokens : const [],
       grammarTriggers: hasTools
           ? [const GrammarTrigger(type: 0, value: '[TOOL_CALLS]')]
           : [],
@@ -132,7 +137,12 @@ class MistralHandler extends ChatTemplateHandler {
 
   @override
   String? buildGrammar(List<ToolDefinition>? tools) {
-    // Mistral uses native template-based tool calling
-    return null;
+    return ToolCallGrammarUtils.buildWrappedArrayGrammar(
+      tools: tools,
+      prefix: '[TOOL_CALLS]',
+      suffix: '',
+      idKey: 'id',
+      idPattern: r'^[a-zA-Z0-9]{9}$',
+    );
   }
 }

--- a/lib/src/core/template/handlers/nemotron_v2_handler.dart
+++ b/lib/src/core/template/handlers/nemotron_v2_handler.dart
@@ -10,6 +10,7 @@ import '../chat_format.dart';
 import '../chat_parse_result.dart';
 import '../chat_template_handler.dart';
 import '../thinking_utils.dart';
+import '../tool_call_grammar_utils.dart';
 
 /// Handler for Nemotron V2 format.
 ///
@@ -49,6 +50,9 @@ class NemotronV2Handler extends ChatTemplateHandler {
     }
 
     final hasTools = tools != null && tools.isNotEmpty;
+    final triggerPattern = thinkingForcedOpen
+        ? r'[\s\S]*?(</think>\s*)(<TOOLCALL>)[\s\S]*'
+        : r'(?:<think>[\s\S]*?</think>\s*)?(<TOOLCALL>)[\s\S]*';
     return LlamaChatTemplateResult(
       prompt: prompt,
       format: format.index,
@@ -60,7 +64,7 @@ class NemotronV2Handler extends ChatTemplateHandler {
         enableThinking: enableThinking,
       ),
       grammarTriggers: hasTools
-          ? [const GrammarTrigger(type: 0, value: '<TOOLCALL>')]
+          ? [GrammarTrigger(type: 3, value: triggerPattern)]
           : [],
     );
   }
@@ -162,6 +166,10 @@ class NemotronV2Handler extends ChatTemplateHandler {
 
   @override
   String? buildGrammar(List<ToolDefinition>? tools) {
-    return null;
+    return ToolCallGrammarUtils.buildWrappedArrayGrammar(
+      tools: tools,
+      prefix: '<TOOLCALL>',
+      suffix: '</TOOLCALL>',
+    );
   }
 }

--- a/lib/src/core/template/handlers/qwen3_coder_xml_handler.dart
+++ b/lib/src/core/template/handlers/qwen3_coder_xml_handler.dart
@@ -20,6 +20,16 @@ class Qwen3CoderXmlHandler extends ChatTemplateHandler {
   List<String> get additionalStops => ['<|im_end|>', '</s>'];
 
   @override
+  List<String> get preservedTokens => const [
+    '<tool_call>',
+    '</tool_call>',
+    '<function=',
+    '</function>',
+    '<parameter=',
+    '</parameter>',
+  ];
+
+  @override
   LlamaChatTemplateResult render({
     required String templateSource,
     required List<LlamaChatMessage> messages,
@@ -47,8 +57,9 @@ class Qwen3CoderXmlHandler extends ChatTemplateHandler {
         hasTools: hasTools,
         enableThinking: enableThinking,
       ),
+      preservedTokens: hasTools ? preservedTokens : const [],
       grammarTriggers: hasTools
-          ? [const GrammarTrigger(type: 0, value: '<tool_code>')]
+          ? [const GrammarTrigger(type: 0, value: '<tool_call>\n<function=')]
           : [],
     );
   }
@@ -84,6 +95,6 @@ class Qwen3CoderXmlHandler extends ChatTemplateHandler {
 
   @override
   String? buildGrammar(List<ToolDefinition>? tools) {
-    return null;
+    return buildXmlToolCallGrammar(tools, XmlToolCallFormat.qwen3Coder);
   }
 }

--- a/lib/src/core/template/handlers/seed_oss_handler.dart
+++ b/lib/src/core/template/handlers/seed_oss_handler.dart
@@ -27,6 +27,18 @@ class SeedOssHandler extends ChatTemplateHandler {
   List<String> get additionalStops => [];
 
   @override
+  List<String> get preservedTokens => const [
+    '<seed:think>',
+    '</seed:think>',
+    '<seed:tool_call>',
+    '</seed:tool_call>',
+    '<function=',
+    '</function>',
+    '<parameter=',
+    '</parameter>',
+  ];
+
+  @override
   LlamaChatTemplateResult render({
     required String templateSource,
     required List<LlamaChatMessage> messages,
@@ -64,8 +76,9 @@ class SeedOssHandler extends ChatTemplateHandler {
         hasTools: hasTools,
         enableThinking: enableThinking,
       ),
+      preservedTokens: hasTools ? preservedTokens : const [],
       grammarTriggers: hasTools
-          ? [const GrammarTrigger(type: 0, value: '<seed:tool_call>')]
+          ? [const GrammarTrigger(type: 0, value: '<seed:tool_call><function=')]
           : [],
     );
   }
@@ -106,6 +119,6 @@ class SeedOssHandler extends ChatTemplateHandler {
 
   @override
   String? buildGrammar(List<ToolDefinition>? tools) {
-    return null;
+    return buildXmlToolCallGrammar(tools, XmlToolCallFormat.seedOss);
   }
 }

--- a/lib/src/core/template/template_workarounds.dart
+++ b/lib/src/core/template/template_workarounds.dart
@@ -302,6 +302,7 @@ class TemplateWorkarounds {
     ChatFormat.minimaxM2,
     ChatFormat.seedOss,
     ChatFormat.llama3,
+    ChatFormat.llama3BuiltinTools,
     ChatFormat.mistralNemo,
     ChatFormat.generic,
   };

--- a/lib/src/core/template/tool_call_grammar_utils.dart
+++ b/lib/src/core/template/tool_call_grammar_utils.dart
@@ -1,0 +1,160 @@
+import '../grammar/json_schema_converter.dart';
+import '../models/tools/tool_definition.dart';
+
+/// Utilities for building tool-call grammars from [ToolDefinition] schemas.
+class ToolCallGrammarUtils {
+  const ToolCallGrammarUtils._();
+
+  /// Builds a grammar for an array of tool calls and wraps it with literals.
+  static String? buildWrappedArrayGrammar({
+    required List<ToolDefinition>? tools,
+    required String prefix,
+    required String suffix,
+    String nameKey = 'name',
+    String argumentsKey = 'arguments',
+    String? idKey,
+    String? idPattern,
+    bool allowParallelToolCalls = true,
+  }) {
+    if (tools == null || tools.isEmpty) {
+      return null;
+    }
+
+    final schema = _buildToolArraySchema(
+      tools,
+      nameKey: nameKey,
+      argumentsKey: argumentsKey,
+      idKey: idKey,
+      idPattern: idPattern,
+      allowParallelToolCalls: allowParallelToolCalls,
+    );
+
+    final grammar = JsonSchemaConverter.convert(schema);
+    return wrapRootGrammar(grammar, prefix: prefix, suffix: suffix);
+  }
+
+  /// Builds a grammar for a single tool call object and wraps it.
+  static String? buildWrappedObjectGrammar({
+    required List<ToolDefinition>? tools,
+    required String prefix,
+    required String suffix,
+    String nameKey = 'name',
+    String argumentsKey = 'arguments',
+    String? idKey,
+    String? idPattern,
+  }) {
+    if (tools == null || tools.isEmpty) {
+      return null;
+    }
+
+    final itemSchemas = tools
+        .map(
+          (tool) => _buildToolObjectSchema(
+            tool,
+            nameKey: nameKey,
+            argumentsKey: argumentsKey,
+            idKey: idKey,
+            idPattern: idPattern,
+          ),
+        )
+        .toList(growable: false);
+
+    final schema = itemSchemas.length == 1
+        ? itemSchemas.first
+        : <String, dynamic>{'anyOf': itemSchemas};
+    final grammar = JsonSchemaConverter.convert(schema);
+    return wrapRootGrammar(grammar, prefix: prefix, suffix: suffix);
+  }
+
+  /// Rewrites the grammar `root` rule with wrapper literals.
+  static String wrapRootGrammar(
+    String grammar, {
+    String prefix = '',
+    String suffix = '',
+  }) {
+    final lines = grammar.trimRight().split('\n');
+    final rootIndex = lines.indexWhere((line) => line.startsWith('root ::= '));
+    if (rootIndex == -1) {
+      return grammar;
+    }
+
+    final rootExpr = lines[rootIndex].substring('root ::= '.length).trim();
+    final prefixExpr = prefix.isEmpty ? '' : '${_literal(prefix)} ';
+    final suffixExpr = suffix.isEmpty ? '' : ' ${_literal(suffix)}';
+    lines[rootIndex] = 'root ::= $prefixExpr$rootExpr$suffixExpr';
+
+    return '${lines.join('\n')}\n';
+  }
+
+  static Map<String, dynamic> _buildToolArraySchema(
+    List<ToolDefinition> tools, {
+    required String nameKey,
+    required String argumentsKey,
+    String? idKey,
+    String? idPattern,
+    required bool allowParallelToolCalls,
+  }) {
+    final itemSchemas = tools
+        .map(
+          (tool) => _buildToolObjectSchema(
+            tool,
+            nameKey: nameKey,
+            argumentsKey: argumentsKey,
+            idKey: idKey,
+            idPattern: idPattern,
+          ),
+        )
+        .toList(growable: false);
+
+    final schema = <String, dynamic>{
+      'type': 'array',
+      'items': itemSchemas.length == 1
+          ? itemSchemas.first
+          : <String, dynamic>{'anyOf': itemSchemas},
+      'minItems': 1,
+    };
+
+    if (!allowParallelToolCalls) {
+      schema['maxItems'] = 1;
+    }
+
+    return schema;
+  }
+
+  static Map<String, dynamic> _buildToolObjectSchema(
+    ToolDefinition tool, {
+    required String nameKey,
+    required String argumentsKey,
+    String? idKey,
+    String? idPattern,
+  }) {
+    final properties = <String, dynamic>{
+      nameKey: <String, dynamic>{'type': 'string', 'const': tool.name},
+      argumentsKey: tool.toJsonSchema(),
+    };
+    final required = <String>[nameKey, argumentsKey];
+
+    if (idKey != null) {
+      properties[idKey] = <String, dynamic>{
+        'type': 'string',
+        if (idPattern != null && idPattern.isNotEmpty) 'pattern': idPattern,
+      };
+      required.add(idKey);
+    }
+
+    return <String, dynamic>{
+      'type': 'object',
+      'properties': properties,
+      'required': required,
+    };
+  }
+
+  static String _literal(String value) {
+    final escaped = value
+        .replaceAll('\\', r'\\')
+        .replaceAll('"', r'\"')
+        .replaceAll('\n', r'\n')
+        .replaceAll('\r', r'\r');
+    return '"$escaped"';
+  }
+}

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: llamadart
 description: A Dart/Flutter plugin for llama.cpp - run LLM inference on any platform using GGUF models
-version: 0.5.1
+version: 0.5.2
 homepage: https://github.com/leehack/llamadart
 repository: https://github.com/leehack/llamadart
 issue_tracker: https://github.com/leehack/llamadart/issues

--- a/test/unit/core/models/inference/generation_params_test.dart
+++ b/test/unit/core/models/inference/generation_params_test.dart
@@ -4,11 +4,22 @@ import 'package:test/test.dart';
 void main() {
   test('GenerationParams copyWith updates selected fields', () {
     const params = GenerationParams(temp: 0.5, maxTokens: 10);
-    final updated = params.copyWith(topK: 12, grammarRoot: 'main');
+    final updated = params.copyWith(
+      topK: 12,
+      grammarRoot: 'main',
+      grammarLazy: true,
+      grammarTriggers: [
+        const GenerationGrammarTrigger(type: 0, value: '<tool_call>'),
+      ],
+      preservedTokens: const ['<tool_call>'],
+    );
 
     expect(updated.temp, 0.5);
     expect(updated.maxTokens, 10);
     expect(updated.topK, 12);
     expect(updated.grammarRoot, 'main');
+    expect(updated.grammarLazy, isTrue);
+    expect(updated.grammarTriggers, hasLength(1));
+    expect(updated.preservedTokens, const ['<tool_call>']);
   });
 }

--- a/test/unit/core/template/handlers/apertus_handler_test.dart
+++ b/test/unit/core/template/handlers/apertus_handler_test.dart
@@ -1,10 +1,55 @@
+import 'dart:convert';
+
+import 'package:llamadart/src/core/models/chat/chat_message.dart';
+import 'package:llamadart/src/core/models/chat/chat_role.dart';
+import 'package:llamadart/src/core/models/tools/tool_definition.dart';
+import 'package:llamadart/src/core/models/tools/tool_param.dart';
 import 'package:llamadart/src/core/template/chat_format.dart';
 import 'package:llamadart/src/core/template/handlers/apertus_handler.dart';
 import 'package:test/test.dart';
 
 void main() {
-  test('ApertusHandler exposes chat format', () {
+  test('ApertusHandler renders lazy wrapped grammar and parses tool calls', () {
     final handler = ApertusHandler();
+    final tools = [
+      ToolDefinition(
+        name: 'get_weather',
+        description: 'Get weather',
+        parameters: [ToolParam.string('city', required: true)],
+        handler: _noop,
+      ),
+    ];
+
+    final rendered = handler.render(
+      templateSource: '{{ messages[0]["content"] }}',
+      messages: const [
+        LlamaChatMessage.fromText(role: LlamaChatRole.user, text: 'hello'),
+      ],
+      metadata: const {},
+      tools: tools,
+    );
+
     expect(handler.format, isA<ChatFormat>());
+    expect(rendered.grammar, isNotNull);
+    expect(rendered.grammar, contains('"<|tools_prefix|>"'));
+    expect(rendered.grammar, contains('"<|tools_suffix|>"'));
+    expect(rendered.grammarLazy, isTrue);
+    expect(rendered.preservedTokens, contains('<|tools_prefix|>'));
+    expect(rendered.grammarTriggers, hasLength(1));
+
+    final parsed = handler.parse(
+      '<|tools_prefix|>[{"name":"get_weather","arguments":{"city":"Seoul"}}]<|tools_suffix|> tail',
+    );
+    expect(parsed.content, equals('tail'));
+    expect(parsed.toolCalls, hasLength(1));
+    expect(parsed.toolCalls.first.function?.name, equals('get_weather'));
+    expect(
+      jsonDecode(parsed.toolCalls.first.function!.arguments!),
+      containsPair('city', 'Seoul'),
+    );
   });
+}
+
+Future<Object?> _noop(_) async {
+  return 'ok';
 }

--- a/test/unit/core/template/handlers/apriel15_handler_test.dart
+++ b/test/unit/core/template/handlers/apriel15_handler_test.dart
@@ -1,5 +1,7 @@
 import 'package:llamadart/src/core/template/chat_format.dart';
 import 'package:llamadart/src/core/template/handlers/apriel15_handler.dart';
+import 'package:llamadart/src/core/models/tools/tool_definition.dart';
+import 'package:llamadart/src/core/models/tools/tool_param.dart';
 import 'package:test/test.dart';
 
 void main() {
@@ -7,4 +9,26 @@ void main() {
     final handler = Apriel15Handler();
     expect(handler.format, isA<ChatFormat>());
   });
+
+  test('Apriel15Handler emits wrapped array grammar for tools', () {
+    final handler = Apriel15Handler();
+    final tools = [
+      ToolDefinition(
+        name: 'lookup',
+        description: 'Lookup data',
+        parameters: [ToolParam.string('query', required: true)],
+        handler: _noop,
+      ),
+    ];
+
+    final grammar = handler.buildGrammar(tools);
+    expect(grammar, isNotNull);
+    expect(grammar, contains('root ::='));
+    expect(grammar, contains('"<tool_calls>"'));
+    expect(grammar, contains('"</tool_calls>"'));
+  });
+}
+
+Future<Object?> _noop(_) async {
+  return 'ok';
 }

--- a/test/unit/core/template/handlers/deepseek_r1_handler_test.dart
+++ b/test/unit/core/template/handlers/deepseek_r1_handler_test.dart
@@ -1,10 +1,64 @@
+import 'dart:convert';
+
+import 'package:llamadart/src/core/models/chat/chat_message.dart';
+import 'package:llamadart/src/core/models/chat/chat_role.dart';
+import 'package:llamadart/src/core/models/tools/tool_definition.dart';
+import 'package:llamadart/src/core/models/tools/tool_param.dart';
 import 'package:llamadart/src/core/template/chat_format.dart';
 import 'package:llamadart/src/core/template/handlers/deepseek_r1_handler.dart';
 import 'package:test/test.dart';
 
 void main() {
-  test('DeepseekR1Handler exposes chat format', () {
+  test('DeepseekR1Handler renders grammar and parses modern tool block', () {
     final handler = DeepseekR1Handler();
+    final tools = [
+      ToolDefinition(
+        name: 'get_weather',
+        description: 'Get weather',
+        parameters: [ToolParam.string('city', required: true)],
+        handler: _noop,
+      ),
+    ];
+
+    final rendered = handler.render(
+      templateSource: '{{ messages[0]["content"] }}<think>',
+      messages: const [
+        LlamaChatMessage.fromText(role: LlamaChatRole.user, text: 'hello'),
+      ],
+      metadata: const {},
+      tools: tools,
+      enableThinking: false,
+    );
+
     expect(handler.format, isA<ChatFormat>());
+    expect(rendered.grammar, isNotNull);
+    expect(rendered.grammar, contains(r'<｜tool\\_calls\\_begin｜>'));
+    expect(rendered.prompt, endsWith('</think>\n'));
+    expect(rendered.additionalStops, contains('<｜tool▁calls▁end｜>'));
+    expect(rendered.grammarTriggers, hasLength(1));
+    expect(
+      rendered.grammarTriggers.first.value,
+      contains(r'<｜tool\\_calls\\_begin｜>'),
+    );
+
+    final parsed = handler.parse(
+      '<think>reasoning</think>answer '
+      '<｜tool▁calls▁begin｜>'
+      '<｜tool▁call▁begin｜>get_weather<｜tool▁sep｜>{"city":"Seoul"}<｜tool▁call▁end｜>'
+      '<｜tool▁calls▁end｜>',
+    );
+
+    expect(parsed.reasoningContent, equals('reasoning'));
+    expect(parsed.content, equals('answer'));
+    expect(parsed.toolCalls, hasLength(1));
+    expect(parsed.toolCalls.first.function?.name, equals('get_weather'));
+    expect(
+      jsonDecode(parsed.toolCalls.first.function!.arguments!),
+      containsPair('city', 'Seoul'),
+    );
   });
+}
+
+Future<Object?> _noop(_) async {
+  return 'ok';
 }

--- a/test/unit/core/template/handlers/deepseek_v3_handler_test.dart
+++ b/test/unit/core/template/handlers/deepseek_v3_handler_test.dart
@@ -33,7 +33,12 @@ void main() {
 
     expect(rendered.prompt, contains('<BOS>sys|hello'));
     expect(rendered.prompt, endsWith('</think>\n'));
+    expect(rendered.grammar, contains(r'<｜tool\\_calls\\_begin｜>'));
     expect(rendered.grammarTriggers, isNotEmpty);
+    expect(
+      rendered.grammarTriggers.first.value,
+      contains(r'<｜tool\\_calls\\_begin｜>'),
+    );
 
     final parsed = handler.parse(
       '<think>reasoning</think>'

--- a/test/unit/core/template/handlers/hermes_handler_test.dart
+++ b/test/unit/core/template/handlers/hermes_handler_test.dart
@@ -1,10 +1,58 @@
+import 'dart:convert';
+
+import 'package:llamadart/src/core/models/chat/chat_message.dart';
+import 'package:llamadart/src/core/models/chat/chat_role.dart';
+import 'package:llamadart/src/core/models/tools/tool_definition.dart';
+import 'package:llamadart/src/core/models/tools/tool_param.dart';
 import 'package:llamadart/src/core/template/chat_format.dart';
 import 'package:llamadart/src/core/template/handlers/hermes_handler.dart';
 import 'package:test/test.dart';
 
 void main() {
-  test('HermesHandler exposes chat format', () {
+  test('HermesHandler renders valid grammar and parses tool calls', () {
     final handler = HermesHandler();
+    final tools = [
+      ToolDefinition(
+        name: 'get_current_weather',
+        description: 'Get weather',
+        parameters: [ToolParam.string('location', required: true)],
+        handler: _noop,
+      ),
+    ];
+
+    final rendered = handler.render(
+      templateSource: '{{ messages[0]["content"] }}',
+      messages: const [
+        LlamaChatMessage.fromText(role: LlamaChatRole.user, text: 'hi'),
+      ],
+      metadata: const {},
+      tools: tools,
+    );
+
     expect(handler.format, isA<ChatFormat>());
+    expect(rendered.grammar, isNotNull);
+    expect(
+      rendered.grammar,
+      contains(r'string ::= "\"" ([^"\\] | "\\\\" .)* "\""'),
+    );
+    expect(rendered.grammar, isNot(contains(r'string ::= "\\\""')));
+
+    final parsed = handler.parse(
+      '<tool_call>{"name":"get_current_weather","arguments":{"location":"Seoul"}}</tool_call> tail',
+    );
+    expect(parsed.toolCalls, hasLength(1));
+    expect(
+      parsed.toolCalls.first.function?.name,
+      equals('get_current_weather'),
+    );
+    expect(
+      jsonDecode(parsed.toolCalls.first.function!.arguments!),
+      containsPair('location', 'Seoul'),
+    );
+    expect(parsed.content, equals('tail'));
   });
+}
+
+Future<Object?> _noop(_) async {
+  return 'ok';
 }

--- a/test/unit/core/template/handlers/lfm2_handler_test.dart
+++ b/test/unit/core/template/handlers/lfm2_handler_test.dart
@@ -1,10 +1,57 @@
+import 'dart:convert';
+
+import 'package:llamadart/src/core/models/chat/chat_message.dart';
+import 'package:llamadart/src/core/models/chat/chat_role.dart';
+import 'package:llamadart/src/core/models/tools/tool_definition.dart';
+import 'package:llamadart/src/core/models/tools/tool_param.dart';
 import 'package:llamadart/src/core/template/chat_format.dart';
 import 'package:llamadart/src/core/template/handlers/lfm2_handler.dart';
 import 'package:test/test.dart';
 
 void main() {
-  test('Lfm2Handler exposes chat format', () {
+  test('Lfm2Handler renders wrapped grammar and parses both call syntaxes', () {
     final handler = Lfm2Handler();
+    final tools = [
+      ToolDefinition(
+        name: 'search',
+        description: 'Search',
+        parameters: [ToolParam.string('query', required: true)],
+        handler: _noop,
+      ),
+    ];
+
+    final rendered = handler.render(
+      templateSource: '{{ messages[0]["content"] }}',
+      messages: const [
+        LlamaChatMessage.fromText(role: LlamaChatRole.user, text: 'hello'),
+      ],
+      metadata: const {},
+      tools: tools,
+    );
+
     expect(handler.format, isA<ChatFormat>());
+    expect(rendered.grammar, isNotNull);
+    expect(rendered.grammar, contains('"<|tool_call_start|>"'));
+    expect(rendered.grammarLazy, isTrue);
+    expect(rendered.grammarTriggers, hasLength(1));
+
+    final modern = handler.parse(
+      '<|tool_call_start|>{"name":"search","arguments":{"query":"llama"}}<|tool_call_end|>',
+    );
+    expect(modern.toolCalls, hasLength(1));
+    expect(modern.toolCalls.first.function?.name, equals('search'));
+    expect(
+      jsonDecode(modern.toolCalls.first.function!.arguments!),
+      containsPair('query', 'llama'),
+    );
+
+    final legacy = handler.parse("[search(query='llama')] and text");
+    expect(legacy.toolCalls, hasLength(1));
+    expect(legacy.toolCalls.first.function?.name, equals('search'));
+    expect(legacy.content, equals('and text'));
   });
+}
+
+Future<Object?> _noop(_) async {
+  return 'ok';
 }

--- a/test/unit/core/template/handlers/llama3_handler_test.dart
+++ b/test/unit/core/template/handlers/llama3_handler_test.dart
@@ -1,10 +1,75 @@
 import 'package:llamadart/src/core/template/chat_format.dart';
 import 'package:llamadart/src/core/template/handlers/llama3_handler.dart';
+import 'package:llamadart/src/core/models/chat/chat_message.dart';
+import 'package:llamadart/src/core/models/tools/tool_definition.dart';
+import 'package:llamadart/src/core/models/tools/tool_param.dart';
 import 'package:test/test.dart';
 
 void main() {
+  final messages = [const LlamaChatMessage(role: 'user', content: 'hello')];
+
   test('Llama3Handler exposes chat format', () {
     final handler = Llama3Handler();
     expect(handler.format, isA<ChatFormat>());
   });
+
+  test('returns content-only format when no tools are provided', () {
+    final handler = Llama3Handler();
+    final result = handler.render(
+      templateSource: '{{ messages[0]["content"] }}',
+      messages: messages,
+      metadata: const {},
+      tools: const [],
+    );
+
+    expect(result.format, ChatFormat.contentOnly.index);
+  });
+
+  test('returns builtin-tools format when builtin tools are available', () {
+    final handler = Llama3Handler();
+    final result = handler.render(
+      templateSource:
+          '<|start_header_id|>ipython<|end_header_id|><|python_tag|>{{ messages[0]["content"] }}',
+      messages: messages,
+      metadata: const {},
+      tools: [
+        ToolDefinition(
+          name: 'code_interpreter',
+          description: 'Execute Python code',
+          parameters: [ToolParam.string('code')],
+          handler: _noopHandler,
+        ),
+      ],
+    );
+
+    expect(result.format, ChatFormat.llama3BuiltinTools.index);
+    expect(result.grammar, isNull);
+  });
+
+  test('returns JSON tool grammar for non-builtin tools', () {
+    final handler = Llama3Handler();
+    final result = handler.render(
+      templateSource:
+          '<|start_header_id|>ipython<|end_header_id|>{{ messages[0]["content"] }}',
+      messages: messages,
+      metadata: const {},
+      tools: [
+        ToolDefinition(
+          name: 'get_weather',
+          description: 'Get weather information',
+          parameters: [ToolParam.string('city', required: true)],
+          handler: _noopHandler,
+        ),
+      ],
+    );
+
+    expect(result.format, ChatFormat.llama3.index);
+    expect(result.grammar, isNotNull);
+    expect(result.grammar, contains('name-kv'));
+    expect(result.grammar, contains('parameters-kv'));
+  });
+}
+
+Future<Object?> _noopHandler(_) async {
+  return null;
 }

--- a/test/unit/core/template/handlers/magistral_handler_test.dart
+++ b/test/unit/core/template/handlers/magistral_handler_test.dart
@@ -1,10 +1,54 @@
+import 'dart:convert';
+
+import 'package:llamadart/src/core/models/chat/chat_message.dart';
+import 'package:llamadart/src/core/models/chat/chat_role.dart';
+import 'package:llamadart/src/core/models/tools/tool_definition.dart';
+import 'package:llamadart/src/core/models/tools/tool_param.dart';
 import 'package:llamadart/src/core/template/chat_format.dart';
 import 'package:llamadart/src/core/template/handlers/magistral_handler.dart';
 import 'package:test/test.dart';
 
 void main() {
-  test('MagistralHandler exposes chat format', () {
+  test('MagistralHandler renders and parses TOOL_CALLS payload', () {
     final handler = MagistralHandler();
+    final tools = [
+      ToolDefinition(
+        name: 'search',
+        description: 'Search docs',
+        parameters: [ToolParam.string('query', required: true)],
+        handler: _noop,
+      ),
+    ];
+
+    final rendered = handler.render(
+      templateSource: '{{ messages[0]["content"] }}',
+      messages: const [
+        LlamaChatMessage.fromText(role: LlamaChatRole.user, text: 'hello'),
+      ],
+      metadata: const {},
+      tools: tools,
+    );
+
     expect(handler.format, isA<ChatFormat>());
+    expect(rendered.grammar, isNotNull);
+    expect(rendered.grammarLazy, isTrue);
+    expect(rendered.additionalStops, contains('[TOOL_CALLS]'));
+    expect(rendered.preservedTokens, contains('[THINK]'));
+    expect(rendered.grammarTriggers.first.value, equals('[TOOL_CALLS]'));
+
+    final parsed = handler.parse(
+      '[TOOL_CALLS][{"name":"search","arguments":{"query":"llama"}}]',
+    );
+    expect(parsed.content, isEmpty);
+    expect(parsed.toolCalls, hasLength(1));
+    expect(parsed.toolCalls.first.function?.name, equals('search'));
+    expect(
+      jsonDecode(parsed.toolCalls.first.function!.arguments!),
+      containsPair('query', 'llama'),
+    );
   });
+}
+
+Future<Object?> _noop(_) async {
+  return 'ok';
 }

--- a/test/unit/core/template/handlers/minimax_m2_handler_test.dart
+++ b/test/unit/core/template/handlers/minimax_m2_handler_test.dart
@@ -30,10 +30,10 @@ void main() {
     expect(rendered.grammarTriggers, isNotEmpty);
 
     final parsed = handler.parse(
-      '<minimax:tool_call>'
-      '<invoke name="get_weather">'
-      '<parameter name="city">"Seoul"</parameter>'
-      '</invoke>'
+      '<minimax:tool_call>\n'
+      '<invoke name="get_weather">\n'
+      '<parameter name="city">"Seoul"</parameter>\n'
+      '</invoke>\n'
       '</minimax:tool_call>'
       'tail',
     );

--- a/test/unit/core/template/handlers/nemotron_v2_handler_test.dart
+++ b/test/unit/core/template/handlers/nemotron_v2_handler_test.dart
@@ -1,10 +1,53 @@
+import 'dart:convert';
+
+import 'package:llamadart/src/core/models/chat/chat_message.dart';
+import 'package:llamadart/src/core/models/chat/chat_role.dart';
+import 'package:llamadart/src/core/models/tools/tool_definition.dart';
+import 'package:llamadart/src/core/models/tools/tool_param.dart';
 import 'package:llamadart/src/core/template/chat_format.dart';
 import 'package:llamadart/src/core/template/handlers/nemotron_v2_handler.dart';
 import 'package:test/test.dart';
 
 void main() {
-  test('NemotronV2Handler exposes chat format', () {
+  test('NemotronV2Handler renders lazy grammar and parses TOOLCALL blocks', () {
     final handler = NemotronV2Handler();
+    final tools = [
+      ToolDefinition(
+        name: 'lookup',
+        description: 'Lookup value',
+        parameters: [ToolParam.string('key', required: true)],
+        handler: _noop,
+      ),
+    ];
+
+    final rendered = handler.render(
+      templateSource: '{{ messages[0]["content"] }}',
+      messages: const [
+        LlamaChatMessage.fromText(role: LlamaChatRole.user, text: 'hello'),
+      ],
+      metadata: const {},
+      tools: tools,
+    );
+
     expect(handler.format, isA<ChatFormat>());
+    expect(rendered.grammar, isNotNull);
+    expect(rendered.grammar, contains('"<TOOLCALL>"'));
+    expect(rendered.grammarLazy, isTrue);
+    expect(rendered.grammarTriggers, hasLength(1));
+
+    final parsed = handler.parse(
+      '<TOOLCALL>[{"name":"lookup","arguments":{"key":"abc"}}]</TOOLCALL>tail',
+    );
+    expect(parsed.content, equals('tail'));
+    expect(parsed.toolCalls, hasLength(1));
+    expect(parsed.toolCalls.first.function?.name, equals('lookup'));
+    expect(
+      jsonDecode(parsed.toolCalls.first.function!.arguments!),
+      containsPair('key', 'abc'),
+    );
   });
+}
+
+Future<Object?> _noop(_) async {
+  return 'ok';
 }

--- a/test/unit/core/template/handlers/qwen3_coder_xml_handler_test.dart
+++ b/test/unit/core/template/handlers/qwen3_coder_xml_handler_test.dart
@@ -31,7 +31,11 @@ void main() {
     expect(rendered.additionalStops, contains('<|im_end|>'));
 
     final parsed = handler.parse(
-      '<function=get_weather><parameter=city>"Seoul"</parameter></function>',
+      '<tool_call>\n'
+      '<function=get_weather>\n'
+      '<parameter=city>\n"Seoul"\n</parameter>\n'
+      '</function>\n'
+      '</tool_call>',
     );
     expect(parsed.toolCalls, hasLength(1));
     expect(parsed.toolCalls.first.function?.name, equals('get_weather'));

--- a/test/unit/core/template/handlers/seed_oss_handler_test.dart
+++ b/test/unit/core/template/handlers/seed_oss_handler_test.dart
@@ -1,10 +1,53 @@
+import 'dart:convert';
+
+import 'package:llamadart/src/core/models/chat/chat_message.dart';
+import 'package:llamadart/src/core/models/chat/chat_role.dart';
+import 'package:llamadart/src/core/models/tools/tool_definition.dart';
+import 'package:llamadart/src/core/models/tools/tool_param.dart';
 import 'package:llamadart/src/core/template/chat_format.dart';
 import 'package:llamadart/src/core/template/handlers/seed_oss_handler.dart';
 import 'package:test/test.dart';
 
 void main() {
-  test('SeedOssHandler exposes chat format', () {
+  test('SeedOssHandler renders XML grammar and parses seed tool call', () {
     final handler = SeedOssHandler();
+    final tools = [
+      ToolDefinition(
+        name: 'get_weather',
+        description: 'Get weather',
+        parameters: [ToolParam.string('city', required: true)],
+        handler: _noop,
+      ),
+    ];
+
+    final rendered = handler.render(
+      templateSource: '{{ messages[0]["content"] }}',
+      messages: const [
+        LlamaChatMessage.fromText(role: LlamaChatRole.user, text: 'hello'),
+      ],
+      metadata: const {},
+      tools: tools,
+    );
+
     expect(handler.format, isA<ChatFormat>());
+    expect(rendered.grammar, isNotNull);
+    expect(rendered.grammarLazy, isTrue);
+    expect(rendered.preservedTokens, contains('<seed:tool_call>'));
+    expect(rendered.grammarTriggers.first.value, contains('<seed:tool_call>'));
+
+    final parsed = handler.parse(
+      '<seed:tool_call><function=get_weather><parameter=city>"Seoul"</parameter></function></seed:tool_call>tail',
+    );
+    expect(parsed.content, equals('tail'));
+    expect(parsed.toolCalls, hasLength(1));
+    expect(parsed.toolCalls.first.function?.name, equals('get_weather'));
+    expect(
+      jsonDecode(parsed.toolCalls.first.function!.arguments!),
+      containsPair('city', 'Seoul'),
+    );
   });
+}
+
+Future<Object?> _noop(_) async {
+  return 'ok';
 }

--- a/test/unit/core/template/handlers/xiaomi_mimo_handler_test.dart
+++ b/test/unit/core/template/handlers/xiaomi_mimo_handler_test.dart
@@ -1,10 +1,52 @@
+import 'dart:convert';
+
+import 'package:llamadart/src/core/models/chat/chat_message.dart';
+import 'package:llamadart/src/core/models/chat/chat_role.dart';
+import 'package:llamadart/src/core/models/tools/tool_definition.dart';
+import 'package:llamadart/src/core/models/tools/tool_param.dart';
 import 'package:llamadart/src/core/template/chat_format.dart';
 import 'package:llamadart/src/core/template/handlers/xiaomi_mimo_handler.dart';
 import 'package:test/test.dart';
 
 void main() {
-  test('XiaomiMimoHandler exposes chat format', () {
+  test('XiaomiMimoHandler keeps lazy trigger and parses tool_call blocks', () {
     final handler = XiaomiMimoHandler();
+    final tools = [
+      ToolDefinition(
+        name: 'weather',
+        description: 'Weather lookup',
+        parameters: [ToolParam.string('city', required: true)],
+        handler: _noop,
+      ),
+    ];
+
+    final rendered = handler.render(
+      templateSource: '{{ messages[0]["content"] }}',
+      messages: const [
+        LlamaChatMessage.fromText(role: LlamaChatRole.user, text: 'hello'),
+      ],
+      metadata: const {},
+      tools: tools,
+    );
+
     expect(handler.format, isA<ChatFormat>());
+    expect(rendered.grammar, isNull);
+    expect(rendered.grammarLazy, isTrue);
+    expect(rendered.grammarTriggers.first.value, equals('<tool_call>'));
+
+    final parsed = handler.parse(
+      '<tool_call>{"name":"weather","arguments":{"city":"Seoul"}}</tool_call> tail',
+    );
+    expect(parsed.content, equals('tail'));
+    expect(parsed.toolCalls, hasLength(1));
+    expect(parsed.toolCalls.first.function?.name, equals('weather'));
+    expect(
+      jsonDecode(parsed.toolCalls.first.function!.arguments!),
+      containsPair('city', 'Seoul'),
+    );
   });
+}
+
+Future<Object?> _noop(_) async {
+  return 'ok';
 }

--- a/test/unit/core/template/tool_call_grammar_utils_test.dart
+++ b/test/unit/core/template/tool_call_grammar_utils_test.dart
@@ -1,0 +1,122 @@
+import 'package:llamadart/src/core/models/tools/tool_definition.dart';
+import 'package:llamadart/src/core/models/tools/tool_param.dart';
+import 'package:llamadart/src/core/template/tool_call_grammar_utils.dart';
+import 'package:test/test.dart';
+
+void main() {
+  test('wrapRootGrammar wraps root rule with literals', () {
+    const grammar = 'root ::= obj\nobj ::= "{}"\n';
+
+    final wrapped = ToolCallGrammarUtils.wrapRootGrammar(
+      grammar,
+      prefix: '<tool>',
+      suffix: '</tool>',
+    );
+
+    expect(wrapped, contains('root ::= "<tool>" obj "</tool>"'));
+    expect(wrapped, endsWith('\n'));
+  });
+
+  test('wrapRootGrammar returns original grammar when root is missing', () {
+    const grammar = 'obj ::= "{}"\n';
+
+    final wrapped = ToolCallGrammarUtils.wrapRootGrammar(
+      grammar,
+      prefix: '<x>',
+      suffix: '</x>',
+    );
+
+    expect(wrapped, equals(grammar));
+  });
+
+  test('buildWrappedArrayGrammar returns null without tools', () {
+    expect(
+      ToolCallGrammarUtils.buildWrappedArrayGrammar(
+        tools: null,
+        prefix: '<calls>',
+        suffix: '</calls>',
+      ),
+      isNull,
+    );
+    expect(
+      ToolCallGrammarUtils.buildWrappedArrayGrammar(
+        tools: const [],
+        prefix: '<calls>',
+        suffix: '</calls>',
+      ),
+      isNull,
+    );
+  });
+
+  test('buildWrappedArrayGrammar applies wrappers and id constraints', () {
+    final tools = [
+      ToolDefinition(
+        name: 'weather',
+        description: 'Weather lookup',
+        parameters: [ToolParam.string('city', required: true)],
+        handler: _noop,
+      ),
+    ];
+
+    final noParallel = ToolCallGrammarUtils.buildWrappedArrayGrammar(
+      tools: tools,
+      prefix: '[TOOL_CALLS]',
+      suffix: '',
+      idKey: 'id',
+      idPattern: r'^[a-z]{3}$',
+      allowParallelToolCalls: false,
+    );
+    final parallel = ToolCallGrammarUtils.buildWrappedArrayGrammar(
+      tools: tools,
+      prefix: '[TOOL_CALLS]',
+      suffix: '',
+      idKey: 'id',
+      idPattern: r'^[a-z]{3}$',
+      allowParallelToolCalls: true,
+    );
+
+    expect(noParallel, isNotNull);
+    expect(noParallel, contains('root ::= "[TOOL_CALLS]"'));
+    expect(noParallel, contains('weather'));
+    expect(noParallel, contains('id'));
+    expect(parallel, isNotNull);
+    expect(noParallel, isNot(equals(parallel)));
+  });
+
+  test('buildWrappedObjectGrammar supports multiple tools and key aliases', () {
+    final tools = [
+      ToolDefinition(
+        name: 'weather',
+        description: 'Weather lookup',
+        parameters: [ToolParam.string('city', required: true)],
+        handler: _noop,
+      ),
+      ToolDefinition(
+        name: 'search',
+        description: 'Search docs',
+        parameters: [ToolParam.string('query', required: true)],
+        handler: _noop,
+      ),
+    ];
+
+    final grammar = ToolCallGrammarUtils.buildWrappedObjectGrammar(
+      tools: tools,
+      prefix: '<tool>',
+      suffix: '</tool>',
+      nameKey: 'function',
+      argumentsKey: 'params',
+    );
+
+    expect(grammar, isNotNull);
+    expect(grammar, contains('root ::= "<tool>"'));
+    expect(grammar, contains('"</tool>"'));
+    expect(grammar, contains('weather'));
+    expect(grammar, contains('search'));
+    expect(grammar, contains('function'));
+    expect(grammar, contains('params'));
+  });
+}
+
+Future<Object?> _noop(_) async {
+  return 'ok';
+}

--- a/test/unit/core/template/xml_tool_call_format_test.dart
+++ b/test/unit/core/template/xml_tool_call_format_test.dart
@@ -6,7 +6,11 @@ import 'package:test/test.dart';
 void main() {
   test('parseXmlToolCalls parses a simple XML-like tool call', () {
     const output =
-        '<function=weather><parameter=city>"Seoul"</parameter></function>';
+        '<tool_call>\n'
+        '<function=weather>\n'
+        '<parameter=city>\n"Seoul"\n</parameter>\n'
+        '</function>\n'
+        '</tool_call>';
     final parsed = parseXmlToolCalls(output, XmlToolCallFormat.qwen3Coder);
 
     expect(parsed.toolCalls, hasLength(1));


### PR DESCRIPTION
## Summary
- Align chat template routing and schema/tool-choice behavior with llama.cpp parity, including lazy grammar handling, trigger propagation, and preserved-token plumbing through engine/backend generation params.
- Harden multiple format handlers (DeepSeek R1/V3, Hermes, Command-R7B, Llama3, Kimi K2, Apertus, LFM2, Nemotron V2, Magistral, MiniMax M2, Seed-OSS, Qwen3 Coder XML) and fix malformed GBNF escaping that could crash generation at grammar init.
- Add shared `ToolCallGrammarUtils`, expand parity-focused handler tests, and include release/docs updates for `0.5.2`.

## Testing
- `dart format --output=none --set-exit-if-changed .`
- `dart analyze`
- `dart test -p vm test/unit/core/template/handlers`
- `dart test -p vm -j 1 --exclude-tags local-only`
- `dart test -p chrome test/unit/core/template/handlers/hermes_handler_test.dart test/unit/core/template/handlers/command_r7b_handler_test.dart`
- `dart pub publish --dry-run`