### PR TITLE
docs: add production-readiness PR checklist

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,33 @@
+## Summary
+-
+
+## Production-readiness scope
+- **User-facing scope:** <!-- What can users do after this merges? -->
+- **Supported platforms/paths:** <!-- Native/WebGPU/Flutter app/docs-only/etc. -->
+- **Unsupported or intentionally unavailable paths:** <!-- Include the error, disabled UI, or fallback users see. Do not silently succeed. -->
+- **Out of scope / follow-ups:** <!-- Link GitHub issues for non-blocking future work, or write "None". -->
+
+## Completeness checklist
+- [ ] Declared scope is fully implemented, or explicitly reduced above.
+- [ ] Unsupported platform/option combinations fail loudly with actionable diagnostics or are clearly documented as unavailable.
+- [ ] Public API docs, README/website docs, examples, support matrices, and changelog entries are updated where relevant.
+- [ ] Regression coverage covers the original issue plus key negative/version-skew paths where relevant.
+- [ ] Security/privacy review completed: no secrets, bearer tokens, signed URLs, or raw secret-bearing paths leak through logs, cache keys, metadata, errors, or snapshots.
+- [ ] Follow-up work that is useful but not required for this PR is tracked in GitHub Issues, or explicitly marked "None" above.
+
+## PR type guidance
+<!-- Keep the relevant line(s), or mark N/A with a short reason. -->
+- **Feature PR:** include API/docs/example updates, platform matrix, unsupported-path behavior, and tests for both happy and negative paths.
+- **Bugfix PR:** include the regression root cause, targeted regression test or documented reason one is impractical, and affected platform matrix.
+- **Docs-only PR:** confirm no runtime behavior changes and note any commands used to validate docs links/builds.
+
+## Test Plan
+<!-- Mark commands as N/A with a short reason for docs-only/template-only changes. -->
+- [ ] `dart format --output=none --set-exit-if-changed .`
+- [ ] `dart analyze --fatal-infos`
+- [ ] `dart test -p vm -j 1 --exclude-tags local-only`
+- [ ] Other targeted/local-only validation: <!-- e.g. Chrome/WebGPU smoke, Flutter app E2E, docs build, N/A -->
+
+## Review Notes
+- Independent review status: <!-- reviewer/tool/verdict, or N/A for trivial docs-only changes -->
+- CI status / head SHA: <!-- fill after CI runs -->

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -24,7 +24,7 @@
 ## Test Plan
 <!-- Mark commands as N/A with a short reason for docs-only/template-only changes. -->
 - [ ] `dart format --output=none --set-exit-if-changed .`
-- [ ] `dart analyze --fatal-infos`
+- [ ] `dart analyze`
 - [ ] `dart test -p vm -j 1 --exclude-tags local-only`
 - [ ] Other targeted/local-only validation: <!-- e.g. Chrome/WebGPU smoke, Flutter app E2E, docs build, N/A -->
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -10,7 +10,7 @@ dart pub get                              # Install dependencies
 dart format .                             # Format all Dart files
 dart format --output=none --set-exit-if-changed .  # Check only, CI-friendly
 dart analyze                              # Run static analysis/linting
-dart analyze --fatal-infos              # Treat info-level lints as errors (CI)
+dart analyze --fatal-infos              # Optional stricter local check for info-level lints
 ```
 
 ### Testing Commands

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -249,6 +249,30 @@ test -d ../llama-web-bridge-assets
 3. Run `dart test` to verify all tests pass
 4. For new features, add tests to maintain >=70% coverage on maintainable source code (generated files are excluded via `// coverage:ignore-file`)
 
+### Production-Readiness Gate
+Treat `main` as production-ready. Before opening or updating a non-trivial PR,
+make sure the PR template can honestly answer:
+
+- **User-facing scope**: what users can do after merge, and what is explicitly
+  out of scope.
+- **Platform matrix**: native, WebGPU, Flutter examples, docs-only, or other
+  relevant paths are listed with actual validation evidence.
+- **Unsupported combinations**: unsupported platforms/options fail loudly with a
+  typed/actionable error, disabled UI, or documented fallback; never report
+  success for a path that is not implemented.
+- **Docs/release notes**: README, website docs, examples, support matrices, and
+  changelog entries are updated when public behavior changes.
+- **Regression coverage**: tests cover the issue plus important negative or
+  version-skew paths where applicable.
+- **Security/privacy**: logs, cache keys, metadata, errors, and snapshots do not
+  expose credentials, bearer tokens, signed URLs, or raw secret-bearing paths.
+- **Follow-ups**: useful but non-blocking work is tracked in GitHub Issues before
+  merge and linked from the PR body.
+
+If the implementation cannot satisfy the full originally planned scope, reduce
+and state the scope instead of merging incomplete behavior. For docs-only PRs,
+state that runtime behavior is unchanged and list the docs validation performed.
+
 ### Syncing Native Version
 When you need to update native version + bindings in this repository:
 ```bash

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -220,5 +220,45 @@ If you need to build binaries for a new release:
 2.  Create a new branch (`git checkout -b feature/my-feature`).
 3.  Commit your changes.
 4.  Push to your fork and submit a Pull Request.
+5.  Complete the production-readiness sections in the pull request template.
+
+### Production-readiness expectations
+
+`main` should remain production-ready. A pull request may reduce its scope, but
+the scope it declares must be complete, documented, and tested before merge.
+Use the pull request template to make that claim explicit.
+
+Every non-trivial pull request should explain:
+
+- **User-facing scope**: what users can do after the PR merges.
+- **Supported platform matrix**: native, WebGPU, Flutter examples, docs-only, or
+  any other relevant path.
+- **Unsupported paths**: combinations that are intentionally unavailable must
+  fail loudly with clear errors, disabled UI, or documented fallback behavior.
+  They must not appear to succeed silently.
+- **Docs and release notes**: README, website docs, examples, support matrices,
+  and changelog entries are updated when public behavior changes.
+- **Regression coverage**: tests cover the original issue and important
+  negative/version-skew paths where applicable.
+- **Security/privacy**: logs, errors, cache keys, metadata, and snapshots must
+  not expose credentials, bearer tokens, signed URLs, or raw secret-bearing
+  paths.
+- **Follow-ups**: useful future work that is outside the declared scope should
+  be linked as GitHub Issues before merge.
+
+If a feature is not ready across all originally imagined paths, prefer reducing
+the declared scope and tracking follow-up issues over merging incomplete or
+ambiguous behavior.
+
+### PR type examples
+
+- **Feature PR**: describes the new API or behavior, supported platforms,
+  unsupported combinations and their errors/fallbacks, docs/examples/changelog
+  updates, and happy-path plus negative-path tests.
+- **Bugfix PR**: states the root cause, the affected platform matrix, the
+  targeted regression coverage, and any manual validation needed to reproduce
+  the fix.
+- **Docs-only PR**: states that runtime behavior is unchanged and lists the docs
+  build/link checks or review performed.
 
 Thank you for contributing!


### PR DESCRIPTION
## Summary
- Add a default pull request template with production-readiness scope, completeness, test-plan, and review-evidence sections.
- Document the merge bar in `CONTRIBUTING.md` for contributors.
- Add matching agent-facing guidance in `AGENTS.md` so future automation keeps PR scope honest.

## Production-readiness scope
- **User-facing scope:** contributors and maintainers get a repeatable checklist for proving a non-trivial PR is complete before merge.
- **Supported platforms/paths:** documentation/process-only change; applies to all future PRs regardless of platform.
- **Unsupported or intentionally unavailable paths:** runtime behavior is unchanged; runtime validation commands can be marked N/A for docs-only/template-only PRs.
- **Out of scope / follow-ups:** None.

## Completeness checklist
- [x] Declared scope is fully implemented, or explicitly reduced above.
- [x] Unsupported platform/option combinations fail loudly with actionable diagnostics or are clearly documented as unavailable.
- [x] Public API docs, README/website docs, examples, support matrices, and changelog entries are updated where relevant.
- [x] Regression coverage covers the original issue plus key negative/version-skew paths where relevant.
- [x] Security/privacy review completed: no secrets, bearer tokens, signed URLs, or raw secret-bearing paths leak through logs, cache keys, metadata, errors, or snapshots.
- [x] Follow-up work that is useful but not required for this PR is tracked in GitHub Issues, or explicitly marked "None" above.

## PR type guidance
- **Docs-only PR:** runtime behavior is unchanged. The docs/process contract was validated with a focused content check and independent review.

## Test Plan
- [x] `git diff --check`
- [x] focused content-contract script requiring the new PR template, contributor docs, and agent guidance to mention production-readiness scope, PR type guidance, security/privacy, unsupported paths, and follow-up handling
- [x] independent review via agent: no blockers
- [x] `dart format --output=none --set-exit-if-changed .` — N/A, Markdown/template-only change
- [x] `dart analyze --fatal-infos` — N/A, Markdown/template-only change
- [x] `dart test -p vm -j 1 --exclude-tags local-only` — N/A, Markdown/template-only change

## Review Notes
- Independent review status: no blockers; incorporated its non-blocking suggestions to allow "None" for follow-ups and N/A for docs-only test commands.
- CI status / head SHA: CI passed for `1c8b9182bde861615e6c59d680740c02ad822dc6` (run `25822499612`).

Closes #131

