### PR TITLE
chore(release): prepare 0.6.7

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,12 @@
+## 0.6.7
+
+* **Native runtime sync and Linux loader hardening**:
+  * Updated native hook pinning and regenerated bindings to `leehack/llamadart-native@b8373`.
+  * Hardened Linux bundle loading for packaged apps and accepted versioned `libllamadart` mappings so colocated native dependencies resolve more reliably at runtime.
+* **Hermes tool-call parsing fix**:
+  * Fixed Hermes handler parsing when whitespace appears between `<tool_call>` and the JSON payload.
+* **Compatibility note**: no public API breaking changes in `0.6.7`.
+
 ## 0.6.6
 
 * **Runtime syncs**:

--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@
 
 ```yaml
 dependencies:
-  llamadart: ^0.6.6
+  llamadart: ^0.6.7
 ```
 
 ### 2. Run with defaults

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: llamadart
 description: A Dart/Flutter plugin for llama.cpp - run LLM inference on any platform using GGUF models
-version: 0.6.6
+version: 0.6.7
 homepage: https://github.com/leehack/llamadart
 repository: https://github.com/leehack/llamadart
 issue_tracker: https://github.com/leehack/llamadart/issues

--- a/website/docs/changelog/recent-releases.md
+++ b/website/docs/changelog/recent-releases.md
@@ -7,6 +7,16 @@ For canonical full release notes, use:
 
 - [`CHANGELOG.md`](https://github.com/leehack/llamadart/blob/main/CHANGELOG.md)
 
+## 0.6.7
+
+- Synced native hook pinning and regenerated bindings to
+  `leehack/llamadart-native@b8373`.
+- Hardened Linux bundle loading for packaged apps and improved versioned
+  `libllamadart` dependency resolution.
+- Fixed Hermes tool-call parsing when whitespace appears between `<tool_call>`
+  and the JSON payload.
+- Compatibility note: no public API breaking changes in `0.6.7`.
+
 ## 0.6.6
 
 - Synced native hook pin to `leehack/llamadart-native@b8216`.

--- a/website/docs/getting-started/installation.md
+++ b/website/docs/getting-started/installation.md
@@ -12,7 +12,7 @@ description: Install llamadart, add the package to your app, and understand the 
 
 ```yaml
 dependencies:
-  llamadart: ^0.6.6
+  llamadart: ^0.6.7
 ```
 
 Then resolve packages:


### PR DESCRIPTION
## Summary
- bump package and docs references from `0.6.6` to `0.6.7` for the upcoming release
- add `0.6.7` release notes covering the `b8373` native sync, Linux loader hardening, and the Hermes tool-call parsing fix
- keep the tag-driven publish and docs workflows aligned with the release branch metadata

## Validation
- dart format --output=none --set-exit-if-changed .
- dart analyze
- ./tool/docs/validate_links.sh
- dart test -p vm -j 1 --exclude-tags local-only