### PR TITLE
chore: prepare v0.6.14 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-## Unreleased
+## 0.6.14
 
 * **WebGPU bridge assets**:
   * Updated the default WebGPU bridge asset pin to
@@ -17,6 +17,9 @@
   * Wired the runnable chat app example through a `ModelDownloadManager` adapter
     so its model-management UI demonstrates the controller while preserving the
     example's multi-asset and web-cache service behavior.
+* **Compatibility note**: no public API breaking changes in `0.6.14`;
+  the WebGPU bridge asset update and `ModelDownloadController` are additive, and
+  existing `0.6.13` callers remain compatible.
 
 ## 0.6.13
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,3 @@
-## Unreleased
-
 ## 0.6.14
 
 * **WebGPU bridge assets**:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,5 @@
+## Unreleased
+
 ## 0.6.14
 
 * **WebGPU bridge assets**:

--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@
 
 ```yaml
 dependencies:
-  llamadart: ^0.6.13
+  llamadart: ^0.6.14
 ```
 
 ### 2. Run with defaults

--- a/example/chat_app/pubspec.lock
+++ b/example/chat_app/pubspec.lock
@@ -349,7 +349,7 @@ packages:
       path: "../.."
       relative: true
     source: path
-    version: "0.6.13"
+    version: "0.6.14"
   logging:
     dependency: transitive
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: llamadart
 description: A Dart/Flutter plugin for llama.cpp - run LLM inference on any platform using GGUF models
-version: 0.6.13
+version: 0.6.14
 homepage: https://github.com/leehack/llamadart
 repository: https://github.com/leehack/llamadart
 issue_tracker: https://github.com/leehack/llamadart/issues

--- a/website/docs/changelog/recent-releases.md
+++ b/website/docs/changelog/recent-releases.md
@@ -7,7 +7,7 @@ For canonical full release notes, use:
 
 - [`CHANGELOG.md`](https://github.com/leehack/llamadart/blob/main/CHANGELOG.md)
 
-## Unreleased
+## 0.6.14
 
 - Updated the default WebGPU bridge asset pin to
   `leehack/llama-web-bridge-assets@v0.1.16` (llama.cpp `b9165`), picking up
@@ -23,6 +23,9 @@ For canonical full release notes, use:
 - Wired the runnable chat app example through a `ModelDownloadManager` adapter
   so its model-management UI demonstrates the controller while preserving the
   example's multi-asset and web-cache service behavior.
+- Compatibility note: no public API breaking changes in `0.6.14`; the WebGPU
+  bridge asset update and `ModelDownloadController` are additive, and existing
+  `0.6.13` callers remain compatible.
 
 ## 0.6.13
 

--- a/website/docs/changelog/recent-releases.md
+++ b/website/docs/changelog/recent-releases.md
@@ -7,6 +7,8 @@ For canonical full release notes, use:
 
 - [`CHANGELOG.md`](https://github.com/leehack/llamadart/blob/main/CHANGELOG.md)
 
+## Unreleased
+
 ## 0.6.14
 
 - Updated the default WebGPU bridge asset pin to

--- a/website/docs/changelog/recent-releases.md
+++ b/website/docs/changelog/recent-releases.md
@@ -7,8 +7,6 @@ For canonical full release notes, use:
 
 - [`CHANGELOG.md`](https://github.com/leehack/llamadart/blob/main/CHANGELOG.md)
 
-## Unreleased
-
 ## 0.6.14
 
 - Updated the default WebGPU bridge asset pin to

--- a/website/docs/getting-started/installation.md
+++ b/website/docs/getting-started/installation.md
@@ -25,7 +25,7 @@ configurations.
 
 ```yaml
 dependencies:
-  llamadart: ^0.6.13
+  llamadart: ^0.6.14
 ```
 
 Then resolve packages:


### PR DESCRIPTION
## Summary
- Prepare the `0.6.14` package release by bumping the root `pubspec.yaml` version.
- Promote the current `Unreleased` notes to `0.6.14` in both the root changelog and website recent releases page.
- Update current install snippets to `llamadart: ^0.6.14` and refresh the chat app example lockfile path dependency metadata.

## Release scope
- Latest published pub.dev version checked before push: `0.6.13`; this PR prepares the next `0.6.14` release.
- Historical versioned website docs are intentionally unchanged.
- Empty `Unreleased` headings are intentionally not kept in committed release prep per `AGENTS.md` and the maintainer release workflow; they should be added back only when the next unreleased change is documented.
- Tag/publish/docs-version automation remains a post-merge/tag maintainer step.

## Test Plan
- [x] `dart format --output=none --set-exit-if-changed .`
- [x] `dart analyze`
- [x] `dart test -p vm -j 1 --exclude-tags local-only`
- [x] `dart test -p chrome --exclude-tags local-only`
- [x] `(cd website && npm run build)`
- [x] `flutter pub publish --dry-run`
- [x] `flutter pub get` in `example/chat_app` to refresh the path dependency lockfile

## Review notes
- Independent release-prep diff review found no release-blocking issues after refreshing `example/chat_app/pubspec.lock`.
- Copilot suggested restoring empty `Unreleased` headings, but repo guidance says not to leave empty `Unreleased` sections in committed release prep; this PR follows the repo guidance.
