### PR TITLE
fix: bump native binaries to b8480 (16KB page-aligned)

### DIFF
--- a/hook/build.dart
+++ b/hook/build.dart
@@ -9,7 +9,7 @@ import 'package:path/path.dart' as path;
 
 import 'package:llamadart/src/hook/native_bundle_config.dart';
 
-const _llamaCppTag = 'b8373';
+const _llamaCppTag = 'b8480';
 const _nativeRepoSlug = 'leehack/llamadart-native';
 const _baseUrl =
     'https://github.com/$_nativeRepoSlug/releases/download/$_llamaCppTag';


### PR DESCRIPTION
## Summary
- Bumps `_llamaCppTag` from `b8373` to `b8480` in `hook/build.dart`
- The `b8480` release of `leehack/llamadart-native` includes 16KB page-aligned Android `.so` files (via leehack/llamadart-native#6), required for Android 15+ and Play Store compliance

## Test plan
- [ ] Build Android AAB and verify with `readelf -lW` that all LOAD segments have `0x4000` alignment

🤖 Generated with [Claude Code](https://claude.com/claude-code)