### PR TITLE
feat(models): improve Hugging Face source ergonomics

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,10 @@
     authenticated bearer/custom headers, cancellation, retry, Range resume,
     cache hit/refresh/cache-only/no-cache policies, SHA-256 verification,
     cache listing, removal, clearing, and age/size pruning.
+  * Improved Hugging Face source ergonomics: `hf://` references now accept
+    `?revision=...` for branch/ref names containing slashes, and docs clarify
+    current single-file behavior, private/gated bearer-token usage, separate
+    `mmproj` asset handling, sharded-GGUF limitations, and redaction guarantees.
   * Serialized concurrent stable-cache downloads for the same remote cache entry
     across manager instances so duplicate callers do not race on shared `.part`
     files or metadata, while distinct cache entries can still download in

--- a/README.md
+++ b/README.md
@@ -129,6 +129,16 @@ cancellation and optional `sha256` verification apply, while remote/download-onl
 options such as cache policies, `cacheDirectory`, authenticated headers, resume,
 and retries are rejected for local paths.
 
+`hf://` references point at one Hugging Face file:
+`hf://owner/repo/path/to/model.gguf` uses `main`,
+`hf://owner/repo@v1.0.0/model.gguf` pins a simple tag/branch, and
+`hf://owner/repo/model.gguf?revision=refs/pr/12` handles revisions containing
+slashes. For private or gated repositories, pass `ModelLoadOptions(bearerToken:
+hfToken)` or custom headers instead of embedding credentials in the source.
+`llamadart` does not list Hugging Face files or expand sharded GGUF manifests;
+pick the exact `.gguf` file path from the repository, and use separate model and
+`mmproj` sources for multimodal assets.
+
 ### 6. Generate embeddings
 
 ```dart

--- a/lib/src/core/models/model_source.dart
+++ b/lib/src/core/models/model_source.dart
@@ -380,14 +380,13 @@ String _huggingFaceCanonicalKey(
   String revision,
   String filePath,
 ) {
-  if (!revision.contains('/')) {
+  final encodedFilePath = _encodedHuggingFaceFilePath(filePath);
+  if (!revision.contains('/') &&
+      revision == Uri.encodeComponent(revision) &&
+      filePath == encodedFilePath) {
     return 'hf://$repoId@$revision/$filePath';
   }
 
-  final encodedFilePath = filePath
-      .split('/')
-      .map(Uri.encodeComponent)
-      .join('/');
   final encodedRevision = Uri.encodeQueryComponent(revision);
   return 'hf://$repoId/$encodedFilePath?revision=$encodedRevision';
 }
@@ -395,13 +394,14 @@ String _huggingFaceCanonicalKey(
 Uri _huggingFaceResolvedUri(String repoId, String revision, String filePath) {
   final encodedRepoId = repoId.split('/').map(Uri.encodeComponent).join('/');
   final encodedRevision = Uri.encodeComponent(revision);
-  final encodedFilePath = filePath
-      .split('/')
-      .map(Uri.encodeComponent)
-      .join('/');
+  final encodedFilePath = _encodedHuggingFaceFilePath(filePath);
   return Uri.parse(
     'https://huggingface.co/$encodedRepoId/resolve/$encodedRevision/$encodedFilePath?download=true',
   );
+}
+
+String _encodedHuggingFaceFilePath(String filePath) {
+  return filePath.split('/').map(Uri.encodeComponent).join('/');
 }
 
 String _validateRepoId(String repoId) {

--- a/lib/src/core/models/model_source.dart
+++ b/lib/src/core/models/model_source.dart
@@ -62,6 +62,10 @@ class ModelSource {
   }
 
   /// Creates a Hugging Face model source from repository details.
+  ///
+  /// The generated download URL uses Hugging Face's `/resolve/{revision}/...`
+  /// endpoint. [revision] defaults to `main`; use a branch, tag, commit SHA, or
+  /// pull-request ref such as `refs/pr/12` when a model must be pinned.
   factory ModelSource.huggingFace({
     required String repoId,
     required String filePath,
@@ -86,12 +90,19 @@ class ModelSource {
         fileName ?? _fileNameFromPath(normalizedFilePath),
         'fileName',
       ),
-      canonicalKey:
-          'hf://$normalizedRepoId@$normalizedRevision/$normalizedFilePath',
+      canonicalKey: _huggingFaceCanonicalKey(
+        normalizedRepoId,
+        normalizedRevision,
+        normalizedFilePath,
+      ),
     );
   }
 
   /// Parses [value] as a local path, HTTP(S) URL, or `hf://` reference.
+  ///
+  /// Hugging Face references use `hf://owner/repo/path/to/model.gguf`. A simple
+  /// branch or tag can be written as `hf://owner/repo@revision/model.gguf`; use
+  /// `?revision=refs/pr/12` when the revision itself contains `/`.
   factory ModelSource.parse(String value) {
     if (value.isEmpty) {
       throw ArgumentError.value(value, 'value', 'Source must not be empty.');
@@ -239,7 +250,7 @@ void _validateRemoteUri(Uri url, String name) {
 
 ModelSource _parseHuggingFaceUri(String value) {
   final reference = value.substring('hf://'.length);
-  if (reference.isEmpty || reference.contains('//')) {
+  if (reference.isEmpty || reference.contains('#')) {
     throw ArgumentError.value(
       value,
       'value',
@@ -247,7 +258,26 @@ ModelSource _parseHuggingFaceUri(String value) {
     );
   }
 
-  final rawParts = reference.split('/');
+  final queryStart = reference.indexOf('?');
+  final pathReference = queryStart == -1
+      ? reference
+      : reference.substring(0, queryStart);
+  final queryRevision = queryStart == -1
+      ? null
+      : _parseHuggingFaceRevisionQuery(
+          reference.substring(queryStart + 1),
+          value,
+        );
+
+  if (pathReference.isEmpty || pathReference.contains('//')) {
+    throw ArgumentError.value(
+      value,
+      'value',
+      'Invalid Hugging Face reference.',
+    );
+  }
+
+  final rawParts = pathReference.split('/');
   if (rawParts.length < 3) {
     throw ArgumentError.value(
       value,
@@ -266,9 +296,17 @@ ModelSource _parseHuggingFaceUri(String value) {
   if (repoRevisionParts.length > 2 || repoRevisionParts.first.isEmpty) {
     throw ArgumentError.value(value, 'value', 'Invalid Hugging Face repo id.');
   }
-  final revision = repoRevisionParts.length == 2
+  final inlineRevision = repoRevisionParts.length == 2
       ? repoRevisionParts[1]
-      : 'main';
+      : null;
+  if (inlineRevision != null && queryRevision != null) {
+    throw ArgumentError.value(
+      value,
+      'value',
+      'Use either @revision or ?revision=, not both.',
+    );
+  }
+  final revision = queryRevision ?? inlineRevision ?? 'main';
   final repoId = '$owner/${repoRevisionParts.first}';
   final decodedFileSegments = rawParts
       .skip(2)
@@ -299,11 +337,70 @@ ModelSource _parseHuggingFaceUri(String value) {
   );
 }
 
+String _parseHuggingFaceRevisionQuery(String rawQuery, String value) {
+  if (rawQuery.isEmpty) {
+    throw ArgumentError.value(
+      value,
+      'value',
+      'Hugging Face reference query must include revision=...',
+    );
+  }
+
+  String? revision;
+  for (final pair in rawQuery.split('&')) {
+    if (pair.isEmpty) {
+      throw ArgumentError.value(value, 'value', 'Invalid Hugging Face query.');
+    }
+    final separator = pair.indexOf('=');
+    final rawKey = separator == -1 ? pair : pair.substring(0, separator);
+    final rawValue = separator == -1 ? '' : pair.substring(separator + 1);
+    final key = _decodeHuggingFaceQueryComponent(rawKey, value);
+    if (key != 'revision') {
+      throw ArgumentError.value(
+        value,
+        'value',
+        'Unsupported Hugging Face query parameter: $key.',
+      );
+    }
+    if (revision != null) {
+      throw ArgumentError.value(
+        value,
+        'value',
+        'Hugging Face revision query must appear only once.',
+      );
+    }
+    revision = _decodeHuggingFaceQueryComponent(rawValue, value);
+  }
+
+  return revision ?? '';
+}
+
+String _huggingFaceCanonicalKey(
+  String repoId,
+  String revision,
+  String filePath,
+) {
+  if (!revision.contains('/')) {
+    return 'hf://$repoId@$revision/$filePath';
+  }
+
+  final encodedFilePath = filePath
+      .split('/')
+      .map(Uri.encodeComponent)
+      .join('/');
+  final encodedRevision = Uri.encodeQueryComponent(revision);
+  return 'hf://$repoId/$encodedFilePath?revision=$encodedRevision';
+}
+
 Uri _huggingFaceResolvedUri(String repoId, String revision, String filePath) {
-  return Uri.https(
-    'huggingface.co',
-    '/$repoId/resolve/$revision/$filePath',
-    const <String, String>{'download': 'true'},
+  final encodedRepoId = repoId.split('/').map(Uri.encodeComponent).join('/');
+  final encodedRevision = Uri.encodeComponent(revision);
+  final encodedFilePath = filePath
+      .split('/')
+      .map(Uri.encodeComponent)
+      .join('/');
+  return Uri.parse(
+    'https://huggingface.co/$encodedRepoId/resolve/$encodedRevision/$encodedFilePath?download=true',
   );
 }
 
@@ -330,6 +427,18 @@ String _decodeHuggingFacePathSegment(String segment, String value) {
   }
 }
 
+String _decodeHuggingFaceQueryComponent(String component, String value) {
+  try {
+    return Uri.decodeComponent(component);
+  } on FormatException catch (error) {
+    throw ArgumentError.value(
+      value,
+      'value',
+      'Hugging Face query contains invalid percent-encoding: ${error.message}',
+    );
+  }
+}
+
 void _validateRepoSegment(String segment, String repoId) {
   final validSegment = RegExp(r'^[A-Za-z0-9][A-Za-z0-9._-]*$');
   if (!validSegment.hasMatch(segment) || segment.contains('..')) {
@@ -342,7 +451,14 @@ void _validateRepoSegment(String segment, String repoId) {
 }
 
 String _validateRevision(String revision) {
-  if (revision.isEmpty || revision.startsWith('/') || revision.contains('..')) {
+  final invalidCharacters = RegExp(r'[\x00-\x20\x7F~^:?*\[\\\]#]');
+  if (revision.isEmpty ||
+      revision.startsWith('/') ||
+      revision.endsWith('/') ||
+      revision.contains('//') ||
+      revision.contains('..') ||
+      revision.contains('@{') ||
+      invalidCharacters.hasMatch(revision)) {
     throw ArgumentError.value(
       revision,
       'revision',

--- a/test/unit/core/models/model_source_test.dart
+++ b/test/unit/core/models/model_source_test.dart
@@ -170,6 +170,132 @@ void main() {
       expect(source.canonicalKey, 'hf://owner/repo@rev/sub/dir/model.gguf');
     });
 
+    test('hf URI accepts revision query for branch names with slashes', () {
+      final source = ModelSource.parse(
+        'hf://owner/repo/sub/dir/model.gguf?revision=refs/pr/12',
+      );
+
+      expect(source.repoId, 'owner/repo');
+      expect(source.revision, 'refs/pr/12');
+      expect(source.filePath, 'sub/dir/model.gguf');
+      expect(
+        source.resolvedUri,
+        Uri.parse(
+          'https://huggingface.co/owner/repo/resolve/refs%2Fpr%2F12/sub/dir/model.gguf?download=true',
+        ),
+      );
+      expect(source.fileName, 'model.gguf');
+      expect(
+        source.canonicalKey,
+        'hf://owner/repo/sub/dir/model.gguf?revision=refs%2Fpr%2F12',
+      );
+      expect(source.metadataSourceKey, isNot(contains('refs/pr/12')));
+    });
+
+    test('hf URI accepts encoded slash revision query', () {
+      final source = ModelSource.parse(
+        'hf://owner/repo/model.gguf?revision=refs%2Fpr%2F12',
+      );
+
+      expect(source.revision, 'refs/pr/12');
+      expect(
+        source.resolvedUri,
+        Uri.parse(
+          'https://huggingface.co/owner/repo/resolve/refs%2Fpr%2F12/model.gguf?download=true',
+        ),
+      );
+    });
+
+    test('factory encodes revision path separators in resolved URL', () {
+      final source = ModelSource.huggingFace(
+        repoId: 'owner/repo',
+        revision: 'refs/pr/12',
+        filePath: 'model.gguf',
+      );
+
+      expect(source.revision, 'refs/pr/12');
+      expect(
+        source.resolvedUri,
+        Uri.parse(
+          'https://huggingface.co/owner/repo/resolve/refs%2Fpr%2F12/model.gguf?download=true',
+        ),
+      );
+      expect(
+        source.canonicalKey,
+        'hf://owner/repo/model.gguf?revision=refs%2Fpr%2F12',
+      );
+    });
+
+    test('slash-containing revisions produce unambiguous cache identities', () {
+      final queryRevisionSource = ModelSource.parse(
+        'hf://owner/repo/model.gguf?revision=a/b',
+      );
+      final inlineRevisionSource = ModelSource.parse(
+        'hf://owner/repo@a/b/model.gguf',
+      );
+
+      expect(queryRevisionSource.revision, 'a/b');
+      expect(queryRevisionSource.filePath, 'model.gguf');
+      expect(
+        queryRevisionSource.canonicalKey,
+        'hf://owner/repo/model.gguf?revision=a%2Fb',
+      );
+      expect(inlineRevisionSource.revision, 'a');
+      expect(inlineRevisionSource.filePath, 'b/model.gguf');
+      expect(
+        inlineRevisionSource.canonicalKey,
+        'hf://owner/repo@a/b/model.gguf',
+      );
+      expect(
+        queryRevisionSource.canonicalKey,
+        isNot(inlineRevisionSource.canonicalKey),
+      );
+      expect(
+        queryRevisionSource.cacheKey,
+        isNot(inlineRevisionSource.cacheKey),
+      );
+    });
+
+    test('hf URI revision query preserves literal plus signs', () {
+      final source = ModelSource.parse(
+        'hf://owner/repo/model.gguf?revision=release+cuda',
+      );
+
+      expect(source.revision, 'release+cuda');
+      expect(
+        source.resolvedUri,
+        Uri.parse(
+          'https://huggingface.co/owner/repo/resolve/release%2Bcuda/model.gguf?download=true',
+        ),
+      );
+    });
+
+    test('hf URI rejects ambiguous or unsupported revision query syntax', () {
+      final invalidValues = <String>[
+        'hf://owner/repo@main/model.gguf?revision=dev',
+        'hf://owner/repo/model.gguf?revision=',
+        'hf://owner/repo/model.gguf?revision=main&revision=dev',
+        'hf://owner/repo/model.gguf?download=true',
+        'hf://owner/repo/model.gguf?',
+        'hf://owner/repo/model.gguf?revision=bad%ZZ',
+        'hf://owner/repo/model.gguf?revision=main%0Ainjected',
+        'hf://owner/repo/model.gguf?revision=main%0Dinjected',
+        'hf://owner/repo/model.gguf?revision=main%09injected',
+        'hf://owner/repo/model.gguf?revision=foo%5Cbar',
+        'hf://owner/repo/model.gguf?revision=foo//bar',
+        'hf://owner/repo/model.gguf?revision=foo/',
+        'hf://owner/repo/model.gguf?revision=foo%20bar',
+      ];
+
+      for (final value in invalidValues) {
+        expect(
+          () => ModelSource.parse(value),
+          throwsArgumentError,
+          reason: value,
+        );
+      }
+    });
+
     test('parse accepts local paths as explicit convenience', () {
       final source = ModelSource.parse('/local/model.gguf');
 

--- a/test/unit/core/models/model_source_test.dart
+++ b/test/unit/core/models/model_source_test.dart
@@ -256,6 +256,46 @@ void main() {
       );
     });
 
+    test('delimiter revisions use query-form canonical keys', () {
+      final source = ModelSource.huggingFace(
+        repoId: 'owner/repo',
+        revision: 'release@v1',
+        filePath: 'model.gguf',
+      );
+
+      expect(source.revision, 'release@v1');
+      expect(
+        source.resolvedUri,
+        Uri.parse(
+          'https://huggingface.co/owner/repo/resolve/release%40v1/model.gguf?download=true',
+        ),
+      );
+      expect(
+        source.canonicalKey,
+        'hf://owner/repo/model.gguf?revision=release%40v1',
+      );
+
+      final reparsed = ModelSource.parse(source.canonicalKey);
+      expect(reparsed.revision, source.revision);
+      expect(reparsed.filePath, source.filePath);
+      expect(reparsed.canonicalKey, source.canonicalKey);
+    });
+
+    test('delimiter file paths use encoded query-form canonical keys', () {
+      final source = ModelSource.parse('hf://owner/repo/nested/model@q4.gguf');
+
+      expect(source.filePath, 'nested/model@q4.gguf');
+      expect(
+        source.canonicalKey,
+        'hf://owner/repo/nested/model%40q4.gguf?revision=main',
+      );
+
+      final reparsed = ModelSource.parse(source.canonicalKey);
+      expect(reparsed.revision, source.revision);
+      expect(reparsed.filePath, source.filePath);
+      expect(reparsed.canonicalKey, source.canonicalKey);
+    });
+
     test('hf URI revision query preserves literal plus signs', () {
       final source = ModelSource.parse(
         'hf://owner/repo/model.gguf?revision=release+cuda',

--- a/website/docs/changelog/recent-releases.md
+++ b/website/docs/changelog/recent-releases.md
@@ -18,6 +18,10 @@ For canonical full release notes, use:
   custom headers, cooperative cancellation, retry, HTTP Range resume, cache
   hit/refresh/cache-only/no-cache policies, SHA-256 verification, and persisted
   redacted metadata for signed URLs.
+- Improved Hugging Face `hf://` ergonomics with `?revision=...` parsing for
+  branch/ref names containing slashes, plus docs for private/gated bearer-token
+  usage, separate `mmproj` assets, sharded-GGUF limitations, and redaction
+  guarantees.
 - Serialized concurrent stable-cache downloads for the same remote cache entry
   across manager instances so duplicate callers do not race on shared `.part`
   files or metadata, while distinct cache entries can still download in

--- a/website/docs/getting-started/finding-models.md
+++ b/website/docs/getting-started/finding-models.md
@@ -45,5 +45,16 @@ When downloading a model, check its file size. Your target device needs enough *
 Once you find a model on Hugging Face:
 1. Go to the **Files and versions** tab of the model repository.
 2. Look for a file ending in `.gguf` (e.g., `model-q4_k_m.gguf`).
-3. Click the download icon next to the file.
-4. Place the downloaded `.gguf` file in your application's assets or a reachable file path for `engine.loadModel()`.
+3. Use the exact repository path with
+   `ModelSource.parse('hf://owner/repo/path/to/model.gguf')`, or click the
+   download icon and place the `.gguf` file in your application's assets or a
+   reachable file path for `engine.loadModel()`.
+
+For package-managed downloads, `hf://` defaults to the repository's `main`
+revision. Use `hf://owner/repo@tag/model.gguf` for simple branch/tag names, or
+`hf://owner/repo/model.gguf?revision=refs/pr/12` when the revision contains `/`.
+Private or gated repositories need `ModelLoadOptions(bearerToken: hfToken)` (or
+custom headers); do not put tokens in source strings. Multimodal repos often
+ship a separate `mmproj` GGUF file—treat it as a separate asset/source. Sharded
+GGUF repos are not expanded automatically by `llamadart`; choose a single-file
+GGUF unless you are handling shards yourself.

--- a/website/docs/guides/model-lifecycle.md
+++ b/website/docs/guides/model-lifecycle.md
@@ -114,9 +114,11 @@ await engine.loadModelSource(
 
 Bearer tokens and custom headers are used only for remote download requests and
 are not part of `ModelSource.canonicalKey`, cache metadata, or `toString()`.
-Signed HTTP(S) URLs keep their full raw URL only for the in-memory cache-key
-hash; persisted metadata redacts query strings and appends the deterministic
-cache key so entries remain distinguishable without storing secrets.
+Signed HTTP(S) URLs are different: `ModelSource.canonicalKey` keeps the full
+raw URL and `cacheKey` hashes that full identity so distinct signed URLs stay
+unique. Persisted cache metadata and `toString()` redact query strings and
+append the deterministic cache key, but callers should not log or persist
+`canonicalKey` for signed URLs that carry secrets.
 
 Current limitations:
 

--- a/website/docs/guides/model-lifecycle.md
+++ b/website/docs/guides/model-lifecycle.md
@@ -70,6 +70,65 @@ cache policies, `cacheDirectory`, authenticated headers, `resume`, and
 Source values expose deterministic cache keys and redacted metadata identities
 so signed URL query strings are not stored in logs or cache metadata.
 
+### Hugging Face `hf://` references
+
+Use `hf://owner/repo/path/to/model.gguf` for a public GGUF file. The shorthand
+resolves to `https://huggingface.co/owner/repo/resolve/main/path/to/model.gguf`
+with `download=true` and uses the stable `hf://...` identity for cache keys.
+
+```dart
+final main = ModelSource.parse(
+  'hf://unsloth/Qwen3.5-0.8B-GGUF/Qwen3.5-0.8B-Q4_K_M.gguf',
+);
+
+final tagged = ModelSource.parse(
+  'hf://owner/repo@v1.0.0/model-Q4_K_M.gguf',
+);
+
+// Use ?revision= when the revision itself contains `/`, such as PR refs.
+final pullRequestRef = ModelSource.parse(
+  'hf://owner/repo/model-Q4_K_M.gguf?revision=refs/pr/12',
+);
+```
+
+`ModelSource.huggingFace(...)` exposes the same pieces directly when building a
+source from app state:
+
+```dart
+final source = ModelSource.huggingFace(
+  repoId: 'owner/repo',
+  revision: 'main',
+  filePath: 'model-Q4_K_M.gguf',
+);
+```
+
+Private or gated repositories should pass credentials through
+`ModelLoadOptions`, not in the source string:
+
+```dart
+await engine.loadModelSource(
+  ModelSource.parse('hf://owner/private-repo/model-Q4_K_M.gguf'),
+  options: ModelLoadOptions(bearerToken: hfToken),
+);
+```
+
+Bearer tokens and custom headers are used only for remote download requests and
+are not part of `ModelSource.canonicalKey`, cache metadata, or `toString()`.
+Signed HTTP(S) URLs keep their full raw URL only for the in-memory cache-key
+hash; persisted metadata redacts query strings and appends the deterministic
+cache key so entries remain distinguishable without storing secrets.
+
+Current limitations:
+
+- `hf://` identifies one file. For multimodal models, create a separate source
+  for the model GGUF and the `mmproj` GGUF, then load/cache each asset according
+  to the API you are using.
+- Sharded GGUF manifests are not expanded automatically; track that as a
+  separate design before relying on sharded repos.
+- `llamadart` does not list Hugging Face files or choose recommended
+  quantizations for you. Pick the exact `.gguf` file path from the repository's
+  **Files and versions** tab.
+
 Native/file-backed backends download remote sources into the package-managed
 cache, verify the completed file, persist metadata, and then call the existing
 local `loadModel(...)` path. URL-capable web backends keep using


### PR DESCRIPTION
## Summary

- Adds `hf://...?revision=` parsing for slash-containing Hugging Face refs while keeping simple `@revision` shorthand.
- Encodes Hugging Face resolve URLs and canonical cache identities safely, including non-colliding cache keys for slash revisions.
- Documents current `hf://` behavior, private/gated repo token guidance, and current limitations around single-file sources, `mmproj`, file listing, and sharded GGUFs.

Closes #136

## Production-readiness scope

- Users can load public Hugging Face GGUF files with `ModelSource.parse('hf://owner/repo/path/to/model.gguf')`.
- Users can pin simple branches/tags/SHAs with `@revision`, and slash-containing refs such as `refs/pr/12` with `?revision=refs/pr/12`.
- Supported behavior is source parsing, resolved download URL construction, deterministic cache identity, and documentation of private/gated downloads through `ModelLoadOptions` credentials.
- Unsupported paths remain explicit documentation non-goals: `hf://` identifies one file only, separate `mmproj` assets require separate sources/load steps, sharded GGUF manifests are not expanded automatically, and llamadart does not list or choose Hugging Face files.
- Existing public API signatures remain compatible; the change is additive plus stricter rejection of invalid/unsafe revision strings.

## Changes

- Parse `?revision=` on `hf://` sources and reject ambiguous `@revision` + `?revision=` combinations.
- Preserve literal `+` in revision queries and reject invalid percent-encoding / unsafe decoded revision strings before they enter metadata or logs.
- Encode resolved Hugging Face URLs component-by-component so slash-containing revisions are a single `/resolve/{revision}/...` segment.
- Use unambiguous query-form canonical keys for slash-containing revisions to avoid cache-key collisions with inline simple revisions plus nested file paths.
- Add regression coverage for revision queries, encoded slash revisions, factory URL encoding, cache-key non-collision, plus decoding, invalid query syntax, and invalid revision input.
- Update README, website docs, changelog, and recent release notes.

## Test Plan

- [x] `dart format --output=none --set-exit-if-changed lib/src/core/models/model_source.dart test/unit/core/models/model_source_test.dart`
- [x] `dart analyze lib/src/core/models/model_source.dart test/unit/core/models/model_source_test.dart`
- [x] `dart analyze`
- [x] `dart test test/unit/core/models/model_source_test.dart`
- [x] `dart test test/unit/core/models`
- [x] `dart test`
- [x] `(cd website && npm run build)`
- [x] `git diff --check origin/main...HEAD`
- [x] Static added-line scan for hardcoded secrets, dangerous exec, raw URL logging, and token-like URL literals: 0 findings

## Review notes

- Deep review initially found blockers around ambiguous canonical/cache identities for slash-containing revisions, `+` query decoding, and unsafe decoded revision strings.
- Those blockers were fixed before submission and covered by new regression tests.
- Final independent review verdict: approved / ready to push and open PR; no blockers.
