### PR TITLE
fix(native): test b9016 runtime and expose mainGpu

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,10 @@
   * Added `ModelParams.splitMode` and wired it to llama.cpp
     `llama_model_params.split_mode`, enabling explicit single-GPU selection
     with `ModelSplitMode.none`.
+* **Windows split-bundle loader fix**:
+  * Resolved ggml backend registry/device APIs from the loaded ggml runtime DLL
+    when the generated default FFI asset cannot see those symbols, restoring
+    explicit Vulkan device selection in Windows split bundles.
 * **Compatibility note**: no public API breaking changes.
 
 ## 0.6.11

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,16 @@
 ## Unreleased
 
+* **Native runtime sync**:
+  * Updated native hook pinning to `leehack/llamadart-native@b9016`,
+    picking up the CUDA 12.8 Blackwell-capable native bundles.
+* **GPU device selection API**:
+  * Added `ModelParams.mainGpu` and wired it to llama.cpp
+    `llama_model_params.main_gpu`.
+  * Added `ModelParams.splitMode` and wired it to llama.cpp
+    `llama_model_params.split_mode`, enabling explicit single-GPU selection
+    with `ModelSplitMode.none`.
+* **Compatibility note**: no public API breaking changes.
+
 ## 0.6.11
 
 * **Native runtime syncs**:

--- a/README.md
+++ b/README.md
@@ -233,6 +233,11 @@ Notes:
 - `ModelParams.batchSize` (`n_batch`) and `ModelParams.microBatchSize` (`n_ubatch`) can be set independently for memory/performance tuning; defaults keep legacy behavior (`n_batch = n_ctx`, `n_ubatch = n_batch`).
 - Apple targets are intentionally non-configurable in this hook path and use consolidated native libraries.
 - The native-assets hook refreshes emitted files each build; if you change `hooks.user_defines` or are upgrading from older cached outputs, run `flutter clean && flutter pub get` before rebuilding.
+- Some Vulkan drivers can crash when probing cooperative matrix support. This
+  is a driver-side failure in the Vulkan property query path, not a llamadart
+  loader failure. Use upstream ggml-vulkan's opt-out environment variables
+  before starting the process:
+  `GGML_VK_DISABLE_COOPMAT=1` and `GGML_VK_DISABLE_COOPMAT2=1`.
 
 If you change `llamadart_native_backends`, run `flutter clean` once so stale native-asset outputs do not override new bundle selection.
 

--- a/README.md
+++ b/README.md
@@ -228,7 +228,8 @@ Notes:
 - `example/chat_app` active backend status reflects the effective backend used for model load (for example `CPU` when GPU fallback is applied).
 - `example/chat_app` exposes `Auto` only on web; native selectors list concrete backend options.
 - CPU mode (`preferredBackend: cpu` or effective `gpuLayers == 0`) also disables context-time GPU offload so context creation stays CPU-only.
-- `ModelParams.mainGpu` passes through to llama.cpp `main_gpu` for explicit primary GPU selection on native backends.
+- `ModelParams.splitMode` passes through to llama.cpp `split_mode`; it defaults to upstream `layer` behavior.
+- `ModelParams.mainGpu` passes through to llama.cpp `main_gpu`. To select one GPU for the full model, use `splitMode: ModelSplitMode.none` with the desired `mainGpu` index.
 - `ModelParams.batchSize` (`n_batch`) and `ModelParams.microBatchSize` (`n_ubatch`) can be set independently for memory/performance tuning; defaults keep legacy behavior (`n_batch = n_ctx`, `n_ubatch = n_batch`).
 - Apple targets are intentionally non-configurable in this hook path and use consolidated native libraries.
 - The native-assets hook refreshes emitted files each build; if you change `hooks.user_defines` or are upgrading from older cached outputs, run `flutter clean && flutter pub get` before rebuilding.

--- a/README.md
+++ b/README.md
@@ -134,7 +134,7 @@ Note: embedding support depends on backend/runtime capabilities.
 <details>
 <summary>Full module matrix (available modules by target)</summary>
 
-Backend module matrix from pinned native tag `b8955`:
+Backend module matrix from pinned native tag `b9016`:
 
 | Target | Available backend modules in bundle |
 |--------|-------------------------------------|
@@ -228,6 +228,7 @@ Notes:
 - `example/chat_app` active backend status reflects the effective backend used for model load (for example `CPU` when GPU fallback is applied).
 - `example/chat_app` exposes `Auto` only on web; native selectors list concrete backend options.
 - CPU mode (`preferredBackend: cpu` or effective `gpuLayers == 0`) also disables context-time GPU offload so context creation stays CPU-only.
+- `ModelParams.mainGpu` passes through to llama.cpp `main_gpu` for explicit primary GPU selection on native backends.
 - `ModelParams.batchSize` (`n_batch`) and `ModelParams.microBatchSize` (`n_ubatch`) can be set independently for memory/performance tuning; defaults keep legacy behavior (`n_batch = n_ctx`, `n_ubatch = n_batch`).
 - Apple targets are intentionally non-configurable in this hook path and use consolidated native libraries.
 - The native-assets hook refreshes emitted files each build; if you change `hooks.user_defines` or are upgrading from older cached outputs, run `flutter clean && flutter pub get` before rebuilding.

--- a/hook/build.dart
+++ b/hook/build.dart
@@ -9,7 +9,7 @@ import 'package:path/path.dart' as path;
 
 import 'package:llamadart/src/hook/native_bundle_config.dart';
 
-const _llamaCppTag = 'b8955';
+const _llamaCppTag = 'b9016';
 const _nativeRepoSlug = 'leehack/llamadart-native';
 const _baseUrl =
     'https://github.com/$_nativeRepoSlug/releases/download/$_llamaCppTag';

--- a/lib/src/backends/llama_cpp/llama_cpp_service.dart
+++ b/lib/src/backends/llama_cpp/llama_cpp_service.dart
@@ -26,6 +26,33 @@ typedef _GgmlBackendScoreNative = Int32 Function();
 typedef _GgmlBackendScoreDart = int Function();
 typedef _GgmlBackendRegisterNative = Void Function(ggml_backend_reg_t);
 typedef _GgmlBackendRegisterDart = void Function(ggml_backend_reg_t);
+typedef _GgmlBackendRegCountNative = Size Function();
+typedef _GgmlBackendRegCountDart = int Function();
+typedef _GgmlBackendRegGetNative = ggml_backend_reg_t Function(Size);
+typedef _GgmlBackendRegGetDart = ggml_backend_reg_t Function(int);
+typedef _GgmlBackendRegNameNative = Pointer<Char> Function(ggml_backend_reg_t);
+typedef _GgmlBackendRegNameDart = Pointer<Char> Function(ggml_backend_reg_t);
+typedef _GgmlBackendRegByNameNative =
+    ggml_backend_reg_t Function(Pointer<Char>);
+typedef _GgmlBackendRegByNameDart = ggml_backend_reg_t Function(Pointer<Char>);
+typedef _GgmlBackendRegDevCountNative = Size Function(ggml_backend_reg_t);
+typedef _GgmlBackendRegDevCountDart = int Function(ggml_backend_reg_t);
+typedef _GgmlBackendRegDevGetNative =
+    ggml_backend_dev_t Function(ggml_backend_reg_t, Size);
+typedef _GgmlBackendRegDevGetDart =
+    ggml_backend_dev_t Function(ggml_backend_reg_t, int);
+typedef _GgmlBackendDevCountNative = Size Function();
+typedef _GgmlBackendDevCountDart = int Function();
+typedef _GgmlBackendDevGetNative = ggml_backend_dev_t Function(Size);
+typedef _GgmlBackendDevGetDart = ggml_backend_dev_t Function(int);
+typedef _GgmlBackendDevNameNative = Pointer<Char> Function(ggml_backend_dev_t);
+typedef _GgmlBackendDevNameDart = Pointer<Char> Function(ggml_backend_dev_t);
+typedef _GgmlBackendDevBackendRegNative =
+    ggml_backend_reg_t Function(ggml_backend_dev_t);
+typedef _GgmlBackendDevBackendRegDart =
+    ggml_backend_reg_t Function(ggml_backend_dev_t);
+typedef _GgmlBackendDevByTypeNative = ggml_backend_dev_t Function(UnsignedInt);
+typedef _GgmlBackendDevByTypeDart = ggml_backend_dev_t Function(int);
 typedef _LlamaDartSetLogLevelNative = Void Function(Int32);
 typedef _LlamaDartSetLogLevelDart = void Function(int);
 typedef _MtmdDefaultMarkerNative = Pointer<Char> Function();
@@ -165,10 +192,22 @@ class LlamaCppService {
   bool _linuxRuntimeDepsPrepared = false;
   String? _linuxPreparedLibraryDirectory;
   bool _ggmlFallbackLookupAttempted = false;
+  String? _ggmlFallbackLookupSearchKey;
   _GgmlBackendLoadDart? _ggmlBackendLoadFallback;
   _GgmlBackendLoadAllDart? _ggmlBackendLoadAllFallback;
   _GgmlBackendLoadAllFromPathDart? _ggmlBackendLoadAllFromPathFallback;
   _GgmlBackendRegisterDart? _ggmlBackendRegisterFallback;
+  _GgmlBackendRegCountDart? _ggmlBackendRegCountFallback;
+  _GgmlBackendRegGetDart? _ggmlBackendRegGetFallback;
+  _GgmlBackendRegNameDart? _ggmlBackendRegNameFallback;
+  _GgmlBackendRegByNameDart? _ggmlBackendRegByNameFallback;
+  _GgmlBackendRegDevCountDart? _ggmlBackendRegDevCountFallback;
+  _GgmlBackendRegDevGetDart? _ggmlBackendRegDevGetFallback;
+  _GgmlBackendDevCountDart? _ggmlBackendDevCountFallback;
+  _GgmlBackendDevGetDart? _ggmlBackendDevGetFallback;
+  _GgmlBackendDevNameDart? _ggmlBackendDevNameFallback;
+  _GgmlBackendDevBackendRegDart? _ggmlBackendDevBackendRegFallback;
+  _GgmlBackendDevByTypeDart? _ggmlBackendDevByTypeFallback;
   bool _logLevelFallbackLookupAttempted = false;
   String? _logLevelFallbackLookupSearchKey;
   _LlamaDartSetLogLevelDart? _llamaDartSetLogLevelFallback;
@@ -457,7 +496,7 @@ class LlamaCppService {
       _tryLoadBackendModule('cpu');
     }
 
-    if (_backendRegistryOr<int>(0, ggml_backend_reg_count) == 0) {
+    if (_ggmlBackendRegCount() == 0) {
       // Fallback path: attempt to load CPU backend by filename resolution.
       _tryLoadBackendModule('cpu');
     }
@@ -1636,11 +1675,6 @@ class LlamaCppService {
   }
 
   void _resolveGgmlFallbackFunctions() {
-    if (_ggmlFallbackLookupAttempted) {
-      return;
-    }
-    _ggmlFallbackLookupAttempted = true;
-
     final fileNameCandidates = _ggmlLibraryCandidateFileNames();
     final candidates = <String>[..._ggmlAssetUriCandidates()];
     final filesystemCandidates = <String>{};
@@ -1653,6 +1687,14 @@ class LlamaCppService {
     // Keep bare-name fallback last so module-dir resolution wins when present.
     filesystemCandidates.addAll(fileNameCandidates);
     candidates.addAll(filesystemCandidates);
+
+    final searchKey = candidates.map(path.normalize).join('|');
+    if (_ggmlFallbackLookupAttempted &&
+        _ggmlFallbackLookupSearchKey == searchKey) {
+      return;
+    }
+    _ggmlFallbackLookupAttempted = true;
+    _ggmlFallbackLookupSearchKey = searchKey;
 
     final seen = <String>{};
     for (final candidate in candidates) {
@@ -1714,10 +1756,151 @@ class LlamaCppService {
         }
       }
 
+      if (_ggmlBackendRegCountFallback == null) {
+        try {
+          _ggmlBackendRegCountFallback = library
+              .lookupFunction<
+                _GgmlBackendRegCountNative,
+                _GgmlBackendRegCountDart
+              >('ggml_backend_reg_count');
+        } catch (_) {
+          // Keep searching other candidates.
+        }
+      }
+
+      if (_ggmlBackendRegGetFallback == null) {
+        try {
+          _ggmlBackendRegGetFallback = library
+              .lookupFunction<_GgmlBackendRegGetNative, _GgmlBackendRegGetDart>(
+                'ggml_backend_reg_get',
+              );
+        } catch (_) {
+          // Keep searching other candidates.
+        }
+      }
+
+      if (_ggmlBackendRegNameFallback == null) {
+        try {
+          _ggmlBackendRegNameFallback = library
+              .lookupFunction<
+                _GgmlBackendRegNameNative,
+                _GgmlBackendRegNameDart
+              >('ggml_backend_reg_name');
+        } catch (_) {
+          // Keep searching other candidates.
+        }
+      }
+
+      if (_ggmlBackendRegByNameFallback == null) {
+        try {
+          _ggmlBackendRegByNameFallback = library
+              .lookupFunction<
+                _GgmlBackendRegByNameNative,
+                _GgmlBackendRegByNameDart
+              >('ggml_backend_reg_by_name');
+        } catch (_) {
+          // Keep searching other candidates.
+        }
+      }
+
+      if (_ggmlBackendRegDevCountFallback == null) {
+        try {
+          _ggmlBackendRegDevCountFallback = library
+              .lookupFunction<
+                _GgmlBackendRegDevCountNative,
+                _GgmlBackendRegDevCountDart
+              >('ggml_backend_reg_dev_count');
+        } catch (_) {
+          // Keep searching other candidates.
+        }
+      }
+
+      if (_ggmlBackendRegDevGetFallback == null) {
+        try {
+          _ggmlBackendRegDevGetFallback = library
+              .lookupFunction<
+                _GgmlBackendRegDevGetNative,
+                _GgmlBackendRegDevGetDart
+              >('ggml_backend_reg_dev_get');
+        } catch (_) {
+          // Keep searching other candidates.
+        }
+      }
+
+      if (_ggmlBackendDevCountFallback == null) {
+        try {
+          _ggmlBackendDevCountFallback = library
+              .lookupFunction<
+                _GgmlBackendDevCountNative,
+                _GgmlBackendDevCountDart
+              >('ggml_backend_dev_count');
+        } catch (_) {
+          // Keep searching other candidates.
+        }
+      }
+
+      if (_ggmlBackendDevGetFallback == null) {
+        try {
+          _ggmlBackendDevGetFallback = library
+              .lookupFunction<_GgmlBackendDevGetNative, _GgmlBackendDevGetDart>(
+                'ggml_backend_dev_get',
+              );
+        } catch (_) {
+          // Keep searching other candidates.
+        }
+      }
+
+      if (_ggmlBackendDevNameFallback == null) {
+        try {
+          _ggmlBackendDevNameFallback = library
+              .lookupFunction<
+                _GgmlBackendDevNameNative,
+                _GgmlBackendDevNameDart
+              >('ggml_backend_dev_name');
+        } catch (_) {
+          // Keep searching other candidates.
+        }
+      }
+
+      if (_ggmlBackendDevBackendRegFallback == null) {
+        try {
+          _ggmlBackendDevBackendRegFallback = library
+              .lookupFunction<
+                _GgmlBackendDevBackendRegNative,
+                _GgmlBackendDevBackendRegDart
+              >('ggml_backend_dev_backend_reg');
+        } catch (_) {
+          // Keep searching other candidates.
+        }
+      }
+
+      if (_ggmlBackendDevByTypeFallback == null) {
+        try {
+          _ggmlBackendDevByTypeFallback = library
+              .lookupFunction<
+                _GgmlBackendDevByTypeNative,
+                _GgmlBackendDevByTypeDart
+              >('ggml_backend_dev_by_type');
+        } catch (_) {
+          // Keep searching other candidates.
+        }
+      }
+
       if (_ggmlBackendLoadFallback != null &&
           _ggmlBackendLoadAllFallback != null &&
           _ggmlBackendLoadAllFromPathFallback != null &&
-          _ggmlBackendRegisterFallback != null) {
+          _ggmlBackendRegisterFallback != null &&
+          _ggmlBackendRegCountFallback != null &&
+          _ggmlBackendRegGetFallback != null &&
+          _ggmlBackendRegNameFallback != null &&
+          _ggmlBackendRegByNameFallback != null &&
+          _ggmlBackendRegDevCountFallback != null &&
+          _ggmlBackendRegDevGetFallback != null &&
+          _ggmlBackendDevCountFallback != null &&
+          _ggmlBackendDevGetFallback != null &&
+          _ggmlBackendDevNameFallback != null &&
+          _ggmlBackendDevBackendRegFallback != null &&
+          _ggmlBackendDevByTypeFallback != null) {
         return;
       }
     }
@@ -1989,16 +2172,122 @@ class LlamaCppService {
     }
   }
 
-  T _backendRegistryOr<T>(T fallback, T Function() call) {
+  T _ggmlRegistryFallbackOr<T>(
+    T fallback,
+    T Function() primaryCall,
+    T? Function() fallbackCall,
+  ) {
+    if (Platform.isWindows) {
+      // Windows split bundles can expose ggml registry state through ggml.dll
+      // while the generated default asset points at llama.dll. Prefer the
+      // explicit ggml runtime lookup when it is available so count/get/name
+      // calls all read the same registry.
+      _resolveGgmlFallbackFunctions();
+      final fallbackValue = fallbackCall();
+      if (fallbackValue != null) {
+        return fallbackValue;
+      }
+    }
+
     try {
-      return call();
+      return primaryCall();
     } on ArgumentError {
-      // Some split bundles may omit a subset of registry symbols on the
-      // primary lookup target. Treat this call as unavailable, but continue
-      // attempting other registry APIs that may still be present.
+      _resolveGgmlFallbackFunctions();
+      final fallbackValue = fallbackCall();
+      if (fallbackValue != null) {
+        return fallbackValue;
+      }
       _backendRegistrySymbolUnavailable = true;
       return fallback;
     }
+  }
+
+  int _ggmlBackendRegCount() {
+    return _ggmlRegistryFallbackOr<int>(
+      0,
+      ggml_backend_reg_count,
+      () => _ggmlBackendRegCountFallback?.call(),
+    );
+  }
+
+  ggml_backend_reg_t _ggmlBackendRegGet(int index) {
+    return _ggmlRegistryFallbackOr<ggml_backend_reg_t>(
+      nullptr,
+      () => ggml_backend_reg_get(index),
+      () => _ggmlBackendRegGetFallback?.call(index),
+    );
+  }
+
+  Pointer<Char> _ggmlBackendRegName(ggml_backend_reg_t reg) {
+    return _ggmlRegistryFallbackOr<Pointer<Char>>(
+      nullptr,
+      () => ggml_backend_reg_name(reg),
+      () => _ggmlBackendRegNameFallback?.call(reg),
+    );
+  }
+
+  ggml_backend_reg_t _ggmlBackendRegByName(Pointer<Char> name) {
+    return _ggmlRegistryFallbackOr<ggml_backend_reg_t>(
+      nullptr,
+      () => ggml_backend_reg_by_name(name),
+      () => _ggmlBackendRegByNameFallback?.call(name),
+    );
+  }
+
+  int _ggmlBackendRegDevCount(ggml_backend_reg_t reg) {
+    return _ggmlRegistryFallbackOr<int>(
+      0,
+      () => ggml_backend_reg_dev_count(reg),
+      () => _ggmlBackendRegDevCountFallback?.call(reg),
+    );
+  }
+
+  ggml_backend_dev_t _ggmlBackendRegDevGet(ggml_backend_reg_t reg, int index) {
+    return _ggmlRegistryFallbackOr<ggml_backend_dev_t>(
+      nullptr,
+      () => ggml_backend_reg_dev_get(reg, index),
+      () => _ggmlBackendRegDevGetFallback?.call(reg, index),
+    );
+  }
+
+  int _ggmlBackendDevCount() {
+    return _ggmlRegistryFallbackOr<int>(
+      0,
+      ggml_backend_dev_count,
+      () => _ggmlBackendDevCountFallback?.call(),
+    );
+  }
+
+  ggml_backend_dev_t _ggmlBackendDevGet(int index) {
+    return _ggmlRegistryFallbackOr<ggml_backend_dev_t>(
+      nullptr,
+      () => ggml_backend_dev_get(index),
+      () => _ggmlBackendDevGetFallback?.call(index),
+    );
+  }
+
+  Pointer<Char> _ggmlBackendDevName(ggml_backend_dev_t dev) {
+    return _ggmlRegistryFallbackOr<Pointer<Char>>(
+      nullptr,
+      () => ggml_backend_dev_name(dev),
+      () => _ggmlBackendDevNameFallback?.call(dev),
+    );
+  }
+
+  ggml_backend_reg_t _ggmlBackendDevBackendReg(ggml_backend_dev_t dev) {
+    return _ggmlRegistryFallbackOr<ggml_backend_reg_t>(
+      nullptr,
+      () => ggml_backend_dev_backend_reg(dev),
+      () => _ggmlBackendDevBackendRegFallback?.call(dev),
+    );
+  }
+
+  ggml_backend_dev_t _ggmlBackendDevByType(ggml_backend_dev_type type) {
+    return _ggmlRegistryFallbackOr<ggml_backend_dev_t>(
+      nullptr,
+      () => ggml_backend_dev_by_type(type),
+      () => _ggmlBackendDevByTypeFallback?.call(type.value),
+    );
   }
 
   static String _backendLibraryFileName(String backend) {
@@ -2033,19 +2322,13 @@ class LlamaCppService {
 
   String _backendDiagnostics() {
     final regs = <String>[];
-    final regCount = _backendRegistryOr<int>(0, ggml_backend_reg_count);
+    final regCount = _ggmlBackendRegCount();
     for (var i = 0; i < regCount; i++) {
-      final reg = _backendRegistryOr<ggml_backend_reg_t>(
-        nullptr,
-        () => ggml_backend_reg_get(i),
-      );
+      final reg = _ggmlBackendRegGet(i);
       if (reg == nullptr) {
         continue;
       }
-      final regNamePtr = _backendRegistryOr<Pointer<Char>>(
-        nullptr,
-        () => ggml_backend_reg_name(reg),
-      );
+      final regNamePtr = _ggmlBackendRegName(reg);
       if (regNamePtr == nullptr) {
         continue;
       }
@@ -2078,11 +2361,8 @@ class LlamaCppService {
       case GpuBackend.auto:
         return null;
       case GpuBackend.cpu:
-        final cpuDev = _backendRegistryOr<ggml_backend_dev_t>(
-          nullptr,
-          () => ggml_backend_dev_by_type(
-            ggml_backend_dev_type.GGML_BACKEND_DEVICE_TYPE_CPU,
-          ),
+        final cpuDev = _ggmlBackendDevByType(
+          ggml_backend_dev_type.GGML_BACKEND_DEVICE_TYPE_CPU,
         );
         if (cpuDev == nullptr) {
           return null;
@@ -2106,28 +2386,19 @@ class LlamaCppService {
   List<ggml_backend_dev_t>? _devicesForBackendRegName(String regName) {
     final regNamePtr = regName.toNativeUtf8();
     try {
-      final reg = _backendRegistryOr<ggml_backend_reg_t>(
-        nullptr,
-        () => ggml_backend_reg_by_name(regNamePtr.cast()),
-      );
+      final reg = _ggmlBackendRegByName(regNamePtr.cast());
       if (reg == nullptr) {
         return null;
       }
 
-      final count = _backendRegistryOr<int>(
-        0,
-        () => ggml_backend_reg_dev_count(reg),
-      );
+      final count = _ggmlBackendRegDevCount(reg);
       if (count <= 0) {
         return null;
       }
 
       final devices = <ggml_backend_dev_t>[];
       for (var i = 0; i < count; i++) {
-        final dev = _backendRegistryOr<ggml_backend_dev_t>(
-          nullptr,
-          () => ggml_backend_reg_dev_get(reg, i),
-        );
+        final dev = _ggmlBackendRegDevGet(reg, i);
         if (dev != nullptr) {
           devices.add(dev);
         }
@@ -3800,32 +4071,20 @@ class LlamaCppService {
 
   /// Returns information about currently initialized backend devices.
   List<String> getBackendInfo() {
-    final count = _backendRegistryOr<int>(0, ggml_backend_dev_count);
+    final count = _ggmlBackendDevCount();
     final devices = <String>{};
     for (var i = 0; i < count; i++) {
-      final dev = _backendRegistryOr<ggml_backend_dev_t>(
-        nullptr,
-        () => ggml_backend_dev_get(i),
-      );
+      final dev = _ggmlBackendDevGet(i);
       if (dev == nullptr) continue;
 
-      final devNamePtr = _backendRegistryOr<Pointer<Char>>(
-        nullptr,
-        () => ggml_backend_dev_name(dev),
-      );
+      final devNamePtr = _ggmlBackendDevName(dev);
       if (devNamePtr == nullptr) continue;
       final devName = devNamePtr.cast<Utf8>().toDartString();
 
       String label = devName;
-      final reg = _backendRegistryOr<ggml_backend_reg_t>(
-        nullptr,
-        () => ggml_backend_dev_backend_reg(dev),
-      );
+      final reg = _ggmlBackendDevBackendReg(dev);
       if (reg != nullptr) {
-        final regNamePtr = _backendRegistryOr<Pointer<Char>>(
-          nullptr,
-          () => ggml_backend_reg_name(reg),
-        );
+        final regNamePtr = _ggmlBackendRegName(reg);
         if (regNamePtr != nullptr) {
           final regName = regNamePtr.cast<Utf8>().toDartString();
           if (regName.toLowerCase() == devName.toLowerCase()) {

--- a/lib/src/backends/llama_cpp/llama_cpp_service.dart
+++ b/lib/src/backends/llama_cpp/llama_cpp_service.dart
@@ -1226,6 +1226,7 @@ class LlamaCppService {
     );
 
     mparams.n_gpu_layers = gpuLayers;
+    mparams.split_modeAsInt = modelParams.splitMode.llamaCppValue;
     mparams.main_gpu = modelParams.mainGpu;
     mparams.use_mmap = true;
     if (preferredDevices != null) {

--- a/lib/src/backends/llama_cpp/llama_cpp_service.dart
+++ b/lib/src/backends/llama_cpp/llama_cpp_service.dart
@@ -1226,6 +1226,7 @@ class LlamaCppService {
     );
 
     mparams.n_gpu_layers = gpuLayers;
+    mparams.main_gpu = modelParams.mainGpu;
     mparams.use_mmap = true;
     if (preferredDevices != null) {
       mparams.devices = preferredDevices;

--- a/lib/src/core/models/inference/model_params.dart
+++ b/lib/src/core/models/inference/model_params.dart
@@ -16,7 +16,7 @@ import '../config/lora_config.dart';
 /// final params = ModelParams(
 ///   contextSize: 4096,
 ///   gpuLayers: 33, // Offload 33 layers to GPU
-///   logLevel: LlamaLogLevel.info,
+///   mainGpu: 1, // Use the second GPU device as the primary device
 /// );
 /// await engine.loadModel('path/to/model.gguf', modelParams: params);
 /// ```
@@ -29,6 +29,13 @@ class ModelParams {
 
   /// Preferred GPU backend for inference.
   final GpuBackend preferredBackend;
+
+  /// Primary GPU device index for model loading.
+  ///
+  /// This is passed through to llama.cpp `llama_model_params.main_gpu`.
+  /// Backend-specific device ordering is defined by llama.cpp and the active
+  /// backend. Defaults to 0 to preserve llama.cpp's default behavior.
+  final int mainGpu;
 
   /// Initial LoRA adapters to load along with the model.
   final List<LoraAdapterConfig> loras;
@@ -78,6 +85,7 @@ class ModelParams {
     this.contextSize = 4096,
     this.gpuLayers = maxGpuLayers,
     this.preferredBackend = GpuBackend.auto,
+    this.mainGpu = 0,
     this.loras = const [],
     this.chatTemplate,
     this.numberOfThreads = 0,
@@ -92,6 +100,7 @@ class ModelParams {
     int? contextSize,
     int? gpuLayers,
     GpuBackend? preferredBackend,
+    int? mainGpu,
     List<LoraAdapterConfig>? loras,
     String? chatTemplate,
     int? numberOfThreads,
@@ -104,6 +113,7 @@ class ModelParams {
       contextSize: contextSize ?? this.contextSize,
       gpuLayers: gpuLayers ?? this.gpuLayers,
       preferredBackend: preferredBackend ?? this.preferredBackend,
+      mainGpu: mainGpu ?? this.mainGpu,
       loras: loras ?? this.loras,
       chatTemplate: chatTemplate ?? this.chatTemplate,
       numberOfThreads: numberOfThreads ?? this.numberOfThreads,

--- a/lib/src/core/models/inference/model_params.dart
+++ b/lib/src/core/models/inference/model_params.dart
@@ -2,6 +2,30 @@ import '../config/gpu_backend.dart';
 
 import '../config/lora_config.dart';
 
+/// Strategy for distributing model tensors across GPU devices.
+///
+/// Mirrors llama.cpp `llama_split_mode`. The default, [layer], preserves
+/// upstream behavior.
+enum ModelSplitMode {
+  /// Use a single GPU selected by [ModelParams.mainGpu].
+  none(0),
+
+  /// Split layers and KV cache across GPUs.
+  layer(1),
+
+  /// Split layers and KV cache across GPUs, with row-level tensor splitting
+  /// where supported by the backend.
+  row(2),
+
+  /// Use tensor parallelism where supported by the backend and model.
+  tensor(3);
+
+  /// Native llama.cpp enum value.
+  final int llamaCppValue;
+
+  const ModelSplitMode(this.llamaCppValue);
+}
+
 /// Configuration parameters for loading a Llama model.
 ///
 /// These parameters affect the initial model loading and context allocation.
@@ -16,7 +40,8 @@ import '../config/lora_config.dart';
 /// final params = ModelParams(
 ///   contextSize: 4096,
 ///   gpuLayers: 33, // Offload 33 layers to GPU
-///   mainGpu: 1, // Use the second GPU device as the primary device
+///   splitMode: ModelSplitMode.none,
+///   mainGpu: 1, // Use the second GPU device for the full model
 /// );
 /// await engine.loadModel('path/to/model.gguf', modelParams: params);
 /// ```
@@ -30,11 +55,20 @@ class ModelParams {
   /// Preferred GPU backend for inference.
   final GpuBackend preferredBackend;
 
+  /// Model tensor distribution strategy across GPU devices.
+  ///
+  /// This is passed through to llama.cpp `llama_model_params.split_mode`.
+  /// Defaults to [ModelSplitMode.layer] to preserve llama.cpp's default
+  /// behavior.
+  final ModelSplitMode splitMode;
+
   /// Primary GPU device index for model loading.
   ///
   /// This is passed through to llama.cpp `llama_model_params.main_gpu`.
   /// Backend-specific device ordering is defined by llama.cpp and the active
-  /// backend. Defaults to 0 to preserve llama.cpp's default behavior.
+  /// backend. Upstream llama.cpp uses this value to select the single GPU when
+  /// [splitMode] is [ModelSplitMode.none]. Defaults to 0 to preserve
+  /// llama.cpp's default behavior.
   final int mainGpu;
 
   /// Initial LoRA adapters to load along with the model.
@@ -85,6 +119,7 @@ class ModelParams {
     this.contextSize = 4096,
     this.gpuLayers = maxGpuLayers,
     this.preferredBackend = GpuBackend.auto,
+    this.splitMode = ModelSplitMode.layer,
     this.mainGpu = 0,
     this.loras = const [],
     this.chatTemplate,
@@ -100,6 +135,7 @@ class ModelParams {
     int? contextSize,
     int? gpuLayers,
     GpuBackend? preferredBackend,
+    ModelSplitMode? splitMode,
     int? mainGpu,
     List<LoraAdapterConfig>? loras,
     String? chatTemplate,
@@ -113,6 +149,7 @@ class ModelParams {
       contextSize: contextSize ?? this.contextSize,
       gpuLayers: gpuLayers ?? this.gpuLayers,
       preferredBackend: preferredBackend ?? this.preferredBackend,
+      splitMode: splitMode ?? this.splitMode,
       mainGpu: mainGpu ?? this.mainGpu,
       loras: loras ?? this.loras,
       chatTemplate: chatTemplate ?? this.chatTemplate,

--- a/test/unit/core/models/inference/model_params_test.dart
+++ b/test/unit/core/models/inference/model_params_test.dart
@@ -9,6 +9,7 @@ void main() {
     expect(params.contextSize, 4096);
     expect(params.gpuLayers, ModelParams.maxGpuLayers);
     expect(params.preferredBackend, GpuBackend.auto);
+    expect(params.splitMode, ModelSplitMode.layer);
     expect(params.mainGpu, 0);
     expect(params.chatTemplate, isNull);
     expect(params.numberOfThreads, 0);
@@ -24,6 +25,7 @@ void main() {
     final updated = params.copyWith(
       gpuLayers: 2,
       preferredBackend: GpuBackend.metal,
+      splitMode: ModelSplitMode.none,
       mainGpu: 1,
       batchSize: 256,
       microBatchSize: 64,
@@ -33,6 +35,7 @@ void main() {
     expect(updated.contextSize, 1024);
     expect(updated.gpuLayers, 2);
     expect(updated.preferredBackend, GpuBackend.metal);
+    expect(updated.splitMode, ModelSplitMode.none);
     expect(updated.mainGpu, 1);
     expect(updated.batchSize, 256);
     expect(updated.microBatchSize, 64);
@@ -44,6 +47,7 @@ void main() {
       contextSize: 3072,
       gpuLayers: 8,
       preferredBackend: GpuBackend.cuda,
+      splitMode: ModelSplitMode.row,
       mainGpu: 2,
       chatTemplate: 'custom-template',
       numberOfThreads: 6,
@@ -58,6 +62,7 @@ void main() {
     expect(updated.contextSize, 3072);
     expect(updated.gpuLayers, 12);
     expect(updated.preferredBackend, GpuBackend.cuda);
+    expect(updated.splitMode, ModelSplitMode.row);
     expect(updated.mainGpu, 2);
     expect(updated.chatTemplate, 'custom-template');
     expect(updated.numberOfThreads, 6);

--- a/test/unit/core/models/inference/model_params_test.dart
+++ b/test/unit/core/models/inference/model_params_test.dart
@@ -9,6 +9,7 @@ void main() {
     expect(params.contextSize, 4096);
     expect(params.gpuLayers, ModelParams.maxGpuLayers);
     expect(params.preferredBackend, GpuBackend.auto);
+    expect(params.mainGpu, 0);
     expect(params.chatTemplate, isNull);
     expect(params.numberOfThreads, 0);
     expect(params.numberOfThreadsBatch, 0);
@@ -23,6 +24,7 @@ void main() {
     final updated = params.copyWith(
       gpuLayers: 2,
       preferredBackend: GpuBackend.metal,
+      mainGpu: 1,
       batchSize: 256,
       microBatchSize: 64,
       maxParallelSequences: 8,
@@ -31,6 +33,7 @@ void main() {
     expect(updated.contextSize, 1024);
     expect(updated.gpuLayers, 2);
     expect(updated.preferredBackend, GpuBackend.metal);
+    expect(updated.mainGpu, 1);
     expect(updated.batchSize, 256);
     expect(updated.microBatchSize, 64);
     expect(updated.maxParallelSequences, 8);
@@ -41,6 +44,7 @@ void main() {
       contextSize: 3072,
       gpuLayers: 8,
       preferredBackend: GpuBackend.cuda,
+      mainGpu: 2,
       chatTemplate: 'custom-template',
       numberOfThreads: 6,
       numberOfThreadsBatch: 4,
@@ -54,6 +58,7 @@ void main() {
     expect(updated.contextSize, 3072);
     expect(updated.gpuLayers, 12);
     expect(updated.preferredBackend, GpuBackend.cuda);
+    expect(updated.mainGpu, 2);
     expect(updated.chatTemplate, 'custom-template');
     expect(updated.numberOfThreads, 6);
     expect(updated.numberOfThreadsBatch, 4);

--- a/website/docs/configuration/runtime-parameters.md
+++ b/website/docs/configuration/runtime-parameters.md
@@ -19,6 +19,7 @@ await engine.loadModel(
     contextSize: 4096,
     gpuLayers: ModelParams.maxGpuLayers,
     preferredBackend: GpuBackend.vulkan,
+    splitMode: ModelSplitMode.layer,
     mainGpu: 0,
     numberOfThreads: 0,
     numberOfThreadsBatch: 0,
@@ -34,7 +35,11 @@ Important fields:
 - `contextSize`: total context window.
 - `gpuLayers`: number of layers offloaded to GPU.
 - `preferredBackend`: backend preference (`auto`, `vulkan`, `metal`, etc).
+- `splitMode`: model tensor distribution mode passed through to llama.cpp
+  `split_mode`. Defaults to upstream `layer` behavior.
 - `mainGpu`: primary GPU device index passed through to llama.cpp `main_gpu`.
+  To select one GPU for the full model, use
+  `splitMode: ModelSplitMode.none` with the desired `mainGpu` index.
 - `batchSize`: context logical batch size (`n_batch`).
 - `microBatchSize`: context micro-batch size (`n_ubatch`).
 - `maxParallelSequences`: max sequence slots (`n_seq_max`) for parallel

--- a/website/docs/configuration/runtime-parameters.md
+++ b/website/docs/configuration/runtime-parameters.md
@@ -19,6 +19,7 @@ await engine.loadModel(
     contextSize: 4096,
     gpuLayers: ModelParams.maxGpuLayers,
     preferredBackend: GpuBackend.vulkan,
+    mainGpu: 0,
     numberOfThreads: 0,
     numberOfThreadsBatch: 0,
     batchSize: 0,
@@ -33,6 +34,7 @@ Important fields:
 - `contextSize`: total context window.
 - `gpuLayers`: number of layers offloaded to GPU.
 - `preferredBackend`: backend preference (`auto`, `vulkan`, `metal`, etc).
+- `mainGpu`: primary GPU device index passed through to llama.cpp `main_gpu`.
 - `batchSize`: context logical batch size (`n_batch`).
 - `microBatchSize`: context micro-batch size (`n_ubatch`).
 - `maxParallelSequences`: max sequence slots (`n_seq_max`) for parallel

--- a/website/docs/platforms/support-matrix.md
+++ b/website/docs/platforms/support-matrix.md
@@ -6,7 +6,7 @@ description: Check which native and web backends are supported by llamadart and 
 This page combines platform support and backend-module configuration for
 `llamadart`.
 
-The native-assets hook currently pins `llamadart-native` tag `b8955`
+The native-assets hook currently pins `llamadart-native` tag `b9016`
 (`hook/build.dart`). Module availability below is for that pinned tag.
 
 ## Platform/architecture coverage
@@ -30,7 +30,7 @@ All iOS targets above require the consuming Flutter/Xcode project to use a
 minimum deployment target of `16.4` or newer (for example
 `platform :ios, '16.4'`).
 
-## Current module availability by bundle (`b8955`)
+## Current module availability by bundle (`b9016`)
 
 | Bundle key | Available backend modules in bundle |
 | --- | --- |

--- a/website/docs/platforms/support-matrix.md
+++ b/website/docs/platforms/support-matrix.md
@@ -143,6 +143,30 @@ no valid entries remain, selection falls back to `cpu_profile` (or default
 - If you change `llamadart_native_backends`, run `flutter clean` once to clear
   stale native-asset outputs.
 
+## Vulkan cooperative matrix driver crashes
+
+Some Vulkan drivers advertise cooperative matrix support but crash inside the
+Vulkan property query calls used by upstream `ggml-vulkan`. This is a driver
+failure, not a llamadart loader failure. Use upstream ggml-vulkan's opt-out
+environment variables before starting the Dart/Flutter process:
+
+```bash
+GGML_VK_DISABLE_COOPMAT=1
+GGML_VK_DISABLE_COOPMAT2=1
+```
+
+On Windows PowerShell:
+
+```powershell
+$env:GGML_VK_DISABLE_COOPMAT = "1"
+$env:GGML_VK_DISABLE_COOPMAT2 = "1"
+flutter run -d windows
+```
+
+These variables disable the cooperative matrix optimized Vulkan paths for that
+process. They can reduce Vulkan performance, so use them only when the Vulkan
+driver crashes or reports device loss in the cooperative matrix path.
+
 ## Related docs
 
 - [Native Build Hooks](./native-build-hooks)


### PR DESCRIPTION
## Summary

- Pins the native runtime hook from `b8955` to `b9016`, consuming the published `llamadart-native` release assets.
- Adds `ModelParams.mainGpu` and passes it through to `llama_model_params.main_gpu` for explicit primary GPU selection (#112).
- Adds `ModelParams.splitMode` and passes it through to `llama_model_params.split_mode`, matching upstream llama.cpp semantics for single-GPU selection via `ModelSplitMode.none`.
- Resolves ggml backend registry/device APIs from the loaded ggml runtime DLL on Windows split bundles when the generated default FFI asset cannot see those symbols.
- Documents the upstream ggml-vulkan cooperative-matrix workaround for driver crashes (`GGML_VK_DISABLE_COOPMAT`, `GGML_VK_DISABLE_COOPMAT2`).
- Updates README, website runtime-parameter docs, support matrix docs, and CHANGELOG entries for the b9016/runtime-parameter/loader changes.

## Validation

- `dart analyze`
- `dart test test/unit/core/models/inference/model_params_test.dart`
- `dart test -p vm test/unit/backends/llama_cpp/llama_cpp_service_test.dart`
- `./tool/docs/build_site.sh`
- GitHub CI passed on docs-only head `577d10a2b`.

## Issue status

- #111 CUDA / Blackwell: reporter confirmed `b9016` works on RTX 5050 Laptop with CUDA.
- #111 Vulkan / Windows split bundle: reporter confirmed the loader fix works on Windows. Diagnostics changed to `registeredBackends=[CPU, Vulkan]`, concrete Vulkan devices, and `registryApisUnavailable=false`.
- #111 Vulkan / driver crashes: remaining AMD Radeon 860M and NVIDIA RTX 5050 Laptop Vulkan crashes are in vendor cooperative-matrix property queries. Reporter confirmed `GGML_VK_DISABLE_COOPMAT` plus `GGML_VK_DISABLE_COOPMAT2` works around them; this workaround is now documented.
- #112 device-selection API: addressed at the Dart API/native wiring level with `mainGpu` plus `splitMode`.
