### PR TITLE
fix: cascade WebGPU batch defaults

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,6 +40,10 @@
   * Forwarded native-compatible `ModelParams` load tuning knobs through the
     WebGPU bridge path, including `maxParallelSequences`, flash attention,
     KV-cache type, KV-unified, RoPE, split-mode, and main-GPU options.
+  * Matched native batch defaults on the WebGPU path so unset `batchSize` /
+    `microBatchSize` cascade to `n_batch = n_ctx` and `n_ubatch = n_batch`,
+    avoiding first-embedding aborts for BERT-class/non-causal encoder models
+    while preserving explicit caller values and Qwen3.5 web tuning.
 * **GPU device selection API**:
   * Added `ModelParams.mainGpu` and wired it to llama.cpp
     `llama_model_params.main_gpu`.

--- a/lib/src/backends/llama_cpp/llama_cpp_service.dart
+++ b/lib/src/backends/llama_cpp/llama_cpp_service.dart
@@ -325,36 +325,13 @@ class LlamaCppService {
 
   /// Resolves effective context batch parameters.
   ///
-  /// Legacy behavior is preserved when [ModelParams.batchSize] and
-  /// [ModelParams.microBatchSize] are not set:
-  ///
-  /// - `n_batch = n_ctx`
-  /// - `n_ubatch = n_batch`
-  ///
-  /// Values are clamped to safe bounds so `n_ubatch <= n_batch <= n_ctx`.
+  /// Uses the shared non-FFI helper so native and WebGPU batch semantics stay
+  /// in sync.
   static ({int batchSize, int microBatchSize}) resolveContextBatchSizes(
     ModelParams modelParams,
     int contextSize,
   ) {
-    final effectiveContextSize = contextSize > 0 ? contextSize : 1;
-
-    final configuredBatchSize = modelParams.batchSize > 0
-        ? modelParams.batchSize
-        : effectiveContextSize;
-    final cappedBatchSize = configuredBatchSize > effectiveContextSize
-        ? effectiveContextSize
-        : configuredBatchSize;
-    final batchSize = cappedBatchSize > 0 ? cappedBatchSize : 1;
-
-    final configuredMicroBatchSize = modelParams.microBatchSize > 0
-        ? modelParams.microBatchSize
-        : batchSize;
-    final cappedMicroBatchSize = configuredMicroBatchSize > batchSize
-        ? batchSize
-        : configuredMicroBatchSize;
-    final microBatchSize = cappedMicroBatchSize > 0 ? cappedMicroBatchSize : 1;
-
-    return (batchSize: batchSize, microBatchSize: microBatchSize);
+    return resolveModelContextBatchSizes(modelParams, contextSize);
   }
 
   /// Resolves whether multimodal projector init should use GPU.

--- a/lib/src/backends/webgpu/webgpu_backend.dart
+++ b/lib/src/backends/webgpu/webgpu_backend.dart
@@ -591,29 +591,28 @@ class WebGpuLlamaBackend
     return attempts;
   }
 
-  ({int? nBatch, int? nUbatch}) _resolveWebBatchTuning({
+  ({int nBatch, int nUbatch}) _resolveWebBatchSizes({
     required String url,
     required ModelParams params,
+    required int contextSize,
   }) {
-    if (params.batchSize > 0 || params.microBatchSize > 0) {
-      return (nBatch: null, nUbatch: null);
-    }
-
-    if (params.preferredBackend == GpuBackend.cpu || params.gpuLayers == 0) {
-      return (nBatch: null, nUbatch: null);
-    }
-
     final normalizedUrl = url.toLowerCase();
     final isQwen35Small =
         normalizedUrl.contains('qwen3.5-0.8b') ||
         normalizedUrl.contains('qwen_qwen3.5-0.8b');
-    if (!isQwen35Small) {
-      return (nBatch: null, nUbatch: null);
+    final shouldUseQwen35SmallTuning =
+        params.batchSize <= 0 &&
+        params.microBatchSize <= 0 &&
+        params.preferredBackend != GpuBackend.cpu &&
+        params.gpuLayers != 0 &&
+        isQwen35Small;
+
+    if (shouldUseQwen35SmallTuning) {
+      return (nBatch: 32, nUbatch: 8);
     }
 
-    final tunedBatch = 32;
-    final tunedUbatch = 8;
-    return (nBatch: tunedBatch, nUbatch: tunedUbatch);
+    final resolved = resolveModelContextBatchSizes(params, contextSize);
+    return (nBatch: resolved.batchSize, nUbatch: resolved.microBatchSize);
   }
 
   int _webGpuFlashAttentionValue(ModelParams params) {
@@ -894,8 +893,6 @@ class WebGpuLlamaBackend
       requestedContextSize: params.contextSize,
       requestedGpuLayers: requestedGpuLayers,
     );
-    final batchTuning = _resolveWebBatchTuning(url: url, params: params);
-
     Object? lastError;
     Map<String, String> lastRuntimeHints = const <String, String>{};
     var retriedWithWasm32 = false;
@@ -909,6 +906,11 @@ class WebGpuLlamaBackend
     for (var index = 0; index < loadAttempts.length; index += 1) {
       final attempt = loadAttempts[index];
       _lastNCtx = attempt.contextSize;
+      final batchSizes = _resolveWebBatchSizes(
+        url: url,
+        params: params,
+        contextSize: attempt.contextSize,
+      );
       LlamaWebGpuBridge? bridgeForAttempt;
       bool? forceRemoteFetchBackend;
       final attemptThreads = switch (index) {
@@ -940,12 +942,8 @@ class WebGpuLlamaBackend
             nThreadsBatch: params.numberOfThreadsBatch > 0
                 ? params.numberOfThreadsBatch
                 : null,
-            nBatch: params.batchSize > 0
-                ? params.batchSize
-                : batchTuning.nBatch,
-            nUbatch: params.microBatchSize > 0
-                ? params.microBatchSize
-                : batchTuning.nUbatch,
+            nBatch: batchSizes.nBatch,
+            nUbatch: batchSizes.nUbatch,
             nGpuLayers: attempt.gpuLayers,
             nSeqMax: math.max(1, params.maxParallelSequences),
             flashAttention: _webGpuFlashAttentionValue(params),

--- a/lib/src/core/models/inference/model_params.dart
+++ b/lib/src/core/models/inference/model_params.dart
@@ -248,3 +248,37 @@ class ModelParams {
     );
   }
 }
+
+/// Resolves llama.cpp-compatible context batch parameters.
+///
+/// Preserves native defaults when [ModelParams.batchSize] and
+/// [ModelParams.microBatchSize] are unset:
+///
+/// - `n_batch = n_ctx`
+/// - `n_ubatch = n_batch`
+///
+/// Values are clamped to safe bounds so `n_ubatch <= n_batch <= n_ctx`.
+({int batchSize, int microBatchSize}) resolveModelContextBatchSizes(
+  ModelParams modelParams,
+  int contextSize,
+) {
+  final effectiveContextSize = contextSize > 0 ? contextSize : 1;
+
+  final configuredBatchSize = modelParams.batchSize > 0
+      ? modelParams.batchSize
+      : effectiveContextSize;
+  final cappedBatchSize = configuredBatchSize > effectiveContextSize
+      ? effectiveContextSize
+      : configuredBatchSize;
+  final batchSize = cappedBatchSize > 0 ? cappedBatchSize : 1;
+
+  final configuredMicroBatchSize = modelParams.microBatchSize > 0
+      ? modelParams.microBatchSize
+      : batchSize;
+  final cappedMicroBatchSize = configuredMicroBatchSize > batchSize
+      ? batchSize
+      : configuredMicroBatchSize;
+  final microBatchSize = cappedMicroBatchSize > 0 ? cappedMicroBatchSize : 1;
+
+  return (batchSize: batchSize, microBatchSize: microBatchSize);
+}

--- a/test/unit/backends/webgpu/webgpu_backend_test.dart
+++ b/test/unit/backends/webgpu/webgpu_backend_test.dart
@@ -12,6 +12,9 @@ import 'package:llamadart/src/backends/webgpu/interop.dart';
 import 'package:llamadart/src/backends/webgpu/webgpu_backend.dart';
 import 'package:test/test.dart';
 
+@JS('Promise.reject')
+external JSPromise<JSAny?> _rejectPromise(JSAny? reason);
+
 void main() {
   group('WebGpuLlamaBackend Unit', () {
     late JSObject bridge;
@@ -24,6 +27,9 @@ void main() {
     int? lastRequestedThreadsBatch;
     int? lastRequestedBatchSize;
     int? lastRequestedMicroBatchSize;
+    late List<int> requestedContextSizes;
+    late List<int> requestedBatchSizes;
+    late List<int> requestedMicroBatchSizes;
     int? lastRequestedSeqMax;
     int? lastRequestedFlashAttention;
     int? lastRequestedCacheTypeK;
@@ -65,6 +71,86 @@ void main() {
       globalContext.delete('__llamadartBridgeThreadPoolSize'.toJS);
     }
 
+    void recordLoadConfig(JSObject? config) {
+      if (config == null) {
+        return;
+      }
+
+      final nCtx = config.getProperty('nCtx'.toJS);
+      if (nCtx.isA<JSNumber>()) {
+        requestedContextSizes.add((nCtx as JSNumber).toDartInt);
+      }
+
+      final nGpuLayers = config.getProperty('nGpuLayers'.toJS);
+      if (nGpuLayers.isA<JSNumber>()) {
+        lastRequestedGpuLayers = (nGpuLayers as JSNumber).toDartInt;
+      }
+
+      final nThreadsBatch = config.getProperty('nThreadsBatch'.toJS);
+      if (nThreadsBatch.isA<JSNumber>()) {
+        lastRequestedThreadsBatch = (nThreadsBatch as JSNumber).toDartInt;
+      }
+
+      final nBatch = config.getProperty('nBatch'.toJS);
+      if (nBatch.isA<JSNumber>()) {
+        lastRequestedBatchSize = (nBatch as JSNumber).toDartInt;
+        requestedBatchSizes.add(lastRequestedBatchSize!);
+      }
+
+      final nUbatch = config.getProperty('nUbatch'.toJS);
+      if (nUbatch.isA<JSNumber>()) {
+        lastRequestedMicroBatchSize = (nUbatch as JSNumber).toDartInt;
+        requestedMicroBatchSizes.add(lastRequestedMicroBatchSize!);
+      }
+
+      final nSeqMax = config.getProperty('nSeqMax'.toJS);
+      if (nSeqMax.isA<JSNumber>()) {
+        lastRequestedSeqMax = (nSeqMax as JSNumber).toDartInt;
+      }
+
+      final flashAttention = config.getProperty('flashAttention'.toJS);
+      if (flashAttention.isA<JSNumber>()) {
+        lastRequestedFlashAttention = (flashAttention as JSNumber).toDartInt;
+      }
+
+      final cacheTypeK = config.getProperty('cacheTypeK'.toJS);
+      if (cacheTypeK.isA<JSNumber>()) {
+        lastRequestedCacheTypeK = (cacheTypeK as JSNumber).toDartInt;
+      }
+
+      final cacheTypeV = config.getProperty('cacheTypeV'.toJS);
+      if (cacheTypeV.isA<JSNumber>()) {
+        lastRequestedCacheTypeV = (cacheTypeV as JSNumber).toDartInt;
+      }
+
+      final kvUnified = config.getProperty('kvUnified'.toJS);
+      if (kvUnified.isA<JSBoolean>()) {
+        lastRequestedKvUnified = (kvUnified as JSBoolean).toDart;
+      }
+
+      final ropeFrequencyBase = config.getProperty('ropeFrequencyBase'.toJS);
+      if (ropeFrequencyBase.isA<JSNumber>()) {
+        lastRequestedRopeFrequencyBase =
+            (ropeFrequencyBase as JSNumber).toDartDouble;
+      }
+
+      final ropeFrequencyScale = config.getProperty('ropeFrequencyScale'.toJS);
+      if (ropeFrequencyScale.isA<JSNumber>()) {
+        lastRequestedRopeFrequencyScale =
+            (ropeFrequencyScale as JSNumber).toDartDouble;
+      }
+
+      final splitMode = config.getProperty('splitMode'.toJS);
+      if (splitMode.isA<JSNumber>()) {
+        lastRequestedSplitMode = (splitMode as JSNumber).toDartInt;
+      }
+
+      final mainGpu = config.getProperty('mainGpu'.toJS);
+      if (mainGpu.isA<JSNumber>()) {
+        lastRequestedMainGpu = (mainGpu as JSNumber).toDartInt;
+      }
+    }
+
     setUp(() {
       clearBridgeGlobals();
 
@@ -77,6 +163,9 @@ void main() {
       lastRequestedThreadsBatch = null;
       lastRequestedBatchSize = null;
       lastRequestedMicroBatchSize = null;
+      requestedContextSizes = <int>[];
+      requestedBatchSizes = <int>[];
+      requestedMicroBatchSizes = <int>[];
       lastRequestedSeqMax = null;
       lastRequestedFlashAttention = null;
       lastRequestedCacheTypeK = null;
@@ -106,80 +195,7 @@ void main() {
       bridge.setProperty(
         'loadModelFromUrl'.toJS,
         ((String url, JSObject? config) {
-          if (config != null) {
-            final nGpuLayers = config.getProperty('nGpuLayers'.toJS);
-            if (nGpuLayers.isA<JSNumber>()) {
-              lastRequestedGpuLayers = (nGpuLayers as JSNumber).toDartInt;
-            }
-
-            final nThreadsBatch = config.getProperty('nThreadsBatch'.toJS);
-            if (nThreadsBatch.isA<JSNumber>()) {
-              lastRequestedThreadsBatch = (nThreadsBatch as JSNumber).toDartInt;
-            }
-
-            final nBatch = config.getProperty('nBatch'.toJS);
-            if (nBatch.isA<JSNumber>()) {
-              lastRequestedBatchSize = (nBatch as JSNumber).toDartInt;
-            }
-
-            final nUbatch = config.getProperty('nUbatch'.toJS);
-            if (nUbatch.isA<JSNumber>()) {
-              lastRequestedMicroBatchSize = (nUbatch as JSNumber).toDartInt;
-            }
-
-            final nSeqMax = config.getProperty('nSeqMax'.toJS);
-            if (nSeqMax.isA<JSNumber>()) {
-              lastRequestedSeqMax = (nSeqMax as JSNumber).toDartInt;
-            }
-
-            final flashAttention = config.getProperty('flashAttention'.toJS);
-            if (flashAttention.isA<JSNumber>()) {
-              lastRequestedFlashAttention =
-                  (flashAttention as JSNumber).toDartInt;
-            }
-
-            final cacheTypeK = config.getProperty('cacheTypeK'.toJS);
-            if (cacheTypeK.isA<JSNumber>()) {
-              lastRequestedCacheTypeK = (cacheTypeK as JSNumber).toDartInt;
-            }
-
-            final cacheTypeV = config.getProperty('cacheTypeV'.toJS);
-            if (cacheTypeV.isA<JSNumber>()) {
-              lastRequestedCacheTypeV = (cacheTypeV as JSNumber).toDartInt;
-            }
-
-            final kvUnified = config.getProperty('kvUnified'.toJS);
-            if (kvUnified.isA<JSBoolean>()) {
-              lastRequestedKvUnified = (kvUnified as JSBoolean).toDart;
-            }
-
-            final ropeFrequencyBase = config.getProperty(
-              'ropeFrequencyBase'.toJS,
-            );
-            if (ropeFrequencyBase.isA<JSNumber>()) {
-              lastRequestedRopeFrequencyBase =
-                  (ropeFrequencyBase as JSNumber).toDartDouble;
-            }
-
-            final ropeFrequencyScale = config.getProperty(
-              'ropeFrequencyScale'.toJS,
-            );
-            if (ropeFrequencyScale.isA<JSNumber>()) {
-              lastRequestedRopeFrequencyScale =
-                  (ropeFrequencyScale as JSNumber).toDartDouble;
-            }
-
-            final splitMode = config.getProperty('splitMode'.toJS);
-            if (splitMode.isA<JSNumber>()) {
-              lastRequestedSplitMode = (splitMode as JSNumber).toDartInt;
-            }
-
-            final mainGpu = config.getProperty('mainGpu'.toJS);
-            if (mainGpu.isA<JSNumber>()) {
-              lastRequestedMainGpu = (mainGpu as JSNumber).toDartInt;
-            }
-          }
-
+          recordLoadConfig(config);
           return Future<void>.value().toJS;
         }).toJS,
       );
@@ -451,6 +467,20 @@ void main() {
       expect(lastRequestedMicroBatchSize, 384);
     });
 
+    test('clamps explicit web batch sizes to context bounds', () async {
+      await backend.modelLoadFromUrl(
+        'https://example.com/model.gguf',
+        const ModelParams(
+          contextSize: 512,
+          batchSize: 2048,
+          microBatchSize: 1024,
+        ),
+      );
+
+      expect(lastRequestedBatchSize, 512);
+      expect(lastRequestedMicroBatchSize, 512);
+    });
+
     test('forwards native-compatible load tuning params', () async {
       await backend.modelLoadFromUrl(
         'https://example.com/model.gguf',
@@ -519,21 +549,76 @@ void main() {
       );
 
       expect(lastRequestedGpuLayers, 99);
+      expect(lastRequestedBatchSize, 4096);
+      expect(lastRequestedMicroBatchSize, 4096);
     });
 
-    test('does not apply qwen3.5-0.8b batch tuning in CPU mode', () async {
+    test('cascades unset WebGPU encoder batches before embedBatch', () async {
       await backend.modelLoadFromUrl(
-        'https://example.com/Qwen_Qwen3.5-0.8B-Q4_K_M.gguf',
+        'https://example.com/multilingual-e5-small-Q8_0.gguf',
+        const ModelParams(contextSize: 512, gpuLayers: 99),
+      );
+
+      expect(lastRequestedGpuLayers, 99);
+      expect(lastRequestedBatchSize, 512);
+      expect(lastRequestedMicroBatchSize, 512);
+
+      final vectors = await backend.embedBatch(1, const <String>[
+        'first sentence',
+        'second sentence',
+      ]);
+      expect(vectors, <List<double>>[
+        <double>[14.0, 1.0],
+        <double>[15.0, 1.0],
+      ]);
+    });
+
+    test('cascades unset batch sizes to context size in CPU mode', () async {
+      await backend.modelLoadFromUrl(
+        'https://example.com/multilingual-e5-small-Q8_0.gguf',
         const ModelParams(
-          contextSize: 4096,
+          contextSize: 512,
           preferredBackend: GpuBackend.cpu,
           gpuLayers: 0,
         ),
       );
 
-      expect(lastRequestedBatchSize, isNull);
-      expect(lastRequestedMicroBatchSize, isNull);
+      expect(lastRequestedBatchSize, 512);
+      expect(lastRequestedMicroBatchSize, 512);
     });
+
+    test(
+      'recomputes cascaded batch sizes for reduced fallback context',
+      () async {
+        var loadCallCount = 0;
+        bridge.setProperty(
+          'loadModelFromUrl'.toJS,
+          ((String url, JSObject? config) {
+            loadCallCount += 1;
+            recordLoadConfig(config);
+
+            if (loadCallCount <= 2) {
+              final error = JSObject();
+              error.setProperty(
+                'message'.toJS,
+                'array buffer allocation failed'.toJS,
+              );
+              return _rejectPromise(error);
+            }
+            return Future<void>.value().toJS;
+          }).toJS,
+        );
+
+        await backend.modelLoadFromUrl(
+          'https://example.com/multilingual-e5-small-Q8_0.gguf',
+          const ModelParams(contextSize: 4096, gpuLayers: 99),
+        );
+
+        expect(requestedContextSizes, <int>[4096, 4096, 2048]);
+        expect(requestedBatchSizes, <int>[4096, 4096, 2048]);
+        expect(requestedMicroBatchSizes, <int>[4096, 4096, 2048]);
+      },
+    );
 
     test('streams generated tokens from bridge callback', () async {
       await backend.modelLoadFromUrl(

--- a/website/docs/changelog/recent-releases.md
+++ b/website/docs/changelog/recent-releases.md
@@ -19,6 +19,10 @@ For canonical full release notes, use:
 - Forwarded native-compatible `ModelParams` load tuning knobs through the
   WebGPU bridge path, including sequence slots, flash attention, KV cache type,
   RoPE overrides, split mode, and main GPU.
+- Matched native batch defaults on WebGPU so unset `batchSize` and
+  `microBatchSize` use `n_batch = n_ctx` and `n_ubatch = n_batch`, avoiding
+  first-embedding aborts for BERT-class/non-causal encoder models while
+  preserving model-specific Qwen3.5-0.8B WebGPU safety tuning.
 - Filtered backend-owned runtime dependencies during native asset bundling so
   CUDA runtime DLLs and OpenBLAS runtime libraries are emitted only when their
   owning backend module is selected, while unknown runtime libraries stay

--- a/website/docs/configuration/runtime-parameters.md
+++ b/website/docs/configuration/runtime-parameters.md
@@ -40,8 +40,13 @@ Important fields:
 - `mainGpu`: primary GPU device index passed through to llama.cpp `main_gpu`.
   To select one GPU for the full model, use
   `splitMode: ModelSplitMode.none` with the desired `mainGpu` index.
-- `batchSize`: context logical batch size (`n_batch`).
-- `microBatchSize`: context micro-batch size (`n_ubatch`).
+- `batchSize`: context logical batch size (`n_batch`). When left at `0`,
+  llamadart uses the effective context size (`n_ctx`) on native and WebGPU
+  backends, except for model-specific WebGPU safety tuning such as the bundled
+  Qwen3.5-0.8B small-model preset.
+- `microBatchSize`: context micro-batch size (`n_ubatch`). When left at `0`,
+  llamadart uses the resolved `batchSize`; explicit values are capped so
+  `n_ubatch <= n_batch <= n_ctx`.
 - `maxParallelSequences`: max sequence slots (`n_seq_max`) for parallel
   sequence workloads (for example, batched embeddings).
 - `chatTemplate`: optional template override.


### PR DESCRIPTION
## Summary
- Resolve WebGPU `ModelParams.batchSize` / `microBatchSize` defaults per load attempt so unset values follow native `n_batch = n_ctx` and `n_ubatch = n_batch` semantics.
- Share the context batch-size resolver between native llama.cpp and WebGPU via a non-FFI helper to avoid backend drift.
- Preserve explicit caller-provided batch sizes, clamp to `n_ubatch <= n_batch <= n_ctx`, and keep the existing Qwen3.5-0.8B WebGPU safety tuning.
- Add regression coverage for encoder `embedBatch`, CPU/Safari-style fallback, explicit clamping, and reduced-context retry attempts.
- Update changelog and runtime-parameter docs.

## Test plan
- [x] `dart format lib/src/core/models/inference/model_params.dart lib/src/backends/llama_cpp/llama_cpp_service.dart lib/src/backends/webgpu/webgpu_backend.dart test/unit/backends/webgpu/webgpu_backend_test.dart`
- [x] `dart test -p chrome test/unit/backends/webgpu/webgpu_backend_test.dart`
- [x] `dart test test/unit/backends/llama_cpp/llama_cpp_service_test.dart --name resolveContextBatchSizes`
- [x] `dart analyze lib/src/core/models/inference/model_params.dart lib/src/backends/llama_cpp/llama_cpp_service.dart lib/src/backends/webgpu/webgpu_backend.dart test/unit/backends/webgpu/webgpu_backend_test.dart`
- [x] Final read-only Codex review: no blocking findings

Note: a broad `dart analyze` from the main-based worktree currently reports pre-existing example/workspace dependency noise (missing example packages such as `sqlite3`, Flutter symbols, and generated example package imports), so this PR also includes the narrower changed-file analyzer check above.

Closes #120
