### PR TITLE
fix(gemma4): stream thought channels as thinking

### DIFF
--- a/lib/src/core/template/handlers/gemma4_handler.dart
+++ b/lib/src/core/template/handlers/gemma4_handler.dart
@@ -34,6 +34,12 @@ class Gemma4Handler extends ChatTemplateHandler {
   ChatFormat get format => ChatFormat.gemma4;
 
   @override
+  String get thinkingStartTag => '<|channel>thought\n';
+
+  @override
+  String get thinkingEndTag => _channelEnd;
+
+  @override
   List<String> get additionalStops => const [_turnEnd, _toolCallEnd];
 
   @override

--- a/test/unit/core/engine/engine_test.dart
+++ b/test/unit/core/engine/engine_test.dart
@@ -12,6 +12,7 @@ class MockLlamaBackend
     this.failModelLoad = false,
     this.failModelLoadFromUrl = false,
     this.failContextCreate = false,
+    this.modelMetadataResponse,
   });
 
   bool _isReady = false;
@@ -31,6 +32,7 @@ class MockLlamaBackend
   final bool failModelLoad;
   final bool failModelLoadFromUrl;
   final bool failContextCreate;
+  final Map<String, String>? modelMetadataResponse;
 
   @override
   bool get isReady => _isReady;
@@ -119,11 +121,12 @@ class MockLlamaBackend
   @override
   Future<Map<String, String>> modelMetadata(int modelHandle) async {
     modelMetadataCalls += 1;
-    return {
-      'llm.context_length': '4096',
-      'tokenizer.chat_template':
-          '{{ bos_token }}{% for message in messages %}{% if message["role"] == "user" %}{{ "user: " + message["content"] }}{% elif message["role"] == "assistant" %}{{ "assistant: " + message["content"] }}{% endif %}{% endfor %}{% if add_generation_prompt %}{{ "assistant: " }}{% endif %}',
-    };
+    return modelMetadataResponse ??
+        {
+          'llm.context_length': '4096',
+          'tokenizer.chat_template':
+              '{{ bos_token }}{% for message in messages %}{% if message["role"] == "user" %}{{ "user: " + message["content"] }}{% elif message["role"] == "assistant" %}{{ "assistant: " + message["content"] }}{% endif %}{% endfor %}{% if add_generation_prompt %}{{ "assistant: " }}{% endif %}',
+        };
   }
 
   @override
@@ -845,6 +848,43 @@ void main() {
         expect(chunks.last.choices.first.finishReason, equals('stop'));
       },
     );
+
+    test('create streams Gemma 4 thought blocks as thinking deltas', () async {
+      final gemmaBackend = MockLlamaBackend(
+        modelMetadataResponse: const {
+          'llm.context_length': '4096',
+          'tokenizer.chat_template':
+              '<|turn>user\n{{ messages[0]["content"] }}<turn|>{% if add_generation_prompt %}<|turn>model\n{% endif %}',
+        },
+      );
+      final gemmaEngine = LlamaEngine(gemmaBackend);
+      gemmaBackend.generationChunks = const [
+        '<|chan',
+        'nel>thought\npl',
+        'an first<chan',
+        'nel|>Final answer.',
+      ];
+
+      await gemmaEngine.loadModel('gemma4-test.gguf');
+
+      final chunks = await gemmaEngine.create(const [
+        LlamaChatMessage.fromText(role: LlamaChatRole.user, text: 'hi'),
+      ]).toList();
+
+      final streamedContent = chunks
+          .map((chunk) => chunk.choices.first.delta.content)
+          .whereType<String>()
+          .join();
+      final streamedThinking = chunks
+          .map((chunk) => chunk.choices.first.delta.thinking)
+          .whereType<String>()
+          .join();
+
+      expect(streamedThinking, equals('plan first'));
+      expect(streamedContent, equals('Final answer.'));
+      expect(streamedContent, isNot(contains('thought')));
+      expect(chunks.last.choices.first.finishReason, equals('stop'));
+    });
 
     test('create handles many plain chunks when tools are enabled', () async {
       backend.generationChunks = List<String>.filled(80, 'a');


### PR DESCRIPTION
## Summary
- Route Gemma 4 `<|channel>thought` stream blocks into `delta.thinking` instead of `delta.content`.
- Add an engine regression test for split Gemma 4 channel markers during streaming.
- Validate the fix against a live Gemma 4 GGUF stream.

Fixes #107

## Testing
- `dart format --output=none --set-exit-if-changed .`
- `dart analyze`
- `dart test -p vm -j 1 --exclude-tags local-only`
- Live model check with `gemma-4-E2B-it-Q4_K_S.gguf`: `thinking_chunks: 22`, `content_chunks: 1`, `content_contains_channel_token: false`