### PR TITLE
chore: update WebGPU bridge assets to v0.1.16

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -99,6 +99,7 @@ a.out.wasm
 
 # Local web bridge artifacts fetched/built for chat_app
 example/chat_app/web/webgpu_bridge/*.js
+example/chat_app/web/webgpu_bridge/*.d.ts
 example/chat_app/web/webgpu_bridge/*.wasm
 example/chat_app/web/webgpu_bridge/manifest.json
 example/chat_app/web/webgpu_bridge/sha256sums.txt

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 ## Unreleased
 
+* **WebGPU bridge assets**:
+  * Updated the default WebGPU bridge asset pin to
+    `leehack/llama-web-bridge-assets@v0.1.16` (llama.cpp `b9165`),
+    picking up the published JS bridge build, TypeScript declaration asset,
+    and refreshed bridge docs.
 * **Docs**:
   * Added WebGPU readiness guidance covering browser capability checks,
     cross-origin isolation, bridge asset/version diagnostics, fallback behavior,

--- a/doc/webgpu_bridge.md
+++ b/doc/webgpu_bridge.md
@@ -19,7 +19,7 @@ pipelines.
    `https://cdn.jsdelivr.net/gh/leehack/llama-web-bridge-assets@<tag>/llama_webgpu_bridge.js`
 2. Local fallback: `./webgpu_bridge/llama_webgpu_bridge.js`
 
-Default pinned tag in the example is `v0.1.15`.
+Default pinned tag in the example is `v0.1.16`.
 
 For broader browser coverage in this repository, fetched/local assets are patched
 to a universal Safari-compatible gate by default (`MIN_SAFARI_VERSION=170400`).
@@ -32,7 +32,7 @@ model bytes.
 To vendor pinned assets into local app web files:
 
 ```bash
-WEBGPU_BRIDGE_ASSETS_TAG=v0.1.15 ./scripts/fetch_webgpu_bridge_assets.sh
+WEBGPU_BRIDGE_ASSETS_TAG=v0.1.16 ./scripts/fetch_webgpu_bridge_assets.sh
 ```
 
 Optional compatibility env vars:
@@ -108,7 +108,7 @@ You can override CDN source/version before the bridge loader runs:
 ```html
 <script>
   window.__llamadartBridgeAssetsRepo = 'leehack/llama-web-bridge-assets';
-  window.__llamadartBridgeAssetsTag = 'v0.1.15';
+  window.__llamadartBridgeAssetsTag = 'v0.1.16';
 </script>
 ```
 

--- a/example/chat_app/web/index.html
+++ b/example/chat_app/web/index.html
@@ -215,8 +215,8 @@
     const bridgeAssetsTag =
       typeof configuredTag === 'string' && configuredTag.length > 0
         ? configuredTag
-        : 'v0.1.15';
-    const localBridgeVersion = 'v0.1.15-local-b9116';
+        : 'v0.1.16';
+    const localBridgeVersion = 'v0.1.16-local-b9165';
     window.__llamadartBridgeLocalVersion = localBridgeVersion;
 
     const localBridgeUrl = `./webgpu_bridge/llama_webgpu_bridge.js?v=${localBridgeVersion}`;

--- a/scripts/fetch_webgpu_bridge_assets.sh
+++ b/scripts/fetch_webgpu_bridge_assets.sh
@@ -4,7 +4,7 @@ set -euo pipefail
 ROOT_DIR="$(git rev-parse --show-toplevel)"
 OUT_DIR="${WEBGPU_BRIDGE_OUT_DIR:-$ROOT_DIR/example/chat_app/web/webgpu_bridge}"
 ASSETS_REPO="${WEBGPU_BRIDGE_ASSETS_REPO:-leehack/llama-web-bridge-assets}"
-ASSETS_TAG="${WEBGPU_BRIDGE_ASSETS_TAG:-v0.1.15}"
+ASSETS_TAG="${WEBGPU_BRIDGE_ASSETS_TAG:-v0.1.16}"
 CDN_BASE="${WEBGPU_BRIDGE_CDN_BASE:-https://cdn.jsdelivr.net/gh/${ASSETS_REPO}@${ASSETS_TAG}}"
 PATCH_SAFARI_COMPAT="${WEBGPU_BRIDGE_PATCH_SAFARI_COMPAT:-1}"
 MIN_SAFARI_VERSION="${WEBGPU_BRIDGE_MIN_SAFARI_VERSION:-170400}"
@@ -14,7 +14,7 @@ if [[ "${1:-}" == "--help" || "${1:-}" == "-h" ]]; then
 Downloads prebuilt WebGPU bridge assets into the chat_app web directory.
 
 Default source:
-  https://cdn.jsdelivr.net/gh/leehack/llama-web-bridge-assets@v0.1.15
+  https://cdn.jsdelivr.net/gh/leehack/llama-web-bridge-assets@v0.1.16
 
 Environment variables:
   WEBGPU_BRIDGE_ASSETS_REPO   Asset repo in owner/repo format
@@ -28,7 +28,7 @@ Usage:
   ./scripts/fetch_webgpu_bridge_assets.sh
 
 Examples:
-  WEBGPU_BRIDGE_ASSETS_TAG=v0.1.15 ./scripts/fetch_webgpu_bridge_assets.sh
+  WEBGPU_BRIDGE_ASSETS_TAG=v0.1.16 ./scripts/fetch_webgpu_bridge_assets.sh
   WEBGPU_BRIDGE_ASSETS_REPO=acme/llama-web-bridge-assets WEBGPU_BRIDGE_ASSETS_TAG=v2 ./scripts/fetch_webgpu_bridge_assets.sh
 USAGE
   exit 0
@@ -77,6 +77,7 @@ download_optional() {
 
 download_required "llama_webgpu_bridge.js"
 download_optional "llama_webgpu_bridge_worker.js"
+download_optional "llama_webgpu_bridge.d.ts"
 download_required "llama_webgpu_core.js"
 download_required "llama_webgpu_core.wasm"
 download_optional "llama_webgpu_core_mem64.js"
@@ -214,6 +215,9 @@ if command -v shasum >/dev/null 2>&1 || command -v sha256sum >/dev/null 2>&1; th
     )
     if [[ -f "llama_webgpu_bridge_worker.js" ]]; then
       files+=("llama_webgpu_bridge_worker.js")
+    fi
+    if [[ -f "llama_webgpu_bridge.d.ts" ]]; then
+      files+=("llama_webgpu_bridge.d.ts")
     fi
     if [[ -f "llama_webgpu_core_mem64.js" ]]; then
       files+=("llama_webgpu_core_mem64.js")

--- a/website/docs/changelog/recent-releases.md
+++ b/website/docs/changelog/recent-releases.md
@@ -9,6 +9,10 @@ For canonical full release notes, use:
 
 ## Unreleased
 
+- Updated the default WebGPU bridge asset pin to
+  `leehack/llama-web-bridge-assets@v0.1.16` (llama.cpp `b9165`), picking up
+  the published JS bridge build, TypeScript declaration asset, and refreshed
+  bridge docs.
 - Added WebGPU readiness guidance covering browser capability checks,
   cross-origin isolation, bridge asset/version diagnostics, fallback behavior,
   model/configuration pressure, and the Flutter Web real-model smoke path.

--- a/website/docs/platforms/webgpu-bridge.md
+++ b/website/docs/platforms/webgpu-bridge.md
@@ -142,13 +142,13 @@ development validation, and CDN-first loading for normal hosted deployments:
 1. On localhost: local asset first, then CDN fallback.
 2. On hosted deployments: CDN asset first, then local fallback.
 
-The example currently pins bridge assets to `v0.1.15`, with local vendored assets
-identified as `v0.1.15-local-b9116`.
+The example currently pins bridge assets to `v0.1.16`, with local vendored assets
+identified as `v0.1.16-local-b9165`.
 
 Fetch pinned local assets with:
 
 ```bash
-WEBGPU_BRIDGE_ASSETS_TAG=v0.1.15 ./scripts/fetch_webgpu_bridge_assets.sh
+WEBGPU_BRIDGE_ASSETS_TAG=v0.1.16 ./scripts/fetch_webgpu_bridge_assets.sh
 ```
 
 To verify the loaded runtime in a browser console, inspect:
@@ -259,7 +259,7 @@ You can override bridge asset source/version before loader startup:
 ```html
 <script>
   window.__llamadartBridgeAssetsRepo = 'leehack/llama-web-bridge-assets';
-  window.__llamadartBridgeAssetsTag = 'v0.1.15';
+  window.__llamadartBridgeAssetsTag = 'v0.1.16';
   // Prefer local runtime even off localhost:
   // window.__llamadartPreferLocalBridgeRuntime = true;
   // Enable verbose bridge bootstrap console logs:


### PR DESCRIPTION
## Summary
- Update the default WebGPU bridge asset pin to `leehack/llama-web-bridge-assets@v0.1.16` (llama.cpp `b9165`).
- Update chat app bootstrap cache-busting/runtime diagnostics to `v0.1.16-local-b9165`.
- Fetch the newly published TypeScript declaration asset when vendoring bridge assets locally, and ignore local fetched `.d.ts` artifacts.
- Refresh current docs and changelog entries for the published bridge asset update.

## Published asset evidence
- Published release: https://github.com/leehack/llama-web-bridge-assets/releases/tag/v0.1.16
- Source: `leehack/llama-web-bridge@99b163f576ce5dd3f41fefa69a78cd4b3e3bfb71`
- Manifest verified locally: `bridge_assets_tag=v0.1.16`, `llama_cpp_tag=b9165`, includes `llama_webgpu_bridge.d.ts` plus wasm32/mem64 runtime assets.
- Default jsDelivr fetch was rechecked after publish propagation and successfully downloaded/verifed v0.1.16, including `llama_webgpu_bridge.d.ts`.

## Test Plan
- [x] `sh -n scripts/fetch_webgpu_bridge_assets.sh`
- [x] `git diff --check`
- [x] `WEBGPU_BRIDGE_CDN_BASE=https://raw.githubusercontent.com/leehack/llama-web-bridge-assets/v0.1.16 ./scripts/fetch_webgpu_bridge_assets.sh`
- [x] `WEBGPU_BRIDGE_OUT_DIR=/tmp/llamadart-webgpu-fetch-v016-check ./scripts/fetch_webgpu_bridge_assets.sh`
- [x] `dart analyze lib/src/backends/webgpu test/integration/backends/webgpu`
- [x] `dart test -p chrome test/integration/backends/webgpu/webgpu_engine_multimodal_browser_integration_test.dart`
- [x] `dart analyze`
- [x] `npm run build --prefix website`
- [x] `tool/testing/playwright_bridge_smoke.py` against local v0.1.16 bridge assets
- [x] `(cd example/chat_app && flutter build web --base-href=/example/chat_app/build/web/)`
- [x] `tool/testing/playwright_chat_app_real_model_smoke.py` against built chat app + Qwen3.5-0.8B-Q4_K_M GGUF; observed response: `2+2 equals 4.`

## Review Notes
- Independent review found no blockers. Follow-up nit about final local checksum regeneration omitting `.d.ts` was fixed before push.
