### PR TITLE
fix: handle whitespace between <tool_call> tag and JSON in Hermes handler

### DIFF
--- a/lib/src/core/template/handlers/hermes_handler.dart
+++ b/lib/src/core/template/handlers/hermes_handler.dart
@@ -130,7 +130,8 @@ class HermesHandler extends ChatTemplateHandler {
         }
         // Skip leading whitespace in namedToolStart to find the actual '{'
         var jsonStart = match.start + startOffset;
-        while (jsonStart < text.length && _isWhitespace(text.codeUnitAt(jsonStart))) {
+        while (jsonStart < text.length &&
+            _isWhitespace(text.codeUnitAt(jsonStart))) {
           jsonStart++;
         }
         final jsonRange = _extractJsonObjectRange(text, jsonStart);

--- a/test/unit/core/template/handlers/hermes_handler_test.dart
+++ b/test/unit/core/template/handlers/hermes_handler_test.dart
@@ -58,7 +58,10 @@ void main() {
       '<tool_call> {"name":"get_current_weather","arguments":{"location":"Seoul"}}</tool_call>',
     );
     expect(parsed.toolCalls, hasLength(1));
-    expect(parsed.toolCalls.first.function?.name, equals('get_current_weather'));
+    expect(
+      parsed.toolCalls.first.function?.name,
+      equals('get_current_weather'),
+    );
     expect(
       jsonDecode(parsed.toolCalls.first.function!.arguments!),
       containsPair('location', 'Seoul'),
@@ -72,19 +75,28 @@ void main() {
       '<tool_call>\n{"name":"get_current_weather","arguments":{"location":"Seoul"}}\n</tool_call>',
     );
     expect(parsed.toolCalls, hasLength(1));
-    expect(parsed.toolCalls.first.function?.name, equals('get_current_weather'));
+    expect(
+      parsed.toolCalls.first.function?.name,
+      equals('get_current_weather'),
+    );
     expect(parsed.content, isEmpty);
   });
 
-  test('parses tool call with multiple whitespace chars between tag and JSON', () {
-    final handler = HermesHandler();
-    final parsed = handler.parse(
-      '<tool_call>  \n  {"name":"get_current_weather","arguments":{"location":"Seoul"}}\n</tool_call>',
-    );
-    expect(parsed.toolCalls, hasLength(1));
-    expect(parsed.toolCalls.first.function?.name, equals('get_current_weather'));
-    expect(parsed.content, isEmpty);
-  });
+  test(
+    'parses tool call with multiple whitespace chars between tag and JSON',
+    () {
+      final handler = HermesHandler();
+      final parsed = handler.parse(
+        '<tool_call>  \n  {"name":"get_current_weather","arguments":{"location":"Seoul"}}\n</tool_call>',
+      );
+      expect(parsed.toolCalls, hasLength(1));
+      expect(
+        parsed.toolCalls.first.function?.name,
+        equals('get_current_weather'),
+      );
+      expect(parsed.content, isEmpty);
+    },
+  );
 
   test('parses <function=name> JSON </function> tool call', () {
     final handler = HermesHandler();


### PR DESCRIPTION
## Summary

- Fix Hermes handler `parse()` failing to extract tool calls when whitespace (space/newline) exists between `<tool_call>` and the JSON object
- This format is produced by Qwen models per their Jinja template: `<tool_call>\n{"name":...}\n</tool_call>`

## Root Cause

`_openRegex` group(3) captures leading whitespace as part of the match (e.g., ` {"name"`). When computing `jsonStart`, the offset pointed to the whitespace character instead of `{`, causing `extractLeadingJsonValue()` to return `null` and the entire tool call to fall back as plain content.

## Fix

Skip leading whitespace after computing `jsonStart` to find the actual `{` before calling `_extractJsonObjectRange()`. This is consistent with how Granite, Mistral, and Magistral handlers already handle whitespace before their `extractLeadingJsonValue()` calls.

## Test plan

- [x] 3 new test cases: space, newline, and mixed whitespace between tag and JSON
- [x] All 1027 existing tests pass
- [x] Verified end-to-end with Qwen3.5-2B on iOS simulator