### PR TITLE
docs: codify agent quality guidelines

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -122,9 +122,39 @@ pass `--mem64` and a smaller `--context-size` to keep the smoke bounded.
 - Modular separation: `engine/`, `backends/`, `models/`, `utils/`
 - Abstract interfaces in `backends/backend.dart`
 
+### Capability & Runtime Semantics
+- Prefer explicit capability probes over structural/interface checks when behavior
+  depends on runtime assets, platform support, browser APIs, or native feature
+  availability. For example, user-facing state persistence checks should use
+  `LlamaEngine.supportsStatePersistence` rather than assuming that a backend
+  implementing `BackendStatePersistence` is currently usable.
+- Unsupported paths must fail loudly with actionable diagnostics. Include the
+  missing capability, platform/runtime condition, and version requirement where
+  known (for example, WebGPU bridge assets that expose `stateSaveFile` and
+  `stateLoadFile`, v0.1.15 or newer).
+- Do not silently report success for unsupported platform/option combinations.
+  Either gate the API with an explicit support flag or throw a typed
+  `LlamaUnsupportedException` before mutating state.
+
+### Web / WebGPU Bridge Expectations
+- WebGPU bridge features are versioned runtime capabilities. When changing bridge
+  behavior, verify the pinned asset tag/manifest, direct bridge calls, worker
+  path, Dart interop wrapper, public engine API, docs, and examples together.
+- Document browser durability precisely. Web bridge filesystem paths are WASMFS
+  virtual paths and are not durable across browser reloads; durable browser
+  storage requires app-level export/import outside Dart file helpers.
+- Add regression coverage for both happy and negative paths: missing bridge API,
+  old bridge assets, `supports* == false`, sync-vs-async error delivery, and
+  alternate JS interop return shapes.
+- Keep README, website docs/support matrix, examples, and changelog aligned with
+  any public capability or platform-support change.
+
 ### Testing Standards
 - New public APIs require unit or integration tests
 - Test both Native (VM) and Web implementations for refactored shared logic
+- Capability-dependent behavior needs tests for unsupported and version-skew
+  paths, not just the happy path. Assert error messages when they are intended
+  to guide users toward a specific bridge/runtime version or configuration.
 - Mark generated files with `// coverage:ignore-file` so coverage gates exclude them
 - Use `expect` matchers over `assert`
 - Close ports/streams in `setUp`/`tearDown` to avoid hanging

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -130,8 +130,8 @@ pass `--mem64` and a smaller `--context-size` to keep the smoke bounded.
   implementing `BackendStatePersistence` is currently usable.
 - Unsupported paths must fail loudly with actionable diagnostics. Include the
   missing capability, platform/runtime condition, and version requirement where
-  known (for example, WebGPU bridge assets that expose `stateSaveFile` and
-  `stateLoadFile`, v0.1.15 or newer).
+  known (for example, a named WebGPU bridge API plus the minimum bridge asset
+  version or runtime flag required for that feature).
 - Do not silently report success for unsupported platform/option combinations.
   Public engine/API paths should either gate behavior with an explicit support
   flag or throw a typed `LlamaUnsupportedException` before mutating state.
@@ -140,9 +140,10 @@ pass `--mem64` and a smaller `--context-size` to keep the smoke bounded.
 - WebGPU bridge features are versioned runtime capabilities. When changing bridge
   behavior, verify the pinned asset tag/manifest, direct bridge calls, worker
   path, Dart interop wrapper, public engine API, docs, and examples together.
-- Document browser durability precisely. Web bridge filesystem paths are WASMFS
-  virtual paths and are not durable across browser reloads; durable browser
-  storage requires app-level export/import outside Dart file helpers.
+- Document browser durability precisely. Web bridge filesystem paths may be
+  virtual or in-memory unless the active bridge documents durable backing
+  storage; durable browser storage can require app-level export/import outside
+  Dart file helpers.
 - Add regression coverage for both happy and negative paths: missing bridge API,
   old bridge assets, `supports* == false`, correctly awaited sync/async errors,
   and alternate JS interop return shapes.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -133,8 +133,8 @@ pass `--mem64` and a smaller `--context-size` to keep the smoke bounded.
   known (for example, WebGPU bridge assets that expose `stateSaveFile` and
   `stateLoadFile`, v0.1.15 or newer).
 - Do not silently report success for unsupported platform/option combinations.
-  Either gate the API with an explicit support flag or throw a typed
-  `LlamaUnsupportedException` before mutating state.
+  Public engine/API paths should either gate behavior with an explicit support
+  flag or throw a typed `LlamaUnsupportedException` before mutating state.
 
 ### Web / WebGPU Bridge Expectations
 - WebGPU bridge features are versioned runtime capabilities. When changing bridge
@@ -144,8 +144,8 @@ pass `--mem64` and a smaller `--context-size` to keep the smoke bounded.
   virtual paths and are not durable across browser reloads; durable browser
   storage requires app-level export/import outside Dart file helpers.
 - Add regression coverage for both happy and negative paths: missing bridge API,
-  old bridge assets, `supports* == false`, sync-vs-async error delivery, and
-  alternate JS interop return shapes.
+  old bridge assets, `supports* == false`, correctly awaited sync/async errors,
+  and alternate JS interop return shapes.
 - Keep README, website docs/support matrix, examples, and changelog aligned with
   any public capability or platform-support change.
 


### PR DESCRIPTION
## Summary
- Add AGENTS.md guidance for capability probes vs structural backend assumptions
- Document Web/WebGPU bridge runtime expectations, WASMFS durability caveats, and actionable unsupported errors
- Call out negative/version-skew regression coverage and docs/changelog alignment for public capability changes

## Test Plan
- [x] `git diff --check HEAD~1..HEAD`
- [x] Markdown sanity check: no tabs/trailing whitespace

## Notes
- Documentation-only agent guidance update; no runtime code changes.
