### PR TITLE
chore(release): prepare 0.6.10

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,9 +1,18 @@
 ## Unreleased
 
+## 0.6.10
+
+* **Native runtime syncs**:
+  * Updated native hook pinning and regenerated bindings through `leehack/llamadart-native@b8638`.
 * **Multimodal context-safety hardening**:
   * Converted native multimodal prompt-evaluation overflow paths into Dart exceptions instead of allowing downstream sampling asserts.
   * Downscaled staged chat-app image picks to a `384px` max edge across Android, iOS, macOS, and Web to reduce multimodal context pressure.
   * Added a local-only macOS Qwen3.5 multimodal repro harness plus CI-safe provider coverage for the new overflow guidance.
+* **Gemma 4 template support and multimodal capability gating**:
+  * Added built-in Gemma 4 template detection, rendering, and parsing support, including thinking and tool-call handling.
+  * Added runtime projector capability checks so multimodal flows and the chat app gate image/audio input against `supportsVision` / `supportsAudio` instead of model-family assumptions.
+  * Documented current Gemma 4 projector behavior in the docs site and chat app guidance.
+* **Compatibility note**: no public API breaking changes in `0.6.10`.
 
 ## 0.6.9
 

--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@
 
 ```yaml
 dependencies:
-  llamadart: ^0.6.9
+  llamadart: ^0.6.10
 ```
 
 ### 2. Run with defaults
@@ -134,7 +134,7 @@ Note: embedding support depends on backend/runtime capabilities.
 <details>
 <summary>Full module matrix (available modules by target)</summary>
 
-Backend module matrix from pinned native tag `b8480`:
+Backend module matrix from pinned native tag `b8638`:
 
 | Target | Available backend modules in bundle |
 |--------|-------------------------------------|

--- a/example/chat_app/README.md
+++ b/example/chat_app/README.md
@@ -165,7 +165,7 @@ final messages = [
 final stream = engine.create(
   messages,
   params: GenerationParams(
-    maxTokens: 4096, // Current default in 0.5.0
+    maxTokens: 4096, // Example value; tune per model/device.
     temp: 0.7,
   ),
 );

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: llamadart
 description: A Dart/Flutter plugin for llama.cpp - run LLM inference on any platform using GGUF models
-version: 0.6.9
+version: 0.6.10
 homepage: https://github.com/leehack/llamadart
 repository: https://github.com/leehack/llamadart
 issue_tracker: https://github.com/leehack/llamadart/issues

--- a/website/docs/changelog/recent-releases.md
+++ b/website/docs/changelog/recent-releases.md
@@ -7,6 +7,20 @@ For canonical full release notes, use:
 
 - [`CHANGELOG.md`](https://github.com/leehack/llamadart/blob/main/CHANGELOG.md)
 
+## 0.6.10
+
+- Synced native hook pinning and regenerated bindings through
+  `leehack/llamadart-native@b8638`.
+- Hardened multimodal prompt overflow handling so native failures surface as
+  Dart exceptions, and reduced staged chat-app image size to a `384px` max edge
+  to lower multimodal context pressure.
+- Added built-in Gemma 4 template detection/render/parse support, including
+  thinking and tool-call handling.
+- Added runtime projector capability gating so multimodal flows and the chat app
+  respect actual `supportsVision` / `supportsAudio` results instead of
+  model-family assumptions.
+- Compatibility note: no public API breaking changes in `0.6.10`.
+
 ## 0.6.9
 
 - Documented that iOS builds require a minimum deployment target of `16.4` or

--- a/website/docs/getting-started/installation.md
+++ b/website/docs/getting-started/installation.md
@@ -25,7 +25,7 @@ configurations.
 
 ```yaml
 dependencies:
-  llamadart: ^0.6.9
+  llamadart: ^0.6.10
 ```
 
 Then resolve packages:

--- a/website/docs/platforms/support-matrix.md
+++ b/website/docs/platforms/support-matrix.md
@@ -6,7 +6,7 @@ description: Check which native and web backends are supported by llamadart and 
 This page combines platform support and backend-module configuration for
 `llamadart`.
 
-The native-assets hook currently pins `llamadart-native` tag `b8480`
+The native-assets hook currently pins `llamadart-native` tag `b8638`
 (`hook/build.dart`). Module availability below is for that pinned tag.
 
 ## Platform/architecture coverage
@@ -30,7 +30,7 @@ All iOS targets above require the consuming Flutter/Xcode project to use a
 minimum deployment target of `16.4` or newer (for example
 `platform :ios, '16.4'`).
 
-## Current module availability by bundle (`b8480`)
+## Current module availability by bundle (`b8638`)
 
 | Bundle key | Available backend modules in bundle |
 | --- | --- |


### PR DESCRIPTION
## Summary
- bump the package to `0.6.10` and add release notes for the Gemma 4, multimodal safety, and native sync changes since `v0.6.9`
- refresh release-facing docs and installation snippets so published docs match the upcoming package version
- update stale native bundle tag references from `b8480` to `b8638` where current docs describe the live hook configuration

## Verification
- dart format --output=none --set-exit-if-changed .
- dart analyze
- dart test -p vm -j 1 --exclude-tags local-only
- ./tool/docs/build_site.sh
- ./tool/docs/validate_links.sh