### PR TITLE
chore(release): prepare v0.6.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-## Unreleased
+## 0.6.4
 
 * **Multimodal projector offload alignment**:
   * Updated native multimodal projector initialization to follow effective model-load configuration.

--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -2,6 +2,30 @@
 
 This document covers the major breaking upgrade paths.
 
+## `0.6.3` -> `0.6.4`
+
+No public API break, but Android arm64 native packaging defaults changed.
+
+- Shorthand config such as `android-arm64: [vulkan]` is still supported.
+- If no CPU policy is set, Android arm64 now defaults to
+  `cpu_profile: full` (all CPU variants).
+- If you want smaller baseline-only packaging, set
+  `cpu_profile: compact` explicitly.
+- `cpu_variants: [...]` (when provided) overrides `cpu_profile`.
+
+Example (preserve compact baseline-style packaging):
+
+```yaml
+hooks:
+  user_defines:
+    llamadart:
+      llamadart_native_backends:
+        platforms:
+          android-arm64:
+            backends: [vulkan]
+            cpu_profile: compact
+```
+
 ## `0.5.x` -> `0.6.x`
 
 ### Template routing / handler APIs

--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@
 
 ```yaml
 dependencies:
-  llamadart: ^0.6.3
+  llamadart: ^0.6.4
 ```
 
 ### 2. Run with defaults
@@ -98,7 +98,7 @@ Future<void> main() async {
 <details>
 <summary>Full module matrix (available modules by target)</summary>
 
-Backend module matrix from pinned native tag `b8099`:
+Backend module matrix from pinned native tag `b8157`:
 
 | Target | Available backend modules in bundle |
 |--------|-------------------------------------|

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: llamadart
 description: A Dart/Flutter plugin for llama.cpp - run LLM inference on any platform using GGUF models
-version: 0.6.3
+version: 0.6.4
 homepage: https://github.com/leehack/llamadart
 repository: https://github.com/leehack/llamadart
 issue_tracker: https://github.com/leehack/llamadart/issues

--- a/website/docs/changelog/recent-releases.md
+++ b/website/docs/changelog/recent-releases.md
@@ -6,6 +6,18 @@ For canonical full release notes, use:
 
 - [`CHANGELOG.md`](https://github.com/leehack/llamadart/blob/main/CHANGELOG.md)
 
+## 0.6.4
+
+- Aligned multimodal projector offload with effective model-load settings,
+  including CPU-only configurations.
+- Added safer backend selection/discovery APIs and improved runtime backend
+  status plus GPU-layer diagnostics accuracy.
+- Improved web large-model handling with cache-prefetch download UX, bridge
+  worker fallback paths, memory-pressure retries, and wasm64-core fallback
+  wiring.
+- Synced native hook tag to `b8157` and added Android arm64 CPU-profile and
+  variant policy support with loader hardening.
+
 ## 0.6.3
 
 - Synced native runtime to llama.cpp `b8138` and picked up Android arm64

--- a/website/docs/getting-started/installation.md
+++ b/website/docs/getting-started/installation.md
@@ -11,7 +11,7 @@ title: Installation
 
 ```yaml
 dependencies:
-  llamadart: ^0.6.3
+  llamadart: ^0.6.4
 ```
 
 Then resolve packages:

--- a/website/docs/migration/upgrade-checklist.md
+++ b/website/docs/migration/upgrade-checklist.md
@@ -30,6 +30,9 @@ Use this checklist when upgrading `llamadart` across minor/major versions.
 
 - Confirm native runtime bundle expectations
 - Confirm web bridge asset tags and compatibility rules
+- For Android arm64 custom config, verify CPU policy intent: shorthand
+  `android-arm64: [vulkan]` now uses default `cpu_profile: full`; set
+  `cpu_profile: compact` if you want baseline-only/smaller packaging.
 
 ## 6. Update docs for your team/app
 

--- a/website/docs/platforms/support-matrix.md
+++ b/website/docs/platforms/support-matrix.md
@@ -5,7 +5,7 @@ title: Platform & Backend Matrix
 This page combines platform support and backend-module configuration for
 `llamadart`.
 
-The native-assets hook currently pins `llamadart-native` tag `b8099`
+The native-assets hook currently pins `llamadart-native` tag `b8157`
 (`hook/build.dart`). Module availability below is for that pinned tag.
 
 ## Platform/architecture coverage
@@ -25,7 +25,7 @@ The native-assets hook currently pins `llamadart-native` tag `b8099`
 | macOS x86_64 | `macos-x86_64` | No (fixed in hook) | Consolidated runtime: `cpu`, `metal` | Supported |
 | Web (browser) | N/A (JS bridge path) | N/A | Bridge router: `webgpu`, `cpu` fallback | Experimental |
 
-## Current module availability by bundle (`b8099`)
+## Current module availability by bundle (`b8157`)
 
 | Bundle key | Available backend modules in bundle |
 | --- | --- |


### PR DESCRIPTION
## Summary
- finalize the `0.6.4` release metadata by bumping package/docs dependency references and promoting changelog notes from `Unreleased`
- add a `0.6.3 -> 0.6.4` migration note for Android arm64 CPU profile defaults, including shorthand config behavior and compact-profile guidance
- align docs with the current native hook pin (`b8157`) and add upgrade checklist guidance for Android arm64 custom backend configs