### PR TITLE
fix: prevent .pubignore from excluding lib model sources

### DIFF
--- a/.pubignore
+++ b/.pubignore
@@ -25,7 +25,7 @@ a.out.wasm
 
 # Large local model/test assets
 *.gguf
-models/
+/models/
 example/basic_app/models/
 test_assets/
 


### PR DESCRIPTION
## Summary
- Anchor the `.pubignore` rule from `models/` to `/models/` so only the repository-root models directory is excluded.
- Prevent accidental exclusion of `lib/src/core/models/**` from published archives, which broke exports and pana checks.
- Verified with `dart pub publish --dry-run` that `lib/src/core/models/inference/*` is included and package validation reports 0 warnings.