### PR TITLE
ci: update actions for Node 24

### DIFF
--- a/.github/workflows/chat_app_hf_static_deploy.yml
+++ b/.github/workflows/chat_app_hf_static_deploy.yml
@@ -33,7 +33,7 @@ jobs:
       HF_CHAT_APP_SPACE_REPO: ${{ vars.HF_CHAT_APP_SPACE_REPO }}
       INPUT_SPACE_REPO: ${{ github.event.inputs.space_repo }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           ref: ${{ github.event.inputs.deploy_ref || github.ref }}
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,7 +16,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 25
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: Setup Flutter
         uses: subosito/flutter-action@v2
@@ -56,7 +56,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 25
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: Setup Flutter
         uses: subosito/flutter-action@v2
@@ -65,7 +65,7 @@ jobs:
           cache: true
 
       - name: Setup Node
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version: '20'
 
@@ -82,7 +82,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 45
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: Setup Flutter
         uses: subosito/flutter-action@v2
@@ -108,7 +108,8 @@ jobs:
           dart run tool/testing/check_lcov_threshold.dart coverage/lcov.info 70
 
       - name: Upload coverage to Codecov
-        uses: codecov/codecov-action@v5
+        if: ${{ github.actor != 'dependabot[bot]' }}
+        uses: codecov/codecov-action@v6
         with:
           files: coverage/lcov.info
           flags: unittests
@@ -126,7 +127,7 @@ jobs:
         os: [macos-latest, windows-latest]
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: Setup Flutter
         uses: subosito/flutter-action@v2
@@ -147,7 +148,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 35
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: Setup Flutter
         uses: subosito/flutter-action@v2

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -108,7 +108,7 @@ jobs:
           dart run tool/testing/check_lcov_threshold.dart coverage/lcov.info 70
 
       - name: Upload coverage to Codecov
-        if: ${{ github.actor != 'dependabot[bot]' }}
+        if: ${{ github.event_name != 'pull_request' || github.event.pull_request.user.login != 'dependabot[bot]' }}
         uses: codecov/codecov-action@v6
         with:
           files: coverage/lcov.info

--- a/.github/workflows/docs_pages.yml
+++ b/.github/workflows/docs_pages.yml
@@ -26,7 +26,7 @@ jobs:
     env:
       DOCS_GA_MEASUREMENT_ID: ${{ vars.DOCS_GA_MEASUREMENT_ID }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           fetch-depth: 0
 
@@ -37,7 +37,7 @@ jobs:
           cache: true
 
       - name: Setup Node
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version: '20'
 
@@ -50,12 +50,13 @@ jobs:
         run: ./tool/docs/build_site.sh
 
       - name: Configure GitHub Pages
-        uses: actions/configure-pages@v5
+        uses: actions/configure-pages@v6
 
       - name: Upload pages artifact
-        uses: actions/upload-pages-artifact@v3
+        uses: actions/upload-pages-artifact@v5
         with:
           path: website/build
+          include-hidden-files: true
 
   deploy:
     name: Deploy to GitHub Pages
@@ -67,4 +68,4 @@ jobs:
     steps:
       - name: Deploy pages
         id: deployment
-        uses: actions/deploy-pages@v4
+        uses: actions/deploy-pages@v5

--- a/.github/workflows/docs_version_cut.yml
+++ b/.github/workflows/docs_version_cut.yml
@@ -14,13 +14,13 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 20
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           ref: ${{ github.ref }}
           fetch-depth: 0
 
       - name: Setup Node
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version: '20'
 

--- a/.github/workflows/sync_native_bindings.yml
+++ b/.github/workflows/sync_native_bindings.yml
@@ -16,7 +16,7 @@ jobs:
   sync:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: Setup Flutter
         uses: subosito/flutter-action@v2
@@ -24,7 +24,7 @@ jobs:
           channel: stable
 
       - name: Cache Pub packages
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: |
             ~/.pub-cache
@@ -53,7 +53,7 @@ jobs:
           sed -i "s/const _llamaCppTag = '.*';/const _llamaCppTag = '$TAG';/" hook/build.dart
 
       - name: Create pull request
-        uses: peter-evans/create-pull-request@v6
+        uses: peter-evans/create-pull-request@v8
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           commit-message: "chore(native): sync native release ${{ steps.sync_headers.outputs.resolved_tag }}"


### PR DESCRIPTION
## Summary
- Update GitHub-owned JavaScript actions to Node 24-compatible major versions.
- Update Codecov and native-sync PR creation actions to current major versions.
- Skip Codecov uploads for Dependabot PRs so dependency-only PRs do not fail when repository secrets are unavailable.
- Preserve hidden-file behavior for the Pages artifact upload after moving to `actions/upload-pages-artifact@v5`.

## Test Plan
- [x] `go run github.com/rhysd/actionlint/cmd/actionlint@latest -color=false .github/workflows/*.yml`
- [x] `git diff --check`
- [x] Verified bumped JS actions use Node 24 metadata: `actions/checkout@v6`, `actions/setup-node@v6`, `actions/cache@v5`, `actions/configure-pages@v6`, `actions/deploy-pages@v5`, `peter-evans/create-pull-request@v8`

## Notes
- This should remove the GitHub Actions Node.js 20 deprecation warning for first-party JavaScript actions.
- Dependabot PR #100 still needs a rebase/re-run or maintainer-applied equivalent after this lands.

## CI / Review Evidence
- [x] PR CI green on head `e8018ce516e15e5e8da055b81d7bec3c086d6b27`
- [x] Verified latest run log no longer contains `Node.js 20 actions are deprecated`
- [x] Addressed and resolved Copilot's Codecov condition comment by keying the skip to `github.event.pull_request.user.login` with a push-event guard
