### PR TITLE
fix: recover cache metadata sidecars

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,10 @@
     across manager instances so duplicate callers do not race on shared `.part`
     files or metadata, while distinct cache entries can still download in
     parallel and waiting-caller cancellation does not cancel the active download.
+  * Hardened versioned cache metadata recovery: completed files can rebuild
+    missing, malformed, or unsupported-schema sidecars without network access,
+    while byte-count and stored/caller SHA-256 mismatches are treated as cache
+    misses and safely re-downloaded.
   * Added `LlamaEngine.loadModelSource(...)` to route local sources through the
     existing native local loader, remote sources through the native download
     cache before local loading, and simple remote sources through URL-capable web

--- a/lib/src/core/models/download/model_download_manager_base.dart
+++ b/lib/src/core/models/download/model_download_manager_base.dart
@@ -182,6 +182,12 @@ abstract interface class ModelDownloadManager {
   /// metadata. Cancelling one waiting caller must not cancel another caller's
   /// active download; cooperative cancellation may be observed after the active
   /// same-entry operation finishes.
+  ///
+  /// Native/file-backed implementations may recover package-managed metadata
+  /// when the completed model file is still present in the deterministic cache
+  /// directory, but should treat missing files, source mismatches, byte-count
+  /// mismatches, and checksum mismatches as cache misses rather than returning
+  /// stale entries.
   Future<ModelCacheEntry> ensureModel(
     ModelSource source, {
     ModelLoadOptions options = ModelLoadOptions.defaults,
@@ -192,10 +198,16 @@ abstract interface class ModelDownloadManager {
   /// including transient `noCache` entries that remain until explicitly
   /// cleared or pruned.
   ///
+  /// Malformed or unsupported metadata entries may be ignored so one corrupt
+  /// cache directory does not make cache inspection unusable.
+  ///
   /// When [cacheDirectory] is omitted, the manager's default cache root is used.
   Future<List<ModelCacheEntry>> list({String? cacheDirectory});
 
   /// Gets a cached model entry by [cacheKey], if present under [cacheDirectory].
+  ///
+  /// Malformed or unsupported metadata entries may be ignored so one corrupt
+  /// cache directory does not block lookup of other candidates.
   ///
   /// When [cacheDirectory] is omitted, the manager's default cache root is used.
   Future<ModelCacheEntry?> get(String cacheKey, {String? cacheDirectory});

--- a/lib/src/platform/io/model_download_manager_io.dart
+++ b/lib/src/platform/io/model_download_manager_io.dart
@@ -345,10 +345,16 @@ class DefaultModelDownloadManager implements ModelDownloadManager {
     File finalFile,
     ModelLoadOptions options,
   ) async {
-    if (!await finalFile.exists()) {
-      return null;
-    }
-    if (!await metadataFile.exists()) {
+    try {
+      if (!await finalFile.exists()) {
+        return null;
+      }
+      if (!await metadataFile.exists()) {
+        return _recoverMetadataEntry(source, metadataFile, finalFile, options);
+      }
+    } on FileSystemException {
+      return _recoverMetadataEntry(source, metadataFile, finalFile, options);
+    } on IOException {
       return _recoverMetadataEntry(source, metadataFile, finalFile, options);
     }
 
@@ -359,6 +365,8 @@ class DefaultModelDownloadManager implements ModelDownloadManager {
       return _recoverMetadataEntry(source, metadataFile, finalFile, options);
     } on ArgumentError {
       return _recoverMetadataEntry(source, metadataFile, finalFile, options);
+    } on FileSystemException {
+      return _recoverMetadataEntry(source, metadataFile, finalFile, options);
     } on IOException {
       return _recoverMetadataEntry(source, metadataFile, finalFile, options);
     }
@@ -368,15 +376,13 @@ class DefaultModelDownloadManager implements ModelDownloadManager {
         entry.filePath != finalFile.path) {
       return null;
     }
-    final verifiedSha256 = await _verifyCompletedFile(
+    final verification = await _verifyCompletedFile(
       finalFile,
       metadataFile,
       entry,
       options,
     );
-    if (!await finalFile.exists() ||
-        (verifiedSha256 == null &&
-            (options.sha256 != null || entry.sha256 != null))) {
+    if (!verification.isValid) {
       return null;
     }
     try {
@@ -386,7 +392,7 @@ class DefaultModelDownloadManager implements ModelDownloadManager {
         fileName: entry.fileName,
         filePath: entry.filePath,
         bytes: await finalFile.length(),
-        sha256: verifiedSha256 ?? entry.sha256,
+        sha256: verification.sha256 ?? entry.sha256,
         etag: entry.etag,
         lastModified: entry.lastModified,
         createdAt: entry.createdAt,
@@ -395,6 +401,9 @@ class DefaultModelDownloadManager implements ModelDownloadManager {
       );
       await _writeMetadata(metadataFile, refreshed);
       return refreshed;
+    } on FileSystemException {
+      await _deleteStaleCompletedEntry(finalFile, metadataFile);
+      return null;
     } on IOException {
       await _deleteStaleCompletedEntry(finalFile, metadataFile);
       return null;
@@ -431,7 +440,7 @@ class DefaultModelDownloadManager implements ModelDownloadManager {
     }
   }
 
-  Future<String?> _verifyCompletedFile(
+  Future<({bool isValid, String? sha256})> _verifyCompletedFile(
     File finalFile,
     File metadataFile,
     ModelCacheEntry entry,
@@ -441,23 +450,26 @@ class DefaultModelDownloadManager implements ModelDownloadManager {
       final recordedBytes = entry.bytes;
       if (recordedBytes != null && await finalFile.length() != recordedBytes) {
         await _deleteStaleCompletedEntry(finalFile, metadataFile);
-        return null;
+        return (isValid: false, sha256: null);
       }
       final storedSha256 = entry.sha256;
       final expectedSha256 = options.sha256;
       if (storedSha256 == null && expectedSha256 == null) {
-        return null;
+        return (isValid: true, sha256: null);
       }
       final actual = await _sha256File(finalFile);
       if ((storedSha256 != null && actual != storedSha256) ||
           (expectedSha256 != null && actual != expectedSha256)) {
         await _deleteStaleCompletedEntry(finalFile, metadataFile);
-        return null;
+        return (isValid: false, sha256: null);
       }
-      return actual;
+      return (isValid: true, sha256: actual);
+    } on FileSystemException {
+      await _deleteStaleCompletedEntry(finalFile, metadataFile);
+      return (isValid: false, sha256: null);
     } on IOException {
       await _deleteStaleCompletedEntry(finalFile, metadataFile);
-      return null;
+      return (isValid: false, sha256: null);
     }
   }
 

--- a/lib/src/platform/io/model_download_manager_io.dart
+++ b/lib/src/platform/io/model_download_manager_io.dart
@@ -443,12 +443,14 @@ class DefaultModelDownloadManager implements ModelDownloadManager {
         await _deleteStaleCompletedEntry(finalFile, metadataFile);
         return null;
       }
-      final expectedSha256 = options.sha256 ?? entry.sha256;
-      if (expectedSha256 == null) {
+      final storedSha256 = entry.sha256;
+      final expectedSha256 = options.sha256;
+      if (storedSha256 == null && expectedSha256 == null) {
         return null;
       }
       final actual = await _sha256File(finalFile);
-      if (actual != expectedSha256) {
+      if ((storedSha256 != null && actual != storedSha256) ||
+          (expectedSha256 != null && actual != expectedSha256)) {
         await _deleteStaleCompletedEntry(finalFile, metadataFile);
         return null;
       }

--- a/lib/src/platform/io/model_download_manager_io.dart
+++ b/lib/src/platform/io/model_download_manager_io.dart
@@ -379,21 +379,26 @@ class DefaultModelDownloadManager implements ModelDownloadManager {
             (options.sha256 != null || entry.sha256 != null))) {
       return null;
     }
-    final refreshed = ModelCacheEntry(
-      sourceCanonicalKey: entry.sourceCanonicalKey,
-      cacheKey: entry.cacheKey,
-      fileName: entry.fileName,
-      filePath: entry.filePath,
-      bytes: await finalFile.length(),
-      sha256: verifiedSha256 ?? entry.sha256,
-      etag: entry.etag,
-      lastModified: entry.lastModified,
-      createdAt: entry.createdAt,
-      updatedAt: DateTime.now().toUtc(),
-      expiresAt: entry.expiresAt,
-    );
-    await _writeMetadata(metadataFile, refreshed);
-    return refreshed;
+    try {
+      final refreshed = ModelCacheEntry(
+        sourceCanonicalKey: entry.sourceCanonicalKey,
+        cacheKey: entry.cacheKey,
+        fileName: entry.fileName,
+        filePath: entry.filePath,
+        bytes: await finalFile.length(),
+        sha256: verifiedSha256 ?? entry.sha256,
+        etag: entry.etag,
+        lastModified: entry.lastModified,
+        createdAt: entry.createdAt,
+        updatedAt: DateTime.now().toUtc(),
+        expiresAt: entry.expiresAt,
+      );
+      await _writeMetadata(metadataFile, refreshed);
+      return refreshed;
+    } on IOException {
+      await _deleteStaleCompletedEntry(finalFile, metadataFile);
+      return null;
+    }
   }
 
   Future<ModelCacheEntry?> _recoverMetadataEntry(

--- a/lib/src/platform/io/model_download_manager_io.dart
+++ b/lib/src/platform/io/model_download_manager_io.dart
@@ -359,6 +359,8 @@ class DefaultModelDownloadManager implements ModelDownloadManager {
       return _recoverMetadataEntry(source, metadataFile, finalFile, options);
     } on ArgumentError {
       return _recoverMetadataEntry(source, metadataFile, finalFile, options);
+    } on IOException {
+      return _recoverMetadataEntry(source, metadataFile, finalFile, options);
     }
 
     if (entry.cacheKey != source.cacheKey ||
@@ -400,23 +402,28 @@ class DefaultModelDownloadManager implements ModelDownloadManager {
     File finalFile,
     ModelLoadOptions options,
   ) async {
-    final verifiedSha256 = await _verifyRecoveredFile(
-      finalFile,
-      metadataFile,
-      options,
-    );
-    if (options.sha256 != null && verifiedSha256 == null) {
+    try {
+      final verifiedSha256 = await _verifyRecoveredFile(
+        finalFile,
+        metadataFile,
+        options,
+      );
+      if (options.sha256 != null && verifiedSha256 == null) {
+        return null;
+      }
+      final now = DateTime.now().toUtc();
+      final recovered = await _entryForFile(
+        source,
+        finalFile,
+        now,
+        sha256Digest: verifiedSha256,
+      );
+      await _writeMetadata(metadataFile, recovered);
+      return recovered;
+    } on IOException {
+      await _deleteStaleCompletedEntry(finalFile, metadataFile);
       return null;
     }
-    final now = DateTime.now().toUtc();
-    final recovered = await _entryForFile(
-      source,
-      finalFile,
-      now,
-      sha256Digest: verifiedSha256,
-    );
-    await _writeMetadata(metadataFile, recovered);
-    return recovered;
   }
 
   Future<String?> _verifyCompletedFile(
@@ -425,23 +432,26 @@ class DefaultModelDownloadManager implements ModelDownloadManager {
     ModelCacheEntry entry,
     ModelLoadOptions options,
   ) async {
-    final recordedBytes = entry.bytes;
-    if (recordedBytes != null && await finalFile.length() != recordedBytes) {
-      await _deleteIfExists(finalFile);
-      await _deleteIfExists(metadataFile);
+    try {
+      final recordedBytes = entry.bytes;
+      if (recordedBytes != null && await finalFile.length() != recordedBytes) {
+        await _deleteStaleCompletedEntry(finalFile, metadataFile);
+        return null;
+      }
+      final expectedSha256 = options.sha256 ?? entry.sha256;
+      if (expectedSha256 == null) {
+        return null;
+      }
+      final actual = await _sha256File(finalFile);
+      if (actual != expectedSha256) {
+        await _deleteStaleCompletedEntry(finalFile, metadataFile);
+        return null;
+      }
+      return actual;
+    } on IOException {
+      await _deleteStaleCompletedEntry(finalFile, metadataFile);
       return null;
     }
-    final expectedSha256 = options.sha256 ?? entry.sha256;
-    if (expectedSha256 == null) {
-      return null;
-    }
-    final actual = await _sha256File(finalFile);
-    if (actual != expectedSha256) {
-      await _deleteIfExists(finalFile);
-      await _deleteIfExists(metadataFile);
-      return null;
-    }
-    return actual;
   }
 
   Future<String?> _verifyRecoveredFile(
@@ -449,17 +459,29 @@ class DefaultModelDownloadManager implements ModelDownloadManager {
     File metadataFile,
     ModelLoadOptions options,
   ) async {
-    final expectedSha256 = options.sha256;
-    if (expectedSha256 == null) {
+    try {
+      final expectedSha256 = options.sha256;
+      if (expectedSha256 == null) {
+        return null;
+      }
+      final actual = await _sha256File(finalFile);
+      if (actual != expectedSha256) {
+        await _deleteStaleCompletedEntry(finalFile, metadataFile);
+        return null;
+      }
+      return actual;
+    } on IOException {
+      await _deleteStaleCompletedEntry(finalFile, metadataFile);
       return null;
     }
-    final actual = await _sha256File(finalFile);
-    if (actual != expectedSha256) {
-      await _deleteIfExists(finalFile);
-      await _deleteIfExists(metadataFile);
-      return null;
-    }
-    return actual;
+  }
+
+  Future<void> _deleteStaleCompletedEntry(
+    File finalFile,
+    File metadataFile,
+  ) async {
+    await _deleteIfExists(finalFile);
+    await _deleteIfExists(metadataFile);
   }
 
   Future<ModelCacheEntry> _download(

--- a/lib/src/platform/io/model_download_manager_io.dart
+++ b/lib/src/platform/io/model_download_manager_io.dart
@@ -391,7 +391,7 @@ class DefaultModelDownloadManager implements ModelDownloadManager {
         cacheKey: entry.cacheKey,
         fileName: entry.fileName,
         filePath: entry.filePath,
-        bytes: await finalFile.length(),
+        bytes: verification.bytes!,
         sha256: verification.sha256 ?? entry.sha256,
         etag: entry.etag,
         lastModified: entry.lastModified,
@@ -402,10 +402,10 @@ class DefaultModelDownloadManager implements ModelDownloadManager {
       await _writeMetadata(metadataFile, refreshed);
       return refreshed;
     } on FileSystemException {
-      await _deleteStaleCompletedEntry(finalFile, metadataFile);
+      await _deleteIfExists(metadataFile);
       return null;
     } on IOException {
-      await _deleteStaleCompletedEntry(finalFile, metadataFile);
+      await _deleteIfExists(metadataFile);
       return null;
     }
   }
@@ -434,42 +434,46 @@ class DefaultModelDownloadManager implements ModelDownloadManager {
       );
       await _writeMetadata(metadataFile, recovered);
       return recovered;
+    } on FileSystemException {
+      await _deleteIfExists(metadataFile);
+      return null;
     } on IOException {
-      await _deleteStaleCompletedEntry(finalFile, metadataFile);
+      await _deleteIfExists(metadataFile);
       return null;
     }
   }
 
-  Future<({bool isValid, String? sha256})> _verifyCompletedFile(
+  Future<({bool isValid, int? bytes, String? sha256})> _verifyCompletedFile(
     File finalFile,
     File metadataFile,
     ModelCacheEntry entry,
     ModelLoadOptions options,
   ) async {
     try {
+      final actualBytes = await finalFile.length();
       final recordedBytes = entry.bytes;
-      if (recordedBytes != null && await finalFile.length() != recordedBytes) {
+      if (recordedBytes != null && actualBytes != recordedBytes) {
         await _deleteStaleCompletedEntry(finalFile, metadataFile);
-        return (isValid: false, sha256: null);
+        return (isValid: false, bytes: null, sha256: null);
       }
       final storedSha256 = entry.sha256;
       final expectedSha256 = options.sha256;
       if (storedSha256 == null && expectedSha256 == null) {
-        return (isValid: true, sha256: null);
+        return (isValid: true, bytes: actualBytes, sha256: null);
       }
       final actual = await _sha256File(finalFile);
       if ((storedSha256 != null && actual != storedSha256) ||
           (expectedSha256 != null && actual != expectedSha256)) {
         await _deleteStaleCompletedEntry(finalFile, metadataFile);
-        return (isValid: false, sha256: null);
+        return (isValid: false, bytes: null, sha256: null);
       }
-      return (isValid: true, sha256: actual);
+      return (isValid: true, bytes: actualBytes, sha256: actual);
     } on FileSystemException {
-      await _deleteStaleCompletedEntry(finalFile, metadataFile);
-      return (isValid: false, sha256: null);
+      await _deleteIfExists(metadataFile);
+      return (isValid: false, bytes: null, sha256: null);
     } on IOException {
-      await _deleteStaleCompletedEntry(finalFile, metadataFile);
-      return (isValid: false, sha256: null);
+      await _deleteIfExists(metadataFile);
+      return (isValid: false, bytes: null, sha256: null);
     }
   }
 
@@ -489,8 +493,11 @@ class DefaultModelDownloadManager implements ModelDownloadManager {
         return null;
       }
       return actual;
+    } on FileSystemException {
+      await _deleteIfExists(metadataFile);
+      return null;
     } on IOException {
-      await _deleteStaleCompletedEntry(finalFile, metadataFile);
+      await _deleteIfExists(metadataFile);
       return null;
     }
   }

--- a/lib/src/platform/io/model_download_manager_io.dart
+++ b/lib/src/platform/io/model_download_manager_io.dart
@@ -345,31 +345,44 @@ class DefaultModelDownloadManager implements ModelDownloadManager {
     File finalFile,
     ModelLoadOptions options,
   ) async {
-    if (!await metadataFile.exists() || !await finalFile.exists()) {
+    if (!await finalFile.exists()) {
       return null;
     }
-    final entry = await _readMetadata(metadataFile);
+    if (!await metadataFile.exists()) {
+      return _recoverMetadataEntry(source, metadataFile, finalFile, options);
+    }
+
+    final ModelCacheEntry entry;
+    try {
+      entry = await _readMetadata(metadataFile);
+    } on FormatException {
+      return _recoverMetadataEntry(source, metadataFile, finalFile, options);
+    } on ArgumentError {
+      return _recoverMetadataEntry(source, metadataFile, finalFile, options);
+    }
+
     if (entry.cacheKey != source.cacheKey ||
         entry.fileName != source.fileName ||
         entry.filePath != finalFile.path) {
       return null;
     }
-    String? verifiedSha256;
-    if (options.sha256 != null) {
-      final actual = await _sha256File(finalFile);
-      if (actual != options.sha256) {
-        await _deleteIfExists(finalFile);
-        await _deleteIfExists(metadataFile);
-        return null;
-      }
-      verifiedSha256 = actual;
+    final verifiedSha256 = await _verifyCompletedFile(
+      finalFile,
+      metadataFile,
+      entry,
+      options,
+    );
+    if (!await finalFile.exists() ||
+        (verifiedSha256 == null &&
+            (options.sha256 != null || entry.sha256 != null))) {
+      return null;
     }
     final refreshed = ModelCacheEntry(
       sourceCanonicalKey: entry.sourceCanonicalKey,
       cacheKey: entry.cacheKey,
       fileName: entry.fileName,
       filePath: entry.filePath,
-      bytes: entry.bytes,
+      bytes: await finalFile.length(),
       sha256: verifiedSha256 ?? entry.sha256,
       etag: entry.etag,
       lastModified: entry.lastModified,
@@ -379,6 +392,74 @@ class DefaultModelDownloadManager implements ModelDownloadManager {
     );
     await _writeMetadata(metadataFile, refreshed);
     return refreshed;
+  }
+
+  Future<ModelCacheEntry?> _recoverMetadataEntry(
+    ModelSource source,
+    File metadataFile,
+    File finalFile,
+    ModelLoadOptions options,
+  ) async {
+    final verifiedSha256 = await _verifyRecoveredFile(
+      finalFile,
+      metadataFile,
+      options,
+    );
+    if (options.sha256 != null && verifiedSha256 == null) {
+      return null;
+    }
+    final now = DateTime.now().toUtc();
+    final recovered = await _entryForFile(
+      source,
+      finalFile,
+      now,
+      sha256Digest: verifiedSha256,
+    );
+    await _writeMetadata(metadataFile, recovered);
+    return recovered;
+  }
+
+  Future<String?> _verifyCompletedFile(
+    File finalFile,
+    File metadataFile,
+    ModelCacheEntry entry,
+    ModelLoadOptions options,
+  ) async {
+    final recordedBytes = entry.bytes;
+    if (recordedBytes != null && await finalFile.length() != recordedBytes) {
+      await _deleteIfExists(finalFile);
+      await _deleteIfExists(metadataFile);
+      return null;
+    }
+    final expectedSha256 = options.sha256 ?? entry.sha256;
+    if (expectedSha256 == null) {
+      return null;
+    }
+    final actual = await _sha256File(finalFile);
+    if (actual != expectedSha256) {
+      await _deleteIfExists(finalFile);
+      await _deleteIfExists(metadataFile);
+      return null;
+    }
+    return actual;
+  }
+
+  Future<String?> _verifyRecoveredFile(
+    File finalFile,
+    File metadataFile,
+    ModelLoadOptions options,
+  ) async {
+    final expectedSha256 = options.sha256;
+    if (expectedSha256 == null) {
+      return null;
+    }
+    final actual = await _sha256File(finalFile);
+    if (actual != expectedSha256) {
+      await _deleteIfExists(finalFile);
+      await _deleteIfExists(metadataFile);
+      return null;
+    }
+    return actual;
   }
 
   Future<ModelCacheEntry> _download(

--- a/test/unit/platform/io/model_download_manager_io_test.dart
+++ b/test/unit/platform/io/model_download_manager_io_test.dart
@@ -367,6 +367,34 @@ void main() {
       },
     );
 
+    test('cacheOnly recovers malformed metadata without network', () async {
+      final manager = DefaultModelDownloadManager(
+        defaultCacheDirectory: tempDir.path,
+      );
+      final source = ModelSource.url(server.modelUri, fileName: 'tiny.gguf');
+
+      server.payload = utf8.encode('cache-only-malformed-metadata-model');
+      final first = await manager.ensureModel(source);
+      final metadataFile = File(
+        path.join(path.dirname(first.filePath), 'metadata.json'),
+      );
+      await metadataFile.writeAsString('{not valid json');
+
+      server.payload = utf8.encode('remote-newer-model');
+      final recovered = await manager.ensureModel(
+        source,
+        options: ModelLoadOptions(cachePolicy: ModelCachePolicy.cacheOnly),
+      );
+
+      expect(server.requestCount, 1);
+      expect(recovered.filePath, first.filePath);
+      expect(
+        File(recovered.filePath).readAsStringSync(),
+        'cache-only-malformed-metadata-model',
+      );
+      expect(metadataFile.readAsStringSync(), contains('"schema_version": 1'));
+    });
+
     test(
       'cacheOnly recovers unsupported metadata schema for an existing file',
       () async {

--- a/test/unit/platform/io/model_download_manager_io_test.dart
+++ b/test/unit/platform/io/model_download_manager_io_test.dart
@@ -303,6 +303,160 @@ void main() {
       expect(File(cached.filePath).readAsStringSync(), 'cached-model');
     });
 
+    test(
+      'cacheOnly recovers missing metadata for an existing model file',
+      () async {
+        final manager = DefaultModelDownloadManager(
+          defaultCacheDirectory: tempDir.path,
+        );
+        final source = ModelSource.url(server.modelUri, fileName: 'tiny.gguf');
+
+        server.payload = utf8.encode('metadata-recovery-model');
+        final first = await manager.ensureModel(source);
+        final metadataFile = File(
+          path.join(path.dirname(first.filePath), 'metadata.json'),
+        );
+        await metadataFile.delete();
+
+        final recovered = await manager.ensureModel(
+          source,
+          options: ModelLoadOptions(cachePolicy: ModelCachePolicy.cacheOnly),
+        );
+
+        expect(server.requestCount, 1);
+        expect(recovered.filePath, first.filePath);
+        expect(recovered.cacheKey, source.cacheKey);
+        expect(recovered.fileName, source.fileName);
+        expect(recovered.bytes, utf8.encode('metadata-recovery-model').length);
+        expect(metadataFile.existsSync(), isTrue);
+        expect(
+          metadataFile.readAsStringSync(),
+          isNot(contains('download=true')),
+        );
+      },
+    );
+
+    test(
+      'cache hit recovers malformed metadata without re-downloading',
+      () async {
+        final manager = DefaultModelDownloadManager(
+          defaultCacheDirectory: tempDir.path,
+        );
+        final source = ModelSource.url(server.modelUri, fileName: 'tiny.gguf');
+
+        server.payload = utf8.encode('malformed-metadata-model');
+        final first = await manager.ensureModel(source);
+        final metadataFile = File(
+          path.join(path.dirname(first.filePath), 'metadata.json'),
+        );
+        await metadataFile.writeAsString('{not valid json');
+
+        server.payload = utf8.encode('remote-newer-model');
+        final recovered = await manager.ensureModel(source);
+
+        expect(server.requestCount, 1);
+        expect(recovered.filePath, first.filePath);
+        expect(
+          File(recovered.filePath).readAsStringSync(),
+          'malformed-metadata-model',
+        );
+        expect(
+          metadataFile.readAsStringSync(),
+          contains('"schema_version": 1'),
+        );
+      },
+    );
+
+    test(
+      'cacheOnly recovers unsupported metadata schema for an existing file',
+      () async {
+        final manager = DefaultModelDownloadManager(
+          defaultCacheDirectory: tempDir.path,
+        );
+        final source = ModelSource.url(server.modelUri, fileName: 'tiny.gguf');
+
+        server.payload = utf8.encode('future-schema-model');
+        final first = await manager.ensureModel(source);
+        final metadataFile = File(
+          path.join(path.dirname(first.filePath), 'metadata.json'),
+        );
+        final metadata =
+            jsonDecode(metadataFile.readAsStringSync()) as Map<String, dynamic>;
+        metadata['schema_version'] = 999;
+        await metadataFile.writeAsString(jsonEncode(metadata));
+
+        final recovered = await manager.ensureModel(
+          source,
+          options: ModelLoadOptions(cachePolicy: ModelCachePolicy.cacheOnly),
+        );
+
+        expect(server.requestCount, 1);
+        expect(recovered.filePath, first.filePath);
+        expect(
+          metadataFile.readAsStringSync(),
+          contains('"schema_version": 1'),
+        );
+      },
+    );
+
+    test(
+      'cache hit redownloads when metadata byte length does not match file',
+      () async {
+        final manager = DefaultModelDownloadManager(
+          defaultCacheDirectory: tempDir.path,
+        );
+        final source = ModelSource.url(server.modelUri, fileName: 'tiny.gguf');
+
+        server.payload = utf8.encode('cached-model');
+        final first = await manager.ensureModel(source);
+        final metadataFile = File(
+          path.join(path.dirname(first.filePath), 'metadata.json'),
+        );
+        final metadata =
+            jsonDecode(metadataFile.readAsStringSync()) as Map<String, dynamic>;
+        metadata['bytes'] = 1024 * 1024;
+        await metadataFile.writeAsString(jsonEncode(metadata));
+
+        server.payload = utf8.encode('redownloaded-model');
+        final refreshed = await manager.ensureModel(source);
+
+        expect(server.requestCount, 2);
+        expect(refreshed.filePath, first.filePath);
+        expect(
+          File(refreshed.filePath).readAsStringSync(),
+          'redownloaded-model',
+        );
+      },
+    );
+
+    test(
+      'cache hit redownloads when stored sha256 no longer matches file',
+      () async {
+        final manager = DefaultModelDownloadManager(
+          defaultCacheDirectory: tempDir.path,
+        );
+        final source = ModelSource.url(server.modelUri, fileName: 'tiny.gguf');
+        server.payload = utf8.encode('checksummed-model');
+        final expectedSha256 = sha256.convert(server.payload).toString();
+
+        final first = await manager.ensureModel(
+          source,
+          options: ModelLoadOptions(sha256: expectedSha256),
+        );
+        await File(first.filePath).writeAsString('corrupted-model');
+
+        server.payload = utf8.encode('redownloaded-model');
+        final refreshed = await manager.ensureModel(source);
+
+        expect(server.requestCount, 2);
+        expect(refreshed.filePath, first.filePath);
+        expect(
+          File(refreshed.filePath).readAsStringSync(),
+          'redownloaded-model',
+        );
+      },
+    );
+
     test('cache hit rejects metadata for a different source', () async {
       final manager = DefaultModelDownloadManager(
         defaultCacheDirectory: tempDir.path,

--- a/test/unit/platform/io/model_download_manager_io_test.dart
+++ b/test/unit/platform/io/model_download_manager_io_test.dart
@@ -443,7 +443,7 @@ void main() {
           source,
           options: ModelLoadOptions(sha256: expectedSha256),
         );
-        await File(first.filePath).writeAsString('corrupted-model');
+        await File(first.filePath).writeAsString('checksum-mismatch');
 
         server.payload = utf8.encode('redownloaded-model');
         final refreshed = await manager.ensureModel(source);
@@ -453,6 +453,39 @@ void main() {
         expect(
           File(refreshed.filePath).readAsStringSync(),
           'redownloaded-model',
+        );
+      },
+    );
+
+    test(
+      'cache hit redownloads when stored sha256 conflicts with caller sha256',
+      () async {
+        final manager = DefaultModelDownloadManager(
+          defaultCacheDirectory: tempDir.path,
+        );
+        final source = ModelSource.url(server.modelUri, fileName: 'tiny.gguf');
+        server.payload = utf8.encode('checksummed-model');
+        final storedSha256 = sha256.convert(server.payload).toString();
+
+        final first = await manager.ensureModel(
+          source,
+          options: ModelLoadOptions(sha256: storedSha256),
+        );
+        server.payload = utf8.encode('checksum-mismatch');
+        final callerSha256 = sha256.convert(server.payload).toString();
+        await File(first.filePath).writeAsString('checksum-mismatch');
+
+        final refreshed = await manager.ensureModel(
+          source,
+          options: ModelLoadOptions(sha256: callerSha256),
+        );
+
+        expect(server.requestCount, 2);
+        expect(refreshed.filePath, first.filePath);
+        expect(refreshed.sha256, callerSha256);
+        expect(
+          File(refreshed.filePath).readAsStringSync(),
+          'checksum-mismatch',
         );
       },
     );

--- a/website/docs/changelog/recent-releases.md
+++ b/website/docs/changelog/recent-releases.md
@@ -22,6 +22,10 @@ For canonical full release notes, use:
   across manager instances so duplicate callers do not race on shared `.part`
   files or metadata, while distinct cache entries can still download in
   parallel and waiting-caller cancellation does not cancel the active download.
+- Hardened versioned cache metadata recovery so completed files can rebuild
+  missing, malformed, or unsupported-schema sidecars without network access,
+  while byte-count and stored/caller SHA-256 mismatches are treated as cache
+  misses and safely re-downloaded.
 - Added `LlamaEngine.loadModelSource(...)` so local path sources keep using the
   existing native loader, remote HTTP(S)/Hugging Face sources download through
   the package-managed native cache before local loading, and URL-capable web

--- a/website/docs/guides/model-lifecycle.md
+++ b/website/docs/guides/model-lifecycle.md
@@ -133,6 +133,18 @@ waiting caller is observed after the active same-entry operation finishes and
 does not cancel that active download; cancellation of the active download
 releases the entry lock so a later caller can retry or resume from a safe `.part`
 file.
+
+Cache metadata uses a versioned `metadata.json` sidecar next to the completed
+model file. A completed cache entry is reused only when the sidecar matches the
+requested cache key, file name, and file path, and the file still satisfies the
+recorded byte length plus any caller-supplied or previously stored SHA-256. If a
+completed file remains but the sidecar is missing, malformed, or written by an
+unsupported schema version, the native manager rebuilds a fresh versioned
+sidecar from the deterministic source/cache identity instead of touching the
+network; `cacheOnly` can therefore recover from metadata-only damage. If the
+file is missing or fails the recorded length/checksum checks, the entry is
+ignored as a cache miss and cache-reusing policies re-download safely.
+
 Retry/resume use HTTP Range only when the partial file has a safe validator
 (ETag/Last-Modified) or the caller supplied a SHA-256 checksum; validator-less
 partials restart from byte zero. If a server ignores a resume request and


### PR DESCRIPTION
## Summary
- Recover missing, malformed, or unsupported-version model cache metadata sidecars when the completed deterministic cache file is still present.
- Treat metadata byte-count mismatches and stored/caller SHA-256 mismatches as cache misses by deleting stale cache artifacts so reuse policies redownload safely and cache-only fails.
- Document metadata invariants and recovery behavior in the public download/cache docs and changelog.

Closes #134

## Production-readiness scope
- Users can keep using package-managed native model downloads when only `metadata.json` is damaged or from an unsupported schema version; the deterministic completed model file is reused without network access.
- Supported paths: native/file-backed `DefaultModelDownloadManager` stable cache entries for HTTP(S)/Hugging Face-derived remote model sources.
- Unsupported/stale paths: missing completed files, source/file/path mismatches, byte-count mismatches, and checksum mismatches are treated as cache misses instead of returning stale entries.
- Existing APIs remain compatible; behavior is an internal cache-hardening change.

## Test Plan
- [x] `dart format --output=none --set-exit-if-changed lib/src/core/models/download/model_download_manager_base.dart lib/src/platform/io/model_download_manager_io.dart test/unit/platform/io/model_download_manager_io_test.dart`
- [x] `dart test -p vm test/unit/platform/io/model_download_manager_io_test.dart`
- [x] `dart analyze`
- [x] `dart test -p vm -j 1 --exclude-tags local-only`

## Review Notes
- Local diff reviewed for issue #134 acceptance criteria: metadata recovery cases, stale-metadata cache-miss behavior, and signed URL redaction guarantees.
