### PR TITLE
fix: serialize same-key model downloads

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,10 @@
     authenticated bearer/custom headers, cancellation, retry, Range resume,
     cache hit/refresh/cache-only/no-cache policies, SHA-256 verification,
     cache listing, removal, clearing, and age/size pruning.
+  * Serialized concurrent stable-cache downloads for the same remote cache entry
+    across manager instances so duplicate callers do not race on shared `.part`
+    files or metadata, while distinct cache entries can still download in
+    parallel and waiting-caller cancellation does not cancel the active download.
   * Added `LlamaEngine.loadModelSource(...)` to route local sources through the
     existing native local loader, remote sources through the native download
     cache before local loading, and simple remote sources through URL-capable web

--- a/lib/src/core/models/download/model_download_manager_base.dart
+++ b/lib/src/core/models/download/model_download_manager_base.dart
@@ -176,6 +176,12 @@ class ModelCacheEntry {
 /// Public API for package-managed model cache/download implementations.
 abstract interface class ModelDownloadManager {
   /// Ensures [source] is available as a local cache entry.
+  ///
+  /// Implementations may serialize stable remote downloads for the same cache
+  /// entry so concurrent callers do not race on shared partial files or
+  /// metadata. Cancelling one waiting caller must not cancel another caller's
+  /// active download; cooperative cancellation may be observed after the active
+  /// same-entry operation finishes.
   Future<ModelCacheEntry> ensureModel(
     ModelSource source, {
     ModelLoadOptions options = ModelLoadOptions.defaults,

--- a/lib/src/platform/io/model_download_manager_io.dart
+++ b/lib/src/platform/io/model_download_manager_io.dart
@@ -1,3 +1,4 @@
+import 'dart:async';
 import 'dart:convert';
 import 'dart:io';
 
@@ -23,12 +24,31 @@ class DefaultModelDownloadManager implements ModelDownloadManager {
   /// Default cache root used when [ModelLoadOptions.cacheDirectory] is absent.
   final String defaultCacheDirectory;
 
+  static final Map<String, Future<void>> _cacheLocks = <String, Future<void>>{};
+
   @override
   Future<ModelCacheEntry> ensureModel(
     ModelSource source, {
     ModelLoadOptions options = ModelLoadOptions.defaults,
     ModelDownloadProgressCallback? onProgress,
   }) async {
+    _throwIfCancelled(options);
+    if (source.isLocal || options.cachePolicy == ModelCachePolicy.noCache) {
+      return _ensureModelUnlocked(source, options, onProgress);
+    }
+
+    final cacheDir = _cacheDirectory(source, options);
+    return _withCacheLock(
+      _cacheLockKey(cacheDir),
+      () => _ensureModelUnlocked(source, options, onProgress),
+    );
+  }
+
+  Future<ModelCacheEntry> _ensureModelUnlocked(
+    ModelSource source,
+    ModelLoadOptions options,
+    ModelDownloadProgressCallback? onProgress,
+  ) async {
     _throwIfCancelled(options);
     if (source.isLocal) {
       return _localEntry(source, options);
@@ -96,6 +116,25 @@ class DefaultModelDownloadManager implements ModelDownloadManager {
     );
     await _writeMetadata(metadataFile, entry);
     return entry;
+  }
+
+  Future<T> _withCacheLock<T>(String key, Future<T> Function() action) async {
+    final previous = _cacheLocks[key];
+    final current = Completer<void>();
+    _cacheLocks[key] = current.future;
+
+    if (previous != null) {
+      await previous;
+    }
+
+    try {
+      return await action();
+    } finally {
+      if (identical(_cacheLocks[key], current.future)) {
+        _cacheLocks.remove(key);
+      }
+      current.complete();
+    }
   }
 
   @override
@@ -222,6 +261,10 @@ class DefaultModelDownloadManager implements ModelDownloadManager {
 
   Directory _rootDirectory(String? cacheDirectory) {
     return Directory(cacheDirectory ?? defaultCacheDirectory);
+  }
+
+  String _cacheLockKey(Directory cacheDirectory) {
+    return path.normalize(path.absolute(cacheDirectory.path));
   }
 
   Future<List<File>> _candidateMetadataFiles(

--- a/test/unit/platform/io/model_download_manager_io_test.dart
+++ b/test/unit/platform/io/model_download_manager_io_test.dart
@@ -1,13 +1,15 @@
 @TestOn('vm')
 library;
 
+import 'dart:async';
 import 'dart:convert';
 import 'dart:io';
 
 import 'package:crypto/crypto.dart';
 import 'package:llamadart/src/core/exceptions.dart';
-import 'package:llamadart/src/platform/io/model_download_manager_io.dart';
+import 'package:llamadart/src/core/models/download/model_download_manager_base.dart';
 import 'package:llamadart/src/core/models/model_load_options.dart';
+import 'package:llamadart/src/platform/io/model_download_manager_io.dart';
 import 'package:llamadart/src/core/models/model_source.dart';
 import 'package:path/path.dart' as path;
 import 'package:test/test.dart';
@@ -86,6 +88,150 @@ void main() {
         );
       },
     );
+
+    test('serializes concurrent downloads for the same cache key', () async {
+      server.payload = utf8.encode('serialized-model');
+      server.responseDelay = const Duration(milliseconds: 100);
+      final manager = DefaultModelDownloadManager(
+        defaultCacheDirectory: tempDir.path,
+      );
+      final source = ModelSource.url(server.modelUri, fileName: 'tiny.gguf');
+
+      final entries = await Future.wait(<Future<ModelCacheEntry>>[
+        manager.ensureModel(source),
+        manager.ensureModel(source),
+        manager.ensureModel(source),
+      ]);
+
+      expect(server.requestCount, 1);
+      expect(server.maxActiveRequests, 1);
+      expect(entries.map((entry) => entry.filePath).toSet(), hasLength(1));
+      expect(
+        File(entries.first.filePath).readAsStringSync(),
+        'serialized-model',
+      );
+      final cacheDir = Directory(path.dirname(entries.first.filePath));
+      expect(
+        File(path.join(cacheDir.path, 'tiny.gguf.part')).existsSync(),
+        isFalse,
+      );
+      expect(
+        File(path.join(cacheDir.path, 'tiny.gguf.part.json')).existsSync(),
+        isFalse,
+      );
+    });
+
+    test('serializes same-key downloads across manager instances', () async {
+      server.payload = utf8.encode('shared-manager-cache');
+      server.responseDelay = const Duration(milliseconds: 100);
+      final firstManager = DefaultModelDownloadManager(
+        defaultCacheDirectory: tempDir.path,
+      );
+      final secondManager = DefaultModelDownloadManager(
+        defaultCacheDirectory: tempDir.path,
+      );
+      final source = ModelSource.url(server.modelUri, fileName: 'tiny.gguf');
+
+      final entries = await Future.wait(<Future<ModelCacheEntry>>[
+        firstManager.ensureModel(source),
+        secondManager.ensureModel(source),
+      ]);
+
+      expect(server.requestCount, 1);
+      expect(server.maxActiveRequests, 1);
+      expect(entries.map((entry) => entry.filePath).toSet(), hasLength(1));
+      expect(
+        File(entries.first.filePath).readAsStringSync(),
+        'shared-manager-cache',
+      );
+    });
+
+    test('keeps different cache keys parallelizable', () async {
+      server.responseDelay = const Duration(milliseconds: 100);
+      final manager = DefaultModelDownloadManager(
+        defaultCacheDirectory: tempDir.path,
+      );
+      final firstSource = ModelSource.url(
+        server.modelUri,
+        fileName: 'first.gguf',
+      );
+      final secondSource = ModelSource.url(
+        server.modelUri.replace(queryParameters: const {'variant': 'second'}),
+        fileName: 'second.gguf',
+      );
+
+      final entries = await Future.wait(<Future<ModelCacheEntry>>[
+        manager.ensureModel(firstSource),
+        manager.ensureModel(secondSource),
+      ]);
+
+      expect(server.requestCount, 2);
+      expect(server.maxActiveRequests, greaterThanOrEqualTo(2));
+      expect(entries.map((entry) => entry.cacheKey).toSet(), hasLength(2));
+      expect(entries.map((entry) => entry.filePath).toSet(), hasLength(2));
+    });
+
+    test(
+      'cancelled same-key waiters do not cancel the active download',
+      () async {
+        server.payload = utf8.encode('leader-model');
+        server.responseDelay = const Duration(milliseconds: 100);
+        final manager = DefaultModelDownloadManager(
+          defaultCacheDirectory: tempDir.path,
+        );
+        final source = ModelSource.url(server.modelUri, fileName: 'tiny.gguf');
+        final waiterToken = ModelDownloadCancelToken();
+
+        final leader = manager.ensureModel(source);
+        await server.firstRequestStarted;
+        final waiter = manager.ensureModel(
+          source,
+          options: ModelLoadOptions(cancelToken: waiterToken),
+        );
+        waiterToken.cancel();
+
+        final leaderEntry = await leader;
+        await expectLater(waiter, throwsA(isA<LlamaStateException>()));
+
+        expect(server.requestCount, 1);
+        expect(File(leaderEntry.filePath).readAsStringSync(), 'leader-model');
+        expect(
+          (await manager.get(source.cacheKey))?.filePath,
+          leaderEntry.filePath,
+        );
+      },
+    );
+
+    test('cancelled same-key leader releases lock for retry', () async {
+      server.payload = utf8.encode('retry-after-leader-cancel');
+      server.responseDelay = const Duration(milliseconds: 100);
+      final manager = DefaultModelDownloadManager(
+        defaultCacheDirectory: tempDir.path,
+      );
+      final source = ModelSource.url(server.modelUri, fileName: 'tiny.gguf');
+      final leaderToken = ModelDownloadCancelToken();
+
+      final leader = manager.ensureModel(
+        source,
+        options: ModelLoadOptions(cancelToken: leaderToken),
+      );
+      await server.firstRequestStarted;
+      final retry = manager.ensureModel(source);
+      leaderToken.cancel();
+
+      await expectLater(leader, throwsA(isA<LlamaStateException>()));
+      final retryEntry = await retry;
+
+      expect(server.requestCount, 2);
+      expect(
+        File(retryEntry.filePath).readAsStringSync(),
+        'retry-after-leader-cancel',
+      );
+      expect(
+        (await manager.get(source.cacheKey))?.filePath,
+        retryEntry.filePath,
+      );
+    });
 
     test(
       'cross-origin redirects do not forward caller supplied headers',
@@ -917,6 +1063,10 @@ class _ModelHttpFixture {
   int failureStatusCode = HttpStatus.internalServerError;
   Uri? redirectTo;
   int requestCount = 0;
+  int activeRequests = 0;
+  int maxActiveRequests = 0;
+  Duration responseDelay = Duration.zero;
+  final Completer<void> _firstRequestStarted = Completer<void>();
   String? lastRange;
   final rangeHistory = <String?>[];
   String? lastIfRange;
@@ -936,62 +1086,86 @@ class _ModelHttpFixture {
 
   Future<void> close() => _server.close(force: true);
 
+  Future<void> get firstRequestStarted => _firstRequestStarted.future;
+
   void _handleRequest(HttpRequest request) async {
     requestCount += 1;
-    lastRange = request.headers.value(HttpHeaders.rangeHeader);
-    rangeHistory.add(lastRange);
-    lastIfRange = request.headers.value(HttpHeaders.ifRangeHeader);
-    lastAuthorization = request.headers.value(HttpHeaders.authorizationHeader);
-    lastTestHeader = request.headers.value('X-Test-Header');
-
-    final currentEtag = etag;
-    if (currentEtag != null) {
-      request.response.headers.set(HttpHeaders.etagHeader, currentEtag);
+    final requestNumber = requestCount;
+    activeRequests += 1;
+    if (activeRequests > maxActiveRequests) {
+      maxActiveRequests = activeRequests;
     }
-
-    final redirectTarget = redirectTo;
-    if (redirectTarget != null) {
-      request.response.statusCode = HttpStatus.temporaryRedirect;
-      request.response.headers.set(
-        HttpHeaders.locationHeader,
-        redirectTarget.toString(),
+    if (!_firstRequestStarted.isCompleted) {
+      _firstRequestStarted.complete();
+    }
+    try {
+      final requestRange = request.headers.value(HttpHeaders.rangeHeader);
+      final requestIfRange = request.headers.value(HttpHeaders.ifRangeHeader);
+      final requestAuthorization = request.headers.value(
+        HttpHeaders.authorizationHeader,
       );
-      await request.response.close();
-      return;
-    }
+      final requestTestHeader = request.headers.value('X-Test-Header');
+      lastRange = requestRange;
+      rangeHistory.add(requestRange);
+      lastIfRange = requestIfRange;
+      lastAuthorization = requestAuthorization;
+      lastTestHeader = requestTestHeader;
 
-    if (requestCount <= failuresBeforeSuccess) {
-      request.response.statusCode = failureStatusCode;
-      await request.response.close();
-      return;
-    }
+      final currentEtag = etag;
+      if (currentEtag != null) {
+        request.response.headers.set(HttpHeaders.etagHeader, currentEtag);
+      }
 
-    final range = lastRange;
-    if (supportRanges && range != null && range.startsWith('bytes=')) {
-      final startText = range.substring('bytes='.length).split('-').first;
-      final start = int.parse(startText);
-      if (start >= payload.length) {
-        request.response.statusCode = HttpStatus.requestedRangeNotSatisfiable;
+      if (responseDelay > Duration.zero) {
+        await Future<void>.delayed(responseDelay);
+      }
+
+      final redirectTarget = redirectTo;
+      if (redirectTarget != null) {
+        request.response.statusCode = HttpStatus.temporaryRedirect;
         request.response.headers.set(
-          HttpHeaders.contentRangeHeader,
-          'bytes */${payload.length}',
+          HttpHeaders.locationHeader,
+          redirectTarget.toString(),
         );
         await request.response.close();
         return;
       }
-      request.response.statusCode = HttpStatus.partialContent;
-      request.response.headers.set(HttpHeaders.acceptRangesHeader, 'bytes');
-      request.response.headers.set(
-        HttpHeaders.contentRangeHeader,
-        'bytes $start-${payload.length - 1}/${payload.length}',
-      );
-      request.response.headers.contentLength = payload.length - start;
-      request.response.add(payload.sublist(start));
-    } else {
-      request.response.statusCode = HttpStatus.ok;
-      request.response.headers.contentLength = payload.length;
-      request.response.add(payload);
+
+      if (requestNumber <= failuresBeforeSuccess) {
+        request.response.statusCode = failureStatusCode;
+        await request.response.close();
+        return;
+      }
+
+      final range = requestRange;
+      if (supportRanges && range != null && range.startsWith('bytes=')) {
+        final startText = range.substring('bytes='.length).split('-').first;
+        final start = int.parse(startText);
+        if (start >= payload.length) {
+          request.response.statusCode = HttpStatus.requestedRangeNotSatisfiable;
+          request.response.headers.set(
+            HttpHeaders.contentRangeHeader,
+            'bytes */${payload.length}',
+          );
+          await request.response.close();
+          return;
+        }
+        request.response.statusCode = HttpStatus.partialContent;
+        request.response.headers.set(HttpHeaders.acceptRangesHeader, 'bytes');
+        request.response.headers.set(
+          HttpHeaders.contentRangeHeader,
+          'bytes $start-${payload.length - 1}/${payload.length}',
+        );
+        request.response.headers.contentLength = payload.length - start;
+        request.response.add(payload.sublist(start));
+      } else {
+        request.response.statusCode = HttpStatus.ok;
+        request.response.headers.contentLength = payload.length;
+        request.response.add(payload);
+      }
+      await request.response.close();
+    } finally {
+      activeRequests -= 1;
     }
-    await request.response.close();
   }
 }

--- a/website/docs/changelog/recent-releases.md
+++ b/website/docs/changelog/recent-releases.md
@@ -18,6 +18,10 @@ For canonical full release notes, use:
   custom headers, cooperative cancellation, retry, HTTP Range resume, cache
   hit/refresh/cache-only/no-cache policies, SHA-256 verification, and persisted
   redacted metadata for signed URLs.
+- Serialized concurrent stable-cache downloads for the same remote cache entry
+  across manager instances so duplicate callers do not race on shared `.part`
+  files or metadata, while distinct cache entries can still download in
+  parallel and waiting-caller cancellation does not cancel the active download.
 - Added `LlamaEngine.loadModelSource(...)` so local path sources keep using the
   existing native loader, remote HTTP(S)/Hugging Face sources download through
   the package-managed native cache before local loading, and URL-capable web

--- a/website/docs/guides/model-lifecycle.md
+++ b/website/docs/guides/model-lifecycle.md
@@ -123,6 +123,16 @@ await manager.clear();
 
 Downloaded files are written to `.part` files and promoted to the completed
 model path only after the HTTP stream and optional SHA-256 verification succeed.
+Stable-cache remote downloads are serialized per cache entry in-process,
+including across `DefaultModelDownloadManager` instances that share a cache root:
+same-entry callers wait for the active operation, cache-reusing policies then
+re-check the completed cache, and different cache entries remain parallel.
+Concurrent `refresh` calls are serialized but each refreshes when its turn runs;
+`noCache` transient downloads are not stable-cache coalesced. Cancelling a
+waiting caller is observed after the active same-entry operation finishes and
+does not cancel that active download; cancellation of the active download
+releases the entry lock so a later caller can retry or resume from a safe `.part`
+file.
 Retry/resume use HTTP Range only when the partial file has a safe validator
 (ETag/Last-Modified) or the caller supplied a SHA-256 checksum; validator-less
 partials restart from byte zero. If a server ignores a resume request and


### PR DESCRIPTION
## Summary
- Serialize stable-cache remote downloads per cache entry in `DefaultModelDownloadManager`, including concurrent callers through different manager instances.
- Keep local sources and `noCache` transient downloads outside the stable-cache lock, and preserve parallel downloads for distinct cache entries.
- Document same-entry concurrency and cancellation semantics in API docs, the model lifecycle guide, and release notes.

Closes #138

## Production-readiness scope
- Users can safely call `ensureModel(...)` concurrently for the same stable remote model source in one Dart process without duplicate writes racing on the same `.part` file or metadata.
- Supported paths: native/file-backed `DefaultModelDownloadManager` stable cache entries (`preferCached`, `cacheOnly`, and serialized `refresh`) under a shared cache root in the same Dart process/isolate.
- Out of scope: cross-process or cross-isolate filesystem locking; `noCache` remains a transient non-reused download path.
- Cancellation behavior: cancelling a waiting same-entry caller does not cancel the active download; cancelling the active caller releases the lock so a later caller can retry/resume safely.

## Test Plan
- [x] `dart format --output=none --set-exit-if-changed lib/src/platform/io/model_download_manager_io.dart lib/src/core/models/download/model_download_manager_base.dart test/unit/platform/io/model_download_manager_io_test.dart`
- [x] `dart analyze lib/src/platform/io/model_download_manager_io.dart lib/src/core/models/download/model_download_manager_base.dart test/unit/platform/io/model_download_manager_io_test.dart`
- [x] `dart test -p vm test/unit/platform/io/model_download_manager_io_test.dart --reporter compact`
- [x] `dart analyze`
- [x] `dart test -p vm -j 1 --exclude-tags local-only --reporter compact`
- [x] `dart test -p chrome test/unit/core/models/download/model_download_manager_stub_test.dart --reporter compact`
- [x] `git diff --check origin/main...HEAD`

## Review Notes
- Ran multiple independent read-only reviews focused on concurrency correctness, docs/changelog coverage, optimization, code cleanliness, and test reliability.
- Addressed review feedback by documenting `refresh`/`noCache` nuances, documenting delayed cooperative waiter cancellation, strengthening test types, and adding a cancelled-leader retry regression test.
