### PR TITLE
Filter backend-owned runtime DLLs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,12 @@
   * Resolved ggml backend registry/device APIs from the loaded ggml runtime DLL
     when the generated default FFI asset cannot see those symbols, restoring
     explicit Vulkan device selection in Windows split bundles.
+* **Native packaging size fix**:
+  * Filtered backend-owned runtime dependencies during native asset bundling so
+    CUDA runtime DLLs and OpenBLAS runtime libraries are emitted only when their
+    owning backend module is selected.
+  * Kept unknown non-core runtime libraries bundled for compatibility with
+    future native bundle layouts.
 * **Compatibility note**: no public API breaking changes.
 
 ## 0.6.11

--- a/README.md
+++ b/README.md
@@ -215,6 +215,11 @@ Notes:
 
 - Module availability depends on the pinned native release bundle and may change when the native tag updates.
 - Configurable targets always keep `cpu` bundled as a fallback.
+- Backend-owned runtime dependencies follow the selected backend module. For
+  example, CUDA runtime DLLs (`cudart64_*`, `cublas64_*`, `cublaslt64_*`) are
+  bundled only when `cuda` is selected, and OpenBLAS runtime libraries are
+  bundled only when `blas` is selected. Unknown runtime libraries are kept for
+  compatibility with future native bundle layouts.
 - Android arm64 defaults to `cpu_profile: full` for best runtime CPU
   optimization coverage.
 - Android keeps OpenCL and Vulkan available for opt-in, but `auto` now prefers CPU by default.

--- a/lib/src/hook/native_bundle_config.dart
+++ b/lib/src/hook/native_bundle_config.dart
@@ -56,6 +56,10 @@ const Map<String, String> _backendAliases = {
   'open-cl': 'opencl',
 };
 
+final _cudaRuntimeDependencyNamePattern = RegExp(
+  r'^(?:cudart64|cublas64|cublaslt64)(?:[_-]?\d+)?$',
+);
+
 const String _androidArm64Bundle = 'android-arm64';
 const String _androidCpuProfileCompact = 'compact';
 const String _androidCpuProfileFull = 'full';
@@ -526,9 +530,19 @@ List<NativeLibraryDescriptor> selectLibrariesForBundling({
 
   final selectedLibraries = libraries
       .where((library) {
-        if (library.isCore || library.backend == null) {
+        if (library.isCore) {
           return true;
         }
+
+        final runtimeBackend = _runtimeDependencyBackendFor(library);
+        if (runtimeBackend != null) {
+          return selectedBackends.contains(runtimeBackend);
+        }
+
+        if (library.backend == null) {
+          return true;
+        }
+
         return selectedBackends.contains(library.backend);
       })
       .toList(growable: false);
@@ -713,5 +727,16 @@ String? _inferBackend(String canonicalName) {
     return 'opencl';
   }
 
+  return null;
+}
+
+String? _runtimeDependencyBackendFor(NativeLibraryDescriptor library) {
+  final canonicalName = library.canonicalName;
+  if (_cudaRuntimeDependencyNamePattern.hasMatch(canonicalName)) {
+    return 'cuda';
+  }
+  if (canonicalName.startsWith('openblas')) {
+    return 'blas';
+  }
   return null;
 }

--- a/test/unit/hook/build_hook_integration_test.dart
+++ b/test/unit/hook/build_hook_integration_test.dart
@@ -43,6 +43,10 @@ void main() {
       'ggml-base-windows-x64.dll',
       'ggml-cpu-windows-x64.dll',
       'ggml-vulkan-windows-x64.dll',
+      'ggml-cuda-windows-x64.dll',
+      'cudart64_12.dll',
+      'cublas64_12.dll',
+      'cublaslt64_12.dll',
     ]);
 
     if (archiveFile.existsSync()) {
@@ -102,6 +106,10 @@ void main() {
           expect(emittedNames, contains('llama-windows-x64.dll'));
           expect(emittedNames, contains('ggml-windows-x64.dll'));
           expect(emittedNames, contains('ggml-base-windows-x64.dll'));
+          expect(emittedNames, isNot(contains('ggml-cuda-windows-x64.dll')));
+          expect(emittedNames, isNot(contains('cudart64_12.dll')));
+          expect(emittedNames, isNot(contains('cublas64_12.dll')));
+          expect(emittedNames, isNot(contains('cublaslt64_12.dll')));
         },
       );
     },
@@ -128,6 +136,7 @@ void main() {
         'ggml-cuda-windows-x64.dll',
         'cudart64_12.dll',
         'cublas64_12.dll',
+        'cublaslt64_12.dll',
       ],
     );
 
@@ -162,6 +171,7 @@ void main() {
         expect(emittedNames, contains('ggml-cuda-windows-x64.dll'));
         expect(emittedNames, contains('cudart64_12.dll'));
         expect(emittedNames, contains('cublas64_12.dll'));
+        expect(emittedNames, contains('cublaslt64_12.dll'));
       },
     );
   });

--- a/test/unit/hook/native_bundle_config_test.dart
+++ b/test/unit/hook/native_bundle_config_test.dart
@@ -69,11 +69,22 @@ void main() {
       expect(descriptor.backend, 'opencl');
     });
 
-    test('does not classify cublas runtime as a backend module', () {
-      final descriptor = describeNativeLibrary('/tmp/cublas64_12.dll');
+    test('does not classify cuda runtimes as backend modules', () {
+      final descriptors = [
+        describeNativeLibrary('/tmp/cudart64_12.dll'),
+        describeNativeLibrary('/tmp/cublas64_12.dll'),
+        describeNativeLibrary('/tmp/cublaslt64_12.dll'),
+      ];
 
-      expect(descriptor.canonicalName, 'cublas64_12');
-      expect(descriptor.backend, isNull);
+      expect(descriptors.map((descriptor) => descriptor.canonicalName), [
+        'cudart64_12',
+        'cublas64_12',
+        'cublaslt64_12',
+      ]);
+      expect(
+        descriptors.map((descriptor) => descriptor.backend),
+        everyElement(isNull),
+      );
     });
 
     test('normalizes Linux SONAME suffix for core libraries', () {
@@ -187,6 +198,130 @@ void main() {
       expect(selectedNames, contains('ggml-vulkan'));
       expect(selectedNames, isNot(contains('ggml-opencl')));
       expect(warnings, isNotEmpty);
+    });
+
+    test(
+      'filters backend runtime dependencies when backend is not selected',
+      () {
+        final windowsSpec = resolveNativeBundleSpec(
+          os: OS.windows,
+          arch: Architecture.x64,
+          isIosSimulator: false,
+        )!;
+        final windowsLibraries = [
+          describeNativeLibrary('/tmp/llamadart-windows-x64.dll'),
+          describeNativeLibrary('/tmp/llama-windows-x64.dll'),
+          describeNativeLibrary('/tmp/ggml-windows-x64.dll'),
+          describeNativeLibrary('/tmp/ggml-base-windows-x64.dll'),
+          describeNativeLibrary('/tmp/ggml-cpu-windows-x64.dll'),
+          describeNativeLibrary('/tmp/ggml-vulkan-windows-x64.dll'),
+          describeNativeLibrary('/tmp/ggml-cuda-windows-x64.dll'),
+          describeNativeLibrary('/tmp/ggml-blas-windows-x64.dll'),
+          describeNativeLibrary('/tmp/cudart64_12.dll'),
+          describeNativeLibrary('/tmp/cublas64_12.dll'),
+          describeNativeLibrary('/tmp/cublaslt64_12.dll'),
+          describeNativeLibrary('/tmp/libopenblas.so.0'),
+          describeNativeLibrary('/tmp/custom-runtime.dll'),
+        ];
+
+        final selected = selectLibrariesForBundling(
+          spec: windowsSpec,
+          libraries: windowsLibraries,
+          rawUserConfig: {
+            'platforms': {
+              'windows-x64': ['vulkan', 'cpu'],
+            },
+          },
+          warn: (_) {},
+        );
+
+        final selectedNames = selected
+            .map((item) => item.canonicalName)
+            .toSet();
+        expect(selectedNames, contains('ggml-cpu'));
+        expect(selectedNames, contains('ggml-vulkan'));
+        expect(selectedNames, contains('custom-runtime'));
+        expect(selectedNames, isNot(contains('ggml-cuda')));
+        expect(selectedNames, isNot(contains('cudart64_12')));
+        expect(selectedNames, isNot(contains('cublas64_12')));
+        expect(selectedNames, isNot(contains('cublaslt64_12')));
+        expect(selectedNames, isNot(contains('ggml-blas')));
+        expect(selectedNames, isNot(contains('openblas')));
+      },
+    );
+
+    test('keeps cuda runtime dependencies when cuda is selected', () {
+      final windowsSpec = resolveNativeBundleSpec(
+        os: OS.windows,
+        arch: Architecture.x64,
+        isIosSimulator: false,
+      )!;
+      final windowsLibraries = [
+        describeNativeLibrary('/tmp/llamadart-windows-x64.dll'),
+        describeNativeLibrary('/tmp/llama-windows-x64.dll'),
+        describeNativeLibrary('/tmp/ggml-windows-x64.dll'),
+        describeNativeLibrary('/tmp/ggml-base-windows-x64.dll'),
+        describeNativeLibrary('/tmp/ggml-cpu-windows-x64.dll'),
+        describeNativeLibrary('/tmp/ggml-vulkan-windows-x64.dll'),
+        describeNativeLibrary('/tmp/ggml-cuda-windows-x64.dll'),
+        describeNativeLibrary('/tmp/cudart64_12.dll'),
+        describeNativeLibrary('/tmp/cublas64_12.dll'),
+        describeNativeLibrary('/tmp/cublaslt64_12.dll'),
+      ];
+
+      final selected = selectLibrariesForBundling(
+        spec: windowsSpec,
+        libraries: windowsLibraries,
+        rawUserConfig: {
+          'platforms': {
+            'windows-x64': ['cuda'],
+          },
+        },
+        warn: (_) {},
+      );
+
+      final selectedNames = selected.map((item) => item.canonicalName).toSet();
+      expect(selectedNames, contains('ggml-cpu'));
+      expect(selectedNames, contains('ggml-cuda'));
+      expect(selectedNames, contains('cudart64_12'));
+      expect(selectedNames, contains('cublas64_12'));
+      expect(selectedNames, contains('cublaslt64_12'));
+      expect(selectedNames, isNot(contains('ggml-vulkan')));
+    });
+
+    test('keeps openblas runtime dependencies when blas is selected', () {
+      final windowsSpec = resolveNativeBundleSpec(
+        os: OS.windows,
+        arch: Architecture.x64,
+        isIosSimulator: false,
+      )!;
+      final windowsLibraries = [
+        describeNativeLibrary('/tmp/llamadart-windows-x64.dll'),
+        describeNativeLibrary('/tmp/llama-windows-x64.dll'),
+        describeNativeLibrary('/tmp/ggml-windows-x64.dll'),
+        describeNativeLibrary('/tmp/ggml-base-windows-x64.dll'),
+        describeNativeLibrary('/tmp/ggml-cpu-windows-x64.dll'),
+        describeNativeLibrary('/tmp/ggml-vulkan-windows-x64.dll'),
+        describeNativeLibrary('/tmp/ggml-blas-windows-x64.dll'),
+        describeNativeLibrary('/tmp/libopenblas.so.0'),
+      ];
+
+      final selected = selectLibrariesForBundling(
+        spec: windowsSpec,
+        libraries: windowsLibraries,
+        rawUserConfig: {
+          'platforms': {
+            'windows-x64': ['blas'],
+          },
+        },
+        warn: (_) {},
+      );
+
+      final selectedNames = selected.map((item) => item.canonicalName).toSet();
+      expect(selectedNames, contains('ggml-cpu'));
+      expect(selectedNames, contains('ggml-blas'));
+      expect(selectedNames, contains('openblas'));
+      expect(selectedNames, isNot(contains('ggml-vulkan')));
     });
 
     test('apple targets ignore backend config and include all libraries', () {

--- a/website/docs/changelog/recent-releases.md
+++ b/website/docs/changelog/recent-releases.md
@@ -7,6 +7,13 @@ For canonical full release notes, use:
 
 - [`CHANGELOG.md`](https://github.com/leehack/llamadart/blob/main/CHANGELOG.md)
 
+## Unreleased
+
+- Filtered backend-owned runtime dependencies during native asset bundling so
+  CUDA runtime DLLs and OpenBLAS runtime libraries are emitted only when their
+  owning backend module is selected, while unknown runtime libraries stay
+  bundled for forward compatibility.
+
 ## 0.6.11
 
 - Synced native hook pinning and regenerated bindings through

--- a/website/docs/platforms/support-matrix.md
+++ b/website/docs/platforms/support-matrix.md
@@ -134,6 +134,11 @@ no valid entries remain, selection falls back to `cpu_profile` (or default
   back to defaults.
 - If defaults are also unavailable, all available modules in that bundle are
   used as fallback.
+- Backend-owned runtime dependencies follow the selected backend module. CUDA
+  runtime DLLs (`cudart64_*`, `cublas64_*`, `cublaslt64_*`) are bundled only
+  when `cuda` is selected, and OpenBLAS runtime libraries are bundled only when
+  `blas` is selected. Unknown runtime libraries are kept for compatibility with
+  future native bundle layouts.
 - Apple targets (`ios-*`, `macos-*`) support `cpu` + `metal`, but ignore
   per-backend module config in this hook path because runtime libraries are
   consolidated.


### PR DESCRIPTION
## Summary

Fixes #114.

This PR filters backend-owned runtime dependencies during native asset bundling. CUDA runtime DLLs are now emitted only when the `cuda` backend module is selected, and OpenBLAS runtime libraries are emitted only when `blas` is selected.

Unknown non-core runtime libraries are still bundled by default for compatibility with future native bundle layouts.

## Root Cause

CUDA runtime DLLs such as `cudart64_12.dll`, `cublas64_12.dll`, and `cublaslt64_12.dll` intentionally have `backend == null` so they do not make CUDA appear available unless `ggml-cuda` is present. The bundling filter previously treated all `backend == null` non-core libraries as always-keep runtime files, so those CUDA DLLs leaked into Windows packages even when CUDA was not selected.

## Changes

- Adds hook-layer classification for known backend-owned runtime dependencies without changing backend availability detection.
- Filters CUDA runtime DLLs based on `cuda` selection.
- Filters OpenBLAS runtime libraries based on `blas` selection.
- Keeps unknown runtime libraries bundled for forward compatibility.
- Adds README, docs-site, and changelog notes for the packaging behavior.

## Validation

- `dart test -p vm test/unit/hook/native_bundle_config_test.dart`
- `dart test -p vm test/unit/hook/build_hook_integration_test.dart`
- `dart analyze`