### PR TITLE
chore(pubspec): remove unused Flutter-root dependencies

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## Unreleased
+
+* **Package metadata cleanup**:
+  * Removed unused Flutter-only constraints/dependencies from the root `pubspec.yaml` (`environment.flutter`, `flutter`, `path_provider`, `json_rpc_2`, `integration_test`) to keep the core package pure Dart.
+  * Kept Flutter-specific dependencies scoped to Flutter example apps.
+
 ## 0.6.3
 
 * **Native runtime sync (llama.cpp b8138)**:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -13,7 +13,6 @@ topics:
 
 environment:
   sdk: ^3.10.7
-  flutter: '>=3.38.0'
 
 dependencies:
   archive: ^4.0.7
@@ -21,21 +20,15 @@ dependencies:
   path: ^1.8.3
   http: ^1.1.0
   web: ^1.0.0
-  flutter:
-    sdk: flutter
   code_assets: ^1.0.0
   hooks: ^1.0.0
   logging: ^1.3.0
-  path_provider: ^2.1.0
-  json_rpc_2: ^4.0.0
   dinja: ^1.0.0
 
 dev_dependencies:
   ffigen: ^20.1.1
   lints: ^6.1.0
   test: ^1.26.3
-  integration_test:
-    sdk: flutter
 
 
 # No plugin section needed for Pure Native Asset FFI package


### PR DESCRIPTION
## Summary
- Remove unused Flutter-only constraints and dependencies from root `pubspec.yaml` to keep the core package pure Dart.
- Keep Flutter-specific dependencies scoped to example apps where they are actually used.
- Add an `Unreleased` changelog entry describing the metadata cleanup.

## Validation
- `dart analyze`
- `dart test`