### PR TITLE
docs: switch GitHub Pages to llamadart.leehack.com

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@
 
 ## 📚 Documentation
 
-- Docs site: https://leehack.github.io/llamadart/
+- Docs site: https://llamadart.leehack.com/
 - API reference: https://pub.dev/documentation/llamadart/latest/
 - Migration guide: [`MIGRATION.md`](https://github.com/leehack/llamadart/blob/main/MIGRATION.md)
 

--- a/website/docusaurus.config.ts
+++ b/website/docusaurus.config.ts
@@ -7,8 +7,8 @@ const config: Config = {
   tagline: 'Run llama.cpp from Dart and Flutter across native and web',
   favicon: 'img/logo.svg',
 
-  url: 'https://leehack.github.io',
-  baseUrl: '/llamadart/',
+  url: 'https://llamadart.leehack.com',
+  baseUrl: '/',
 
   organizationName: 'leehack',
   projectName: 'llamadart',

--- a/website/static/CNAME
+++ b/website/static/CNAME
@@ -1,0 +1,1 @@
+llamadart.leehack.com


### PR DESCRIPTION
## Summary
- switch docs site canonical URL to `https://llamadart.leehack.com`
- set Docusaurus `baseUrl` to `/` for custom-domain hosting
- add `website/static/CNAME` for GitHub Pages custom domain binding
- update README docs link to the custom domain

## Files
- `website/docusaurus.config.ts`
- `website/static/CNAME`
- `README.md`
