### PR TITLE
fix: sync b8373 and harden Linux bundle loading

### DIFF
--- a/README.md
+++ b/README.md
@@ -130,7 +130,7 @@ Note: embedding support depends on backend/runtime capabilities.
 <details>
 <summary>Full module matrix (available modules by target)</summary>
 
-Backend module matrix from pinned native tag `b8216`:
+Backend module matrix from pinned native tag `b8373`:
 
 | Target | Available backend modules in bundle |
 |--------|-------------------------------------|

--- a/hook/build.dart
+++ b/hook/build.dart
@@ -9,7 +9,7 @@ import 'package:path/path.dart' as path;
 
 import 'package:llamadart/src/hook/native_bundle_config.dart';
 
-const _llamaCppTag = 'b8216';
+const _llamaCppTag = 'b8373';
 const _nativeRepoSlug = 'leehack/llamadart-native';
 const _baseUrl =
     'https://github.com/$_nativeRepoSlug/releases/download/$_llamaCppTag';

--- a/lib/src/backends/llama_cpp/bindings.dart
+++ b/lib/src/backends/llama_cpp/bindings.dart
@@ -62,6 +62,21 @@ external void llama_attach_threadpool(
 external void llama_detach_threadpool(ffi.Pointer<llama_context> ctx);
 
 @ffi.Native<
+  ffi.Pointer<llama_model> Function(
+    ffi.Pointer<gguf_context>,
+    llama_model_set_tensor_data_t,
+    ffi.Pointer<ffi.Void>,
+    llama_model_params,
+  )
+>()
+external ffi.Pointer<llama_model> llama_model_init_from_user(
+  ffi.Pointer<gguf_context> metadata,
+  llama_model_set_tensor_data_t set_tensor_data,
+  ffi.Pointer<ffi.Void> set_tensor_data_ud,
+  llama_model_params params,
+);
+
+@ffi.Native<
   ffi.Pointer<llama_model> Function(ffi.Pointer<ffi.Char>, llama_model_params)
 >()
 external ffi.Pointer<llama_model> llama_load_model_from_file(
@@ -1429,7 +1444,7 @@ external ffi.Pointer<llama_sampler> llama_sampler_init_mirostat_v2(
   double eta,
 );
 
-/// @details Intializes a GBNF grammar, see grammars/README.md for details.
+/// @details Initializes a GBNF grammar, see grammars/README.md for details.
 /// @param vocab The vocabulary that this grammar will be used with.
 /// @param grammar_str The production rules for the grammar, encoded as a string. Returns an empty grammar if empty. Returns NULL if parsing of grammar_str fails.
 /// @param grammar_root The name of the start symbol for the grammar.
@@ -1868,11 +1883,6 @@ int ggml_type_size(ggml_type type) => _ggml_type_size(type.value);
 external int _ggml_row_size(int type, int ne);
 
 int ggml_row_size(ggml_type type, int ne) => _ggml_row_size(type.value, ne);
-
-@ffi.Native<ffi.Double Function(ffi.UnsignedInt)>(symbol: 'ggml_type_sizef')
-external double _ggml_type_sizef(int type);
-
-double ggml_type_sizef(ggml_type type) => _ggml_type_sizef(type.value);
 
 @ffi.Native<ffi.Pointer<ffi.Char> Function(ffi.UnsignedInt)>(
   symbol: 'ggml_type_name',
@@ -5840,6 +5850,27 @@ external ffi.Pointer<ggml_tensor> ggml_solve_tri(
   ffi.Pointer<ggml_tensor> Function(
     ffi.Pointer<ggml_context>,
     ffi.Pointer<ggml_tensor>,
+    ffi.Pointer<ggml_tensor>,
+    ffi.Pointer<ggml_tensor>,
+    ffi.Pointer<ggml_tensor>,
+    ffi.Pointer<ggml_tensor>,
+    ffi.Pointer<ggml_tensor>,
+  )
+>()
+external ffi.Pointer<ggml_tensor> ggml_gated_delta_net(
+  ffi.Pointer<ggml_context> ctx,
+  ffi.Pointer<ggml_tensor> q,
+  ffi.Pointer<ggml_tensor> k,
+  ffi.Pointer<ggml_tensor> v,
+  ffi.Pointer<ggml_tensor> g,
+  ffi.Pointer<ggml_tensor> beta,
+  ffi.Pointer<ggml_tensor> state,
+);
+
+@ffi.Native<
+  ffi.Pointer<ggml_tensor> Function(
+    ffi.Pointer<ggml_context>,
+    ffi.Pointer<ggml_tensor>,
     ggml_custom1_op_t,
     ffi.Int,
     ffi.Pointer<ffi.Void>,
@@ -7133,7 +7164,7 @@ external bool mtmd_support_vision(ffi.Pointer<mtmd_context> ctx);
 external bool mtmd_support_audio(ffi.Pointer<mtmd_context> ctx);
 
 @ffi.Native<ffi.Int Function(ffi.Pointer<mtmd_context>)>()
-external int mtmd_get_audio_bitrate(ffi.Pointer<mtmd_context> ctx);
+external int mtmd_get_audio_sample_rate(ffi.Pointer<mtmd_context> ctx);
 
 @ffi.Native<
   ffi.Pointer<mtmd_bitmap> Function(
@@ -7512,7 +7543,8 @@ enum ggml_type {
   GGML_TYPE_TQ1_0(34),
   GGML_TYPE_TQ2_0(35),
   GGML_TYPE_MXFP4(39),
-  GGML_TYPE_COUNT(40);
+  GGML_TYPE_NVFP4(40),
+  GGML_TYPE_COUNT(41);
 
   final int value;
   const ggml_type(this.value);
@@ -7550,7 +7582,8 @@ enum ggml_type {
     34 => GGML_TYPE_TQ1_0,
     35 => GGML_TYPE_TQ2_0,
     39 => GGML_TYPE_MXFP4,
-    40 => GGML_TYPE_COUNT,
+    40 => GGML_TYPE_NVFP4,
+    41 => GGML_TYPE_COUNT,
     _ => throw ArgumentError('Unknown value for ggml_type: $value'),
   };
 }
@@ -7643,17 +7676,18 @@ enum ggml_op {
   GGML_OP_GATED_LINEAR_ATTN(82),
   GGML_OP_RWKV_WKV7(83),
   GGML_OP_SOLVE_TRI(84),
-  GGML_OP_UNARY(85),
-  GGML_OP_MAP_CUSTOM1(86),
-  GGML_OP_MAP_CUSTOM2(87),
-  GGML_OP_MAP_CUSTOM3(88),
-  GGML_OP_CUSTOM(89),
-  GGML_OP_CROSS_ENTROPY_LOSS(90),
-  GGML_OP_CROSS_ENTROPY_LOSS_BACK(91),
-  GGML_OP_OPT_STEP_ADAMW(92),
-  GGML_OP_OPT_STEP_SGD(93),
-  GGML_OP_GLU(94),
-  GGML_OP_COUNT(95);
+  GGML_OP_GATED_DELTA_NET(85),
+  GGML_OP_UNARY(86),
+  GGML_OP_MAP_CUSTOM1(87),
+  GGML_OP_MAP_CUSTOM2(88),
+  GGML_OP_MAP_CUSTOM3(89),
+  GGML_OP_CUSTOM(90),
+  GGML_OP_CROSS_ENTROPY_LOSS(91),
+  GGML_OP_CROSS_ENTROPY_LOSS_BACK(92),
+  GGML_OP_OPT_STEP_ADAMW(93),
+  GGML_OP_OPT_STEP_SGD(94),
+  GGML_OP_GLU(95),
+  GGML_OP_COUNT(96);
 
   final int value;
   const ggml_op(this.value);
@@ -7744,17 +7778,18 @@ enum ggml_op {
     82 => GGML_OP_GATED_LINEAR_ATTN,
     83 => GGML_OP_RWKV_WKV7,
     84 => GGML_OP_SOLVE_TRI,
-    85 => GGML_OP_UNARY,
-    86 => GGML_OP_MAP_CUSTOM1,
-    87 => GGML_OP_MAP_CUSTOM2,
-    88 => GGML_OP_MAP_CUSTOM3,
-    89 => GGML_OP_CUSTOM,
-    90 => GGML_OP_CROSS_ENTROPY_LOSS,
-    91 => GGML_OP_CROSS_ENTROPY_LOSS_BACK,
-    92 => GGML_OP_OPT_STEP_ADAMW,
-    93 => GGML_OP_OPT_STEP_SGD,
-    94 => GGML_OP_GLU,
-    95 => GGML_OP_COUNT,
+    85 => GGML_OP_GATED_DELTA_NET,
+    86 => GGML_OP_UNARY,
+    87 => GGML_OP_MAP_CUSTOM1,
+    88 => GGML_OP_MAP_CUSTOM2,
+    89 => GGML_OP_MAP_CUSTOM3,
+    90 => GGML_OP_CUSTOM,
+    91 => GGML_OP_CROSS_ENTROPY_LOSS,
+    92 => GGML_OP_CROSS_ENTROPY_LOSS_BACK,
+    93 => GGML_OP_OPT_STEP_ADAMW,
+    94 => GGML_OP_OPT_STEP_SGD,
+    95 => GGML_OP_GLU,
+    96 => GGML_OP_COUNT,
     _ => throw ArgumentError('Unknown value for ggml_op: $value'),
   };
 }
@@ -8047,6 +8082,7 @@ enum llama_ftype {
   LLAMA_FTYPE_MOSTLY_TQ1_0(36),
   LLAMA_FTYPE_MOSTLY_TQ2_0(37),
   LLAMA_FTYPE_MOSTLY_MXFP4_MOE(38),
+  LLAMA_FTYPE_MOSTLY_NVFP4(39),
   LLAMA_FTYPE_GUESSED(1024);
 
   final int value;
@@ -8086,6 +8122,7 @@ enum llama_ftype {
     36 => LLAMA_FTYPE_MOSTLY_TQ1_0,
     37 => LLAMA_FTYPE_MOSTLY_TQ2_0,
     38 => LLAMA_FTYPE_MOSTLY_MXFP4_MOE,
+    39 => LLAMA_FTYPE_MOSTLY_NVFP4,
     1024 => LLAMA_FTYPE_GUESSED,
     _ => throw ArgumentError('Unknown value for llama_ftype: $value'),
   };
@@ -8589,6 +8626,20 @@ enum ggml_numa_strategy {
 final class ggml_threadpool extends ffi.Opaque {}
 
 typedef ggml_threadpool_t = ffi.Pointer<ggml_threadpool>;
+typedef llama_model_set_tensor_data_tFunction =
+    ffi.Void Function(
+      ffi.Pointer<ggml_tensor> tensor,
+      ffi.Pointer<ffi.Void> userdata,
+    );
+typedef Dartllama_model_set_tensor_data_tFunction =
+    void Function(
+      ffi.Pointer<ggml_tensor> tensor,
+      ffi.Pointer<ffi.Void> userdata,
+    );
+typedef llama_model_set_tensor_data_t =
+    ffi.Pointer<ffi.NativeFunction<llama_model_set_tensor_data_tFunction>>;
+
+final class gguf_context extends ffi.Opaque {}
 
 enum llama_params_fit_status {
   LLAMA_PARAMS_FIT_STATUS_SUCCESS(0),
@@ -8871,7 +8922,8 @@ enum ggml_ftype {
   GGML_FTYPE_MOSTLY_IQ4_XS(22),
   GGML_FTYPE_MOSTLY_IQ1_M(23),
   GGML_FTYPE_MOSTLY_BF16(24),
-  GGML_FTYPE_MOSTLY_MXFP4(25);
+  GGML_FTYPE_MOSTLY_MXFP4(25),
+  GGML_FTYPE_MOSTLY_NVFP4(26);
 
   final int value;
   const ggml_ftype(this.value);
@@ -8902,6 +8954,7 @@ enum ggml_ftype {
     23 => GGML_FTYPE_MOSTLY_IQ1_M,
     24 => GGML_FTYPE_MOSTLY_BF16,
     25 => GGML_FTYPE_MOSTLY_MXFP4,
+    26 => GGML_FTYPE_MOSTLY_NVFP4,
     _ => throw ArgumentError('Unknown value for ggml_ftype: $value'),
   };
 }
@@ -9052,89 +9105,7 @@ final class ggml_init_params extends ffi.Struct {
 
 typedef ggml_guid_t = ffi.Pointer<ffi.Pointer<ffi.Uint8>>;
 
-final class _IO_marker extends ffi.Opaque {}
-
-typedef __off_t = ffi.Long;
-typedef Dart__off_t = int;
-typedef _IO_lock_t = ffi.Void;
-typedef Dart_IO_lock_t = void;
-typedef __off64_t = ffi.Long;
-typedef Dart__off64_t = int;
-
-final class _IO_codecvt extends ffi.Opaque {}
-
-final class _IO_wide_data extends ffi.Opaque {}
-
-final class _IO_FILE extends ffi.Struct {
-  @ffi.Int()
-  external int _flags;
-
-  external ffi.Pointer<ffi.Char> _IO_read_ptr;
-
-  external ffi.Pointer<ffi.Char> _IO_read_end;
-
-  external ffi.Pointer<ffi.Char> _IO_read_base;
-
-  external ffi.Pointer<ffi.Char> _IO_write_base;
-
-  external ffi.Pointer<ffi.Char> _IO_write_ptr;
-
-  external ffi.Pointer<ffi.Char> _IO_write_end;
-
-  external ffi.Pointer<ffi.Char> _IO_buf_base;
-
-  external ffi.Pointer<ffi.Char> _IO_buf_end;
-
-  external ffi.Pointer<ffi.Char> _IO_save_base;
-
-  external ffi.Pointer<ffi.Char> _IO_backup_base;
-
-  external ffi.Pointer<ffi.Char> _IO_save_end;
-
-  external ffi.Pointer<_IO_marker> _markers;
-
-  external ffi.Pointer<_IO_FILE> _chain;
-
-  @ffi.Int()
-  external int _fileno;
-
-  @ffi.Int()
-  external int _flags2;
-
-  @__off_t()
-  external int _old_offset;
-
-  @ffi.UnsignedShort()
-  external int _cur_column;
-
-  @ffi.SignedChar()
-  external int _vtable_offset;
-
-  @ffi.Array.multi([1])
-  external ffi.Array<ffi.Char> _shortbuf;
-
-  external ffi.Pointer<_IO_lock_t> _lock;
-
-  @__off64_t()
-  external int _offset;
-
-  external ffi.Pointer<_IO_codecvt> _codecvt;
-
-  external ffi.Pointer<_IO_wide_data> _wide_data;
-
-  external ffi.Pointer<_IO_FILE> _freeres_list;
-
-  external ffi.Pointer<ffi.Void> _freeres_buf;
-
-  @ffi.Size()
-  external int __pad5;
-
-  @ffi.Int()
-  external int _mode;
-
-  @ffi.Array.multi([20])
-  external ffi.Array<ffi.Char> _unused2;
-}
+final class _IO_FILE extends ffi.Opaque {}
 
 typedef FILE = _IO_FILE;
 

--- a/lib/src/backends/llama_cpp/llama_cpp_service.dart
+++ b/lib/src/backends/llama_cpp/llama_cpp_service.dart
@@ -111,6 +111,10 @@ typedef _MtmdHelperEvalChunksDart =
 typedef _MtmdLogSetNative = Void Function(ggml_log_callback, Pointer<Void>);
 typedef _MtmdLogSetDart = void Function(ggml_log_callback, Pointer<Void>);
 
+final RegExp _linuxLlamadartProcMapsPattern = RegExp(
+  r'/libllamadart\.so(?:\.\d+)?$',
+);
+
 /// Service responsible for managing Llama.cpp models and contexts.
 ///
 /// This service handles the direct interaction with the native Llama.cpp library,
@@ -417,6 +421,7 @@ class LlamaCppService {
     }
     _applyConfiguredLogLevel();
     llama_backend_init();
+    _refreshBackendModuleDirectoryAfterPrimaryLoad();
     _applyConfiguredLogLevel();
 
     // Startup path should remain CPU-safe so reading backend options does not
@@ -548,26 +553,28 @@ class LlamaCppService {
   }
 
   String? _resolveLinuxPrimaryLibraryDirectory() {
-    final candidates = <String>{
-      path.join(Directory.current.path, '.dart_tool', 'lib'),
-      path.dirname(Platform.resolvedExecutable),
-      Directory.current.path,
-    };
+    return resolveLinuxPrimaryLibraryDirectory(
+      resolvedExecutablePath: Platform.resolvedExecutable,
+      currentDirectoryPath: Directory.current.path,
+      environment: Platform.environment,
+    );
+  }
 
-    for (final candidate in candidates) {
-      final directory = Directory(candidate);
-      if (!directory.existsSync()) {
-        continue;
-      }
-      final hasPrimary =
-          File(path.join(candidate, 'libllamadart.so')).existsSync() ||
-          File(path.join(candidate, 'libllamadart.so.0')).existsSync();
-      if (hasPrimary) {
-        return candidate;
-      }
+  void _refreshBackendModuleDirectoryAfterPrimaryLoad() {
+    if (_backendModuleDirectory != null) {
+      return;
     }
 
-    return null;
+    if (!Platform.isAndroid && !Platform.isLinux) {
+      return;
+    }
+
+    _backendModuleDirectory = resolveBackendModuleDirectory();
+    if (_backendModuleDirectory == null && Platform.isLinux) {
+      _backendModuleDirectory =
+          _linuxPreparedLibraryDirectory ??
+          _resolveLinuxPrimaryLibraryDirectory();
+    }
   }
 
   List<String> _linuxDependencySourceDirectories(String targetDirectory) {
@@ -844,6 +851,57 @@ class LlamaCppService {
     return executableDir;
   }
 
+  /// Resolves the primary Linux native-library directory.
+  ///
+  /// Resolution order:
+  /// 1. Explicit environment override (`LLAMADART_NATIVE_LIB_DIR` or
+  ///    `LLAMADART_BACKEND_MODULE_DIR`)
+  /// 2. `.dart_tool/lib`
+  /// 3. Executable-adjacent `lib/` directory
+  /// 4. Directory of resolved executable
+  /// 5. Current working directory `lib/`
+  /// 6. Current working directory
+  static String? resolveLinuxPrimaryLibraryDirectory({
+    required String resolvedExecutablePath,
+    required String currentDirectoryPath,
+    required Map<String, String> environment,
+  }) {
+    final overrideCandidates = <String>[
+      environment['LLAMADART_NATIVE_LIB_DIR'] ?? '',
+      environment['LLAMADART_BACKEND_MODULE_DIR'] ?? '',
+    ];
+    for (final override in overrideCandidates) {
+      if (override.isEmpty) {
+        continue;
+      }
+      if (_containsLinuxPrimaryLibrary(override)) {
+        return override;
+      }
+    }
+
+    final executableDir = path.dirname(resolvedExecutablePath);
+    final candidates = <String>[
+      path.join(currentDirectoryPath, '.dart_tool', 'lib'),
+      path.join(executableDir, 'lib'),
+      executableDir,
+      path.join(currentDirectoryPath, 'lib'),
+      currentDirectoryPath,
+    ];
+
+    final seen = <String>{};
+    for (final candidate in candidates) {
+      final normalized = path.normalize(candidate);
+      if (!seen.add(normalized)) {
+        continue;
+      }
+      if (_containsLinuxPrimaryLibrary(normalized)) {
+        return normalized;
+      }
+    }
+
+    return null;
+  }
+
   static String? _preferredWindowsBundleName() {
     switch (Abi.current()) {
       case Abi.windowsX64:
@@ -975,6 +1033,20 @@ class LlamaCppService {
     }
   }
 
+  static bool _containsLinuxPrimaryLibrary(String directoryPath) {
+    try {
+      final directory = Directory(directoryPath);
+      if (!directory.existsSync()) {
+        return false;
+      }
+
+      return File(path.join(directoryPath, 'libllamadart.so')).existsSync() ||
+          File(path.join(directoryPath, 'libllamadart.so.0')).existsSync();
+    } catch (_) {
+      return false;
+    }
+  }
+
   static String? _findDartToolLibDirectory(String currentDirectoryPath) {
     var cursor = Directory(currentDirectoryPath).absolute;
     while (true) {
@@ -1013,7 +1085,7 @@ class LlamaCppService {
           ? mappedPath.substring(0, mappedPath.length - ' (deleted)'.length)
           : mappedPath;
 
-      if (!normalizedPath.endsWith('/libllamadart.so')) {
+      if (!_linuxLlamadartProcMapsPattern.hasMatch(normalizedPath)) {
         continue;
       }
 

--- a/test/unit/backends/llama_cpp/llama_cpp_service_test.dart
+++ b/test/unit/backends/llama_cpp/llama_cpp_service_test.dart
@@ -435,6 +435,17 @@ void main() {
       );
     });
 
+    test('accepts versioned Linux libllamadart mappings', () {
+      const maps = '''
+7f8a0000-7f8b0000 r-xp 00000000 103:04 12345 /opt/app/lib/libllamadart.so.0
+''';
+
+      expect(
+        LlamaCppService.parseBackendModuleDirectoryFromProcMaps(maps),
+        '/opt/app/lib',
+      );
+    });
+
     test('returns null when libllamadart mapping is missing', () {
       const maps = '''
 7f8a0000-7f8b0000 r-xp 00000000 103:04 12345 /system/lib64/libc.so
@@ -602,6 +613,70 @@ void main() {
     );
   });
 
+  group('resolveLinuxPrimaryLibraryDirectory', () {
+    late Directory tempRoot;
+
+    setUp(() {
+      tempRoot = Directory.systemTemp.createTempSync(
+        'llamadart-linux-primary-',
+      );
+    });
+
+    tearDown(() {
+      if (tempRoot.existsSync()) {
+        tempRoot.deleteSync(recursive: true);
+      }
+    });
+
+    test('uses explicit environment override when valid', () {
+      final overrideDir = Directory(path.join(tempRoot.path, 'override'))
+        ..createSync(recursive: true);
+      _createLinuxBundleMarkerFiles(overrideDir.path);
+
+      final resolved = LlamaCppService.resolveLinuxPrimaryLibraryDirectory(
+        resolvedExecutablePath: path.join(tempRoot.path, 'dart'),
+        currentDirectoryPath: tempRoot.path,
+        environment: {'LLAMADART_NATIVE_LIB_DIR': overrideDir.path},
+      );
+
+      expect(path.normalize(resolved!), path.normalize(overrideDir.path));
+    });
+
+    test('prefers executable-adjacent lib directory for packaged bundles', () {
+      final bundleDir = Directory(path.join(tempRoot.path, 'bundle'))
+        ..createSync(recursive: true);
+      final executableDir = Directory(path.join(bundleDir.path, 'app'))
+        ..createSync(recursive: true);
+      final libDir = Directory(path.join(executableDir.path, 'lib'))
+        ..createSync(recursive: true);
+      _createLinuxBundleMarkerFiles(libDir.path);
+
+      final resolved = LlamaCppService.resolveLinuxPrimaryLibraryDirectory(
+        resolvedExecutablePath: path.join(executableDir.path, 'my_app'),
+        currentDirectoryPath: bundleDir.path,
+        environment: const {},
+      );
+
+      expect(path.normalize(resolved!), path.normalize(libDir.path));
+    });
+
+    test('falls back to current working directory lib folder', () {
+      final currentDir = Directory(path.join(tempRoot.path, 'cwd'))
+        ..createSync(recursive: true);
+      final libDir = Directory(path.join(currentDir.path, 'lib'))
+        ..createSync(recursive: true);
+      _createLinuxBundleMarkerFiles(libDir.path, versionedPrimary: true);
+
+      final resolved = LlamaCppService.resolveLinuxPrimaryLibraryDirectory(
+        resolvedExecutablePath: path.join(tempRoot.path, 'dart'),
+        currentDirectoryPath: currentDir.path,
+        environment: const {},
+      );
+
+      expect(path.normalize(resolved!), path.normalize(libDir.path));
+    });
+  });
+
   group('Linux runtime dependency helpers', () {
     late Directory tempRoot;
 
@@ -728,6 +803,20 @@ void _createWindowsBundleMarkerFiles(
     'llama$suffix.dll',
     'ggml$suffix.dll',
     'ggml-cpu$suffix.dll',
+  ];
+  for (final fileName in markerFiles) {
+    File(path.join(directoryPath, fileName)).writeAsStringSync('');
+  }
+}
+
+void _createLinuxBundleMarkerFiles(
+  String directoryPath, {
+  bool versionedPrimary = false,
+}) {
+  final markerFiles = <String>[
+    versionedPrimary ? 'libllamadart.so.0' : 'libllamadart.so',
+    'libllama.so',
+    'libggml.so',
   ];
   for (final fileName in markerFiles) {
     File(path.join(directoryPath, fileName)).writeAsStringSync('');

--- a/website/docs/platforms/support-matrix.md
+++ b/website/docs/platforms/support-matrix.md
@@ -6,7 +6,7 @@ description: Check which native and web backends are supported by llamadart and 
 This page combines platform support and backend-module configuration for
 `llamadart`.
 
-The native-assets hook currently pins `llamadart-native` tag `b8216`
+The native-assets hook currently pins `llamadart-native` tag `b8373`
 (`hook/build.dart`). Module availability below is for that pinned tag.
 
 ## Platform/architecture coverage
@@ -26,7 +26,7 @@ The native-assets hook currently pins `llamadart-native` tag `b8216`
 | macOS x86_64 | `macos-x86_64` | No (fixed in hook) | Consolidated runtime: `cpu`, `metal` | Supported |
 | Web (browser) | N/A (JS bridge path) | N/A | Bridge router: `webgpu`, `cpu` fallback | Experimental |
 
-## Current module availability by bundle (`b8216`)
+## Current module availability by bundle (`b8373`)
 
 | Bundle key | Available backend modules in bundle |
 | --- | --- |


### PR DESCRIPTION
## Summary
- sync the native hook to `llamadart-native@b8373` and regenerate `bindings.dart` so the Dart FFI surface matches the published headers
- harden Linux packaged-app library discovery so bundled `lib/` directories and versioned `libllamadart.so.0` mappings resolve backend modules and colocated dependencies reliably
- refresh current bundle-matrix docs to reflect the active native tag

## Testing
- `dart analyze hook/build.dart lib/src/backends/llama_cpp/bindings.dart lib/src/backends/llama_cpp/llama_cpp_service.dart test/unit/backends/llama_cpp/llama_cpp_service_test.dart`
- `dart test test/unit/backends/llama_cpp/llama_cpp_service_test.dart`
- `dart test test/unit/hook/build_hook_linux_integration_test.dart`
- `dart test test/unit/hook/build_hook_android_integration_test.dart`
- `dart test test/unit/hook/build_hook_integration_test.dart`

Fixes #87.