### PR TITLE
feat(api): expose state_save_file / state_load_file on LlamaEngine

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,17 @@
+## Unreleased
+
+* **State persistence API (native backend)**:
+  * Added `LlamaEngine.supportsStatePersistence`,
+    `LlamaEngine.stateSaveFile(...)`, and
+    `LlamaEngine.stateLoadFile(...)` so native callers can persist and restore
+    llama.cpp KV-cache state for fast raw-prompt resume/fork workflows.
+  * Added `BackendStatePersistence` and `StateLoadResult` for custom backend
+    implementers and diagnostics.
+  * Documented that state files are opaque llama.cpp artifacts tied to the same
+    model and runtime/build, that WebGPU does not support state persistence, and
+    that `ChatSession` message history must be persisted separately.
+* **Compatibility note**: no public API breaking changes in the next release.
+
 ## 0.6.12
 
 * **Native runtime sync**:

--- a/README.md
+++ b/README.md
@@ -26,6 +26,8 @@
   - Web: WebGPU via bridge runtime (with CPU fallback)
 - 🧭 **Embeddings API**: Generate vectors with `embed(...)` and
   `embedBatch(...)`.
+- 💾 **Native State Persistence**: Save and restore llama.cpp KV-cache state
+  with `stateSaveFile(...)` / `stateLoadFile(...)` for fast raw-prompt resumes.
 - 🖼️ **Multimodal Support**: Vision/audio model runtime support.
 - **LoRA Support**: Runtime GGUF adapter application.
 - 🔇 **Split Logging Control**: Dart logs and native logs can be configured independently.
@@ -117,6 +119,33 @@ Note: embedding support depends on backend/runtime capabilities.
 - Native runtime supports single and batched embeddings.
 - Web runtime requires bridge assets with embedding APIs (`v0.1.7` or newer).
 - See the full guide: https://llamadart.leehack.com/docs/guides/embeddings
+
+### 6. Optional: save and restore native KV-cache state
+
+Native backends can persist llama.cpp KV-cache state for fast raw-prompt
+resume/fork workflows:
+
+```dart
+final prompt = 'You are a concise assistant. Summarize llamadart.';
+final tokens = await engine.tokenize(prompt);
+
+// Populate the KV cache, then save it with the token sequence that produced it.
+await engine.generate(prompt).drain<void>();
+await engine.stateSaveFile('assistant.state', tokens: tokens);
+
+// Later, after loading the same model with a compatible runtime build:
+final restored = await engine.stateLoadFile(
+  'assistant.state',
+  tokenCapacity: await engine.getContextSize(),
+);
+print('Restored ${restored.tokens.length} prompt tokens');
+```
+
+State persistence is native-only; WebGPU bridge sessions report
+`supportsStatePersistence == false` and throw `LlamaUnsupportedException` if
+called. State files are opaque llama.cpp artifacts tied to the same model and
+runtime/build. `ChatSession` message history is not restored automatically, so
+persist chat messages separately when using the high-level chat API.
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -130,7 +130,9 @@ final prompt = 'You are a concise assistant. Summarize llamadart.';
 final tokens = await engine.tokenize(prompt);
 
 // Populate the KV cache, then save it with the token sequence that produced it.
-await engine.generate(prompt).drain<void>();
+await engine
+    .generate(prompt, params: const GenerationParams(maxTokens: 1))
+    .drain<void>();
 await engine.stateSaveFile('assistant.state', tokens: tokens);
 
 // Later, after loading the same model with a compatible runtime build:

--- a/lib/llamadart.dart
+++ b/lib/llamadart.dart
@@ -45,7 +45,9 @@ export 'src/backends/backend.dart'
         BackendPerfContextData,
         BackendPerformanceDiagnostics,
         BackendEmbeddings,
-        BackendBatchEmbeddings;
+        BackendBatchEmbeddings,
+        BackendStatePersistence,
+        StateLoadResult;
 
 // Models - Inference
 export 'src/core/models/inference/model_params.dart';

--- a/lib/src/backends/backend.dart
+++ b/lib/src/backends/backend.dart
@@ -204,3 +204,42 @@ abstract class BackendBatchEmbeddings extends BackendEmbeddings {
     bool normalize = true,
   });
 }
+
+/// Result of [BackendStatePersistence.stateLoadFile]. Contains the token
+/// sequence the saved state was produced from. Callers should re-feed
+/// these tokens to the chat session so its in-Dart history matches the
+/// restored KV cache.
+class StateLoadResult {
+  /// The token IDs that the saved state was produced from.
+  final List<int> tokens;
+
+  /// Creates a new [StateLoadResult].
+  const StateLoadResult({required this.tokens});
+}
+
+/// Optional backend capability for persisting the KV cache to disk and
+/// restoring it later, mirroring `llama_state_save_file` /
+/// `llama_state_load_file` in llama.cpp. Saving captures the entire
+/// runtime state of [contextHandle] together with the token sequence
+/// that produced it; loading restores both, skipping the prompt-eval
+/// pass on subsequent inference rounds.
+abstract class BackendStatePersistence {
+  /// Writes the KV cache state of [contextHandle] together with the
+  /// token sequence in [tokens] to [path]. The file format is the one
+  /// llama.cpp emits — opaque, version-tied, and not portable across
+  /// llama.cpp builds.
+  ///
+  /// Returns true on success.
+  Future<bool> stateSaveFile(int contextHandle, String path, List<int> tokens);
+
+  /// Restores the KV cache of [contextHandle] from a file previously
+  /// written by [stateSaveFile]. [tokenCapacity] caps how many tokens
+  /// the caller is willing to receive — typically the context size of
+  /// the loaded model. Throws if the file is corrupt or was produced
+  /// by a different llama.cpp build.
+  Future<StateLoadResult> stateLoadFile(
+    int contextHandle,
+    String path,
+    int tokenCapacity,
+  );
+}

--- a/lib/src/backends/backend.dart
+++ b/lib/src/backends/backend.dart
@@ -206,9 +206,12 @@ abstract class BackendBatchEmbeddings extends BackendEmbeddings {
 }
 
 /// Result of [BackendStatePersistence.stateLoadFile]. Contains the token
-/// sequence the saved state was produced from. Callers should re-feed
-/// these tokens to the chat session so its in-Dart history matches the
-/// restored KV cache.
+/// sequence saved alongside the native KV-cache state.
+///
+/// Loading restores the native KV cache only. Callers using higher-level
+/// chat abstractions must persist and reconstruct their chat message
+/// history separately; these raw token IDs are exposed mainly for
+/// diagnostics and raw-prompt callers.
 class StateLoadResult {
   /// The token IDs that the saved state was produced from.
   final List<int> tokens;
@@ -219,10 +222,12 @@ class StateLoadResult {
 
 /// Optional backend capability for persisting the KV cache to disk and
 /// restoring it later, mirroring `llama_state_save_file` /
-/// `llama_state_load_file` in llama.cpp. Saving captures the entire
+/// `llama_state_load_file` in llama.cpp. Saving captures the native
 /// runtime state of [contextHandle] together with the token sequence
-/// that produced it; loading restores both, skipping the prompt-eval
-/// pass on subsequent inference rounds.
+/// that produced it. Loading restores the native KV cache and returns
+/// the saved token sequence; subsequent inference can skip prompt
+/// evaluation when callers re-issue a prompt with the restored token
+/// prefix and prompt-prefix reuse enabled.
 abstract class BackendStatePersistence {
   /// Writes the KV cache state of [contextHandle] together with the
   /// token sequence in [tokens] to [path]. The file format is the one

--- a/lib/src/backends/llama_cpp/llama_cpp_backend.dart
+++ b/lib/src/backends/llama_cpp/llama_cpp_backend.dart
@@ -20,7 +20,8 @@ class NativeLlamaBackend
         BackendRuntimeDiagnostics,
         BackendPerformanceDiagnostics,
         BackendEmbeddings,
-        BackendBatchEmbeddings {
+        BackendBatchEmbeddings,
+        BackendStatePersistence {
   Isolate? _isolate;
   SendPort? _sendPort;
   final ReceivePort _responsesPort = ReceivePort();
@@ -308,6 +309,49 @@ class NativeLlamaBackend
     rp.close();
     if (res is MetadataResponse) return res.metadata;
     return {};
+  }
+
+  @override
+  Future<bool> stateSaveFile(
+    int contextHandle,
+    String path,
+    List<int> tokens,
+  ) async {
+    await _ensureIsolate();
+    final rp = ReceivePort();
+    _sendPort!.send(
+      StateSaveFileRequest(
+        contextHandle,
+        path,
+        List<int>.from(tokens),
+        rp.sendPort,
+      ),
+    );
+    final res = await rp.first;
+    rp.close();
+    if (res is StateSaveFileResponse) return res.success;
+    if (res is ErrorResponse) throw Exception(res.message);
+    throw Exception('State save failed');
+  }
+
+  @override
+  Future<StateLoadResult> stateLoadFile(
+    int contextHandle,
+    String path,
+    int tokenCapacity,
+  ) async {
+    await _ensureIsolate();
+    final rp = ReceivePort();
+    _sendPort!.send(
+      StateLoadFileRequest(contextHandle, path, tokenCapacity, rp.sendPort),
+    );
+    final res = await rp.first;
+    rp.close();
+    if (res is StateLoadFileResponse) {
+      return StateLoadResult(tokens: res.tokens);
+    }
+    if (res is ErrorResponse) throw Exception(res.message);
+    throw Exception('State load failed');
   }
 
   @override

--- a/lib/src/backends/llama_cpp/llama_cpp_service.dart
+++ b/lib/src/backends/llama_cpp/llama_cpp_service.dart
@@ -3382,16 +3382,13 @@ class LlamaCppService {
 
     final reusedPrefix = _sharedPrefixLength(cachedTokens, tokensPtr, nTokens);
 
-    if (reusedPrefix <= 0 || reusedPrefix >= nTokens) {
-      final canReuseCachedCopy =
-          reusedPrefix == nTokens && cachedTokens.length == nTokens;
+    if (reusedPrefix <= 0) {
       return _decodeAndCacheFullPrompt(
         batch,
         tokensPtr,
         ctx,
         nTokens,
         maxBatchTokens: maxBatchTokens,
-        existingCachedTokens: canReuseCachedCopy ? cachedTokens : null,
       );
     }
 
@@ -3406,7 +3403,15 @@ class LlamaCppService {
       );
     }
 
-    final decodeStart = reusedPrefix;
+    // When the new prompt exactly matches the cached/restored token sequence
+    // (typical after a stateLoadFile resume), there are no new prefix tokens
+    // to decode. Re-decode only the final token so the sampler has fresh
+    // logits to draw from, without clearing or re-evaluating the restored
+    // KV cache. decodeStart = nTokens - 1 gives us a one-token segment whose
+    // KV slot we evict and rewrite in place.
+    final exactMatch =
+        reusedPrefix == nTokens && cachedTokens.length == nTokens;
+    final decodeStart = exactMatch ? nTokens - 1 : reusedPrefix;
 
     final maxSeqPos = llama_memory_seq_pos_max(memory, 0);
     final removeTo = maxSeqPos >= decodeStart ? maxSeqPos + 1 : decodeStart;
@@ -3431,7 +3436,9 @@ class LlamaCppService {
       maxBatchTokens: maxBatchTokens,
     );
 
-    ctx.cachedPromptTokens = _copyPromptTokens(tokensPtr, nTokens);
+    ctx.cachedPromptTokens = exactMatch
+        ? cachedTokens
+        : _copyPromptTokens(tokensPtr, nTokens);
 
     return nTokens;
   }

--- a/lib/src/backends/llama_cpp/llama_cpp_service.dart
+++ b/lib/src/backends/llama_cpp/llama_cpp_service.dart
@@ -3953,6 +3953,15 @@ class LlamaCppService {
         );
       }
       final actual = countPtr.value;
+      // Defensive bounds check: llama_state_load_file should never write
+      // more tokens than tokenCapacity, but an explicit guard prevents OOB
+      // reads if the native contract changes in a future build.
+      if (actual > tokenCapacity) {
+        throw StateError(
+          'llama_state_load_file returned actual=$actual '
+          'exceeding capacity=$tokenCapacity',
+        );
+      }
       final loaded = List<int>.generate(actual, (i) => tokensPtr[i]);
       ctx.cachedPromptTokens = loaded;
       return loaded;

--- a/lib/src/backends/llama_cpp/llama_cpp_service.dart
+++ b/lib/src/backends/llama_cpp/llama_cpp_service.dart
@@ -3382,13 +3382,34 @@ class LlamaCppService {
 
     final reusedPrefix = _sharedPrefixLength(cachedTokens, tokensPtr, nTokens);
 
-    if (reusedPrefix <= 0) {
+    // Special case: the new prompt exactly matches a KV state freshly
+    // restored from stateLoadFile and not yet touched by inference. The
+    // restored KV is byte-for-byte the state at the end of the persisted
+    // prompt decode, but the loaded context has no live logits to sample
+    // from. Re-decode only the final token to produce fresh logits while
+    // keeping the rest of the restored prefix intact. This is the
+    // resume-after-state-load fast path.
+    //
+    // We require kvFromStateLoad to be true so the regular reuse path
+    // (post-generate cache) still pays the full re-decode cost and stays
+    // bit-exact against a cleared baseline — the property the native
+    // prompt-reuse parity tool asserts.
+    final exactStateLoadMatch =
+        ctx.kvFromStateLoad &&
+        reusedPrefix == nTokens &&
+        cachedTokens.length == nTokens;
+
+    if (reusedPrefix <= 0 ||
+        (reusedPrefix >= nTokens && !exactStateLoadMatch)) {
+      final canReuseCachedCopy =
+          reusedPrefix == nTokens && cachedTokens.length == nTokens;
       return _decodeAndCacheFullPrompt(
         batch,
         tokensPtr,
         ctx,
         nTokens,
         maxBatchTokens: maxBatchTokens,
+        existingCachedTokens: canReuseCachedCopy ? cachedTokens : null,
       );
     }
 
@@ -3403,15 +3424,7 @@ class LlamaCppService {
       );
     }
 
-    // When the new prompt exactly matches the cached/restored token sequence
-    // (typical after a stateLoadFile resume), there are no new prefix tokens
-    // to decode. Re-decode only the final token so the sampler has fresh
-    // logits to draw from, without clearing or re-evaluating the restored
-    // KV cache. decodeStart = nTokens - 1 gives us a one-token segment whose
-    // KV slot we evict and rewrite in place.
-    final exactMatch =
-        reusedPrefix == nTokens && cachedTokens.length == nTokens;
-    final decodeStart = exactMatch ? nTokens - 1 : reusedPrefix;
+    final decodeStart = exactStateLoadMatch ? nTokens - 1 : reusedPrefix;
 
     final maxSeqPos = llama_memory_seq_pos_max(memory, 0);
     final removeTo = maxSeqPos >= decodeStart ? maxSeqPos + 1 : decodeStart;
@@ -3436,9 +3449,13 @@ class LlamaCppService {
       maxBatchTokens: maxBatchTokens,
     );
 
-    ctx.cachedPromptTokens = exactMatch
+    ctx.cachedPromptTokens = exactStateLoadMatch
         ? cachedTokens
         : _copyPromptTokens(tokensPtr, nTokens);
+    // Once we've decoded anything against the restored KV, the in-memory
+    // state has diverged from the on-disk snapshot — drop the flag so the
+    // next ingest goes through the normal reuse path.
+    ctx.kvFromStateLoad = false;
 
     return nTokens;
   }
@@ -3462,6 +3479,7 @@ class LlamaCppService {
     );
     ctx.cachedPromptTokens =
         existingCachedTokens ?? _copyPromptTokens(tokensPtr, nTokens);
+    ctx.kvFromStateLoad = false;
     return nTokens;
   }
 
@@ -3964,6 +3982,7 @@ class LlamaCppService {
       }
       final loaded = List<int>.generate(actual, (i) => tokensPtr[i]);
       ctx.cachedPromptTokens = loaded;
+      ctx.kvFromStateLoad = true;
       return loaded;
     } finally {
       malloc.free(pathPtr);
@@ -4888,6 +4907,17 @@ class _LlamaContextWrapper {
   final Pointer<llama_context> pointer;
   final _LlamaModelWrapper? _modelKeepAlive;
   List<int>? cachedPromptTokens;
+
+  /// True when [cachedPromptTokens] reflects a KV-cache state that was
+  /// just loaded from disk via stateLoadFile and has not yet been
+  /// extended by any decode/generate. In this narrow window the
+  /// exact-prompt ingest path can skip re-decoding the prefix and only
+  /// re-decode the trailing token to produce fresh logits. Any
+  /// subsequent generate clears the flag, so the parity property
+  /// (cleared+full-decode equals reused) still holds for the
+  /// in-process prompt-reuse path.
+  bool kvFromStateLoad = false;
+
   double lastPerfPromptEvalMs = 0;
   double lastPerfEvalMs = 0;
   double lastPerfSampleMs = 0;
@@ -4899,6 +4929,7 @@ class _LlamaContextWrapper {
     // ignore: unused_local_variable
     final _ = _modelKeepAlive;
     cachedPromptTokens = null;
+    kvFromStateLoad = false;
     llama_free(pointer);
   }
 }

--- a/lib/src/backends/llama_cpp/llama_cpp_service.dart
+++ b/lib/src/backends/llama_cpp/llama_cpp_service.dart
@@ -232,6 +232,7 @@ class LlamaCppService {
   final Map<int, Map<String, double>> _activeLoras = {};
   final Map<int, String> _modelBackendNames = <int, String>{};
   final Map<int, int> _modelResolvedGpuLayers = <int, int>{};
+  final Set<int> _generatingContexts = {};
 
   // Mapping: modelHandle -> mtmdContextHandle
   final Map<int, int> _modelToMtmd = {};
@@ -2559,6 +2560,7 @@ class LlamaCppService {
   }) async* {
     var ctx = _contexts[contextHandle];
     if (ctx == null) throw Exception("Invalid context handle");
+    _generatingContexts.add(contextHandle);
 
     final modelHandle = _contextToModel[contextHandle]!;
     final model = _models[modelHandle]!;
@@ -2657,6 +2659,7 @@ class LlamaCppService {
 
       llama_sampler_free(sampler);
     } finally {
+      _generatingContexts.remove(contextHandle);
       malloc.free(tokensPtr);
       malloc.free(pieceBuf);
       if (grammarPtr != nullptr) malloc.free(grammarPtr);
@@ -3858,6 +3861,11 @@ class LlamaCppService {
   bool stateSaveFile(int contextHandle, String path, List<int> tokens) {
     final ctx = _contexts[contextHandle];
     if (ctx == null) return false;
+    if (_generatingContexts.contains(contextHandle)) {
+      throw StateError(
+        'Cannot save state while generation is active on context $contextHandle',
+      );
+    }
     final pathPtr = path.toNativeUtf8();
     final tokensPtr = tokens.isEmpty ? nullptr : malloc<Int32>(tokens.length);
     try {
@@ -3886,6 +3894,11 @@ class LlamaCppService {
     if (ctx == null) {
       throw StateError('Unknown context handle: $contextHandle');
     }
+    if (_generatingContexts.contains(contextHandle)) {
+      throw StateError(
+        'Cannot load state while generation is active on context $contextHandle',
+      );
+    }
     if (tokenCapacity <= 0) {
       throw ArgumentError.value(
         tokenCapacity,
@@ -3912,7 +3925,9 @@ class LlamaCppService {
         );
       }
       final actual = countPtr.value;
-      return List<int>.generate(actual, (i) => tokensPtr[i]);
+      final loaded = List<int>.generate(actual, (i) => tokensPtr[i]);
+      ctx.cachedPromptTokens = loaded;
+      return loaded;
     } finally {
       malloc.free(pathPtr);
       malloc.free(tokensPtr);

--- a/lib/src/backends/llama_cpp/llama_cpp_service.dart
+++ b/lib/src/backends/llama_cpp/llama_cpp_service.dart
@@ -232,7 +232,13 @@ class LlamaCppService {
   final Map<int, Map<String, double>> _activeLoras = {};
   final Map<int, String> _modelBackendNames = <int, String>{};
   final Map<int, int> _modelResolvedGpuLayers = <int, int>{};
-  final Set<int> _generatingContexts = {};
+
+  /// Per-context refcount of in-flight `generate()` calls. Tracked as a map
+  /// (not a set) so overlapping generations on the same context don't have
+  /// the first-to-complete clear the marker while another decode is still
+  /// running — which would let stateSaveFile / stateLoadFile race the
+  /// remaining in-flight decode.
+  final Map<int, int> _generatingContexts = <int, int>{};
 
   // Mapping: modelHandle -> mtmdContextHandle
   final Map<int, int> _modelToMtmd = {};
@@ -2560,7 +2566,11 @@ class LlamaCppService {
   }) async* {
     var ctx = _contexts[contextHandle];
     if (ctx == null) throw Exception("Invalid context handle");
-    _generatingContexts.add(contextHandle);
+    _generatingContexts.update(
+      contextHandle,
+      (count) => count + 1,
+      ifAbsent: () => 1,
+    );
 
     final modelHandle = _contextToModel[contextHandle]!;
     final model = _models[modelHandle]!;
@@ -2659,7 +2669,12 @@ class LlamaCppService {
 
       llama_sampler_free(sampler);
     } finally {
-      _generatingContexts.remove(contextHandle);
+      final remaining = (_generatingContexts[contextHandle] ?? 1) - 1;
+      if (remaining <= 0) {
+        _generatingContexts.remove(contextHandle);
+      } else {
+        _generatingContexts[contextHandle] = remaining;
+      }
       malloc.free(tokensPtr);
       malloc.free(pieceBuf);
       if (grammarPtr != nullptr) malloc.free(grammarPtr);
@@ -3861,7 +3876,7 @@ class LlamaCppService {
   bool stateSaveFile(int contextHandle, String path, List<int> tokens) {
     final ctx = _contexts[contextHandle];
     if (ctx == null) return false;
-    if (_generatingContexts.contains(contextHandle)) {
+    if (_generatingContexts.containsKey(contextHandle)) {
       throw StateError(
         'Cannot save state while generation is active on context $contextHandle',
       );
@@ -3894,7 +3909,7 @@ class LlamaCppService {
     if (ctx == null) {
       throw StateError('Unknown context handle: $contextHandle');
     }
-    if (_generatingContexts.contains(contextHandle)) {
+    if (_generatingContexts.containsKey(contextHandle)) {
       throw StateError(
         'Cannot load state while generation is active on context $contextHandle',
       );

--- a/lib/src/backends/llama_cpp/llama_cpp_service.dart
+++ b/lib/src/backends/llama_cpp/llama_cpp_service.dart
@@ -2569,44 +2569,48 @@ class LlamaCppService {
       ifAbsent: () => 1,
     );
 
-    final modelHandle = _contextToModel[contextHandle]!;
-    final model = _models[modelHandle]!;
-    final modelParams = _contextParams[contextHandle]!;
-    final vocab = llama_model_get_vocab(model.pointer);
-    final hasMediaParts =
-        parts?.any((p) => p is LlamaImageContent || p is LlamaAudioContent) ??
-        false;
-
-    // 1. Reset Context
-    ctx = _resetContext(
-      contextHandle,
-      ctx,
-      clearMemory: hasMediaParts || !params.reusePromptPrefix,
-    );
-    llama_perf_context_reset(ctx.pointer);
-    final existingSampler = _samplers[contextHandle];
-    if (existingSampler != null) {
-      llama_perf_sampler_reset(existingSampler);
-    }
-
-    // 2. Prepare Resources
-    final nCtx = llama_n_ctx(ctx.pointer);
-    final batch = _batches[contextHandle]!;
-    final tokensPtr = malloc<Int32>(nCtx);
-    final pieceBuf = malloc<Uint8>(256);
+    Pointer<Int32> tokensPtr = nullptr;
+    Pointer<Uint8> pieceBuf = nullptr;
     Pointer<Utf8> grammarPtr = nullptr;
     Pointer<Utf8> rootPtr = nullptr;
     _LazyGrammarConfig? lazyGrammarConfig;
-
-    if (params.grammar != null) {
-      grammarPtr = params.grammar!.toNativeUtf8();
-      rootPtr = params.grammarRoot.toNativeUtf8();
-      if (params.grammarLazy && params.grammarTriggers.isNotEmpty) {
-        lazyGrammarConfig = _buildLazyGrammarConfig(params);
-      }
-    }
+    Pointer<llama_sampler> sampler = nullptr;
 
     try {
+      final modelHandle = _contextToModel[contextHandle]!;
+      final model = _models[modelHandle]!;
+      final modelParams = _contextParams[contextHandle]!;
+      final vocab = llama_model_get_vocab(model.pointer);
+      final hasMediaParts =
+          parts?.any((p) => p is LlamaImageContent || p is LlamaAudioContent) ??
+          false;
+
+      // 1. Reset Context
+      ctx = _resetContext(
+        contextHandle,
+        ctx,
+        clearMemory: hasMediaParts || !params.reusePromptPrefix,
+      );
+      llama_perf_context_reset(ctx.pointer);
+      final existingSampler = _samplers[contextHandle];
+      if (existingSampler != null) {
+        llama_perf_sampler_reset(existingSampler);
+      }
+
+      // 2. Prepare Resources
+      final nCtx = llama_n_ctx(ctx.pointer);
+      final batch = _batches[contextHandle]!;
+      tokensPtr = malloc<Int32>(nCtx);
+      pieceBuf = malloc<Uint8>(256);
+
+      if (params.grammar != null) {
+        grammarPtr = params.grammar!.toNativeUtf8();
+        rootPtr = params.grammarRoot.toNativeUtf8();
+        if (params.grammarLazy && params.grammarTriggers.isNotEmpty) {
+          lazyGrammarConfig = _buildLazyGrammarConfig(params);
+        }
+      }
+
       // 3. Ingest Prompt (Text or Multimodal)
       final promptEvalStopwatch = Stopwatch()..start();
       final initialTokens = _ingestPrompt(
@@ -2630,7 +2634,7 @@ class LlamaCppService {
       _ensureLogitsAvailableAfterPromptEval(ctx.pointer);
 
       // 4. Initialize and Run Sampler Loop
-      final sampler = _initializeSampler(
+      sampler = _initializeSampler(
         params,
         vocab,
         grammarPtr,
@@ -2663,17 +2667,16 @@ class LlamaCppService {
         preservedTokenIds,
         effectiveStopSequences,
       );
-
-      llama_sampler_free(sampler);
     } finally {
+      if (sampler != nullptr) llama_sampler_free(sampler);
       final remaining = (_generatingContexts[contextHandle] ?? 1) - 1;
       if (remaining <= 0) {
         _generatingContexts.remove(contextHandle);
       } else {
         _generatingContexts[contextHandle] = remaining;
       }
-      malloc.free(tokensPtr);
-      malloc.free(pieceBuf);
+      if (tokensPtr != nullptr) malloc.free(tokensPtr);
+      if (pieceBuf != nullptr) malloc.free(pieceBuf);
       if (grammarPtr != nullptr) malloc.free(grammarPtr);
       if (rootPtr != nullptr) malloc.free(rootPtr);
       lazyGrammarConfig?.dispose();
@@ -3932,6 +3935,14 @@ class LlamaCppService {
         tokenCapacity,
         'tokenCapacity',
         'must be positive',
+      );
+    }
+    final contextCapacity = llama_n_ctx(ctx.pointer);
+    if (tokenCapacity > contextCapacity) {
+      throw ArgumentError.value(
+        tokenCapacity,
+        'tokenCapacity',
+        'must not exceed context size ($contextCapacity)',
       );
     }
     llama_synchronize(ctx.pointer);

--- a/lib/src/backends/llama_cpp/llama_cpp_service.dart
+++ b/lib/src/backends/llama_cpp/llama_cpp_service.dart
@@ -3888,6 +3888,9 @@ class LlamaCppService {
         'Cannot save state while generation is active on context $contextHandle',
       );
     }
+    // Drain any outstanding async work on the context (GPU/async backends)
+    // so the persisted state reflects fully committed KV contents.
+    llama_synchronize(ctx.pointer);
     final pathPtr = path.toNativeUtf8();
     final tokensPtr = tokens.isEmpty ? nullptr : malloc<Int32>(tokens.length);
     try {
@@ -3928,6 +3931,9 @@ class LlamaCppService {
         'must be positive',
       );
     }
+    // Drain pending async work before mutating context state, mirroring
+    // _resetContext / embed.
+    llama_synchronize(ctx.pointer);
     final pathPtr = path.toNativeUtf8();
     final tokensPtr = malloc<Int32>(tokenCapacity);
     final countPtr = malloc<Size>();

--- a/lib/src/backends/llama_cpp/llama_cpp_service.dart
+++ b/lib/src/backends/llama_cpp/llama_cpp_service.dart
@@ -233,11 +233,8 @@ class LlamaCppService {
   final Map<int, String> _modelBackendNames = <int, String>{};
   final Map<int, int> _modelResolvedGpuLayers = <int, int>{};
 
-  /// Per-context refcount of in-flight `generate()` calls. Tracked as a map
-  /// (not a set) so overlapping generations on the same context don't have
-  /// the first-to-complete clear the marker while another decode is still
-  /// running — which would let stateSaveFile / stateLoadFile race the
-  /// remaining in-flight decode.
+  /// Refcount of in-flight `generate()` calls per context. A set would let the
+  /// first completion clear the marker while another decode is still running.
   final Map<int, int> _generatingContexts = <int, int>{};
 
   // Mapping: modelHandle -> mtmdContextHandle
@@ -3382,18 +3379,9 @@ class LlamaCppService {
 
     final reusedPrefix = _sharedPrefixLength(cachedTokens, tokensPtr, nTokens);
 
-    // Special case: the new prompt exactly matches a KV state freshly
-    // restored from stateLoadFile and not yet touched by inference. The
-    // restored KV is byte-for-byte the state at the end of the persisted
-    // prompt decode, but the loaded context has no live logits to sample
-    // from. Re-decode only the final token to produce fresh logits while
-    // keeping the rest of the restored prefix intact. This is the
-    // resume-after-state-load fast path.
-    //
-    // We require kvFromStateLoad to be true so the regular reuse path
-    // (post-generate cache) still pays the full re-decode cost and stays
-    // bit-exact against a cleared baseline — the property the native
-    // prompt-reuse parity tool asserts.
+    // Loaded KV holds no live logits; re-decode only the final token. Gated
+    // on kvFromStateLoad so the in-process reuse path stays bit-exact against
+    // a cleared baseline (parity property).
     final exactStateLoadMatch =
         ctx.kvFromStateLoad &&
         reusedPrefix == nTokens &&
@@ -3452,9 +3440,6 @@ class LlamaCppService {
     ctx.cachedPromptTokens = exactStateLoadMatch
         ? cachedTokens
         : _copyPromptTokens(tokensPtr, nTokens);
-    // Once we've decoded anything against the restored KV, the in-memory
-    // state has diverged from the on-disk snapshot — drop the flag so the
-    // next ingest goes through the normal reuse path.
     ctx.kvFromStateLoad = false;
 
     return nTokens;
@@ -3906,8 +3891,6 @@ class LlamaCppService {
         'Cannot save state while generation is active on context $contextHandle',
       );
     }
-    // Drain any outstanding async work on the context (GPU/async backends)
-    // so the persisted state reflects fully committed KV contents.
     llama_synchronize(ctx.pointer);
     final pathPtr = path.toNativeUtf8();
     final tokensPtr = tokens.isEmpty ? nullptr : malloc<Int32>(tokens.length);
@@ -3949,8 +3932,6 @@ class LlamaCppService {
         'must be positive',
       );
     }
-    // Drain pending async work before mutating context state, mirroring
-    // _resetContext / embed.
     llama_synchronize(ctx.pointer);
     final pathPtr = path.toNativeUtf8();
     final tokensPtr = malloc<Int32>(tokenCapacity);
@@ -3971,9 +3952,6 @@ class LlamaCppService {
         );
       }
       final actual = countPtr.value;
-      // Defensive bounds check: llama_state_load_file should never write
-      // more tokens than tokenCapacity, but an explicit guard prevents OOB
-      // reads if the native contract changes in a future build.
       if (actual > tokenCapacity) {
         throw StateError(
           'llama_state_load_file returned actual=$actual '
@@ -4908,14 +4886,9 @@ class _LlamaContextWrapper {
   final _LlamaModelWrapper? _modelKeepAlive;
   List<int>? cachedPromptTokens;
 
-  /// True when [cachedPromptTokens] reflects a KV-cache state that was
-  /// just loaded from disk via stateLoadFile and has not yet been
-  /// extended by any decode/generate. In this narrow window the
-  /// exact-prompt ingest path can skip re-decoding the prefix and only
-  /// re-decode the trailing token to produce fresh logits. Any
-  /// subsequent generate clears the flag, so the parity property
-  /// (cleared+full-decode equals reused) still holds for the
-  /// in-process prompt-reuse path.
+  /// Set by stateLoadFile, cleared by any decode. Gates the exact-prompt
+  /// single-token resume path; without the gate, the in-process reuse path
+  /// would diverge from the cleared+full-decode baseline (parity property).
   bool kvFromStateLoad = false;
 
   double lastPerfPromptEvalMs = 0;

--- a/lib/src/backends/llama_cpp/llama_cpp_service.dart
+++ b/lib/src/backends/llama_cpp/llama_cpp_service.dart
@@ -3885,7 +3885,9 @@ class LlamaCppService {
   /// Wraps `llama_state_save_file`. Returns true on success.
   bool stateSaveFile(int contextHandle, String path, List<int> tokens) {
     final ctx = _contexts[contextHandle];
-    if (ctx == null) return false;
+    if (ctx == null) {
+      throw StateError('Unknown context handle: $contextHandle');
+    }
     if (_generatingContexts.containsKey(contextHandle)) {
       throw StateError(
         'Cannot save state while generation is active on context $contextHandle',

--- a/lib/src/backends/llama_cpp/llama_cpp_service.dart
+++ b/lib/src/backends/llama_cpp/llama_cpp_service.dart
@@ -3873,6 +3873,76 @@ class LlamaCppService {
     return utf8.decode(bytes, allowMalformed: true);
   }
 
+  /// Persists the KV-cache state of [contextHandle] to [path] together
+  /// with the producing token sequence so a later [stateLoadFile] can
+  /// resume inference without paying the prompt-eval cost again.
+  ///
+  /// Wraps `llama_state_save_file`. Returns true on success.
+  bool stateSaveFile(int contextHandle, String path, List<int> tokens) {
+    final ctx = _contexts[contextHandle];
+    if (ctx == null) return false;
+    final pathPtr = path.toNativeUtf8();
+    final tokensPtr = tokens.isEmpty ? nullptr : malloc<Int32>(tokens.length);
+    try {
+      for (int i = 0; i < tokens.length; i++) {
+        tokensPtr[i] = tokens[i];
+      }
+      return llama_state_save_file(
+        ctx.pointer,
+        pathPtr.cast(),
+        tokensPtr,
+        tokens.length,
+      );
+    } finally {
+      malloc.free(pathPtr);
+      if (tokensPtr != nullptr) malloc.free(tokensPtr);
+    }
+  }
+
+  /// Restores a previously saved KV-cache state into [contextHandle].
+  /// [tokenCapacity] caps the number of tokens read back.
+  ///
+  /// Wraps `llama_state_load_file`. Throws on failure (corrupt file,
+  /// schema mismatch, etc.).
+  List<int> stateLoadFile(int contextHandle, String path, int tokenCapacity) {
+    final ctx = _contexts[contextHandle];
+    if (ctx == null) {
+      throw StateError('Unknown context handle: $contextHandle');
+    }
+    if (tokenCapacity <= 0) {
+      throw ArgumentError.value(
+        tokenCapacity,
+        'tokenCapacity',
+        'must be positive',
+      );
+    }
+    final pathPtr = path.toNativeUtf8();
+    final tokensPtr = malloc<Int32>(tokenCapacity);
+    final countPtr = malloc<Size>();
+    try {
+      countPtr.value = 0;
+      final ok = llama_state_load_file(
+        ctx.pointer,
+        pathPtr.cast(),
+        tokensPtr,
+        tokenCapacity,
+        countPtr,
+      );
+      if (!ok) {
+        throw StateError(
+          'llama_state_load_file failed for "$path" '
+          '(corrupt file, version mismatch, or capacity too small)',
+        );
+      }
+      final actual = countPtr.value;
+      return List<int>.generate(actual, (i) => tokensPtr[i]);
+    } finally {
+      malloc.free(pathPtr);
+      malloc.free(tokensPtr);
+      malloc.free(countPtr);
+    }
+  }
+
   /// Returns metadata for the specified [modelHandle].
   Map<String, String> getMetadata(int modelHandle) {
     final model = _models[modelHandle];

--- a/lib/src/backends/llama_cpp/worker.dart
+++ b/lib/src/backends/llama_cpp/worker.dart
@@ -207,6 +207,22 @@ void llamaWorkerEntry(SendPort initialSendPort) {
             message.sendPort.send(
               ErrorResponse("Chat template not implemented in service yet"),
             );
+
+          case StateSaveFileRequest():
+            final ok = service.stateSaveFile(
+              message.contextHandle,
+              message.path,
+              message.tokens,
+            );
+            message.sendPort.send(StateSaveFileResponse(ok));
+
+          case StateLoadFileRequest():
+            final tokens = service.stateLoadFile(
+              message.contextHandle,
+              message.path,
+              message.tokenCapacity,
+            );
+            message.sendPort.send(StateLoadFileResponse(tokens));
         }
       } catch (e) {
         message.sendPort.send(ErrorResponse(e.toString()));

--- a/lib/src/backends/llama_cpp/worker_messages.dart
+++ b/lib/src/backends/llama_cpp/worker_messages.dart
@@ -292,6 +292,49 @@ class SystemInfoRequest extends WorkerRequest {
   SystemInfoRequest(super.sendPort);
 }
 
+/// Request to write the KV-cache state of [contextHandle] to [path]
+/// together with the producing token sequence (for state restore).
+class StateSaveFileRequest extends WorkerRequest {
+  /// Context whose state to persist.
+  final int contextHandle;
+
+  /// Destination file path.
+  final String path;
+
+  /// Token sequence the current state was produced from.
+  final List<int> tokens;
+
+  /// Creates a new [StateSaveFileRequest].
+  StateSaveFileRequest(
+    this.contextHandle,
+    this.path,
+    this.tokens,
+    super.sendPort,
+  );
+}
+
+/// Request to load a previously saved KV-cache state from [path].
+/// [tokenCapacity] caps the number of tokens the caller can hold —
+/// typically the loaded model's context size.
+class StateLoadFileRequest extends WorkerRequest {
+  /// Context to restore the saved state into.
+  final int contextHandle;
+
+  /// Source file path.
+  final String path;
+
+  /// Maximum number of tokens to read back.
+  final int tokenCapacity;
+
+  /// Creates a new [StateLoadFileRequest].
+  StateLoadFileRequest(
+    this.contextHandle,
+    this.path,
+    this.tokenCapacity,
+    super.sendPort,
+  );
+}
+
 /// Request to apply a chat template.
 class ChatTemplateRequest extends WorkerRequest {
   /// The handle of the model.
@@ -386,6 +429,25 @@ class GetContextSizeResponse {
 
   /// Creates a new [GetContextSizeResponse].
   GetContextSizeResponse(this.size);
+}
+
+/// Response from a [StateSaveFileRequest]: success / failure.
+class StateSaveFileResponse {
+  /// Whether the save succeeded.
+  final bool success;
+
+  /// Creates a new [StateSaveFileResponse].
+  StateSaveFileResponse(this.success);
+}
+
+/// Response from a [StateLoadFileRequest]: the token sequence the
+/// restored state was originally produced from.
+class StateLoadFileResponse {
+  /// The recovered token IDs.
+  final List<int> tokens;
+
+  /// Creates a new [StateLoadFileResponse].
+  StateLoadFileResponse(this.tokens);
 }
 
 /// Response containing an error message.

--- a/lib/src/core/engine/engine.dart
+++ b/lib/src/core/engine/engine.dart
@@ -980,6 +980,55 @@ class LlamaEngine {
   }
 
   // ============================================================
+  // STATE PERSISTENCE
+  // ============================================================
+
+  /// Whether the active backend can save and restore KV-cache state to
+  /// disk via [stateSaveFile] / [stateLoadFile]. Native backends do; the
+  /// WebGPU backend does not.
+  bool get supportsStatePersistence => backend is BackendStatePersistence;
+
+  /// Persists the KV-cache state of the loaded model to [path] together
+  /// with [tokens] — the token sequence the current state was produced
+  /// from. A later [stateLoadFile] call rebuilds the same in-memory
+  /// state without re-evaluating the prompt, which is the difference
+  /// between a 30-second resume on phone CPUs and an instant one.
+  ///
+  /// File format is whatever llama.cpp emits — opaque, not portable
+  /// across builds, and tied to the same model used at save time.
+  ///
+  /// Returns true on success.
+  Future<bool> stateSaveFile(String path, {required List<int> tokens}) {
+    _ensureReady();
+    final persistence = _resolveStatePersistence();
+    return persistence.stateSaveFile(_contextHandle!, path, tokens);
+  }
+
+  /// Restores a previously saved state from [path]. [tokenCapacity]
+  /// caps how many tokens to read back; passing the loaded model's
+  /// `n_ctx` is a safe default. Returns the token sequence the saved
+  /// state was originally produced from — feed it back into the chat
+  /// session so its in-Dart history matches the restored KV cache.
+  Future<StateLoadResult> stateLoadFile(
+    String path, {
+    required int tokenCapacity,
+  }) {
+    _ensureReady();
+    final persistence = _resolveStatePersistence();
+    return persistence.stateLoadFile(_contextHandle!, path, tokenCapacity);
+  }
+
+  BackendStatePersistence _resolveStatePersistence() {
+    final candidate = backend;
+    if (candidate is BackendStatePersistence) {
+      return candidate as BackendStatePersistence;
+    }
+    throw LlamaUnsupportedException(
+      'State persistence is not supported by the active backend.',
+    );
+  }
+
+  // ============================================================
   // MODEL INTROSPECTION
   // ============================================================
 

--- a/lib/src/core/engine/engine.dart
+++ b/lib/src/core/engine/engine.dart
@@ -1006,9 +1006,15 @@ class LlamaEngine {
 
   /// Restores a previously saved state from [path]. [tokenCapacity]
   /// caps how many tokens to read back; passing the loaded model's
-  /// `n_ctx` is a safe default. Returns the token sequence the saved
-  /// state was originally produced from — feed it back into the chat
-  /// session so its in-Dart history matches the restored KV cache.
+  /// `n_ctx` is a safe default.
+  ///
+  /// Returns the token sequence the saved state was originally produced
+  /// from. This API restores the native KV cache only — callers that use
+  /// [ChatSession] must persist and reconstruct the chat message history
+  /// separately (e.g. on disk), since [ChatSession.addMessage] takes
+  /// [LlamaChatMessage] objects, not raw token ids. The returned token
+  /// list is exposed mainly for diagnostics and for callers driving the
+  /// engine at the raw prompt level.
   Future<StateLoadResult> stateLoadFile(
     String path, {
     required int tokenCapacity,

--- a/test/integration/state_persistence_test.dart
+++ b/test/integration/state_persistence_test.dart
@@ -72,4 +72,57 @@ void main() async {
     final loaded = await engine.stateLoadFile(savePath, tokenCapacity: 64);
     expect(loaded.tokens, isEmpty);
   });
+
+  test('generate after stateLoadFile reuses KV prefix, not full prompt eval', () async {
+    const prompt = 'Once upon a time in a land far away';
+
+    // Evaluate the prompt into the KV cache via a short generation.
+    await engine
+        .generate(
+          prompt,
+          params: const GenerationParams(
+            maxTokens: 3,
+            reusePromptPrefix: true,
+          ),
+        )
+        .drain<void>();
+    final fullPerf = await engine.getPerformanceContext();
+    final fullEvalTokens = fullPerf?.promptEvalTokens ?? 0;
+    expect(
+      fullEvalTokens,
+      greaterThan(0),
+      reason: 'first generate must evaluate the prompt',
+    );
+
+    // Save the KV state together with the producing token sequence.
+    final tokens = await engine.tokenize(prompt);
+    final savePath = '${tmpDir.path}/kv_reuse.bin';
+    expect(await engine.stateSaveFile(savePath, tokens: tokens), isTrue);
+
+    // Load the state — this must seed cachedPromptTokens.
+    final loadResult = await engine.stateLoadFile(savePath, tokenCapacity: 512);
+    expect(loadResult.tokens, equals(tokens));
+
+    // Generate with the same prompt again.  If cachedPromptTokens was seeded
+    // correctly the KV prefix is already in place and only the empty suffix
+    // (zero tokens) should be evaluated, not the full prompt again.
+    await engine
+        .generate(
+          prompt,
+          params: const GenerationParams(
+            maxTokens: 3,
+            reusePromptPrefix: true,
+          ),
+        )
+        .drain<void>();
+    final cachedPerf = await engine.getPerformanceContext();
+    final cachedEvalTokens = cachedPerf?.promptEvalTokens ?? fullEvalTokens;
+
+    expect(
+      cachedEvalTokens,
+      lessThan(fullEvalTokens),
+      reason:
+          'generate after stateLoadFile should reuse the KV prefix and not re-evaluate the full prompt',
+    );
+  });
 }

--- a/test/integration/state_persistence_test.dart
+++ b/test/integration/state_persistence_test.dart
@@ -80,6 +80,14 @@ void main() async {
     );
   });
 
+  test('rejects token capacity larger than context size', () async {
+    final unusedPath = '${tmpDir.path}/oversized-capacity.bin';
+    expect(
+      () => engine.stateLoadFile(unusedPath, tokenCapacity: 257),
+      throwsA(isA<Exception>()),
+    );
+  });
+
   test('round-trips an empty token sequence', () async {
     final savePath = '${tmpDir.path}/empty.bin';
     final saved = await engine.stateSaveFile(savePath, tokens: const []);
@@ -95,6 +103,7 @@ void main() async {
 
       // --- Engine A: seed the KV cache and persist it to disk. ---
       final engineA = LlamaEngine(LlamaBackend());
+      var engineADisposed = false;
       LlamaEngine? engineB;
       try {
         await engineA.loadModel(
@@ -126,6 +135,7 @@ void main() async {
         // Drop engine A so the next decode genuinely starts cold — no
         // warmed KV cache in memory to mask a regression in stateLoadFile.
         await engineA.dispose();
+        engineADisposed = true;
 
         // --- Engine B: cold start, load the persisted state, resume. ---
         engineB = LlamaEngine(LlamaBackend());
@@ -136,7 +146,7 @@ void main() async {
 
         final loadResult = await engineB.stateLoadFile(
           savePath,
-          tokenCapacity: 512,
+          tokenCapacity: 256,
         );
         expect(
           loadResult.tokens,
@@ -178,6 +188,9 @@ void main() async {
         if (engineB != null) {
           await engineB.dispose();
         }
+        if (!engineADisposed) {
+          await engineA.dispose();
+        }
       }
     },
   );
@@ -188,6 +201,7 @@ void main() async {
       const prompt = 'Once upon a time in a small village';
 
       final engineA = LlamaEngine(LlamaBackend());
+      var engineADisposed = false;
       LlamaEngine? engineB;
       try {
         await engineA.loadModel(
@@ -209,6 +223,7 @@ void main() async {
         final savePath = '${tmpDir.path}/exact_match.bin';
         expect(await engineA.stateSaveFile(savePath, tokens: tokens), isTrue);
         await engineA.dispose();
+        engineADisposed = true;
 
         engineB = LlamaEngine(LlamaBackend());
         await engineB.loadModel(
@@ -216,7 +231,7 @@ void main() async {
           modelParams: const ModelParams(contextSize: 256),
         );
 
-        await engineB.stateLoadFile(savePath, tokenCapacity: 512);
+        await engineB.stateLoadFile(savePath, tokenCapacity: 256);
 
         // Re-issue the EXACT same prompt — reusedPrefix == nTokens. The
         // exact-match branch must NOT clear the restored KV cache; only the
@@ -245,6 +260,9 @@ void main() async {
       } finally {
         if (engineB != null) {
           await engineB.dispose();
+        }
+        if (!engineADisposed) {
+          await engineA.dispose();
         }
       }
     },

--- a/test/integration/state_persistence_test.dart
+++ b/test/integration/state_persistence_test.dart
@@ -1,0 +1,75 @@
+@TestOn('vm')
+@Timeout(Duration(minutes: 5))
+library;
+
+import 'dart:io';
+import 'package:test/test.dart';
+import 'package:llamadart/llamadart.dart';
+import '../test_helper.dart';
+
+/// Round-trip integration test for `llama_state_save_file` and
+/// `llama_state_load_file` exposed via [LlamaEngine].
+///
+/// Saves the KV-cache state of a tiny model after seeding it with a
+/// known prompt, then verifies that [stateLoadFile] returns the same
+/// token sequence and that the destination context can resume
+/// generation without re-evaluating the prompt.
+void main() async {
+  late File modelFile;
+  late LlamaEngine engine;
+  late LlamaBackend backend;
+  late Directory tmpDir;
+
+  setUpAll(() async {
+    modelFile = await TestHelper.getTestModel();
+    backend = LlamaBackend();
+    engine = LlamaEngine(backend);
+    await engine.loadModel(
+      modelFile.path,
+      modelParams: const ModelParams(contextSize: 256),
+    );
+    tmpDir = Directory.systemTemp.createTempSync('llamadart_state_test_');
+  });
+
+  tearDownAll(() async {
+    await engine.dispose();
+    if (tmpDir.existsSync()) {
+      tmpDir.deleteSync(recursive: true);
+    }
+  });
+
+  test('reports state persistence support on the native backend', () {
+    expect(engine.supportsStatePersistence, isTrue);
+  });
+
+  test('saves and loads KV state, recovering the original tokens', () async {
+    // Seed the context by tokenizing a known prompt and saving state.
+    final tokens = await engine.tokenize('Once upon a time in a quiet land');
+    expect(tokens, isNotEmpty);
+
+    final savePath = '${tmpDir.path}/state.bin';
+    final saved = await engine.stateSaveFile(savePath, tokens: tokens);
+    expect(saved, isTrue, reason: 'stateSaveFile should succeed');
+    expect(File(savePath).existsSync(), isTrue);
+    expect(File(savePath).lengthSync(), greaterThan(0));
+
+    final result = await engine.stateLoadFile(savePath, tokenCapacity: 256);
+    expect(result.tokens, equals(tokens));
+  });
+
+  test('rejects non-existent state files', () async {
+    final missingPath = '${tmpDir.path}/does-not-exist.bin';
+    expect(
+      () => engine.stateLoadFile(missingPath, tokenCapacity: 256),
+      throwsA(isA<Exception>()),
+    );
+  });
+
+  test('round-trips an empty token sequence', () async {
+    final savePath = '${tmpDir.path}/empty.bin';
+    final saved = await engine.stateSaveFile(savePath, tokens: const []);
+    expect(saved, isTrue);
+    final loaded = await engine.stateLoadFile(savePath, tokenCapacity: 64);
+    expect(loaded.tokens, isEmpty);
+  });
+}

--- a/test/integration/state_persistence_test.dart
+++ b/test/integration/state_persistence_test.dart
@@ -73,56 +73,68 @@ void main() async {
     expect(loaded.tokens, isEmpty);
   });
 
-  test('generate after stateLoadFile reuses KV prefix, not full prompt eval', () async {
-    const prompt = 'Once upon a time in a land far away';
+  test(
+    'generate after stateLoadFile reuses KV prefix, not full prompt eval',
+    () async {
+      const prompt = 'Once upon a time in a land far away';
 
-    // Evaluate the prompt into the KV cache via a short generation.
-    await engine
-        .generate(
-          prompt,
-          params: const GenerationParams(
-            maxTokens: 3,
-            reusePromptPrefix: true,
-          ),
-        )
-        .drain<void>();
-    final fullPerf = await engine.getPerformanceContext();
-    final fullEvalTokens = fullPerf?.promptEvalTokens ?? 0;
-    expect(
-      fullEvalTokens,
-      greaterThan(0),
-      reason: 'first generate must evaluate the prompt',
-    );
+      // Evaluate the prompt into the KV cache via a short generation.
+      final tokens = await engine.tokenize(prompt);
+      await engine
+          .generate(
+            prompt,
+            params: const GenerationParams(
+              maxTokens: 3,
+              reusePromptPrefix: true,
+            ),
+          )
+          .drain<void>();
+      final fullPerf = await engine.getPerformanceContext();
+      final fullEvalTokens = fullPerf?.promptEvalTokens ?? 0;
+      expect(
+        fullEvalTokens,
+        greaterThan(1),
+        reason: 'first generate must evaluate the prompt',
+      );
 
-    // Save the KV state together with the producing token sequence.
-    final tokens = await engine.tokenize(prompt);
-    final savePath = '${tmpDir.path}/kv_reuse.bin';
-    expect(await engine.stateSaveFile(savePath, tokens: tokens), isTrue);
+      // Save the KV state together with the producing token sequence.
+      final savePath = '${tmpDir.path}/kv_reuse.bin';
+      expect(await engine.stateSaveFile(savePath, tokens: tokens), isTrue);
 
-    // Load the state — this must seed cachedPromptTokens.
-    final loadResult = await engine.stateLoadFile(savePath, tokenCapacity: 512);
-    expect(loadResult.tokens, equals(tokens));
+      // Load the state — this must seed cachedPromptTokens.
+      final loadResult = await engine.stateLoadFile(
+        savePath,
+        tokenCapacity: 512,
+      );
+      expect(loadResult.tokens, equals(tokens));
 
-    // Generate with the same prompt again.  If cachedPromptTokens was seeded
-    // correctly the KV prefix is already in place and only the empty suffix
-    // (zero tokens) should be evaluated, not the full prompt again.
-    await engine
-        .generate(
-          prompt,
-          params: const GenerationParams(
-            maxTokens: 3,
-            reusePromptPrefix: true,
-          ),
-        )
-        .drain<void>();
-    final cachedPerf = await engine.getPerformanceContext();
-    final cachedEvalTokens = cachedPerf?.promptEvalTokens ?? fullEvalTokens;
+      // Generate with prompt + a short suffix.  If cachedPromptTokens was
+      // seeded correctly the KV prefix is already in place and only the suffix
+      // tokens are evaluated, not the full prompt.  We use the native
+      // n_p_eval counter (returned when > 0) which reflects the actual decode
+      // count for this call; the Dart fallback always returns the full prompt
+      // length so we need at least one suffix token to get a native reading.
+      const suffix = ' and they';
+      await engine
+          .generate(
+            prompt + suffix,
+            params: const GenerationParams(
+              maxTokens: 3,
+              reusePromptPrefix: true,
+            ),
+          )
+          .drain<void>();
+      final cachedPerf = await engine.getPerformanceContext();
+      final cachedEvalTokens = cachedPerf?.promptEvalTokens ?? fullEvalTokens;
 
-    expect(
-      cachedEvalTokens,
-      lessThan(fullEvalTokens),
-      reason:
-          'generate after stateLoadFile should reuse the KV prefix and not re-evaluate the full prompt',
-    );
-  });
+      // Only the suffix tokens should have been evaluated (not the full prompt).
+      expect(
+        cachedEvalTokens,
+        lessThan(fullEvalTokens),
+        reason:
+            'generate after stateLoadFile should reuse the KV prefix; '
+            'only suffix tokens should be evaluated, not the full prompt',
+      );
+    },
+  );
 }

--- a/test/integration/state_persistence_test.dart
+++ b/test/integration/state_persistence_test.dart
@@ -43,15 +43,30 @@ void main() async {
   });
 
   test('saves and loads KV state, recovering the original tokens', () async {
-    // Seed the context by tokenizing a known prompt and saving state.
-    final tokens = await engine.tokenize('Once upon a time in a quiet land');
+    // Tokenization alone does not populate the KV cache; seed it by running
+    // a short generate so the persisted file actually contains real state.
+    const prompt = 'Once upon a time in a quiet land';
+    final tokens = await engine.tokenize(prompt);
     expect(tokens, isNotEmpty);
+
+    await engine
+        .generate(
+          prompt,
+          params: const GenerationParams(maxTokens: 2, reusePromptPrefix: true),
+        )
+        .drain<void>();
 
     final savePath = '${tmpDir.path}/state.bin';
     final saved = await engine.stateSaveFile(savePath, tokens: tokens);
     expect(saved, isTrue, reason: 'stateSaveFile should succeed');
     expect(File(savePath).existsSync(), isTrue);
-    expect(File(savePath).lengthSync(), greaterThan(0));
+    // A file holding real KV state for a non-empty prompt is far larger than
+    // the bare token list; reject the trivial token-roundtrip case.
+    expect(
+      File(savePath).lengthSync(),
+      greaterThan(tokens.length * 8),
+      reason: 'saved state must contain KV data, not just the token header',
+    );
 
     final result = await engine.stateLoadFile(savePath, tokenCapacity: 256);
     expect(result.tokens, equals(tokens));
@@ -74,67 +89,164 @@ void main() async {
   });
 
   test(
-    'generate after stateLoadFile reuses KV prefix, not full prompt eval',
+    'fresh engine resumes from saved state without re-evaluating the prompt',
     () async {
       const prompt = 'Once upon a time in a land far away';
 
-      // Evaluate the prompt into the KV cache via a short generation.
-      final tokens = await engine.tokenize(prompt);
-      await engine
-          .generate(
-            prompt,
-            params: const GenerationParams(
-              maxTokens: 3,
-              reusePromptPrefix: true,
-            ),
-          )
-          .drain<void>();
-      final fullPerf = await engine.getPerformanceContext();
-      final fullEvalTokens = fullPerf?.promptEvalTokens ?? 0;
-      expect(
-        fullEvalTokens,
-        greaterThan(1),
-        reason: 'first generate must evaluate the prompt',
-      );
+      // --- Engine A: seed the KV cache and persist it to disk. ---
+      final engineA = LlamaEngine(LlamaBackend());
+      LlamaEngine? engineB;
+      try {
+        await engineA.loadModel(
+          modelFile.path,
+          modelParams: const ModelParams(contextSize: 256),
+        );
 
-      // Save the KV state together with the producing token sequence.
-      final savePath = '${tmpDir.path}/kv_reuse.bin';
-      expect(await engine.stateSaveFile(savePath, tokens: tokens), isTrue);
+        final tokens = await engineA.tokenize(prompt);
+        await engineA
+            .generate(
+              prompt,
+              params: const GenerationParams(
+                maxTokens: 3,
+                reusePromptPrefix: true,
+              ),
+            )
+            .drain<void>();
+        final perfA = await engineA.getPerformanceContext();
+        final fullEvalTokens = perfA?.promptEvalTokens ?? 0;
+        expect(
+          fullEvalTokens,
+          greaterThan(1),
+          reason: 'engine A must evaluate the prompt',
+        );
 
-      // Load the state — this must seed cachedPromptTokens.
-      final loadResult = await engine.stateLoadFile(
-        savePath,
-        tokenCapacity: 512,
-      );
-      expect(loadResult.tokens, equals(tokens));
+        final savePath = '${tmpDir.path}/kv_reuse_fresh.bin';
+        expect(await engineA.stateSaveFile(savePath, tokens: tokens), isTrue);
 
-      // Generate with prompt + a short suffix.  If cachedPromptTokens was
-      // seeded correctly the KV prefix is already in place and only the suffix
-      // tokens are evaluated, not the full prompt.  We use the native
-      // n_p_eval counter (returned when > 0) which reflects the actual decode
-      // count for this call; the Dart fallback always returns the full prompt
-      // length so we need at least one suffix token to get a native reading.
-      const suffix = ' and they';
-      await engine
-          .generate(
-            prompt + suffix,
-            params: const GenerationParams(
-              maxTokens: 3,
-              reusePromptPrefix: true,
-            ),
-          )
-          .drain<void>();
-      final cachedPerf = await engine.getPerformanceContext();
-      final cachedEvalTokens = cachedPerf?.promptEvalTokens ?? fullEvalTokens;
+        // Drop engine A so the next decode genuinely starts cold — no
+        // warmed KV cache in memory to mask a regression in stateLoadFile.
+        await engineA.dispose();
 
-      // Only the suffix tokens should have been evaluated (not the full prompt).
-      expect(
-        cachedEvalTokens,
-        lessThan(fullEvalTokens),
-        reason:
-            'generate after stateLoadFile should reuse the KV prefix; '
-            'only suffix tokens should be evaluated, not the full prompt',
-      );
+        // --- Engine B: cold start, load the persisted state, resume. ---
+        engineB = LlamaEngine(LlamaBackend());
+        await engineB.loadModel(
+          modelFile.path,
+          modelParams: const ModelParams(contextSize: 256),
+        );
+
+        final loadResult = await engineB.stateLoadFile(
+          savePath,
+          tokenCapacity: 512,
+        );
+        expect(
+          loadResult.tokens,
+          equals(tokens),
+          reason: 'loaded tokens must round-trip on a fresh engine',
+        );
+
+        // Generate with prompt + a short suffix on the fresh engine. If
+        // cachedPromptTokens was seeded by stateLoadFile, only the suffix
+        // is decoded; otherwise the full prompt re-evaluates. We use the
+        // native n_p_eval counter (returned when > 0) which reflects the
+        // actual decode count for this call; the Dart fallback returns
+        // the full prompt length so we need at least one suffix token to
+        // get a native reading.
+        const suffix = ' and they';
+        await engineB
+            .generate(
+              prompt + suffix,
+              params: const GenerationParams(
+                maxTokens: 3,
+                reusePromptPrefix: true,
+              ),
+            )
+            .drain<void>();
+        final perfB = await engineB.getPerformanceContext();
+        final cachedEvalTokens = perfB?.promptEvalTokens ?? fullEvalTokens;
+
+        expect(
+          cachedEvalTokens,
+          lessThan(fullEvalTokens),
+          reason:
+              'fresh-engine generate after stateLoadFile must reuse the '
+              'KV prefix; only suffix tokens should be evaluated, not the '
+              'full prompt',
+        );
+      } finally {
+        // Dispose explicitly; do not use addTearDown to avoid a
+        // double-dispose hang on the (already-disposed) engineA.
+        if (engineB != null) {
+          await engineB.dispose();
+        }
+      }
+    },
+  );
+
+  test(
+    'exact-prompt resume samples without re-decoding the cached prefix',
+    () async {
+      const prompt = 'Once upon a time in a small village';
+
+      final engineA = LlamaEngine(LlamaBackend());
+      LlamaEngine? engineB;
+      try {
+        await engineA.loadModel(
+          modelFile.path,
+          modelParams: const ModelParams(contextSize: 256),
+        );
+
+        final tokens = await engineA.tokenize(prompt);
+        await engineA
+            .generate(
+              prompt,
+              params: const GenerationParams(
+                maxTokens: 2,
+                reusePromptPrefix: true,
+              ),
+            )
+            .drain<void>();
+
+        final savePath = '${tmpDir.path}/exact_match.bin';
+        expect(await engineA.stateSaveFile(savePath, tokens: tokens), isTrue);
+        await engineA.dispose();
+
+        engineB = LlamaEngine(LlamaBackend());
+        await engineB.loadModel(
+          modelFile.path,
+          modelParams: const ModelParams(contextSize: 256),
+        );
+
+        await engineB.stateLoadFile(savePath, tokenCapacity: 512);
+
+        // Re-issue the EXACT same prompt — reusedPrefix == nTokens. The
+        // exact-match branch must NOT clear the restored KV cache; only the
+        // final token is re-decoded so the sampler has fresh logits. We
+        // assert this by checking that the native prompt-eval token count
+        // is below the full prompt length (it should be 1, but allow slack
+        // for the Dart fallback path).
+        await engineB
+            .generate(
+              prompt,
+              params: const GenerationParams(
+                maxTokens: 2,
+                reusePromptPrefix: true,
+              ),
+            )
+            .drain<void>();
+        final perf = await engineB.getPerformanceContext();
+        final evalTokens = perf?.promptEvalTokens ?? tokens.length;
+        expect(
+          evalTokens,
+          lessThan(tokens.length),
+          reason:
+              'exact-match resume must re-decode at most one trailing token, '
+              'not the full restored prefix',
+        );
+      } finally {
+        if (engineB != null) {
+          await engineB.dispose();
+        }
+      }
     },
   );
 }

--- a/test/unit/backends/backend_test.dart
+++ b/test/unit/backends/backend_test.dart
@@ -13,4 +13,20 @@ void main() {
   test('BackendBatchEmbeddings capability interface is available', () {
     expect(BackendBatchEmbeddings, isNotNull);
   });
+
+  test('BackendStatePersistence capability interface is available', () {
+    expect(BackendStatePersistence, isNotNull);
+  });
+
+  group('StateLoadResult', () {
+    test('exposes the recovered token sequence', () {
+      const result = StateLoadResult(tokens: [1, 2, 3]);
+      expect(result.tokens, [1, 2, 3]);
+    });
+
+    test('accepts an empty token list', () {
+      const result = StateLoadResult(tokens: []);
+      expect(result.tokens, isEmpty);
+    });
+  });
 }

--- a/test/unit/backends/llama_cpp/llama_cpp_service_test.dart
+++ b/test/unit/backends/llama_cpp/llama_cpp_service_test.dart
@@ -93,6 +93,13 @@ void main() {
       );
     });
 
+    test('stateSaveFile throws for unknown context handle', () {
+      expect(
+        () => service.stateSaveFile(-1, '/tmp/state.bin', const <int>[]),
+        throwsA(isA<StateError>()),
+      );
+    });
+
     test('createMultimodalContext throws for unknown model handle', () {
       expect(
         () => service.createMultimodalContext(-1, 'mmproj.gguf'),

--- a/website/docs/guides/api-levels.md
+++ b/website/docs/guides/api-levels.md
@@ -22,6 +22,8 @@ chat history management.
 - **Template-aware**: Uses model chat templates and parsing behavior automatically.
 - **Tool support**: Works with structured tool-call outputs.
 - **Embedding APIs**: `embed(...)` and `embedBatch(...)` on the same engine.
+- **State persistence**: Native backends can save/restore KV-cache state with
+  `stateSaveFile(...)` / `stateLoadFile(...)` for raw-prompt resume workflows.
 
 ```dart
 import 'package:llamadart/llamadart.dart';
@@ -61,6 +63,8 @@ streams.
 **Advantages:**
 - **Granular control**: Manage handles and pipeline steps directly.
 - **Integration flexibility**: Useful for specialized runtime integrations.
+- **Optional capabilities**: Backends can expose extra interfaces such as
+  `BackendStatePersistence` when a runtime supports native KV-cache snapshots.
 
 ```dart
 import 'dart:convert';

--- a/website/docs/guides/model-lifecycle.md
+++ b/website/docs/guides/model-lifecycle.md
@@ -36,6 +36,57 @@ await engine.loadModelFromUrl(
 
 `loadModelFromUrl` requires a backend with URL loading support.
 
+## Native state persistence
+
+Native backends can save and restore llama.cpp KV-cache state to avoid
+re-evaluating a long raw prompt on resume or when forking a prompt prefix. Gate
+the flow with `supportsStatePersistence` because the WebGPU bridge does not
+expose llama.cpp state files.
+
+```dart
+if (!engine.supportsStatePersistence) {
+  throw LlamaUnsupportedException('State persistence is native-only.');
+}
+
+final prompt = 'You are a concise assistant. Summarize llamadart.';
+final tokens = await engine.tokenize(prompt);
+
+// Populate the KV cache, then persist it with the token sequence that produced
+// the state. Use your app's own writable path for the state file.
+await engine.generate(
+  prompt,
+  params: const GenerationParams(reusePromptPrefix: true),
+).drain<void>();
+await engine.stateSaveFile('/path/to/prompt-prefix.state', tokens: tokens);
+
+// Later, after loading the same model with a compatible native runtime build:
+final restored = await engine.stateLoadFile(
+  '/path/to/prompt-prefix.state',
+  tokenCapacity: await engine.getContextSize(),
+);
+
+await for (final token in engine.generate(
+  '$prompt Continue from the saved prefix.',
+  params: const GenerationParams(reusePromptPrefix: true),
+)) {
+  print(token);
+}
+
+print('Restored ${restored.tokens.length} prompt tokens');
+```
+
+Important caveats:
+
+- State files are opaque llama.cpp artifacts. Treat them as tied to the same
+  model file and compatible native runtime/build that created them.
+- `stateLoadFile(...)` restores native KV-cache state only. It does not rebuild
+  `ChatSession` message history; persist and reconstruct chat messages
+  separately when using the high-level chat API.
+- Pass a `tokenCapacity` large enough for the saved prompt token sequence. The
+  current context size is usually a safe default.
+- WebGPU sessions should check `supportsStatePersistence` and use a normal
+  prompt re-evaluation fallback.
+
 ## Multimodal projector lifecycle
 
 ```dart

--- a/website/docs/guides/model-lifecycle.md
+++ b/website/docs/guides/model-lifecycle.md
@@ -55,7 +55,7 @@ final tokens = await engine.tokenize(prompt);
 // the state. Use your app's own writable path for the state file.
 await engine.generate(
   prompt,
-  params: const GenerationParams(reusePromptPrefix: true),
+  params: const GenerationParams(maxTokens: 1, reusePromptPrefix: true),
 ).drain<void>();
 await engine.stateSaveFile('/path/to/prompt-prefix.state', tokens: tokens);
 

--- a/website/docs/platforms/support-matrix.md
+++ b/website/docs/platforms/support-matrix.md
@@ -30,6 +30,15 @@ All iOS targets above require the consuming Flutter/Xcode project to use a
 minimum deployment target of `16.4` or newer (for example
 `platform :ios, '16.4'`).
 
+## Runtime capability notes
+
+- **State persistence** (`LlamaEngine.stateSaveFile(...)` /
+  `stateLoadFile(...)`) is available only on native backends that expose
+  `BackendStatePersistence`. The WebGPU bridge does not support llama.cpp state
+  files, so applications should gate this flow with
+  `engine.supportsStatePersistence` and fall back to prompt re-evaluation on
+  web.
+
 ## Current module availability by bundle (`b9016`)
 
 | Bundle key | Available backend modules in bundle |


### PR DESCRIPTION
## What

Expose `llama_state_save_file` / `llama_state_load_file` (already in the
FFI bindings) through to the public Dart API.

- New `BackendStatePersistence` ability interface and `StateLoadResult`
  payload, alongside the existing `BackendEmbeddings` /
  `BackendBatchEmbeddings` pattern.
- `NativeLlamaBackend` implements it. WebGPU intentionally does not —
  there's no meaningful KV cache to persist in that backend.
- `LlamaEngine.stateSaveFile(path, tokens:)` and
  `LlamaEngine.stateLoadFile(path, tokenCapacity:)`, plus a
  `supportsStatePersistence` capability flag.
- Worker isolate gets `StateSaveFileRequest` / `StateLoadFileRequest`
  messages + matching handlers; the service layer marshals FFI calls
  and frees temporary buffers.

## Why

Resuming a long conversation today re-runs prompt-eval from scratch —
on a phone CPU with an 8B model that's 30+ seconds of dead air. With
state persistence, restoring a saved snapshot is effectively
instantaneous, which unblocks "resume chat", "fork a conversation",
and "preload a long system prompt" workflows.

## How (file map)

- `lib/src/backends/backend.dart` — new `BackendStatePersistence`
  abstract class + `StateLoadResult`.
- `lib/src/backends/llama_cpp/llama_cpp_service.dart` —
  `stateSaveFile` / `stateLoadFile` that wrap the FFI calls, allocating
  + freeing native buffers.
- `lib/src/backends/llama_cpp/worker.dart` +
  `worker_messages.dart` — request/response plumbing for the isolate.
- `lib/src/backends/llama_cpp/llama_cpp_backend.dart` — implements
  `BackendStatePersistence` on the native backend.
- `lib/src/core/engine/engine.dart` — public engine methods +
  `supportsStatePersistence`.
- `lib/llamadart.dart` — re-export `BackendStatePersistence` and
  `StateLoadResult`.

## Tests

- Unit: `test/unit/backends/backend_test.dart` covers the new ability
  interface and `StateLoadResult`.
- Integration: `test/integration/state_persistence_test.dart` runs a
  real round trip on stories15M — save + load recovers the original
  token sequence, missing files throw, empty token sequence round-trips.

All 583 unit tests pass locally. Integration test passes against the
b9016 native bundle.

## Test plan

- [x] `dart analyze lib/` — clean
- [x] `dart format lib/ test/` — clean
- [x] `dart test -p vm test/unit/` — 583 pass
- [x] `dart test -p vm test/integration/state_persistence_test.dart` — 4 pass
- [ ] Coverage delta — adds public API + 4 integration tests; should
      stay above the 70% threshold

## Notes

- Web backend is unaffected — `LlamaEngine.supportsStatePersistence`
  returns false there, and calls throw `LlamaUnsupportedException`.
- File format is whatever llama.cpp emits (opaque, version-tied to
  the same llama.cpp build, must reload onto the same model). The
  doc comments call this out.