### PR TITLE
feat: add model download cache manager

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -91,6 +91,15 @@ pass `--mem64` and a smaller `--context-size` to keep the smoke bounded.
 - Parameter and return types documented
 - No TODO/FIXME comments in committed code
 
+### Changelog Discipline
+- Never add unreleased work to an already-published version section in
+  `CHANGELOG.md` or `website/docs/changelog/recent-releases.md`.
+- Before editing release notes, check the top of `CHANGELOG.md`. If the latest
+  section is a concrete released version (for example `## 0.6.12`), create a
+  new `## Unreleased` section above it and place new PR entries there.
+- Only move entries from `## Unreleased` into a numbered version section as part
+  of an explicit release/version-bump task.
+
 ### Error Handling
 - Use custom `LlamaException` hierarchy (defined in `lib/src/core/exceptions.dart`)
 - Subtypes: `LlamaModelException`, `LlamaContextException`, `LlamaInferenceException`, `LlamaStateException`, `LlamaUnsupportedException`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,17 +1,23 @@
 ## 0.6.12
 
-* **Model source API foundation**:
+* **Model source download/cache manager**:
   * Added `ModelSource` for local paths, HTTP(S) URLs, and Hugging Face
     `hf://owner/repo/path/to/model.gguf` references, including deterministic
     cache keys and redacted metadata/log identities for signed URLs.
   * Added `ModelLoadOptions`, `ModelCachePolicy`, resolver targets, and
-    download/cache value models as the public foundation for package-managed
-    model download and cache management.
+    download/cache metadata/progress value models for package-managed model
+    download and cache management.
+  * Added native/file-backed `DefaultModelDownloadManager` support for streaming
+    HTTP downloads, `.part` files, atomic promotion, persisted metadata,
+    authenticated bearer/custom headers, cancellation, retry, Range resume,
+    cache hit/refresh/cache-only/no-cache policies, SHA-256 verification,
+    cache listing, removal, clearing, and age/size pruning.
   * Added `LlamaEngine.loadModelSource(...)` to route local sources through the
-    existing native local loader and remote sources through URL-capable backends.
-    Native download/cache IO remains intentionally unsupported until the next
-    implementation phase, with unsupported cache/auth/checksum/retry/resume
-    options rejected explicitly.
+    existing native local loader, remote sources through the native download
+    cache before local loading, and simple remote sources through URL-capable web
+    backends when available.
+  * Migrated server/testing helpers away from ad-hoc model downloads so examples
+    dogfood the package-managed cache manager.
 * **Native runtime sync**:
   * Updated native hook pinning to `leehack/llamadart-native@b9016`,
     picking up the CUDA 12.8 Blackwell-capable native bundles.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-## 0.6.12
+## Unreleased
 
 * **Model source download/cache manager**:
   * Added `ModelSource` for local paths, HTTP(S) URLs, and Hugging Face
@@ -18,6 +18,11 @@
     backends when available.
   * Migrated server/testing helpers away from ad-hoc model downloads so examples
     dogfood the package-managed cache manager.
+* **Compatibility note**: no public API breaking changes; the model source APIs
+  are additive and existing `loadModel(...)` callers are unchanged.
+
+## 0.6.12
+
 * **Native runtime sync**:
   * Updated native hook pinning to `leehack/llamadart-native@b9016`,
     picking up the CUDA 12.8 Blackwell-capable native bundles.
@@ -78,8 +83,7 @@
     owning backend module is selected.
   * Kept unknown non-core runtime libraries bundled for compatibility with
     future native bundle layouts.
-* **Compatibility note**: no public API breaking changes in `0.6.12`; the model
-  source APIs are additive and existing `loadModel(...)` callers are unchanged.
+* **Compatibility note**: no public API breaking changes in `0.6.12`.
 
 ## 0.6.11
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,17 @@
 ## 0.6.12
 
+* **Model source API foundation**:
+  * Added `ModelSource` for local paths, HTTP(S) URLs, and Hugging Face
+    `hf://owner/repo/path/to/model.gguf` references, including deterministic
+    cache keys and redacted metadata/log identities for signed URLs.
+  * Added `ModelLoadOptions`, `ModelCachePolicy`, resolver targets, and
+    download/cache value models as the public foundation for package-managed
+    model download and cache management.
+  * Added `LlamaEngine.loadModelSource(...)` to route local sources through the
+    existing native local loader and remote sources through URL-capable backends.
+    Native download/cache IO remains intentionally unsupported until the next
+    implementation phase, with unsupported cache/auth/checksum/retry/resume
+    options rejected explicitly.
 * **Native runtime sync**:
   * Updated native hook pinning to `leehack/llamadart-native@b9016`,
     picking up the CUDA 12.8 Blackwell-capable native bundles.
@@ -60,7 +72,8 @@
     owning backend module is selected.
   * Kept unknown non-core runtime libraries bundled for compatibility with
     future native bundle layouts.
-* **Compatibility note**: no public API breaking changes in `0.6.12`.
+* **Compatibility note**: no public API breaking changes in `0.6.12`; the model
+  source APIs are additive and existing `loadModel(...)` callers are unchanged.
 
 ## 0.6.11
 

--- a/README.md
+++ b/README.md
@@ -118,8 +118,11 @@ Future<void> main() async {
 ```
 
 Native/file-backed backends stream remote models into the package-managed cache,
-resume partial `.part` downloads when the server supports HTTP Range, verify
-optional SHA-256 checksums, and redact signed URL credentials from metadata.
+resume partial `.part` downloads when the server supports HTTP Range and the
+partial has a safe validator (ETag/Last-Modified) or caller-provided SHA-256,
+verify optional SHA-256 checksums, and redact signed URL credentials from
+metadata. Validator-less partial files restart from byte zero instead of being
+appended.
 
 ### 6. Generate embeddings
 

--- a/README.md
+++ b/README.md
@@ -90,7 +90,38 @@ Future<void> main() async {
 }
 ```
 
-### 5. Generate embeddings
+### 5. Download and cache a remote GGUF
+
+```dart
+import 'package:llamadart/llamadart.dart';
+
+Future<void> main() async {
+  final engine = LlamaEngine(LlamaBackend());
+  try {
+    await engine.loadModelSource(
+      ModelSource.parse('hf://owner/repo/model-Q4_K_M.gguf'),
+      options: ModelLoadOptions(
+        cachePolicy: ModelCachePolicy.preferCached,
+        cacheDirectory: '/path/to/app/model-cache',
+      ),
+      onProgress: (progress) {
+        final fraction = progress.fraction;
+        if (fraction != null) {
+          print('download ${(fraction * 100).toStringAsFixed(1)}%');
+        }
+      },
+    );
+  } finally {
+    await engine.dispose();
+  }
+}
+```
+
+Native/file-backed backends stream remote models into the package-managed cache,
+resume partial `.part` downloads when the server supports HTTP Range, verify
+optional SHA-256 checksums, and redact signed URL credentials from metadata.
+
+### 6. Generate embeddings
 
 ```dart
 import 'package:llamadart/llamadart.dart';

--- a/README.md
+++ b/README.md
@@ -26,6 +26,8 @@
   - Web: WebGPU via bridge runtime (with CPU fallback)
 - 🧭 **Embeddings API**: Generate vectors with `embed(...)` and
   `embedBatch(...)`.
+- 📦 **Structured Model Sources**: Describe local, HTTP(S), and Hugging Face
+  GGUF sources with deterministic cache identities for download/cache workflows.
 - 🖼️ **Multimodal Support**: Vision/audio model runtime support.
 - **LoRA Support**: Runtime GGUF adapter application.
 - 🔇 **Split Logging Control**: Dart logs and native logs can be configured independently.

--- a/example/chat_app/README.md
+++ b/example/chat_app/README.md
@@ -38,6 +38,14 @@ flutter test
 
 Note: this is a Flutter app, so use `flutter test` (not `dart test`).
 
+Slow device E2E tests are tagged `local-only` and skipped by default. To run
+the real model/mmproj download-cache-load check manually on a selected device:
+
+```bash
+flutter test --run-skipped -t local-only \
+  integration_test/model_cache_mmproj_e2e_test.dart -d <device>
+```
+
 ### 2. Choose and Download a Model
 1. The app will open to a **Manage Models** screen.
 2. Select one of the pre-configured models (for example: FunctionGemma 270M, Qwen3.5 0.8B/2B/4B/9B, Llama 3.2 3B, Gemma 3/3n, DeepSeek R1 distills).

--- a/example/chat_app/dart_test.yaml
+++ b/example/chat_app/dart_test.yaml
@@ -1,0 +1,5 @@
+tags:
+  local-only:
+    skip: "Runs only on local machines. Use: flutter test --run-skipped -t local-only integration_test/model_cache_mmproj_e2e_test.dart -d <device>"
+  e2e:
+    timeout: 30m

--- a/example/chat_app/integration_test/model_cache_mmproj_e2e_test.dart
+++ b/example/chat_app/integration_test/model_cache_mmproj_e2e_test.dart
@@ -85,7 +85,7 @@ void main() {
           : p.join(modelsDir, model.filename);
       final mmprojLoadRef = kIsWeb || mmprojSource is LocalModelAssetSource
           ? mmprojSource.loadReference
-          : p.join(modelsDir, model.mmprojFilename);
+          : p.join(modelsDir, mmprojSource.displayName);
 
       final chatService = ChatService();
       try {

--- a/example/chat_app/integration_test/model_cache_mmproj_e2e_test.dart
+++ b/example/chat_app/integration_test/model_cache_mmproj_e2e_test.dart
@@ -1,0 +1,115 @@
+@Tags(['local-only', 'e2e'])
+@Timeout(Duration(minutes: 30))
+/// Local-only chat app E2E for the model/mmproj download-cache-load path.
+///
+/// This downloads the default LFM2-VL 450M model and its mmproj, so it is
+/// intentionally skipped by default. Run it manually with:
+///
+/// ```bash
+/// cd example/chat_app
+/// flutter test --run-skipped -t local-only \
+///   integration_test/model_cache_mmproj_e2e_test.dart -d <device>
+/// ```
+library;
+
+import 'package:dio/dio.dart';
+import 'package:flutter/foundation.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:integration_test/integration_test.dart';
+import 'package:llamadart/llamadart.dart' show GpuBackend, LlamaLogLevel;
+import 'package:path/path.dart' as p;
+
+import 'package:llamadart_chat_example/models/chat_settings.dart';
+import 'package:llamadart_chat_example/models/downloadable_model.dart';
+import 'package:llamadart_chat_example/services/chat_service.dart';
+import 'package:llamadart_chat_example/services/model_service_base.dart';
+
+void main() {
+  IntegrationTestWidgetsFlutterBinding.ensureInitialized();
+
+  testWidgets(
+    'downloads, caches, and loads tiny multimodal model + mmproj',
+    (tester) async {
+      final model = DownloadableModel.defaultModels.firstWhere(
+        (candidate) => candidate.name == 'LFM2-VL 450M',
+      );
+      expect(model.multimodalProjectorSource, isNotNull);
+
+      final service = ModelService();
+      final modelsDir = await service.getModelsDirectory();
+
+      await service.deleteModel(modelsDir, model);
+      var downloaded = await service.getDownloadedModels([model]);
+      expect(downloaded.contains(model.filename), isFalse);
+
+      final stages = <ModelDownloadStage>{};
+      final progressEvents = <ModelDownloadProgress>[];
+      Object? downloadError;
+      String? successFilename;
+
+      await service.downloadModel(
+        model: model,
+        modelsDir: modelsDir,
+        cancelToken: CancelToken(),
+        onProgress: (_) {},
+        onProgressDetail: (detail) {
+          stages.add(detail.stage);
+          progressEvents.add(detail);
+          debugPrint(
+            'E2E download ${detail.stage.name} '
+            '${(detail.overallProgress * 100).toStringAsFixed(1)}% '
+            '${detail.stageDownloadedBytes}/${detail.stageTotalBytes ?? -1}',
+          );
+        },
+        onSuccess: (filename) {
+          successFilename = filename;
+        },
+        onError: (error) {
+          downloadError = error;
+        },
+      );
+
+      expect(downloadError, isNull);
+      expect(successFilename, model.filename);
+      expect(stages, contains(ModelDownloadStage.model));
+      expect(stages, contains(ModelDownloadStage.multimodalProjector));
+      expect(progressEvents.last.overallProgress, 1.0);
+
+      downloaded = await service.getDownloadedModels([model]);
+      expect(downloaded, contains(model.filename));
+
+      final modelSource = model.modelSource;
+      final mmprojSource = model.multimodalProjectorSource!;
+      final modelLoadRef = kIsWeb || modelSource is LocalModelAssetSource
+          ? modelSource.loadReference
+          : p.join(modelsDir, model.filename);
+      final mmprojLoadRef = kIsWeb || mmprojSource is LocalModelAssetSource
+          ? mmprojSource.loadReference
+          : p.join(modelsDir, model.mmprojFilename);
+
+      final chatService = ChatService();
+      try {
+        await chatService.init(
+          ChatSettings(
+            modelPath: modelLoadRef,
+            mmprojPath: mmprojLoadRef,
+            preferredBackend: GpuBackend.cpu,
+            gpuLayers: 0,
+            contextSize: 512,
+            maxTokens: 32,
+            nativeLogLevel: LlamaLogLevel.warn,
+          ),
+          eagerLoadMultimodalProjector: true,
+          onProgress: (progress) =>
+              debugPrint('E2E load ${(progress * 100).toStringAsFixed(1)}%'),
+        );
+
+        expect(chatService.engine.isReady, isTrue);
+        expect(await chatService.engine.supportsVision, isTrue);
+      } finally {
+        await chatService.dispose();
+      }
+    },
+    timeout: const Timeout(Duration(minutes: 30)),
+  );
+}

--- a/example/chat_app/lib/models/downloadable_model.dart
+++ b/example/chat_app/lib/models/downloadable_model.dart
@@ -1,3 +1,120 @@
+import 'dart:convert';
+
+import 'package:crypto/crypto.dart';
+
+String _basename(String pathOrUrl) {
+  final withoutQuery = pathOrUrl.split('?').first.split('#').first;
+  final normalized = withoutQuery.replaceAll('\\', '/');
+  final parts = normalized.split('/').where((part) => part.isNotEmpty);
+  return parts.isEmpty ? pathOrUrl : parts.last;
+}
+
+String _sourceFilename(ModelAssetSource source) {
+  return source is RemoteModelAssetSource
+      ? source.filename
+      : source.displayName;
+}
+
+String _assetCacheKey(String canonicalKey) {
+  return sha256.convert(utf8.encode(canonicalKey)).toString();
+}
+
+enum ModelAssetRole { model, multimodalProjector }
+
+abstract class ModelAssetSource {
+  const ModelAssetSource();
+
+  String get displayName;
+
+  String get canonicalKey;
+
+  String get cacheKey;
+
+  String get loadReference;
+
+  bool get isRemote => this is RemoteModelAssetSource;
+
+  bool get isLocal => this is LocalModelAssetSource;
+}
+
+class LocalModelAssetSource extends ModelAssetSource {
+  final String path;
+
+  const LocalModelAssetSource(this.path);
+
+  @override
+  String get displayName => _basename(path);
+
+  @override
+  String get canonicalKey => 'local:$path';
+
+  @override
+  String get cacheKey => _assetCacheKey(canonicalKey);
+
+  @override
+  String get loadReference => path;
+}
+
+class RemoteModelAssetSource extends ModelAssetSource {
+  final String url;
+  final String filename;
+  final int? sizeBytes;
+  final String? sha256;
+  final Map<String, String>? headers;
+
+  const RemoteModelAssetSource({
+    required this.url,
+    required this.filename,
+    this.sizeBytes,
+    this.sha256,
+    this.headers,
+  });
+
+  @override
+  String get displayName => filename;
+
+  @override
+  String get canonicalKey => 'remote:$url#$filename';
+
+  @override
+  String get cacheKey => _assetCacheKey(canonicalKey);
+
+  @override
+  String get loadReference => url;
+}
+
+class ResolvedModelAsset {
+  final ModelAssetRole role;
+  final ModelAssetSource source;
+  final String loadReference;
+  final bool isLocal;
+
+  const ResolvedModelAsset({
+    required this.role,
+    required this.source,
+    required this.loadReference,
+    required this.isLocal,
+  });
+}
+
+class ModelCapabilities {
+  final bool supportsVision;
+  final bool supportsAudio;
+  final bool supportsVideo;
+  final bool supportsToolCalling;
+  final bool supportsThinking;
+
+  const ModelCapabilities({
+    this.supportsVision = false,
+    this.supportsAudio = false,
+    this.supportsVideo = false,
+    this.supportsToolCalling = false,
+    this.supportsThinking = false,
+  });
+
+  bool get isMultimodal => supportsVision || supportsAudio;
+}
+
 class ModelPreset {
   final double temperature;
   final int topK;
@@ -26,7 +143,38 @@ class ModelPreset {
   });
 }
 
+class ModelProfile {
+  final String id;
+  final String name;
+  final String description;
+  final ModelAssetSource modelSource;
+  final ModelAssetSource? multimodalProjectorSource;
+  final int sizeBytes;
+  final ModelCapabilities capabilities;
+
+  /// Recommended generation/model-loading preset for this model.
+  final ModelPreset preset;
+
+  /// Minimum RAM/VRAM in GB recommended for this model.
+  final int minRamGb;
+
+  const ModelProfile({
+    required this.id,
+    required this.name,
+    required this.description,
+    required this.modelSource,
+    this.multimodalProjectorSource,
+    this.sizeBytes = 0,
+    this.capabilities = const ModelCapabilities(),
+    this.minRamGb = 2,
+    this.preset = const ModelPreset(),
+  });
+
+  bool get isMultimodal => capabilities.isMultimodal;
+}
+
 class DownloadableModel {
+  final String id;
   final String name;
   final String description;
   final String url;
@@ -39,6 +187,8 @@ class DownloadableModel {
   final bool supportsVideo;
   final bool supportsToolCalling;
   final bool supportsThinking;
+  final ModelAssetSource? _modelSourceOverride;
+  final ModelAssetSource? _multimodalProjectorSourceOverride;
 
   /// Recommended generation/model-loading preset for this model.
   final ModelPreset preset;
@@ -61,7 +211,66 @@ class DownloadableModel {
     this.supportsThinking = false,
     this.minRamGb = 2,
     this.preset = const ModelPreset(),
-  });
+  }) : id = filename,
+       _modelSourceOverride = null,
+       _multimodalProjectorSourceOverride = null;
+
+  DownloadableModel.fromSources({
+    String? id,
+    required this.name,
+    required this.description,
+    required ModelAssetSource modelSource,
+    ModelAssetSource? multimodalProjectorSource,
+    this.sizeBytes = 0,
+    this.supportsVision = false,
+    this.supportsAudio = false,
+    this.supportsVideo = false,
+    this.supportsToolCalling = false,
+    this.supportsThinking = false,
+    this.minRamGb = 2,
+    this.preset = const ModelPreset(),
+  }) : id = id ?? modelSource.displayName,
+       url = modelSource.loadReference,
+       filename = _sourceFilename(modelSource),
+       mmprojUrl = multimodalProjectorSource is RemoteModelAssetSource
+           ? multimodalProjectorSource.url
+           : null,
+       mmprojFilename = multimodalProjectorSource == null
+           ? null
+           : _sourceFilename(multimodalProjectorSource),
+       _modelSourceOverride = modelSource,
+       _multimodalProjectorSourceOverride = multimodalProjectorSource;
+
+  ModelAssetSource get modelSource {
+    final override = _modelSourceOverride;
+    if (override != null) {
+      return override;
+    }
+    return RemoteModelAssetSource(
+      url: url,
+      filename: filename,
+      sizeBytes: sizeBytes,
+    );
+  }
+
+  ModelAssetSource? get multimodalProjectorSource {
+    final override = _multimodalProjectorSourceOverride;
+    if (override != null) {
+      return override;
+    }
+    if (mmprojUrl == null || mmprojFilename == null || mmprojUrl!.isEmpty) {
+      return null;
+    }
+    return RemoteModelAssetSource(url: mmprojUrl!, filename: mmprojFilename!);
+  }
+
+  ModelCapabilities get capabilities => ModelCapabilities(
+    supportsVision: supportsVision,
+    supportsAudio: supportsAudio,
+    supportsVideo: supportsVideo,
+    supportsToolCalling: supportsToolCalling,
+    supportsThinking: supportsThinking,
+  );
 
   bool get isMultimodal => supportsVision || supportsAudio;
 

--- a/example/chat_app/lib/models/downloadable_model.dart
+++ b/example/chat_app/lib/models/downloadable_model.dart
@@ -74,7 +74,7 @@ class RemoteModelAssetSource extends ModelAssetSource {
   String get displayName => filename;
 
   @override
-  String get canonicalKey => 'remote:$url#$filename';
+  String get canonicalKey => 'remote:${jsonEncode([url, filename])}';
 
   @override
   String get cacheKey => _assetCacheKey(canonicalKey);

--- a/example/chat_app/lib/screens/manage_models_screen.dart
+++ b/example/chat_app/lib/screens/manage_models_screen.dart
@@ -909,7 +909,9 @@ class _ManageModelsScreenState extends State<ManageModelsScreen>
     }
 
     for (final model in _models) {
-      if (path == model.url || path == _resolveModelLoadReference(model)) {
+      if (path == model.url ||
+          ((kIsWeb || _modelsDir != null) &&
+              path == _resolveModelLoadReference(model))) {
         return model;
       }
       if (path.contains(model.filename)) {
@@ -939,7 +941,7 @@ class _ManageModelsScreenState extends State<ManageModelsScreen>
       return remote.url;
     }
     if (_modelsDir == null) {
-      return remote.filename;
+      throw StateError('Models directory is not initialized.');
     }
     return '${_modelsDir!}/${remote.filename}';
   }

--- a/example/chat_app/lib/screens/manage_models_screen.dart
+++ b/example/chat_app/lib/screens/manage_models_screen.dart
@@ -5,7 +5,7 @@ import 'dart:math' as math;
 import 'package:dio/dio.dart';
 import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
-import 'package:llamadart/llamadart.dart';
+import 'package:llamadart/llamadart.dart' hide ModelDownloadProgress;
 import 'package:provider/provider.dart';
 import 'package:shared_preferences/shared_preferences.dart';
 

--- a/example/chat_app/lib/screens/manage_models_screen.dart
+++ b/example/chat_app/lib/screens/manage_models_screen.dart
@@ -700,26 +700,24 @@ class _ManageModelsScreenState extends State<ManageModelsScreen>
       return;
     }
 
+    if (kIsWeb && _hasUnsupportedWebAsset(model)) {
+      ScaffoldMessenger.of(context).showSnackBar(
+        const SnackBar(
+          content: Text('Web builds require remote URLs for model assets.'),
+        ),
+      );
+      return;
+    }
+
     final provider = context.read<ChatProvider>();
-    final pathOrUrl = kIsWeb ? model.url : '${_modelsDir!}/${model.filename}';
+    final pathOrUrl = _resolveModelLoadReference(model);
 
     provider.updateModelPath(pathOrUrl);
     provider.applyModelPreset(model);
 
     if (model.isMultimodal) {
-      if (kIsWeb) {
-        if (model.mmprojUrl != null && model.mmprojUrl!.isNotEmpty) {
-          provider.updateMmprojPath(model.mmprojUrl!);
-        } else {
-          provider.updateMmprojPath(pathOrUrl);
-        }
-      } else if (model.mmprojFilename != null) {
-        provider.updateMmprojPath('${_modelsDir!}/${model.mmprojFilename}');
-      } else if (model.supportsVision || model.supportsAudio) {
-        provider.updateMmprojPath(pathOrUrl);
-      } else {
-        provider.updateMmprojPath('');
-      }
+      final mmprojPath = _resolveMmprojPathForModel(model);
+      provider.updateMmprojPath(mmprojPath ?? '');
     } else {
       provider.updateMmprojPath('');
     }
@@ -911,11 +909,39 @@ class _ManageModelsScreenState extends State<ManageModelsScreen>
     }
 
     for (final model in _models) {
-      if (path == model.url || path.contains(model.filename)) {
+      if (path == model.url || path == _resolveModelLoadReference(model)) {
+        return model;
+      }
+      if (path.contains(model.filename)) {
         return model;
       }
     }
     return null;
+  }
+
+  String _resolveModelLoadReference(DownloadableModel model) {
+    return _resolveAssetLoadReference(model.modelSource);
+  }
+
+  bool _hasUnsupportedWebAsset(DownloadableModel model) {
+    if (model.modelSource is LocalModelAssetSource) {
+      return true;
+    }
+    return model.multimodalProjectorSource is LocalModelAssetSource;
+  }
+
+  String _resolveAssetLoadReference(ModelAssetSource source) {
+    if (source is LocalModelAssetSource) {
+      return source.path;
+    }
+    final remote = source as RemoteModelAssetSource;
+    if (kIsWeb) {
+      return remote.url;
+    }
+    if (_modelsDir == null) {
+      return remote.filename;
+    }
+    return '${_modelsDir!}/${remote.filename}';
   }
 
   String? _resolveMmprojPathForModel(DownloadableModel model) {
@@ -923,23 +949,13 @@ class _ManageModelsScreenState extends State<ManageModelsScreen>
       return null;
     }
 
-    if (kIsWeb) {
-      if (model.mmprojUrl != null && model.mmprojUrl!.isNotEmpty) {
-        return model.mmprojUrl!;
-      }
-      return (model.supportsVision || model.supportsAudio) ? model.url : null;
+    final source = model.multimodalProjectorSource;
+    if (source != null) {
+      return _resolveAssetLoadReference(source);
     }
 
-    if (_modelsDir == null) {
-      return null;
-    }
-
-    if (model.mmprojFilename != null && model.mmprojFilename!.isNotEmpty) {
-      return '${_modelsDir!}/${model.mmprojFilename}';
-    }
-
-    return (model.supportsVision || model.supportsAudio)
-        ? '${_modelsDir!}/${model.filename}'
+    return model.supportsVision || model.supportsAudio
+        ? _resolveModelLoadReference(model)
         : null;
   }
 
@@ -1203,11 +1219,7 @@ class _ManageModelsScreenState extends State<ManageModelsScreen>
                       )
                     else
                       ..._models.map((model) {
-                        final selectedPath = kIsWeb
-                            ? model.url
-                            : (_modelsDir != null
-                                  ? '${_modelsDir!}/${model.filename}'
-                                  : '');
+                        final selectedPath = _resolveModelLoadReference(model);
                         final isActivating = _activatingModel == model.filename;
                         final downloadStateListenable = _downloadUiStateFor(
                           model.filename,

--- a/example/chat_app/lib/services/model_service_io.dart
+++ b/example/chat_app/lib/services/model_service_io.dart
@@ -80,21 +80,39 @@ class ModelServiceIO implements ModelService {
     required Function(String filename) onSuccess,
     required Function(dynamic error) onError,
   }) async {
-    final hasMmproj = model.multimodalProjectorSource is RemoteModelAssetSource;
-    final stageCount = hasMmproj ? 2 : 1;
+    final modelRemoteSource = model.modelSource is RemoteModelAssetSource
+        ? model.modelSource as RemoteModelAssetSource
+        : null;
+    final mmprojRemoteSource =
+        model.multimodalProjectorSource is RemoteModelAssetSource
+        ? model.multimodalProjectorSource as RemoteModelAssetSource
+        : null;
+    final stageCount = [
+      modelRemoteSource,
+      mmprojRemoteSource,
+    ].whereType<RemoteModelAssetSource>().length;
+    final modelStageIndex = modelRemoteSource == null ? 0 : 1;
+    final mmprojStageIndex = mmprojRemoteSource == null
+        ? 0
+        : modelRemoteSource == null
+        ? 1
+        : 2;
+    final providedTotalBytes =
+        modelRemoteSource == null && mmprojRemoteSource != null
+        ? mmprojRemoteSource.sizeBytes
+        : (model.sizeBytes > 0 ? model.sizeBytes : null);
     final progressDispatcher = _ProgressDispatcher(
       onProgress: onProgress,
       onProgressDetail: onProgressDetail,
     );
     final aggregate = ModelDownloadProgressTracker(
-      includeMmproj: hasMmproj,
-      providedTotalBytes: model.sizeBytes > 0 ? model.sizeBytes : null,
+      includeMmproj: mmprojRemoteSource != null,
+      providedTotalBytes: providedTotalBytes,
     );
 
     try {
       await _validateLocalSource(model.modelSource);
-      final modelRemoteSource = model.modelSource;
-      if (modelRemoteSource is RemoteModelAssetSource) {
+      if (modelRemoteSource != null) {
         final modelSavePath = _assetPath(modelsDir, modelRemoteSource);
         await _downloadFileWithResume(
           url: modelRemoteSource.url,
@@ -105,7 +123,7 @@ class ModelServiceIO implements ModelService {
             progressDispatcher.emit(
               aggregate.buildProgress(
                 stage: ModelDownloadStage.model,
-                stageIndex: 1,
+                stageIndex: modelStageIndex,
                 stageCount: stageCount,
                 stageDownloadedBytes: downloadedBytes,
                 stageTotalBytes: totalBytes,
@@ -118,10 +136,10 @@ class ModelServiceIO implements ModelService {
 
       final mmprojSource = model.multimodalProjectorSource;
       await _validateLocalSource(mmprojSource);
-      if (mmprojSource is RemoteModelAssetSource) {
-        final mmprojSavePath = _assetPath(modelsDir, mmprojSource);
+      if (mmprojRemoteSource != null) {
+        final mmprojSavePath = _assetPath(modelsDir, mmprojRemoteSource);
         await _downloadFileWithResume(
-          url: mmprojSource.url,
+          url: mmprojRemoteSource.url,
           savePath: mmprojSavePath,
           cancelToken: cancelToken,
           onProgress: (downloadedBytes, totalBytes, resumed) {
@@ -129,7 +147,7 @@ class ModelServiceIO implements ModelService {
             progressDispatcher.emit(
               aggregate.buildProgress(
                 stage: ModelDownloadStage.multimodalProjector,
-                stageIndex: 2,
+                stageIndex: mmprojStageIndex,
                 stageCount: stageCount,
                 stageDownloadedBytes: downloadedBytes,
                 stageTotalBytes: totalBytes,
@@ -140,10 +158,12 @@ class ModelServiceIO implements ModelService {
         );
       }
 
-      progressDispatcher.emit(
-        aggregate.finalProgress(stageCount: stageCount),
-        force: true,
-      );
+      if (stageCount > 0) {
+        progressDispatcher.emit(
+          aggregate.finalProgress(stageCount: stageCount),
+          force: true,
+        );
+      }
 
       onSuccess(model.filename);
     } catch (e) {

--- a/example/chat_app/lib/services/model_service_io.dart
+++ b/example/chat_app/lib/services/model_service_io.dart
@@ -48,23 +48,21 @@ class ModelServiceIO implements ModelService {
     final Set<String> downloaded = {};
 
     for (final model in models) {
-      final modelFile = File(p.join(dirPath, model.filename));
-      final partialFile = File(p.join(dirPath, '${model.filename}.download'));
-      final legacyMeta = File(p.join(dirPath, '${model.filename}.meta'));
-      var hasRequiredMmproj = true;
-      if (model.mmprojFilename != null) {
-        final mmprojFile = File(p.join(dirPath, model.mmprojFilename!));
-        final mmprojPartial = File(
-          p.join(dirPath, '${model.mmprojFilename!}.download'),
-        );
-        hasRequiredMmproj =
-            await mmprojFile.exists() && !await mmprojPartial.exists();
-      }
+      final hasModel = await _isAssetAvailable(
+        dirPath,
+        model.modelSource,
+        role: ModelAssetRole.model,
+      );
+      final mmprojSource = model.multimodalProjectorSource;
+      final hasMmproj =
+          mmprojSource == null ||
+          await _isAssetAvailable(
+            dirPath,
+            mmprojSource,
+            role: ModelAssetRole.multimodalProjector,
+          );
 
-      if (await modelFile.exists() &&
-          !await partialFile.exists() &&
-          !await legacyMeta.exists() &&
-          hasRequiredMmproj) {
+      if (hasModel && hasMmproj) {
         downloaded.add(model.filename);
       }
     }
@@ -82,7 +80,7 @@ class ModelServiceIO implements ModelService {
     required Function(String filename) onSuccess,
     required Function(dynamic error) onError,
   }) async {
-    final hasMmproj = model.mmprojUrl != null && model.mmprojFilename != null;
+    final hasMmproj = model.multimodalProjectorSource is RemoteModelAssetSource;
     final stageCount = hasMmproj ? 2 : 1;
     final progressDispatcher = _ProgressDispatcher(
       onProgress: onProgress,
@@ -94,30 +92,36 @@ class ModelServiceIO implements ModelService {
     );
 
     try {
-      final modelSavePath = p.join(modelsDir, model.filename);
-      await _downloadFileWithResume(
-        url: model.url,
-        savePath: modelSavePath,
-        cancelToken: cancelToken,
-        onProgress: (downloadedBytes, totalBytes, resumed) {
-          aggregate.updateModel(downloadedBytes, totalBytes);
-          progressDispatcher.emit(
-            aggregate.buildProgress(
-              stage: ModelDownloadStage.model,
-              stageIndex: 1,
-              stageCount: stageCount,
-              stageDownloadedBytes: downloadedBytes,
-              stageTotalBytes: totalBytes,
-              resumed: resumed,
-            ),
-          );
-        },
-      );
-
-      if (hasMmproj) {
-        final mmprojSavePath = p.join(modelsDir, model.mmprojFilename!);
+      await _validateLocalSource(model.modelSource);
+      final modelRemoteSource = model.modelSource;
+      if (modelRemoteSource is RemoteModelAssetSource) {
+        final modelSavePath = _assetPath(modelsDir, modelRemoteSource);
         await _downloadFileWithResume(
-          url: model.mmprojUrl!,
+          url: modelRemoteSource.url,
+          savePath: modelSavePath,
+          cancelToken: cancelToken,
+          onProgress: (downloadedBytes, totalBytes, resumed) {
+            aggregate.updateModel(downloadedBytes, totalBytes);
+            progressDispatcher.emit(
+              aggregate.buildProgress(
+                stage: ModelDownloadStage.model,
+                stageIndex: 1,
+                stageCount: stageCount,
+                stageDownloadedBytes: downloadedBytes,
+                stageTotalBytes: totalBytes,
+                resumed: resumed,
+              ),
+            );
+          },
+        );
+      }
+
+      final mmprojSource = model.multimodalProjectorSource;
+      await _validateLocalSource(mmprojSource);
+      if (mmprojSource is RemoteModelAssetSource) {
+        final mmprojSavePath = _assetPath(modelsDir, mmprojSource);
+        await _downloadFileWithResume(
+          url: mmprojSource.url,
           savePath: mmprojSavePath,
           cancelToken: cancelToken,
           onProgress: (downloadedBytes, totalBytes, resumed) {
@@ -144,6 +148,47 @@ class ModelServiceIO implements ModelService {
       onSuccess(model.filename);
     } catch (e) {
       onError(e);
+    }
+  }
+
+  Future<bool> _isAssetAvailable(
+    String modelsDir,
+    ModelAssetSource source, {
+    required ModelAssetRole role,
+  }) async {
+    final path = _assetPath(modelsDir, source);
+    final file = File(path);
+    final partialFile = File('$path.download');
+    if (!await file.exists() || await partialFile.exists()) {
+      return false;
+    }
+
+    if (source is RemoteModelAssetSource && role == ModelAssetRole.model) {
+      final legacyMeta = File('$path.meta');
+      if (await legacyMeta.exists()) {
+        return false;
+      }
+    }
+
+    return true;
+  }
+
+  String _assetPath(String modelsDir, ModelAssetSource source) {
+    if (source is LocalModelAssetSource) {
+      return source.path;
+    }
+    return p.join(modelsDir, (source as RemoteModelAssetSource).filename);
+  }
+
+  Future<void> _validateLocalSource(ModelAssetSource? source) async {
+    if (source is! LocalModelAssetSource) {
+      return;
+    }
+    if (!await File(source.path).exists()) {
+      throw FileSystemException(
+        'Local model asset does not exist',
+        source.path,
+      );
     }
   }
 
@@ -626,28 +671,35 @@ class ModelServiceIO implements ModelService {
 
   @override
   Future<void> deleteModel(String modelsDir, DownloadableModel model) async {
-    final file = File(p.join(modelsDir, model.filename));
+    await _deleteCachedAsset(modelsDir, model.modelSource);
+    final mmprojSource = model.multimodalProjectorSource;
+    if (mmprojSource != null) {
+      await _deleteCachedAsset(modelsDir, mmprojSource);
+    }
+  }
+
+  Future<void> _deleteCachedAsset(
+    String modelsDir,
+    ModelAssetSource source,
+  ) async {
+    if (source is LocalModelAssetSource) {
+      return;
+    }
+
+    final path = _assetPath(modelsDir, source);
+    final file = File(path);
     if (await file.exists()) {
       await file.delete();
     }
 
-    final tempFile = File(p.join(modelsDir, '${model.filename}.download'));
+    final tempFile = File('$path.download');
     if (await tempFile.exists()) {
       await tempFile.delete();
     }
 
-    if (model.mmprojFilename != null) {
-      final mmprojFile = File(p.join(modelsDir, model.mmprojFilename!));
-      if (await mmprojFile.exists()) {
-        await mmprojFile.delete();
-      }
-
-      final mmprojTempFile = File(
-        p.join(modelsDir, '${model.mmprojFilename!}.download'),
-      );
-      if (await mmprojTempFile.exists()) {
-        await mmprojTempFile.delete();
-      }
+    final legacyMeta = File('$path.meta');
+    if (await legacyMeta.exists()) {
+      await legacyMeta.delete();
     }
   }
 }

--- a/example/chat_app/lib/services/model_service_web.dart
+++ b/example/chat_app/lib/services/model_service_web.dart
@@ -32,8 +32,33 @@ class ModelServiceWeb implements ModelService {
   ) async {
     final prefs = await SharedPreferences.getInstance();
     final downloaded = prefs.getStringList(_downloadedModelsKey) ?? const [];
-    final valid = models.map((m) => m.filename).toSet();
-    return downloaded.where(valid.contains).toSet();
+    return models
+        .where((model) => _isProfileCached(model, downloaded.toSet()))
+        .map((model) => model.filename)
+        .toSet();
+  }
+
+  bool _isProfileCached(DownloadableModel model, Set<String> downloaded) {
+    final sources = _remoteSourcesFor(model);
+    if (sources.length != _assetSourcesFor(model).length) {
+      return false;
+    }
+
+    return sources.every((source) => downloaded.contains(source.cacheKey));
+  }
+
+  List<ModelAssetSource> _assetSourcesFor(DownloadableModel model) {
+    return <ModelAssetSource>[
+      model.modelSource,
+      if (model.multimodalProjectorSource != null)
+        model.multimodalProjectorSource!,
+    ];
+  }
+
+  List<RemoteModelAssetSource> _remoteSourcesFor(DownloadableModel model) {
+    return _assetSourcesFor(
+      model,
+    ).whereType<RemoteModelAssetSource>().toList(growable: false);
   }
 
   @override
@@ -46,7 +71,17 @@ class ModelServiceWeb implements ModelService {
     required Function(String filename) onSuccess,
     required Function(dynamic error) onError,
   }) async {
-    final hasMmproj = model.mmprojUrl != null && model.mmprojUrl!.isNotEmpty;
+    final modelSource = model.modelSource;
+    final assetSources = _assetSourcesFor(model);
+    if (assetSources.any((source) => source is! RemoteModelAssetSource)) {
+      onError(
+        UnsupportedError('Web downloads require remote URLs for all assets'),
+      );
+      return;
+    }
+    final remoteModelSource = modelSource as RemoteModelAssetSource;
+    final mmprojSource = model.multimodalProjectorSource;
+    final hasMmproj = mmprojSource is RemoteModelAssetSource;
     final stageCount = hasMmproj ? 2 : 1;
     final aggregate = ModelDownloadProgressTracker(
       includeMmproj: hasMmproj,
@@ -70,7 +105,7 @@ class ModelServiceWeb implements ModelService {
 
           await _prefetchStage(
             bridge,
-            model.url,
+            remoteModelSource.url,
             stage: ModelDownloadStage.model,
             stageIndex: 1,
             stageCount: stageCount,
@@ -83,7 +118,7 @@ class ModelServiceWeb implements ModelService {
           if (hasMmproj) {
             await _prefetchStage(
               bridge,
-              model.mmprojUrl!,
+              mmprojSource.url,
               stage: ModelDownloadStage.multimodalProjector,
               stageIndex: 2,
               stageCount: stageCount,
@@ -104,7 +139,7 @@ class ModelServiceWeb implements ModelService {
 
       if (!usedBridgePrefetch) {
         await _verifyRemoteStage(
-          model.url,
+          remoteModelSource.url,
           stage: ModelDownloadStage.model,
           stageIndex: 1,
           stageCount: stageCount,
@@ -117,7 +152,7 @@ class ModelServiceWeb implements ModelService {
 
         if (hasMmproj) {
           await _verifyRemoteStage(
-            model.mmprojUrl!,
+            mmprojSource.url,
             stage: ModelDownloadStage.multimodalProjector,
             stageIndex: 2,
             stageCount: stageCount,
@@ -136,16 +171,16 @@ class ModelServiceWeb implements ModelService {
 
       final prefs = await SharedPreferences.getInstance();
       final downloaded =
-          prefs.getStringList(_downloadedModelsKey) ?? <String>[];
-      if (!downloaded.contains(model.filename)) {
-        downloaded.add(model.filename);
-        await prefs.setStringList(_downloadedModelsKey, downloaded);
+          prefs.getStringList(_downloadedModelsKey)?.toSet() ?? <String>{};
+      for (final source in _remoteSourcesFor(model)) {
+        downloaded.add(source.cacheKey);
       }
+      await prefs.setStringList(_downloadedModelsKey, downloaded.toList());
 
       onSuccess(model.filename);
     } catch (error) {
       if (_looksCancelled(error) || cancelToken.isCancelled) {
-        onError(_cancelledException(model.url));
+        onError(_cancelledException(remoteModelSource.url));
       } else {
         onError(error);
       }
@@ -312,11 +347,24 @@ class ModelServiceWeb implements ModelService {
 
   DioException _cancelledException(String url) {
     return DioException(
-      requestOptions: RequestOptions(path: url),
+      requestOptions: RequestOptions(path: _redactedUrl(url)),
       type: DioExceptionType.cancel,
       message: 'Download cancelled',
       error: 'Download cancelled',
     );
+  }
+
+  String _redactedUrl(String url) {
+    final uri = Uri.tryParse(url);
+    if (uri == null || !uri.hasScheme) {
+      return url.split('?').first.split('#').first;
+    }
+    return Uri(
+      scheme: uri.scheme,
+      host: uri.host,
+      port: uri.hasPort ? uri.port : null,
+      path: uri.path,
+    ).toString();
   }
 
   Future<void> _verifyRemoteStage(
@@ -396,9 +444,13 @@ class ModelServiceWeb implements ModelService {
   @override
   Future<void> deleteModel(String modelsDir, DownloadableModel model) async {
     final prefs = await SharedPreferences.getInstance();
-    final downloaded = prefs.getStringList(_downloadedModelsKey) ?? <String>[];
+    final downloaded =
+        prefs.getStringList(_downloadedModelsKey)?.toSet() ?? <String>{};
     downloaded.remove(model.filename);
-    await prefs.setStringList(_downloadedModelsKey, downloaded);
+    for (final source in _remoteSourcesFor(model)) {
+      downloaded.remove(source.cacheKey);
+    }
+    await prefs.setStringList(_downloadedModelsKey, downloaded.toList());
 
     final bridge = _tryCreateBridge();
     if (bridge == null) {
@@ -406,21 +458,13 @@ class ModelServiceWeb implements ModelService {
     }
 
     try {
-      final modelEvictPromise = bridge.evictModelFromCache(
-        model.url,
-        _WebModelCacheOptions(cacheName: _modelCacheName.toJS),
-      );
-      if (modelEvictPromise != null) {
-        await modelEvictPromise.toDart;
-      }
-
-      if (model.mmprojUrl != null && model.mmprojUrl!.isNotEmpty) {
-        final mmprojEvictPromise = bridge.evictModelFromCache(
-          model.mmprojUrl!,
+      for (final source in _remoteSourcesFor(model)) {
+        final evictPromise = bridge.evictModelFromCache(
+          source.url,
           _WebModelCacheOptions(cacheName: _modelCacheName.toJS),
         );
-        if (mmprojEvictPromise != null) {
-          await mmprojEvictPromise.toDart;
+        if (evictPromise != null) {
+          await evictPromise.toDart;
         }
       }
     } catch (_) {

--- a/example/chat_app/lib/services/model_service_web.dart
+++ b/example/chat_app/lib/services/model_service_web.dart
@@ -447,7 +447,6 @@ class ModelServiceWeb implements ModelService {
     final prefs = await SharedPreferences.getInstance();
     final downloaded =
         prefs.getStringList(_downloadedModelsKey)?.toSet() ?? <String>{};
-    downloaded.remove(model.filename);
     for (final source in _remoteSourcesFor(model)) {
       downloaded.remove(source.cacheKey);
     }

--- a/example/chat_app/lib/services/model_service_web.dart
+++ b/example/chat_app/lib/services/model_service_web.dart
@@ -33,10 +33,32 @@ class ModelServiceWeb implements ModelService {
     final prefs = await SharedPreferences.getInstance();
     final downloaded = prefs.getStringList(_downloadedModelsKey) ?? const [];
     final downloadedSet = downloaded.toSet();
-    return models
-        .where((model) => _isProfileCached(model, downloadedSet))
-        .map((model) => model.filename)
-        .toSet();
+    final cachedModels = <String>{};
+    var migratedLegacyMarkers = false;
+
+    for (final model in models) {
+      if (_isProfileCached(model, downloadedSet)) {
+        cachedModels.add(model.filename);
+        continue;
+      }
+
+      final sources = _remoteSourcesFor(model);
+      if (downloadedSet.contains(model.filename) &&
+          sources.length == _assetSourcesFor(model).length) {
+        downloadedSet.remove(model.filename);
+        for (final source in sources) {
+          downloadedSet.add(source.cacheKey);
+        }
+        cachedModels.add(model.filename);
+        migratedLegacyMarkers = true;
+      }
+    }
+
+    if (migratedLegacyMarkers) {
+      await prefs.setStringList(_downloadedModelsKey, downloadedSet.toList());
+    }
+
+    return cachedModels;
   }
 
   bool _isProfileCached(DownloadableModel model, Set<String> downloaded) {

--- a/example/chat_app/lib/services/model_service_web.dart
+++ b/example/chat_app/lib/services/model_service_web.dart
@@ -32,8 +32,9 @@ class ModelServiceWeb implements ModelService {
   ) async {
     final prefs = await SharedPreferences.getInstance();
     final downloaded = prefs.getStringList(_downloadedModelsKey) ?? const [];
+    final downloadedSet = downloaded.toSet();
     return models
-        .where((model) => _isProfileCached(model, downloaded.toSet()))
+        .where((model) => _isProfileCached(model, downloadedSet))
         .map((model) => model.filename)
         .toSet();
   }

--- a/example/chat_app/lib/services/model_service_web.dart
+++ b/example/chat_app/lib/services/model_service_web.dart
@@ -81,11 +81,11 @@ class ModelServiceWeb implements ModelService {
       return;
     }
     final remoteModelSource = modelSource as RemoteModelAssetSource;
-    final mmprojSource = model.multimodalProjectorSource;
-    final hasMmproj = mmprojSource is RemoteModelAssetSource;
-    final stageCount = hasMmproj ? 2 : 1;
+    final mmprojUrl =
+        (model.multimodalProjectorSource as RemoteModelAssetSource?)?.url;
+    final stageCount = mmprojUrl == null ? 1 : 2;
     final aggregate = ModelDownloadProgressTracker(
-      includeMmproj: hasMmproj,
+      includeMmproj: mmprojUrl != null,
       providedTotalBytes: model.sizeBytes > 0 ? model.sizeBytes : null,
     );
     final bridge = _tryCreateBridge();
@@ -116,10 +116,10 @@ class ModelServiceWeb implements ModelService {
             onProgressDetail: onProgressDetail,
           );
 
-          if (hasMmproj) {
+          if (mmprojUrl != null) {
             await _prefetchStage(
               bridge,
-              mmprojSource.url,
+              mmprojUrl,
               stage: ModelDownloadStage.multimodalProjector,
               stageIndex: 2,
               stageCount: stageCount,
@@ -151,9 +151,9 @@ class ModelServiceWeb implements ModelService {
           onProgressDetail: onProgressDetail,
         );
 
-        if (hasMmproj) {
+        if (mmprojUrl != null) {
           await _verifyRemoteStage(
-            mmprojSource.url,
+            mmprojUrl,
             stage: ModelDownloadStage.multimodalProjector,
             stageIndex: 2,
             stageCount: stageCount,

--- a/example/chat_app/pubspec.lock
+++ b/example/chat_app/pubspec.lock
@@ -114,7 +114,7 @@ packages:
     source: hosted
     version: "0.3.5+2"
   crypto:
-    dependency: transitive
+    dependency: "direct main"
     description:
       name: crypto
       sha256: c8ea0233063ba03258fbcf2ca4d6dadfefe14f02fab57702265467a19f27fadf

--- a/example/chat_app/pubspec.lock
+++ b/example/chat_app/pubspec.lock
@@ -349,7 +349,7 @@ packages:
       path: "../.."
       relative: true
     source: path
-    version: "0.6.10"
+    version: "0.6.12"
   logging:
     dependency: transitive
     description:

--- a/example/chat_app/pubspec.yaml
+++ b/example/chat_app/pubspec.yaml
@@ -17,6 +17,7 @@ dependencies:
   file_picker: ^10.3.10
   path: ^1.9.0
   dio: ^5.9.0
+  crypto: ^3.0.6
   path_provider: ^2.1.5
   google_fonts: ^8.0.0
   flutter_markdown: ^0.7.7+1

--- a/example/chat_app/test/model_asset_source_test.dart
+++ b/example/chat_app/test/model_asset_source_test.dart
@@ -47,6 +47,23 @@ void main() {
       expect(first.cacheKey, isNot(contains('model.gguf')));
     });
 
+    test(
+      'remote canonical keys are unambiguous when values contain delimiters',
+      () {
+        const first = RemoteModelAssetSource(
+          url: 'https://example.com/model.gguf',
+          filename: 'projector#v1.gguf',
+        );
+        const second = RemoteModelAssetSource(
+          url: 'https://example.com/model.gguf#projector',
+          filename: 'v1.gguf',
+        );
+
+        expect(first.canonicalKey, isNot(second.canonicalKey));
+        expect(first.cacheKey, isNot(second.cacheKey));
+      },
+    );
+
     test('legacy constructor maps model and projector to remote sources', () {
       final profile = DownloadableModel(
         name: 'Remote VLM',

--- a/example/chat_app/test/model_asset_source_test.dart
+++ b/example/chat_app/test/model_asset_source_test.dart
@@ -1,0 +1,69 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:llamadart_chat_example/models/downloadable_model.dart';
+
+void main() {
+  group('Model asset sources', () {
+    test('remote model and local mmproj remain independent assets', () {
+      final profile = DownloadableModel.fromSources(
+        name: 'Mixed VLM',
+        description: 'Remote model with local projector',
+        modelSource: RemoteModelAssetSource(
+          url: 'https://example.com/model.gguf?download=true',
+          filename: 'model.gguf',
+          sizeBytes: 1024,
+        ),
+        multimodalProjectorSource: LocalModelAssetSource(
+          '/models/custom-mmproj.gguf',
+        ),
+        supportsVision: true,
+        sizeBytes: 1024,
+      );
+
+      expect(profile.modelSource, isA<RemoteModelAssetSource>());
+      expect(profile.multimodalProjectorSource, isA<LocalModelAssetSource>());
+      expect(profile.url, 'https://example.com/model.gguf?download=true');
+      expect(profile.filename, 'model.gguf');
+      expect(profile.mmprojUrl, isNull);
+      expect(profile.mmprojFilename, 'custom-mmproj.gguf');
+      expect(
+        profile.modelSource.cacheKey,
+        isNot(profile.multimodalProjectorSource!.cacheKey),
+      );
+    });
+
+    test('remote cache keys keep full URL identity without storing tokens', () {
+      const first = RemoteModelAssetSource(
+        url: 'https://example.com/model.gguf?token=secret-one',
+        filename: 'model.gguf',
+      );
+      const second = RemoteModelAssetSource(
+        url: 'https://example.com/model.gguf?token=secret-two',
+        filename: 'model.gguf',
+      );
+
+      expect(first.cacheKey, isNot(second.cacheKey));
+      expect(first.cacheKey, hasLength(64));
+      expect(first.cacheKey, isNot(contains('secret-one')));
+      expect(first.cacheKey, isNot(contains('model.gguf')));
+    });
+
+    test('legacy constructor maps model and projector to remote sources', () {
+      final profile = DownloadableModel(
+        name: 'Remote VLM',
+        description: 'Remote model and projector',
+        url: 'https://example.com/model.gguf',
+        filename: 'model.gguf',
+        mmprojUrl: 'https://cdn.example.net/mmproj.gguf',
+        mmprojFilename: 'mmproj.gguf',
+        sizeBytes: 2048,
+        supportsVision: true,
+      );
+
+      expect(profile.modelSource, isA<RemoteModelAssetSource>());
+      expect(profile.multimodalProjectorSource, isA<RemoteModelAssetSource>());
+      expect(profile.url, 'https://example.com/model.gguf');
+      expect(profile.mmprojUrl, 'https://cdn.example.net/mmproj.gguf');
+      expect(profile.mmprojFilename, 'mmproj.gguf');
+    });
+  });
+}

--- a/example/chat_app/test/model_service_test.dart
+++ b/example/chat_app/test/model_service_test.dart
@@ -225,6 +225,38 @@ void main() {
     expect(tempFile.existsSync(), isFalse); // Should be cleaned up
   });
 
+  test('Remote model can depend on local mmproj availability', () async {
+    final localMmproj = File(p.join(tempDir.path, 'local-mmproj.gguf'));
+    final model = DownloadableModel.fromSources(
+      name: 'Mixed Source VLM',
+      description: 'Test',
+      modelSource: RemoteModelAssetSource(
+        url: '$baseUrl/model.gguf',
+        filename: 'mixed-model.gguf',
+        sizeBytes: testDataSize,
+      ),
+      multimodalProjectorSource: LocalModelAssetSource(localMmproj.path),
+      sizeBytes: testDataSize,
+      supportsVision: true,
+    );
+
+    await File(p.join(tempDir.path, 'mixed-model.gguf')).writeAsBytes(testData);
+
+    var downloaded = await service.getDownloadedModels([model]);
+    expect(downloaded, isNot(contains(model.filename)));
+
+    await localMmproj.writeAsBytes(mmprojData);
+    downloaded = await service.getDownloadedModels([model]);
+    expect(downloaded, contains(model.filename));
+
+    await service.deleteModel(tempDir.path, model);
+    expect(
+      File(p.join(tempDir.path, 'mixed-model.gguf')).existsSync(),
+      isFalse,
+    );
+    expect(localMmproj.existsSync(), isTrue);
+  });
+
   test('Incomplete download is not marked as downloaded', () async {
     final model = DownloadableModel(
       name: 'Existing Model',

--- a/example/chat_app/test/model_service_test.dart
+++ b/example/chat_app/test/model_service_test.dart
@@ -164,6 +164,49 @@ void main() {
     expect(updates.last.overallProgress, closeTo(1.0, 0.0001));
   });
 
+  test(
+    'Local model with remote mmproj reports a single projector stage',
+    () async {
+      final localModel = File(p.join(tempDir.path, 'local-model.gguf'));
+      await localModel.writeAsBytes(testData);
+      final model = DownloadableModel.fromSources(
+        name: 'Local model remote projector',
+        description: 'Test',
+        modelSource: LocalModelAssetSource(localModel.path),
+        multimodalProjectorSource: RemoteModelAssetSource(
+          url: '$baseUrl/mmproj.gguf',
+          filename: 'remote-mmproj.gguf',
+          sizeBytes: mmprojDataSize,
+        ),
+        supportsVision: true,
+      );
+
+      final updates = <ModelDownloadProgress>[];
+
+      await service.downloadModel(
+        model: model,
+        modelsDir: tempDir.path,
+        cancelToken: CancelToken(),
+        onProgress: (_) {},
+        onProgressDetail: updates.add,
+        onSuccess: (_) {},
+        onError: (e) => fail('Download failed: $e'),
+      );
+
+      expect(
+        updates.where((u) => u.stage == ModelDownloadStage.model),
+        isEmpty,
+      );
+      final projectorUpdates = updates
+          .where((u) => u.stage == ModelDownloadStage.multimodalProjector)
+          .toList();
+      expect(projectorUpdates, isNotEmpty);
+      expect(projectorUpdates.every((u) => u.stageIndex == 1), isTrue);
+      expect(projectorUpdates.every((u) => u.stageCount == 1), isTrue);
+      expect(updates.last.overallProgress, closeTo(1.0, 0.0001));
+    },
+  );
+
   test('Resume functionality works', () async {
     final model = DownloadableModel(
       name: 'Test Model',

--- a/example/llamadart_server/lib/src/features/model_management/infrastructure/model_service.dart
+++ b/example/llamadart_server/lib/src/features/model_management/infrastructure/model_service.dart
@@ -6,12 +6,16 @@ import 'package:path/path.dart' as path;
 /// Resolves a model path or downloads a model URL into local cache.
 class ModelService {
   /// Creates a model service with optional custom [cacheDir].
-  ModelService([String? cacheDir])
-    : cacheDir = cacheDir ?? path.join(Directory.current.path, 'models'),
+  ModelService([String? cacheDir]) : this._(cacheDir ?? _defaultCacheDir());
+
+  ModelService._(String resolvedCacheDir)
+    : cacheDir = resolvedCacheDir,
       _downloadManager = DefaultModelDownloadManager(
-        defaultCacheDirectory:
-            cacheDir ?? path.join(Directory.current.path, 'models'),
+        defaultCacheDirectory: resolvedCacheDir,
       );
+
+  static String _defaultCacheDir() =>
+      path.join(Directory.current.path, 'models');
 
   /// Directory where downloaded model files are cached.
   final String cacheDir;

--- a/example/llamadart_server/lib/src/features/model_management/infrastructure/model_service.dart
+++ b/example/llamadart_server/lib/src/features/model_management/infrastructure/model_service.dart
@@ -1,93 +1,50 @@
 import 'dart:io';
 
-import 'package:http/http.dart' as http;
+import 'package:llamadart/llamadart.dart';
 import 'package:path/path.dart' as path;
 
 /// Resolves a model path or downloads a model URL into local cache.
 class ModelService {
+  /// Creates a model service with optional custom [cacheDir].
+  ModelService([String? cacheDir])
+    : cacheDir = cacheDir ?? path.join(Directory.current.path, 'models'),
+      _downloadManager = DefaultModelDownloadManager(
+        defaultCacheDirectory:
+            cacheDir ?? path.join(Directory.current.path, 'models'),
+      );
+
   /// Directory where downloaded model files are cached.
   final String cacheDir;
 
-  /// Creates a model service with optional custom [cacheDir].
-  ModelService([String? cacheDir])
-    : cacheDir = cacheDir ?? path.join(Directory.current.path, 'models');
+  final ModelDownloadManager _downloadManager;
 
   /// Ensures [urlOrPath] exists locally, downloading when needed.
   Future<File> ensureModel(String urlOrPath) async {
-    if (urlOrPath.startsWith('http://') || urlOrPath.startsWith('https://')) {
-      return _downloadModel(urlOrPath);
-    }
-
-    final file = File(urlOrPath);
-    if (!file.existsSync()) {
-      throw Exception('Model file not found at: $urlOrPath');
-    }
-
-    return file;
-  }
-
-  Future<File> _downloadModel(String url) async {
-    final fileName = url.split('/').last.split('?').first;
-    final file = File(path.join(cacheDir, fileName));
-
-    if (file.existsSync() && file.lengthSync() > 0) {
-      return file;
-    }
-
-    if (!file.parent.existsSync()) {
-      file.parent.createSync(recursive: true);
-    }
-
-    stdout.writeln('Downloading model: $fileName');
-
-    final client = http.Client();
-    try {
-      final request = http.Request('GET', Uri.parse(url));
-      final response = await client.send(request);
-
-      if (response.statusCode != HttpStatus.ok) {
-        throw Exception(
-          'Failed to download model: '
-          '${response.statusCode} ${response.reasonPhrase}',
-        );
+    final source = ModelSource.parse(urlOrPath);
+    if (source.isLocal) {
+      final file = File(source.path!);
+      if (!file.existsSync()) {
+        throw Exception('Model file not found at: ${source.path}');
       }
-
-      final contentLength = response.contentLength ?? 0;
-      var downloaded = 0;
-      final sink = file.openWrite();
-
-      await response.stream
-          .listen(
-            (List<int> chunk) {
-              sink.add(chunk);
-              downloaded += chunk.length;
-
-              if (contentLength > 0) {
-                final progress = (downloaded / contentLength * 100)
-                    .toStringAsFixed(1);
-                stdout.write('\rProgress: $progress%');
-              } else {
-                final mb = (downloaded / 1024 / 1024).toStringAsFixed(1);
-                stdout.write('\rDownloaded: $mb MB');
-              }
-            },
-            onDone: () async {
-              await sink.close();
-              stdout.writeln('\nDownload complete.');
-            },
-            onError: (Object error) {
-              sink.close();
-              if (file.existsSync()) {
-                file.deleteSync();
-              }
-              throw error;
-            },
-          )
-          .asFuture<void>();
-
       return file;
-    } finally {
-      client.close();
     }
+
+    stdout.writeln(
+      'Resolving model download/cache entry: ${source.displayName}',
+    );
+    final entry = await _downloadManager.ensureModel(
+      source,
+      onProgress: (progress) {
+        final fraction = progress.fraction;
+        if (fraction != null) {
+          stdout.write('\rProgress: ${(fraction * 100).toStringAsFixed(1)}%');
+        } else {
+          final mb = (progress.receivedBytes / 1024 / 1024).toStringAsFixed(1);
+          stdout.write('\rDownloaded: $mb MB');
+        }
+      },
+    );
+    stdout.writeln('\nModel ready: ${entry.filePath}');
+    return File(entry.filePath);
   }
 }

--- a/example/tui_coding_agent/lib/src/coding_agent_session.dart
+++ b/example/tui_coding_agent/lib/src/coding_agent_session.dart
@@ -1,6 +1,6 @@
 import 'dart:convert';
 
-import 'package:llamadart/llamadart.dart';
+import 'package:llamadart/llamadart.dart' hide ModelDownloadProgress;
 
 import 'coding_agent_config.dart';
 import 'model_source_resolver.dart';

--- a/lib/llamadart.dart
+++ b/lib/llamadart.dart
@@ -52,6 +52,12 @@ export 'src/core/models/inference/model_params.dart';
 export 'src/core/models/inference/generation_params.dart';
 export 'src/core/models/inference/tool_choice.dart';
 
+// Models - Sources, resolution, and downloads
+export 'src/core/models/model_source.dart';
+export 'src/core/models/model_resolver.dart';
+export 'src/core/models/model_load_options.dart';
+export 'src/core/models/download/model_download_manager.dart';
+
 // Models - Chat
 export 'src/core/models/chat/chat_message.dart';
 export 'src/core/models/chat/content_part.dart';

--- a/lib/src/core/engine/engine.dart
+++ b/lib/src/core/engine/engine.dart
@@ -1291,10 +1291,14 @@ class LlamaEngine {
   }
 
   Object _redactedErrorDetails(Object error) {
-    return error.toString().replaceAllMapped(
+    final message = error.toString().replaceAllMapped(
       RegExp(r'https?://[^\s)]+'),
       (match) => _redactedUriForLogs(match.group(0)!),
     );
+    return <String, Object?>{
+      'type': error.runtimeType.toString(),
+      'message': message,
+    };
   }
 
   int? _firstNonWhitespaceIndex(String value) {

--- a/lib/src/core/engine/engine.dart
+++ b/lib/src/core/engine/engine.dart
@@ -219,10 +219,9 @@ class LlamaEngine {
           );
         }
         if (!backend.supportsUrlLoading) {
-          final downloadSource = ModelSource.url(
-            url,
-            fileName: source.fileName,
-          );
+          final downloadSource = source.isRemote
+              ? source.withResolvedUri(url)
+              : ModelSource.url(url, fileName: source.fileName);
           final entry = await modelDownloadManager.ensureModel(
             downloadSource,
             options: options,

--- a/lib/src/core/engine/engine.dart
+++ b/lib/src/core/engine/engine.dart
@@ -203,6 +203,14 @@ class LlamaEngine {
             'Explicit local model paths are not supported by URL-loading backends.',
           );
         }
+        if (source.isLocal) {
+          final entry = await modelDownloadManager.ensureModel(
+            source,
+            options: options,
+            onProgress: onProgress,
+          );
+          return loadModel(entry.filePath, modelParams: modelParams);
+        }
         return loadModel(path, modelParams: modelParams);
       case RemoteModelUrl(:final url, :final useBrowserCache):
         if (!useBrowserCache) {
@@ -1240,6 +1248,11 @@ class LlamaEngine {
     if (options.bearerToken != null || options.headers.isNotEmpty) {
       throw LlamaUnsupportedException(
         'Authenticated model URL loading requires the native download/cache manager.',
+      );
+    }
+    if (options.cancelToken != null) {
+      throw LlamaUnsupportedException(
+        'Cancellation tokens require the native download/cache manager.',
       );
     }
     if (options.sha256 != null) {

--- a/lib/src/core/engine/engine.dart
+++ b/lib/src/core/engine/engine.dart
@@ -14,6 +14,10 @@ import '../llama_logger.dart';
 import '../models/inference/model_params.dart';
 import '../models/inference/generation_params.dart';
 import '../models/inference/tool_choice.dart';
+import '../models/model_load_options.dart';
+import '../models/model_resolver.dart';
+import '../models/model_source.dart';
+import '../models/download/model_download_manager_base.dart';
 import '../models/tools/tool_definition.dart';
 
 enum _ToolStreamingMode { undecided, raw, parsed }
@@ -65,6 +69,9 @@ class _ThinkingSplitResult {
 class LlamaEngine {
   /// The backend implementation used for inference.
   final LlamaBackend backend;
+
+  /// Resolves source-aware model loading requests.
+  final ModelResolver modelResolver;
   int? _modelHandle;
   int? _contextHandle;
   int? _mmContextHandle;
@@ -88,7 +95,8 @@ class LlamaEngine {
   }
 
   /// Creates a new [LlamaEngine] instance with the given [backend].
-  LlamaEngine(this.backend);
+  LlamaEngine(this.backend, {ModelResolver? modelResolver})
+    : modelResolver = modelResolver ?? const DefaultModelResolver();
 
   /// Sets both Dart and native log levels to [level].
   ///
@@ -163,6 +171,52 @@ class LlamaEngine {
     }
   }
 
+  /// Loads a model from a structured [source].
+  ///
+  /// Local path sources are dispatched through [loadModel]. Remote URL targets
+  /// are dispatched through [loadModelFromUrl] when the backend supports URL
+  /// loading. Native download/cache IO is intentionally left for later tasks.
+  Future<void> loadModelSource(
+    ModelSource source, {
+    ModelParams modelParams = const ModelParams(),
+    ModelLoadOptions options = ModelLoadOptions.defaults,
+    ModelDownloadProgressCallback? onProgress,
+  }) async {
+    final target = await modelResolver.resolve(
+      source,
+      ModelResolveRequest(options: options, onProgress: onProgress),
+    );
+
+    switch (target) {
+      case LocalModelFile(:final path):
+        if (backend.supportsUrlLoading) {
+          throw LlamaUnsupportedException(
+            'Explicit local model paths are not supported by URL-loading backends.',
+          );
+        }
+        return loadModel(path, modelParams: modelParams);
+      case RemoteModelUrl(:final url, :final useBrowserCache):
+        if (!useBrowserCache) {
+          throw LlamaUnsupportedException(
+            'Remote model loading without browser/backend cache is not supported yet.',
+          );
+        }
+        if (!backend.supportsUrlLoading) {
+          throw LlamaUnsupportedException(
+            'Resolved remote model URLs require a backend that supports URL loading.',
+          );
+        }
+        return loadModelFromUrl(
+          url.toString(),
+          modelParams: modelParams,
+          onProgress: onProgress == null
+              ? null
+              : (progress) =>
+                    onProgress(ModelDownloadProgress.fraction(progress)),
+        );
+    }
+  }
+
   /// Loads a model from a [url].
   ///
   /// This is typically used on the Web platform. Use [ModelParams] to
@@ -173,18 +227,19 @@ class LlamaEngine {
     Function(double progress)? onProgress,
   }) async {
     final modelName = _displayNameForSource(url);
+    final redactedUrl = _redactedUriForLogs(url);
     LlamaLogger.instance.info('Loading model from URL: $modelName');
 
     if (!backend.supportsUrlLoading) {
-      throw UnimplementedError(
-        "loadModelFromUrl for Native should be handled by the caller or a helper.",
+      throw LlamaUnsupportedException(
+        'loadModelFromUrl requires a backend that supports URL loading.',
       );
     }
 
     try {
       await backend.setLogLevel(_nativeLogLevel);
       _ensureNotReady();
-      _modelPath = url;
+      _modelPath = redactedUrl;
       _cachedModelMetadata = null;
 
       _modelHandle = await backend.modelLoadFromUrl(
@@ -196,17 +251,17 @@ class LlamaEngine {
       _isReady = true;
 
       LlamaLogger.instance.info(
-        'Model $modelName loaded successfully from $url',
+        'Model $modelName loaded successfully from $redactedUrl',
       );
     } catch (e, stackTrace) {
       await _cleanupFailedLoadState();
 
       LlamaLogger.instance.error(
-        'Failed to load model $modelName from URL $url',
-        e,
+        'Failed to load model $modelName from URL $redactedUrl',
+        null,
         stackTrace,
       );
-      throw LlamaModelException("Failed to load model from $url", e);
+      throw LlamaModelException('Failed to load model from $redactedUrl');
     }
   }
 
@@ -1171,6 +1226,19 @@ class LlamaEngine {
     final segments = normalizedSource.split('/');
     final lastSegment = segments.isNotEmpty ? segments.last : source;
     return lastSegment.isNotEmpty ? lastSegment : source;
+  }
+
+  String _redactedUriForLogs(String source) {
+    final uri = Uri.tryParse(source);
+    if (uri == null || !uri.hasScheme) {
+      return _displayNameForSource(source);
+    }
+    return Uri(
+      scheme: uri.scheme,
+      host: uri.hasAuthority ? uri.host : null,
+      port: uri.hasPort ? uri.port : null,
+      path: uri.path,
+    ).toString();
   }
 
   int? _firstNonWhitespaceIndex(String value) {

--- a/lib/src/core/engine/engine.dart
+++ b/lib/src/core/engine/engine.dart
@@ -211,8 +211,12 @@ class LlamaEngine {
           );
         }
         if (!backend.supportsUrlLoading) {
+          final downloadSource = ModelSource.url(
+            url,
+            fileName: source.fileName,
+          );
           final entry = await modelDownloadManager.ensureModel(
-            source,
+            downloadSource,
             options: options,
             onProgress: onProgress,
           );

--- a/lib/src/core/engine/engine.dart
+++ b/lib/src/core/engine/engine.dart
@@ -17,7 +17,7 @@ import '../models/inference/tool_choice.dart';
 import '../models/model_load_options.dart';
 import '../models/model_resolver.dart';
 import '../models/model_source.dart';
-import '../models/download/model_download_manager_base.dart';
+import '../models/download/model_download_manager.dart';
 import '../models/tools/tool_definition.dart';
 
 enum _ToolStreamingMode { undecided, raw, parsed }
@@ -72,6 +72,9 @@ class LlamaEngine {
 
   /// Resolves source-aware model loading requests.
   final ModelResolver modelResolver;
+
+  /// Downloads and caches remote model sources for native/file-backed backends.
+  final ModelDownloadManager modelDownloadManager;
   int? _modelHandle;
   int? _contextHandle;
   int? _mmContextHandle;
@@ -95,8 +98,13 @@ class LlamaEngine {
   }
 
   /// Creates a new [LlamaEngine] instance with the given [backend].
-  LlamaEngine(this.backend, {ModelResolver? modelResolver})
-    : modelResolver = modelResolver ?? const DefaultModelResolver();
+  LlamaEngine(
+    this.backend, {
+    ModelResolver? modelResolver,
+    ModelDownloadManager? modelDownloadManager,
+  }) : modelResolver = modelResolver ?? const DefaultModelResolver(),
+       modelDownloadManager =
+           modelDownloadManager ?? DefaultModelDownloadManager();
 
   /// Sets both Dart and native log levels to [level].
   ///
@@ -174,8 +182,9 @@ class LlamaEngine {
   /// Loads a model from a structured [source].
   ///
   /// Local path sources are dispatched through [loadModel]. Remote URL targets
-  /// are dispatched through [loadModelFromUrl] when the backend supports URL
-  /// loading. Native download/cache IO is intentionally left for later tasks.
+  /// use the native download/cache manager on file-backed backends, then load
+  /// the cached local file. URL-capable web backends keep using
+  /// [loadModelFromUrl] for unauthenticated prefer-cached requests.
   Future<void> loadModelSource(
     ModelSource source, {
     ModelParams modelParams = const ModelParams(),
@@ -202,10 +211,14 @@ class LlamaEngine {
           );
         }
         if (!backend.supportsUrlLoading) {
-          throw LlamaUnsupportedException(
-            'Resolved remote model URLs require a backend that supports URL loading.',
+          final entry = await modelDownloadManager.ensureModel(
+            source,
+            options: options,
+            onProgress: onProgress,
           );
+          return loadModel(entry.filePath, modelParams: modelParams);
         }
+        _rejectUnsupportedUrlBackendOptions(options);
         return loadModelFromUrl(
           url.toString(),
           modelParams: modelParams,
@@ -1209,6 +1222,39 @@ class LlamaEngine {
     _modelPath = null;
     _cachedModelMetadata = null;
     _isReady = false;
+  }
+
+  void _rejectUnsupportedUrlBackendOptions(ModelLoadOptions options) {
+    if (options.cachePolicy != ModelCachePolicy.preferCached) {
+      throw LlamaUnsupportedException(
+        '${options.cachePolicy.name} model loading requires the native download/cache manager.',
+      );
+    }
+    if (options.bearerToken != null || options.headers.isNotEmpty) {
+      throw LlamaUnsupportedException(
+        'Authenticated model URL loading requires the native download/cache manager.',
+      );
+    }
+    if (options.sha256 != null) {
+      throw LlamaUnsupportedException(
+        'Checksum verification requires the native download/cache manager.',
+      );
+    }
+    if (options.cacheDirectory != null) {
+      throw LlamaUnsupportedException(
+        'cacheDirectory is not supported by URL-loading backends.',
+      );
+    }
+    if (!options.resume) {
+      throw LlamaUnsupportedException(
+        'Disabling resume is not supported by URL-loading backends.',
+      );
+    }
+    if (options.maxRetries != ModelLoadOptions.defaults.maxRetries) {
+      throw LlamaUnsupportedException(
+        'Custom maxRetries is not supported by URL-loading backends.',
+      );
+    }
   }
 
   String _displayNameForSource(String source) {

--- a/lib/src/core/engine/engine.dart
+++ b/lib/src/core/engine/engine.dart
@@ -271,10 +271,13 @@ class LlamaEngine {
 
       LlamaLogger.instance.error(
         'Failed to load model $modelName from URL $redactedUrl',
-        null,
+        _redactedErrorDetails(e),
         stackTrace,
       );
-      throw LlamaModelException('Failed to load model from $redactedUrl');
+      throw LlamaModelException(
+        'Failed to load model from $redactedUrl',
+        _redactedErrorDetails(e),
+      );
     }
   }
 
@@ -1285,6 +1288,13 @@ class LlamaEngine {
       port: uri.hasPort ? uri.port : null,
       path: uri.path,
     ).toString();
+  }
+
+  Object _redactedErrorDetails(Object error) {
+    return error.toString().replaceAllMapped(
+      RegExp(r'https?://[^\s)]+'),
+      (match) => _redactedUriForLogs(match.group(0)!),
+    );
   }
 
   int? _firstNonWhitespaceIndex(String value) {

--- a/lib/src/core/engine/engine.dart
+++ b/lib/src/core/engine/engine.dart
@@ -203,15 +203,13 @@ class LlamaEngine {
             'Explicit local model paths are not supported by URL-loading backends.',
           );
         }
-        if (source.isLocal) {
-          final entry = await modelDownloadManager.ensureModel(
-            source,
-            options: options,
-            onProgress: onProgress,
-          );
-          return loadModel(entry.filePath, modelParams: modelParams);
-        }
-        return loadModel(path, modelParams: modelParams);
+        final localSource = ModelSource.path(path);
+        final entry = await modelDownloadManager.ensureModel(
+          localSource,
+          options: options,
+          onProgress: onProgress,
+        );
+        return loadModel(entry.filePath, modelParams: modelParams);
       case RemoteModelUrl(:final url, :final useBrowserCache):
         if (!useBrowserCache) {
           throw LlamaUnsupportedException(

--- a/lib/src/core/models/download/model_download_manager.dart
+++ b/lib/src/core/models/download/model_download_manager.dart
@@ -1,3 +1,3 @@
 export 'model_download_manager_base.dart';
 export 'model_download_manager_stub.dart'
-    if (dart.library.io) 'model_download_manager_io.dart';
+    if (dart.library.io) '../../../platform/io/model_download_manager_io.dart';

--- a/lib/src/core/models/download/model_download_manager.dart
+++ b/lib/src/core/models/download/model_download_manager.dart
@@ -1,0 +1,3 @@
+export 'model_download_manager_base.dart';
+export 'model_download_manager_stub.dart'
+    if (dart.library.io) 'model_download_manager_io.dart';

--- a/lib/src/core/models/download/model_download_manager_base.dart
+++ b/lib/src/core/models/download/model_download_manager_base.dart
@@ -328,7 +328,7 @@ String _metadataSafeSourceKey(String sourceCanonicalKey, String cacheKey) {
 }
 
 String _validatedCacheFileName(String fileName) {
-  final decoded = Uri.decodeComponent(fileName);
+  final decoded = _decodeCacheComponent(fileName, 'fileName');
   if (decoded.isEmpty ||
       decoded == '.' ||
       decoded == '..' ||
@@ -343,6 +343,18 @@ String _validatedCacheFileName(String fileName) {
   return fileName;
 }
 
+String _decodeCacheComponent(String value, String name) {
+  try {
+    return Uri.decodeComponent(value);
+  } on FormatException catch (error) {
+    throw ArgumentError.value(
+      value,
+      name,
+      'Cache $name contains invalid percent-encoding: ${error.message}',
+    );
+  }
+}
+
 String _validatedCacheFilePath(String filePath) {
   if (filePath.isEmpty) {
     throw ArgumentError.value(
@@ -352,13 +364,15 @@ String _validatedCacheFilePath(String filePath) {
     );
   }
   final normalized = filePath.replaceAll('\\', '/');
-  final decodedPath = Uri.decodeComponent(normalized).replaceAll('\\', '/');
+  final decodedPath = _decodeCacheComponent(
+    normalized,
+    'filePath',
+  ).replaceAll('\\', '/');
   for (final segment in decodedPath.split('/')) {
     if (segment.isEmpty) {
       continue;
     }
-    final decoded = Uri.decodeComponent(segment);
-    if (decoded == '.' || decoded == '..') {
+    if (segment == '.' || segment == '..') {
       throw ArgumentError.value(
         filePath,
         'filePath',

--- a/lib/src/core/models/download/model_download_manager_base.dart
+++ b/lib/src/core/models/download/model_download_manager_base.dart
@@ -363,12 +363,9 @@ String _validatedCacheFilePath(String filePath) {
       'Cache filePath must not be empty.',
     );
   }
-  final normalized = filePath.replaceAll('\\', '/');
-  final decodedPath = _decodeCacheComponent(
-    normalized,
-    'filePath',
-  ).replaceAll('\\', '/');
-  for (final segment in decodedPath.split('/')) {
+  final decodedPath = _decodeCacheComponent(filePath, 'filePath');
+  final normalizedForValidation = decodedPath.replaceAll('\\', '/');
+  for (final segment in normalizedForValidation.split('/')) {
     if (segment.isEmpty) {
       continue;
     }

--- a/lib/src/core/models/download/model_download_manager_base.dart
+++ b/lib/src/core/models/download/model_download_manager_base.dart
@@ -340,7 +340,7 @@ String _validatedCacheFileName(String fileName) {
       'Cache fileName must be a safe basename.',
     );
   }
-  return fileName;
+  return decoded;
 }
 
 String _decodeCacheComponent(String value, String name) {
@@ -380,5 +380,5 @@ String _validatedCacheFilePath(String filePath) {
       );
     }
   }
-  return filePath;
+  return decodedPath;
 }

--- a/lib/src/core/models/download/model_download_manager_base.dart
+++ b/lib/src/core/models/download/model_download_manager_base.dart
@@ -173,7 +173,8 @@ abstract interface class ModelDownloadManager {
     ModelDownloadProgressCallback? onProgress,
   });
 
-  /// Lists all known cached model entries.
+  /// Lists all known package-managed cache entries, including transient
+  /// `noCache` entries that remain until explicitly cleared or pruned.
   Future<List<ModelCacheEntry>> list();
 
   /// Gets a cached model entry by [cacheKey], if present.
@@ -182,10 +183,12 @@ abstract interface class ModelDownloadManager {
   /// Removes a cached model entry by [cacheKey].
   Future<void> remove(String cacheKey);
 
-  /// Clears all package-managed cached model entries.
+  /// Clears all package-managed cached model entries, including transient
+  /// `noCache` entries.
   Future<void> clear();
 
-  /// Prunes cached model entries and returns removed entries.
+  /// Prunes cached model entries, including transient `noCache` entries, and
+  /// returns removed entries.
   Future<List<ModelCacheEntry>> prune({Duration? maxAge, int? maxBytes});
 }
 
@@ -299,7 +302,7 @@ String _validatedCacheFileName(String fileName) {
       decoded == '.' ||
       decoded == '..' ||
       decoded.contains('/') ||
-      decoded.contains(r'\')) {
+      decoded.contains('\\')) {
     throw ArgumentError.value(
       fileName,
       'fileName',
@@ -317,8 +320,9 @@ String _validatedCacheFilePath(String filePath) {
       'Cache filePath must not be empty.',
     );
   }
-  final normalized = filePath.replaceAll(r'\', '/');
-  for (final segment in normalized.split('/')) {
+  final normalized = filePath.replaceAll('\\', '/');
+  final decodedPath = Uri.decodeComponent(normalized).replaceAll('\\', '/');
+  for (final segment in decodedPath.split('/')) {
     if (segment.isEmpty) {
       continue;
     }

--- a/lib/src/core/models/download/model_download_manager_base.dart
+++ b/lib/src/core/models/download/model_download_manager_base.dart
@@ -182,23 +182,38 @@ abstract interface class ModelDownloadManager {
     ModelDownloadProgressCallback? onProgress,
   });
 
-  /// Lists all known package-managed cache entries, including transient
-  /// `noCache` entries that remain until explicitly cleared or pruned.
-  Future<List<ModelCacheEntry>> list();
+  /// Lists all known package-managed cache entries under [cacheDirectory],
+  /// including transient `noCache` entries that remain until explicitly
+  /// cleared or pruned.
+  ///
+  /// When [cacheDirectory] is omitted, the manager's default cache root is used.
+  Future<List<ModelCacheEntry>> list({String? cacheDirectory});
 
-  /// Gets a cached model entry by [cacheKey], if present.
-  Future<ModelCacheEntry?> get(String cacheKey);
+  /// Gets a cached model entry by [cacheKey], if present under [cacheDirectory].
+  ///
+  /// When [cacheDirectory] is omitted, the manager's default cache root is used.
+  Future<ModelCacheEntry?> get(String cacheKey, {String? cacheDirectory});
 
-  /// Removes a cached model entry by [cacheKey].
-  Future<void> remove(String cacheKey);
+  /// Removes cached model entries by [cacheKey] under [cacheDirectory].
+  ///
+  /// When [cacheDirectory] is omitted, the manager's default cache root is used.
+  Future<void> remove(String cacheKey, {String? cacheDirectory});
 
-  /// Clears all package-managed cached model entries, including transient
-  /// `noCache` entries.
-  Future<void> clear();
+  /// Clears all package-managed cached model entries under [cacheDirectory],
+  /// including transient `noCache` entries.
+  ///
+  /// When [cacheDirectory] is omitted, the manager's default cache root is used.
+  Future<void> clear({String? cacheDirectory});
 
   /// Prunes cached model entries, including transient `noCache` entries, and
   /// returns removed entries.
-  Future<List<ModelCacheEntry>> prune({Duration? maxAge, int? maxBytes});
+  ///
+  /// When [cacheDirectory] is omitted, the manager's default cache root is used.
+  Future<List<ModelCacheEntry>> prune({
+    Duration? maxAge,
+    int? maxBytes,
+    String? cacheDirectory,
+  });
 }
 
 /// Base implementation for download managers that do not implement IO yet.
@@ -221,27 +236,34 @@ abstract class ThrowingModelDownloadManager implements ModelDownloadManager {
   }
 
   @override
-  Future<List<ModelCacheEntry>> list() async {
+  Future<List<ModelCacheEntry>> list({String? cacheDirectory}) async {
     throw unsupported('list');
   }
 
   @override
-  Future<ModelCacheEntry?> get(String cacheKey) async {
+  Future<ModelCacheEntry?> get(
+    String cacheKey, {
+    String? cacheDirectory,
+  }) async {
     throw unsupported('get');
   }
 
   @override
-  Future<void> remove(String cacheKey) async {
+  Future<void> remove(String cacheKey, {String? cacheDirectory}) async {
     throw unsupported('remove');
   }
 
   @override
-  Future<void> clear() async {
+  Future<void> clear({String? cacheDirectory}) async {
     throw unsupported('clear');
   }
 
   @override
-  Future<List<ModelCacheEntry>> prune({Duration? maxAge, int? maxBytes}) async {
+  Future<List<ModelCacheEntry>> prune({
+    Duration? maxAge,
+    int? maxBytes,
+    String? cacheDirectory,
+  }) async {
     throw unsupported('prune');
   }
 }

--- a/lib/src/core/models/download/model_download_manager_base.dart
+++ b/lib/src/core/models/download/model_download_manager_base.dart
@@ -57,6 +57,10 @@ class ModelDownloadProgress {
 class ModelCacheEntry {
   /// Creates cache metadata for a model file.
   factory ModelCacheEntry({
+    /// Raw canonical source key used to derive [cacheKey].
+    ///
+    /// The stored [sourceCanonicalKey] value is sanitized for metadata by
+    /// redacting URL secrets and appending the deterministic cache key.
     required String sourceCanonicalKey,
     required String cacheKey,
     required String fileName,
@@ -115,10 +119,15 @@ class ModelCacheEntry {
     );
   }
 
-  /// Canonical source key that produced this cached model.
+  /// Metadata-safe source identity that produced this cached model.
+  ///
+  /// For URL-backed sources this is not the raw canonical key: query strings,
+  /// fragments, and user info are redacted before persistence, and [cacheKey]
+  /// is appended so distinct secret-bearing URLs remain distinguishable without
+  /// leaking those secrets into cache metadata.
   final String sourceCanonicalKey;
 
-  /// Deterministic cache key for [sourceCanonicalKey].
+  /// Deterministic cache key derived from the raw canonical source key.
   final String cacheKey;
 
   /// Cached model file name.

--- a/lib/src/core/models/download/model_download_manager_base.dart
+++ b/lib/src/core/models/download/model_download_manager_base.dart
@@ -309,13 +309,19 @@ int? _optionalInt(Object? value) {
 }
 
 String _metadataSafeSourceKey(String sourceCanonicalKey, String cacheKey) {
-  final candidate = sourceCanonicalKey.startsWith('url:')
-      ? sourceCanonicalKey.substring('url:'.length).split('#').first
+  final isUrlKey = sourceCanonicalKey.startsWith('url:');
+  final candidate = isUrlKey
+      ? sourceCanonicalKey
+            .substring('url:'.length)
+            .split('#')
+            .first
+            .split(RegExp(r'\s'))
+            .first
       : sourceCanonicalKey;
 
   final uri = Uri.tryParse(candidate);
   if (uri == null || (uri.scheme != 'http' && uri.scheme != 'https')) {
-    return sourceCanonicalKey;
+    return isUrlKey ? 'url:<redacted>#cacheKey=$cacheKey' : sourceCanonicalKey;
   }
 
   final redactedUri = Uri(

--- a/lib/src/core/models/download/model_download_manager_base.dart
+++ b/lib/src/core/models/download/model_download_manager_base.dart
@@ -1,0 +1,335 @@
+import '../../exceptions.dart';
+import '../model_load_options.dart';
+import '../model_source.dart';
+
+/// Callback invoked with model download progress.
+typedef ModelDownloadProgressCallback =
+    void Function(ModelDownloadProgress progress);
+
+/// Progress information for a package-managed model download.
+class ModelDownloadProgress {
+  /// Creates download progress information.
+  const ModelDownloadProgress({required this.receivedBytes, this.totalBytes})
+    : _fraction = null;
+
+  /// Creates progress information when only a completion fraction is known.
+  const ModelDownloadProgress.fraction(double fraction)
+    : receivedBytes = 0,
+      totalBytes = null,
+      _fraction = fraction;
+
+  /// Bytes received so far.
+  final int receivedBytes;
+
+  /// Total expected bytes, when known.
+  final int? totalBytes;
+
+  final double? _fraction;
+
+  /// Download completion fraction clamped to `[0, 1]`, or null if unknown.
+  double? get fraction {
+    final knownFraction = _fraction;
+    if (knownFraction != null) {
+      if (knownFraction < 0) {
+        return 0;
+      }
+      if (knownFraction > 1) {
+        return 1;
+      }
+      return knownFraction;
+    }
+    final total = totalBytes;
+    if (total == null || total <= 0) {
+      return null;
+    }
+    final value = receivedBytes / total;
+    if (value < 0) {
+      return 0;
+    }
+    if (value > 1) {
+      return 1;
+    }
+    return value;
+  }
+}
+
+/// Metadata describing a package-managed cached model file.
+class ModelCacheEntry {
+  /// Creates cache metadata for a model file.
+  factory ModelCacheEntry({
+    required String sourceCanonicalKey,
+    required String cacheKey,
+    required String fileName,
+    required String filePath,
+    required DateTime createdAt,
+    required DateTime updatedAt,
+    int? bytes,
+    String? sha256,
+    String? etag,
+    String? lastModified,
+    DateTime? expiresAt,
+  }) {
+    return ModelCacheEntry._(
+      sourceCanonicalKey: _metadataSafeSourceKey(sourceCanonicalKey, cacheKey),
+      cacheKey: cacheKey,
+      fileName: _validatedCacheFileName(fileName),
+      filePath: _validatedCacheFilePath(filePath),
+      bytes: bytes,
+      sha256: sha256,
+      etag: etag,
+      lastModified: lastModified,
+      createdAt: createdAt,
+      updatedAt: updatedAt,
+      expiresAt: expiresAt,
+    );
+  }
+
+  const ModelCacheEntry._({
+    required this.sourceCanonicalKey,
+    required this.cacheKey,
+    required this.fileName,
+    required this.filePath,
+    required this.createdAt,
+    required this.updatedAt,
+    this.bytes,
+    this.sha256,
+    this.etag,
+    this.lastModified,
+    this.expiresAt,
+  });
+
+  /// Creates cache metadata from a JSON map using snake_case keys.
+  factory ModelCacheEntry.fromJson(Map<String, Object?> json) {
+    return ModelCacheEntry(
+      sourceCanonicalKey: _requiredString(json, 'source_canonical_key'),
+      cacheKey: _requiredString(json, 'cache_key'),
+      fileName: _requiredString(json, 'file_name'),
+      filePath: _requiredString(json, 'file_path'),
+      bytes: _optionalInt(json['bytes']),
+      sha256: json['sha256'] as String?,
+      etag: json['etag'] as String?,
+      lastModified: json['last_modified'] as String?,
+      createdAt: _requiredDateTime(json, 'created_at'),
+      updatedAt: _requiredDateTime(json, 'updated_at'),
+      expiresAt: _optionalDateTime(json['expires_at']),
+    );
+  }
+
+  /// Canonical source key that produced this cached model.
+  final String sourceCanonicalKey;
+
+  /// Deterministic cache key for [sourceCanonicalKey].
+  final String cacheKey;
+
+  /// Cached model file name.
+  final String fileName;
+
+  /// Full path to the cached model file.
+  final String filePath;
+
+  /// Optional model file byte length.
+  final int? bytes;
+
+  /// Optional model file SHA-256 checksum.
+  final String? sha256;
+
+  /// Optional HTTP ETag associated with this model.
+  final String? etag;
+
+  /// Optional HTTP Last-Modified value associated with this model.
+  final String? lastModified;
+
+  /// Creation timestamp for this cache entry.
+  final DateTime createdAt;
+
+  /// Last update timestamp for this cache entry.
+  final DateTime updatedAt;
+
+  /// Optional expiration timestamp for this cache entry.
+  final DateTime? expiresAt;
+
+  /// Converts this entry to JSON using snake_case keys.
+  Map<String, Object?> toJson() => <String, Object?>{
+    'source_canonical_key': sourceCanonicalKey,
+    'cache_key': cacheKey,
+    'file_name': fileName,
+    'file_path': filePath,
+    if (bytes != null) 'bytes': bytes,
+    if (sha256 != null) 'sha256': sha256,
+    if (etag != null) 'etag': etag,
+    if (lastModified != null) 'last_modified': lastModified,
+    'created_at': createdAt.toUtc().toIso8601String(),
+    'updated_at': updatedAt.toUtc().toIso8601String(),
+    if (expiresAt != null) 'expires_at': expiresAt!.toUtc().toIso8601String(),
+  };
+}
+
+/// Public API for package-managed model cache/download implementations.
+abstract interface class ModelDownloadManager {
+  /// Ensures [source] is available as a local cache entry.
+  Future<ModelCacheEntry> ensureModel(
+    ModelSource source, {
+    ModelLoadOptions options = ModelLoadOptions.defaults,
+    ModelDownloadProgressCallback? onProgress,
+  });
+
+  /// Lists all known cached model entries.
+  Future<List<ModelCacheEntry>> list();
+
+  /// Gets a cached model entry by [cacheKey], if present.
+  Future<ModelCacheEntry?> get(String cacheKey);
+
+  /// Removes a cached model entry by [cacheKey].
+  Future<void> remove(String cacheKey);
+
+  /// Clears all package-managed cached model entries.
+  Future<void> clear();
+
+  /// Prunes cached model entries and returns removed entries.
+  Future<List<ModelCacheEntry>> prune({Duration? maxAge, int? maxBytes});
+}
+
+/// Base implementation for download managers that do not implement IO yet.
+abstract class ThrowingModelDownloadManager implements ModelDownloadManager {
+  /// Creates a throwing model download manager.
+  const ThrowingModelDownloadManager();
+
+  /// Exception thrown by unsupported operations.
+  Object unsupported(String operation) => LlamaUnsupportedException(
+    'Model downloads are not supported by this implementation: $operation.',
+  );
+
+  @override
+  Future<ModelCacheEntry> ensureModel(
+    ModelSource source, {
+    ModelLoadOptions options = ModelLoadOptions.defaults,
+    ModelDownloadProgressCallback? onProgress,
+  }) async {
+    throw unsupported('ensureModel');
+  }
+
+  @override
+  Future<List<ModelCacheEntry>> list() async {
+    throw unsupported('list');
+  }
+
+  @override
+  Future<ModelCacheEntry?> get(String cacheKey) async {
+    throw unsupported('get');
+  }
+
+  @override
+  Future<void> remove(String cacheKey) async {
+    throw unsupported('remove');
+  }
+
+  @override
+  Future<void> clear() async {
+    throw unsupported('clear');
+  }
+
+  @override
+  Future<List<ModelCacheEntry>> prune({Duration? maxAge, int? maxBytes}) async {
+    throw unsupported('prune');
+  }
+}
+
+String _requiredString(Map<String, Object?> json, String key) {
+  final value = json[key];
+  if (value is! String) {
+    throw ArgumentError.value(json, 'json', 'Missing required string: $key.');
+  }
+  return value;
+}
+
+DateTime _requiredDateTime(Map<String, Object?> json, String key) {
+  final value = json[key];
+  if (value is! String) {
+    throw ArgumentError.value(
+      json,
+      'json',
+      'Missing required timestamp: $key.',
+    );
+  }
+  return DateTime.parse(value);
+}
+
+DateTime? _optionalDateTime(Object? value) {
+  if (value == null) {
+    return null;
+  }
+  if (value is! String) {
+    throw ArgumentError.value(value, 'value', 'Expected ISO-8601 timestamp.');
+  }
+  return DateTime.parse(value);
+}
+
+int? _optionalInt(Object? value) {
+  if (value == null) {
+    return null;
+  }
+  if (value is! int) {
+    throw ArgumentError.value(value, 'value', 'Expected integer.');
+  }
+  return value;
+}
+
+String _metadataSafeSourceKey(String sourceCanonicalKey, String cacheKey) {
+  final candidate = sourceCanonicalKey.startsWith('url:')
+      ? sourceCanonicalKey.substring('url:'.length).split('#').first
+      : sourceCanonicalKey;
+
+  final uri = Uri.tryParse(candidate);
+  if (uri == null || (uri.scheme != 'http' && uri.scheme != 'https')) {
+    return sourceCanonicalKey;
+  }
+
+  final redactedUri = Uri(
+    scheme: uri.scheme,
+    host: uri.host,
+    port: uri.hasPort ? uri.port : null,
+    path: uri.path,
+  );
+  return 'url:${redactedUri.toString()}#cacheKey=$cacheKey';
+}
+
+String _validatedCacheFileName(String fileName) {
+  final decoded = Uri.decodeComponent(fileName);
+  if (decoded.isEmpty ||
+      decoded == '.' ||
+      decoded == '..' ||
+      decoded.contains('/') ||
+      decoded.contains(r'\')) {
+    throw ArgumentError.value(
+      fileName,
+      'fileName',
+      'Cache fileName must be a safe basename.',
+    );
+  }
+  return fileName;
+}
+
+String _validatedCacheFilePath(String filePath) {
+  if (filePath.isEmpty) {
+    throw ArgumentError.value(
+      filePath,
+      'filePath',
+      'Cache filePath must not be empty.',
+    );
+  }
+  final normalized = filePath.replaceAll(r'\', '/');
+  for (final segment in normalized.split('/')) {
+    if (segment.isEmpty) {
+      continue;
+    }
+    final decoded = Uri.decodeComponent(segment);
+    if (decoded == '.' || decoded == '..') {
+      throw ArgumentError.value(
+        filePath,
+        'filePath',
+        'Cache filePath must not contain traversal segments.',
+      );
+    }
+  }
+  return filePath;
+}

--- a/lib/src/core/models/download/model_download_manager_io.dart
+++ b/lib/src/core/models/download/model_download_manager_io.dart
@@ -1,15 +1,639 @@
+import 'dart:convert';
+import 'dart:io';
+
+import 'package:crypto/crypto.dart';
+import 'package:path/path.dart' as path;
+
 import '../../exceptions.dart';
+import '../model_load_options.dart';
+import '../model_source.dart';
 import 'model_download_manager_base.dart';
 
-/// Native placeholder for the package-managed model download manager.
-///
-/// Real native HTTP download/resume/cache IO is implemented in later tasks.
-class DefaultModelDownloadManager extends ThrowingModelDownloadManager {
-  /// Creates a native placeholder download manager.
-  const DefaultModelDownloadManager();
+const String _metadataFileName = 'metadata.json';
+const int _metadataSchemaVersion = 1;
+
+/// Native file-backed package-managed model download manager.
+class DefaultModelDownloadManager implements ModelDownloadManager {
+  /// Creates a native model download/cache manager.
+  DefaultModelDownloadManager({String? defaultCacheDirectory})
+    : defaultCacheDirectory =
+          defaultCacheDirectory ??
+          path.join(Directory.systemTemp.path, 'llamadart', 'models');
+
+  /// Default cache root used when [ModelLoadOptions.cacheDirectory] is absent.
+  final String defaultCacheDirectory;
 
   @override
-  Object unsupported(String operation) => LlamaUnsupportedException(
-    'Native model download manager $operation is not implemented yet.',
-  );
+  Future<ModelCacheEntry> ensureModel(
+    ModelSource source, {
+    ModelLoadOptions options = ModelLoadOptions.defaults,
+    ModelDownloadProgressCallback? onProgress,
+  }) async {
+    _throwIfCancelled(options);
+    if (source.isLocal) {
+      return _localEntry(source, options);
+    }
+
+    final cachePolicy = options.cachePolicy;
+    final cacheDir = _cacheDirectory(source, options);
+    final finalFile = File(path.join(cacheDir.path, source.fileName));
+    final partFile = File('${finalFile.path}.part');
+    final metadataFile = File(path.join(cacheDir.path, _metadataFileName));
+
+    if (cachePolicy != ModelCachePolicy.refresh &&
+        cachePolicy != ModelCachePolicy.noCache) {
+      final cached = await _readCompletedEntry(
+        metadataFile,
+        finalFile,
+        options,
+      );
+      if (cached != null) {
+        return cached;
+      }
+      if (cachePolicy == ModelCachePolicy.cacheOnly) {
+        throw LlamaStateException(
+          'No cached model is available for ${source.displayName}.',
+        );
+      }
+    }
+
+    if (cachePolicy == ModelCachePolicy.noCache) {
+      final transientDir = await _createTransientCacheDirectory(
+        source,
+        options,
+      );
+      final transientFile = File(path.join(transientDir.path, source.fileName));
+      final entry = await _download(
+        source,
+        options,
+        transientFile,
+        null,
+        onProgress,
+      );
+      await _writeMetadata(
+        File(path.join(transientDir.path, _metadataFileName)),
+        entry,
+      );
+      return entry;
+    }
+
+    await cacheDir.create(recursive: true);
+    final entry = await _download(
+      source,
+      options,
+      finalFile,
+      partFile,
+      onProgress,
+    );
+    await _writeMetadata(metadataFile, entry);
+    return entry;
+  }
+
+  @override
+  Future<List<ModelCacheEntry>> list() async {
+    final root = Directory(defaultCacheDirectory);
+    if (!await root.exists()) {
+      return <ModelCacheEntry>[];
+    }
+    final entries = <ModelCacheEntry>[];
+    await for (final entity in root.list(followLinks: false)) {
+      if (entity is! Directory) {
+        continue;
+      }
+      final metadataFile = File(path.join(entity.path, _metadataFileName));
+      if (!await metadataFile.exists()) {
+        continue;
+      }
+      try {
+        final entry = await _readMetadata(metadataFile);
+        if (await File(entry.filePath).exists()) {
+          entries.add(entry);
+        }
+      } catch (_) {
+        // Ignore malformed cache entries so one corrupt metadata file does not
+        // make cache inspection unusable.
+      }
+    }
+    entries.sort((a, b) => b.updatedAt.compareTo(a.updatedAt));
+    return entries;
+  }
+
+  @override
+  Future<ModelCacheEntry?> get(String cacheKey) async {
+    for (final entry in await list()) {
+      if (entry.cacheKey == cacheKey) {
+        return entry;
+      }
+    }
+    return null;
+  }
+
+  @override
+  Future<void> remove(String cacheKey) async {
+    final root = Directory(defaultCacheDirectory);
+    if (!await root.exists()) {
+      return;
+    }
+    await for (final entity in root.list(followLinks: false)) {
+      if (entity is! Directory) {
+        continue;
+      }
+      final metadataFile = File(path.join(entity.path, _metadataFileName));
+      if (!await metadataFile.exists()) {
+        continue;
+      }
+      try {
+        final entry = await _readMetadata(metadataFile);
+        if (entry.cacheKey == cacheKey) {
+          await entity.delete(recursive: true);
+          return;
+        }
+      } catch (_) {
+        // Keep scanning; malformed metadata may not be the requested entry.
+      }
+    }
+  }
+
+  @override
+  Future<void> clear() async {
+    final root = Directory(defaultCacheDirectory);
+    if (await root.exists()) {
+      await root.delete(recursive: true);
+    }
+  }
+
+  @override
+  Future<List<ModelCacheEntry>> prune({Duration? maxAge, int? maxBytes}) async {
+    final entries = await list();
+    final removed = <ModelCacheEntry>[];
+    final now = DateTime.now().toUtc();
+
+    for (final entry in entries) {
+      if (maxAge != null && now.difference(entry.updatedAt.toUtc()) > maxAge) {
+        await remove(entry.cacheKey);
+        removed.add(entry);
+      }
+    }
+
+    if (maxBytes != null) {
+      final remaining = (await list()).toList()
+        ..sort((a, b) => a.updatedAt.compareTo(b.updatedAt));
+      var total = remaining.fold<int>(
+        0,
+        (sum, entry) => sum + (entry.bytes ?? 0),
+      );
+      for (final entry in remaining) {
+        if (total <= maxBytes) {
+          break;
+        }
+        await remove(entry.cacheKey);
+        removed.add(entry);
+        total -= entry.bytes ?? 0;
+      }
+    }
+
+    return removed;
+  }
+
+  Directory _cacheDirectory(ModelSource source, ModelLoadOptions options) {
+    return Directory(
+      path.join(
+        options.cacheDirectory ?? defaultCacheDirectory,
+        source.cacheDirectoryName,
+      ),
+    );
+  }
+
+  Future<Directory> _createTransientCacheDirectory(
+    ModelSource source,
+    ModelLoadOptions options,
+  ) async {
+    final root = Directory(options.cacheDirectory ?? defaultCacheDirectory);
+    await root.create(recursive: true);
+    final timestamp = DateTime.now().toUtc().microsecondsSinceEpoch;
+    return Directory(
+      path.join(root.path, '${source.cacheDirectoryName}-nocache-$timestamp'),
+    )..createSync(recursive: true);
+  }
+
+  Future<ModelCacheEntry> _localEntry(
+    ModelSource source,
+    ModelLoadOptions options,
+  ) async {
+    final file = File(source.path!);
+    if (!await file.exists()) {
+      throw LlamaModelException(
+        'Local model file does not exist: ${source.displayName}.',
+      );
+    }
+    return _entryForFile(source, file, DateTime.now().toUtc(), options);
+  }
+
+  Future<ModelCacheEntry?> _readCompletedEntry(
+    File metadataFile,
+    File finalFile,
+    ModelLoadOptions options,
+  ) async {
+    if (!await metadataFile.exists() || !await finalFile.exists()) {
+      return null;
+    }
+    final entry = await _readMetadata(metadataFile);
+    if (entry.filePath != finalFile.path) {
+      return null;
+    }
+    if (options.sha256 != null) {
+      final actual = await _sha256File(finalFile);
+      if (actual != options.sha256) {
+        await _deleteIfExists(finalFile);
+        await _deleteIfExists(metadataFile);
+        return null;
+      }
+    }
+    final refreshed = ModelCacheEntry(
+      sourceCanonicalKey: entry.sourceCanonicalKey,
+      cacheKey: entry.cacheKey,
+      fileName: entry.fileName,
+      filePath: entry.filePath,
+      bytes: entry.bytes,
+      sha256: entry.sha256,
+      etag: entry.etag,
+      lastModified: entry.lastModified,
+      createdAt: entry.createdAt,
+      updatedAt: DateTime.now().toUtc(),
+      expiresAt: entry.expiresAt,
+    );
+    await _writeMetadata(metadataFile, refreshed);
+    return refreshed;
+  }
+
+  Future<ModelCacheEntry> _download(
+    ModelSource source,
+    ModelLoadOptions options,
+    File finalFile,
+    File? partFile,
+    ModelDownloadProgressCallback? onProgress,
+  ) async {
+    final uri = source.resolvedUri;
+    if (uri == null) {
+      throw LlamaModelException('Remote model source has no resolved URL.');
+    }
+
+    Object? lastError;
+    for (var attempt = 0; attempt <= options.maxRetries; attempt += 1) {
+      _throwIfCancelled(options);
+      try {
+        return await _downloadOnce(
+          source,
+          options,
+          uri,
+          finalFile,
+          partFile,
+          onProgress,
+        );
+      } on LlamaStateException {
+        rethrow;
+      } on LlamaModelException catch (error) {
+        lastError = error;
+        if (!_isRetryable(error) || attempt == options.maxRetries) {
+          rethrow;
+        }
+      } on IOException catch (error) {
+        lastError = error;
+        if (attempt == options.maxRetries) {
+          throw LlamaModelException(
+            'Failed to download ${source.displayName}.',
+            error,
+          );
+        }
+      }
+    }
+    throw LlamaModelException(
+      'Failed to download ${source.displayName}.',
+      lastError,
+    );
+  }
+
+  Future<ModelCacheEntry> _downloadOnce(
+    ModelSource source,
+    ModelLoadOptions options,
+    Uri uri,
+    File finalFile,
+    File? partFile,
+    ModelDownloadProgressCallback? onProgress,
+  ) async {
+    await finalFile.parent.create(recursive: true);
+    final downloadFile = partFile ?? File('${finalFile.path}.download');
+    final partMetadataFile = partFile == null
+        ? null
+        : _partMetadataFile(partFile);
+    final partMetadata = partMetadataFile == null
+        ? null
+        : await _readPartMetadata(partMetadataFile);
+    var existingBytes = 0;
+    final canResumePartial =
+        partFile != null &&
+        options.resume &&
+        await partFile.exists() &&
+        (partMetadata != null || options.sha256 != null);
+    if (canResumePartial) {
+      existingBytes = await partFile.length();
+    } else {
+      await _deleteIfExists(downloadFile);
+      if (partMetadataFile != null) {
+        await _deleteIfExists(partMetadataFile);
+      }
+    }
+
+    final client = HttpClient();
+    try {
+      final request = await client.getUrl(uri);
+      request.followRedirects = true;
+      request.maxRedirects = 10;
+      for (final header in options.headers.entries) {
+        request.headers.set(header.key, header.value);
+      }
+      final bearerToken = options.bearerToken;
+      if (bearerToken != null) {
+        request.headers.set(
+          HttpHeaders.authorizationHeader,
+          'Bearer $bearerToken',
+        );
+      }
+      if (existingBytes > 0) {
+        request.headers.set(HttpHeaders.rangeHeader, 'bytes=$existingBytes-');
+        final validator = partMetadata?.etag ?? partMetadata?.lastModified;
+        if (validator != null) {
+          request.headers.set(HttpHeaders.ifRangeHeader, validator);
+        }
+      }
+
+      final response = await request.close();
+      final statusCode = response.statusCode;
+      final responsePartMetadata = _PartMetadata.fromResponse(response);
+      final append =
+          existingBytes > 0 && statusCode == HttpStatus.partialContent;
+      if (existingBytes > 0 && statusCode == HttpStatus.partialContent) {
+        _validateContentRange(response, existingBytes, source);
+        _validateResumeValidator(partMetadata, responsePartMetadata, source);
+      } else if (existingBytes > 0 && statusCode == HttpStatus.ok) {
+        existingBytes = 0;
+        await _deleteIfExists(downloadFile);
+        if (partMetadataFile != null) {
+          await _deleteIfExists(partMetadataFile);
+        }
+      } else if (statusCode != HttpStatus.ok) {
+        throw LlamaModelException(
+          'Failed to download ${source.displayName}: HTTP $statusCode.',
+          statusCode,
+        );
+      }
+
+      if (partMetadataFile != null) {
+        await _writePartMetadata(partMetadataFile, responsePartMetadata);
+      }
+
+      final sink = downloadFile.openWrite(
+        mode: append ? FileMode.append : FileMode.write,
+      );
+      var receivedBytes = existingBytes;
+      final totalBytes = _totalBytes(response, existingBytes);
+      try {
+        await for (final chunk in response) {
+          _throwIfCancelled(options);
+          sink.add(chunk);
+          receivedBytes += chunk.length;
+          onProgress?.call(
+            ModelDownloadProgress(
+              receivedBytes: receivedBytes,
+              totalBytes: totalBytes,
+            ),
+          );
+        }
+      } finally {
+        await sink.close();
+      }
+      _throwIfCancelled(options);
+
+      if (options.sha256 != null) {
+        final actual = await _sha256File(downloadFile);
+        if (actual != options.sha256) {
+          await _deleteIfExists(downloadFile);
+          throw LlamaModelException(
+            'Checksum mismatch for ${source.displayName}.',
+          );
+        }
+      }
+      await downloadFile.rename(finalFile.path);
+      if (partMetadataFile != null) {
+        await _deleteIfExists(partMetadataFile);
+      }
+      final entry = await _entryForFile(
+        source,
+        finalFile,
+        DateTime.now().toUtc(),
+        options,
+        etag: responsePartMetadata.etag,
+        lastModified: responsePartMetadata.lastModified,
+      );
+      onProgress?.call(
+        ModelDownloadProgress(
+          receivedBytes: entry.bytes ?? 0,
+          totalBytes: entry.bytes,
+        ),
+      );
+      return entry;
+    } finally {
+      client.close(force: true);
+      if (partFile == null) {
+        await _deleteIfExists(downloadFile);
+      }
+    }
+  }
+
+  Future<ModelCacheEntry> _entryForFile(
+    ModelSource source,
+    File file,
+    DateTime timestamp,
+    ModelLoadOptions options, {
+    String? etag,
+    String? lastModified,
+  }) async {
+    final bytes = await file.length();
+    final digest = await _sha256File(file);
+    return ModelCacheEntry(
+      sourceCanonicalKey: source.metadataSourceKey,
+      cacheKey: source.cacheKey,
+      fileName: source.fileName,
+      filePath: file.path,
+      bytes: bytes,
+      sha256: digest,
+      etag: etag,
+      lastModified: lastModified,
+      createdAt: timestamp,
+      updatedAt: timestamp,
+    );
+  }
+
+  Future<ModelCacheEntry> _readMetadata(File metadataFile) async {
+    final decoded = jsonDecode(await metadataFile.readAsString());
+    if (decoded is! Map<String, Object?>) {
+      throw const FormatException('Model cache metadata must be an object.');
+    }
+    final schemaVersion = decoded['schema_version'];
+    if (schemaVersion != _metadataSchemaVersion) {
+      throw FormatException(
+        'Unsupported model cache metadata schema: $schemaVersion.',
+      );
+    }
+    return ModelCacheEntry.fromJson(decoded);
+  }
+
+  Future<void> _writeMetadata(File metadataFile, ModelCacheEntry entry) async {
+    await metadataFile.parent.create(recursive: true);
+    final tempFile = File('${metadataFile.path}.tmp');
+    final json = <String, Object?>{
+      'schema_version': _metadataSchemaVersion,
+      ...entry.toJson(),
+    };
+    await tempFile.writeAsString(
+      '${const JsonEncoder.withIndent('  ').convert(json)}\n',
+    );
+    await tempFile.rename(metadataFile.path);
+  }
+}
+
+class _PartMetadata {
+  const _PartMetadata({this.etag, this.lastModified});
+
+  factory _PartMetadata.fromResponse(HttpClientResponse response) {
+    return _PartMetadata(
+      etag: response.headers.value(HttpHeaders.etagHeader),
+      lastModified: response.headers.value(HttpHeaders.lastModifiedHeader),
+    );
+  }
+
+  factory _PartMetadata.fromJson(Map<String, Object?> json) {
+    return _PartMetadata(
+      etag: json['etag'] as String?,
+      lastModified: json['last_modified'] as String?,
+    );
+  }
+
+  final String? etag;
+  final String? lastModified;
+
+  bool get hasValidator => etag != null || lastModified != null;
+
+  Map<String, Object?> toJson() => <String, Object?>{
+    if (etag != null) 'etag': etag,
+    if (lastModified != null) 'last_modified': lastModified,
+  };
+}
+
+File _partMetadataFile(File partFile) => File('${partFile.path}.json');
+
+Future<_PartMetadata?> _readPartMetadata(File file) async {
+  try {
+    if (!await file.exists()) {
+      return null;
+    }
+    final decoded = jsonDecode(await file.readAsString());
+    if (decoded is! Map<String, Object?>) {
+      return null;
+    }
+    final metadata = _PartMetadata.fromJson(decoded);
+    return metadata.hasValidator ? metadata : null;
+  } catch (_) {
+    return null;
+  }
+}
+
+Future<void> _writePartMetadata(File file, _PartMetadata metadata) async {
+  if (!metadata.hasValidator) {
+    await _deleteIfExists(file);
+    return;
+  }
+  await file.writeAsString('${jsonEncode(metadata.toJson())}\n');
+}
+
+void _throwIfCancelled(ModelLoadOptions options) {
+  if (options.cancelToken?.isCancelled ?? false) {
+    throw LlamaStateException('Model download was cancelled.');
+  }
+}
+
+bool _isRetryable(LlamaModelException error) {
+  final details = error.details;
+  return details is int && details >= 500;
+}
+
+int? _totalBytes(HttpClientResponse response, int existingBytes) {
+  final contentRange = response.headers.value(HttpHeaders.contentRangeHeader);
+  if (contentRange != null) {
+    final totalPart = contentRange.split('/').last;
+    final total = int.tryParse(totalPart);
+    if (total != null) {
+      return total;
+    }
+  }
+  final length = response.contentLength;
+  if (length >= 0) {
+    return existingBytes + length;
+  }
+  return null;
+}
+
+void _validateContentRange(
+  HttpClientResponse response,
+  int expectedStart,
+  ModelSource source,
+) {
+  final contentRange = response.headers.value(HttpHeaders.contentRangeHeader);
+  if (contentRange == null ||
+      !contentRange.startsWith('bytes $expectedStart-')) {
+    throw LlamaModelException(
+      'Server returned an invalid resume range for ${source.displayName}.',
+    );
+  }
+}
+
+void _validateResumeValidator(
+  _PartMetadata? previous,
+  _PartMetadata current,
+  ModelSource source,
+) {
+  if (previous == null) {
+    return;
+  }
+  final previousEtag = previous.etag;
+  if (previousEtag != null) {
+    if (current.etag != previousEtag) {
+      throw LlamaModelException(
+        'Server returned a different entity validator while resuming ${source.displayName}.',
+      );
+    }
+    return;
+  }
+  final previousLastModified = previous.lastModified;
+  if (previousLastModified != null &&
+      current.lastModified != previousLastModified) {
+    throw LlamaModelException(
+      'Server returned a different modification timestamp while resuming ${source.displayName}.',
+    );
+  }
+}
+
+Future<String> _sha256File(File file) async {
+  final digest = await sha256.bind(file.openRead()).first;
+  return digest.toString();
+}
+
+Future<void> _deleteIfExists(File file) async {
+  try {
+    if (await file.exists()) {
+      await file.delete();
+    }
+  } on FileSystemException {
+    // Best effort cleanup; later file operations surface actionable errors.
+  }
 }

--- a/lib/src/core/models/download/model_download_manager_io.dart
+++ b/lib/src/core/models/download/model_download_manager_io.dart
@@ -1,0 +1,15 @@
+import '../../exceptions.dart';
+import 'model_download_manager_base.dart';
+
+/// Native placeholder for the package-managed model download manager.
+///
+/// Real native HTTP download/resume/cache IO is implemented in later tasks.
+class DefaultModelDownloadManager extends ThrowingModelDownloadManager {
+  /// Creates a native placeholder download manager.
+  const DefaultModelDownloadManager();
+
+  @override
+  Object unsupported(String operation) => LlamaUnsupportedException(
+    'Native model download manager $operation is not implemented yet.',
+  );
+}

--- a/lib/src/core/models/download/model_download_manager_io.dart
+++ b/lib/src/core/models/download/model_download_manager_io.dart
@@ -211,9 +211,11 @@ class DefaultModelDownloadManager implements ModelDownloadManager {
     final root = Directory(options.cacheDirectory ?? defaultCacheDirectory);
     await root.create(recursive: true);
     final timestamp = DateTime.now().toUtc().microsecondsSinceEpoch;
-    return Directory(
+    final directory = Directory(
       path.join(root.path, '${source.cacheDirectoryName}-nocache-$timestamp'),
-    )..createSync(recursive: true);
+    );
+    await directory.create(recursive: true);
+    return directory;
   }
 
   Future<ModelCacheEntry> _localEntry(

--- a/lib/src/core/models/download/model_download_manager_stub.dart
+++ b/lib/src/core/models/download/model_download_manager_stub.dart
@@ -1,0 +1,13 @@
+import '../../exceptions.dart';
+import 'model_download_manager_base.dart';
+
+/// Non-IO placeholder for the package-managed model download manager.
+class DefaultModelDownloadManager extends ThrowingModelDownloadManager {
+  /// Creates a non-IO placeholder download manager.
+  const DefaultModelDownloadManager();
+
+  @override
+  Object unsupported(String operation) => LlamaUnsupportedException(
+    'Model download manager $operation is not supported on this platform.',
+  );
+}

--- a/lib/src/core/models/download/model_download_manager_stub.dart
+++ b/lib/src/core/models/download/model_download_manager_stub.dart
@@ -4,7 +4,7 @@ import 'model_download_manager_base.dart';
 /// Non-IO placeholder for the package-managed model download manager.
 class DefaultModelDownloadManager extends ThrowingModelDownloadManager {
   /// Creates a non-IO placeholder download manager.
-  const DefaultModelDownloadManager();
+  const DefaultModelDownloadManager({String? defaultCacheDirectory});
 
   @override
   Object unsupported(String operation) => LlamaUnsupportedException(

--- a/lib/src/core/models/model_load_options.dart
+++ b/lib/src/core/models/model_load_options.dart
@@ -1,0 +1,108 @@
+/// Controls how model source resolution should interact with caches.
+enum ModelCachePolicy {
+  /// Use a cached model when available and download only when missing.
+  preferCached,
+
+  /// Refresh remote metadata/content even when a cached model exists.
+  refresh,
+
+  /// Require a cached model and fail when it is unavailable.
+  cacheOnly,
+
+  /// Do not read from or write to a package-managed model cache.
+  noCache,
+}
+
+/// Cooperative cancellation token for model downloads and resolution.
+class ModelDownloadCancelToken {
+  bool _isCancelled = false;
+
+  /// Whether [cancel] has been requested.
+  bool get isCancelled => _isCancelled;
+
+  /// Requests cancellation. Calling this method more than once is safe.
+  void cancel() {
+    _isCancelled = true;
+  }
+}
+
+/// Options used when resolving and loading model sources.
+///
+/// The default foundation resolver only supports unauthenticated remote URL
+/// loading with [ModelCachePolicy.preferCached]. Native download/cache
+/// implementations added in later tasks may honor refresh/no-cache/cache-only
+/// policies, cache directory, checksum, headers, resume, and retry fields.
+class ModelLoadOptions {
+  /// Creates model load options.
+  factory ModelLoadOptions({
+    ModelCachePolicy cachePolicy = ModelCachePolicy.preferCached,
+    String? cacheDirectory,
+    String? sha256,
+    String? bearerToken,
+    Map<String, String> headers = const <String, String>{},
+    ModelDownloadCancelToken? cancelToken,
+    bool resume = true,
+    int maxRetries = 3,
+  }) {
+    if (maxRetries < 0) {
+      throw ArgumentError.value(
+        maxRetries,
+        'maxRetries',
+        'Maximum retry attempts must not be negative.',
+      );
+    }
+    return ModelLoadOptions._(
+      cachePolicy: cachePolicy,
+      cacheDirectory: cacheDirectory,
+      sha256: sha256,
+      bearerToken: bearerToken,
+      headers: Map<String, String>.unmodifiable(headers),
+      cancelToken: cancelToken,
+      resume: resume,
+      maxRetries: maxRetries,
+    );
+  }
+
+  const ModelLoadOptions._({
+    required this.cachePolicy,
+    required this.headers,
+    required this.resume,
+    required this.maxRetries,
+    this.cacheDirectory,
+    this.sha256,
+    this.bearerToken,
+    this.cancelToken,
+  });
+
+  /// Compile-time default options for API default parameters.
+  static const ModelLoadOptions defaults = ModelLoadOptions._(
+    cachePolicy: ModelCachePolicy.preferCached,
+    headers: <String, String>{},
+    resume: true,
+    maxRetries: 3,
+  );
+
+  /// Cache behavior for this load.
+  final ModelCachePolicy cachePolicy;
+
+  /// Optional package-managed cache directory override.
+  final String? cacheDirectory;
+
+  /// Optional expected SHA-256 checksum for the model file.
+  final String? sha256;
+
+  /// Optional bearer token for authenticated remote model access.
+  final String? bearerToken;
+
+  /// Additional HTTP headers for remote model access.
+  final Map<String, String> headers;
+
+  /// Optional cancellation token for cooperative cancellation.
+  final ModelDownloadCancelToken? cancelToken;
+
+  /// Whether interrupted native downloads may be resumed by later tasks.
+  final bool resume;
+
+  /// Maximum retry attempts for native downloads in later tasks.
+  final int maxRetries;
+}

--- a/lib/src/core/models/model_load_options.dart
+++ b/lib/src/core/models/model_load_options.dart
@@ -52,10 +52,11 @@ class ModelLoadOptions {
         'Maximum retry attempts must not be negative.',
       );
     }
+    final normalizedSha256 = _normalizeSha256(sha256);
     return ModelLoadOptions._(
       cachePolicy: cachePolicy,
       cacheDirectory: cacheDirectory,
-      sha256: sha256,
+      sha256: normalizedSha256,
       bearerToken: bearerToken,
       headers: Map<String, String>.unmodifiable(headers),
       cancelToken: cancelToken,
@@ -90,6 +91,9 @@ class ModelLoadOptions {
   final String? cacheDirectory;
 
   /// Optional expected SHA-256 checksum for the model file.
+  ///
+  /// Non-null values are validated as 64-character hexadecimal digests and
+  /// normalized to lowercase.
   final String? sha256;
 
   /// Optional bearer token for authenticated remote model access.
@@ -106,4 +110,19 @@ class ModelLoadOptions {
 
   /// Maximum retry attempts for native downloads.
   final int maxRetries;
+}
+
+String? _normalizeSha256(String? sha256) {
+  if (sha256 == null) {
+    return null;
+  }
+  final normalized = sha256.toLowerCase();
+  if (!RegExp(r'^[0-9a-f]{64}$').hasMatch(normalized)) {
+    throw ArgumentError.value(
+      sha256,
+      'sha256',
+      'SHA-256 checksum must be a 64-character hexadecimal string.',
+    );
+  }
+  return normalized;
 }

--- a/lib/src/core/models/model_load_options.dart
+++ b/lib/src/core/models/model_load_options.dart
@@ -28,10 +28,11 @@ class ModelDownloadCancelToken {
 
 /// Options used when resolving and loading model sources.
 ///
-/// The default foundation resolver only supports unauthenticated remote URL
-/// loading with [ModelCachePolicy.preferCached]. Native download/cache
-/// implementations added in later tasks may honor refresh/no-cache/cache-only
-/// policies, cache directory, checksum, headers, resume, and retry fields.
+/// Native/file-backed backends use the package-managed download/cache manager
+/// for remote HTTP(S) and Hugging Face sources. URL-loading web backends can
+/// load remote URLs directly and reject options that require native cache IO,
+/// such as authenticated headers, checksum verification, and explicit cache
+/// policy changes.
 class ModelLoadOptions {
   /// Creates model load options.
   factory ModelLoadOptions({
@@ -100,9 +101,9 @@ class ModelLoadOptions {
   /// Optional cancellation token for cooperative cancellation.
   final ModelDownloadCancelToken? cancelToken;
 
-  /// Whether interrupted native downloads may be resumed by later tasks.
+  /// Whether interrupted native downloads may be resumed with HTTP Range.
   final bool resume;
 
-  /// Maximum retry attempts for native downloads in later tasks.
+  /// Maximum retry attempts for native downloads.
   final int maxRetries;
 }

--- a/lib/src/core/models/model_load_options.dart
+++ b/lib/src/core/models/model_load_options.dart
@@ -9,7 +9,11 @@ enum ModelCachePolicy {
   /// Require a cached model and fail when it is unavailable.
   cacheOnly,
 
-  /// Do not read from or write to a package-managed model cache.
+  /// Do not reuse stable package-managed cache entries.
+  ///
+  /// File-backed download managers may still write the resolved model into a
+  /// transient package-managed directory so native loaders can receive a local
+  /// path and later cleanup can remove the temporary entry.
   noCache,
 }
 

--- a/lib/src/core/models/model_resolver.dart
+++ b/lib/src/core/models/model_resolver.dart
@@ -78,43 +78,9 @@ class DefaultModelResolver implements ModelResolver {
     if (request.options.cancelToken?.isCancelled ?? false) {
       throw LlamaStateException('Model source resolution was cancelled.');
     }
-    _rejectUnsupportedFoundationOptions(request.options);
     if (source.isLocal) {
       return LocalModelFile(source.path!);
     }
     return RemoteModelUrl(source.resolvedUri!, useBrowserCache: true);
-  }
-}
-
-void _rejectUnsupportedFoundationOptions(ModelLoadOptions options) {
-  if (options.cachePolicy != ModelCachePolicy.preferCached) {
-    throw LlamaUnsupportedException(
-      '${options.cachePolicy.name} model resolution requires a concrete cache-aware resolver.',
-    );
-  }
-  if (options.bearerToken != null || options.headers.isNotEmpty) {
-    throw LlamaUnsupportedException(
-      'Authenticated model resolution requires a concrete resolver that can apply HTTP credentials.',
-    );
-  }
-  if (options.sha256 != null) {
-    throw LlamaUnsupportedException(
-      'Checksum verification requires a concrete cache-backed resolver.',
-    );
-  }
-  if (options.cacheDirectory != null) {
-    throw LlamaUnsupportedException(
-      'cacheDirectory requires a concrete cache-backed resolver.',
-    );
-  }
-  if (!options.resume) {
-    throw LlamaUnsupportedException(
-      'Disabling resume requires a concrete download-backed resolver.',
-    );
-  }
-  if (options.maxRetries != ModelLoadOptions.defaults.maxRetries) {
-    throw LlamaUnsupportedException(
-      'Custom maxRetries requires a concrete download-backed resolver.',
-    );
   }
 }

--- a/lib/src/core/models/model_resolver.dart
+++ b/lib/src/core/models/model_resolver.dart
@@ -1,0 +1,120 @@
+import '../exceptions.dart';
+import 'model_load_options.dart';
+import 'model_source.dart';
+import 'download/model_download_manager_base.dart';
+
+/// Callback invoked with model download or resolution progress.
+typedef ModelProgressCallback = void Function(ModelDownloadProgress progress);
+
+/// Request data passed to a [ModelResolver].
+class ModelResolveRequest {
+  /// Creates a resolver request.
+  const ModelResolveRequest({required this.options, this.onProgress});
+
+  /// Load options for this resolution.
+  final ModelLoadOptions options;
+
+  /// Optional progress callback.
+  final ModelProgressCallback? onProgress;
+}
+
+/// Resolves a [ModelSource] to a concrete load target for the engine.
+abstract interface class ModelResolver {
+  /// Resolves [source] using [request].
+  Future<ModelLoadTarget> resolve(
+    ModelSource source,
+    ModelResolveRequest request,
+  );
+}
+
+/// Concrete model target after source resolution.
+sealed class ModelLoadTarget {
+  const ModelLoadTarget();
+
+  /// Whether this target points at a local model file.
+  bool get isLocal;
+
+  /// Whether this target points at a remote model URL.
+  bool get isRemote => !isLocal;
+}
+
+/// A resolved local model file path.
+class LocalModelFile extends ModelLoadTarget {
+  /// Creates a local model file target.
+  const LocalModelFile(this.path);
+
+  /// Local filesystem path to pass to the native backend.
+  final String path;
+
+  @override
+  bool get isLocal => true;
+}
+
+/// A resolved remote model URL.
+class RemoteModelUrl extends ModelLoadTarget {
+  /// Creates a remote model URL target.
+  const RemoteModelUrl(this.url, {this.useBrowserCache = true});
+
+  /// Remote URL suitable for backends that support URL loading.
+  final Uri url;
+
+  /// Whether web runtimes should allow the browser cache to participate.
+  final bool useBrowserCache;
+
+  @override
+  bool get isLocal => false;
+}
+
+/// Minimal default resolver for Task 1-3 API foundation.
+class DefaultModelResolver implements ModelResolver {
+  /// Creates the default model resolver.
+  const DefaultModelResolver();
+
+  @override
+  Future<ModelLoadTarget> resolve(
+    ModelSource source,
+    ModelResolveRequest request,
+  ) async {
+    if (request.options.cancelToken?.isCancelled ?? false) {
+      throw LlamaStateException('Model source resolution was cancelled.');
+    }
+    _rejectUnsupportedFoundationOptions(request.options);
+    if (source.isLocal) {
+      return LocalModelFile(source.path!);
+    }
+    return RemoteModelUrl(source.resolvedUri!, useBrowserCache: true);
+  }
+}
+
+void _rejectUnsupportedFoundationOptions(ModelLoadOptions options) {
+  if (options.cachePolicy != ModelCachePolicy.preferCached) {
+    throw LlamaUnsupportedException(
+      '${options.cachePolicy.name} model resolution requires a concrete cache-aware resolver.',
+    );
+  }
+  if (options.bearerToken != null || options.headers.isNotEmpty) {
+    throw LlamaUnsupportedException(
+      'Authenticated model resolution requires a concrete resolver that can apply HTTP credentials.',
+    );
+  }
+  if (options.sha256 != null) {
+    throw LlamaUnsupportedException(
+      'Checksum verification requires a concrete cache-backed resolver.',
+    );
+  }
+  if (options.cacheDirectory != null) {
+    throw LlamaUnsupportedException(
+      'cacheDirectory requires a concrete cache-backed resolver.',
+    );
+  }
+  if (!options.resume) {
+    throw LlamaUnsupportedException(
+      'Disabling resume requires a concrete download-backed resolver.',
+    );
+  }
+  if (options.maxRetries != ModelLoadOptions.defaults.maxRetries) {
+    throw LlamaUnsupportedException(
+      'Custom maxRetries requires a concrete download-backed resolver.',
+    );
+  }
+}

--- a/lib/src/core/models/model_resolver.dart
+++ b/lib/src/core/models/model_resolver.dart
@@ -3,9 +3,6 @@ import 'model_load_options.dart';
 import 'model_source.dart';
 import 'download/model_download_manager_base.dart';
 
-/// Callback invoked with model download or resolution progress.
-typedef ModelProgressCallback = void Function(ModelDownloadProgress progress);
-
 /// Request data passed to a [ModelResolver].
 class ModelResolveRequest {
   /// Creates a resolver request.
@@ -15,7 +12,7 @@ class ModelResolveRequest {
   final ModelLoadOptions options;
 
   /// Optional progress callback.
-  final ModelProgressCallback? onProgress;
+  final ModelDownloadProgressCallback? onProgress;
 }
 
 /// Resolves a [ModelSource] to a concrete load target for the engine.

--- a/lib/src/core/models/model_source.dart
+++ b/lib/src/core/models/model_source.dart
@@ -195,6 +195,46 @@ class ModelSource {
 
   @override
   String toString() => metadataSourceKey;
+
+  /// Returns a copy that downloads/loads from [resolvedUri] while preserving
+  /// this source's canonical cache identity.
+  ///
+  /// This is intended for resolvers that translate a stable user-facing source
+  /// such as `hf://owner/repo/model.gguf` to a concrete HTTP(S) URL. Cache
+  /// operations should still use the original [canonicalKey], [cacheKey], and
+  /// [cacheDirectoryName] so entries remain discoverable by the caller's source.
+  ModelSource withResolvedUri(Uri resolvedUri) {
+    if (isLocal) {
+      throw StateError('Local model sources cannot be resolved to a URL.');
+    }
+    _validateRemoteUri(resolvedUri, 'resolvedUri');
+    return ModelSource._(
+      kind: kind,
+      url: resolvedUri,
+      repoId: repoId,
+      revision: revision,
+      filePath: filePath,
+      fileName: fileName,
+      canonicalKey: canonicalKey,
+    );
+  }
+}
+
+void _validateRemoteUri(Uri url, String name) {
+  if (url.scheme != 'http' && url.scheme != 'https') {
+    throw ArgumentError.value(
+      url,
+      name,
+      'Only http and https URLs are supported.',
+    );
+  }
+  if (!url.hasAuthority || url.host.isEmpty) {
+    throw ArgumentError.value(
+      url,
+      name,
+      'HTTP(S) model URLs must include a host.',
+    );
+  }
 }
 
 ModelSource _parseHuggingFaceUri(String value) {

--- a/lib/src/core/models/model_source.dart
+++ b/lib/src/core/models/model_source.dart
@@ -1,0 +1,402 @@
+import 'dart:convert';
+
+import 'package:crypto/crypto.dart';
+
+/// The kind of model source represented by a [ModelSource].
+enum ModelSourceKind {
+  /// A local filesystem path supplied explicitly by the caller.
+  path,
+
+  /// An HTTP or HTTPS URL.
+  http,
+
+  /// A Hugging Face repository reference.
+  huggingFace,
+}
+
+/// Describes where a GGUF model can be loaded from.
+///
+/// [ModelSource] is a value object only; creating one does not perform network
+/// or filesystem access.
+class ModelSource {
+  /// Creates a local filesystem path model source.
+  factory ModelSource.path(String path) {
+    if (path.isEmpty) {
+      throw ArgumentError.value(path, 'path', 'Path must not be empty.');
+    }
+    return ModelSource._(
+      kind: ModelSourceKind.path,
+      path: path,
+      fileName: _fileNameFromPath(path),
+      canonicalKey: 'path:$path',
+    );
+  }
+
+  /// Creates an HTTP(S) URL model source.
+  factory ModelSource.url(Uri url, {String? fileName}) {
+    if (url.scheme != 'http' && url.scheme != 'https') {
+      throw ArgumentError.value(
+        url,
+        'url',
+        'Only http and https URLs are supported.',
+      );
+    }
+    if (!url.hasAuthority || url.host.isEmpty) {
+      throw ArgumentError.value(
+        url,
+        'url',
+        'HTTP(S) model URLs must include a host.',
+      );
+    }
+    final inferredFileName = fileName == null
+        ? _fileNameFromUri(url)
+        : _validateRemoteFileName(fileName, 'fileName');
+    return ModelSource._(
+      kind: ModelSourceKind.http,
+      url: url,
+      fileName: inferredFileName,
+      canonicalKey: url.toString(),
+    );
+  }
+
+  /// Creates a Hugging Face model source from repository details.
+  factory ModelSource.huggingFace({
+    required String repoId,
+    required String filePath,
+    String revision = 'main',
+    String? fileName,
+  }) {
+    final normalizedRepoId = _validateRepoId(repoId);
+    final normalizedRevision = _validateRevision(revision);
+    final normalizedFilePath = _validateFilePath(filePath);
+    final resolvedUri = _huggingFaceResolvedUri(
+      normalizedRepoId,
+      normalizedRevision,
+      normalizedFilePath,
+    );
+    return ModelSource._(
+      kind: ModelSourceKind.huggingFace,
+      url: resolvedUri,
+      repoId: normalizedRepoId,
+      revision: normalizedRevision,
+      filePath: normalizedFilePath,
+      fileName: _validateRemoteFileName(
+        fileName ?? _fileNameFromPath(normalizedFilePath),
+        'fileName',
+      ),
+      canonicalKey:
+          'hf://$normalizedRepoId@$normalizedRevision/$normalizedFilePath',
+    );
+  }
+
+  /// Parses [value] as a local path, HTTP(S) URL, or `hf://` reference.
+  factory ModelSource.parse(String value) {
+    if (value.isEmpty) {
+      throw ArgumentError.value(value, 'value', 'Source must not be empty.');
+    }
+
+    if (value.startsWith('hf://')) {
+      return _parseHuggingFaceUri(value);
+    }
+
+    final parsedUri = Uri.tryParse(value);
+    if (parsedUri != null && parsedUri.hasScheme) {
+      if (parsedUri.scheme == 'http' || parsedUri.scheme == 'https') {
+        return ModelSource.url(parsedUri);
+      }
+      if (_looksLikeWindowsPath(value, parsedUri.scheme)) {
+        return ModelSource.path(value);
+      }
+      throw ArgumentError.value(
+        value,
+        'value',
+        'Unsupported model source scheme: ${parsedUri.scheme}.',
+      );
+    }
+
+    return ModelSource.path(value);
+  }
+
+  const ModelSource._({
+    required this.kind,
+    required this.fileName,
+    required this.canonicalKey,
+    this.path,
+    this.url,
+    this.repoId,
+    this.revision,
+    this.filePath,
+  });
+
+  /// The source kind.
+  final ModelSourceKind kind;
+
+  /// The local path when [kind] is [ModelSourceKind.path].
+  final String? path;
+
+  /// The resolved remote URI for HTTP(S) and Hugging Face sources.
+  final Uri? url;
+
+  /// The Hugging Face repository id (`owner/repo`) when applicable.
+  final String? repoId;
+
+  /// The Hugging Face revision when applicable.
+  final String? revision;
+
+  /// The Hugging Face file path inside the repository when applicable.
+  final String? filePath;
+
+  /// The inferred or supplied model file name.
+  final String fileName;
+
+  /// A canonical identity string used for deterministic cache keys.
+  final String canonicalKey;
+
+  /// Whether this source is a local filesystem path.
+  bool get isLocal => kind == ModelSourceKind.path;
+
+  /// Whether this source resolves to a remote URI.
+  bool get isRemote => !isLocal;
+
+  /// The remote URI to load or download, if any.
+  Uri? get resolvedUri => url;
+
+  /// The URL scheme for remote sources or `path` for local sources.
+  String get scheme => isLocal ? 'path' : url!.scheme;
+
+  /// Human-friendly source name suitable for logs.
+  String get displayName => fileName;
+
+  /// SHA-256 digest of [canonicalKey], used as a deterministic cache key.
+  String get cacheKey => sha256.convert(utf8.encode(canonicalKey)).toString();
+
+  /// Redacted source identity suitable for persisted metadata and logs.
+  ///
+  /// [canonicalKey] intentionally remains the full source identity so cache keys
+  /// stay unique for signed URLs. This value omits raw URL query strings while
+  /// including [cacheKey] so persisted metadata can still be correlated with the
+  /// deterministic cache entry without storing credentials.
+  String get metadataSourceKey {
+    if (kind == ModelSourceKind.http) {
+      final redactedUri = _uriWithoutQueryOrFragment(url!);
+      return 'url:${redactedUri.toString()}#cacheKey=$cacheKey';
+    }
+    return canonicalKey;
+  }
+
+  /// Safe deterministic cache directory name for this source.
+  String get cacheDirectoryName {
+    final stem = _fileStem(fileName);
+    final safeStem = _safeName(stem.isEmpty ? 'model' : stem);
+    return '$safeStem-${cacheKey.substring(0, 12)}';
+  }
+
+  @override
+  String toString() => metadataSourceKey;
+}
+
+ModelSource _parseHuggingFaceUri(String value) {
+  final reference = value.substring('hf://'.length);
+  if (reference.isEmpty || reference.contains('//')) {
+    throw ArgumentError.value(
+      value,
+      'value',
+      'Invalid Hugging Face reference.',
+    );
+  }
+
+  final rawParts = reference.split('/');
+  if (rawParts.length < 3) {
+    throw ArgumentError.value(
+      value,
+      'value',
+      'Hugging Face references require owner, repo, and file path.',
+    );
+  }
+
+  final owner = rawParts[0];
+  final repoAndRevision = rawParts[1];
+  if (owner.isEmpty || repoAndRevision.isEmpty) {
+    throw ArgumentError.value(value, 'value', 'Invalid Hugging Face repo id.');
+  }
+
+  final repoRevisionParts = repoAndRevision.split('@');
+  if (repoRevisionParts.length > 2 || repoRevisionParts.first.isEmpty) {
+    throw ArgumentError.value(value, 'value', 'Invalid Hugging Face repo id.');
+  }
+  final revision = repoRevisionParts.length == 2
+      ? repoRevisionParts[1]
+      : 'main';
+  final repoId = '$owner/${repoRevisionParts.first}';
+  final decodedFileSegments = rawParts
+      .skip(2)
+      .map((segment) {
+        if (segment.isEmpty) {
+          throw ArgumentError.value(
+            value,
+            'value',
+            'Hugging Face file path contains an empty segment.',
+          );
+        }
+        final decodedSegment = Uri.decodeComponent(segment);
+        if (decodedSegment.contains('/') || decodedSegment.contains('\\')) {
+          throw ArgumentError.value(
+            value,
+            'value',
+            'Hugging Face file path contains an encoded separator.',
+          );
+        }
+        return decodedSegment;
+      })
+      .toList(growable: false);
+
+  return ModelSource.huggingFace(
+    repoId: repoId,
+    revision: revision,
+    filePath: decodedFileSegments.join('/'),
+  );
+}
+
+Uri _huggingFaceResolvedUri(String repoId, String revision, String filePath) {
+  return Uri.https(
+    'huggingface.co',
+    '/$repoId/resolve/$revision/$filePath',
+    const <String, String>{'download': 'true'},
+  );
+}
+
+String _validateRepoId(String repoId) {
+  final parts = repoId.split('/');
+  if (parts.length != 2 || parts.any((part) => part.isEmpty)) {
+    throw ArgumentError.value(repoId, 'repoId', 'Repo id must be owner/repo.');
+  }
+  for (final part in parts) {
+    _validateRepoSegment(part, repoId);
+  }
+  return repoId;
+}
+
+void _validateRepoSegment(String segment, String repoId) {
+  final validSegment = RegExp(r'^[A-Za-z0-9][A-Za-z0-9._-]*$');
+  if (!validSegment.hasMatch(segment) || segment.contains('..')) {
+    throw ArgumentError.value(
+      repoId,
+      'repoId',
+      'Invalid Hugging Face repo id.',
+    );
+  }
+}
+
+String _validateRevision(String revision) {
+  if (revision.isEmpty || revision.startsWith('/') || revision.contains('..')) {
+    throw ArgumentError.value(
+      revision,
+      'revision',
+      'Invalid Hugging Face revision.',
+    );
+  }
+  return revision;
+}
+
+String _validateFilePath(String filePath) {
+  if (filePath.isEmpty || filePath.startsWith('/')) {
+    throw ArgumentError.value(
+      filePath,
+      'filePath',
+      'Hugging Face file path must be relative.',
+    );
+  }
+
+  final segments = filePath.split('/');
+  for (final segment in segments) {
+    if (segment.isEmpty ||
+        segment == '.' ||
+        segment == '..' ||
+        segment.contains('\\')) {
+      throw ArgumentError.value(
+        filePath,
+        'filePath',
+        'Invalid Hugging Face file path.',
+      );
+    }
+  }
+  return filePath;
+}
+
+String _fileNameFromUri(Uri uri) {
+  final rawSegments = uri.path
+      .split('/')
+      .where((segment) => segment.isNotEmpty);
+  if (rawSegments.isEmpty) {
+    throw ArgumentError.value(
+      uri,
+      'url',
+      'URL must include a model file name.',
+    );
+  }
+  for (final segment in rawSegments) {
+    _validateRemoteFileName(segment, 'url');
+  }
+  return _validateRemoteFileName(rawSegments.last, 'url');
+}
+
+String _validateRemoteFileName(String fileName, String name) {
+  final decodedFileName = _decodeFileNameComponent(fileName, name);
+  if (decodedFileName.isEmpty ||
+      decodedFileName == '.' ||
+      decodedFileName == '..' ||
+      decodedFileName.contains('/') ||
+      decodedFileName.contains('\\')) {
+    throw ArgumentError.value(
+      fileName,
+      name,
+      'Remote model file name must be a non-empty base name.',
+    );
+  }
+  return fileName;
+}
+
+String _decodeFileNameComponent(String fileName, String name) {
+  try {
+    return Uri.decodeComponent(fileName);
+  } on FormatException catch (error) {
+    throw ArgumentError.value(fileName, name, error.message);
+  }
+}
+
+String _fileNameFromPath(String path) {
+  final normalized = path.replaceAll('\\', '/');
+  final segments = normalized.split('/');
+  final last = segments.isEmpty ? path : segments.last;
+  return last.isEmpty ? 'model.gguf' : last;
+}
+
+String _fileStem(String fileName) {
+  final dot = fileName.lastIndexOf('.');
+  if (dot <= 0) {
+    return fileName;
+  }
+  return fileName.substring(0, dot);
+}
+
+String _safeName(String value) {
+  final sanitized = value.replaceAll(RegExp(r'[^A-Za-z0-9._-]+'), '-');
+  final trimmed = sanitized.replaceAll(RegExp(r'^-+|-+$'), '');
+  return trimmed.isEmpty ? 'model' : trimmed;
+}
+
+bool _looksLikeWindowsPath(String value, String scheme) {
+  return scheme.length == 1 &&
+      value.length >= 3 &&
+      value.codeUnitAt(1) == 0x3A &&
+      (value.codeUnitAt(2) == 0x5C || value.codeUnitAt(2) == 0x2F);
+}
+
+Uri _uriWithoutQueryOrFragment(Uri uri) {
+  return Uri(
+    scheme: uri.scheme,
+    host: uri.host,
+    port: uri.hasPort ? uri.port : null,
+    path: uri.path,
+  );
+}

--- a/lib/src/core/models/model_source.dart
+++ b/lib/src/core/models/model_source.dart
@@ -55,7 +55,9 @@ class ModelSource {
       kind: ModelSourceKind.http,
       url: url,
       fileName: inferredFileName,
-      canonicalKey: url.toString(),
+      canonicalKey: fileName == null
+          ? url.toString()
+          : 'url:${url.toString()}\nfileName:$inferredFileName',
     );
   }
 
@@ -365,7 +367,7 @@ String _validateRemoteFileName(String fileName, String name) {
       'Remote model file name must be a non-empty base name.',
     );
   }
-  return fileName;
+  return decodedFileName;
 }
 
 String _decodeFileNameComponent(String fileName, String name) {

--- a/lib/src/core/models/model_source.dart
+++ b/lib/src/core/models/model_source.dart
@@ -238,7 +238,7 @@ ModelSource _parseHuggingFaceUri(String value) {
             'Hugging Face file path contains an empty segment.',
           );
         }
-        final decodedSegment = Uri.decodeComponent(segment);
+        final decodedSegment = _decodeHuggingFacePathSegment(segment, value);
         if (decodedSegment.contains('/') || decodedSegment.contains('\\')) {
           throw ArgumentError.value(
             value,
@@ -274,6 +274,18 @@ String _validateRepoId(String repoId) {
     _validateRepoSegment(part, repoId);
   }
   return repoId;
+}
+
+String _decodeHuggingFacePathSegment(String segment, String value) {
+  try {
+    return Uri.decodeComponent(segment);
+  } on FormatException catch (error) {
+    throw ArgumentError.value(
+      value,
+      'value',
+      'Hugging Face file path contains invalid percent-encoding: ${error.message}',
+    );
+  }
 }
 
 void _validateRepoSegment(String segment, String repoId) {

--- a/lib/src/core/models/model_source.dart
+++ b/lib/src/core/models/model_source.dart
@@ -359,8 +359,7 @@ String _validateRemoteFileName(String fileName, String name) {
   if (decodedFileName.isEmpty ||
       decodedFileName == '.' ||
       decodedFileName == '..' ||
-      decodedFileName.contains('/') ||
-      decodedFileName.contains('\\')) {
+      RegExp(r'[<>:"/\\|?*\x00-\x1F]').hasMatch(decodedFileName)) {
     throw ArgumentError.value(
       fileName,
       name,

--- a/lib/src/platform/io/model_download_manager_io.dart
+++ b/lib/src/platform/io/model_download_manager_io.dart
@@ -130,28 +130,7 @@ class DefaultModelDownloadManager implements ModelDownloadManager {
 
   @override
   Future<void> remove(String cacheKey) async {
-    final root = Directory(defaultCacheDirectory);
-    if (!await root.exists()) {
-      return;
-    }
-    await for (final entity in root.list(followLinks: false)) {
-      if (entity is! Directory) {
-        continue;
-      }
-      final metadataFile = File(path.join(entity.path, _metadataFileName));
-      if (!await metadataFile.exists()) {
-        continue;
-      }
-      try {
-        final entry = await _readMetadata(metadataFile);
-        if (entry.cacheKey == cacheKey) {
-          await entity.delete(recursive: true);
-          return;
-        }
-      } catch (_) {
-        // Keep scanning; malformed metadata may not be the requested entry.
-      }
-    }
+    await _removeByCacheKey(cacheKey);
   }
 
   @override
@@ -170,25 +149,28 @@ class DefaultModelDownloadManager implements ModelDownloadManager {
 
     for (final entry in entries) {
       if (maxAge != null && now.difference(entry.updatedAt.toUtc()) > maxAge) {
-        await remove(entry.cacheKey);
-        removed.add(entry);
+        if (await _removeEntry(entry)) {
+          removed.add(entry);
+        }
       }
     }
 
     if (maxBytes != null) {
       final remaining = (await list()).toList()
         ..sort((a, b) => a.updatedAt.compareTo(b.updatedAt));
-      var total = remaining.fold<int>(
-        0,
-        (sum, entry) => sum + (entry.bytes ?? 0),
-      );
+      var total = 0;
+      for (final entry in remaining) {
+        total += await _entrySize(entry);
+      }
       for (final entry in remaining) {
         if (total <= maxBytes) {
           break;
         }
-        await remove(entry.cacheKey);
-        removed.add(entry);
-        total -= entry.bytes ?? 0;
+        final size = await _entrySize(entry);
+        if (await _removeEntry(entry)) {
+          removed.add(entry);
+          total -= size;
+        }
       }
     }
 
@@ -416,6 +398,7 @@ class DefaultModelDownloadManager implements ModelDownloadManager {
       }
       _throwIfCancelled(options);
 
+      String? verifiedSha256;
       if (options.sha256 != null) {
         final actual = await _sha256File(downloadFile);
         if (actual != options.sha256) {
@@ -424,6 +407,7 @@ class DefaultModelDownloadManager implements ModelDownloadManager {
             'Checksum mismatch for ${source.displayName}.',
           );
         }
+        verifiedSha256 = actual;
       }
       await downloadFile.rename(finalFile.path);
       if (partMetadataFile != null) {
@@ -436,6 +420,7 @@ class DefaultModelDownloadManager implements ModelDownloadManager {
         options,
         etag: responsePartMetadata.etag,
         lastModified: responsePartMetadata.lastModified,
+        sha256Digest: verifiedSha256,
       );
       onProgress?.call(
         ModelDownloadProgress(
@@ -459,9 +444,10 @@ class DefaultModelDownloadManager implements ModelDownloadManager {
     ModelLoadOptions options, {
     String? etag,
     String? lastModified,
+    String? sha256Digest,
   }) async {
     final bytes = await file.length();
-    final digest = await _sha256File(file);
+    final digest = sha256Digest ?? await _sha256File(file);
     return ModelCacheEntry(
       sourceCanonicalKey: source.metadataSourceKey,
       cacheKey: source.cacheKey,
@@ -501,6 +487,25 @@ class DefaultModelDownloadManager implements ModelDownloadManager {
       '${const JsonEncoder.withIndent('  ').convert(json)}\n',
     );
     await tempFile.rename(metadataFile.path);
+  }
+
+  Future<List<ModelCacheEntry>> _removeByCacheKey(String cacheKey) async {
+    final removed = <ModelCacheEntry>[];
+    for (final entry in await list()) {
+      if (entry.cacheKey == cacheKey && await _removeEntry(entry)) {
+        removed.add(entry);
+      }
+    }
+    return removed;
+  }
+
+  Future<bool> _removeEntry(ModelCacheEntry entry) async {
+    final directory = Directory(path.dirname(entry.filePath));
+    if (!await directory.exists()) {
+      return false;
+    }
+    await directory.delete(recursive: true);
+    return true;
   }
 }
 
@@ -628,6 +633,18 @@ void _validateResumeValidator(
 Future<String> _sha256File(File file) async {
   final digest = await sha256.bind(file.openRead()).first;
   return digest.toString();
+}
+
+Future<int> _entrySize(ModelCacheEntry entry) async {
+  final bytes = entry.bytes;
+  if (bytes != null) {
+    return bytes;
+  }
+  try {
+    return await File(entry.filePath).length();
+  } on FileSystemException {
+    return 0;
+  }
 }
 
 Future<void> _deleteIfExists(File file) async {

--- a/lib/src/platform/io/model_download_manager_io.dart
+++ b/lib/src/platform/io/model_download_manager_io.dart
@@ -414,28 +414,52 @@ class DefaultModelDownloadManager implements ModelDownloadManager {
 
     final client = HttpClient();
     try {
-      final request = await client.getUrl(uri);
-      request.followRedirects = true;
-      request.maxRedirects = 10;
-      for (final header in options.headers.entries) {
-        request.headers.set(header.key, header.value);
-      }
-      final bearerToken = options.bearerToken;
-      if (bearerToken != null) {
-        request.headers.set(
-          HttpHeaders.authorizationHeader,
-          'Bearer $bearerToken',
-        );
-      }
-      if (existingBytes > 0) {
-        request.headers.set(HttpHeaders.rangeHeader, 'bytes=$existingBytes-');
-        final validator = partMetadata?.etag ?? partMetadata?.lastModified;
-        if (validator != null) {
-          request.headers.set(HttpHeaders.ifRangeHeader, validator);
+      var requestUri = uri;
+      late HttpClientResponse response;
+      for (var redirectCount = 0; ; redirectCount += 1) {
+        final request = await client.getUrl(requestUri);
+        request.followRedirects = false;
+        final includeCallerHeaders = _sameOrigin(uri, requestUri);
+        if (includeCallerHeaders) {
+          for (final header in options.headers.entries) {
+            request.headers.set(header.key, header.value);
+          }
+          final bearerToken = options.bearerToken;
+          if (bearerToken != null) {
+            request.headers.set(
+              HttpHeaders.authorizationHeader,
+              'Bearer $bearerToken',
+            );
+          }
         }
-      }
+        if (existingBytes > 0) {
+          request.headers.set(HttpHeaders.rangeHeader, 'bytes=$existingBytes-');
+          final validator = partMetadata?.etag ?? partMetadata?.lastModified;
+          if (validator != null) {
+            request.headers.set(HttpHeaders.ifRangeHeader, validator);
+          }
+        }
 
-      final response = await request.close();
+        response = await request.close();
+        if (!_isRedirectStatus(response.statusCode)) {
+          break;
+        }
+        if (redirectCount >= 10) {
+          await response.drain<void>();
+          throw LlamaModelException(
+            'Too many redirects while downloading ${source.displayName}.',
+          );
+        }
+        final location = response.headers.value(HttpHeaders.locationHeader);
+        if (location == null || location.isEmpty) {
+          await response.drain<void>();
+          throw LlamaModelException(
+            'Redirect missing Location while downloading ${source.displayName}.',
+          );
+        }
+        requestUri = requestUri.resolve(location);
+        await response.drain<void>();
+      }
       final statusCode = response.statusCode;
       final responsePartMetadata = _PartMetadata.fromResponse(response);
       final append =
@@ -771,6 +795,20 @@ void _throwIfCancelled(ModelLoadOptions options) {
 bool _isRetryable(LlamaModelException error) {
   final details = error.details;
   return details is int && details >= 500;
+}
+
+bool _isRedirectStatus(int statusCode) {
+  return statusCode == HttpStatus.movedPermanently ||
+      statusCode == HttpStatus.found ||
+      statusCode == HttpStatus.seeOther ||
+      statusCode == HttpStatus.temporaryRedirect ||
+      statusCode == HttpStatus.permanentRedirect;
+}
+
+bool _sameOrigin(Uri first, Uri second) {
+  return first.scheme == second.scheme &&
+      first.host == second.host &&
+      first.port == second.port;
 }
 
 int? _totalBytes(HttpClientResponse response, int existingBytes) {

--- a/lib/src/platform/io/model_download_manager_io.dart
+++ b/lib/src/platform/io/model_download_manager_io.dart
@@ -306,8 +306,7 @@ class DefaultModelDownloadManager implements ModelDownloadManager {
       return null;
     }
     final entry = await _readMetadata(metadataFile);
-    if (entry.sourceCanonicalKey != source.metadataSourceKey ||
-        entry.cacheKey != source.cacheKey ||
+    if (entry.cacheKey != source.cacheKey ||
         entry.fileName != source.fileName ||
         entry.filePath != finalFile.path) {
       return null;

--- a/lib/src/platform/io/model_download_manager_io.dart
+++ b/lib/src/platform/io/model_download_manager_io.dart
@@ -266,9 +266,15 @@ class DefaultModelDownloadManager implements ModelDownloadManager {
     ModelLoadOptions options,
   ) async {
     final file = File(path.normalize(path.absolute(source.path!)));
-    if (!await file.exists()) {
+    final stat = await file.stat();
+    if (stat.type == FileSystemEntityType.notFound) {
       throw LlamaModelException(
         'Local model file does not exist: ${source.path}.',
+      );
+    }
+    if (stat.type != FileSystemEntityType.file) {
+      throw LlamaModelException(
+        'Local model path is not a file: ${source.path}.',
       );
     }
     String? verifiedSha256;

--- a/lib/src/platform/io/model_download_manager_io.dart
+++ b/lib/src/platform/io/model_download_manager_io.dart
@@ -64,18 +64,25 @@ class DefaultModelDownloadManager implements ModelDownloadManager {
       );
       final transientFile = File(path.join(transientDir.path, source.fileName));
       final transientPartFile = File('${transientFile.path}.part');
-      final entry = await _download(
-        source,
-        options,
-        transientFile,
-        transientPartFile,
-        onProgress,
-      );
-      await _writeMetadata(
-        File(path.join(transientDir.path, _metadataFileName)),
-        entry,
-      );
-      return entry;
+      try {
+        final entry = await _download(
+          source,
+          options,
+          transientFile,
+          transientPartFile,
+          onProgress,
+        );
+        await _writeMetadata(
+          File(path.join(transientDir.path, _metadataFileName)),
+          entry,
+        );
+        return entry;
+      } catch (_) {
+        if (await transientDir.exists()) {
+          await transientDir.delete(recursive: true);
+        }
+        rethrow;
+      }
     }
 
     await cacheDir.create(recursive: true);
@@ -579,7 +586,7 @@ class DefaultModelDownloadManager implements ModelDownloadManager {
   ) async {
     final root = _rootDirectory(cacheDirectory);
     if (!await root.exists()) {
-      return const <ModelCacheEntry>[];
+      return <ModelCacheEntry>[];
     }
 
     final removed = <ModelCacheEntry>[];

--- a/lib/src/platform/io/model_download_manager_io.dart
+++ b/lib/src/platform/io/model_download_manager_io.dart
@@ -106,7 +106,8 @@ class DefaultModelDownloadManager implements ModelDownloadManager {
       }
       try {
         final entry = await _readMetadata(metadataFile);
-        if (await File(entry.filePath).exists()) {
+        final entryFile = _entryFileInCacheDirectory(entry, entity);
+        if (entryFile != null && await entryFile.exists()) {
           entries.add(entry);
         }
       } catch (_) {
@@ -130,7 +131,13 @@ class DefaultModelDownloadManager implements ModelDownloadManager {
     )) {
       try {
         final entry = await _readMetadata(metadataFile);
-        if (entry.cacheKey == cacheKey && await File(entry.filePath).exists()) {
+        final entryFile = _entryFileInCacheDirectory(
+          entry,
+          metadataFile.parent,
+        );
+        if (entry.cacheKey == cacheKey &&
+            entryFile != null &&
+            await entryFile.exists()) {
           entries.add(entry);
         }
       } catch (_) {
@@ -167,7 +174,7 @@ class DefaultModelDownloadManager implements ModelDownloadManager {
 
     for (final entry in entries) {
       if (maxAge != null && now.difference(entry.updatedAt.toUtc()) > maxAge) {
-        if (await _removeEntry(entry)) {
+        if (await _removeEntry(entry, cacheDirectory: cacheDirectory)) {
           removed.add(entry);
         }
       }
@@ -185,7 +192,7 @@ class DefaultModelDownloadManager implements ModelDownloadManager {
           break;
         }
         final size = await _entrySize(entry);
-        if (await _removeEntry(entry)) {
+        if (await _removeEntry(entry, cacheDirectory: cacheDirectory)) {
           removed.add(entry);
           total -= size;
         }
@@ -556,15 +563,39 @@ class DefaultModelDownloadManager implements ModelDownloadManager {
   }) async {
     final removed = <ModelCacheEntry>[];
     for (final entry in await list(cacheDirectory: cacheDirectory)) {
-      if (entry.cacheKey == cacheKey && await _removeEntry(entry)) {
+      if (entry.cacheKey == cacheKey &&
+          await _removeEntry(entry, cacheDirectory: cacheDirectory)) {
         removed.add(entry);
       }
     }
     return removed;
   }
 
-  Future<bool> _removeEntry(ModelCacheEntry entry) async {
-    final directory = Directory(path.dirname(entry.filePath));
+  File? _entryFileInCacheDirectory(ModelCacheEntry entry, Directory directory) {
+    final directoryPath = path.normalize(path.absolute(directory.path));
+    final filePath = path.normalize(path.absolute(entry.filePath));
+    if (!path.isWithin(directoryPath, filePath) ||
+        !path.equals(path.dirname(filePath), directoryPath)) {
+      return null;
+    }
+    return File(filePath);
+  }
+
+  Future<bool> _removeEntry(
+    ModelCacheEntry entry, {
+    String? cacheDirectory,
+  }) async {
+    final rootPath = path.normalize(
+      path.absolute(_rootDirectory(cacheDirectory).path),
+    );
+    final directoryPath = path.normalize(
+      path.absolute(path.dirname(entry.filePath)),
+    );
+    if (path.equals(directoryPath, rootPath) ||
+        !path.isWithin(rootPath, directoryPath)) {
+      return false;
+    }
+    final directory = Directory(directoryPath);
     if (!await directory.exists()) {
       return false;
     }

--- a/lib/src/platform/io/model_download_manager_io.dart
+++ b/lib/src/platform/io/model_download_manager_io.dart
@@ -562,10 +562,25 @@ class DefaultModelDownloadManager implements ModelDownloadManager {
     String? cacheDirectory,
   }) async {
     final removed = <ModelCacheEntry>[];
-    for (final entry in await list(cacheDirectory: cacheDirectory)) {
-      if (entry.cacheKey == cacheKey &&
-          await _removeEntry(entry, cacheDirectory: cacheDirectory)) {
-        removed.add(entry);
+    for (final metadataFile in await _candidateMetadataFiles(
+      cacheKey,
+      cacheDirectory: cacheDirectory,
+    )) {
+      try {
+        final entry = await _readMetadata(metadataFile);
+        if (entry.cacheKey != cacheKey ||
+            _entryFileInCacheDirectory(entry, metadataFile.parent) == null) {
+          continue;
+        }
+        if (await _removeCacheDirectory(
+          metadataFile.parent,
+          cacheDirectory: cacheDirectory,
+        )) {
+          removed.add(entry);
+        }
+      } catch (_) {
+        // Ignore malformed metadata so a corrupt entry does not block removing
+        // other cache directories with the same key prefix.
       }
     }
     return removed;
@@ -585,21 +600,29 @@ class DefaultModelDownloadManager implements ModelDownloadManager {
     ModelCacheEntry entry, {
     String? cacheDirectory,
   }) async {
+    return _removeCacheDirectory(
+      Directory(path.dirname(entry.filePath)),
+      cacheDirectory: cacheDirectory,
+    );
+  }
+
+  Future<bool> _removeCacheDirectory(
+    Directory directory, {
+    String? cacheDirectory,
+  }) async {
     final rootPath = path.normalize(
       path.absolute(_rootDirectory(cacheDirectory).path),
     );
-    final directoryPath = path.normalize(
-      path.absolute(path.dirname(entry.filePath)),
-    );
+    final directoryPath = path.normalize(path.absolute(directory.path));
     if (path.equals(directoryPath, rootPath) ||
         !path.isWithin(rootPath, directoryPath)) {
       return false;
     }
-    final directory = Directory(directoryPath);
-    if (!await directory.exists()) {
+    final cacheDirectoryToRemove = Directory(directoryPath);
+    if (!await cacheDirectoryToRemove.exists()) {
       return false;
     }
-    await directory.delete(recursive: true);
+    await cacheDirectoryToRemove.delete(recursive: true);
     return true;
   }
 }

--- a/lib/src/platform/io/model_download_manager_io.dart
+++ b/lib/src/platform/io/model_download_manager_io.dart
@@ -459,6 +459,21 @@ class DefaultModelDownloadManager implements ModelDownloadManager {
         if (partMetadataFile != null) {
           await _deleteIfExists(partMetadataFile);
         }
+      } else if (existingBytes > 0 &&
+          statusCode == HttpStatus.requestedRangeNotSatisfiable) {
+        await response.drain<void>();
+        await _deleteIfExists(downloadFile);
+        if (partMetadataFile != null) {
+          await _deleteIfExists(partMetadataFile);
+        }
+        return _downloadOnce(
+          source,
+          options,
+          uri,
+          finalFile,
+          partFile,
+          onProgress,
+        );
       } else if (statusCode != HttpStatus.ok) {
         throw LlamaModelException(
           'Failed to download ${source.displayName}: HTTP $statusCode.',

--- a/lib/src/platform/io/model_download_manager_io.dart
+++ b/lib/src/platform/io/model_download_manager_io.dart
@@ -90,8 +90,8 @@ class DefaultModelDownloadManager implements ModelDownloadManager {
   }
 
   @override
-  Future<List<ModelCacheEntry>> list() async {
-    final root = Directory(defaultCacheDirectory);
+  Future<List<ModelCacheEntry>> list({String? cacheDirectory}) async {
+    final root = _rootDirectory(cacheDirectory);
     if (!await root.exists()) {
       return <ModelCacheEntry>[];
     }
@@ -119,8 +119,11 @@ class DefaultModelDownloadManager implements ModelDownloadManager {
   }
 
   @override
-  Future<ModelCacheEntry?> get(String cacheKey) async {
-    for (final entry in await list()) {
+  Future<ModelCacheEntry?> get(
+    String cacheKey, {
+    String? cacheDirectory,
+  }) async {
+    for (final entry in await list(cacheDirectory: cacheDirectory)) {
       if (entry.cacheKey == cacheKey) {
         return entry;
       }
@@ -129,21 +132,25 @@ class DefaultModelDownloadManager implements ModelDownloadManager {
   }
 
   @override
-  Future<void> remove(String cacheKey) async {
-    await _removeByCacheKey(cacheKey);
+  Future<void> remove(String cacheKey, {String? cacheDirectory}) async {
+    await _removeByCacheKey(cacheKey, cacheDirectory: cacheDirectory);
   }
 
   @override
-  Future<void> clear() async {
-    final root = Directory(defaultCacheDirectory);
+  Future<void> clear({String? cacheDirectory}) async {
+    final root = _rootDirectory(cacheDirectory);
     if (await root.exists()) {
       await root.delete(recursive: true);
     }
   }
 
   @override
-  Future<List<ModelCacheEntry>> prune({Duration? maxAge, int? maxBytes}) async {
-    final entries = await list();
+  Future<List<ModelCacheEntry>> prune({
+    Duration? maxAge,
+    int? maxBytes,
+    String? cacheDirectory,
+  }) async {
+    final entries = await list(cacheDirectory: cacheDirectory);
     final removed = <ModelCacheEntry>[];
     final now = DateTime.now().toUtc();
 
@@ -156,7 +163,7 @@ class DefaultModelDownloadManager implements ModelDownloadManager {
     }
 
     if (maxBytes != null) {
-      final remaining = (await list()).toList()
+      final remaining = (await list(cacheDirectory: cacheDirectory)).toList()
         ..sort((a, b) => a.updatedAt.compareTo(b.updatedAt));
       var total = 0;
       for (final entry in remaining) {
@@ -184,6 +191,10 @@ class DefaultModelDownloadManager implements ModelDownloadManager {
         source.cacheDirectoryName,
       ),
     );
+  }
+
+  Directory _rootDirectory(String? cacheDirectory) {
+    return Directory(cacheDirectory ?? defaultCacheDirectory);
   }
 
   Future<Directory> _createTransientCacheDirectory(
@@ -426,7 +437,7 @@ class DefaultModelDownloadManager implements ModelDownloadManager {
         }
         verifiedSha256 = actual;
       }
-      await downloadFile.rename(finalFile.path);
+      await _replaceFile(downloadFile, finalFile);
       if (partMetadataFile != null) {
         await _deleteIfExists(partMetadataFile);
       }
@@ -501,12 +512,15 @@ class DefaultModelDownloadManager implements ModelDownloadManager {
     await tempFile.writeAsString(
       '${const JsonEncoder.withIndent('  ').convert(json)}\n',
     );
-    await tempFile.rename(metadataFile.path);
+    await _replaceFile(tempFile, metadataFile);
   }
 
-  Future<List<ModelCacheEntry>> _removeByCacheKey(String cacheKey) async {
+  Future<List<ModelCacheEntry>> _removeByCacheKey(
+    String cacheKey, {
+    String? cacheDirectory,
+  }) async {
     final removed = <ModelCacheEntry>[];
-    for (final entry in await list()) {
+    for (final entry in await list(cacheDirectory: cacheDirectory)) {
       if (entry.cacheKey == cacheKey && await _removeEntry(entry)) {
         removed.add(entry);
       }
@@ -659,6 +673,44 @@ Future<int> _entrySize(ModelCacheEntry entry) async {
     return await File(entry.filePath).length();
   } on FileSystemException {
     return 0;
+  }
+}
+
+Future<void> _replaceFile(File source, File destination) async {
+  try {
+    await source.rename(destination.path);
+    return;
+  } on FileSystemException {
+    if (!await destination.exists()) {
+      rethrow;
+    }
+  }
+
+  final backup = File(
+    '${destination.path}.replace-${DateTime.now().toUtc().microsecondsSinceEpoch}.bak',
+  );
+  var backedUp = false;
+  try {
+    await destination.rename(backup.path);
+    backedUp = true;
+    await source.rename(destination.path);
+    await _deleteIfExists(backup);
+  } catch (error) {
+    if (backedUp && await backup.exists() && !await destination.exists()) {
+      try {
+        await backup.rename(destination.path);
+      } on FileSystemException {
+        // Preserve the original replacement failure; later cache operations can
+        // surface the backup path if manual recovery is needed.
+      }
+    }
+    if (error is FileSystemException) {
+      rethrow;
+    }
+    throw FileSystemException(
+      'Failed to replace ${destination.path}: $error.',
+      source.path,
+    );
   }
 }
 

--- a/lib/src/platform/io/model_download_manager_io.dart
+++ b/lib/src/platform/io/model_download_manager_io.dart
@@ -210,7 +210,22 @@ class DefaultModelDownloadManager implements ModelDownloadManager {
         'Local model file does not exist: ${source.path}.',
       );
     }
-    return _entryForFile(source, file, DateTime.now().toUtc(), options);
+    String? verifiedSha256;
+    if (options.sha256 != null) {
+      final actual = await _sha256File(file);
+      if (actual != options.sha256) {
+        throw LlamaModelException(
+          'Checksum mismatch for local model file: ${source.path}.',
+        );
+      }
+      verifiedSha256 = actual;
+    }
+    return _entryForFile(
+      source,
+      file,
+      DateTime.now().toUtc(),
+      sha256Digest: verifiedSha256,
+    );
   }
 
   Future<ModelCacheEntry?> _readCompletedEntry(
@@ -225,6 +240,7 @@ class DefaultModelDownloadManager implements ModelDownloadManager {
     if (entry.filePath != finalFile.path) {
       return null;
     }
+    String? verifiedSha256;
     if (options.sha256 != null) {
       final actual = await _sha256File(finalFile);
       if (actual != options.sha256) {
@@ -232,6 +248,7 @@ class DefaultModelDownloadManager implements ModelDownloadManager {
         await _deleteIfExists(metadataFile);
         return null;
       }
+      verifiedSha256 = actual;
     }
     final refreshed = ModelCacheEntry(
       sourceCanonicalKey: entry.sourceCanonicalKey,
@@ -239,7 +256,7 @@ class DefaultModelDownloadManager implements ModelDownloadManager {
       fileName: entry.fileName,
       filePath: entry.filePath,
       bytes: entry.bytes,
-      sha256: entry.sha256,
+      sha256: verifiedSha256 ?? entry.sha256,
       etag: entry.etag,
       lastModified: entry.lastModified,
       createdAt: entry.createdAt,
@@ -417,7 +434,6 @@ class DefaultModelDownloadManager implements ModelDownloadManager {
         source,
         finalFile,
         DateTime.now().toUtc(),
-        options,
         etag: responsePartMetadata.etag,
         lastModified: responsePartMetadata.lastModified,
         sha256Digest: verifiedSha256,
@@ -440,14 +456,13 @@ class DefaultModelDownloadManager implements ModelDownloadManager {
   Future<ModelCacheEntry> _entryForFile(
     ModelSource source,
     File file,
-    DateTime timestamp,
-    ModelLoadOptions options, {
+    DateTime timestamp, {
     String? etag,
     String? lastModified,
     String? sha256Digest,
   }) async {
     final bytes = await file.length();
-    final digest = sha256Digest ?? options.sha256;
+    final digest = sha256Digest;
     return ModelCacheEntry(
       sourceCanonicalKey: source.metadataSourceKey,
       cacheKey: source.cacheKey,

--- a/lib/src/platform/io/model_download_manager_io.dart
+++ b/lib/src/platform/io/model_download_manager_io.dart
@@ -207,7 +207,7 @@ class DefaultModelDownloadManager implements ModelDownloadManager {
     final file = File(source.path!);
     if (!await file.exists()) {
       throw LlamaModelException(
-        'Local model file does not exist: ${source.displayName}.',
+        'Local model file does not exist: ${source.path}.',
       );
     }
     return _entryForFile(source, file, DateTime.now().toUtc(), options);
@@ -447,7 +447,7 @@ class DefaultModelDownloadManager implements ModelDownloadManager {
     String? sha256Digest,
   }) async {
     final bytes = await file.length();
-    final digest = sha256Digest ?? await _sha256File(file);
+    final digest = sha256Digest ?? options.sha256;
     return ModelCacheEntry(
       sourceCanonicalKey: source.metadataSourceKey,
       cacheKey: source.cacheKey,

--- a/lib/src/platform/io/model_download_manager_io.dart
+++ b/lib/src/platform/io/model_download_manager_io.dart
@@ -123,12 +123,23 @@ class DefaultModelDownloadManager implements ModelDownloadManager {
     String cacheKey, {
     String? cacheDirectory,
   }) async {
-    for (final entry in await list(cacheDirectory: cacheDirectory)) {
-      if (entry.cacheKey == cacheKey) {
-        return entry;
+    final entries = <ModelCacheEntry>[];
+    for (final metadataFile in await _candidateMetadataFiles(
+      cacheKey,
+      cacheDirectory: cacheDirectory,
+    )) {
+      try {
+        final entry = await _readMetadata(metadataFile);
+        if (entry.cacheKey == cacheKey && await File(entry.filePath).exists()) {
+          entries.add(entry);
+        }
+      } catch (_) {
+        // Ignore malformed candidates so a corrupt entry does not make cache
+        // inspection unusable.
       }
     }
-    return null;
+    entries.sort((a, b) => b.updatedAt.compareTo(a.updatedAt));
+    return entries.isEmpty ? null : entries.first;
   }
 
   @override
@@ -195,6 +206,30 @@ class DefaultModelDownloadManager implements ModelDownloadManager {
 
   Directory _rootDirectory(String? cacheDirectory) {
     return Directory(cacheDirectory ?? defaultCacheDirectory);
+  }
+
+  Future<List<File>> _candidateMetadataFiles(
+    String cacheKey, {
+    String? cacheDirectory,
+  }) async {
+    final root = _rootDirectory(cacheDirectory);
+    if (!await root.exists()) {
+      return const <File>[];
+    }
+    final prefixLength = cacheKey.length < 12 ? cacheKey.length : 12;
+    final directoryKeyPrefix = cacheKey.substring(0, prefixLength);
+    final files = <File>[];
+    await for (final entity in root.list(followLinks: false)) {
+      if (entity is! Directory) {
+        continue;
+      }
+      final name = path.basename(entity.path);
+      if (name.endsWith('-$directoryKeyPrefix') ||
+          name.contains('-$directoryKeyPrefix-nocache-')) {
+        files.add(File(path.join(entity.path, _metadataFileName)));
+      }
+    }
+    return files;
   }
 
   Future<Directory> _createTransientCacheDirectory(

--- a/lib/src/platform/io/model_download_manager_io.dart
+++ b/lib/src/platform/io/model_download_manager_io.dart
@@ -250,7 +250,7 @@ class DefaultModelDownloadManager implements ModelDownloadManager {
     ModelSource source,
     ModelLoadOptions options,
   ) async {
-    final file = File(source.path!);
+    final file = File(path.normalize(path.absolute(source.path!)));
     if (!await file.exists()) {
       throw LlamaModelException(
         'Local model file does not exist: ${source.path}.',

--- a/lib/src/platform/io/model_download_manager_io.dart
+++ b/lib/src/platform/io/model_download_manager_io.dart
@@ -169,7 +169,7 @@ class DefaultModelDownloadManager implements ModelDownloadManager {
     String? cacheDirectory,
   }) async {
     final entries = await list(cacheDirectory: cacheDirectory);
-    final removed = <ModelCacheEntry>[];
+    final removed = await _removeStaleMetadataEntries(cacheDirectory);
     final now = DateTime.now().toUtc();
 
     for (final entry in entries) {
@@ -427,8 +427,24 @@ class DefaultModelDownloadManager implements ModelDownloadManager {
       final append =
           existingBytes > 0 && statusCode == HttpStatus.partialContent;
       if (existingBytes > 0 && statusCode == HttpStatus.partialContent) {
-        _validateContentRange(response, existingBytes, source);
-        _validateResumeValidator(partMetadata, responsePartMetadata, source);
+        try {
+          _validateContentRange(response, existingBytes, source);
+          _validateResumeValidator(partMetadata, responsePartMetadata, source);
+        } on LlamaModelException {
+          await response.drain<void>();
+          await _deleteIfExists(downloadFile);
+          if (partMetadataFile != null) {
+            await _deleteIfExists(partMetadataFile);
+          }
+          return _downloadOnce(
+            source,
+            options,
+            uri,
+            finalFile,
+            partFile,
+            onProgress,
+          );
+        }
       } else if (existingBytes > 0 && statusCode == HttpStatus.ok) {
         existingBytes = 0;
         await _deleteIfExists(downloadFile);
@@ -555,6 +571,42 @@ class DefaultModelDownloadManager implements ModelDownloadManager {
       '${const JsonEncoder.withIndent('  ').convert(json)}\n',
     );
     await _replaceFile(tempFile, metadataFile);
+  }
+
+  Future<List<ModelCacheEntry>> _removeStaleMetadataEntries(
+    String? cacheDirectory,
+  ) async {
+    final root = _rootDirectory(cacheDirectory);
+    if (!await root.exists()) {
+      return const <ModelCacheEntry>[];
+    }
+
+    final removed = <ModelCacheEntry>[];
+    await for (final entity in root.list(followLinks: false)) {
+      if (entity is! Directory) {
+        continue;
+      }
+      final metadataFile = File(path.join(entity.path, _metadataFileName));
+      if (!await metadataFile.exists()) {
+        continue;
+      }
+      try {
+        final entry = await _readMetadata(metadataFile);
+        final entryFile = _entryFileInCacheDirectory(entry, entity);
+        if (entryFile != null && !await entryFile.exists()) {
+          if (await _removeCacheDirectory(
+            entity,
+            cacheDirectory: cacheDirectory,
+          )) {
+            removed.add(entry);
+          }
+        }
+      } catch (_) {
+        // Ignore malformed cache entries so one corrupt metadata file does not
+        // make cache pruning unusable.
+      }
+    }
+    return removed;
   }
 
   Future<List<ModelCacheEntry>> _removeByCacheKey(

--- a/lib/src/platform/io/model_download_manager_io.dart
+++ b/lib/src/platform/io/model_download_manager_io.dart
@@ -63,11 +63,12 @@ class DefaultModelDownloadManager implements ModelDownloadManager {
         options,
       );
       final transientFile = File(path.join(transientDir.path, source.fileName));
+      final transientPartFile = File('${transientFile.path}.part');
       final entry = await _download(
         source,
         options,
         transientFile,
-        null,
+        transientPartFile,
         onProgress,
       );
       await _writeMetadata(

--- a/lib/src/platform/io/model_download_manager_io.dart
+++ b/lib/src/platform/io/model_download_manager_io.dart
@@ -43,6 +43,7 @@ class DefaultModelDownloadManager implements ModelDownloadManager {
     if (cachePolicy != ModelCachePolicy.refresh &&
         cachePolicy != ModelCachePolicy.noCache) {
       final cached = await _readCompletedEntry(
+        source,
         metadataFile,
         finalFile,
         options,
@@ -296,6 +297,7 @@ class DefaultModelDownloadManager implements ModelDownloadManager {
   }
 
   Future<ModelCacheEntry?> _readCompletedEntry(
+    ModelSource source,
     File metadataFile,
     File finalFile,
     ModelLoadOptions options,
@@ -304,7 +306,10 @@ class DefaultModelDownloadManager implements ModelDownloadManager {
       return null;
     }
     final entry = await _readMetadata(metadataFile);
-    if (entry.filePath != finalFile.path) {
+    if (entry.sourceCanonicalKey != source.metadataSourceKey ||
+        entry.cacheKey != source.cacheKey ||
+        entry.fileName != source.fileName ||
+        entry.filePath != finalFile.path) {
       return null;
     }
     String? verifiedSha256;

--- a/lib/src/platform/io/model_download_manager_io.dart
+++ b/lib/src/platform/io/model_download_manager_io.dart
@@ -4,10 +4,10 @@ import 'dart:io';
 import 'package:crypto/crypto.dart';
 import 'package:path/path.dart' as path;
 
-import '../../exceptions.dart';
-import '../model_load_options.dart';
-import '../model_source.dart';
-import 'model_download_manager_base.dart';
+import '../../core/exceptions.dart';
+import '../../core/models/download/model_download_manager_base.dart';
+import '../../core/models/model_load_options.dart';
+import '../../core/models/model_source.dart';
 
 const String _metadataFileName = 'metadata.json';
 const int _metadataSchemaVersion = 1;

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -19,6 +19,7 @@ dependencies:
   ffi: ^2.1.0
   path: ^1.8.3
   http: ^1.1.0
+  crypto: ^3.0.0
   web: ^1.0.0
   code_assets: ^1.0.0
   hooks: ^1.0.0

--- a/test/integration/engine_integration_test.dart
+++ b/test/integration/engine_integration_test.dart
@@ -130,9 +130,15 @@ void main() async {
       expect(accumulated, isNotEmpty, reason: 'Generation should have started');
     });
 
-    test('loadModelFromUrl throws Unimplemented on Native', () async {
-      expect(engine.loadModelFromUrl('http://test'), throwsUnimplementedError);
-    });
+    test(
+      'loadModelFromUrl throws LlamaUnsupportedException on Native',
+      () async {
+        expect(
+          engine.loadModelFromUrl('http://test'),
+          throwsA(isA<LlamaUnsupportedException>()),
+        );
+      },
+    );
 
     test('getContextSize prefers active context over metadata', () async {
       // Use a fresh engine to avoid disrupting the shared one and to test cleanup

--- a/test/unit/core/engine/engine_test.dart
+++ b/test/unit/core/engine/engine_test.dart
@@ -379,8 +379,38 @@ void main() {
               webEngine.loadModelSource(ModelSource.path('/models/model.gguf')),
           throwsA(isA<LlamaUnsupportedException>()),
         );
-        expect(webBackend.modelLoadCalls, 0);
-        expect(webBackend.modelLoadFromUrlCalls, 0);
+      },
+    );
+
+    test(
+      'native loadModelSource applies load options for local path sources',
+      () async {
+        final source = ModelSource.path('/models/model.gguf');
+        final entry = ModelCacheEntry(
+          sourceCanonicalKey: source.metadataSourceKey,
+          cacheKey: source.cacheKey,
+          fileName: source.fileName,
+          filePath: '/models/model.gguf',
+          createdAt: DateTime.utc(2026),
+          updatedAt: DateTime.utc(2026),
+        );
+        final downloadManager = MockModelDownloadManager(entry);
+        final nativeBackend = MockLlamaBackend();
+        final nativeEngine = LlamaEngine(
+          nativeBackend,
+          modelDownloadManager: downloadManager,
+        );
+        final options = ModelLoadOptions(
+          sha256:
+              '0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef',
+        );
+
+        await nativeEngine.loadModelSource(source, options: options);
+
+        expect(downloadManager.ensureModelCalls, 1);
+        expect(downloadManager.lastSource, source);
+        expect(downloadManager.lastOptions, same(options));
+        expect(nativeBackend.lastModelPath, '/models/model.gguf');
       },
     );
 
@@ -529,6 +559,23 @@ void main() {
         expect(downloadManager.lastSource?.resolvedUri, resolvedUrl);
         expect(downloadManager.lastSource?.fileName, 'resolved.gguf');
         expect(nativeBackend.lastModelPath, '/cache/resolved.gguf');
+      },
+    );
+
+    test(
+      'loadModelSource rejects unsupported cancellation on URL backends',
+      () async {
+        final webBackend = MockLlamaBackend(urlLoadingSupported: true);
+        final webEngine = LlamaEngine(webBackend);
+
+        await expectLater(
+          () => webEngine.loadModelSource(
+            ModelSource.url(Uri.parse('https://example.com/model.gguf')),
+            options: ModelLoadOptions(cancelToken: ModelDownloadCancelToken()),
+          ),
+          throwsA(isA<LlamaUnsupportedException>()),
+        );
+        expect(webBackend.modelLoadFromUrlCalls, 0);
       },
     );
 

--- a/test/unit/core/engine/engine_test.dart
+++ b/test/unit/core/engine/engine_test.dart
@@ -16,6 +16,7 @@ class MockLlamaBackend
   });
 
   bool _isReady = false;
+  String? lastModelPath;
   String? lastLoraPath;
   String? lastModelUrl;
   double? lastLoraScale;
@@ -41,6 +42,7 @@ class MockLlamaBackend
   @override
   Future<int> modelLoad(String path, ModelParams params) async {
     modelLoadCalls += 1;
+    lastModelPath = path;
     if (failModelLoad) {
       throw Exception('model load failed');
     }
@@ -203,6 +205,49 @@ class MockLlamaBackend
   }) async {
     return messages.map((m) => "${m['role']}: ${m['content']}").join('\n');
   }
+}
+
+class MockModelDownloadManager implements ModelDownloadManager {
+  MockModelDownloadManager(this.entry);
+
+  final ModelCacheEntry entry;
+  ModelSource? lastSource;
+  ModelLoadOptions? lastOptions;
+  int ensureModelCalls = 0;
+
+  @override
+  Future<ModelCacheEntry> ensureModel(
+    ModelSource source, {
+    ModelLoadOptions options = ModelLoadOptions.defaults,
+    ModelDownloadProgressCallback? onProgress,
+  }) async {
+    ensureModelCalls += 1;
+    lastSource = source;
+    lastOptions = options;
+    onProgress?.call(
+      const ModelDownloadProgress(receivedBytes: 1, totalBytes: 2),
+    );
+    return entry;
+  }
+
+  @override
+  Future<void> clear() async {}
+
+  @override
+  Future<ModelCacheEntry?> get(String cacheKey) async =>
+      cacheKey == entry.cacheKey ? entry : null;
+
+  @override
+  Future<List<ModelCacheEntry>> list() async => <ModelCacheEntry>[entry];
+
+  @override
+  Future<List<ModelCacheEntry>> prune({
+    Duration? maxAge,
+    int? maxBytes,
+  }) async => <ModelCacheEntry>[];
+
+  @override
+  Future<void> remove(String cacheKey) async {}
 }
 
 class MockEmbeddingBackend extends MockLlamaBackend
@@ -382,6 +427,50 @@ void main() {
       expect(progressEvents.single.totalBytes, isNull);
       expect(progressEvents.single.fraction, 0.25);
     });
+
+    test(
+      'loadModelSource downloads remote sources before native model load',
+      () async {
+        final source = ModelSource.url(
+          Uri.parse('https://example.com/model.gguf'),
+        );
+        final entry = ModelCacheEntry(
+          sourceCanonicalKey: source.metadataSourceKey,
+          cacheKey: source.cacheKey,
+          fileName: source.fileName,
+          filePath: '/cache/model.gguf',
+          createdAt: DateTime.utc(2026),
+          updatedAt: DateTime.utc(2026),
+          bytes: 12,
+        );
+        final downloadManager = MockModelDownloadManager(entry);
+        final nativeBackend = MockLlamaBackend();
+        final nativeEngine = LlamaEngine(
+          nativeBackend,
+          modelDownloadManager: downloadManager,
+        );
+        final options = ModelLoadOptions(
+          cachePolicy: ModelCachePolicy.refresh,
+          bearerToken: 'secret-token',
+        );
+        final progressEvents = <ModelDownloadProgress>[];
+
+        await nativeEngine.loadModelSource(
+          source,
+          options: options,
+          onProgress: progressEvents.add,
+        );
+
+        expect(downloadManager.ensureModelCalls, 1);
+        expect(downloadManager.lastSource, source);
+        expect(downloadManager.lastOptions, same(options));
+        expect(nativeBackend.modelLoadCalls, 1);
+        expect(nativeBackend.modelLoadFromUrlCalls, 0);
+        expect(nativeBackend.lastModelPath, '/cache/model.gguf');
+        expect(nativeEngine.isReady, isTrue);
+        expect(progressEvents.single.fraction, 0.5);
+      },
+    );
 
     test(
       'loadModelSource rejects unsupported noCache remote URL option',

--- a/test/unit/core/engine/engine_test.dart
+++ b/test/unit/core/engine/engine_test.dart
@@ -207,6 +207,22 @@ class MockLlamaBackend
   }
 }
 
+class MockModelResolver implements ModelResolver {
+  MockModelResolver(this.target);
+
+  final ModelLoadTarget target;
+  ModelSource? lastSource;
+
+  @override
+  Future<ModelLoadTarget> resolve(
+    ModelSource source,
+    ModelResolveRequest request,
+  ) async {
+    lastSource = source;
+    return target;
+  }
+}
+
 class MockModelDownloadManager implements ModelDownloadManager {
   MockModelDownloadManager(this.entry);
 
@@ -466,13 +482,53 @@ void main() {
         );
 
         expect(downloadManager.ensureModelCalls, 1);
-        expect(downloadManager.lastSource, source);
+        expect(downloadManager.lastSource?.resolvedUri, source.resolvedUri);
+        expect(downloadManager.lastSource?.fileName, source.fileName);
         expect(downloadManager.lastOptions, same(options));
         expect(nativeBackend.modelLoadCalls, 1);
         expect(nativeBackend.modelLoadFromUrlCalls, 0);
         expect(nativeBackend.lastModelPath, '/cache/model.gguf');
         expect(nativeEngine.isReady, isTrue);
         expect(progressEvents.single.fraction, 0.5);
+      },
+    );
+
+    test(
+      'native loadModelSource downloads resolved remote URL target',
+      () async {
+        final source = ModelSource.huggingFace(
+          repoId: 'owner/repo',
+          filePath: 'models/original.gguf',
+          fileName: 'resolved.gguf',
+        );
+        final resolvedUrl = Uri.parse('https://cdn.example.com/resolved.gguf');
+        final resolvedSource = ModelSource.url(
+          resolvedUrl,
+          fileName: source.fileName,
+        );
+        final entry = ModelCacheEntry(
+          sourceCanonicalKey: resolvedSource.metadataSourceKey,
+          cacheKey: resolvedSource.cacheKey,
+          fileName: resolvedSource.fileName,
+          filePath: '/cache/resolved.gguf',
+          createdAt: DateTime.utc(2026),
+          updatedAt: DateTime.utc(2026),
+        );
+        final resolver = MockModelResolver(RemoteModelUrl(resolvedUrl));
+        final downloadManager = MockModelDownloadManager(entry);
+        final nativeBackend = MockLlamaBackend();
+        final nativeEngine = LlamaEngine(
+          nativeBackend,
+          modelResolver: resolver,
+          modelDownloadManager: downloadManager,
+        );
+
+        await nativeEngine.loadModelSource(source);
+
+        expect(resolver.lastSource, source);
+        expect(downloadManager.lastSource?.resolvedUri, resolvedUrl);
+        expect(downloadManager.lastSource?.fileName, 'resolved.gguf');
+        expect(nativeBackend.lastModelPath, '/cache/resolved.gguf');
       },
     );
 

--- a/test/unit/core/engine/engine_test.dart
+++ b/test/unit/core/engine/engine_test.dart
@@ -231,23 +231,27 @@ class MockModelDownloadManager implements ModelDownloadManager {
   }
 
   @override
-  Future<void> clear() async {}
+  Future<void> clear({String? cacheDirectory}) async {}
 
   @override
-  Future<ModelCacheEntry?> get(String cacheKey) async =>
-      cacheKey == entry.cacheKey ? entry : null;
+  Future<ModelCacheEntry?> get(
+    String cacheKey, {
+    String? cacheDirectory,
+  }) async => cacheKey == entry.cacheKey ? entry : null;
 
   @override
-  Future<List<ModelCacheEntry>> list() async => <ModelCacheEntry>[entry];
+  Future<List<ModelCacheEntry>> list({String? cacheDirectory}) async =>
+      <ModelCacheEntry>[entry];
 
   @override
   Future<List<ModelCacheEntry>> prune({
     Duration? maxAge,
     int? maxBytes,
+    String? cacheDirectory,
   }) async => <ModelCacheEntry>[];
 
   @override
-  Future<void> remove(String cacheKey) async {}
+  Future<void> remove(String cacheKey, {String? cacheDirectory}) async {}
 }
 
 class MockEmbeddingBackend extends MockLlamaBackend

--- a/test/unit/core/engine/engine_test.dart
+++ b/test/unit/core/engine/engine_test.dart
@@ -532,14 +532,10 @@ void main() {
           fileName: 'resolved.gguf',
         );
         final resolvedUrl = Uri.parse('https://cdn.example.com/resolved.gguf');
-        final resolvedSource = ModelSource.url(
-          resolvedUrl,
-          fileName: source.fileName,
-        );
         final entry = ModelCacheEntry(
-          sourceCanonicalKey: resolvedSource.metadataSourceKey,
-          cacheKey: resolvedSource.cacheKey,
-          fileName: resolvedSource.fileName,
+          sourceCanonicalKey: source.metadataSourceKey,
+          cacheKey: source.cacheKey,
+          fileName: source.fileName,
           filePath: '/cache/resolved.gguf',
           createdAt: DateTime.utc(2026),
           updatedAt: DateTime.utc(2026),
@@ -558,6 +554,11 @@ void main() {
         expect(resolver.lastSource, source);
         expect(downloadManager.lastSource?.resolvedUri, resolvedUrl);
         expect(downloadManager.lastSource?.fileName, 'resolved.gguf');
+        expect(downloadManager.lastSource?.cacheKey, source.cacheKey);
+        expect(
+          downloadManager.lastSource?.cacheDirectoryName,
+          source.cacheDirectoryName,
+        );
         expect(nativeBackend.lastModelPath, '/cache/resolved.gguf');
       },
     );

--- a/test/unit/core/engine/engine_test.dart
+++ b/test/unit/core/engine/engine_test.dart
@@ -514,6 +514,26 @@ void main() {
         expect(thrown.toString(), isNot(contains('secret')));
         expect(thrown.toString(), isNot(contains('token=abc123')));
         expect(thrown.toString(), contains('https://example.com/model.gguf'));
+        final exception = thrown as LlamaModelException;
+        expect(
+          exception.details,
+          isA<Map<String, Object?>>()
+              .having(
+                (details) => details['type'].toString(),
+                'type',
+                contains('Exception'),
+              )
+              .having(
+                (details) => details['message'].toString(),
+                'message',
+                contains('url model load failed'),
+              )
+              .having(
+                (details) => details['message'].toString(),
+                'redacted message',
+                isNot(anyOf(contains('secret'), contains('token=abc123'))),
+              ),
+        );
       },
     );
 

--- a/test/unit/core/engine/engine_test.dart
+++ b/test/unit/core/engine/engine_test.dart
@@ -17,6 +17,7 @@ class MockLlamaBackend
 
   bool _isReady = false;
   String? lastLoraPath;
+  String? lastModelUrl;
   double? lastLoraScale;
   int resolvedGpuLayers = 0;
   int modelLoadCalls = 0;
@@ -54,8 +55,10 @@ class MockLlamaBackend
     Function(double progress)? onProgress,
   }) async {
     modelLoadFromUrlCalls += 1;
+    lastModelUrl = url;
+    onProgress?.call(0.25);
     if (failModelLoadFromUrl) {
-      throw Exception('url model load failed');
+      throw Exception('url model load failed: $url');
     }
     _isReady = true;
     return 1;
@@ -300,10 +303,26 @@ void main() {
       expect(webEngine.isReady, isTrue);
     });
 
-    test('loadModelFromUrl successful', () async {
+    test(
+      'loadModelSource rejects explicit local paths on URL backends',
+      () async {
+        final webBackend = MockLlamaBackend(urlLoadingSupported: true);
+        final webEngine = LlamaEngine(webBackend);
+
+        await expectLater(
+          () =>
+              webEngine.loadModelSource(ModelSource.path('/models/model.gguf')),
+          throwsA(isA<LlamaUnsupportedException>()),
+        );
+        expect(webBackend.modelLoadCalls, 0);
+        expect(webBackend.modelLoadFromUrlCalls, 0);
+      },
+    );
+
+    test('loadModelFromUrl unsupported on non-URL backend', () async {
       expect(
         () => engine.loadModelFromUrl('http://test.gguf'),
-        throwsUnimplementedError,
+        throwsA(isA<LlamaUnsupportedException>()),
       );
     });
 
@@ -321,6 +340,87 @@ void main() {
         expect(webEngine.isReady, isTrue);
         expect(webEngine.modelHandle, isNotNull);
         expect(webEngine.contextHandle, isNotNull);
+      },
+    );
+
+    test(
+      'loadModelFromUrl redacts completion model metadata for signed URLs',
+      () async {
+        final webBackend = MockLlamaBackend(urlLoadingSupported: true)
+          ..generationText = 'hello';
+        final webEngine = LlamaEngine(webBackend);
+
+        await webEngine.loadModelFromUrl(
+          'https://user:secret@example.com/model.gguf?token=abc123#fragment',
+        );
+        final chunks = await webEngine.create(const [
+          LlamaChatMessage.fromText(role: LlamaChatRole.user, text: 'hi'),
+        ]).toList();
+
+        expect(chunks, isNotEmpty);
+        for (final chunk in chunks) {
+          expect(chunk.model, 'https://example.com/model.gguf');
+          expect(chunk.model, isNot(contains('secret')));
+          expect(chunk.model, isNot(contains('token=abc123')));
+        }
+      },
+    );
+
+    test('loadModelSource forwards progress for remote URL targets', () async {
+      final webBackend = MockLlamaBackend(urlLoadingSupported: true);
+      final webEngine = LlamaEngine(webBackend);
+      final progressEvents = <ModelDownloadProgress>[];
+
+      await webEngine.loadModelSource(
+        ModelSource.url(Uri.parse('https://example.com/model.gguf')),
+        onProgress: progressEvents.add,
+      );
+
+      expect(webBackend.lastModelUrl, 'https://example.com/model.gguf');
+      expect(progressEvents, hasLength(1));
+      expect(progressEvents.single.receivedBytes, 0);
+      expect(progressEvents.single.totalBytes, isNull);
+      expect(progressEvents.single.fraction, 0.25);
+    });
+
+    test(
+      'loadModelSource rejects unsupported noCache remote URL option',
+      () async {
+        final webBackend = MockLlamaBackend(urlLoadingSupported: true);
+        final webEngine = LlamaEngine(webBackend);
+
+        await expectLater(
+          () => webEngine.loadModelSource(
+            ModelSource.url(Uri.parse('https://example.com/model.gguf')),
+            options: ModelLoadOptions(cachePolicy: ModelCachePolicy.noCache),
+          ),
+          throwsA(isA<LlamaUnsupportedException>()),
+        );
+      },
+    );
+
+    test(
+      'loadModelFromUrl redacts credentials from thrown exception messages',
+      () async {
+        final failingBackend = MockLlamaBackend(
+          urlLoadingSupported: true,
+          failModelLoadFromUrl: true,
+        );
+        final failingEngine = LlamaEngine(failingBackend);
+
+        Object? thrown;
+        try {
+          await failingEngine.loadModelFromUrl(
+            'https://user:secret@example.com/model.gguf?token=abc123#fragment',
+          );
+        } catch (e) {
+          thrown = e;
+        }
+
+        expect(thrown, isA<LlamaModelException>());
+        expect(thrown.toString(), isNot(contains('secret')));
+        expect(thrown.toString(), isNot(contains('token=abc123')));
+        expect(thrown.toString(), contains('https://example.com/model.gguf'));
       },
     );
 

--- a/test/unit/core/engine/engine_test.dart
+++ b/test/unit/core/engine/engine_test.dart
@@ -408,9 +408,42 @@ void main() {
         await nativeEngine.loadModelSource(source, options: options);
 
         expect(downloadManager.ensureModelCalls, 1);
-        expect(downloadManager.lastSource, source);
+        expect(downloadManager.lastSource?.path, source.path);
+        expect(downloadManager.lastSource?.cacheKey, source.cacheKey);
         expect(downloadManager.lastOptions, same(options));
         expect(nativeBackend.lastModelPath, '/models/model.gguf');
+      },
+    );
+
+    test(
+      'native loadModelSource honors resolver-provided local path',
+      () async {
+        final source = ModelSource.path('/models/original.gguf');
+        final resolvedSource = ModelSource.path('/models/resolved.gguf');
+        final entry = ModelCacheEntry(
+          sourceCanonicalKey: resolvedSource.metadataSourceKey,
+          cacheKey: resolvedSource.cacheKey,
+          fileName: resolvedSource.fileName,
+          filePath: '/models/resolved.gguf',
+          createdAt: DateTime.utc(2026),
+          updatedAt: DateTime.utc(2026),
+        );
+        final resolver = MockModelResolver(
+          const LocalModelFile('/models/resolved.gguf'),
+        );
+        final downloadManager = MockModelDownloadManager(entry);
+        final nativeBackend = MockLlamaBackend();
+        final nativeEngine = LlamaEngine(
+          nativeBackend,
+          modelResolver: resolver,
+          modelDownloadManager: downloadManager,
+        );
+
+        await nativeEngine.loadModelSource(source);
+
+        expect(resolver.lastSource, source);
+        expect(downloadManager.lastSource?.path, '/models/resolved.gguf');
+        expect(nativeBackend.lastModelPath, '/models/resolved.gguf');
       },
     );
 

--- a/test/unit/core/models/download/model_cache_entry_test.dart
+++ b/test/unit/core/models/download/model_cache_entry_test.dart
@@ -142,6 +142,20 @@ void main() {
       );
     });
 
+    test('normalizes percent-encoded cache file names and paths', () {
+      final entry = ModelCacheEntry(
+        sourceCanonicalKey: 'path:/models/model.gguf',
+        cacheKey: 'abc123',
+        fileName: 'model%2Egguf',
+        filePath: r'C:\cache\model%2Egguf',
+        createdAt: DateTime.utc(2026, 1, 2),
+        updatedAt: DateTime.utc(2026, 1, 2),
+      );
+
+      expect(entry.fileName, 'model.gguf');
+      expect(entry.filePath, 'C:/cache/model.gguf');
+    });
+
     test('rejects unsafe cache file names and traversal paths', () {
       for (final fileName in <String>[
         '',

--- a/test/unit/core/models/download/model_cache_entry_test.dart
+++ b/test/unit/core/models/download/model_cache_entry_test.dart
@@ -171,6 +171,8 @@ void main() {
         '',
         '/cache/../model.gguf',
         '/cache/%2e%2e/model.gguf',
+        '/cache/%2e%2e%2fmodel.gguf',
+        r'C:\cache\..\model.gguf',
       ]) {
         expect(
           () => ModelCacheEntry(

--- a/test/unit/core/models/download/model_cache_entry_test.dart
+++ b/test/unit/core/models/download/model_cache_entry_test.dart
@@ -152,6 +152,7 @@ void main() {
         r'dir\model.gguf',
         '%2e%2e',
         '..%2Fmodel.gguf',
+        '%',
       ]) {
         expect(
           () => ModelCacheEntry(
@@ -172,6 +173,7 @@ void main() {
         '/cache/../model.gguf',
         '/cache/%2e%2e/model.gguf',
         '/cache/%2e%2e%2fmodel.gguf',
+        '/cache/%/model.gguf',
         r'C:\cache\..\model.gguf',
       ]) {
         expect(

--- a/test/unit/core/models/download/model_cache_entry_test.dart
+++ b/test/unit/core/models/download/model_cache_entry_test.dart
@@ -153,7 +153,7 @@ void main() {
       );
 
       expect(entry.fileName, 'model.gguf');
-      expect(entry.filePath, 'C:/cache/model.gguf');
+      expect(entry.filePath, r'C:\cache\model.gguf');
     });
 
     test('rejects unsafe cache file names and traversal paths', () {

--- a/test/unit/core/models/download/model_cache_entry_test.dart
+++ b/test/unit/core/models/download/model_cache_entry_test.dart
@@ -1,0 +1,202 @@
+import 'dart:convert';
+
+import 'package:llamadart/llamadart.dart';
+import 'package:test/test.dart';
+
+void main() {
+  group('ModelDownloadProgress', () {
+    test('fraction is null when total bytes is null or zero', () {
+      expect(
+        const ModelDownloadProgress(
+          receivedBytes: 10,
+          totalBytes: null,
+        ).fraction,
+        isNull,
+      );
+      expect(
+        const ModelDownloadProgress(receivedBytes: 10, totalBytes: 0).fraction,
+        isNull,
+      );
+    });
+
+    test('fraction clamps to zero through one', () {
+      expect(
+        const ModelDownloadProgress(
+          receivedBytes: -10,
+          totalBytes: 100,
+        ).fraction,
+        0,
+      );
+      expect(
+        const ModelDownloadProgress(
+          receivedBytes: 50,
+          totalBytes: 100,
+        ).fraction,
+        0.5,
+      );
+      expect(
+        const ModelDownloadProgress(
+          receivedBytes: 150,
+          totalBytes: 100,
+        ).fraction,
+        1,
+      );
+      expect(const ModelDownloadProgress.fraction(-0.5).fraction, 0);
+      expect(const ModelDownloadProgress.fraction(0.25).fraction, 0.25);
+      expect(const ModelDownloadProgress.fraction(2).fraction, 1);
+    });
+  });
+
+  group('ModelCacheEntry', () {
+    test('toJson and fromJson round-trip all fields', () {
+      final entry = ModelCacheEntry(
+        sourceCanonicalKey: 'hf://owner/repo@main/model.gguf',
+        cacheKey: 'abc123',
+        fileName: 'model.gguf',
+        filePath: '/cache/model.gguf',
+        bytes: 1234,
+        sha256: 'def456',
+        etag: 'etag-value',
+        lastModified: 'Wed, 21 Oct 2015 07:28:00 GMT',
+        createdAt: DateTime.utc(2026, 1, 2, 3, 4, 5),
+        updatedAt: DateTime.utc(2026, 1, 3, 3, 4, 5),
+        expiresAt: DateTime.utc(2026, 2, 3, 3, 4, 5),
+      );
+
+      final decoded = ModelCacheEntry.fromJson(entry.toJson());
+
+      expect(decoded.sourceCanonicalKey, entry.sourceCanonicalKey);
+      expect(decoded.cacheKey, entry.cacheKey);
+      expect(decoded.fileName, entry.fileName);
+      expect(decoded.filePath, entry.filePath);
+      expect(decoded.bytes, entry.bytes);
+      expect(decoded.sha256, entry.sha256);
+      expect(decoded.etag, entry.etag);
+      expect(decoded.lastModified, entry.lastModified);
+      expect(decoded.createdAt, entry.createdAt);
+      expect(decoded.updatedAt, entry.updatedAt);
+      expect(decoded.expiresAt, entry.expiresAt);
+      expect(decoded.toJson(), entry.toJson());
+    });
+
+    test('missing optional JSON fields do not crash parsing', () {
+      final decoded = ModelCacheEntry.fromJson(const <String, Object?>{
+        'source_canonical_key': 'path:/models/model.gguf',
+        'cache_key': 'abc123',
+        'file_name': 'model.gguf',
+        'file_path': '/models/model.gguf',
+        'created_at': '2026-01-02T03:04:05.000Z',
+        'updated_at': '2026-01-03T03:04:05.000Z',
+      });
+
+      expect(decoded.bytes, isNull);
+      expect(decoded.sha256, isNull);
+      expect(decoded.etag, isNull);
+      expect(decoded.lastModified, isNull);
+      expect(decoded.expiresAt, isNull);
+    });
+
+    test('toJson redacts credential-bearing URL source keys', () {
+      final source = ModelSource.url(
+        Uri.parse(
+          'https://user:secret@host/model.gguf?token=secret&download=1',
+        ),
+      );
+      final entry = ModelCacheEntry(
+        sourceCanonicalKey: source.canonicalKey,
+        cacheKey: source.cacheKey,
+        fileName: source.fileName,
+        filePath: '/cache/model.gguf',
+        createdAt: DateTime.utc(2026, 1, 2),
+        updatedAt: DateTime.utc(2026, 1, 2),
+      );
+
+      final encoded = jsonEncode(entry.toJson());
+
+      expect(encoded, isNot(contains('secret')));
+      expect(encoded, isNot(contains('user:secret')));
+      expect(encoded, isNot(contains('token=secret')));
+      expect(encoded, isNot(contains(source.canonicalKey)));
+      expect(entry.sourceCanonicalKey, source.metadataSourceKey);
+      expect(entry.cacheKey, source.cacheKey);
+    });
+
+    test('toJson redacts url-prefixed credential-bearing source keys', () {
+      final entry = ModelCacheEntry(
+        sourceCanonicalKey:
+            'url:https://user:secret@host/model.gguf?token=secret#fragment',
+        cacheKey: 'abc123',
+        fileName: 'model.gguf',
+        filePath: '/cache/model.gguf',
+        createdAt: DateTime.utc(2026, 1, 2),
+        updatedAt: DateTime.utc(2026, 1, 2),
+      );
+
+      final encoded = jsonEncode(entry.toJson());
+
+      expect(encoded, isNot(contains('secret')));
+      expect(encoded, isNot(contains('token=secret')));
+      expect(
+        entry.sourceCanonicalKey,
+        'url:https://host/model.gguf#cacheKey=abc123',
+      );
+    });
+
+    test('rejects unsafe cache file names and traversal paths', () {
+      for (final fileName in <String>[
+        '',
+        '.',
+        '..',
+        '../model.gguf',
+        'dir/model.gguf',
+        r'dir\model.gguf',
+        '%2e%2e',
+        '..%2Fmodel.gguf',
+      ]) {
+        expect(
+          () => ModelCacheEntry(
+            sourceCanonicalKey: 'path:/models/model.gguf',
+            cacheKey: 'abc123',
+            fileName: fileName,
+            filePath: '/cache/model.gguf',
+            createdAt: DateTime.utc(2026, 1, 2),
+            updatedAt: DateTime.utc(2026, 1, 2),
+          ),
+          throwsArgumentError,
+          reason: fileName,
+        );
+      }
+
+      for (final filePath in <String>[
+        '',
+        '/cache/../model.gguf',
+        '/cache/%2e%2e/model.gguf',
+      ]) {
+        expect(
+          () => ModelCacheEntry(
+            sourceCanonicalKey: 'path:/models/model.gguf',
+            cacheKey: 'abc123',
+            fileName: 'model.gguf',
+            filePath: filePath,
+            createdAt: DateTime.utc(2026, 1, 2),
+            updatedAt: DateTime.utc(2026, 1, 2),
+          ),
+          throwsArgumentError,
+          reason: filePath,
+        );
+      }
+    });
+  });
+
+  group('ModelDownloadCancelToken', () {
+    test('cancel is idempotent and reports cancellation', () {
+      final token = ModelDownloadCancelToken();
+
+      expect(token.isCancelled, isFalse);
+      token.cancel();
+      token.cancel();
+
+      expect(token.isCancelled, isTrue);
+    });
+  });
+}

--- a/test/unit/core/models/download/model_cache_entry_test.dart
+++ b/test/unit/core/models/download/model_cache_entry_test.dart
@@ -142,6 +142,28 @@ void main() {
       );
     });
 
+    test('toJson redacts url canonical keys with explicit file names', () {
+      final entry = ModelCacheEntry(
+        sourceCanonicalKey:
+            'url:https://user:secret@host/model.gguf?token=secret\nfileName:model.gguf',
+        cacheKey: 'abc123',
+        fileName: 'model.gguf',
+        filePath: '/cache/model.gguf',
+        createdAt: DateTime.utc(2026, 1, 2),
+        updatedAt: DateTime.utc(2026, 1, 2),
+      );
+
+      final encoded = jsonEncode(entry.toJson());
+
+      expect(encoded, isNot(contains('secret')));
+      expect(encoded, isNot(contains('token=secret')));
+      expect(encoded, isNot(contains('fileName:model.gguf')));
+      expect(
+        entry.sourceCanonicalKey,
+        'url:https://host/model.gguf#cacheKey=abc123',
+      );
+    });
+
     test('normalizes percent-encoded cache file names and paths', () {
       final entry = ModelCacheEntry(
         sourceCanonicalKey: 'path:/models/model.gguf',

--- a/test/unit/core/models/download/model_download_manager_base_test.dart
+++ b/test/unit/core/models/download/model_download_manager_base_test.dart
@@ -1,0 +1,26 @@
+import 'package:llamadart/src/core/models/download/model_download_manager_base.dart';
+import 'package:llamadart/src/core/models/model_source.dart';
+import 'package:test/test.dart';
+
+void main() {
+  group('ThrowingModelDownloadManager', () {
+    test('base placeholder throws for all operations', () async {
+      const manager = _TestDownloadManager();
+      final source = ModelSource.path('/models/model.gguf');
+
+      await expectLater(manager.ensureModel(source), throwsUnsupportedError);
+      await expectLater(manager.list(), throwsUnsupportedError);
+      await expectLater(manager.get('abc123'), throwsUnsupportedError);
+      await expectLater(manager.remove('abc123'), throwsUnsupportedError);
+      await expectLater(manager.clear(), throwsUnsupportedError);
+      await expectLater(manager.prune(), throwsUnsupportedError);
+    });
+  });
+}
+
+class _TestDownloadManager extends ThrowingModelDownloadManager {
+  const _TestDownloadManager();
+
+  @override
+  Object unsupported(String operation) => UnsupportedError(operation);
+}

--- a/test/unit/core/models/download/model_download_manager_io_test.dart
+++ b/test/unit/core/models/download/model_download_manager_io_test.dart
@@ -1,20 +1,517 @@
 @TestOn('vm')
 library;
 
+import 'dart:convert';
+import 'dart:io';
+
+import 'package:crypto/crypto.dart';
 import 'package:llamadart/src/core/exceptions.dart';
 import 'package:llamadart/src/core/models/download/model_download_manager_io.dart';
+import 'package:llamadart/src/core/models/model_load_options.dart';
 import 'package:llamadart/src/core/models/model_source.dart';
+import 'package:path/path.dart' as path;
 import 'package:test/test.dart';
 
 void main() {
-  group('DefaultModelDownloadManager IO placeholder', () {
-    test('throws unsupported exception for ensureModel', () async {
-      const manager = DefaultModelDownloadManager();
+  group('DefaultModelDownloadManager IO', () {
+    late Directory tempDir;
+    late _ModelHttpFixture server;
+
+    setUp(() async {
+      tempDir = await Directory.systemTemp.createTemp(
+        'llamadart_model_cache_test_',
+      );
+      server = await _ModelHttpFixture.start();
+    });
+
+    tearDown(() async {
+      await server.close();
+      if (await tempDir.exists()) {
+        await tempDir.delete(recursive: true);
+      }
+    });
+
+    test(
+      'downloads remote source, writes metadata, reports progress, and reuses cache',
+      () async {
+        server.payload = utf8.encode('model-bytes-v1');
+        final manager = DefaultModelDownloadManager(
+          defaultCacheDirectory: tempDir.path,
+        );
+        final source = ModelSource.url(server.modelUri, fileName: 'tiny.gguf');
+        final progress = <double>[];
+
+        final entry = await manager.ensureModel(
+          source,
+          options: ModelLoadOptions(
+            bearerToken: 'secret-token',
+            headers: const <String, String>{'X-Test-Header': 'present'},
+          ),
+          onProgress: (event) {
+            final fraction = event.fraction;
+            if (fraction != null) {
+              progress.add(fraction);
+            }
+          },
+        );
+
+        expect(server.requestCount, 1);
+        expect(server.lastAuthorization, 'Bearer secret-token');
+        expect(server.lastTestHeader, 'present');
+        expect(File(entry.filePath).readAsBytesSync(), server.payload);
+        expect(entry.bytes, server.payload.length);
+        expect(entry.sha256, sha256.convert(server.payload).toString());
+        expect(entry.sourceCanonicalKey, isNot(contains('secret-token')));
+        expect(progress, isNotEmpty);
+        expect(progress.last, 1);
+        expect(
+          File(
+            path.join(path.dirname(entry.filePath), 'metadata.json'),
+          ).existsSync(),
+          isTrue,
+        );
+
+        server.payload = utf8.encode('model-bytes-v2');
+        final cached = await manager.ensureModel(source);
+
+        expect(
+          server.requestCount,
+          1,
+          reason: 'preferCached should not re-download a completed entry',
+        );
+        expect(cached.filePath, entry.filePath);
+        expect(
+          File(cached.filePath).readAsBytesSync(),
+          utf8.encode('model-bytes-v1'),
+        );
+      },
+    );
+
+    test(
+      'cacheOnly fails on cache miss without touching the network',
+      () async {
+        final manager = DefaultModelDownloadManager(
+          defaultCacheDirectory: tempDir.path,
+        );
+        final source = ModelSource.url(server.modelUri, fileName: 'tiny.gguf');
+
+        await expectLater(
+          manager.ensureModel(
+            source,
+            options: ModelLoadOptions(cachePolicy: ModelCachePolicy.cacheOnly),
+          ),
+          throwsA(isA<LlamaStateException>()),
+        );
+
+        expect(server.requestCount, 0);
+      },
+    );
+
+    test('cacheOnly returns an existing completed cache entry', () async {
+      final manager = DefaultModelDownloadManager(
+        defaultCacheDirectory: tempDir.path,
+      );
+      final source = ModelSource.url(server.modelUri, fileName: 'tiny.gguf');
+
+      server.payload = utf8.encode('cached-model');
+      final first = await manager.ensureModel(source);
+      server.payload = utf8.encode('remote-newer-model');
+
+      final cached = await manager.ensureModel(
+        source,
+        options: ModelLoadOptions(cachePolicy: ModelCachePolicy.cacheOnly),
+      );
+
+      expect(server.requestCount, 1);
+      expect(cached.filePath, first.filePath);
+      expect(File(cached.filePath).readAsStringSync(), 'cached-model');
+    });
+
+    test(
+      'noCache creates transient entries that cache cleanup can remove',
+      () async {
+        final manager = DefaultModelDownloadManager(
+          defaultCacheDirectory: tempDir.path,
+        );
+        final source = ModelSource.url(server.modelUri, fileName: 'tiny.gguf');
+
+        server.payload = utf8.encode('first-transient');
+        final first = await manager.ensureModel(
+          source,
+          options: ModelLoadOptions(cachePolicy: ModelCachePolicy.noCache),
+        );
+        server.payload = utf8.encode('second-transient');
+        final second = await manager.ensureModel(
+          source,
+          options: ModelLoadOptions(cachePolicy: ModelCachePolicy.noCache),
+        );
+
+        expect(server.requestCount, 2);
+        expect(first.filePath, isNot(second.filePath));
+        expect(
+          path.basename(path.dirname(first.filePath)),
+          contains('-nocache-'),
+        );
+        expect(await manager.list(), hasLength(2));
+
+        await manager.clear();
+
+        expect(File(first.filePath).existsSync(), isFalse);
+        expect(File(second.filePath).existsSync(), isFalse);
+        expect(await manager.list(), isEmpty);
+      },
+    );
+
+    test('retries retryable HTTP failures and then succeeds', () async {
+      final manager = DefaultModelDownloadManager(
+        defaultCacheDirectory: tempDir.path,
+      );
+      final source = ModelSource.url(server.modelUri, fileName: 'tiny.gguf');
+      server.failuresBeforeSuccess = 1;
+      server.failureStatusCode = HttpStatus.internalServerError;
+      server.payload = utf8.encode('eventual-model');
+
+      final entry = await manager.ensureModel(
+        source,
+        options: ModelLoadOptions(maxRetries: 1),
+      );
+
+      expect(server.requestCount, 2);
+      expect(File(entry.filePath).readAsStringSync(), 'eventual-model');
+    });
+
+    test('does not retry non-retryable HTTP failures', () async {
+      final manager = DefaultModelDownloadManager(
+        defaultCacheDirectory: tempDir.path,
+      );
+      final source = ModelSource.url(server.modelUri, fileName: 'tiny.gguf');
+      server.failuresBeforeSuccess = 1;
+      server.failureStatusCode = HttpStatus.notFound;
 
       await expectLater(
-        manager.ensureModel(ModelSource.path('/models/model.gguf')),
-        throwsA(isA<LlamaUnsupportedException>()),
+        manager.ensureModel(source, options: ModelLoadOptions(maxRetries: 3)),
+        throwsA(isA<LlamaModelException>()),
+      );
+
+      expect(server.requestCount, 1);
+    });
+
+    test(
+      'refresh re-downloads and replaces the cached file atomically',
+      () async {
+        final manager = DefaultModelDownloadManager(
+          defaultCacheDirectory: tempDir.path,
+        );
+        final source = ModelSource.url(server.modelUri, fileName: 'tiny.gguf');
+
+        server.payload = utf8.encode('old-model');
+        final first = await manager.ensureModel(source);
+        expect(File(first.filePath).readAsStringSync(), 'old-model');
+
+        server.payload = utf8.encode('new-model');
+        final refreshed = await manager.ensureModel(
+          source,
+          options: ModelLoadOptions(cachePolicy: ModelCachePolicy.refresh),
+        );
+
+        expect(server.requestCount, 2);
+        expect(refreshed.filePath, first.filePath);
+        expect(File(refreshed.filePath).readAsStringSync(), 'new-model');
+        expect(path.basename(refreshed.filePath), 'tiny.gguf');
+        expect(
+          Directory(
+            path.dirname(refreshed.filePath),
+          ).listSync().whereType<File>().map((f) => path.basename(f.path)),
+          isNot(contains('tiny.gguf.tmp')),
+        );
+      },
+    );
+
+    test(
+      'failed refresh preserves the previous completed cache entry',
+      () async {
+        final manager = DefaultModelDownloadManager(
+          defaultCacheDirectory: tempDir.path,
+        );
+        final source = ModelSource.url(server.modelUri, fileName: 'tiny.gguf');
+
+        server.payload = utf8.encode('old-model');
+        final first = await manager.ensureModel(source);
+        final metadataFile = File(
+          path.join(path.dirname(first.filePath), 'metadata.json'),
+        );
+        final metadataBefore = metadataFile.readAsStringSync();
+
+        server.payload = utf8.encode('corrupt-new-model');
+        await expectLater(
+          manager.ensureModel(
+            source,
+            options: ModelLoadOptions(
+              cachePolicy: ModelCachePolicy.refresh,
+              sha256: List.filled(64, '0').join(),
+            ),
+          ),
+          throwsA(isA<LlamaModelException>()),
+        );
+
+        expect(File(first.filePath).readAsStringSync(), 'old-model');
+        expect(metadataFile.readAsStringSync(), metadataBefore);
+        expect((await manager.get(source.cacheKey))?.filePath, first.filePath);
+      },
+    );
+
+    test('checksum mismatch removes final file and metadata', () async {
+      final manager = DefaultModelDownloadManager(
+        defaultCacheDirectory: tempDir.path,
+      );
+      final source = ModelSource.url(server.modelUri, fileName: 'tiny.gguf');
+      server.payload = utf8.encode('bad-checksum-content');
+
+      await expectLater(
+        manager.ensureModel(
+          source,
+          options: ModelLoadOptions(sha256: List.filled(64, '0').join()),
+        ),
+        throwsA(isA<LlamaModelException>()),
+      );
+
+      final cacheDir = Directory(
+        path.join(tempDir.path, source.cacheDirectoryName),
+      );
+      expect(File(path.join(cacheDir.path, 'tiny.gguf')).existsSync(), isFalse);
+      expect(
+        File(path.join(cacheDir.path, 'metadata.json')).existsSync(),
+        isFalse,
       );
     });
+
+    test(
+      'resumes a partial download only when the server returns matching 206',
+      () async {
+        final manager = DefaultModelDownloadManager(
+          defaultCacheDirectory: tempDir.path,
+        );
+        final source = ModelSource.url(server.modelUri, fileName: 'tiny.gguf');
+        server.payload = utf8.encode('0123456789');
+        server.supportRanges = true;
+        final cacheDir = Directory(
+          path.join(tempDir.path, source.cacheDirectoryName),
+        )..createSync(recursive: true);
+        File(
+          path.join(cacheDir.path, 'tiny.gguf.part'),
+        ).writeAsStringSync('0123');
+        File(path.join(cacheDir.path, 'tiny.gguf.part.json')).writeAsStringSync(
+          '${jsonEncode(<String, Object?>{'etag': server.etag})}\n',
+        );
+
+        final entry = await manager.ensureModel(source);
+
+        expect(server.lastRange, 'bytes=4-');
+        expect(server.lastIfRange, server.etag);
+        expect(File(entry.filePath).readAsStringSync(), '0123456789');
+      },
+    );
+
+    test(
+      'restarts validator-less partial downloads instead of appending',
+      () async {
+        final manager = DefaultModelDownloadManager(
+          defaultCacheDirectory: tempDir.path,
+        );
+        final source = ModelSource.url(server.modelUri, fileName: 'tiny.gguf');
+        server.payload = utf8.encode('fresh-model');
+        server.supportRanges = true;
+        final cacheDir = Directory(
+          path.join(tempDir.path, source.cacheDirectoryName),
+        )..createSync(recursive: true);
+        File(
+          path.join(cacheDir.path, 'tiny.gguf.part'),
+        ).writeAsStringSync('stale');
+
+        final entry = await manager.ensureModel(source);
+
+        expect(server.lastRange, isNull);
+        expect(File(entry.filePath).readAsStringSync(), 'fresh-model');
+      },
+    );
+
+    test(
+      'restarts from byte zero when a resume request receives HTTP 200',
+      () async {
+        final manager = DefaultModelDownloadManager(
+          defaultCacheDirectory: tempDir.path,
+        );
+        final source = ModelSource.url(server.modelUri, fileName: 'tiny.gguf');
+        server.payload = utf8.encode('fresh-content');
+        server.supportRanges = false;
+        final cacheDir = Directory(
+          path.join(tempDir.path, source.cacheDirectoryName),
+        )..createSync(recursive: true);
+        File(
+          path.join(cacheDir.path, 'tiny.gguf.part'),
+        ).writeAsStringSync('stale-partial');
+        File(path.join(cacheDir.path, 'tiny.gguf.part.json')).writeAsStringSync(
+          '${jsonEncode(<String, Object?>{'etag': server.etag})}\n',
+        );
+
+        final entry = await manager.ensureModel(source);
+
+        expect(server.lastRange, 'bytes=13-');
+        expect(server.lastIfRange, server.etag);
+        expect(File(entry.filePath).readAsStringSync(), 'fresh-content');
+      },
+    );
+
+    test('cancellation leaves no completed cache entry or metadata', () async {
+      final manager = DefaultModelDownloadManager(
+        defaultCacheDirectory: tempDir.path,
+      );
+      final source = ModelSource.url(server.modelUri, fileName: 'tiny.gguf');
+      server.payload = List<int>.generate(64 * 1024, (index) => index % 251);
+      final token = ModelDownloadCancelToken();
+
+      await expectLater(
+        manager.ensureModel(
+          source,
+          options: ModelLoadOptions(cancelToken: token),
+          onProgress: (event) {
+            if (event.receivedBytes > 0) {
+              token.cancel();
+            }
+          },
+        ),
+        throwsA(isA<LlamaStateException>()),
+      );
+
+      final cacheDir = Directory(
+        path.join(tempDir.path, source.cacheDirectoryName),
+      );
+      expect(File(path.join(cacheDir.path, 'tiny.gguf')).existsSync(), isFalse);
+      expect(
+        File(path.join(cacheDir.path, 'metadata.json')).existsSync(),
+        isFalse,
+      );
+    });
+
+    test(
+      'list, get, remove, clear, and prune operate on persisted metadata',
+      () async {
+        final manager = DefaultModelDownloadManager(
+          defaultCacheDirectory: tempDir.path,
+        );
+        server.payload = utf8.encode('first');
+        final firstSource = ModelSource.url(
+          server.modelUri,
+          fileName: 'first.gguf',
+        );
+        final first = await manager.ensureModel(firstSource);
+
+        server.payload = utf8.encode('second');
+        final secondSource = ModelSource.url(
+          server.modelUri.replace(queryParameters: <String, String>{'id': '2'}),
+          fileName: 'second.gguf',
+        );
+        final second = await manager.ensureModel(secondSource);
+
+        expect(
+          (await manager.list()).map((entry) => entry.cacheKey),
+          containsAll(<String>[first.cacheKey, second.cacheKey]),
+        );
+        expect((await manager.get(first.cacheKey))?.fileName, 'first.gguf');
+
+        await manager.remove(first.cacheKey);
+        expect(await manager.get(first.cacheKey), isNull);
+        expect(File(first.filePath).existsSync(), isFalse);
+        expect(await manager.get(second.cacheKey), isNotNull);
+
+        final pruned = await manager.prune(maxBytes: 1);
+        expect(
+          pruned.map((entry) => entry.cacheKey),
+          contains(second.cacheKey),
+        );
+        expect(await manager.list(), isEmpty);
+
+        final third = await manager.ensureModel(
+          firstSource,
+          options: ModelLoadOptions(cachePolicy: ModelCachePolicy.refresh),
+        );
+        expect(File(third.filePath).existsSync(), isTrue);
+        await manager.clear();
+        expect(await manager.list(), isEmpty);
+        expect(
+          Directory(
+            path.join(tempDir.path, firstSource.cacheDirectoryName),
+          ).existsSync(),
+          isFalse,
+        );
+      },
+    );
   });
+}
+
+class _ModelHttpFixture {
+  _ModelHttpFixture._(this._server);
+
+  final HttpServer _server;
+  List<int> payload = utf8.encode('model-bytes');
+  bool supportRanges = false;
+  String? etag = '"fixture-v1"';
+  int failuresBeforeSuccess = 0;
+  int failureStatusCode = HttpStatus.internalServerError;
+  int requestCount = 0;
+  String? lastRange;
+  String? lastIfRange;
+  String? lastAuthorization;
+  String? lastTestHeader;
+
+  Uri get modelUri => Uri.parse(
+    'http://127.0.0.1:${_server.port}/models/tiny.gguf?download=true',
+  );
+
+  static Future<_ModelHttpFixture> start() async {
+    final server = await HttpServer.bind(InternetAddress.loopbackIPv4, 0);
+    final fixture = _ModelHttpFixture._(server);
+    server.listen(fixture._handleRequest);
+    return fixture;
+  }
+
+  Future<void> close() => _server.close(force: true);
+
+  void _handleRequest(HttpRequest request) async {
+    requestCount += 1;
+    lastRange = request.headers.value(HttpHeaders.rangeHeader);
+    lastIfRange = request.headers.value(HttpHeaders.ifRangeHeader);
+    lastAuthorization = request.headers.value(HttpHeaders.authorizationHeader);
+    lastTestHeader = request.headers.value('X-Test-Header');
+
+    final currentEtag = etag;
+    if (currentEtag != null) {
+      request.response.headers.set(HttpHeaders.etagHeader, currentEtag);
+    }
+
+    if (requestCount <= failuresBeforeSuccess) {
+      request.response.statusCode = failureStatusCode;
+      await request.response.close();
+      return;
+    }
+
+    final range = lastRange;
+    if (supportRanges && range != null && range.startsWith('bytes=')) {
+      final startText = range.substring('bytes='.length).split('-').first;
+      final start = int.parse(startText);
+      request.response.statusCode = HttpStatus.partialContent;
+      request.response.headers.set(HttpHeaders.acceptRangesHeader, 'bytes');
+      request.response.headers.set(
+        HttpHeaders.contentRangeHeader,
+        'bytes $start-${payload.length - 1}/${payload.length}',
+      );
+      request.response.headers.contentLength = payload.length - start;
+      request.response.add(payload.sublist(start));
+    } else {
+      request.response.statusCode = HttpStatus.ok;
+      request.response.headers.contentLength = payload.length;
+      request.response.add(payload);
+    }
+    await request.response.close();
+  }
 }

--- a/test/unit/core/models/download/model_download_manager_io_test.dart
+++ b/test/unit/core/models/download/model_download_manager_io_test.dart
@@ -1,0 +1,20 @@
+@TestOn('vm')
+library;
+
+import 'package:llamadart/src/core/exceptions.dart';
+import 'package:llamadart/src/core/models/download/model_download_manager_io.dart';
+import 'package:llamadart/src/core/models/model_source.dart';
+import 'package:test/test.dart';
+
+void main() {
+  group('DefaultModelDownloadManager IO placeholder', () {
+    test('throws unsupported exception for ensureModel', () async {
+      const manager = DefaultModelDownloadManager();
+
+      await expectLater(
+        manager.ensureModel(ModelSource.path('/models/model.gguf')),
+        throwsA(isA<LlamaUnsupportedException>()),
+      );
+    });
+  });
+}

--- a/test/unit/core/models/download/model_download_manager_stub_test.dart
+++ b/test/unit/core/models/download/model_download_manager_stub_test.dart
@@ -1,0 +1,20 @@
+@TestOn('browser')
+library;
+
+import 'package:llamadart/src/core/exceptions.dart';
+import 'package:llamadart/src/core/models/download/model_download_manager_stub.dart';
+import 'package:llamadart/src/core/models/model_source.dart';
+import 'package:test/test.dart';
+
+void main() {
+  group('DefaultModelDownloadManager stub placeholder', () {
+    test('throws unsupported exception for ensureModel', () async {
+      const manager = DefaultModelDownloadManager();
+
+      await expectLater(
+        manager.ensureModel(ModelSource.path('/models/model.gguf')),
+        throwsA(isA<LlamaUnsupportedException>()),
+      );
+    });
+  });
+}

--- a/test/unit/core/models/download/model_download_manager_test.dart
+++ b/test/unit/core/models/download/model_download_manager_test.dart
@@ -1,23 +1,29 @@
+@TestOn('vm')
+library;
+
+import 'dart:io';
+
 import 'package:llamadart/llamadart.dart';
 import 'package:test/test.dart';
 
 void main() {
   group('model_download_manager export', () {
-    test('exports base API and default implementation', () {
-      const manager = DefaultModelDownloadManager();
-
-      expect(manager, isA<ModelDownloadManager>());
-    });
-
-    test('default IO placeholder throws LlamaUnsupportedException', () async {
-      const manager = DefaultModelDownloadManager();
-
-      await expectLater(
-        () => manager.ensureModel(
-          ModelSource.url(Uri.parse('https://host/model.gguf')),
-        ),
-        throwsA(isA<LlamaUnsupportedException>()),
+    test('exports base API and default IO implementation', () async {
+      final tempDir = await Directory.systemTemp.createTemp(
+        'llamadart_model_manager_export_test_',
       );
+      try {
+        final manager = DefaultModelDownloadManager(
+          defaultCacheDirectory: tempDir.path,
+        );
+
+        expect(manager, isA<ModelDownloadManager>());
+        expect(await manager.list(), isEmpty);
+      } finally {
+        if (await tempDir.exists()) {
+          await tempDir.delete(recursive: true);
+        }
+      }
     });
   });
 }

--- a/test/unit/core/models/download/model_download_manager_test.dart
+++ b/test/unit/core/models/download/model_download_manager_test.dart
@@ -1,0 +1,23 @@
+import 'package:llamadart/llamadart.dart';
+import 'package:test/test.dart';
+
+void main() {
+  group('model_download_manager export', () {
+    test('exports base API and default implementation', () {
+      const manager = DefaultModelDownloadManager();
+
+      expect(manager, isA<ModelDownloadManager>());
+    });
+
+    test('default IO placeholder throws LlamaUnsupportedException', () async {
+      const manager = DefaultModelDownloadManager();
+
+      await expectLater(
+        () => manager.ensureModel(
+          ModelSource.url(Uri.parse('https://host/model.gguf')),
+        ),
+        throwsA(isA<LlamaUnsupportedException>()),
+      );
+    });
+  });
+}

--- a/test/unit/core/models/model_load_options_test.dart
+++ b/test/unit/core/models/model_load_options_test.dart
@@ -1,0 +1,45 @@
+import 'package:llamadart/llamadart.dart';
+import 'package:test/test.dart';
+
+void main() {
+  group('ModelLoadOptions', () {
+    test('stores all supplied values', () {
+      final token = ModelDownloadCancelToken();
+      final options = ModelLoadOptions(
+        cachePolicy: ModelCachePolicy.refresh,
+        cacheDirectory: '/cache',
+        sha256: 'abc123',
+        bearerToken: 'token',
+        headers: const <String, String>{'x-test': 'true'},
+        cancelToken: token,
+        resume: false,
+        maxRetries: 7,
+      );
+
+      expect(options.cachePolicy, ModelCachePolicy.refresh);
+      expect(options.cacheDirectory, '/cache');
+      expect(options.sha256, 'abc123');
+      expect(options.bearerToken, 'token');
+      expect(options.headers, const <String, String>{'x-test': 'true'});
+      expect(options.cancelToken, same(token));
+      expect(options.resume, isFalse);
+      expect(options.maxRetries, 7);
+    });
+
+    test('headers are immutable and copied from supplied map', () {
+      final headers = <String, String>{'authorization': 'Bearer test'};
+      final options = ModelLoadOptions(headers: headers);
+
+      headers['authorization'] = 'Bearer changed';
+
+      expect(options.headers, const <String, String>{
+        'authorization': 'Bearer test',
+      });
+      expect(() => options.headers['x-new'] = 'value', throwsUnsupportedError);
+    });
+
+    test('rejects negative maxRetries', () {
+      expect(() => ModelLoadOptions(maxRetries: -1), throwsArgumentError);
+    });
+  });
+}

--- a/test/unit/core/models/model_load_options_test.dart
+++ b/test/unit/core/models/model_load_options_test.dart
@@ -5,10 +5,11 @@ void main() {
   group('ModelLoadOptions', () {
     test('stores all supplied values', () {
       final token = ModelDownloadCancelToken();
+      final checksum = List.filled(64, 'A').join();
       final options = ModelLoadOptions(
         cachePolicy: ModelCachePolicy.refresh,
         cacheDirectory: '/cache',
-        sha256: 'abc123',
+        sha256: checksum,
         bearerToken: 'token',
         headers: const <String, String>{'x-test': 'true'},
         cancelToken: token,
@@ -18,7 +19,7 @@ void main() {
 
       expect(options.cachePolicy, ModelCachePolicy.refresh);
       expect(options.cacheDirectory, '/cache');
-      expect(options.sha256, 'abc123');
+      expect(options.sha256, List.filled(64, 'a').join());
       expect(options.bearerToken, 'token');
       expect(options.headers, const <String, String>{'x-test': 'true'});
       expect(options.cancelToken, same(token));
@@ -40,6 +41,18 @@ void main() {
 
     test('rejects negative maxRetries', () {
       expect(() => ModelLoadOptions(maxRetries: -1), throwsArgumentError);
+    });
+
+    test('validates sha256 format', () {
+      expect(() => ModelLoadOptions(sha256: 'abc123'), throwsArgumentError);
+      expect(
+        () => ModelLoadOptions(sha256: List.filled(64, 'g').join()),
+        throwsArgumentError,
+      );
+      expect(
+        () => ModelLoadOptions(sha256: List.filled(63, 'a').join()),
+        throwsArgumentError,
+      );
     });
   });
 }

--- a/test/unit/core/models/model_resolver_test.dart
+++ b/test/unit/core/models/model_resolver_test.dart
@@ -71,7 +71,7 @@ void main() {
               cachePolicy: ModelCachePolicy.refresh,
               bearerToken: 'token',
               headers: const <String, String>{'x-token': 'token'},
-              sha256: 'abc123',
+              sha256: List.filled(64, 'a').join(),
               cacheDirectory: '/tmp/cache',
               resume: false,
               maxRetries: 0,

--- a/test/unit/core/models/model_resolver_test.dart
+++ b/test/unit/core/models/model_resolver_test.dart
@@ -1,0 +1,98 @@
+import 'package:llamadart/llamadart.dart';
+import 'package:test/test.dart';
+
+void main() {
+  group('model resolver value models', () {
+    test('LocalModelFile exposes path for engine/backend dispatch', () {
+      const target = LocalModelFile('/models/model.gguf');
+
+      expect(target.path, '/models/model.gguf');
+      expect(target.isLocal, isTrue);
+      expect(target.isRemote, isFalse);
+    });
+
+    test('RemoteModelUrl exposes URL for engine/backend dispatch', () {
+      final url = Uri.parse('https://host/model.gguf');
+      final target = RemoteModelUrl(url, useBrowserCache: false);
+
+      expect(target.url, url);
+      expect(target.useBrowserCache, isFalse);
+      expect(target.isLocal, isFalse);
+      expect(target.isRemote, isTrue);
+    });
+
+    test('ModelLoadOptions defaults prefer cached policy', () {
+      final options = ModelLoadOptions.defaults;
+
+      expect(options.cachePolicy, ModelCachePolicy.preferCached);
+      expect(options.headers, isEmpty);
+      expect(options.resume, isTrue);
+      expect(options.maxRetries, 3);
+    });
+
+    test(
+      'DefaultModelResolver resolves local paths to local file targets',
+      () async {
+        const resolver = DefaultModelResolver();
+        final target = await resolver.resolve(
+          ModelSource.path('/models/model.gguf'),
+          const ModelResolveRequest(options: ModelLoadOptions.defaults),
+        );
+
+        expect(target, isA<LocalModelFile>());
+        expect((target as LocalModelFile).path, '/models/model.gguf');
+      },
+    );
+
+    test('DefaultModelResolver throws LlamaStateException when cancelled', () {
+      const resolver = DefaultModelResolver();
+      final cancelToken = ModelDownloadCancelToken()..cancel();
+
+      expect(
+        () => resolver.resolve(
+          ModelSource.url(Uri.parse('https://host/model.gguf')),
+          ModelResolveRequest(
+            options: ModelLoadOptions(cancelToken: cancelToken),
+          ),
+        ),
+        throwsA(isA<LlamaStateException>()),
+      );
+    });
+
+    test(
+      'DefaultModelResolver rejects unsupported foundation options for local and remote sources',
+      () {
+        const resolver = DefaultModelResolver();
+        final sources = <ModelSource>[
+          ModelSource.path('/models/model.gguf'),
+          ModelSource.url(Uri.parse('https://host/model.gguf')),
+        ];
+
+        for (final source in sources) {
+          for (final options in <ModelLoadOptions>[
+            ModelLoadOptions(cachePolicy: ModelCachePolicy.refresh),
+            ModelLoadOptions(cachePolicy: ModelCachePolicy.cacheOnly),
+            ModelLoadOptions(cachePolicy: ModelCachePolicy.noCache),
+            ModelLoadOptions(bearerToken: 'token'),
+            ModelLoadOptions(
+              headers: const <String, String>{'x-token': 'token'},
+            ),
+            ModelLoadOptions(sha256: 'abc123'),
+            ModelLoadOptions(cacheDirectory: '/tmp/cache'),
+            ModelLoadOptions(resume: false),
+            ModelLoadOptions(maxRetries: 0),
+          ]) {
+            expect(
+              () => resolver.resolve(
+                source,
+                ModelResolveRequest(options: options),
+              ),
+              throwsA(isA<LlamaUnsupportedException>()),
+              reason: '${source.metadataSourceKey} with $options',
+            );
+          }
+        }
+      },
+    );
+  });
+}

--- a/test/unit/core/models/model_resolver_test.dart
+++ b/test/unit/core/models/model_resolver_test.dart
@@ -60,38 +60,27 @@ void main() {
     });
 
     test(
-      'DefaultModelResolver rejects unsupported foundation options for local and remote sources',
-      () {
+      'DefaultModelResolver leaves download/cache options for engine or manager',
+      () async {
         const resolver = DefaultModelResolver();
-        final sources = <ModelSource>[
-          ModelSource.path('/models/model.gguf'),
-          ModelSource.url(Uri.parse('https://host/model.gguf')),
-        ];
-
-        for (final source in sources) {
-          for (final options in <ModelLoadOptions>[
-            ModelLoadOptions(cachePolicy: ModelCachePolicy.refresh),
-            ModelLoadOptions(cachePolicy: ModelCachePolicy.cacheOnly),
-            ModelLoadOptions(cachePolicy: ModelCachePolicy.noCache),
-            ModelLoadOptions(bearerToken: 'token'),
-            ModelLoadOptions(
+        final source = ModelSource.url(Uri.parse('https://host/model.gguf'));
+        final target = await resolver.resolve(
+          source,
+          ModelResolveRequest(
+            options: ModelLoadOptions(
+              cachePolicy: ModelCachePolicy.refresh,
+              bearerToken: 'token',
               headers: const <String, String>{'x-token': 'token'},
+              sha256: 'abc123',
+              cacheDirectory: '/tmp/cache',
+              resume: false,
+              maxRetries: 0,
             ),
-            ModelLoadOptions(sha256: 'abc123'),
-            ModelLoadOptions(cacheDirectory: '/tmp/cache'),
-            ModelLoadOptions(resume: false),
-            ModelLoadOptions(maxRetries: 0),
-          ]) {
-            expect(
-              () => resolver.resolve(
-                source,
-                ModelResolveRequest(options: options),
-              ),
-              throwsA(isA<LlamaUnsupportedException>()),
-              reason: '${source.metadataSourceKey} with $options',
-            );
-          }
-        }
+          ),
+        );
+
+        expect(target, isA<RemoteModelUrl>());
+        expect((target as RemoteModelUrl).url, source.resolvedUri);
       },
     );
   });

--- a/test/unit/core/models/model_source_test.dart
+++ b/test/unit/core/models/model_source_test.dart
@@ -1,0 +1,203 @@
+import 'package:llamadart/llamadart.dart';
+import 'package:test/test.dart';
+
+void main() {
+  group('ModelSource', () {
+    test('path remains local and does not attempt network resolution', () {
+      final source = ModelSource.path('/local/model.gguf');
+
+      expect(source.kind, ModelSourceKind.path);
+      expect(source.isLocal, isTrue);
+      expect(source.isRemote, isFalse);
+      expect(source.path, '/local/model.gguf');
+      expect(source.resolvedUri, isNull);
+      expect(source.fileName, 'model.gguf');
+      expect(source.canonicalKey, 'path:/local/model.gguf');
+    });
+
+    test('https URI resolves as HTTP with inferred file name', () {
+      final source = ModelSource.url(
+        Uri.parse('https://host/path/model.gguf?download=true'),
+      );
+
+      expect(source.kind, ModelSourceKind.http);
+      expect(source.isRemote, isTrue);
+      expect(
+        source.resolvedUri,
+        Uri.parse('https://host/path/model.gguf?download=true'),
+      );
+      expect(source.fileName, 'model.gguf');
+      expect(source.canonicalKey, 'https://host/path/model.gguf?download=true');
+      expect(source.metadataSourceKey, isNot(contains('download=true')));
+      expect(source.toString(), isNot(contains('download=true')));
+    });
+
+    test('http URLs require an authority and host', () {
+      expect(
+        () => ModelSource.url(Uri.parse('https:model.gguf')),
+        throwsArgumentError,
+      );
+      expect(() => ModelSource.parse('https:model.gguf'), throwsArgumentError);
+    });
+
+    test('remote explicit file names reject traversal and separators', () {
+      final invalidNames = <String>[
+        '',
+        '.',
+        '..',
+        '../x.gguf',
+        'dir/x.gguf',
+        r'dir\x.gguf',
+        '/x.gguf',
+        r'\x.gguf',
+        '%2e',
+        '%2e%2e',
+        '..%2Fx.gguf',
+        'dir%2Fx.gguf',
+        r'dir%5Cx.gguf',
+      ];
+
+      for (final fileName in invalidNames) {
+        expect(
+          () => ModelSource.url(
+            Uri.parse('https://host/model.gguf'),
+            fileName: fileName,
+          ),
+          throwsArgumentError,
+          reason: 'url fileName=$fileName',
+        );
+        expect(
+          () => ModelSource.huggingFace(
+            repoId: 'owner/repo',
+            filePath: 'model.gguf',
+            fileName: fileName,
+          ),
+          throwsArgumentError,
+          reason: 'hf fileName=$fileName',
+        );
+      }
+    });
+
+    test('inferred URL file names reject encoded traversal and separators', () {
+      final invalidUrls = <String>[
+        'https://host/',
+        'https://host/.',
+        'https://host/..',
+        'https://host/%2e',
+        'https://host/%2e%2e',
+        'https://host/dir%2Fx.gguf',
+        'https://host/dir%5Cx.gguf',
+        'https://host/%2e%2e%2Fx.gguf',
+      ];
+
+      for (final value in invalidUrls) {
+        expect(
+          () => ModelSource.url(Uri.parse(value)),
+          throwsArgumentError,
+          reason: value,
+        );
+      }
+    });
+
+    test('hf URI resolves to Hugging Face main download URL', () {
+      final source = ModelSource.parse(
+        'hf://unsloth/Qwen3.5-0.8B-GGUF/Qwen3.5-0.8B-Q4_K_M.gguf',
+      );
+
+      expect(source.kind, ModelSourceKind.huggingFace);
+      expect(source.repoId, 'unsloth/Qwen3.5-0.8B-GGUF');
+      expect(source.revision, 'main');
+      expect(source.filePath, 'Qwen3.5-0.8B-Q4_K_M.gguf');
+      expect(
+        source.resolvedUri,
+        Uri.parse(
+          'https://huggingface.co/unsloth/Qwen3.5-0.8B-GGUF/resolve/main/Qwen3.5-0.8B-Q4_K_M.gguf?download=true',
+        ),
+      );
+      expect(source.fileName, 'Qwen3.5-0.8B-Q4_K_M.gguf');
+      expect(
+        source.canonicalKey,
+        'hf://unsloth/Qwen3.5-0.8B-GGUF@main/Qwen3.5-0.8B-Q4_K_M.gguf',
+      );
+    });
+
+    test('hf URI resolves explicit revision and nested file path', () {
+      final source = ModelSource.parse(
+        'hf://owner/repo@rev/sub/dir/model.gguf',
+      );
+
+      expect(source.repoId, 'owner/repo');
+      expect(source.revision, 'rev');
+      expect(source.filePath, 'sub/dir/model.gguf');
+      expect(
+        source.resolvedUri,
+        Uri.parse(
+          'https://huggingface.co/owner/repo/resolve/rev/sub/dir/model.gguf?download=true',
+        ),
+      );
+      expect(source.fileName, 'model.gguf');
+      expect(source.canonicalKey, 'hf://owner/repo@rev/sub/dir/model.gguf');
+    });
+
+    test('parse accepts local paths as explicit convenience', () {
+      final source = ModelSource.parse('/local/model.gguf');
+
+      expect(source.kind, ModelSourceKind.path);
+      expect(source.path, '/local/model.gguf');
+      expect(source.resolvedUri, isNull);
+    });
+
+    test('parse rejects invalid schemes', () {
+      expect(
+        () => ModelSource.parse('ftp://host/model.gguf'),
+        throwsArgumentError,
+      );
+    });
+
+    test('rejects invalid Hugging Face references', () {
+      final invalidValues = <String>[
+        'hf://owner/repo',
+        'hf://owner',
+        'hf://owner//model.gguf',
+        'hf://owner/repo/../model.gguf',
+        'hf://owner/repo//absolute.gguf',
+        'hf://owner/repo/%2e%2e/model.gguf',
+        'hf://owner/repo/sub/%2E%2E/model.gguf',
+        'hf://owner/repo/dir%2Fx.gguf',
+        r'hf://owner/repo/dir%5Cx.gguf',
+      ];
+
+      for (final value in invalidValues) {
+        expect(
+          () => ModelSource.parse(value),
+          throwsArgumentError,
+          reason: value,
+        );
+      }
+    });
+
+    test('canonical sources produce stable deterministic cache keys', () {
+      final source = ModelSource.huggingFace(
+        repoId: 'owner/repo',
+        filePath: 'sub/model.gguf',
+      );
+      final equivalent = ModelSource.parse('hf://owner/repo/sub/model.gguf');
+      final differentRevision = ModelSource.parse(
+        'hf://owner/repo@other/sub/model.gguf',
+      );
+      final differentPath = ModelSource.parse('hf://owner/repo/other.gguf');
+
+      expect(source.canonicalKey, equivalent.canonicalKey);
+      expect(source.cacheKey, equivalent.cacheKey);
+      expect(source.cacheDirectoryName, equivalent.cacheDirectoryName);
+      expect(source.cacheKey, hasLength(64));
+      expect(source.cacheDirectoryName, startsWith('model-'));
+      expect(
+        source.cacheDirectoryName,
+        contains(source.cacheKey.substring(0, 12)),
+      );
+      expect(source.cacheKey, isNot(differentRevision.cacheKey));
+      expect(source.cacheKey, isNot(differentPath.cacheKey));
+    });
+  });
+}

--- a/test/unit/core/models/model_source_test.dart
+++ b/test/unit/core/models/model_source_test.dart
@@ -232,5 +232,24 @@ void main() {
       expect(source.cacheKey, isNot(differentRevision.cacheKey));
       expect(source.cacheKey, isNot(differentPath.cacheKey));
     });
+
+    test('resolved URI preserves canonical cache identity', () {
+      final source = ModelSource.huggingFace(
+        repoId: 'owner/repo',
+        filePath: 'sub/model.gguf',
+      );
+      final resolved = source.withResolvedUri(
+        Uri.parse('https://cdn.example.com/model.gguf?token=secret'),
+      );
+
+      expect(
+        resolved.resolvedUri,
+        Uri.parse('https://cdn.example.com/model.gguf?token=secret'),
+      );
+      expect(resolved.fileName, source.fileName);
+      expect(resolved.canonicalKey, source.canonicalKey);
+      expect(resolved.cacheKey, source.cacheKey);
+      expect(resolved.cacheDirectoryName, source.cacheDirectoryName);
+    });
   });
 }

--- a/test/unit/core/models/model_source_test.dart
+++ b/test/unit/core/models/model_source_test.dart
@@ -32,6 +32,25 @@ void main() {
       expect(source.toString(), isNot(contains('download=true')));
     });
 
+    test(
+      'explicit URL file names are decoded and included in cache identity',
+      () {
+        final first = ModelSource.url(
+          Uri.parse('https://host/path/model.gguf?download=true'),
+          fileName: 'model%2Egguf',
+        );
+        final second = ModelSource.url(
+          Uri.parse('https://host/path/model.gguf?download=true'),
+          fileName: 'renamed.gguf',
+        );
+
+        expect(first.fileName, 'model.gguf');
+        expect(first.canonicalKey, contains('fileName:model.gguf'));
+        expect(second.canonicalKey, contains('fileName:renamed.gguf'));
+        expect(first.cacheKey, isNot(second.cacheKey));
+      },
+    );
+
     test('http URLs require an authority and host', () {
       expect(
         () => ModelSource.url(Uri.parse('https:model.gguf')),

--- a/test/unit/core/models/model_source_test.dart
+++ b/test/unit/core/models/model_source_test.dart
@@ -66,14 +66,22 @@ void main() {
         '..',
         '../x.gguf',
         'dir/x.gguf',
-        r'dir\x.gguf',
+        r'dir\\x.gguf',
         '/x.gguf',
-        r'\x.gguf',
+        r'\\x.gguf',
         '%2e',
         '%2e%2e',
         '..%2Fx.gguf',
         'dir%2Fx.gguf',
         r'dir%5Cx.gguf',
+        'bad<name.gguf',
+        'bad>name.gguf',
+        'bad:name.gguf',
+        'bad%22name.gguf',
+        'bad|name.gguf',
+        'bad?name.gguf',
+        'bad*name.gguf',
+        'bad%00name.gguf',
       ];
 
       for (final fileName in invalidNames) {
@@ -107,6 +115,10 @@ void main() {
         'https://host/dir%2Fx.gguf',
         'https://host/dir%5Cx.gguf',
         'https://host/%2e%2e%2Fx.gguf',
+        'https://host/bad:name.gguf',
+        'https://host/bad%22name.gguf',
+        'https://host/bad%7Cname.gguf',
+        'https://host/bad*name.gguf',
       ];
 
       for (final value in invalidUrls) {

--- a/test/unit/core/models/model_source_test.dart
+++ b/test/unit/core/models/model_source_test.dart
@@ -165,6 +165,8 @@ void main() {
         'hf://owner/repo/sub/%2E%2E/model.gguf',
         'hf://owner/repo/dir%2Fx.gguf',
         r'hf://owner/repo/dir%5Cx.gguf',
+        'hf://owner/repo/bad%/model.gguf',
+        'hf://owner/repo/bad%ZZ/model.gguf',
       ];
 
       for (final value in invalidValues) {

--- a/test/unit/platform/io/model_download_manager_io_test.dart
+++ b/test/unit/platform/io/model_download_manager_io_test.dart
@@ -127,6 +127,60 @@ void main() {
       expect(File(cached.filePath).readAsStringSync(), 'cached-model');
     });
 
+    test('management APIs can target the per-call cache directory', () async {
+      final manager = DefaultModelDownloadManager(
+        defaultCacheDirectory: tempDir.path,
+      );
+      final customCacheDirectory = path.join(tempDir.path, 'custom-cache');
+      server.payload = utf8.encode('custom-cache-model');
+      final source = ModelSource.url(server.modelUri, fileName: 'tiny.gguf');
+
+      final entry = await manager.ensureModel(
+        source,
+        options: ModelLoadOptions(cacheDirectory: customCacheDirectory),
+      );
+
+      expect(await manager.list(), isEmpty);
+      expect(
+        await manager.list(cacheDirectory: customCacheDirectory),
+        hasLength(1),
+      );
+      expect(
+        await manager.get(
+          source.cacheKey,
+          cacheDirectory: customCacheDirectory,
+        ),
+        isNotNull,
+      );
+      expect(File(entry.filePath).existsSync(), isTrue);
+
+      final pruned = await manager.prune(
+        maxBytes: 0,
+        cacheDirectory: customCacheDirectory,
+      );
+      expect(pruned.single.cacheKey, source.cacheKey);
+      expect(File(entry.filePath).existsSync(), isFalse);
+
+      final refreshed = await manager.ensureModel(
+        source,
+        options: ModelLoadOptions(cacheDirectory: customCacheDirectory),
+      );
+      expect(File(refreshed.filePath).existsSync(), isTrue);
+
+      await manager.remove(
+        source.cacheKey,
+        cacheDirectory: customCacheDirectory,
+      );
+      expect(await manager.list(cacheDirectory: customCacheDirectory), isEmpty);
+
+      await manager.ensureModel(
+        source,
+        options: ModelLoadOptions(cacheDirectory: customCacheDirectory),
+      );
+      await manager.clear(cacheDirectory: customCacheDirectory);
+      expect(await manager.list(cacheDirectory: customCacheDirectory), isEmpty);
+    });
+
     test('stores sha256 metadata only when checksum is requested', () async {
       final manager = DefaultModelDownloadManager(
         defaultCacheDirectory: tempDir.path,

--- a/test/unit/platform/io/model_download_manager_io_test.dart
+++ b/test/unit/platform/io/model_download_manager_io_test.dart
@@ -402,6 +402,42 @@ void main() {
       },
     );
 
+    test('failed noCache download removes transient cache directory', () async {
+      final manager = DefaultModelDownloadManager(
+        defaultCacheDirectory: tempDir.path,
+      );
+      final source = ModelSource.url(server.modelUri, fileName: 'tiny.gguf');
+      server.failuresBeforeSuccess = 1;
+      server.failureStatusCode = HttpStatus.badRequest;
+
+      await expectLater(
+        manager.ensureModel(
+          source,
+          options: ModelLoadOptions(cachePolicy: ModelCachePolicy.noCache),
+        ),
+        throwsA(isA<LlamaModelException>()),
+      );
+
+      expect(
+        tempDir.listSync().whereType<Directory>().where(
+          (dir) => path
+              .basename(dir.path)
+              .startsWith('${source.cacheDirectoryName}-nocache-'),
+        ),
+        isEmpty,
+      );
+    });
+
+    test('prune on missing cache root returns empty list', () async {
+      final manager = DefaultModelDownloadManager(
+        defaultCacheDirectory: path.join(tempDir.path, 'missing-cache-root'),
+      );
+
+      final removed = await manager.prune(maxBytes: 1);
+
+      expect(removed, isEmpty);
+    });
+
     test(
       'get finds newest matching cache entry without full metadata scan',
       () async {

--- a/test/unit/platform/io/model_download_manager_io_test.dart
+++ b/test/unit/platform/io/model_download_manager_io_test.dart
@@ -6,7 +6,7 @@ import 'dart:io';
 
 import 'package:crypto/crypto.dart';
 import 'package:llamadart/src/core/exceptions.dart';
-import 'package:llamadart/src/core/models/download/model_download_manager_io.dart';
+import 'package:llamadart/src/platform/io/model_download_manager_io.dart';
 import 'package:llamadart/src/core/models/model_load_options.dart';
 import 'package:llamadart/src/core/models/model_source.dart';
 import 'package:path/path.dart' as path;

--- a/test/unit/platform/io/model_download_manager_io_test.dart
+++ b/test/unit/platform/io/model_download_manager_io_test.dart
@@ -154,7 +154,7 @@ void main() {
         );
         expect(await manager.list(), hasLength(2));
 
-        await manager.clear();
+        await manager.remove(source.cacheKey);
 
         expect(File(first.filePath).existsSync(), isFalse);
         expect(File(second.filePath).existsSync(), isFalse);
@@ -423,6 +423,17 @@ void main() {
         expect(await manager.get(first.cacheKey), isNull);
         expect(File(first.filePath).existsSync(), isFalse);
         expect(await manager.get(second.cacheKey), isNotNull);
+
+        final secondMetadataFile = File(
+          path.join(path.dirname(second.filePath), 'metadata.json'),
+        );
+        final secondMetadata = Map<String, Object?>.from(
+          jsonDecode(secondMetadataFile.readAsStringSync()) as Map,
+        );
+        secondMetadata.remove('bytes');
+        secondMetadataFile.writeAsStringSync(
+          '${const JsonEncoder.withIndent('  ').convert(secondMetadata)}\n',
+        );
 
         final pruned = await manager.prune(maxBytes: 1);
         expect(

--- a/test/unit/platform/io/model_download_manager_io_test.dart
+++ b/test/unit/platform/io/model_download_manager_io_test.dart
@@ -216,6 +216,26 @@ void main() {
       },
     );
 
+    test(
+      'remove deletes matching cache directories even when cached file is missing',
+      () async {
+        final manager = DefaultModelDownloadManager(
+          defaultCacheDirectory: tempDir.path,
+        );
+        server.payload = utf8.encode('cached-model');
+        final source = ModelSource.url(server.modelUri, fileName: 'tiny.gguf');
+        final entry = await manager.ensureModel(source);
+        final cacheEntryDirectory = Directory(path.dirname(entry.filePath));
+
+        await File(entry.filePath).delete();
+
+        expect(await manager.list(), isEmpty);
+        await manager.remove(source.cacheKey);
+
+        expect(cacheEntryDirectory.existsSync(), isFalse);
+      },
+    );
+
     test('stores sha256 metadata only when checksum is requested', () async {
       final manager = DefaultModelDownloadManager(
         defaultCacheDirectory: tempDir.path,

--- a/test/unit/platform/io/model_download_manager_io_test.dart
+++ b/test/unit/platform/io/model_download_manager_io_test.dart
@@ -157,6 +157,36 @@ void main() {
       expect(File(cached.filePath).readAsStringSync(), 'cached-model');
     });
 
+    test('cache hit rejects metadata for a different source', () async {
+      final manager = DefaultModelDownloadManager(
+        defaultCacheDirectory: tempDir.path,
+      );
+      final source = ModelSource.url(server.modelUri, fileName: 'tiny.gguf');
+      final otherSource = ModelSource.url(
+        server.modelUri.replace(queryParameters: const {'variant': 'other'}),
+        fileName: 'other.gguf',
+      );
+
+      server.payload = utf8.encode('cached-model');
+      final first = await manager.ensureModel(source);
+      final metadataFile = File(
+        path.join(path.dirname(first.filePath), 'metadata.json'),
+      );
+      final metadata =
+          jsonDecode(metadataFile.readAsStringSync()) as Map<String, dynamic>;
+      metadata['cache_key'] = otherSource.cacheKey;
+      metadata['file_name'] = otherSource.fileName;
+      metadataFile.writeAsStringSync(jsonEncode(metadata));
+
+      server.payload = utf8.encode('fresh-model');
+      final refreshed = await manager.ensureModel(source);
+
+      expect(server.requestCount, 2);
+      expect(refreshed.cacheKey, source.cacheKey);
+      expect(refreshed.fileName, source.fileName);
+      expect(File(refreshed.filePath).readAsStringSync(), 'fresh-model');
+    });
+
     test('management APIs can target the per-call cache directory', () async {
       final manager = DefaultModelDownloadManager(
         defaultCacheDirectory: tempDir.path,

--- a/test/unit/platform/io/model_download_manager_io_test.dart
+++ b/test/unit/platform/io/model_download_manager_io_test.dart
@@ -181,6 +181,41 @@ void main() {
       expect(await manager.list(cacheDirectory: customCacheDirectory), isEmpty);
     });
 
+    test(
+      'ignores metadata whose file path points outside its cache entry',
+      () async {
+        final manager = DefaultModelDownloadManager(
+          defaultCacheDirectory: tempDir.path,
+        );
+        server.payload = utf8.encode('cached-model');
+        final source = ModelSource.url(server.modelUri, fileName: 'tiny.gguf');
+        final entry = await manager.ensureModel(source);
+        final metadataFile = File(
+          path.join(path.dirname(entry.filePath), 'metadata.json'),
+        );
+        final outsideDir = await Directory.systemTemp.createTemp(
+          'llamadart_outside_cache_',
+        );
+        addTearDown(() async {
+          if (await outsideDir.exists()) {
+            await outsideDir.delete(recursive: true);
+          }
+        });
+        final outsideFile = File(path.join(outsideDir.path, 'outside.gguf'))
+          ..writeAsStringSync('outside');
+        final metadata =
+            jsonDecode(metadataFile.readAsStringSync()) as Map<String, dynamic>;
+        metadata['file_path'] = outsideFile.path;
+        metadataFile.writeAsStringSync(jsonEncode(metadata));
+
+        expect(await manager.list(), isEmpty);
+
+        await manager.remove(source.cacheKey);
+
+        expect(outsideFile.existsSync(), isTrue);
+      },
+    );
+
     test('stores sha256 metadata only when checksum is requested', () async {
       final manager = DefaultModelDownloadManager(
         defaultCacheDirectory: tempDir.path,

--- a/test/unit/platform/io/model_download_manager_io_test.dart
+++ b/test/unit/platform/io/model_download_manager_io_test.dart
@@ -149,6 +149,60 @@ void main() {
       );
     });
 
+    test('cache hit with sha256 verifies and persists the digest', () async {
+      final manager = DefaultModelDownloadManager(
+        defaultCacheDirectory: tempDir.path,
+      );
+      server.payload = utf8.encode('cached-checksum-model');
+      final source = ModelSource.url(server.modelUri, fileName: 'tiny.gguf');
+      final first = await manager.ensureModel(source);
+      final expectedSha256 = sha256.convert(server.payload).toString();
+
+      expect(first.sha256, isNull);
+
+      final verified = await manager.ensureModel(
+        source,
+        options: ModelLoadOptions(sha256: expectedSha256),
+      );
+
+      expect(server.requestCount, 1);
+      expect(verified.filePath, first.filePath);
+      expect(verified.sha256, expectedSha256);
+      expect(
+        File(
+          path.join(path.dirname(verified.filePath), 'metadata.json'),
+        ).readAsStringSync(),
+        contains(expectedSha256),
+      );
+    });
+
+    test('local path sha256 is verified before metadata is returned', () async {
+      final manager = DefaultModelDownloadManager(
+        defaultCacheDirectory: tempDir.path,
+      );
+      final localFile = File(path.join(tempDir.path, 'local-model.gguf'))
+        ..writeAsStringSync('local-model');
+      final expectedSha256 = sha256
+          .convert(utf8.encode('local-model'))
+          .toString();
+
+      final entry = await manager.ensureModel(
+        ModelSource.path(localFile.path),
+        options: ModelLoadOptions(sha256: expectedSha256),
+      );
+
+      expect(entry.filePath, localFile.path);
+      expect(entry.sha256, expectedSha256);
+
+      await expectLater(
+        manager.ensureModel(
+          ModelSource.path(localFile.path),
+          options: ModelLoadOptions(sha256: List.filled(64, '0').join()),
+        ),
+        throwsA(isA<LlamaModelException>()),
+      );
+    });
+
     test('missing local path errors include the full path', () async {
       final manager = DefaultModelDownloadManager(
         defaultCacheDirectory: tempDir.path,

--- a/test/unit/platform/io/model_download_manager_io_test.dart
+++ b/test/unit/platform/io/model_download_manager_io_test.dart
@@ -367,6 +367,25 @@ void main() {
       );
     });
 
+    test('local directory path fails with a clear file error', () async {
+      final manager = DefaultModelDownloadManager(
+        defaultCacheDirectory: tempDir.path,
+      );
+      final directory = Directory(path.join(tempDir.path, 'model-dir'))
+        ..createSync();
+
+      await expectLater(
+        manager.ensureModel(ModelSource.path(directory.path)),
+        throwsA(
+          isA<LlamaModelException>().having(
+            (error) => error.message,
+            'message',
+            allOf(contains('not a file'), contains(directory.path)),
+          ),
+        ),
+      );
+    });
+
     test(
       'noCache creates transient entries that cache cleanup can remove',
       () async {

--- a/test/unit/platform/io/model_download_manager_io_test.dart
+++ b/test/unit/platform/io/model_download_manager_io_test.dart
@@ -181,6 +181,23 @@ void main() {
       expect(await manager.list(cacheDirectory: customCacheDirectory), isEmpty);
     });
 
+    test('prune removes stale metadata entries with missing files', () async {
+      final manager = DefaultModelDownloadManager(
+        defaultCacheDirectory: tempDir.path,
+      );
+      server.payload = utf8.encode('stale-cache-model');
+      final source = ModelSource.url(server.modelUri, fileName: 'tiny.gguf');
+      final entry = await manager.ensureModel(source);
+      final cacheDir = Directory(path.dirname(entry.filePath));
+      await File(entry.filePath).delete();
+
+      final pruned = await manager.prune();
+
+      expect(pruned.single.cacheKey, source.cacheKey);
+      expect(await cacheDir.exists(), isFalse);
+      expect(await manager.list(), isEmpty);
+    });
+
     test(
       'ignores metadata whose file path points outside its cache entry',
       () async {
@@ -613,6 +630,34 @@ void main() {
 
         expect(server.lastRange, 'bytes=13-');
         expect(server.lastIfRange, server.etag);
+        expect(File(entry.filePath).readAsStringSync(), 'fresh-content');
+      },
+    );
+
+    test(
+      'restarts stale partial downloads when resume validators mismatch',
+      () async {
+        final manager = DefaultModelDownloadManager(
+          defaultCacheDirectory: tempDir.path,
+        );
+        final source = ModelSource.url(server.modelUri, fileName: 'tiny.gguf');
+        server.payload = utf8.encode('fresh-content');
+        server.supportRanges = true;
+        server.etag = '"new-etag"';
+        final cacheDir = Directory(
+          path.join(tempDir.path, source.cacheDirectoryName),
+        )..createSync(recursive: true);
+        File(
+          path.join(cacheDir.path, 'tiny.gguf.part'),
+        ).writeAsStringSync('stale');
+        File(path.join(cacheDir.path, 'tiny.gguf.part.json')).writeAsStringSync(
+          '${jsonEncode(<String, Object?>{'etag': '"old-etag"'})}\n',
+        );
+
+        final entry = await manager.ensureModel(source);
+
+        expect(server.requestCount, 2);
+        expect(server.lastRange, isNull);
         expect(File(entry.filePath).readAsStringSync(), 'fresh-content');
       },
     );

--- a/test/unit/platform/io/model_download_manager_io_test.dart
+++ b/test/unit/platform/io/model_download_manager_io_test.dart
@@ -60,7 +60,7 @@ void main() {
         expect(server.lastTestHeader, 'present');
         expect(File(entry.filePath).readAsBytesSync(), server.payload);
         expect(entry.bytes, server.payload.length);
-        expect(entry.sha256, sha256.convert(server.payload).toString());
+        expect(entry.sha256, isNull);
         expect(entry.sourceCanonicalKey, isNot(contains('secret-token')));
         expect(progress, isNotEmpty);
         expect(progress.last, 1);
@@ -125,6 +125,46 @@ void main() {
       expect(server.requestCount, 1);
       expect(cached.filePath, first.filePath);
       expect(File(cached.filePath).readAsStringSync(), 'cached-model');
+    });
+
+    test('stores sha256 metadata only when checksum is requested', () async {
+      final manager = DefaultModelDownloadManager(
+        defaultCacheDirectory: tempDir.path,
+      );
+      server.payload = utf8.encode('checksummed-model');
+      final source = ModelSource.url(server.modelUri, fileName: 'tiny.gguf');
+      final expectedSha256 = sha256.convert(server.payload).toString();
+
+      final entry = await manager.ensureModel(
+        source,
+        options: ModelLoadOptions(sha256: expectedSha256),
+      );
+
+      expect(entry.sha256, expectedSha256);
+      expect(
+        File(
+          path.join(path.dirname(entry.filePath), 'metadata.json'),
+        ).readAsStringSync(),
+        contains(expectedSha256),
+      );
+    });
+
+    test('missing local path errors include the full path', () async {
+      final manager = DefaultModelDownloadManager(
+        defaultCacheDirectory: tempDir.path,
+      );
+      final missingPath = path.join(tempDir.path, 'missing', 'model.gguf');
+
+      await expectLater(
+        manager.ensureModel(ModelSource.path(missingPath)),
+        throwsA(
+          isA<LlamaModelException>().having(
+            (error) => error.message,
+            'message',
+            contains(missingPath),
+          ),
+        ),
+      );
     });
 
     test(

--- a/test/unit/platform/io/model_download_manager_io_test.dart
+++ b/test/unit/platform/io/model_download_manager_io_test.dart
@@ -257,6 +257,26 @@ void main() {
       );
     });
 
+    test('normalizes local paths before returning metadata', () async {
+      final manager = DefaultModelDownloadManager(
+        defaultCacheDirectory: tempDir.path,
+      );
+      await Directory(path.join(tempDir.path, 'nested')).create();
+      final localFile = File(path.join(tempDir.path, 'local-model.gguf'))
+        ..writeAsStringSync('local-model');
+      final traversalPath = path.join(
+        tempDir.path,
+        'nested',
+        '..',
+        'local-model.gguf',
+      );
+
+      final entry = await manager.ensureModel(ModelSource.path(traversalPath));
+
+      expect(entry.filePath, path.normalize(path.absolute(localFile.path)));
+      expect(entry.filePath, isNot(contains('..')));
+    });
+
     test('missing local path errors include the full path', () async {
       final manager = DefaultModelDownloadManager(
         defaultCacheDirectory: tempDir.path,

--- a/test/unit/platform/io/model_download_manager_io_test.dart
+++ b/test/unit/platform/io/model_download_manager_io_test.dart
@@ -88,6 +88,36 @@ void main() {
     );
 
     test(
+      'cross-origin redirects do not forward caller supplied headers',
+      () async {
+        final redirectedServer = await _ModelHttpFixture.start();
+        addTearDown(redirectedServer.close);
+        server.redirectTo = redirectedServer.modelUri;
+        redirectedServer.payload = utf8.encode('redirected-model');
+        final manager = DefaultModelDownloadManager(
+          defaultCacheDirectory: tempDir.path,
+        );
+        final source = ModelSource.url(server.modelUri, fileName: 'tiny.gguf');
+
+        final entry = await manager.ensureModel(
+          source,
+          options: ModelLoadOptions(
+            bearerToken: 'secret-token',
+            headers: const <String, String>{'X-Test-Header': 'present'},
+          ),
+        );
+
+        expect(server.requestCount, 1);
+        expect(server.lastAuthorization, 'Bearer secret-token');
+        expect(server.lastTestHeader, 'present');
+        expect(redirectedServer.requestCount, 1);
+        expect(redirectedServer.lastAuthorization, isNull);
+        expect(redirectedServer.lastTestHeader, isNull);
+        expect(File(entry.filePath).readAsStringSync(), 'redirected-model');
+      },
+    );
+
+    test(
       'cacheOnly fails on cache miss without touching the network',
       () async {
         final manager = DefaultModelDownloadManager(
@@ -855,6 +885,7 @@ class _ModelHttpFixture {
   String? etag = '"fixture-v1"';
   int failuresBeforeSuccess = 0;
   int failureStatusCode = HttpStatus.internalServerError;
+  Uri? redirectTo;
   int requestCount = 0;
   String? lastRange;
   final rangeHistory = <String?>[];
@@ -886,6 +917,17 @@ class _ModelHttpFixture {
     final currentEtag = etag;
     if (currentEtag != null) {
       request.response.headers.set(HttpHeaders.etagHeader, currentEtag);
+    }
+
+    final redirectTarget = redirectTo;
+    if (redirectTarget != null) {
+      request.response.statusCode = HttpStatus.temporaryRedirect;
+      request.response.headers.set(
+        HttpHeaders.locationHeader,
+        redirectTarget.toString(),
+      );
+      await request.response.close();
+      return;
     }
 
     if (requestCount <= failuresBeforeSuccess) {

--- a/test/unit/platform/io/model_download_manager_io_test.dart
+++ b/test/unit/platform/io/model_download_manager_io_test.dart
@@ -310,6 +310,38 @@ void main() {
       },
     );
 
+    test(
+      'get finds newest matching cache entry without full metadata scan',
+      () async {
+        final manager = DefaultModelDownloadManager(
+          defaultCacheDirectory: tempDir.path,
+        );
+        final source = ModelSource.url(server.modelUri, fileName: 'tiny.gguf');
+
+        server.payload = utf8.encode('stable-entry');
+        await manager.ensureModel(source);
+
+        final malformedCandidate = Directory(
+          path.join(tempDir.path, '${source.cacheDirectoryName}-nocache-bad'),
+        )..createSync(recursive: true);
+        File(
+          path.join(malformedCandidate.path, 'metadata.json'),
+        ).writeAsStringSync('{not valid json');
+
+        server.payload = utf8.encode('transient-entry');
+        final transient = await manager.ensureModel(
+          source,
+          options: ModelLoadOptions(cachePolicy: ModelCachePolicy.noCache),
+        );
+
+        final found = await manager.get(source.cacheKey);
+
+        expect(found, isNotNull);
+        expect(found!.filePath, transient.filePath);
+        expect(File(found.filePath).readAsStringSync(), 'transient-entry');
+      },
+    );
+
     test('retries retryable HTTP failures and then succeeds', () async {
       final manager = DefaultModelDownloadManager(
         defaultCacheDirectory: tempDir.path,

--- a/test/unit/platform/io/model_download_manager_io_test.dart
+++ b/test/unit/platform/io/model_download_manager_io_test.dart
@@ -671,6 +671,37 @@ void main() {
     );
 
     test(
+      'restarts from byte zero when a resume request receives HTTP 416',
+      () async {
+        final manager = DefaultModelDownloadManager(
+          defaultCacheDirectory: tempDir.path,
+        );
+        final source = ModelSource.url(server.modelUri, fileName: 'tiny.gguf');
+        server.payload = utf8.encode('short');
+        server.supportRanges = true;
+        final cacheDir = Directory(
+          path.join(tempDir.path, source.cacheDirectoryName),
+        )..createSync(recursive: true);
+        File(
+          path.join(cacheDir.path, 'tiny.gguf.part'),
+        ).writeAsStringSync('stale-partial');
+        File(path.join(cacheDir.path, 'tiny.gguf.part.json')).writeAsStringSync(
+          '${jsonEncode(<String, Object?>{'etag': server.etag})}\n',
+        );
+
+        final entry = await manager.ensureModel(source);
+
+        expect(server.requestCount, 2);
+        expect(server.rangeHistory, <String?>['bytes=13-', null]);
+        expect(File(entry.filePath).readAsStringSync(), 'short');
+        expect(
+          File(path.join(cacheDir.path, 'tiny.gguf.part.json')).existsSync(),
+          isFalse,
+        );
+      },
+    );
+
+    test(
       'restarts stale partial downloads when resume validators mismatch',
       () async {
         final manager = DefaultModelDownloadManager(
@@ -807,6 +838,7 @@ class _ModelHttpFixture {
   int failureStatusCode = HttpStatus.internalServerError;
   int requestCount = 0;
   String? lastRange;
+  final rangeHistory = <String?>[];
   String? lastIfRange;
   String? lastAuthorization;
   String? lastTestHeader;
@@ -827,6 +859,7 @@ class _ModelHttpFixture {
   void _handleRequest(HttpRequest request) async {
     requestCount += 1;
     lastRange = request.headers.value(HttpHeaders.rangeHeader);
+    rangeHistory.add(lastRange);
     lastIfRange = request.headers.value(HttpHeaders.ifRangeHeader);
     lastAuthorization = request.headers.value(HttpHeaders.authorizationHeader);
     lastTestHeader = request.headers.value('X-Test-Header');
@@ -846,6 +879,15 @@ class _ModelHttpFixture {
     if (supportRanges && range != null && range.startsWith('bytes=')) {
       final startText = range.substring('bytes='.length).split('-').first;
       final start = int.parse(startText);
+      if (start >= payload.length) {
+        request.response.statusCode = HttpStatus.requestedRangeNotSatisfiable;
+        request.response.headers.set(
+          HttpHeaders.contentRangeHeader,
+          'bytes */${payload.length}',
+        );
+        await request.response.close();
+        return;
+      }
       request.response.statusCode = HttpStatus.partialContent;
       request.response.headers.set(HttpHeaders.acceptRangesHeader, 'bytes');
       request.response.headers.set(

--- a/tool/testing/verify_models.dart
+++ b/tool/testing/verify_models.dart
@@ -208,7 +208,11 @@ Future<void> main(List<String> args) async {
     print('================================================================');
 
     if (!file.existsSync()) {
-      print('Model not found at legacy path: $legacyFilePath');
+      print(
+        cachedEntry == null
+            ? 'Model not found at legacy path: $legacyFilePath'
+            : 'Model not found at cached path: $filePath',
+      );
       print('Downloading...');
       try {
         filePath = await _ensureModel(

--- a/tool/testing/verify_models.dart
+++ b/tool/testing/verify_models.dart
@@ -190,9 +190,17 @@ Future<void> main(List<String> args) async {
     if (filter != null && !model.name.toLowerCase().contains(filter)) {
       continue;
     }
+    final source = ModelSource.url(
+      Uri.parse(model.downloadUrl),
+      fileName: model.fileName,
+    );
+    final manager = DefaultModelDownloadManager(
+      defaultCacheDirectory: modelsDir.path,
+    );
+    final cachedEntry = await manager.get(source.cacheKey);
     final legacyFilePath = path.join(modelsDir.path, model.fileName);
-    var filePath = legacyFilePath;
-    final file = File(legacyFilePath);
+    var filePath = cachedEntry?.filePath ?? legacyFilePath;
+    final file = File(filePath);
 
     print('\n================================================================');
     print('TESTING MODEL: ${model.name}');
@@ -214,7 +222,11 @@ Future<void> main(List<String> args) async {
         continue;
       }
     } else {
-      print('Model found locally.');
+      print(
+        cachedEntry == null
+            ? 'Model found at legacy path.'
+            : 'Model found in package cache.',
+      );
     }
     print('FILE: $filePath');
 

--- a/tool/testing/verify_models.dart
+++ b/tool/testing/verify_models.dart
@@ -197,11 +197,11 @@ Future<void> main(List<String> args) async {
     print('\n================================================================');
     print('TESTING MODEL: ${model.name}');
     print('CATEGORY: ${model.category}');
-    print('FILE: $filePath');
     print('================================================================');
 
     if (!file.existsSync()) {
-      print('Model not found locally. Downloading...');
+      print('Model not found at legacy path: $legacyFilePath');
+      print('Downloading...');
       try {
         filePath = await _ensureModel(
           modelsDir: modelsDir,
@@ -216,6 +216,7 @@ Future<void> main(List<String> args) async {
     } else {
       print('Model found locally.');
     }
+    print('FILE: $filePath');
 
     try {
       print('Loading model...');

--- a/tool/testing/verify_models.dart
+++ b/tool/testing/verify_models.dart
@@ -1,7 +1,6 @@
 import 'dart:io';
 import 'dart:async';
 import 'dart:convert';
-import 'package:http/http.dart' as http;
 import 'package:llamadart/llamadart.dart';
 import 'package:path/path.dart' as path;
 
@@ -191,8 +190,9 @@ Future<void> main(List<String> args) async {
     if (filter != null && !model.name.toLowerCase().contains(filter)) {
       continue;
     }
-    final filePath = path.join(modelsDir.path, model.fileName);
-    final file = File(filePath);
+    final legacyFilePath = path.join(modelsDir.path, model.fileName);
+    var filePath = legacyFilePath;
+    final file = File(legacyFilePath);
 
     print('\n================================================================');
     print('TESTING MODEL: ${model.name}');
@@ -203,7 +203,11 @@ Future<void> main(List<String> args) async {
     if (!file.existsSync()) {
       print('Model not found locally. Downloading...');
       try {
-        await _downloadModel(model.downloadUrl, filePath);
+        filePath = await _ensureModel(
+          modelsDir: modelsDir,
+          fileName: model.fileName,
+          downloadUrl: model.downloadUrl,
+        );
         print('Download complete.');
       } catch (e) {
         print('FAILED to download model: $e');
@@ -460,28 +464,23 @@ class VerificationResult {
   });
 }
 
-Future<void> _downloadModel(String url, String destPath) async {
-  final file = File(destPath);
-  final request = http.Request('GET', Uri.parse(url));
-  final response = await http.Client().send(request);
-
-  if (response.statusCode != 200) {
-    throw Exception('Failed to download model: ${response.statusCode}');
-  }
-
-  final totalBytes = response.contentLength;
-  int receivedBytes = 0;
-  final sink = file.openWrite();
-
-  await for (final chunk in response.stream) {
-    sink.add(chunk);
-    receivedBytes += chunk.length;
-    if (totalBytes != null) {
-      final progress = (receivedBytes / totalBytes) * 100;
-      stdout.write('\rDownloading: ${progress.toStringAsFixed(2)}%');
-    }
-  }
-
-  await sink.close();
+Future<String> _ensureModel({
+  required Directory modelsDir,
+  required String fileName,
+  required String downloadUrl,
+}) async {
+  final manager = DefaultModelDownloadManager(
+    defaultCacheDirectory: modelsDir.path,
+  );
+  final entry = await manager.ensureModel(
+    ModelSource.url(Uri.parse(downloadUrl), fileName: fileName),
+    onProgress: (progress) {
+      final fraction = progress.fraction;
+      if (fraction != null) {
+        stdout.write('\rDownloading: ${(fraction * 100).toStringAsFixed(2)}%');
+      }
+    },
+  );
   print(''); // New line after progress
+  return entry.filePath;
 }

--- a/tool/testing/verify_recommended_models.dart
+++ b/tool/testing/verify_recommended_models.dart
@@ -4,9 +4,7 @@ import 'dart:io';
 import 'dart:math' as math;
 import 'dart:typed_data';
 
-import 'package:http/http.dart' as http;
 import 'package:llamadart/llamadart.dart';
-import 'package:path/path.dart' as path;
 
 enum _ModelKind { text, vision, audio }
 
@@ -299,34 +297,28 @@ Future<String> _ensureFile({
   required String fileName,
   required String downloadUrl,
 }) async {
-  final String filePath = path.join(modelsDir.path, fileName);
-  final File file = File(filePath);
-  if (file.existsSync() && file.lengthSync() > 0) {
-    stdout.writeln('Using cached file: $fileName');
-    return filePath;
-  }
-
-  stdout.writeln('Downloading $fileName');
-  final http.Request request = http.Request('GET', Uri.parse(downloadUrl));
-  final http.StreamedResponse response = await http.Client().send(request);
-  if (response.statusCode != 200) {
-    throw Exception('Failed download ($fileName): HTTP ${response.statusCode}');
-  }
-
-  final IOSink sink = file.openWrite();
-  final int? total = response.contentLength;
-  int received = 0;
-  await for (final List<int> chunk in response.stream) {
-    sink.add(chunk);
-    received += chunk.length;
-    if (total != null && received % (32 * 1024 * 1024) < chunk.length) {
-      final double pct = (received / total) * 100;
-      stdout.write('\r  $fileName ${(pct).toStringAsFixed(1)}%');
-    }
-  }
-  await sink.close();
-  stdout.writeln('\nDownloaded $fileName');
-  return filePath;
+  final manager = DefaultModelDownloadManager(
+    defaultCacheDirectory: modelsDir.path,
+  );
+  final source = ModelSource.url(Uri.parse(downloadUrl), fileName: fileName);
+  stdout.writeln('Ensuring cached model: $fileName');
+  final entry = await manager.ensureModel(
+    source,
+    onProgress: (progress) {
+      final total = progress.totalBytes;
+      if (total != null &&
+          progress.receivedBytes % (32 * 1024 * 1024) < 1024 * 1024) {
+        final pct = progress.fraction == null
+            ? null
+            : (progress.fraction! * 100).toStringAsFixed(1);
+        if (pct != null) {
+          stdout.write('\r  $fileName $pct%');
+        }
+      }
+    },
+  );
+  stdout.writeln('\nReady: ${entry.filePath}');
+  return entry.filePath;
 }
 
 Future<_ModelResult> _runTextModel(

--- a/website/docs/changelog/recent-releases.md
+++ b/website/docs/changelog/recent-releases.md
@@ -9,6 +9,14 @@ For canonical full release notes, use:
 
 ## 0.6.12
 
+- Added the model source API foundation: `ModelSource`, `ModelLoadOptions`,
+  `ModelCachePolicy`, resolver targets, and download/cache value models for
+  future package-managed model download and cache flows.
+- Added `LlamaEngine.loadModelSource(...)` so local path sources keep using the
+  existing native loader while remote HTTP(S)/Hugging Face sources can route
+  through URL-capable backends. Native download/cache IO is still intentionally
+  unsupported in this foundation phase and unsupported cache/auth/checksum/retry
+  options fail explicitly.
 - Synced default WebGPU bridge asset pinning to
   `leehack/llama-web-bridge-assets@v0.1.14` (llama.cpp `b9016`) to match the
   native runtime pin.
@@ -27,7 +35,8 @@ For canonical full release notes, use:
   CUDA runtime DLLs and OpenBLAS runtime libraries are emitted only when their
   owning backend module is selected, while unknown runtime libraries stay
   bundled for forward compatibility.
-- Compatibility note: no public API breaking changes in `0.6.12`.
+- Compatibility note: no public API breaking changes in `0.6.12`; existing
+  `loadModel(...)` callers are unchanged.
 
 ## 0.6.11
 

--- a/website/docs/changelog/recent-releases.md
+++ b/website/docs/changelog/recent-releases.md
@@ -9,14 +9,19 @@ For canonical full release notes, use:
 
 ## 0.6.12
 
-- Added the model source API foundation: `ModelSource`, `ModelLoadOptions`,
-  `ModelCachePolicy`, resolver targets, and download/cache value models for
-  future package-managed model download and cache flows.
+- Added package-managed model source downloads and cache management:
+  `ModelSource`, `ModelLoadOptions`, `ModelCachePolicy`, resolver targets,
+  download/cache metadata, progress callbacks, cache inspection, removal,
+  clearing, and age/size pruning.
+- Added native/file-backed `DefaultModelDownloadManager` support for streaming
+  HTTP downloads, `.part` files with atomic promotion, authenticated bearer and
+  custom headers, cooperative cancellation, retry, HTTP Range resume, cache
+  hit/refresh/cache-only/no-cache policies, SHA-256 verification, and persisted
+  redacted metadata for signed URLs.
 - Added `LlamaEngine.loadModelSource(...)` so local path sources keep using the
-  existing native loader while remote HTTP(S)/Hugging Face sources can route
-  through URL-capable backends. Native download/cache IO is still intentionally
-  unsupported in this foundation phase and unsupported cache/auth/checksum/retry
-  options fail explicitly.
+  existing native loader, remote HTTP(S)/Hugging Face sources download through
+  the package-managed native cache before local loading, and URL-capable web
+  backends keep using direct URL loading for simple unauthenticated requests.
 - Synced default WebGPU bridge asset pinning to
   `leehack/llama-web-bridge-assets@v0.1.14` (llama.cpp `b9016`) to match the
   native runtime pin.

--- a/website/docs/changelog/recent-releases.md
+++ b/website/docs/changelog/recent-releases.md
@@ -7,7 +7,7 @@ For canonical full release notes, use:
 
 - [`CHANGELOG.md`](https://github.com/leehack/llamadart/blob/main/CHANGELOG.md)
 
-## 0.6.12
+## Unreleased
 
 - Added package-managed model source downloads and cache management:
   `ModelSource`, `ModelLoadOptions`, `ModelCachePolicy`, resolver targets,
@@ -22,6 +22,11 @@ For canonical full release notes, use:
   existing native loader, remote HTTP(S)/Hugging Face sources download through
   the package-managed native cache before local loading, and URL-capable web
   backends keep using direct URL loading for simple unauthenticated requests.
+- Compatibility note: no public API breaking changes; existing
+  `loadModel(...)` callers are unchanged.
+
+## 0.6.12
+
 - Synced default WebGPU bridge asset pinning to
   `leehack/llama-web-bridge-assets@v0.1.14` (llama.cpp `b9016`) to match the
   native runtime pin.
@@ -40,8 +45,7 @@ For canonical full release notes, use:
   CUDA runtime DLLs and OpenBLAS runtime libraries are emitted only when their
   owning backend module is selected, while unknown runtime libraries stay
   bundled for forward compatibility.
-- Compatibility note: no public API breaking changes in `0.6.12`; existing
-  `loadModel(...)` callers are unchanged.
+- Compatibility note: no public API breaking changes in `0.6.12`.
 
 ## 0.6.11
 

--- a/website/docs/guides/model-lifecycle.md
+++ b/website/docs/guides/model-lifecycle.md
@@ -36,6 +36,42 @@ await engine.loadModelFromUrl(
 
 `loadModelFromUrl` requires a backend with URL loading support.
 
+## Structured model sources
+
+Use `loadModelSource(...)` when the caller wants to describe the model location
+as a value object instead of branching on raw strings:
+
+```dart
+await engine.loadModelSource(ModelSource.path('/path/to/model.gguf'));
+
+await engine.loadModelSource(
+  ModelSource.url(Uri.parse('https://example.com/model.gguf')),
+  onProgress: (progress) {
+    final fraction = progress.fraction;
+    if (fraction != null) {
+      print('download progress: ${(fraction * 100).toStringAsFixed(1)}%');
+    }
+  },
+);
+
+await engine.loadModelSource(
+  ModelSource.parse('hf://owner/repo/path/to/model.gguf'),
+);
+```
+
+`ModelSource.parse(...)` accepts local paths, HTTP(S) URLs, and `hf://`
+Hugging Face references. Source values expose deterministic cache keys and
+redacted metadata identities so signed URL query strings are not stored in logs
+or cache metadata.
+
+This release adds the API foundation only. Local sources still use the existing
+native `loadModel(...)` path, while remote sources require a backend that already
+supports URL loading. Package-managed native download/cache IO, authenticated
+requests, checksum verification, refresh/cache-only/no-cache policies, and
+custom retry/resume behavior are reserved for a later implementation phase and
+currently fail with `LlamaUnsupportedException` when requested through the
+default resolver.
+
 ## Multimodal projector lifecycle
 
 ```dart

--- a/website/docs/guides/model-lifecycle.md
+++ b/website/docs/guides/model-lifecycle.md
@@ -101,8 +101,9 @@ Cache policies:
 - `preferCached`: reuse a completed cache entry when present; otherwise download.
 - `refresh`: replace the cached file atomically.
 - `cacheOnly`: fail without a network request when the entry is missing.
-- `noCache`: download to a temporary manager entry and remove it on later cache
-  pruning/cleanup; use this for callers that do not want source-keyed reuse.
+- `noCache`: download to a temporary manager entry without source-keyed reuse; call
+  `remove(entry.cacheKey)`/`clear()` when the returned file is no longer needed, or
+  use thresholded `prune(...)` for age/size-based cleanup.
 
 The download manager can also inspect and clean the persisted cache:
 

--- a/website/docs/guides/model-lifecycle.md
+++ b/website/docs/guides/model-lifecycle.md
@@ -64,13 +64,74 @@ Hugging Face references. Source values expose deterministic cache keys and
 redacted metadata identities so signed URL query strings are not stored in logs
 or cache metadata.
 
-This release adds the API foundation only. Local sources still use the existing
-native `loadModel(...)` path, while remote sources require a backend that already
-supports URL loading. Package-managed native download/cache IO, authenticated
-requests, checksum verification, refresh/cache-only/no-cache policies, and
-custom retry/resume behavior are reserved for a later implementation phase and
-currently fail with `LlamaUnsupportedException` when requested through the
-default resolver.
+Native/file-backed backends download remote sources into the package-managed
+cache, verify the completed file, persist metadata, and then call the existing
+local `loadModel(...)` path. URL-capable web backends keep using
+`loadModelFromUrl(...)` for simple unauthenticated `preferCached` requests; use
+native/file-backed targets when you need authenticated headers, checksum
+verification, explicit cache policies, retries, or resume.
+
+```dart
+final cancelToken = ModelDownloadCancelToken();
+
+await engine.loadModelSource(
+  ModelSource.url(Uri.parse('https://example.com/model.gguf')),
+  options: ModelLoadOptions(
+    cachePolicy: ModelCachePolicy.preferCached,
+    cacheDirectory: '/app/cache/llamadart-models',
+    sha256: 'expected-lowercase-sha256',
+    bearerToken: 'hf_xxx',
+    cancelToken: cancelToken,
+    resume: true,
+    maxRetries: 3,
+  ),
+  onProgress: (progress) {
+    final fraction = progress.fraction;
+    if (fraction != null) {
+      print('download progress: ${(fraction * 100).toStringAsFixed(1)}%');
+    }
+  },
+);
+```
+
+Cache policies:
+
+- `preferCached`: reuse a completed cache entry when present; otherwise download.
+- `refresh`: replace the cached file atomically.
+- `cacheOnly`: fail without a network request when the entry is missing.
+- `noCache`: download to a temporary manager entry and remove it on later cache
+  pruning/cleanup; use this for callers that do not want source-keyed reuse.
+
+The download manager can also inspect and clean the persisted cache:
+
+```dart
+final manager = DefaultModelDownloadManager(
+  defaultCacheDirectory: '/app/cache/llamadart-models',
+);
+
+final cached = await manager.list();
+final entry = await manager.get(ModelSource.parse('hf://owner/repo/model.gguf').cacheKey);
+await manager.remove(entry!.cacheKey);
+await manager.prune(maxAge: const Duration(days: 30), maxBytes: 20 * 1024 * 1024 * 1024);
+await manager.clear();
+```
+
+Downloaded files are written to `.part` files and promoted to the completed
+model path only after the HTTP stream and optional SHA-256 verification succeed.
+Retry/resume use HTTP Range when possible; if a server ignores a resume request
+and returns `200 OK`, the manager restarts from byte zero. Signed URL query
+strings, fragments, and userinfo are redacted from display strings and metadata.
+
+### Mobile large-download guidance
+
+For Flutter apps, pass an app-controlled `cacheDirectory` from your storage
+strategy (for example an application-support or documents directory selected by
+`path_provider`). Surface progress/cancel controls in the UI, keep downloads
+serialized for large GGUF files, and expect OS backgrounding to interrupt active
+requests. The `.part` resume support lets a later foreground session continue
+when the server supports Range requests. On Android, prefer app-private storage
+unless the app intentionally exposes model files to the user; on iOS, avoid
+cache directories that the OS may purge while a model is still needed.
 
 ## Multimodal projector lifecycle
 

--- a/website/docs/guides/model-lifecycle.md
+++ b/website/docs/guides/model-lifecycle.md
@@ -79,7 +79,7 @@ await engine.loadModelSource(
   options: ModelLoadOptions(
     cachePolicy: ModelCachePolicy.preferCached,
     cacheDirectory: '/app/cache/llamadart-models',
-    sha256: 'expected-lowercase-sha256',
+    sha256: '0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef',
     bearerToken: 'hf_xxx',
     cancelToken: cancelToken,
     resume: true,

--- a/website/docs/guides/model-lifecycle.md
+++ b/website/docs/guides/model-lifecycle.md
@@ -118,8 +118,10 @@ await manager.clear();
 
 Downloaded files are written to `.part` files and promoted to the completed
 model path only after the HTTP stream and optional SHA-256 verification succeed.
-Retry/resume use HTTP Range when possible; if a server ignores a resume request
-and returns `200 OK`, the manager restarts from byte zero. Signed URL query
+Retry/resume use HTTP Range only when the partial file has a safe validator
+(ETag/Last-Modified) or the caller supplied a SHA-256 checksum; validator-less
+partials restart from byte zero. If a server ignores a resume request and
+returns `200 OK`, the manager also restarts from byte zero. Signed URL query
 strings, fragments, and userinfo are redacted from display strings and metadata.
 
 ### Mobile large-download guidance
@@ -129,9 +131,10 @@ strategy (for example an application-support or documents directory selected by
 `path_provider`). Surface progress/cancel controls in the UI, keep downloads
 serialized for large GGUF files, and expect OS backgrounding to interrupt active
 requests. The `.part` resume support lets a later foreground session continue
-when the server supports Range requests. On Android, prefer app-private storage
-unless the app intentionally exposes model files to the user; on iOS, avoid
-cache directories that the OS may purge while a model is still needed.
+when the server supports Range requests and exposes a safe validator or the
+caller supplies SHA-256. On Android, prefer app-private storage unless the app
+intentionally exposes model files to the user; on iOS, avoid cache directories
+that the OS may purge while a model is still needed.
 
 ## Multimodal projector lifecycle
 

--- a/website/docs/guides/model-lifecycle.md
+++ b/website/docs/guides/model-lifecycle.md
@@ -113,7 +113,9 @@ final manager = DefaultModelDownloadManager(
 
 final cached = await manager.list();
 final entry = await manager.get(ModelSource.parse('hf://owner/repo/model.gguf').cacheKey);
-await manager.remove(entry!.cacheKey);
+if (entry != null) {
+  await manager.remove(entry.cacheKey);
+}
 await manager.prune(maxAge: const Duration(days: 30), maxBytes: 20 * 1024 * 1024 * 1024);
 await manager.clear();
 ```

--- a/website/docs/guides/model-lifecycle.md
+++ b/website/docs/guides/model-lifecycle.md
@@ -60,9 +60,11 @@ await engine.loadModelSource(
 ```
 
 `ModelSource.parse(...)` accepts local paths, HTTP(S) URLs, and `hf://`
-Hugging Face references. Source values expose deterministic cache keys and
-redacted metadata identities so signed URL query strings are not stored in logs
-or cache metadata.
+Hugging Face references. Local path sources require native/file-backed targets;
+URL-loading web backends reject explicit local filesystem paths and should use
+HTTP(S) or `hf://` sources instead. Source values expose deterministic cache
+keys and redacted metadata identities so signed URL query strings are not stored
+in logs or cache metadata.
 
 Native/file-backed backends download remote sources into the package-managed
 cache, verify the completed file, persist metadata, and then call the existing


### PR DESCRIPTION
## Summary
- Implements the native model download/cache manager for remote model sources, including cache policies, metadata, checksum validation, retries, cancellation, resumable downloads, and cache cleanup APIs.
- Wires `LlamaEngine.loadModelSource` so file-backed/native backends download to a local cached path before loading, while URL-capable backends reject native-cache-only options.
- Splits chat-app GGUF model and `mmproj` handling into independent asset sources so model/projector cache, download, delete, and activation behavior no longer assumes both files come from the same origin.
- Hardens web cache identities by persisting digest-based cache markers instead of raw/redacted signed URLs, and rejects unsupported web local-filesystem asset combinations loudly instead of silently succeeding.
- Migrates example server and model verification tools away from ad-hoc download logic and updates README/changelog/docs for the full download/cache behavior.

Closes #125

## Production-readiness scope
This PR is intended to be merge-ready for the declared feature scope:

- Users can load existing local models exactly as before via `loadModel(...)`.
- Users can load remote/local structured sources via the additive `loadModelSource(...)` API.
- Native/file-backed users get managed download/cache behavior with progress, retry, resume, cancellation, metadata, checksum validation, and cache maintenance APIs.
- URL-capable web users keep direct URL loading for simple supported requests.
- Unsupported option/platform combinations fail with explicit errors instead of being treated as successful.
- Chat app model and `mmproj` assets are resolved independently for mixed local/remote source combinations where the platform can actually load them.
- No public API breaking changes are intended; existing `loadModel(...)` and `loadModelFromUrl(...)` callers are unchanged.

## Intentionally deferred follow-ups
These are not required for the current feature to work, and are tracked separately to avoid merging incomplete scope into `main`:

- #130 Standardize local-only E2E runners across Dart, Flutter, and Web smoke tests.
- #131 Add a production-readiness checklist for PRs.
- #132 Improve chat-app model/mmproj asset-level cache UX.
- #133 Consider source-based multimodal projector loading API.
- #134 Harden cache metadata versioning and recovery policy.
- #135 Add model download task/controller helper for apps.
- #136 Improve Hugging Face source ergonomics.
- #137 Clarify local `ModelSource` option semantics.
- #138 Serialize concurrent downloads for the same cache key.

## Test Plan
- [x] `dart analyze lib test tool/testing/verify_recommended_models.dart tool/testing/verify_models.dart`
- [x] `dart test -p vm -j 1 --exclude-tags local-only --reporter compact`
- [x] `dart test -p chrome test/unit/core/models/download/model_download_manager_stub_test.dart --reporter compact`
- [x] `cd example/llamadart_server && dart test --reporter compact`
- [x] `cd example/chat_app && flutter analyze`
- [x] `cd example/chat_app && flutter test`
- [x] `cd example/chat_app && flutter test integration_test/model_cache_mmproj_e2e_test.dart -d macos` confirms local-only E2E is skipped by default
- [x] `cd example/chat_app && flutter test --run-skipped -t local-only integration_test/model_cache_mmproj_e2e_test.dart -d macos`
- [x] Root `dart format --output=none --set-exit-if-changed .`
- [x] Root `dart analyze`
- [x] `git diff --check`
- [x] Manual platform smoke/E2E coverage: macOS, Web Playwright real-app smoke, iOS simulator, Android emulator
- [x] GitHub CI: Analyze & Lint, Docs Build Check, Test Linux & Web, Test Native macOS, Test Native Windows, Native Prompt Reuse Parity

## Review Notes
- Final independent pre-commit/read-only reviews found no remaining merge blockers.
- A second-pass production-readiness review after the latest PR body update returned `PASS` for the declared scope. Non-blocking follow-ups were either already tracked or have been filed as #137/#138 and added to #132.
- Review-found blockers were fixed before the latest green CI run:
  - Web cache markers no longer use raw/redacted URL strings that could collapse query-only differences; persisted keys use a digest of the canonical identity.
  - Web activation/download now rejects local filesystem projector sources instead of treating unsupported combinations as successful.
  - Percent-encoded traversal, async transient directory creation, URL-load error redaction, and resume documentation comments were addressed in later commits.
- Added regression coverage for cache hits/misses, `noCache` cleanup, refresh preservation, retry policy, checksum mismatch cleanup, partial resume validators/`If-Range`, cancellation cleanup, cache list/get/remove/clear/prune, browser stub behavior, engine remote-source wiring, independent model/mmproj asset handling, and local-only real model+projector loading.

## Current review-comment status
All Copilot review threads have been resolved after verifying that the comments were addressed by follow-up commits or updated documentation. No unaddressed merge-blocking review comment is known.