### PR TITLE
fix: tolerate missing optional webgpu checksum assets

### DIFF
--- a/scripts/fetch_webgpu_bridge_assets.sh
+++ b/scripts/fetch_webgpu_bridge_assets.sh
@@ -107,6 +107,8 @@ if [[ -f "$OUT_DIR/sha256sums.txt" ]]; then
         continue
       fi
 
+      file_name="${file_name#\*}"
+
       if was_downloaded "$file_name" && [[ -f "$file_name" ]]; then
         printf '%s  %s\n' "$checksum" "$file_name" >> "$filtered_sums"
       elif is_required_checksum_file "$file_name"; then

--- a/scripts/fetch_webgpu_bridge_assets.sh
+++ b/scripts/fetch_webgpu_bridge_assets.sh
@@ -69,13 +69,50 @@ if [[ -f "$OUT_DIR/sha256sums.txt" ]]; then
   echo "[webgpu-assets] verifying checksums"
   (
     cd "$OUT_DIR"
-    if command -v sha256sum >/dev/null 2>&1; then
-      sha256sum -c sha256sums.txt
+
+    is_required_checksum_file() {
+      case "$1" in
+        llama_webgpu_bridge.js|llama_webgpu_core.js|llama_webgpu_core.wasm)
+          return 0
+          ;;
+        *)
+          return 1
+          ;;
+      esac
+    }
+
+    filtered_sums="$(mktemp)"
+    missing_required=0
+    while read -r checksum file_name; do
+      if [[ -z "${checksum:-}" || -z "${file_name:-}" ]]; then
+        continue
+      fi
+
+      if [[ -f "$file_name" ]]; then
+        printf '%s  %s\n' "$checksum" "$file_name" >> "$filtered_sums"
+      elif is_required_checksum_file "$file_name"; then
+        echo "[webgpu-assets] error: checksum lists required asset that was not downloaded: $file_name"
+        missing_required=1
+      else
+        echo "[webgpu-assets] warning: checksum lists optional asset that was not downloaded: $file_name; skipping"
+      fi
+    done < sha256sums.txt
+
+    if [[ "$missing_required" == "1" ]]; then
+      rm -f "$filtered_sums"
+      exit 1
+    fi
+
+    if [[ ! -s "$filtered_sums" ]]; then
+      echo "[webgpu-assets] warning: checksum file did not include any downloaded assets; skipping checksum verification"
+    elif command -v sha256sum >/dev/null 2>&1; then
+      sha256sum -c "$filtered_sums"
     elif command -v shasum >/dev/null 2>&1; then
-      shasum -a 256 -c sha256sums.txt
+      shasum -a 256 -c "$filtered_sums"
     else
       echo "[webgpu-assets] warning: no sha256 tool found; skipping checksum verification"
     fi
+    rm -f "$filtered_sums"
   )
 fi
 

--- a/scripts/fetch_webgpu_bridge_assets.sh
+++ b/scripts/fetch_webgpu_bridge_assets.sh
@@ -35,6 +35,22 @@ USAGE
 fi
 
 mkdir -p "$OUT_DIR"
+downloaded_files=()
+
+mark_downloaded() {
+  downloaded_files+=("$1")
+}
+
+was_downloaded() {
+  local expected="$1"
+  local downloaded
+  for downloaded in "${downloaded_files[@]}"; do
+    if [[ "$downloaded" == "$expected" ]]; then
+      return 0
+    fi
+  done
+  return 1
+}
 
 download_required() {
   local file_name="$1"
@@ -43,6 +59,7 @@ download_required() {
 
   echo "[webgpu-assets] downloading $source_url"
   curl -fL --retry 3 --retry-delay 1 "$source_url" -o "$target_path"
+  mark_downloaded "$file_name"
 }
 
 download_optional() {
@@ -50,9 +67,11 @@ download_optional() {
   local source_url="$CDN_BASE/$file_name"
   local target_path="$OUT_DIR/$file_name"
 
+  rm -f "$target_path"
   if curl -fsI "$source_url" >/dev/null; then
     echo "[webgpu-assets] downloading optional $source_url"
     curl -fL --retry 3 --retry-delay 1 "$source_url" -o "$target_path"
+    mark_downloaded "$file_name"
   fi
 }
 
@@ -88,7 +107,7 @@ if [[ -f "$OUT_DIR/sha256sums.txt" ]]; then
         continue
       fi
 
-      if [[ -f "$file_name" ]]; then
+      if was_downloaded "$file_name" && [[ -f "$file_name" ]]; then
         printf '%s  %s\n' "$checksum" "$file_name" >> "$filtered_sums"
       elif is_required_checksum_file "$file_name"; then
         echo "[webgpu-assets] error: checksum lists required asset that was not downloaded: $file_name"
@@ -213,3 +232,4 @@ echo "[webgpu-assets] done"
 echo "  repo: $ASSETS_REPO"
 echo "  tag : $ASSETS_TAG"
 echo "  out : $OUT_DIR"
+


### PR DESCRIPTION
## Summary
- make WebGPU bridge checksum verification ignore checksum entries for optional assets that were not downloaded in the current run
- remove optional targets before probing/downloading so stale optional files cannot be carried forward or verified accidentally
- normalize `sha256sum -b` binary-mode filename markers before matching downloaded assets
- keep required bridge assets fatal when missing and checksum-verified when present

## Test Plan
- [x] `bash -n scripts/fetch_webgpu_bridge_assets.sh`
- [x] `WEBGPU_BRIDGE_OUT_DIR=<tmp> ./scripts/fetch_webgpu_bridge_assets.sh`
- [x] fake CDN regression where `sha256sums.txt` lists missing optional assets while stale optional files already exist in the output directory
- [x] fake CDN regression where `sha256sums.txt` uses binary-mode `*filename` entries

## Review Notes
- Addressed Copilot's stale optional asset comment by tracking assets downloaded in the current run and removing skipped optional targets before probing.
- Addressed Copilot's binary-mode checksum comment by stripping the optional `*` marker before matching filenames.

## Notes
This fixes the post-merge Hugging Face chat app deploy failure from run https://github.com/leehack/llamadart/actions/runs/25804017386. The failure was in deploy-time asset fetching/checksum handling, not in the WebGPU bridge runtime code itself.
