### PR TITLE
chore(release): prepare 0.6.6

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-## Unreleased
+## 0.6.6
 
 * **Runtime syncs**:
   * Updated native hook pinning to `leehack/llamadart-native@b8216`.
@@ -10,6 +10,7 @@
   * Updated Android chat app defaults to prefer CPU for Qwen3.5 `0.8B` and `2B`, and reduced Android `0.8B` context to `2048` for lower first-token latency.
   * Hardened Android multimodal handling by downscaling staged images in the chat app and forcing Qwen3.5 `0.8B` projector work onto CPU on Android.
   * Fixed WebGPU Qwen prompt/control-token handling and committed companion bridge-side streaming/multimodal fixes required by the local chat app runtime.
+* **Compatibility note**: no public API breaking changes in `0.6.6`.
 
 ## 0.6.5
 

--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@
 
 ```yaml
 dependencies:
-  llamadart: ^0.6.5
+  llamadart: ^0.6.6
 ```
 
 ### 2. Run with defaults

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: llamadart
 description: A Dart/Flutter plugin for llama.cpp - run LLM inference on any platform using GGUF models
-version: 0.6.5
+version: 0.6.6
 homepage: https://github.com/leehack/llamadart
 repository: https://github.com/leehack/llamadart
 issue_tracker: https://github.com/leehack/llamadart/issues

--- a/website/docs/changelog/recent-releases.md
+++ b/website/docs/changelog/recent-releases.md
@@ -7,7 +7,7 @@ For canonical full release notes, use:
 
 - [`CHANGELOG.md`](https://github.com/leehack/llamadart/blob/main/CHANGELOG.md)
 
-## Unreleased
+## 0.6.6
 
 - Synced native hook pin to `leehack/llamadart-native@b8216`.
 - Updated default web bridge asset pinning to
@@ -20,6 +20,7 @@ For canonical full release notes, use:
   `0.8B` / `2B`.
 - Fixed local web chat app bridge/runtime handling for Qwen prompt streaming and
   multimodal fallback behavior.
+- Compatibility note: no public API breaking changes in `0.6.6`.
 
 ## 0.6.5
 

--- a/website/docs/getting-started/installation.md
+++ b/website/docs/getting-started/installation.md
@@ -12,7 +12,7 @@ description: Install llamadart, add the package to your app, and understand the 
 
 ```yaml
 dependencies:
-  llamadart: ^0.6.5
+  llamadart: ^0.6.6
 ```
 
 Then resolve packages:


### PR DESCRIPTION
## Summary
- bump the package version to `0.6.6`
- publish the current release notes in the changelog and recent-releases docs
- update installation snippets to reference `^0.6.6`

## Testing
- `dart format --output=none --set-exit-if-changed .`
- `dart analyze`
- `dart test`
- `./tool/docs/build_site.sh`
- `./tool/docs/validate_links.sh`