### PR TITLE
chore(release): prepare 0.6.11

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,16 @@
 ## Unreleased
 
+## 0.6.11
+
+* **Native runtime syncs**:
+  * Updated native hook pinning and regenerated bindings through `leehack/llamadart-native@b8955`.
+* **Gemma 4 streaming fix**:
+  * Parsed streamed `<|channel>thought ... <channel|>` blocks into thinking deltas instead of leaking Gemma 4 thought markers into content output.
+  * Added engine coverage for Gemma 4 thought-channel chunks split across native stream boundaries.
+* **Release stability**:
+  * Tracked the chat app lockfile so generated Flutter plugin metadata stays stable in CI and release validation.
+* **Compatibility note**: no public API breaking changes in `0.6.11`.
+
 ## 0.6.10
 
 * **Native runtime syncs**:

--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@
 
 ```yaml
 dependencies:
-  llamadart: ^0.6.10
+  llamadart: ^0.6.11
 ```
 
 ### 2. Run with defaults
@@ -134,7 +134,7 @@ Note: embedding support depends on backend/runtime capabilities.
 <details>
 <summary>Full module matrix (available modules by target)</summary>
 
-Backend module matrix from pinned native tag `b8638`:
+Backend module matrix from pinned native tag `b8955`:
 
 | Target | Available backend modules in bundle |
 |--------|-------------------------------------|

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: llamadart
 description: A Dart/Flutter plugin for llama.cpp - run LLM inference on any platform using GGUF models
-version: 0.6.10
+version: 0.6.11
 homepage: https://github.com/leehack/llamadart
 repository: https://github.com/leehack/llamadart
 issue_tracker: https://github.com/leehack/llamadart/issues

--- a/website/docs/changelog/recent-releases.md
+++ b/website/docs/changelog/recent-releases.md
@@ -7,6 +7,17 @@ For canonical full release notes, use:
 
 - [`CHANGELOG.md`](https://github.com/leehack/llamadart/blob/main/CHANGELOG.md)
 
+## 0.6.11
+
+- Synced native hook pinning and regenerated bindings through
+  `leehack/llamadart-native@b8955`.
+- Fixed Gemma 4 streaming so `<|channel>thought ... <channel|>` output is
+  emitted as thinking deltas instead of content text, including when channel
+  markers are split across streamed chunks.
+- Tracked the chat app lockfile for stable generated Flutter plugin metadata in
+  CI and release validation.
+- Compatibility note: no public API breaking changes in `0.6.11`.
+
 ## 0.6.10
 
 - Synced native hook pinning and regenerated bindings through

--- a/website/docs/getting-started/installation.md
+++ b/website/docs/getting-started/installation.md
@@ -25,7 +25,7 @@ configurations.
 
 ```yaml
 dependencies:
-  llamadart: ^0.6.10
+  llamadart: ^0.6.11
 ```
 
 Then resolve packages:

--- a/website/docs/guides/chat-template-and-parsing.md
+++ b/website/docs/guides/chat-template-and-parsing.md
@@ -68,6 +68,10 @@ Built-in handlers include newer formats such as Gemma 4. In practice that means
 - `<|channel>thought ... <channel|>` reasoning output,
 - `<|tool_call>call:name{args}<tool_call|>` tool-call envelopes.
 
+Gemma 4 thought-channel output is parsed incrementally during streaming, so
+`chunk.choices.first.delta.thinking` carries reasoning text while
+`chunk.choices.first.delta.content` remains reserved for final answer content.
+
 ## Custom template overrides
 
 For application code, the supported customization path is `customTemplate` on

--- a/website/docs/guides/generation-and-streaming.md
+++ b/website/docs/guides/generation-and-streaming.md
@@ -61,6 +61,11 @@ await for (final chunk in engine.create(
   messages,
   params: const GenerationParams(maxTokens: 128, topP: 0.95),
 )) {
+  final thinking = chunk.choices.first.delta.thinking;
+  if (thinking != null) {
+    print('[thinking] $thinking');
+  }
+
   final text = chunk.choices.first.delta.content;
   if (text != null) {
     print(text);

--- a/website/docs/platforms/support-matrix.md
+++ b/website/docs/platforms/support-matrix.md
@@ -6,7 +6,7 @@ description: Check which native and web backends are supported by llamadart and 
 This page combines platform support and backend-module configuration for
 `llamadart`.
 
-The native-assets hook currently pins `llamadart-native` tag `b8638`
+The native-assets hook currently pins `llamadart-native` tag `b8955`
 (`hook/build.dart`). Module availability below is for that pinned tag.
 
 ## Platform/architecture coverage
@@ -30,7 +30,7 @@ All iOS targets above require the consuming Flutter/Xcode project to use a
 minimum deployment target of `16.4` or newer (for example
 `platform :ios, '16.4'`).
 
-## Current module availability by bundle (`b8638`)
+## Current module availability by bundle (`b8955`)
 
 | Bundle key | Available backend modules in bundle |
 | --- | --- |


### PR DESCRIPTION
## Summary
- Bump package release metadata and install snippets to `0.6.11`.
- Document the native runtime sync through `llamadart-native@b8955`.
- Add release notes and docs for Gemma 4 streamed thinking deltas.

## Validation
- `dart format --output=none --set-exit-if-changed .`
- `dart analyze`
- `dart test -p vm -j 1 --exclude-tags local-only`
- `./tool/docs/build_site.sh`
- `./tool/docs/validate_links.sh`
- `dart pub publish --dry-run`