### PR TITLE
fix(models): reject remote-only options for local sources

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,10 @@
     missing, malformed, or unsupported-schema sidecars without network access,
     while byte-count and stored/caller SHA-256 mismatches are treated as cache
     misses and safely re-downloaded.
+  * Clarified `ModelSource.path(...)` option semantics: local paths now reject
+    remote/download-only options (non-default cache policies, cache directories,
+    authenticated headers, resume, and retry overrides) while continuing to
+    support cancellation and optional local SHA-256 verification.
   * Added `LlamaEngine.loadModelSource(...)` to route local sources through the
     existing native local loader, remote sources through the native download
     cache before local loading, and simple remote sources through URL-capable web

--- a/README.md
+++ b/README.md
@@ -124,7 +124,10 @@ resume partial `.part` downloads when the server supports HTTP Range and the
 partial has a safe validator (ETag/Last-Modified) or caller-provided SHA-256,
 verify optional SHA-256 checksums, and redact signed URL credentials from
 metadata. Validator-less partial files restart from byte zero instead of being
-appended.
+appended. Local `ModelSource.path(...)` values are already files: only
+cancellation and optional `sha256` verification apply, while remote/download-only
+options such as cache policies, `cacheDirectory`, authenticated headers, resume,
+and retries are rejected for local paths.
 
 ### 6. Generate embeddings
 

--- a/lib/src/core/models/download/model_download_manager_base.dart
+++ b/lib/src/core/models/download/model_download_manager_base.dart
@@ -183,6 +183,11 @@ abstract interface class ModelDownloadManager {
   /// active download; cooperative cancellation may be observed after the active
   /// same-entry operation finishes.
   ///
+  /// Local path sources are already available as files. Native/file-backed
+  /// implementations may verify a caller-provided SHA-256 checksum before
+  /// returning metadata, but should reject remote/cache-only options that cannot
+  /// affect local files instead of silently ignoring them.
+  ///
   /// Native/file-backed implementations may recover package-managed metadata
   /// when the completed model file is still present in the deterministic cache
   /// directory, but should treat missing files, source mismatches, byte-count

--- a/lib/src/core/models/model_load_options.dart
+++ b/lib/src/core/models/model_load_options.dart
@@ -33,10 +33,14 @@ class ModelDownloadCancelToken {
 /// Options used when resolving and loading model sources.
 ///
 /// Native/file-backed backends use the package-managed download/cache manager
-/// for remote HTTP(S) and Hugging Face sources. URL-loading web backends can
-/// load remote URLs directly and reject options that require native cache IO,
-/// such as authenticated headers, checksum verification, and explicit cache
-/// policy changes.
+/// for remote HTTP(S) and Hugging Face sources. Local [ModelSource.path(...)]
+/// values are already files: only [sha256] verification and cancellation are
+/// meaningful for them. Remote/download-only options such as authenticated
+/// headers, explicit cache policies, cache directories, resume, and retries are
+/// rejected for local paths. URL-loading web backends can load remote URLs
+/// directly and reject options that require native cache IO, such as
+/// authenticated headers, checksum verification, and explicit cache policy
+/// changes.
 class ModelLoadOptions {
   /// Creates model load options.
   factory ModelLoadOptions({

--- a/lib/src/platform/io/model_download_manager_io.dart
+++ b/lib/src/platform/io/model_download_manager_io.dart
@@ -267,6 +267,34 @@ class DefaultModelDownloadManager implements ModelDownloadManager {
     return path.normalize(path.absolute(cacheDirectory.path));
   }
 
+  void _rejectUnsupportedLocalOptions(ModelLoadOptions options) {
+    if (options.cachePolicy != ModelCachePolicy.preferCached) {
+      throw LlamaUnsupportedException(
+        'Local ModelSource.path loads do not use package-managed cache policies.',
+      );
+    }
+    if (options.cacheDirectory != null) {
+      throw LlamaUnsupportedException(
+        'Local ModelSource.path loads do not use cacheDirectory.',
+      );
+    }
+    if (options.bearerToken != null || options.headers.isNotEmpty) {
+      throw LlamaUnsupportedException(
+        'Local ModelSource.path loads do not use remote authentication headers.',
+      );
+    }
+    if (!options.resume) {
+      throw LlamaUnsupportedException(
+        'Local ModelSource.path loads do not use download resume options.',
+      );
+    }
+    if (options.maxRetries != ModelLoadOptions.defaults.maxRetries) {
+      throw LlamaUnsupportedException(
+        'Local ModelSource.path loads do not use download retry options.',
+      );
+    }
+  }
+
   Future<List<File>> _candidateMetadataFiles(
     String cacheKey, {
     String? cacheDirectory,
@@ -309,6 +337,7 @@ class DefaultModelDownloadManager implements ModelDownloadManager {
     ModelSource source,
     ModelLoadOptions options,
   ) async {
+    _rejectUnsupportedLocalOptions(options);
     final file = File(path.normalize(path.absolute(source.path!)));
     final stat = await file.stat();
     if (stat.type == FileSystemEntityType.notFound) {

--- a/test/unit/core/engine/engine_test.dart
+++ b/test/unit/core/engine/engine_test.dart
@@ -1,5 +1,6 @@
 import 'dart:async';
 import 'dart:convert';
+import 'dart:io';
 import 'dart:math' as math;
 import 'package:test/test.dart';
 import 'package:llamadart/llamadart.dart';
@@ -415,6 +416,28 @@ void main() {
       },
     );
 
+    test('native loadModelSource rejects local remote-only options', () async {
+      final tempDir = await Directory.systemTemp.createTemp(
+        'llamadart_engine_local_source_test_',
+      );
+      try {
+        final localFile = File('${tempDir.path}/local-model.gguf')
+          ..writeAsStringSync('local-model');
+        final nativeBackend = MockLlamaBackend();
+        final nativeEngine = LlamaEngine(nativeBackend);
+
+        await expectLater(
+          () => nativeEngine.loadModelSource(
+            ModelSource.path(localFile.path),
+            options: ModelLoadOptions(cachePolicy: ModelCachePolicy.refresh),
+          ),
+          throwsA(isA<LlamaUnsupportedException>()),
+        );
+        expect(nativeBackend.modelLoadCalls, 0);
+      } finally {
+        await tempDir.delete(recursive: true);
+      }
+    }, testOn: 'vm');
     test(
       'native loadModelSource honors resolver-provided local path',
       () async {

--- a/test/unit/core/engine/engine_test.dart
+++ b/test/unit/core/engine/engine_test.dart
@@ -1,6 +1,5 @@
 import 'dart:async';
 import 'dart:convert';
-import 'dart:io';
 import 'dart:math' as math;
 import 'package:test/test.dart';
 import 'package:llamadart/llamadart.dart';
@@ -417,27 +416,19 @@ void main() {
     );
 
     test('native loadModelSource rejects local remote-only options', () async {
-      final tempDir = await Directory.systemTemp.createTemp(
-        'llamadart_engine_local_source_test_',
-      );
-      try {
-        final localFile = File('${tempDir.path}/local-model.gguf')
-          ..writeAsStringSync('local-model');
-        final nativeBackend = MockLlamaBackend();
-        final nativeEngine = LlamaEngine(nativeBackend);
+      final nativeBackend = MockLlamaBackend();
+      final nativeEngine = LlamaEngine(nativeBackend);
 
-        await expectLater(
-          () => nativeEngine.loadModelSource(
-            ModelSource.path(localFile.path),
-            options: ModelLoadOptions(cachePolicy: ModelCachePolicy.refresh),
-          ),
-          throwsA(isA<LlamaUnsupportedException>()),
-        );
-        expect(nativeBackend.modelLoadCalls, 0);
-      } finally {
-        await tempDir.delete(recursive: true);
-      }
-    }, testOn: 'vm');
+      await expectLater(
+        () => nativeEngine.loadModelSource(
+          ModelSource.path('/models/local-model.gguf'),
+          options: ModelLoadOptions(cachePolicy: ModelCachePolicy.refresh),
+        ),
+        throwsA(isA<LlamaUnsupportedException>()),
+      );
+      expect(nativeBackend.modelLoadCalls, 0);
+    });
+
     test(
       'native loadModelSource honors resolver-provided local path',
       () async {

--- a/test/unit/platform/io/model_download_manager_io_test.dart
+++ b/test/unit/platform/io/model_download_manager_io_test.dart
@@ -750,6 +750,54 @@ void main() {
       );
     });
 
+    test('local path rejects remote cache/download options', () async {
+      final manager = DefaultModelDownloadManager(
+        defaultCacheDirectory: tempDir.path,
+      );
+      final localFile = File(path.join(tempDir.path, 'local-model.gguf'))
+        ..writeAsStringSync('local-model');
+      final source = ModelSource.path(localFile.path);
+      final remoteOnlyOptions = <ModelLoadOptions>[
+        ModelLoadOptions(cachePolicy: ModelCachePolicy.refresh),
+        ModelLoadOptions(cachePolicy: ModelCachePolicy.cacheOnly),
+        ModelLoadOptions(cachePolicy: ModelCachePolicy.noCache),
+        ModelLoadOptions(cacheDirectory: path.join(tempDir.path, 'cache')),
+        ModelLoadOptions(bearerToken: 'secret-token'),
+        ModelLoadOptions(headers: const <String, String>{'X-Test': 'value'}),
+        ModelLoadOptions(resume: false),
+        ModelLoadOptions(maxRetries: 0),
+      ];
+
+      for (final options in remoteOnlyOptions) {
+        await expectLater(
+          manager.ensureModel(source, options: options),
+          throwsA(
+            isA<LlamaUnsupportedException>().having(
+              (error) => error.message,
+              'message',
+              allOf(contains('Local'), contains('ModelSource.path')),
+            ),
+          ),
+        );
+      }
+    });
+
+    test('local path honors cancellation before filesystem work', () async {
+      final manager = DefaultModelDownloadManager(
+        defaultCacheDirectory: tempDir.path,
+      );
+      final token = ModelDownloadCancelToken()..cancel();
+      final missingPath = path.join(tempDir.path, 'missing-local-model.gguf');
+
+      await expectLater(
+        manager.ensureModel(
+          ModelSource.path(missingPath),
+          options: ModelLoadOptions(cancelToken: token),
+        ),
+        throwsA(isA<LlamaStateException>()),
+      );
+    });
+
     test('normalizes local paths before returning metadata', () async {
       final manager = DefaultModelDownloadManager(
         defaultCacheDirectory: tempDir.path,

--- a/website/docs/guides/model-lifecycle.md
+++ b/website/docs/guides/model-lifecycle.md
@@ -62,9 +62,13 @@ await engine.loadModelSource(
 `ModelSource.parse(...)` accepts local paths, HTTP(S) URLs, and `hf://`
 Hugging Face references. Local path sources require native/file-backed targets;
 URL-loading web backends reject explicit local filesystem paths and should use
-HTTP(S) or `hf://` sources instead. Source values expose deterministic cache
-keys and redacted metadata identities so signed URL query strings are not stored
-in logs or cache metadata.
+HTTP(S) or `hf://` sources instead. Local paths already point at a file, so the
+native manager only applies cancellation and optional `sha256` verification to
+`ModelSource.path(...)` loads. Remote/download-only options such as non-default
+cache policies, `cacheDirectory`, authenticated headers, `resume`, and
+`maxRetries` are rejected for local paths instead of being silently ignored.
+Source values expose deterministic cache keys and redacted metadata identities
+so signed URL query strings are not stored in logs or cache metadata.
 
 Native/file-backed backends download remote sources into the package-managed
 cache, verify the completed file, persist metadata, and then call the existing


### PR DESCRIPTION
## Summary
- Reject non-default remote/download-only `ModelLoadOptions` for local `ModelSource.path(...)` inputs with a typed `LlamaUnsupportedException` instead of silently ignoring them.
- Preserve the meaningful local-path options: cancellation before local filesystem work and optional local SHA-256 verification.
- Document the local-vs-remote option boundary across API docs, README, website guide, and changelog.
- Add regression coverage at both the download-manager layer and the public `LlamaEngine.loadModelSource(...)` path.

Closes #137

## Production-readiness scope
- Users can keep using local `ModelSource.path(...)` sources with default options, cancellation, and optional `sha256` verification.
- Supported platforms/paths: native/file-backed local paths through `DefaultModelDownloadManager`; remote URL/cache flows are unchanged.
- Unsupported combinations fail loudly: local paths now reject non-default `cachePolicy`, `cacheDirectory`, bearer tokens, custom headers, `resume: false`, and custom `maxRetries` before local metadata is returned.
- Existing APIs remain source-compatible; this tightens runtime validation for previously ignored local-source download/cache knobs.
- Nuance: default-valued options remain accepted because the options object cannot distinguish explicit defaults from omitted values.

## Intentionally deferred follow-ups
- None for the declared #137 scope.

## Test Plan
- [x] `dart format --output=none --set-exit-if-changed lib/src/core/models/model_load_options.dart lib/src/core/models/download/model_download_manager_base.dart lib/src/platform/io/model_download_manager_io.dart test/unit/platform/io/model_download_manager_io_test.dart test/unit/core/engine/engine_test.dart`
- [x] `dart analyze`
- [x] `dart analyze lib/src/core/models/model_load_options.dart lib/src/core/models/download/model_download_manager_base.dart lib/src/platform/io/model_download_manager_io.dart test/unit/platform/io/model_download_manager_io_test.dart test/unit/core/engine/engine_test.dart`
- [x] `dart test test/unit/platform/io/model_download_manager_io_test.dart`
- [x] `dart test test/unit/core/engine/engine_test.dart`
- [x] `dart test -p vm -j 1 --exclude-tags local-only --reporter compact` (840 passed, 1 skipped)
- [x] `git diff --check origin/main`
- [x] After Copilot feedback fix: `dart analyze test/unit/core/engine/engine_test.dart lib/src/platform/io/model_download_manager_io.dart test/unit/platform/io/model_download_manager_io_test.dart`
- [x] After Copilot feedback fix: `dart test test/unit/core/engine/engine_test.dart`
- [x] After Copilot feedback fix: `dart test test/unit/platform/io/model_download_manager_io_test.dart`
- [x] CI for `efb2aa89ed49d293adcc04fcfe5741c4703903da`: all required jobs passing

## Review Notes
- Independent deep review found no blockers.
- Follow-up review suggestions addressed before PR submission: added explicit local cancellation coverage and a public `LlamaEngine.loadModelSource(...)` local remote-only option regression test.
- Copilot flagged the first public regression test for a browser-unsafe top-level `dart:io` import; fixed by removing filesystem use from that test while keeping the public rejection coverage.
- No active unresolved review threads remain after the latest push; the earlier Copilot thread is outdated.
- Static scan found no hardcoded secrets, dangerous execution patterns, or raw URL logging additions.

