### PR TITLE
fix(android): honor preferred backend during native model loading

### DIFF
--- a/example/chat_app/lib/providers/chat_provider.dart
+++ b/example/chat_app/lib/providers/chat_provider.dart
@@ -1047,7 +1047,13 @@ class ChatProvider extends ChangeNotifier {
   }
 
   Future<void> updatePreferredBackend(GpuBackend backend) async {
-    _settings = _settings.copyWith(preferredBackend: backend);
+    final effectiveGpuLayers = backend == GpuBackend.cpu
+        ? 0
+        : _settings.gpuLayers;
+    _settings = _settings.copyWith(
+      preferredBackend: backend,
+      gpuLayers: effectiveGpuLayers,
+    );
     await _settingsService.saveSettings(_settings);
     _messages.add(
       ChatMessage(

--- a/example/chat_app/test/unit_test.dart
+++ b/example/chat_app/test/unit_test.dart
@@ -103,6 +103,16 @@ void main() {
       expect(provider.settings.nativeLogLevel, LlamaLogLevel.warn);
     });
 
+    test('switching to CPU backend forces gpu layers to zero', () async {
+      provider.updateGpuLayers(48);
+      expect(provider.settings.gpuLayers, 48);
+
+      await provider.updatePreferredBackend(GpuBackend.cpu);
+
+      expect(provider.settings.preferredBackend, GpuBackend.cpu);
+      expect(provider.settings.gpuLayers, 0);
+    });
+
     test('applyModelPreset updates generation and tool settings', () {
       const model = DownloadableModel(
         name: 'Preset model',

--- a/test/unit/backends/llama_cpp/llama_cpp_service_test.dart
+++ b/test/unit/backends/llama_cpp/llama_cpp_service_test.dart
@@ -2,11 +2,33 @@
 library;
 
 import 'package:llamadart/src/backends/llama_cpp/llama_cpp_service.dart';
+import 'package:llamadart/src/core/models/config/gpu_backend.dart';
+import 'package:llamadart/src/core/models/inference/model_params.dart';
 import 'package:test/test.dart';
 
 void main() {
   test('LlamaCppService can be instantiated', () {
     final service = LlamaCppService();
     expect(service, isA<LlamaCppService>());
+  });
+
+  group('resolveGpuLayersForLoad', () {
+    test('forces CPU mode to zero gpu layers', () {
+      const params = ModelParams(
+        gpuLayers: ModelParams.maxGpuLayers,
+        preferredBackend: GpuBackend.cpu,
+      );
+
+      expect(LlamaCppService.resolveGpuLayersForLoad(params), 0);
+    });
+
+    test('preserves configured gpu layers for non-CPU backends', () {
+      const params = ModelParams(
+        gpuLayers: 42,
+        preferredBackend: GpuBackend.vulkan,
+      );
+
+      expect(LlamaCppService.resolveGpuLayersForLoad(params), 42);
+    });
   });
 }


### PR DESCRIPTION
## Summary
- Make native llama.cpp model loading respect `ModelParams.preferredBackend` by setting explicit backend device lists and forcing CPU mode to disable GPU offload (`n_gpu_layers = 0`).
- Align chat app behavior so selecting CPU backend also sets GPU layers to `0`, avoiding misleading settings state.
- Add regression tests for CPU/non-CPU GPU-layer resolution and chat-provider CPU backend behavior.

## Testing
- `dart analyze lib/src/backends/llama_cpp/llama_cpp_service.dart test/unit/backends/llama_cpp/llama_cpp_service_test.dart`
- `dart test test/unit/backends/llama_cpp/llama_cpp_service_test.dart`
- `flutter analyze lib/providers/chat_provider.dart test/unit_test.dart` (in `example/chat_app`)
- `flutter test test/unit_test.dart` (in `example/chat_app`)

## Validation Needed
- I could not reproduce on physical Android hardware locally. Please ask the reporter on #36 to test this branch/build on the affected device, especially CPU backend selection and model load stability.

Fixes #36