### PR TITLE
Prepare 0.6.12 release

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -228,6 +228,13 @@ To refresh local pinned bridge assets for `example/chat_app/web`:
 WEBGPU_BRIDGE_ASSETS_TAG=<tag> ./scripts/fetch_webgpu_bridge_assets.sh
 ```
 
+### Preparing Releases
+- When cutting a release, move accumulated `CHANGELOG.md` and
+  `website/docs/changelog/recent-releases.md` entries from `Unreleased` into
+  the new version section.
+- Do not leave an empty `Unreleased` section in committed release prep. Add
+  `Unreleased` back only when the next unreleased change is documented.
+
 ### Adding New Features
 1. Create public API in appropriate `lib/src/` subdirectory
 2. Export via `lib/src/api/llamadart.dart` if part of public API

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-## Unreleased
+## 0.6.12
 
 * **Native runtime sync**:
   * Updated native hook pinning to `leehack/llamadart-native@b9016`,
@@ -56,7 +56,7 @@
     owning backend module is selected.
   * Kept unknown non-core runtime libraries bundled for compatibility with
     future native bundle layouts.
-* **Compatibility note**: no public API breaking changes.
+* **Compatibility note**: no public API breaking changes in `0.6.12`.
 
 ## 0.6.11
 

--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@
 
 ```yaml
 dependencies:
-  llamadart: ^0.6.11
+  llamadart: ^0.6.12
 ```
 
 ### 2. Run with defaults

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: llamadart
 description: A Dart/Flutter plugin for llama.cpp - run LLM inference on any platform using GGUF models
-version: 0.6.11
+version: 0.6.12
 homepage: https://github.com/leehack/llamadart
 repository: https://github.com/leehack/llamadart
 issue_tracker: https://github.com/leehack/llamadart/issues

--- a/website/docs/changelog/recent-releases.md
+++ b/website/docs/changelog/recent-releases.md
@@ -7,7 +7,7 @@ For canonical full release notes, use:
 
 - [`CHANGELOG.md`](https://github.com/leehack/llamadart/blob/main/CHANGELOG.md)
 
-## Unreleased
+## 0.6.12
 
 - Synced default WebGPU bridge asset pinning to
   `leehack/llama-web-bridge-assets@v0.1.14` (llama.cpp `b9016`) to match the
@@ -23,6 +23,7 @@ For canonical full release notes, use:
   CUDA runtime DLLs and OpenBLAS runtime libraries are emitted only when their
   owning backend module is selected, while unknown runtime libraries stay
   bundled for forward compatibility.
+- Compatibility note: no public API breaking changes in `0.6.12`.
 
 ## 0.6.11
 

--- a/website/docs/getting-started/installation.md
+++ b/website/docs/getting-started/installation.md
@@ -25,7 +25,7 @@ configurations.
 
 ```yaml
 dependencies:
-  llamadart: ^0.6.11
+  llamadart: ^0.6.12
 ```
 
 Then resolve packages:

--- a/website/docs/maintainers/release-workflow.md
+++ b/website/docs/maintainers/release-workflow.md
@@ -22,6 +22,9 @@ Ensure migration/changelog docs reflect behavior in the release branch.
 
 - Update `pubspec.yaml` version.
 - Update `CHANGELOG.md`.
+- Move accumulated `Unreleased` entries into the new version section; remove
+  the `Unreleased` heading when it would otherwise be empty. Add it back only
+  when the next unreleased change is documented.
 - Update `MIGRATION.md` if breaking behavior changed.
 - Keep docs pages aligned with new defaults/options.
 


### PR DESCRIPTION
## Summary
- bump package/docs install snippets to 0.6.12
- move the accumulated release notes into the 0.6.12 changelog section
- document the release workflow rule for removing empty Unreleased sections

## Verification
- dart format --output=none --set-exit-if-changed .
- dart analyze
- dart test -p vm -j 1 --exclude-tags local-only
- ./tool/docs/build_site.sh
- ./tool/docs/validate_links.sh
- flutter pub publish --dry-run