### PR TITLE
chore: prepare v0.6.13 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-## Unreleased
+## 0.6.13
 
 * **Model source download/cache manager**:
   * Added `ModelSource` for local paths, HTTP(S) URLs, and Hugging Face
@@ -48,10 +48,11 @@
   * Added WebGPU bridge state persistence wiring for bridge assets `v0.1.15+`,
     including Dart JS interop, backend forwarding, and browser integration test
     coverage.
-* **Compatibility note**: existing `loadModel(...)` callers are unchanged. Code
-  that probes state persistence support should prefer
-  `LlamaEngine.supportsStatePersistence` over structural backend type checks so
-  web/router backends can report bridge-version-dependent support accurately.
+* **Compatibility note**: no public API breaking changes in `0.6.13`;
+  existing `loadModel(...)` callers are unchanged. Code that probes state
+  persistence support should prefer `LlamaEngine.supportsStatePersistence` over
+  structural backend type checks so web/router backends can report
+  bridge-version-dependent support accurately.
 
 ## 0.6.12
 

--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@
 
 ```yaml
 dependencies:
-  llamadart: ^0.6.12
+  llamadart: ^0.6.13
 ```
 
 ### 2. Run with defaults

--- a/example/chat_app/pubspec.lock
+++ b/example/chat_app/pubspec.lock
@@ -349,7 +349,7 @@ packages:
       path: "../.."
       relative: true
     source: path
-    version: "0.6.12"
+    version: "0.6.13"
   logging:
     dependency: transitive
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: llamadart
 description: A Dart/Flutter plugin for llama.cpp - run LLM inference on any platform using GGUF models
-version: 0.6.12
+version: 0.6.13
 homepage: https://github.com/leehack/llamadart
 repository: https://github.com/leehack/llamadart
 issue_tracker: https://github.com/leehack/llamadart/issues

--- a/website/docs/changelog/recent-releases.md
+++ b/website/docs/changelog/recent-releases.md
@@ -7,7 +7,7 @@ For canonical full release notes, use:
 
 - [`CHANGELOG.md`](https://github.com/leehack/llamadart/blob/main/CHANGELOG.md)
 
-## Unreleased
+## 0.6.13
 
 - Added package-managed model source downloads and cache management:
   `ModelSource`, `ModelLoadOptions`, `ModelCachePolicy`, resolver targets,
@@ -22,19 +22,18 @@ For canonical full release notes, use:
   branch/ref names containing slashes, plus docs for private/gated bearer-token
   usage, separate `mmproj` assets, sharded-GGUF limitations, and redaction
   guarantees.
-- Serialized concurrent stable-cache downloads for the same remote cache entry
-  across manager instances so duplicate callers do not race on shared `.part`
-  files or metadata, while distinct cache entries can still download in
-  parallel and waiting-caller cancellation does not cancel the active download.
-- Hardened versioned cache metadata recovery so completed files can rebuild
-  missing, malformed, or unsupported-schema sidecars without network access,
-  while byte-count and stored/caller SHA-256 mismatches are treated as cache
-  misses and safely re-downloaded.
+- Hardened download/cache correctness by serializing concurrent same-entry
+  downloads, recovering missing or malformed cache metadata sidecars, treating
+  mismatched byte-count/SHA-256 metadata as cache misses, and rejecting
+  remote-only options for local `ModelSource.path(...)` inputs.
 - Added `LlamaEngine.loadModelSource(...)` so local path sources keep using the
   existing native loader, remote HTTP(S)/Hugging Face sources download through
   the package-managed native cache before local loading, and URL-capable web
   backends keep using direct URL loading for simple unauthenticated requests.
-- Compatibility note: no public API breaking changes; existing
+- Added KV-cache state persistence APIs: `LlamaEngine.supportsStatePersistence`,
+  `stateSaveFile(...)`, `stateLoadFile(...)`, backend support diagnostics, and
+  WebGPU bridge forwarding for bridge assets `v0.1.15+`.
+- Compatibility note: no public API breaking changes in `0.6.13`; existing
   `loadModel(...)` callers are unchanged.
 
 ## 0.6.12

--- a/website/docs/getting-started/installation.md
+++ b/website/docs/getting-started/installation.md
@@ -25,7 +25,7 @@ configurations.
 
 ```yaml
 dependencies:
-  llamadart: ^0.6.12
+  llamadart: ^0.6.13
 ```
 
 Then resolve packages:


### PR DESCRIPTION
## Summary
- Bump package version to `0.6.13`.
- Promote accumulated `Unreleased` notes into the `0.6.13` changelog section.
- Update current README/docs install snippets and recent release highlights.
- Refresh the chat app lockfile path-dependency version.

## Release scope
- Model source download/cache manager APIs and hardening.
- `LlamaEngine.loadModelSource(...)` native/web routing.
- KV-cache state persistence APIs and WebGPU bridge forwarding for bridge assets `v0.1.15+`.
- No public API breaking changes; existing `loadModel(...)` callers remain unchanged.

## Test Plan
- [x] `dart pub get`
- [x] `(cd example/chat_app && flutter pub get)`
- [x] `dart format --output=none --set-exit-if-changed .`
- [x] `dart analyze`
- [x] `dart test`
- [x] `./tool/docs/build_site.sh`
- [x] `./tool/docs/validate_links.sh`
- [x] `dart pub publish --dry-run`
- [x] Independent release-prep review: passed, no blockers.

## Notes
- Per release workflow, the actual publish/docs-version automation should run from tag `v0.6.13` after this PR merges.
