### PR TITLE
chore(release): prepare 0.6.8

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+## 0.6.8
+
+* **Native runtime sync**:
+  * Updated native hook pinning and regenerated bindings to `leehack/llamadart-native@b8480`.
+  * Refreshed generated low-level FFI bindings to match the synced upstream headers.
+* **Compatibility note**: no public API breaking changes in `0.6.8`.
+
 ## 0.6.7
 
 * **Native runtime sync and Linux loader hardening**:

--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@
 
 ```yaml
 dependencies:
-  llamadart: ^0.6.7
+  llamadart: ^0.6.8
 ```
 
 ### 2. Run with defaults
@@ -130,7 +130,7 @@ Note: embedding support depends on backend/runtime capabilities.
 <details>
 <summary>Full module matrix (available modules by target)</summary>
 
-Backend module matrix from pinned native tag `b8373`:
+Backend module matrix from pinned native tag `b8480`:
 
 | Target | Available backend modules in bundle |
 |--------|-------------------------------------|

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: llamadart
 description: A Dart/Flutter plugin for llama.cpp - run LLM inference on any platform using GGUF models
-version: 0.6.7
+version: 0.6.8
 homepage: https://github.com/leehack/llamadart
 repository: https://github.com/leehack/llamadart
 issue_tracker: https://github.com/leehack/llamadart/issues

--- a/website/docs/changelog/recent-releases.md
+++ b/website/docs/changelog/recent-releases.md
@@ -7,6 +7,14 @@ For canonical full release notes, use:
 
 - [`CHANGELOG.md`](https://github.com/leehack/llamadart/blob/main/CHANGELOG.md)
 
+## 0.6.8
+
+- Synced native hook pinning and regenerated bindings to
+  `leehack/llamadart-native@b8480`.
+- Refreshed generated low-level FFI bindings to match the synced upstream
+  headers.
+- Compatibility note: no public API breaking changes in `0.6.8`.
+
 ## 0.6.7
 
 - Synced native hook pinning and regenerated bindings to

--- a/website/docs/getting-started/installation.md
+++ b/website/docs/getting-started/installation.md
@@ -12,7 +12,7 @@ description: Install llamadart, add the package to your app, and understand the 
 
 ```yaml
 dependencies:
-  llamadart: ^0.6.7
+  llamadart: ^0.6.8
 ```
 
 Then resolve packages:

--- a/website/docs/platforms/support-matrix.md
+++ b/website/docs/platforms/support-matrix.md
@@ -6,7 +6,7 @@ description: Check which native and web backends are supported by llamadart and 
 This page combines platform support and backend-module configuration for
 `llamadart`.
 
-The native-assets hook currently pins `llamadart-native` tag `b8373`
+The native-assets hook currently pins `llamadart-native` tag `b8480`
 (`hook/build.dart`). Module availability below is for that pinned tag.
 
 ## Platform/architecture coverage
@@ -26,7 +26,7 @@ The native-assets hook currently pins `llamadart-native` tag `b8373`
 | macOS x86_64 | `macos-x86_64` | No (fixed in hook) | Consolidated runtime: `cpu`, `metal` | Supported |
 | Web (browser) | N/A (JS bridge path) | N/A | Bridge router: `webgpu`, `cpu` fallback | Experimental |
 
-## Current module availability by bundle (`b8373`)
+## Current module availability by bundle (`b8480`)
 
 | Bundle key | Available backend modules in bundle |
 | --- | --- |


### PR DESCRIPTION
## Summary
- bump the package and install docs from 0.6.7 to 0.6.8 so the release branch matches the next publish target
- document the `leehack/llamadart-native@b8480` sync in the changelog and recent release notes
- update pinned native tag references in the README and support matrix so release docs match the shipped hook configuration

## Validation
- dart format --output=none --set-exit-if-changed .
- dart analyze
- dart test
- ./tool/docs/build_site.sh
- ./tool/docs/validate_links.sh