### PR TITLE
Update WebGPU bridge assets to v0.1.14

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,11 +4,14 @@
   * Updated native hook pinning to `leehack/llamadart-native@b9016`,
     picking up the CUDA 12.8 Blackwell-capable native bundles.
   * Updated default web bridge asset pinning to
-    `leehack/llama-web-bridge-assets@v0.1.13` (llama.cpp `b9016`) so
+    `leehack/llama-web-bridge-assets@v0.1.14` (llama.cpp `b9016`) so
     native and web runtimes track the same upstream revision.
   * Picked up the bridge-side Qwen UTF-8 streaming stabilization and
     multimodal fallback narrowing, while preserving control-token output for
     parser consumers.
+  * Picked up the bridge-side BERT embedding thread-pool sizing fix so
+    automatic thread selection does not exceed the compiled WebAssembly
+    pthread pool.
 * **Load-time tuning knobs**:
   * Added `ModelParams.useMmap` (default `true`) and
     `ModelParams.useMlock` (default `false`), wired to

--- a/doc/webgpu_bridge.md
+++ b/doc/webgpu_bridge.md
@@ -19,7 +19,7 @@ pipelines.
    `https://cdn.jsdelivr.net/gh/leehack/llama-web-bridge-assets@<tag>/llama_webgpu_bridge.js`
 2. Local fallback: `./webgpu_bridge/llama_webgpu_bridge.js`
 
-Default pinned tag in the example is `v0.1.13`.
+Default pinned tag in the example is `v0.1.14`.
 
 For broader browser coverage in this repository, fetched/local assets are patched
 to a universal Safari-compatible gate by default (`MIN_SAFARI_VERSION=170400`).
@@ -32,7 +32,7 @@ model bytes.
 To vendor pinned assets into local app web files:
 
 ```bash
-WEBGPU_BRIDGE_ASSETS_TAG=v0.1.13 ./scripts/fetch_webgpu_bridge_assets.sh
+WEBGPU_BRIDGE_ASSETS_TAG=v0.1.14 ./scripts/fetch_webgpu_bridge_assets.sh
 ```
 
 Optional compatibility env vars:
@@ -108,7 +108,7 @@ You can override CDN source/version before the bridge loader runs:
 ```html
 <script>
   window.__llamadartBridgeAssetsRepo = 'leehack/llama-web-bridge-assets';
-  window.__llamadartBridgeAssetsTag = 'v0.1.13';
+  window.__llamadartBridgeAssetsTag = 'v0.1.14';
 </script>
 ```
 

--- a/example/chat_app/web/index.html
+++ b/example/chat_app/web/index.html
@@ -215,8 +215,8 @@
     const bridgeAssetsTag =
       typeof configuredTag === 'string' && configuredTag.length > 0
         ? configuredTag
-        : 'v0.1.13';
-    const localBridgeVersion = 'v0.1.13-local-b9016';
+        : 'v0.1.14';
+    const localBridgeVersion = 'v0.1.14-local-b9016';
     window.__llamadartBridgeLocalVersion = localBridgeVersion;
 
     const localBridgeUrl = `./webgpu_bridge/llama_webgpu_bridge.js?v=${localBridgeVersion}`;

--- a/scripts/fetch_webgpu_bridge_assets.sh
+++ b/scripts/fetch_webgpu_bridge_assets.sh
@@ -4,7 +4,7 @@ set -euo pipefail
 ROOT_DIR="$(git rev-parse --show-toplevel)"
 OUT_DIR="${WEBGPU_BRIDGE_OUT_DIR:-$ROOT_DIR/example/chat_app/web/webgpu_bridge}"
 ASSETS_REPO="${WEBGPU_BRIDGE_ASSETS_REPO:-leehack/llama-web-bridge-assets}"
-ASSETS_TAG="${WEBGPU_BRIDGE_ASSETS_TAG:-v0.1.13}"
+ASSETS_TAG="${WEBGPU_BRIDGE_ASSETS_TAG:-v0.1.14}"
 CDN_BASE="${WEBGPU_BRIDGE_CDN_BASE:-https://cdn.jsdelivr.net/gh/${ASSETS_REPO}@${ASSETS_TAG}}"
 PATCH_SAFARI_COMPAT="${WEBGPU_BRIDGE_PATCH_SAFARI_COMPAT:-1}"
 MIN_SAFARI_VERSION="${WEBGPU_BRIDGE_MIN_SAFARI_VERSION:-170400}"
@@ -14,7 +14,7 @@ if [[ "${1:-}" == "--help" || "${1:-}" == "-h" ]]; then
 Downloads prebuilt WebGPU bridge assets into the chat_app web directory.
 
 Default source:
-  https://cdn.jsdelivr.net/gh/leehack/llama-web-bridge-assets@v0.1.13
+  https://cdn.jsdelivr.net/gh/leehack/llama-web-bridge-assets@v0.1.14
 
 Environment variables:
   WEBGPU_BRIDGE_ASSETS_REPO   Asset repo in owner/repo format
@@ -28,7 +28,7 @@ Usage:
   ./scripts/fetch_webgpu_bridge_assets.sh
 
 Examples:
-  WEBGPU_BRIDGE_ASSETS_TAG=v0.1.13 ./scripts/fetch_webgpu_bridge_assets.sh
+  WEBGPU_BRIDGE_ASSETS_TAG=v0.1.14 ./scripts/fetch_webgpu_bridge_assets.sh
   WEBGPU_BRIDGE_ASSETS_REPO=acme/llama-web-bridge-assets WEBGPU_BRIDGE_ASSETS_TAG=v2 ./scripts/fetch_webgpu_bridge_assets.sh
 USAGE
   exit 0

--- a/website/docs/changelog/recent-releases.md
+++ b/website/docs/changelog/recent-releases.md
@@ -10,10 +10,12 @@ For canonical full release notes, use:
 ## Unreleased
 
 - Synced default WebGPU bridge asset pinning to
-  `leehack/llama-web-bridge-assets@v0.1.13` (llama.cpp `b9016`) to match the
+  `leehack/llama-web-bridge-assets@v0.1.14` (llama.cpp `b9016`) to match the
   native runtime pin.
 - Picked up bridge-side Qwen UTF-8 streaming stabilization and multimodal
   fallback narrowing while preserving control-token output for parser consumers.
+- Picked up the bridge-side BERT embedding thread-pool sizing fix so automatic
+  thread selection does not exceed the compiled WebAssembly pthread pool.
 - Forwarded native-compatible `ModelParams` load tuning knobs through the
   WebGPU bridge path, including sequence slots, flash attention, KV cache type,
   RoPE overrides, split mode, and main GPU.

--- a/website/docs/platforms/webgpu-bridge.md
+++ b/website/docs/platforms/webgpu-bridge.md
@@ -21,7 +21,7 @@ development validation, and CDN-first loading for normal hosted deployments:
 Fetch pinned local assets with:
 
 ```bash
-WEBGPU_BRIDGE_ASSETS_TAG=v0.1.13 ./scripts/fetch_webgpu_bridge_assets.sh
+WEBGPU_BRIDGE_ASSETS_TAG=v0.1.14 ./scripts/fetch_webgpu_bridge_assets.sh
 ```
 
 ## Compatibility and safeguards
@@ -32,6 +32,9 @@ WEBGPU_BRIDGE_ASSETS_TAG=v0.1.13 ./scripts/fetch_webgpu_bridge_assets.sh
   RoPE overrides, split mode, and main GPU.
 - `v0.1.13+` bridge assets keep control-token output available for parser
   consumers while narrowing multimodal CPU fallback to recovery paths.
+- `v0.1.14+` bridge assets cap automatically selected WebAssembly threads to
+  the compiled pthread pool size, preventing BERT-style embedding models from
+  aborting on hosts with higher hardware concurrency than the bridge pool.
 - CPU fallback is available through bridge runtime routing.
 - Safari compatibility guard and fallback behavior are integrated in this repo.
 - Legacy bridge assets may be forced to CPU in Safari when GPU layers are
@@ -50,7 +53,7 @@ You can override bridge asset source/version before loader startup:
 ```html
 <script>
   window.__llamadartBridgeAssetsRepo = 'leehack/llama-web-bridge-assets';
-  window.__llamadartBridgeAssetsTag = 'v0.1.13';
+  window.__llamadartBridgeAssetsTag = 'v0.1.14';
   // Optional knobs:
   // window.__llamadartBridgeEnableMem64 = false;
   // window.__llamadartBridgeAllowAutoRemoteFetchBackend = false;


### PR DESCRIPTION
## Summary
- bump the default WebGPU bridge asset tag to v0.1.14
- document the BERT embedding pthread-pool sizing fix from leehack/llama-web-bridge#5
- keep the llama.cpp revision aligned at b9016

## Verification
- bash -n scripts/fetch_webgpu_bridge_assets.sh
- WEBGPU_BRIDGE_ASSETS_TAG=v0.1.14 ./scripts/fetch_webgpu_bridge_assets.sh
- dart test -p chrome test/unit/backends/webgpu/interop_test.dart test/unit/backends/webgpu/webgpu_backend_test.dart
- dart analyze