### PR TITLE
feat(webgpu): wire bridge state persistence

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,8 +31,8 @@
     `LlamaEngine.stateSaveFile(...)`, and
     `LlamaEngine.stateLoadFile(...)` so callers can persist and restore
     llama.cpp KV-cache state for fast raw-prompt resume/fork workflows.
-  * Added `BackendStatePersistence` and `StateLoadResult` for custom backend
-    implementers and diagnostics.
+  * Added `BackendStatePersistence`, `BackendStatePersistenceSupport`, and
+    `StateLoadResult` for custom backend implementers and diagnostics.
   * Documented that state files are opaque llama.cpp artifacts tied to the same
     model and runtime/build, that native paths use the app filesystem while web
     paths use the bridge WASMFS virtual filesystem, and that `ChatSession`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,16 +26,20 @@
     backends when available.
   * Migrated server/testing helpers away from ad-hoc model downloads so examples
     dogfood the package-managed cache manager.
-* **State persistence API (native backend)**:
+* **State persistence API**:
   * Added `LlamaEngine.supportsStatePersistence`,
     `LlamaEngine.stateSaveFile(...)`, and
-    `LlamaEngine.stateLoadFile(...)` so native callers can persist and restore
+    `LlamaEngine.stateLoadFile(...)` so callers can persist and restore
     llama.cpp KV-cache state for fast raw-prompt resume/fork workflows.
   * Added `BackendStatePersistence` and `StateLoadResult` for custom backend
     implementers and diagnostics.
   * Documented that state files are opaque llama.cpp artifacts tied to the same
-    model and runtime/build, that WebGPU does not support state persistence, and
-    that `ChatSession` message history must be persisted separately.
+    model and runtime/build, that native paths use the app filesystem while web
+    paths use the bridge WASMFS virtual filesystem, and that `ChatSession`
+    message history must be persisted separately.
+  * Added WebGPU bridge state persistence wiring for bridge assets `v0.1.15+`,
+    including Dart JS interop, backend forwarding, and browser integration test
+    coverage.
 * **Compatibility note**: no public API breaking changes; the model source and
   state persistence APIs are additive and existing `loadModel(...)` callers are
   unchanged.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,9 +40,10 @@
   * Added WebGPU bridge state persistence wiring for bridge assets `v0.1.15+`,
     including Dart JS interop, backend forwarding, and browser integration test
     coverage.
-* **Compatibility note**: no public API breaking changes; the model source and
-  state persistence APIs are additive and existing `loadModel(...)` callers are
-  unchanged.
+* **Compatibility note**: existing `loadModel(...)` callers are unchanged. Code
+  that probes state persistence support should prefer
+  `LlamaEngine.supportsStatePersistence` over structural backend type checks so
+  web/router backends can report bridge-version-dependent support accurately.
 
 ## 0.6.12
 

--- a/README.md
+++ b/README.md
@@ -168,6 +168,10 @@ across page reloads.
 final prompt = 'You are a concise assistant. Summarize llamadart.';
 final tokens = await engine.tokenize(prompt);
 
+if (!engine.supportsStatePersistence) {
+  throw UnsupportedError('State persistence is not available on this backend.');
+}
+
 // Populate the KV cache, then save it with the token sequence that produced it.
 await engine
     .generate(prompt, params: const GenerationParams(maxTokens: 1))

--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@
   `embedBatch(...)`.
 - 📦 **Structured Model Sources**: Describe local, HTTP(S), and Hugging Face
   GGUF sources with deterministic cache identities for download/cache workflows.
-- 💾 **Native State Persistence**: Save and restore llama.cpp KV-cache state
+- 💾 **KV-cache State Persistence**: Save and restore llama.cpp KV-cache state
   with `stateSaveFile(...)` / `stateLoadFile(...)` for fast raw-prompt resumes.
 - 🖼️ **Multimodal Support**: Vision/audio model runtime support.
 - **LoRA Support**: Runtime GGUF adapter application.
@@ -156,10 +156,13 @@ Note: embedding support depends on backend/runtime capabilities.
 - Web runtime requires bridge assets with embedding APIs (`v0.1.7` or newer).
 - See the full guide: https://llamadart.leehack.com/docs/guides/embeddings
 
-### 7. Optional: save and restore native KV-cache state
+### 7. Optional: save and restore KV-cache state
 
-Native backends can persist llama.cpp KV-cache state for fast raw-prompt
-resume/fork workflows:
+Native backends and WebGPU bridge assets `v0.1.15+` can persist llama.cpp
+KV-cache state for fast raw-prompt resume/fork workflows. On native platforms,
+`path` is an app-writable filesystem path. On web, `path` is a bridge WASMFS
+virtual path; use an app-managed browser storage layer if you need durable state
+across page reloads.
 
 ```dart
 final prompt = 'You are a concise assistant. Summarize llamadart.';
@@ -179,9 +182,7 @@ final restored = await engine.stateLoadFile(
 print('Restored ${restored.tokens.length} prompt tokens');
 ```
 
-State persistence is native-only; WebGPU bridge sessions report
-`supportsStatePersistence == false` and throw `LlamaUnsupportedException` if
-called. State files are opaque llama.cpp artifacts tied to the same model and
+State files are opaque llama.cpp artifacts tied to the same model and
 runtime/build. `ChatSession` message history is not restored automatically, so
 persist chat messages separately when using the high-level chat API.
 

--- a/doc/webgpu_bridge.md
+++ b/doc/webgpu_bridge.md
@@ -19,7 +19,7 @@ pipelines.
    `https://cdn.jsdelivr.net/gh/leehack/llama-web-bridge-assets@<tag>/llama_webgpu_bridge.js`
 2. Local fallback: `./webgpu_bridge/llama_webgpu_bridge.js`
 
-Default pinned tag in the example is `v0.1.14`.
+Default pinned tag in the example is `v0.1.15`.
 
 For broader browser coverage in this repository, fetched/local assets are patched
 to a universal Safari-compatible gate by default (`MIN_SAFARI_VERSION=170400`).
@@ -32,7 +32,7 @@ model bytes.
 To vendor pinned assets into local app web files:
 
 ```bash
-WEBGPU_BRIDGE_ASSETS_TAG=v0.1.14 ./scripts/fetch_webgpu_bridge_assets.sh
+WEBGPU_BRIDGE_ASSETS_TAG=v0.1.15 ./scripts/fetch_webgpu_bridge_assets.sh
 ```
 
 Optional compatibility env vars:
@@ -108,7 +108,7 @@ You can override CDN source/version before the bridge loader runs:
 ```html
 <script>
   window.__llamadartBridgeAssetsRepo = 'leehack/llama-web-bridge-assets';
-  window.__llamadartBridgeAssetsTag = 'v0.1.14';
+  window.__llamadartBridgeAssetsTag = 'v0.1.15';
 </script>
 ```
 
@@ -134,6 +134,8 @@ window.LlamaWebGpuBridge = class LlamaWebGpuBridge {
 - `createCompletion(prompt, { nPredict, temp, topK, topP, penalty, seed, grammar, onToken, parts, signal })`
 - `tokenize(text, addSpecial)`
 - `detokenize(tokens, special)`
+- `stateSaveFile(path, tokens)`
+- `stateLoadFile(path, tokenCapacity)`
 - `embed(text, { normalize })`
 - `embedBatch(texts, { normalize })`
 - `getModelMetadata()`
@@ -149,6 +151,10 @@ window.LlamaWebGpuBridge = class LlamaWebGpuBridge {
 - Web backend remains GGUF URL-based (`modelLoadFromUrl`).
 - If bridge activation fails, model loading fails (no alternate web backend).
 - Embeddings on web require bridge assets with embedding APIs (`v0.1.7+`).
+- State persistence on web requires bridge assets with state APIs (`v0.1.15+`);
+  paths are bridge WASMFS virtual paths and are not durable across page reloads.
+  Durable browser storage currently requires app-level export/import outside the
+  Dart `stateSaveFile` / `stateLoadFile` helpers.
 - During this experimental phase, bridge can be supplied by:
   - preloaded global `window.LlamaWebGpuBridge`, or
   - dynamic import URL via `WebGpuLlamaBackend(bridgeScriptUrl: ...)`.

--- a/example/chat_app/web/index.html
+++ b/example/chat_app/web/index.html
@@ -215,8 +215,8 @@
     const bridgeAssetsTag =
       typeof configuredTag === 'string' && configuredTag.length > 0
         ? configuredTag
-        : 'v0.1.14';
-    const localBridgeVersion = 'v0.1.14-local-b9016';
+        : 'v0.1.15';
+    const localBridgeVersion = 'v0.1.15-local-b9116';
     window.__llamadartBridgeLocalVersion = localBridgeVersion;
 
     const localBridgeUrl = `./webgpu_bridge/llama_webgpu_bridge.js?v=${localBridgeVersion}`;

--- a/lib/llamadart.dart
+++ b/lib/llamadart.dart
@@ -47,6 +47,7 @@ export 'src/backends/backend.dart'
         BackendEmbeddings,
         BackendBatchEmbeddings,
         BackendStatePersistence,
+        BackendStatePersistenceSupport,
         StateLoadResult;
 
 // Models - Inference

--- a/lib/src/backends/backend.dart
+++ b/lib/src/backends/backend.dart
@@ -248,3 +248,15 @@ abstract class BackendStatePersistence {
     int tokenCapacity,
   );
 }
+
+/// Optional backend capability for reporting whether
+/// [BackendStatePersistence] is actually available for the active runtime.
+///
+/// This is useful for delegating/router backends where the wrapper may expose
+/// the persistence methods but support depends on the selected concrete
+/// backend. Backends that do not implement this interface fall back to the
+/// structural `is BackendStatePersistence` check used by older versions.
+abstract class BackendStatePersistenceSupport {
+  /// Whether state save/load calls are expected to be supported by this backend.
+  bool get supportsStatePersistence;
+}

--- a/lib/src/backends/web/web_backend.dart
+++ b/lib/src/backends/web/web_backend.dart
@@ -14,7 +14,8 @@ class WebAutoBackend
         LlamaBackend,
         BackendAvailability,
         BackendBatchEmbeddings,
-        BackendStatePersistence {
+        BackendStatePersistence,
+        BackendStatePersistenceSupport {
   final LlamaBackend _delegate;
 
   /// Creates a web backend router.
@@ -25,6 +26,16 @@ class WebAutoBackend
 
   @override
   bool get isReady => _delegate.isReady;
+
+  @override
+  bool get supportsStatePersistence {
+    final delegate = _delegate;
+    if (delegate is BackendStatePersistenceSupport) {
+      return (delegate as BackendStatePersistenceSupport)
+          .supportsStatePersistence;
+    }
+    return delegate is BackendStatePersistence;
+  }
 
   @override
   Future<int> modelLoad(String path, ModelParams params) {

--- a/lib/src/backends/web/web_backend.dart
+++ b/lib/src/backends/web/web_backend.dart
@@ -10,7 +10,11 @@ LlamaBackend createBackend() => WebAutoBackend();
 
 /// Uses the unified web backend implementation.
 class WebAutoBackend
-    implements LlamaBackend, BackendAvailability, BackendBatchEmbeddings {
+    implements
+        LlamaBackend,
+        BackendAvailability,
+        BackendBatchEmbeddings,
+        BackendStatePersistence {
   final LlamaBackend _delegate;
 
   /// Creates a web backend router.
@@ -125,6 +129,40 @@ class WebAutoBackend
 
     throw UnsupportedError(
       'Embeddings are not supported by the active web backend.',
+    );
+  }
+
+  @override
+  Future<bool> stateSaveFile(int contextHandle, String path, List<int> tokens) {
+    final delegate = _delegate;
+    if (delegate is BackendStatePersistence) {
+      return (delegate as BackendStatePersistence).stateSaveFile(
+        contextHandle,
+        path,
+        tokens,
+      );
+    }
+    throw UnsupportedError(
+      'State persistence is not supported by the active web backend.',
+    );
+  }
+
+  @override
+  Future<StateLoadResult> stateLoadFile(
+    int contextHandle,
+    String path,
+    int tokenCapacity,
+  ) {
+    final delegate = _delegate;
+    if (delegate is BackendStatePersistence) {
+      return (delegate as BackendStatePersistence).stateLoadFile(
+        contextHandle,
+        path,
+        tokenCapacity,
+      );
+    }
+    throw UnsupportedError(
+      'State persistence is not supported by the active web backend.',
     );
   }
 

--- a/lib/src/backends/webgpu/interop.dart
+++ b/lib/src/backends/webgpu/interop.dart
@@ -51,6 +51,12 @@ extension type LlamaWebGpuBridge._(JSObject _) implements JSObject {
   /// Detokenizes token ids.
   external JSPromise<JSString>? detokenize(JSArray tokens, [bool? special]);
 
+  /// Saves the active KV-cache/session state to a bridge WASMFS path.
+  external JSPromise<JSAny?>? stateSaveFile(String path, JSArray tokens);
+
+  /// Loads KV-cache/session state from a bridge WASMFS path.
+  external JSPromise<JSAny?>? stateLoadFile(String path, int tokenCapacity);
+
   /// Generates a single embedding vector for [text].
   external JSPromise<JSAny?>? embed(
     String text, [

--- a/lib/src/backends/webgpu/webgpu_backend.dart
+++ b/lib/src/backends/webgpu/webgpu_backend.dart
@@ -25,7 +25,8 @@ class WebGpuLlamaBackend
         LlamaBackend,
         BackendAvailability,
         BackendBatchEmbeddings,
-        BackendStatePersistence {
+        BackendStatePersistence,
+        BackendStatePersistenceSupport {
   static const Duration _bridgeReadyTimeout = Duration(seconds: 12);
   static const Duration _bridgePollInterval = Duration(milliseconds: 100);
   static const int _defaultRemoteFetchChunkBytes = 4 * 1024 * 1024;
@@ -72,6 +73,9 @@ class WebGpuLlamaBackend
 
   @override
   bool get isReady => _isReady;
+
+  @override
+  bool get supportsStatePersistence => true;
 
   Future<void> _loadBridgeScript() async {
     final scriptUrl = _bridgeScriptUrl;

--- a/lib/src/backends/webgpu/webgpu_backend.dart
+++ b/lib/src/backends/webgpu/webgpu_backend.dart
@@ -75,7 +75,18 @@ class WebGpuLlamaBackend
   bool get isReady => _isReady;
 
   @override
-  bool get supportsStatePersistence => true;
+  bool get supportsStatePersistence {
+    final bridge = _bridge;
+    return _usingBridge &&
+        bridge != null &&
+        _hasBridgeFunction(bridge, 'stateSaveFile') &&
+        _hasBridgeFunction(bridge, 'stateLoadFile');
+  }
+
+  bool _hasBridgeFunction(LlamaWebGpuBridge bridge, String name) {
+    final value = bridge.getProperty(name.toJS);
+    return value.isA<JSFunction>();
+  }
 
   Future<void> _loadBridgeScript() async {
     final scriptUrl = _bridgeScriptUrl;
@@ -2003,6 +2014,12 @@ class WebGpuLlamaBackend
     List<int> tokens,
   ) async {
     final bridge = _requireBridge();
+    if (!supportsStatePersistence) {
+      throw UnsupportedError(
+        'Web state persistence requires bridge assets with state support '
+        '(v0.1.15 or newer).',
+      );
+    }
     final jsTokens = tokens.map((token) => token.toJS).toList().toJS;
     try {
       final result = await _toFuture(bridge.stateSaveFile(path, jsTokens));
@@ -2031,6 +2048,12 @@ class WebGpuLlamaBackend
     int tokenCapacity,
   ) async {
     final bridge = _requireBridge();
+    if (!supportsStatePersistence) {
+      throw UnsupportedError(
+        'Web state persistence requires bridge assets with state support '
+        '(v0.1.15 or newer).',
+      );
+    }
     try {
       final result = await _toFuture(bridge.stateLoadFile(path, tokenCapacity));
       JSAny? rawTokens;

--- a/lib/src/backends/webgpu/webgpu_backend.dart
+++ b/lib/src/backends/webgpu/webgpu_backend.dart
@@ -21,7 +21,11 @@ external JSArray _objectKeys(JSObject obj);
 
 /// Web backend backed by the llama.cpp bridge runtime.
 class WebGpuLlamaBackend
-    implements LlamaBackend, BackendAvailability, BackendBatchEmbeddings {
+    implements
+        LlamaBackend,
+        BackendAvailability,
+        BackendBatchEmbeddings,
+        BackendStatePersistence {
   static const Duration _bridgeReadyTimeout = Duration(seconds: 12);
   static const Duration _bridgePollInterval = Duration(milliseconds: 100);
   static const int _defaultRemoteFetchChunkBytes = 4 * 1024 * 1024;
@@ -1923,6 +1927,45 @@ class WebGpuLlamaBackend
     '[gMASK]<sop>',
   ];
 
+  List<int> _parseTokenList(JSAny? value) {
+    if (value == null) {
+      return const <int>[];
+    }
+
+    if (value.isA<JSUint32Array>()) {
+      return (value as JSUint32Array).toDart.cast<int>().toList();
+    }
+
+    if (value.isA<JSInt32Array>()) {
+      return (value as JSInt32Array).toDart.cast<int>().toList();
+    }
+
+    if (value.isA<JSArray>()) {
+      final arr = value as JSArray;
+      final tokens = <int>[];
+      for (int i = 0; i < arr.length; i++) {
+        final item = arr.getProperty(i.toJS);
+        if (item.isA<JSNumber>()) {
+          tokens.add((item as JSNumber).toDartInt);
+        }
+      }
+      return tokens;
+    }
+
+    return const <int>[];
+  }
+
+  bool _isStatePersistenceMethodUnavailableError(Object error) {
+    final lowered = _errorText(error).toLowerCase();
+    return lowered.contains('statesavefile is not a function') ||
+        lowered.contains('stateloadfile is not a function') ||
+        lowered.contains('bridge.statesavefile is not a function') ||
+        lowered.contains('bridge.stateloadfile is not a function') ||
+        lowered.contains('llamadart_webgpu_state_save_file') ||
+        lowered.contains('llamadart_webgpu_state_load_file') ||
+        lowered.contains('unknown function') && lowered.contains('state_');
+  }
+
   @override
   Future<List<int>> tokenize(
     int modelHandle,
@@ -1934,31 +1977,7 @@ class WebGpuLlamaBackend
         ? _normalizePromptForBridge(text, bridge)
         : text;
     final result = await _toFuture(bridge.tokenize(normalizedText, addSpecial));
-    if (result == null) {
-      return const <int>[];
-    }
-
-    if (result.isA<JSUint32Array>()) {
-      return (result as JSUint32Array).toDart.cast<int>().toList();
-    }
-
-    if (result.isA<JSInt32Array>()) {
-      return (result as JSInt32Array).toDart.cast<int>().toList();
-    }
-
-    if (result.isA<JSArray>()) {
-      final arr = result as JSArray;
-      final tokens = <int>[];
-      for (int i = 0; i < arr.length; i++) {
-        final value = arr.getProperty(i.toJS);
-        if (value.isA<JSNumber>()) {
-          tokens.add((value as JSNumber).toDartInt);
-        }
-      }
-      return tokens;
-    }
-
-    return const <int>[];
+    return _parseTokenList(result);
   }
 
   @override
@@ -1971,6 +1990,65 @@ class WebGpuLlamaBackend
     final jsTokens = tokens.map((t) => t.toJS).toList().toJS;
     final result = await _toFuture(bridge.detokenize(jsTokens, special));
     return (result as JSString?)?.toDart ?? '';
+  }
+
+  @override
+  Future<bool> stateSaveFile(
+    int contextHandle,
+    String path,
+    List<int> tokens,
+  ) async {
+    final bridge = _requireBridge();
+    final jsTokens = tokens.map((token) => token.toJS).toList().toJS;
+    try {
+      final result = await _toFuture(bridge.stateSaveFile(path, jsTokens));
+      if (result == null) {
+        return true;
+      }
+      if (result.isA<JSBoolean>()) {
+        return (result as JSBoolean).toDart;
+      }
+      return true;
+    } catch (error) {
+      if (_isStatePersistenceMethodUnavailableError(error)) {
+        throw UnsupportedError(
+          'Web state persistence requires bridge assets with state support '
+          '(v0.1.15 or newer).',
+        );
+      }
+      rethrow;
+    }
+  }
+
+  @override
+  Future<StateLoadResult> stateLoadFile(
+    int contextHandle,
+    String path,
+    int tokenCapacity,
+  ) async {
+    final bridge = _requireBridge();
+    try {
+      final result = await _toFuture(bridge.stateLoadFile(path, tokenCapacity));
+      JSAny? rawTokens;
+      if (result != null &&
+          result.isA<JSObject>() &&
+          !result.isA<JSArray>() &&
+          !result.isA<JSUint32Array>() &&
+          !result.isA<JSInt32Array>()) {
+        rawTokens = (result as JSObject).getProperty('tokens'.toJS);
+      } else {
+        rawTokens = result;
+      }
+      return StateLoadResult(tokens: _parseTokenList(rawTokens));
+    } catch (error) {
+      if (_isStatePersistenceMethodUnavailableError(error)) {
+        throw UnsupportedError(
+          'Web state persistence requires bridge assets with state support '
+          '(v0.1.15 or newer).',
+        );
+      }
+      rethrow;
+    }
   }
 
   @override

--- a/lib/src/core/engine/engine.dart
+++ b/lib/src/core/engine/engine.dart
@@ -1064,8 +1064,8 @@ class LlamaEngine {
   // ============================================================
 
   /// Whether the active backend can save and restore KV-cache state to
-  /// disk via [stateSaveFile] / [stateLoadFile]. Native backends do; the
-  /// WebGPU backend does not.
+  /// disk (native) or the bridge virtual filesystem (WebGPU bridge assets
+  /// v0.1.15+) via [stateSaveFile] / [stateLoadFile].
   bool get supportsStatePersistence => backend is BackendStatePersistence;
 
   /// Persists the KV-cache state of the loaded model to [path] together

--- a/lib/src/core/engine/engine.dart
+++ b/lib/src/core/engine/engine.dart
@@ -1063,10 +1063,21 @@ class LlamaEngine {
   // STATE PERSISTENCE
   // ============================================================
 
-  /// Whether the active backend can save and restore KV-cache state to
-  /// disk (native) or the bridge virtual filesystem (WebGPU bridge assets
-  /// v0.1.15+) via [stateSaveFile] / [stateLoadFile].
-  bool get supportsStatePersistence => backend is BackendStatePersistence;
+  /// Whether the active backend reports state save/load support.
+  ///
+  /// Native backends persist to disk. WebGPU backends persist to the bridge
+  /// virtual filesystem when using bridge assets `v0.1.15+`; older or custom
+  /// bridge assets can still throw from [stateSaveFile] / [stateLoadFile]
+  /// because bridge API availability is detected when the call reaches the
+  /// loaded JavaScript runtime.
+  bool get supportsStatePersistence {
+    final candidate = backend;
+    if (candidate is BackendStatePersistenceSupport) {
+      return (candidate as BackendStatePersistenceSupport)
+          .supportsStatePersistence;
+    }
+    return candidate is BackendStatePersistence;
+  }
 
   /// Persists the KV-cache state of the loaded model to [path] together
   /// with [tokens] — the token sequence the current state was produced

--- a/lib/src/core/engine/engine.dart
+++ b/lib/src/core/engine/engine.dart
@@ -1065,11 +1065,11 @@ class LlamaEngine {
 
   /// Whether the active backend reports state save/load support.
   ///
-  /// Native backends persist to disk. WebGPU backends persist to the bridge
-  /// virtual filesystem when using bridge assets `v0.1.15+`; older or custom
-  /// bridge assets can still throw from [stateSaveFile] / [stateLoadFile]
-  /// because bridge API availability is detected when the call reaches the
-  /// loaded JavaScript runtime.
+  /// Native backends persist to disk. WebGPU backends report support only after
+  /// the active JavaScript bridge exposes the `stateSaveFile` and
+  /// `stateLoadFile` APIs introduced in bridge assets `v0.1.15`; older or
+  /// custom bridge assets report false and calls throw [LlamaUnsupportedException]
+  /// before reaching the bridge.
   bool get supportsStatePersistence {
     final candidate = backend;
     if (candidate is BackendStatePersistenceSupport) {
@@ -1117,6 +1117,13 @@ class LlamaEngine {
 
   BackendStatePersistence _resolveStatePersistence() {
     final candidate = backend;
+    if (candidate is BackendStatePersistenceSupport &&
+        !(candidate as BackendStatePersistenceSupport)
+            .supportsStatePersistence) {
+      throw LlamaUnsupportedException(
+        'State persistence is not supported by the active backend.',
+      );
+    }
     if (candidate is BackendStatePersistence) {
       return candidate as BackendStatePersistence;
     }

--- a/lib/src/core/engine/engine.dart
+++ b/lib/src/core/engine/engine.dart
@@ -1121,7 +1121,9 @@ class LlamaEngine {
         !(candidate as BackendStatePersistenceSupport)
             .supportsStatePersistence) {
       throw LlamaUnsupportedException(
-        'State persistence is not supported by the active backend.',
+        'State persistence is not supported by the active backend. '
+        'For WebGPU, use bridge assets that expose stateSaveFile/stateLoadFile '
+        '(v0.1.15 or newer).',
       );
     }
     if (candidate is BackendStatePersistence) {

--- a/scripts/fetch_webgpu_bridge_assets.sh
+++ b/scripts/fetch_webgpu_bridge_assets.sh
@@ -4,7 +4,7 @@ set -euo pipefail
 ROOT_DIR="$(git rev-parse --show-toplevel)"
 OUT_DIR="${WEBGPU_BRIDGE_OUT_DIR:-$ROOT_DIR/example/chat_app/web/webgpu_bridge}"
 ASSETS_REPO="${WEBGPU_BRIDGE_ASSETS_REPO:-leehack/llama-web-bridge-assets}"
-ASSETS_TAG="${WEBGPU_BRIDGE_ASSETS_TAG:-v0.1.14}"
+ASSETS_TAG="${WEBGPU_BRIDGE_ASSETS_TAG:-v0.1.15}"
 CDN_BASE="${WEBGPU_BRIDGE_CDN_BASE:-https://cdn.jsdelivr.net/gh/${ASSETS_REPO}@${ASSETS_TAG}}"
 PATCH_SAFARI_COMPAT="${WEBGPU_BRIDGE_PATCH_SAFARI_COMPAT:-1}"
 MIN_SAFARI_VERSION="${WEBGPU_BRIDGE_MIN_SAFARI_VERSION:-170400}"
@@ -14,7 +14,7 @@ if [[ "${1:-}" == "--help" || "${1:-}" == "-h" ]]; then
 Downloads prebuilt WebGPU bridge assets into the chat_app web directory.
 
 Default source:
-  https://cdn.jsdelivr.net/gh/leehack/llama-web-bridge-assets@v0.1.14
+  https://cdn.jsdelivr.net/gh/leehack/llama-web-bridge-assets@v0.1.15
 
 Environment variables:
   WEBGPU_BRIDGE_ASSETS_REPO   Asset repo in owner/repo format
@@ -28,7 +28,7 @@ Usage:
   ./scripts/fetch_webgpu_bridge_assets.sh
 
 Examples:
-  WEBGPU_BRIDGE_ASSETS_TAG=v0.1.14 ./scripts/fetch_webgpu_bridge_assets.sh
+  WEBGPU_BRIDGE_ASSETS_TAG=v0.1.15 ./scripts/fetch_webgpu_bridge_assets.sh
   WEBGPU_BRIDGE_ASSETS_REPO=acme/llama-web-bridge-assets WEBGPU_BRIDGE_ASSETS_TAG=v2 ./scripts/fetch_webgpu_bridge_assets.sh
 USAGE
   exit 0

--- a/test/integration/backends/webgpu/webgpu_engine_multimodal_browser_integration_test.dart
+++ b/test/integration/backends/webgpu/webgpu_engine_multimodal_browser_integration_test.dart
@@ -17,11 +17,19 @@ void main() {
     late LlamaEngine engine;
     late bool mmLoaded;
     late bool sawAudioPart;
+    String? lastStateSavePath;
+    List<int>? lastStateSaveTokens;
+    String? lastStateLoadPath;
+    int? lastStateLoadCapacity;
 
     setUp(() {
       bridge = JSObject();
       mmLoaded = false;
       sawAudioPart = false;
+      lastStateSavePath = null;
+      lastStateSaveTokens = null;
+      lastStateLoadPath = null;
+      lastStateLoadCapacity = null;
 
       bridge.setProperty(
         'loadModelFromUrl'.toJS,
@@ -93,6 +101,35 @@ void main() {
         'detokenize'.toJS,
         ((JSArray tokens, bool special) {
           return Future<JSString>.value('decoded'.toJS).toJS;
+        }).toJS,
+      );
+
+      bridge.setProperty(
+        'stateSaveFile'.toJS,
+        ((String path, JSArray tokens) {
+          lastStateSavePath = path;
+          lastStateSaveTokens = <int>[];
+          for (int i = 0; i < tokens.length; i++) {
+            final raw = tokens.getProperty(i.toJS);
+            if (raw.isA<JSNumber>()) {
+              lastStateSaveTokens!.add((raw as JSNumber).toDartInt);
+            }
+          }
+          return Future<JSBoolean>.value(true.toJS).toJS;
+        }).toJS,
+      );
+
+      bridge.setProperty(
+        'stateLoadFile'.toJS,
+        ((String path, int tokenCapacity) {
+          lastStateLoadPath = path;
+          lastStateLoadCapacity = tokenCapacity;
+          final result = JSObject();
+          result.setProperty(
+            'tokens'.toJS,
+            <JSNumber>[7.toJS, 8.toJS, 9.toJS].toJS,
+          );
+          return Future<JSObject>.value(result).toJS;
         }).toJS,
       );
 
@@ -224,6 +261,31 @@ void main() {
         <double>[5.0, 1.0],
         <double>[4.0, 1.0],
       ]);
+    });
+
+    test('LlamaEngine state persistence forwards to web bridge', () async {
+      await engine.loadModelFromUrl(
+        'https://example.com/model.gguf',
+        modelParams: const ModelParams(contextSize: 1024),
+      );
+
+      expect(engine.supportsStatePersistence, isTrue);
+
+      final saved = await engine.stateSaveFile(
+        '/prompt-state.bin',
+        tokens: const <int>[1, 2, 3],
+      );
+      expect(saved, isTrue);
+      expect(lastStateSavePath, '/prompt-state.bin');
+      expect(lastStateSaveTokens, <int>[1, 2, 3]);
+
+      final restored = await engine.stateLoadFile(
+        '/prompt-state.bin',
+        tokenCapacity: 1024,
+      );
+      expect(restored.tokens, <int>[7, 8, 9]);
+      expect(lastStateLoadPath, '/prompt-state.bin');
+      expect(lastStateLoadCapacity, 1024);
     });
   });
 }

--- a/test/unit/backends/web/web_backend_test.dart
+++ b/test/unit/backends/web/web_backend_test.dart
@@ -34,7 +34,13 @@ void main() {
     await expectLater(
       () =>
           engine.stateSaveFile('/prompt-prefix.state', tokens: const <int>[1]),
-      throwsA(isA<LlamaUnsupportedException>()),
+      throwsA(
+        isA<LlamaUnsupportedException>().having(
+          (error) => error.message,
+          'message',
+          contains('v0.1.15'),
+        ),
+      ),
     );
   });
 }

--- a/test/unit/backends/web/web_backend_test.dart
+++ b/test/unit/backends/web/web_backend_test.dart
@@ -4,6 +4,9 @@ library;
 import 'package:llamadart/src/backends/backend.dart';
 import 'package:llamadart/src/backends/web/web_backend.dart';
 import 'package:llamadart/src/core/engine/engine.dart';
+import 'package:llamadart/src/core/exceptions.dart';
+import 'package:llamadart/src/core/models/config/log_level.dart';
+import 'package:llamadart/src/core/models/inference/model_params.dart';
 import 'package:test/test.dart';
 
 void main() {
@@ -16,24 +19,54 @@ void main() {
     expect(backend, isA<BackendBatchEmbeddings>());
     expect(backend, isA<BackendStatePersistence>());
     expect(backend, isA<BackendStatePersistenceSupport>());
-    expect((backend as WebAutoBackend).supportsStatePersistence, isTrue);
+    expect((backend as WebAutoBackend).supportsStatePersistence, isFalse);
   });
 
-  test('WebAutoBackend reports state support from injected delegate', () {
+  test('WebAutoBackend reports state support from injected delegate', () async {
     final backend = WebAutoBackend(webBackend: _NoStateBackend());
     final engine = LlamaEngine(backend);
 
     expect(backend.supportsStatePersistence, isFalse);
     expect(engine.supportsStatePersistence, isFalse);
+
+    await engine.loadModel('/model.gguf');
+    expect(engine.supportsStatePersistence, isFalse);
+    expect(
+      () =>
+          engine.stateSaveFile('/prompt-prefix.state', tokens: const <int>[1]),
+      throwsA(isA<LlamaUnsupportedException>()),
+    );
   });
 }
 
 class _NoStateBackend implements LlamaBackend {
   @override
-  bool get isReady => false;
+  bool get isReady => true;
 
   @override
   bool get supportsUrlLoading => true;
+
+  @override
+  Future<int> modelLoad(String path, ModelParams params) async => 1;
+
+  @override
+  Future<int> modelLoadFromUrl(
+    String url,
+    ModelParams params, {
+    Function(double progress)? onProgress,
+  }) async => 1;
+
+  @override
+  Future<int> contextCreate(int modelHandle, ModelParams params) async => 1;
+
+  @override
+  Future<void> contextFree(int contextHandle) async {}
+
+  @override
+  Future<void> modelFree(int modelHandle) async {}
+
+  @override
+  Future<void> setLogLevel(LlamaLogLevel level) async {}
 
   @override
   dynamic noSuchMethod(Invocation invocation) => super.noSuchMethod(invocation);

--- a/test/unit/backends/web/web_backend_test.dart
+++ b/test/unit/backends/web/web_backend_test.dart
@@ -3,6 +3,7 @@ library;
 
 import 'package:llamadart/src/backends/backend.dart';
 import 'package:llamadart/src/backends/web/web_backend.dart';
+import 'package:llamadart/src/core/engine/engine.dart';
 import 'package:test/test.dart';
 
 void main() {
@@ -13,5 +14,27 @@ void main() {
     expect(backend, isA<WebAutoBackend>());
     expect(backend, isA<BackendEmbeddings>());
     expect(backend, isA<BackendBatchEmbeddings>());
+    expect(backend, isA<BackendStatePersistence>());
+    expect(backend, isA<BackendStatePersistenceSupport>());
+    expect((backend as WebAutoBackend).supportsStatePersistence, isTrue);
   });
+
+  test('WebAutoBackend reports state support from injected delegate', () {
+    final backend = WebAutoBackend(webBackend: _NoStateBackend());
+    final engine = LlamaEngine(backend);
+
+    expect(backend.supportsStatePersistence, isFalse);
+    expect(engine.supportsStatePersistence, isFalse);
+  });
+}
+
+class _NoStateBackend implements LlamaBackend {
+  @override
+  bool get isReady => false;
+
+  @override
+  bool get supportsUrlLoading => true;
+
+  @override
+  dynamic noSuchMethod(Invocation invocation) => super.noSuchMethod(invocation);
 }

--- a/test/unit/backends/web/web_backend_test.dart
+++ b/test/unit/backends/web/web_backend_test.dart
@@ -31,7 +31,7 @@ void main() {
 
     await engine.loadModel('/model.gguf');
     expect(engine.supportsStatePersistence, isFalse);
-    expect(
+    await expectLater(
       () =>
           engine.stateSaveFile('/prompt-prefix.state', tokens: const <int>[1]),
       throwsA(isA<LlamaUnsupportedException>()),

--- a/test/unit/backends/webgpu/webgpu_backend_test.dart
+++ b/test/unit/backends/webgpu/webgpu_backend_test.dart
@@ -803,10 +803,12 @@ void main() {
     });
 
     test('forwards state persistence calls to bridge', () async {
+      expect(backend.supportsStatePersistence, isFalse);
       await backend.modelLoadFromUrl(
         'https://example.com/model.gguf',
         const ModelParams(),
       );
+      expect(backend.supportsStatePersistence, isTrue);
 
       final saved = await backend.stateSaveFile(
         1,
@@ -867,7 +869,9 @@ void main() {
           const ModelParams(),
         );
 
+        expect(backend.supportsStatePersistence, isTrue);
         bridge.delete('stateSaveFile'.toJS);
+        expect(backend.supportsStatePersistence, isFalse);
         await expectLater(
           () => backend.stateSaveFile(1, '/missing.state', const <int>[1]),
           throwsA(
@@ -879,7 +883,15 @@ void main() {
           ),
         );
 
+        bridge.setProperty(
+          'stateSaveFile'.toJS,
+          ((String path, JSArray tokens) {
+            return Future<JSBoolean>.value(true.toJS).toJS;
+          }).toJS,
+        );
+        expect(backend.supportsStatePersistence, isTrue);
         bridge.delete('stateLoadFile'.toJS);
+        expect(backend.supportsStatePersistence, isFalse);
         await expectLater(
           () => backend.stateLoadFile(1, '/missing.state', 128),
           throwsA(

--- a/test/unit/backends/webgpu/webgpu_backend_test.dart
+++ b/test/unit/backends/webgpu/webgpu_backend_test.dart
@@ -48,10 +48,16 @@ void main() {
     int? lastTokenEventFlushMs;
     int? lastTokenEventFlushChars;
     String? lastPrompt;
+    String? lastStateSavePath;
+    List<int>? lastStateSaveTokens;
+    String? lastStateLoadPath;
+    int? lastStateLoadCapacity;
     WebGpuBridgeConfig? lastBridgeConfig;
     late int runtimeGpuLayers;
     late bool runtimeGpuActive;
     late int runtimeThreads;
+    late bool stateSaveResult;
+    late String stateLoadReturnShape;
     int createCompletionCallCount = 0;
     int warmupCallCount = 0;
     int cancelCallCount = 0;
@@ -184,10 +190,16 @@ void main() {
       lastTokenEventFlushMs = null;
       lastTokenEventFlushChars = null;
       lastPrompt = null;
+      lastStateSavePath = null;
+      lastStateSaveTokens = null;
+      lastStateLoadPath = null;
+      lastStateLoadCapacity = null;
       lastBridgeConfig = null;
       runtimeGpuLayers = 99;
       runtimeGpuActive = true;
       runtimeThreads = 4;
+      stateSaveResult = true;
+      stateLoadReturnShape = 'object';
       createCompletionCallCount = 0;
       warmupCallCount = 0;
       cancelCallCount = 0;
@@ -338,6 +350,49 @@ void main() {
         'detokenize'.toJS,
         ((JSArray tokens, bool special) {
           return Future<JSString>.value('decoded'.toJS).toJS;
+        }).toJS,
+      );
+
+      bridge.setProperty(
+        'stateSaveFile'.toJS,
+        ((String path, JSArray tokens) {
+          lastStateSavePath = path;
+          lastStateSaveTokens = <int>[];
+          for (int i = 0; i < tokens.length; i++) {
+            final raw = tokens.getProperty(i.toJS);
+            if (raw.isA<JSNumber>()) {
+              lastStateSaveTokens!.add((raw as JSNumber).toDartInt);
+            }
+          }
+          return Future<JSBoolean>.value(stateSaveResult.toJS).toJS;
+        }).toJS,
+      );
+
+      bridge.setProperty(
+        'stateLoadFile'.toJS,
+        ((String path, int tokenCapacity) {
+          lastStateLoadPath = path;
+          lastStateLoadCapacity = tokenCapacity;
+
+          JSAny result;
+          if (stateLoadReturnShape == 'array') {
+            result = <JSNumber>[7.toJS, 8.toJS, 9.toJS].toJS;
+          } else if (stateLoadReturnShape == 'uint32') {
+            final arr = JSUint32Array.withLength(3);
+            arr.toDart[0] = 7;
+            arr.toDart[1] = 8;
+            arr.toDart[2] = 9;
+            result = arr;
+          } else {
+            final obj = JSObject();
+            obj.setProperty(
+              'tokens'.toJS,
+              <JSNumber>[7.toJS, 8.toJS, 9.toJS].toJS,
+            );
+            result = obj;
+          }
+
+          return Future<JSAny>.value(result).toJS;
         }).toJS,
       );
 
@@ -746,6 +801,97 @@ void main() {
         ),
       );
     });
+
+    test('forwards state persistence calls to bridge', () async {
+      await backend.modelLoadFromUrl(
+        'https://example.com/model.gguf',
+        const ModelParams(),
+      );
+
+      final saved = await backend.stateSaveFile(
+        1,
+        '/prompt-prefix.state',
+        const <int>[1, 2, 3],
+      );
+      expect(saved, isTrue);
+      expect(lastStateSavePath, '/prompt-prefix.state');
+      expect(lastStateSaveTokens, <int>[1, 2, 3]);
+
+      final loaded = await backend.stateLoadFile(
+        1,
+        '/prompt-prefix.state',
+        128,
+      );
+      expect(lastStateLoadPath, '/prompt-prefix.state');
+      expect(lastStateLoadCapacity, 128);
+      expect(loaded.tokens, <int>[7, 8, 9]);
+    });
+
+    test('propagates false state save bridge result', () async {
+      await backend.modelLoadFromUrl(
+        'https://example.com/model.gguf',
+        const ModelParams(),
+      );
+
+      stateSaveResult = false;
+      expect(
+        await backend.stateSaveFile(1, '/prompt-prefix.state', const <int>[1]),
+        isFalse,
+      );
+    });
+
+    test('accepts direct array and typed array state load results', () async {
+      await backend.modelLoadFromUrl(
+        'https://example.com/model.gguf',
+        const ModelParams(),
+      );
+
+      stateLoadReturnShape = 'array';
+      expect(
+        (await backend.stateLoadFile(1, '/array.state', 128)).tokens,
+        <int>[7, 8, 9],
+      );
+
+      stateLoadReturnShape = 'uint32';
+      expect(
+        (await backend.stateLoadFile(1, '/typed.state', 128)).tokens,
+        <int>[7, 8, 9],
+      );
+    });
+
+    test(
+      'throws clear error when state persistence API is unavailable',
+      () async {
+        await backend.modelLoadFromUrl(
+          'https://example.com/model.gguf',
+          const ModelParams(),
+        );
+
+        bridge.delete('stateSaveFile'.toJS);
+        await expectLater(
+          () => backend.stateSaveFile(1, '/missing.state', const <int>[1]),
+          throwsA(
+            isA<UnsupportedError>().having(
+              (UnsupportedError error) => error.message,
+              'message',
+              contains('v0.1.15'),
+            ),
+          ),
+        );
+
+        bridge.delete('stateLoadFile'.toJS);
+        await expectLater(
+          () => backend.stateLoadFile(1, '/missing.state', 128),
+          throwsA(
+            isA<UnsupportedError>().having(
+              (UnsupportedError error) => error.message,
+              'message',
+              contains('v0.1.15'),
+            ),
+          ),
+        );
+      },
+    );
 
     test(
       'passes core module URL from bootstrap global to bridge config',

--- a/website/docs/guides/api-levels.md
+++ b/website/docs/guides/api-levels.md
@@ -22,8 +22,9 @@ chat history management.
 - **Template-aware**: Uses model chat templates and parsing behavior automatically.
 - **Tool support**: Works with structured tool-call outputs.
 - **Embedding APIs**: `embed(...)` and `embedBatch(...)` on the same engine.
-- **State persistence**: Native backends can save/restore KV-cache state with
-  `stateSaveFile(...)` / `stateLoadFile(...)` for raw-prompt resume workflows.
+- **State persistence**: Native backends and WebGPU bridge assets `v0.1.15+`
+  can save/restore KV-cache state with `stateSaveFile(...)` /
+  `stateLoadFile(...)` for raw-prompt resume workflows.
 
 ```dart
 import 'package:llamadart/llamadart.dart';

--- a/website/docs/guides/model-lifecycle.md
+++ b/website/docs/guides/model-lifecycle.md
@@ -182,17 +182,19 @@ final prompt = 'You are a concise assistant. Summarize llamadart.';
 final tokens = await engine.tokenize(prompt);
 
 // Populate the KV cache, then persist it with the token sequence that produced
-// state. On native platforms, use your app's own writable path for the state
-// file. On web, use a bridge WASMFS virtual path such as '/prompt-prefix.state'.
+// state. This sample uses a WebGPU bridge WASMFS virtual path. Native apps
+// should replace it with an app-writable filesystem path.
+const statePath = '/prompt-prefix.state';
+
 await engine.generate(
   prompt,
   params: const GenerationParams(maxTokens: 1, reusePromptPrefix: true),
 ).drain<void>();
-await engine.stateSaveFile('/path/to/prompt-prefix.state', tokens: tokens);
+await engine.stateSaveFile(statePath, tokens: tokens);
 
-// Later, after loading the same model with a compatible native runtime build:
+// Later, after loading the same model with a compatible runtime/bridge build:
 final restored = await engine.stateLoadFile(
-  '/path/to/prompt-prefix.state',
+  statePath,
   tokenCapacity: await engine.getContextSize(),
 );
 

--- a/website/docs/guides/model-lifecycle.md
+++ b/website/docs/guides/model-lifecycle.md
@@ -163,23 +163,27 @@ caller supplies SHA-256. On Android, prefer app-private storage unless the app
 intentionally exposes model files to the user; on iOS, avoid cache directories
 that the OS may purge while a model is still needed.
 
-## Native state persistence
+## State persistence
 
-Native backends can save and restore llama.cpp KV-cache state to avoid
-re-evaluating a long raw prompt on resume or when forking a prompt prefix. Gate
-the flow with `supportsStatePersistence` because the WebGPU bridge does not
-expose llama.cpp state files.
+Native backends and WebGPU bridge assets `v0.1.15+` can save and restore
+llama.cpp KV-cache state to avoid re-evaluating a long raw prompt on resume or
+when forking a prompt prefix. Gate the flow with `supportsStatePersistence` so
+backends that do not implement state persistence can fall back to prompt
+re-evaluation. If a web app overrides the bridge to older/custom assets that do
+not expose state APIs, `stateSaveFile(...)` / `stateLoadFile(...)` throw a clear
+unsupported error and callers should use the same fallback path.
 
 ```dart
 if (!engine.supportsStatePersistence) {
-  throw LlamaUnsupportedException('State persistence is native-only.');
+  throw LlamaUnsupportedException('State persistence is not supported by this backend.');
 }
 
 final prompt = 'You are a concise assistant. Summarize llamadart.';
 final tokens = await engine.tokenize(prompt);
 
 // Populate the KV cache, then persist it with the token sequence that produced
-// the state. Use your app's own writable path for the state file.
+// state. On native platforms, use your app's own writable path for the state
+// file. On web, use a bridge WASMFS virtual path such as '/prompt-prefix.state'.
 await engine.generate(
   prompt,
   params: const GenerationParams(maxTokens: 1, reusePromptPrefix: true),
@@ -205,14 +209,15 @@ print('Restored ${restored.tokens.length} prompt tokens');
 Important caveats:
 
 - State files are opaque llama.cpp artifacts. Treat them as tied to the same
-  model file and compatible native runtime/build that created them.
+  model file and compatible runtime/build that created them. Web paths refer to
+  the bridge WASMFS virtual filesystem and are not durable across page reloads.
+  Durable browser storage currently requires app-level export/import outside the
+  Dart `stateSaveFile` / `stateLoadFile` helpers.
 - `stateLoadFile(...)` restores native KV-cache state only. It does not rebuild
   `ChatSession` message history; persist and reconstruct chat messages
   separately when using the high-level chat API.
 - Pass a `tokenCapacity` large enough for the saved prompt token sequence. The
   current context size is usually a safe default.
-- WebGPU sessions should check `supportsStatePersistence` and use a normal
-  prompt re-evaluation fallback.
 
 ## Multimodal projector lifecycle
 

--- a/website/docs/platforms/support-matrix.md
+++ b/website/docs/platforms/support-matrix.md
@@ -33,11 +33,11 @@ minimum deployment target of `16.4` or newer (for example
 ## Runtime capability notes
 
 - **State persistence** (`LlamaEngine.stateSaveFile(...)` /
-  `stateLoadFile(...)`) is available only on native backends that expose
-  `BackendStatePersistence`. The WebGPU bridge does not support llama.cpp state
-  files, so applications should gate this flow with
-  `engine.supportsStatePersistence` and fall back to prompt re-evaluation on
-  web.
+  `stateLoadFile(...)`) is available on native backends and on WebGPU bridge
+  assets `v0.1.15+` that expose `BackendStatePersistence`. On web, state paths
+  refer to the bridge WASMFS virtual filesystem and are not durable across page
+  reloads. Durable browser storage currently requires app-level export/import
+  outside the Dart `stateSaveFile` / `stateLoadFile` helpers.
 
 ## Current module availability by bundle (`b9016`)
 

--- a/website/docs/platforms/support-matrix.md
+++ b/website/docs/platforms/support-matrix.md
@@ -34,10 +34,11 @@ minimum deployment target of `16.4` or newer (for example
 
 - **State persistence** (`LlamaEngine.stateSaveFile(...)` /
   `stateLoadFile(...)`) is available on native backends and on WebGPU bridge
-  assets `v0.1.15+` that expose `BackendStatePersistence`. On web, state paths
-  refer to the bridge WASMFS virtual filesystem and are not durable across page
-  reloads. Durable browser storage currently requires app-level export/import
-  outside the Dart `stateSaveFile` / `stateLoadFile` helpers.
+  assets `v0.1.15+` that expose `stateSaveFile` / `stateLoadFile` bridge APIs.
+  On web, state paths refer to the bridge WASMFS virtual filesystem and are not
+  durable across page reloads. Durable browser storage currently requires
+  app-level export/import outside the Dart `stateSaveFile` / `stateLoadFile`
+  helpers.
 
 ## Current module availability by bundle (`b9016`)
 

--- a/website/docs/platforms/webgpu-bridge.md
+++ b/website/docs/platforms/webgpu-bridge.md
@@ -21,7 +21,7 @@ development validation, and CDN-first loading for normal hosted deployments:
 Fetch pinned local assets with:
 
 ```bash
-WEBGPU_BRIDGE_ASSETS_TAG=v0.1.14 ./scripts/fetch_webgpu_bridge_assets.sh
+WEBGPU_BRIDGE_ASSETS_TAG=v0.1.15 ./scripts/fetch_webgpu_bridge_assets.sh
 ```
 
 ## Compatibility and safeguards
@@ -35,6 +35,11 @@ WEBGPU_BRIDGE_ASSETS_TAG=v0.1.14 ./scripts/fetch_webgpu_bridge_assets.sh
 - `v0.1.14+` bridge assets cap automatically selected WebAssembly threads to
   the compiled pthread pool size, preventing BERT-style embedding models from
   aborting on hosts with higher hardware concurrency than the bridge pool.
+- `v0.1.15+` bridge assets expose state persistence APIs consumed by
+  `LlamaEngine.stateSaveFile(...)` / `stateLoadFile(...)`. Web paths are bridge
+  WASMFS virtual paths and are not durable across page reloads. Durable browser
+  storage currently requires app-level export/import outside the Dart
+  `stateSaveFile` / `stateLoadFile` helpers.
 - CPU fallback is available through bridge runtime routing.
 - Safari compatibility guard and fallback behavior are integrated in this repo.
 - Legacy bridge assets may be forced to CPU in Safari when GPU layers are
@@ -53,7 +58,7 @@ You can override bridge asset source/version before loader startup:
 ```html
 <script>
   window.__llamadartBridgeAssetsRepo = 'leehack/llama-web-bridge-assets';
-  window.__llamadartBridgeAssetsTag = 'v0.1.14';
+  window.__llamadartBridgeAssetsTag = 'v0.1.15';
   // Optional knobs:
   // window.__llamadartBridgeEnableMem64 = false;
   // window.__llamadartBridgeAllowAutoRemoteFetchBackend = false;


### PR DESCRIPTION
## Summary
- Update the default WebGPU bridge asset pin/cache-buster to `v0.1.15` / llama.cpp `b9116`.
- Wire WebGPU bridge KV-cache state save/load through `stateSaveFile(...)` and `stateLoadFile(...)`, including JS interop and web backend delegation.
- Document native vs WebGPU state persistence behavior, including the web WASMFS virtual-path durability caveat.
- Add browser regression coverage for state save/load forwarding, false save returns, load return-shape handling, and clear older-bridge unsupported errors.

## Production-readiness scope
- Users can call `LlamaEngine.stateSaveFile(...)` / `stateLoadFile(...)` on native backends and WebGPU bridge assets `v0.1.15+`.
- Supported platforms/paths: native app filesystem paths; WebGPU bridge WASMFS virtual paths.
- Unsupported/older WebGPU bridge assets fail loudly with a `v0.1.15 or newer` unsupported error instead of silently succeeding.
- Existing `loadModel(...)` and existing non-state APIs remain compatible; this is an additive API/runtime wiring update.

## Intentionally deferred follow-ups
- Durable browser storage/export/import for state artifacts across reloads remains app-level work outside the Dart file helpers.

## Test Plan
- [x] `git diff --check`
- [x] static added-line security scan
- [x] `dart format --output=none --set-exit-if-changed .`
- [x] `dart analyze --fatal-infos`
- [x] `dart test -p chrome test/unit/backends/webgpu/webgpu_backend_test.dart`
- [x] `dart test -p chrome test/integration/backends/webgpu/webgpu_engine_multimodal_browser_integration_test.dart`
- [x] `dart test -p chrome test/unit/backends/web/web_backend_test.dart` (includes delegated state-support capability regression)
- [x] `dart test -p vm -j 1 --exclude-tags local-only`

## Review Notes
- Independent review passed with no blockers.
- Copilot comments were addressed in `b62cb38c`: `LlamaEngine.supportsStatePersistence` now respects `BackendStatePersistenceSupport`, `WebAutoBackend` reports state support from its active delegate, older/custom WebGPU bridge asset caveats are documented, and the handled threads were resolved.
- Second independent review of the review-fix patch passed with no blockers.
