### PR TITLE
test: add local E2E scenario runner

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -18,12 +18,26 @@ dart analyze --fatal-infos              # Optional stricter local check for info
 dart test                                 # Run all platform-compatible tests (VM or browser)
 dart test -p vm                           # Run only VM (native) tests
 dart test -p chrome                       # Run only Chrome (web) tests
-dart test --run-skipped -t local-only     # Run local-only E2E scenarios
+dart run tool/testing/run_local_e2e.dart --list  # Discover local-only E2E scenarios
+dart test --run-skipped -t local-only     # Run root local-only Dart E2E scenarios
 dart test test/path/to/test_file.dart     # Run a single test file
 dart test -p vm --coverage=coverage       # Run VM tests and collect coverage
 dart pub global run coverage:format_coverage --lcov --in=coverage/test --out=coverage/lcov.info --report-on=lib --check-ignore
 dart run tool/testing/check_lcov_threshold.dart coverage/lcov.info 70
 ```
+
+### Local-Only E2E Runner
+Use the scenario runner as the discovery entry point for heavyweight manual checks:
+
+```bash
+dart run tool/testing/run_local_e2e.dart --list
+dart run tool/testing/run_local_e2e.dart --scenario <name> --dry-run
+dart run tool/testing/run_local_e2e.dart --scenario chat-app-model-cache --device macos
+```
+
+Heavy scenarios remain skipped by default and out of CI unless explicitly requested.
+Use `--dry-run` before Web smoke scenarios to see the required build/server/
+Playwright steps and model URL defaults.
 
 ### Local Chat App Web E2E
 Use the real chat app path for WebGPU bridge validation after bridge/runtime

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,13 @@
+## Unreleased
+
+* **Testing**:
+  * Added `tool/testing/run_local_e2e.dart` as a discovery and orchestration
+    entry point for heavyweight local-only Dart E2E, Flutter device, and
+    Web/Playwright smoke scenarios.
+  * Documented that real-model/device/WebGPU scenarios remain skipped from
+    default CI and should be opted into explicitly with `--list` and
+    `--dry-run` first.
+
 ## 0.6.14
 
 * **WebGPU bridge assets**:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -125,7 +125,13 @@ Running `dart test` will run VM and Chrome-compatible tests. Tests tagged
 # Run default suite (VM + Chrome-compatible tests)
 dart test
 
-# Run local-only E2E tests
+# Discover heavyweight local-only E2E scenarios
+dart run tool/testing/run_local_e2e.dart --list
+
+# Preview the commands for one scenario without running it
+dart run tool/testing/run_local_e2e.dart --scenario chat-app-model-cache --device macos --dry-run
+
+# Run root local-only Dart E2E tests directly
 dart test --run-skipped -t local-only
 ```
 

--- a/README.md
+++ b/README.md
@@ -728,12 +728,15 @@ Check out our [LoRA Training Notebook](https://github.com/leehack/llamadart/blob
 This project maintains a high standard of quality with **>=70% line coverage on maintainable `lib/` code** (auto-generated files marked with `// coverage:ignore-file` are excluded).
 
 - **Multi-Platform Testing**: `dart test` runs VM and Chrome-compatible suites automatically.
-- **Local-Only Scenarios**: Slow E2E tests are tagged `local-only` and skipped by default.
+- **Local-Only Scenarios**: Slow E2E tests are tagged `local-only` and skipped by default; use `tool/testing/run_local_e2e.dart` to discover the root Dart, Flutter device, and Web smoke commands.
 - **CI/CD**: Automatic analysis, linting, and cross-platform test execution on every PR.
 
 ```bash
 # Run default test suite (VM + Chrome-compatible tests)
 dart test
+
+# Discover local-only E2E scenarios
+dart run tool/testing/run_local_e2e.dart --list
 
 # Run local-only E2E scenarios
 dart test --run-skipped -t local-only

--- a/test/unit/tooling/run_local_e2e_test.dart
+++ b/test/unit/tooling/run_local_e2e_test.dart
@@ -1,0 +1,170 @@
+@TestOn('vm')
+library;
+
+import 'dart:io';
+
+import 'package:test/test.dart';
+
+import '../../../tool/testing/run_local_e2e.dart';
+
+void main() {
+  group('run_local_e2e', () {
+    test('lists local-only Dart, Flutter, and Web smoke scenarios', () async {
+      final result = await runLocalE2e(const ['--list'], projectRoot: '/repo');
+
+      expect(result.exitCode, 0);
+      expect(result.stdout, contains('root-template-e2e'));
+      expect(result.stdout, contains('root-native-tool-e2e'));
+      expect(result.stdout, contains('qwen35-multimodal-macos-repro'));
+      expect(result.stdout, contains('webgpu-multimodal-regression'));
+      expect(result.stdout, contains('chat-app-model-cache'));
+      expect(result.stdout, contains('chat-app-web-real-model-smoke'));
+      expect(result.stdout, contains('bridge-smoke'));
+      expect(result.stdout, contains('Dart local-only'));
+      expect(result.stdout, contains('Flutter device'));
+      expect(result.stdout, contains('Web smoke'));
+    });
+
+    test(
+      'dry-runs a Flutter device scenario with the requested device',
+      () async {
+        final result = await runLocalE2e(const [
+          '--scenario',
+          'chat-app-model-cache',
+          '--device',
+          'macos',
+          '--dry-run',
+        ], projectRoot: '/repo');
+
+        expect(result.exitCode, 0);
+        expect(result.stdout, contains('chat-app-model-cache'));
+        expect(
+          result.stdout,
+          contains(
+            'cd /repo/example/chat_app && flutter test --run-skipped '
+            '-t local-only integration_test/model_cache_mmproj_e2e_test.dart '
+            '-d macos',
+          ),
+        );
+      },
+    );
+
+    test(
+      'dry-runs Web real-model smoke with build, serve, and Playwright steps',
+      () async {
+        final result = await runLocalE2e(const [
+          '--scenario',
+          'chat-app-web-real-model-smoke',
+          '--model-url',
+          'http://127.0.0.1:7358/models/tiny.gguf',
+          '--expect',
+          'ok',
+          '--python',
+          '/custom/python',
+          '--dry-run',
+        ], projectRoot: '/repo');
+
+        expect(result.exitCode, 0);
+        expect(result.stdout, contains('flutter build web'));
+        expect(result.stdout, contains('serve_static_with_headers.py'));
+        expect(
+          result.stdout,
+          contains('playwright_chat_app_real_model_smoke.py'),
+        );
+        expect(
+          result.stdout,
+          contains(
+            '/custom/python tool/testing/playwright_chat_app_real_model_smoke.py',
+          ),
+        );
+        expect(
+          result.stdout,
+          contains('--model-url http://127.0.0.1:7358/models/tiny.gguf'),
+        );
+        expect(result.stdout, contains('--expect ok'));
+      },
+    );
+
+    test('dry-runs WebGPU regression with forwarded runner options', () async {
+      final result = await runLocalE2e(const [
+        '--scenario',
+        'webgpu-multimodal-regression',
+        '--port',
+        '9123',
+        '--python',
+        '/custom/python',
+        '--skip-build',
+        '--dry-run',
+      ], projectRoot: '/repo');
+
+      expect(result.exitCode, 0);
+      expect(result.stdout, contains('PLAYWRIGHT_GATE_PORT=9123'));
+      expect(result.stdout, contains('PLAYWRIGHT_PYTHON=/custom/python'));
+      expect(result.stdout, contains('LLAMADART_SKIP_WEB_BUILD=1'));
+      expect(
+        result.stdout,
+        contains('bash tool/testing/run_webgpu_multimodal_regression_gate.sh'),
+      );
+    });
+
+    test('reports unknown scenarios without executing anything', () async {
+      final result = await runLocalE2e(const [
+        '--scenario',
+        'does-not-exist',
+        '--dry-run',
+      ], projectRoot: '/repo');
+
+      expect(result.exitCode, isNot(0));
+      expect(
+        result.stderr,
+        contains('Unknown local E2E scenario: does-not-exist'),
+      );
+      expect(result.stderr, contains('Use --list'));
+    });
+
+    test('reports port conflicts before starting Web smoke servers', () async {
+      final socket = await ServerSocket.bind(InternetAddress.loopbackIPv4, 0);
+      addTearDown(socket.close);
+
+      final result = await runLocalE2e([
+        '--scenario',
+        'bridge-smoke',
+        '--port',
+        '${socket.port}',
+      ], projectRoot: '/repo');
+
+      expect(result.exitCode, isNot(0));
+      expect(
+        result.stdout,
+        contains('Running local E2E scenario: bridge-smoke'),
+      );
+      expect(result.stderr, contains('Port ${socket.port} is already in use'));
+    });
+
+    test('reports background server startup failures', () async {
+      final socket = await ServerSocket.bind(InternetAddress.loopbackIPv4, 0);
+      final port = socket.port;
+      await socket.close();
+
+      final tempDir = await Directory.systemTemp.createTemp(
+        'run_local_e2e_test_',
+      );
+      addTearDown(() => tempDir.delete(recursive: true));
+      await Directory(
+        '${tempDir.path}/example/chat_app/web',
+      ).create(recursive: true);
+
+      final result = await runLocalE2e([
+        '--scenario',
+        'bridge-smoke',
+        '--python',
+        'dart',
+        '--port',
+        '$port',
+      ], projectRoot: tempDir.path);
+
+      expect(result.exitCode, isNot(0));
+      expect(result.stderr, contains('Background server exited'));
+    });
+  });
+}

--- a/tool/testing/run_local_e2e.dart
+++ b/tool/testing/run_local_e2e.dart
@@ -1,0 +1,624 @@
+#!/usr/bin/env dart
+
+import 'dart:async';
+import 'dart:io';
+
+/// Result returned by [runLocalE2e].
+class LocalE2eResult {
+  const LocalE2eResult(this.exitCode, {this.stdout = '', this.stderr = ''});
+
+  final int exitCode;
+  final String stdout;
+  final String stderr;
+}
+
+enum LocalE2eScenarioGroup {
+  dartLocalOnly('Dart local-only'),
+  flutterDevice('Flutter device'),
+  webSmoke('Web smoke');
+
+  const LocalE2eScenarioGroup(this.label);
+
+  final String label;
+}
+
+class LocalE2eCommandStep {
+  const LocalE2eCommandStep({
+    required this.workingDirectory,
+    required this.executable,
+    required this.arguments,
+    required this.description,
+    this.environment = const {},
+    this.background = false,
+    this.waitForPort,
+  });
+
+  final String workingDirectory;
+  final String executable;
+  final List<String> arguments;
+  final Map<String, String> environment;
+  final String description;
+  final bool background;
+  final int? waitForPort;
+
+  String toDisplayString() {
+    final envPrefix = environment.entries
+        .map((entry) => '${entry.key}=${_shellQuote(entry.value)}')
+        .join(' ');
+    final command = [executable, ...arguments].map(_shellQuote).join(' ');
+    final rendered = envPrefix.isEmpty ? command : '$envPrefix $command';
+    final suffix = background ? ' &' : '';
+    return 'cd ${_shellQuote(workingDirectory)} && $rendered$suffix';
+  }
+}
+
+class LocalE2eRunContext {
+  const LocalE2eRunContext({
+    required this.projectRoot,
+    required this.device,
+    required this.port,
+    required this.python,
+    required this.modelUrl,
+    required this.expect,
+    required this.skipBuild,
+  });
+
+  final String projectRoot;
+  final String device;
+  final int port;
+  final String python;
+  final String? modelUrl;
+  final String expect;
+  final bool skipBuild;
+
+  String get chatAppDir => '$projectRoot/example/chat_app';
+  String get chatAppWebDir => '$chatAppDir/web';
+  String get webBuildUrl =>
+      'http://127.0.0.1:$port/example/chat_app/build/web/';
+  String get defaultModelUrl =>
+      'http://127.0.0.1:$port/example/llamadart_server/models/Qwen3.5-0.8B-Q4_K_M.gguf';
+}
+
+class LocalE2eScenario {
+  const LocalE2eScenario({
+    required this.name,
+    required this.group,
+    required this.description,
+    required this.requiresDevice,
+    required this.stepsBuilder,
+  });
+
+  final String name;
+  final LocalE2eScenarioGroup group;
+  final String description;
+  final bool requiresDevice;
+  final List<LocalE2eCommandStep> Function(LocalE2eRunContext context)
+  stepsBuilder;
+
+  List<LocalE2eCommandStep> steps(LocalE2eRunContext context) =>
+      stepsBuilder(context);
+}
+
+List<LocalE2eScenario> buildLocalE2eScenarios({String? projectRoot}) {
+  return [
+    LocalE2eScenario(
+      name: 'root-template-e2e',
+      group: LocalE2eScenarioGroup.dartLocalOnly,
+      description: 'Run local-only upstream/template parity E2E tests.',
+      requiresDevice: false,
+      stepsBuilder: (context) => [
+        LocalE2eCommandStep(
+          workingDirectory: context.projectRoot,
+          executable: 'dart',
+          arguments: const [
+            'test',
+            '--run-skipped',
+            '-t',
+            'local-only',
+            'test/e2e/template',
+          ],
+          description: 'Dart template E2E',
+        ),
+      ],
+    ),
+    LocalE2eScenario(
+      name: 'root-native-tool-e2e',
+      group: LocalE2eScenarioGroup.dartLocalOnly,
+      description: 'Run the local-only native tool chat-template E2E test.',
+      requiresDevice: false,
+      stepsBuilder: (context) => [
+        LocalE2eCommandStep(
+          workingDirectory: context.projectRoot,
+          executable: 'dart',
+          arguments: const [
+            'test',
+            '--run-skipped',
+            '-t',
+            'local-only',
+            'test/e2e/tooling/native_tool_e2e_test.dart',
+          ],
+          description: 'Dart native tool E2E',
+        ),
+      ],
+    ),
+    LocalE2eScenario(
+      name: 'qwen35-multimodal-macos-repro',
+      group: LocalE2eScenarioGroup.dartLocalOnly,
+      description:
+          'Run the macOS-only Qwen3.5 multimodal native repro harness.',
+      requiresDevice: false,
+      stepsBuilder: (context) => [
+        LocalE2eCommandStep(
+          workingDirectory: context.projectRoot,
+          executable: 'dart',
+          arguments: const [
+            'test',
+            '--run-skipped',
+            '-t',
+            'local-only',
+            'test/e2e/tooling/qwen35_multimodal_macos_repro_e2e_test.dart',
+          ],
+          description: 'Qwen3.5 multimodal macOS repro E2E',
+        ),
+      ],
+    ),
+    LocalE2eScenario(
+      name: 'webgpu-multimodal-regression',
+      group: LocalE2eScenarioGroup.webSmoke,
+      description: 'Run CPU and WebGPU Qwen multimodal regression gate.',
+      requiresDevice: false,
+      stepsBuilder: (context) => [
+        LocalE2eCommandStep(
+          workingDirectory: context.projectRoot,
+          executable: 'bash',
+          arguments: const [
+            'tool/testing/run_webgpu_multimodal_regression_gate.sh',
+          ],
+          environment: {
+            'PLAYWRIGHT_GATE_PORT': '${context.port}',
+            'PLAYWRIGHT_PYTHON': context.python,
+            'LLAMADART_SKIP_WEB_BUILD': context.skipBuild ? '1' : '0',
+          },
+          description: 'WebGPU multimodal regression E2E',
+        ),
+      ],
+    ),
+    LocalE2eScenario(
+      name: 'chat-app-model-cache',
+      group: LocalE2eScenarioGroup.flutterDevice,
+      description: 'Run chat app model/mmproj download-cache-load E2E.',
+      requiresDevice: true,
+      stepsBuilder: (context) => [
+        LocalE2eCommandStep(
+          workingDirectory: context.chatAppDir,
+          executable: 'flutter',
+          arguments: [
+            'test',
+            '--run-skipped',
+            '-t',
+            'local-only',
+            'integration_test/model_cache_mmproj_e2e_test.dart',
+            '-d',
+            context.device,
+          ],
+          description: 'Flutter chat app model cache E2E',
+        ),
+      ],
+    ),
+    LocalE2eScenario(
+      name: 'chat-app-web-real-model-smoke',
+      group: LocalE2eScenarioGroup.webSmoke,
+      description:
+          'Build chat_app web and run the real-model Playwright smoke.',
+      requiresDevice: false,
+      stepsBuilder: (context) {
+        final steps = <LocalE2eCommandStep>[];
+        if (!context.skipBuild) {
+          steps.add(
+            LocalE2eCommandStep(
+              workingDirectory: context.chatAppDir,
+              executable: 'flutter',
+              arguments: const [
+                'build',
+                'web',
+                '--base-href=/example/chat_app/build/web/',
+              ],
+              description: 'Build Flutter web chat app',
+            ),
+          );
+        }
+        steps.addAll([
+          LocalE2eCommandStep(
+            workingDirectory: context.projectRoot,
+            executable: context.python,
+            arguments: [
+              'tool/testing/serve_static_with_headers.py',
+              '--directory',
+              '.',
+              '--port',
+              '${context.port}',
+            ],
+            description: 'Serve repo root with COOP/COEP headers',
+            background: true,
+            waitForPort: context.port,
+          ),
+          LocalE2eCommandStep(
+            workingDirectory: context.projectRoot,
+            executable: context.python,
+            arguments: [
+              'tool/testing/playwright_chat_app_real_model_smoke.py',
+              context.webBuildUrl,
+              '--model-url',
+              context.modelUrl ?? context.defaultModelUrl,
+              '--expect',
+              context.expect,
+            ],
+            description: 'Run Playwright real-model chat app smoke',
+          ),
+        ]);
+        return steps;
+      },
+    ),
+    LocalE2eScenario(
+      name: 'bridge-smoke',
+      group: LocalE2eScenarioGroup.webSmoke,
+      description: 'Run the cheap WebGPU bridge bootstrap smoke.',
+      requiresDevice: false,
+      stepsBuilder: (context) => [
+        LocalE2eCommandStep(
+          workingDirectory: context.chatAppWebDir,
+          executable: context.python,
+          arguments: [
+            '-m',
+            'http.server',
+            '${context.port}',
+            '--bind',
+            '127.0.0.1',
+          ],
+          description: 'Serve repo root for bridge smoke',
+          background: true,
+          waitForPort: context.port,
+        ),
+        LocalE2eCommandStep(
+          workingDirectory: context.projectRoot,
+          executable: context.python,
+          arguments: [
+            'tool/testing/playwright_bridge_smoke.py',
+            'http://127.0.0.1:${context.port}',
+          ],
+          description: 'Run bridge smoke',
+        ),
+      ],
+    ),
+  ];
+}
+
+Future<LocalE2eResult> runLocalE2e(
+  List<String> args, {
+  String? projectRoot,
+}) async {
+  final parsed = _ParsedArgs.parse(args);
+  if (parsed.help) {
+    return LocalE2eResult(0, stdout: _usage());
+  }
+
+  final root = projectRoot ?? Directory.current.path;
+  final scenarios = buildLocalE2eScenarios(projectRoot: root);
+  if (parsed.list) {
+    return LocalE2eResult(0, stdout: _formatScenarioList(scenarios));
+  }
+
+  final scenarioName = parsed.scenario;
+  if (scenarioName == null || scenarioName.isEmpty) {
+    return LocalE2eResult(
+      64,
+      stderr: 'Missing --scenario. Use --list to inspect scenarios.\n',
+    );
+  }
+
+  final scenario = scenarios.cast<LocalE2eScenario?>().firstWhere(
+    (candidate) => candidate?.name == scenarioName,
+    orElse: () => null,
+  );
+  if (scenario == null) {
+    return LocalE2eResult(
+      64,
+      stderr:
+          'Unknown local E2E scenario: $scenarioName\nUse --list to inspect scenarios.\n',
+    );
+  }
+
+  final context = LocalE2eRunContext(
+    projectRoot: root,
+    device: parsed.device,
+    port: parsed.port,
+    python: parsed.python,
+    modelUrl: parsed.modelUrl,
+    expect: parsed.expect,
+    skipBuild: parsed.skipBuild,
+  );
+  final steps = scenario.steps(context);
+
+  if (parsed.dryRun) {
+    return LocalE2eResult(0, stdout: _formatDryRun(scenario, steps));
+  }
+
+  final buffer = StringBuffer()
+    ..writeln('Running local E2E scenario: ${scenario.name}');
+  final backgroundProcesses = <Process>[];
+  try {
+    for (final step in steps) {
+      buffer.writeln('[local-e2e] ${step.description}');
+      if (step.background) {
+        final port = step.waitForPort;
+        if (port != null) {
+          await _ensurePortAvailable(port);
+        }
+        final process = await Process.start(
+          step.executable,
+          step.arguments,
+          workingDirectory: step.workingDirectory,
+          environment: step.environment.isEmpty ? null : step.environment,
+          runInShell: false,
+        );
+        backgroundProcesses.add(process);
+        process.stdout.transform(systemEncoding.decoder).listen(buffer.write);
+        process.stderr.transform(systemEncoding.decoder).listen(buffer.write);
+        if (port != null) {
+          await _waitForPort(port, process);
+        }
+        continue;
+      }
+
+      final result = await Process.run(
+        step.executable,
+        step.arguments,
+        workingDirectory: step.workingDirectory,
+        environment: step.environment.isEmpty ? null : step.environment,
+        runInShell: false,
+      );
+      buffer
+        ..write(result.stdout)
+        ..write(result.stderr);
+      if (result.exitCode != 0) {
+        return LocalE2eResult(result.exitCode, stdout: buffer.toString());
+      }
+    }
+    return LocalE2eResult(0, stdout: buffer.toString());
+  } on Object catch (error) {
+    return LocalE2eResult(1, stdout: buffer.toString(), stderr: '$error\n');
+  } finally {
+    for (final process in backgroundProcesses.reversed) {
+      process.kill();
+      await process.exitCode.timeout(
+        const Duration(seconds: 5),
+        onTimeout: () => -1,
+      );
+    }
+  }
+}
+
+Future<void> _ensurePortAvailable(int port) async {
+  ServerSocket? socket;
+  try {
+    socket = await ServerSocket.bind(InternetAddress.loopbackIPv4, port);
+  } on SocketException catch (error) {
+    throw StateError(
+      'Port $port is already in use; stop the existing server or choose a different --port. $error',
+    );
+  } finally {
+    await socket?.close();
+  }
+}
+
+Future<void> _waitForPort(int port, Process owner) async {
+  final deadline = DateTime.now().add(const Duration(seconds: 30));
+  Object? lastError;
+  while (DateTime.now().isBefore(deadline)) {
+    final exitCode = await _pollExitCode(owner);
+    if (exitCode != null) {
+      throw StateError(
+        'Background server exited before port $port became ready (exit code $exitCode).',
+      );
+    }
+    try {
+      final socket = await Socket.connect(
+        InternetAddress.loopbackIPv4,
+        port,
+        timeout: const Duration(milliseconds: 500),
+      );
+      await socket.close();
+      final lateExitCode = await _pollExitCode(owner);
+      if (lateExitCode != null) {
+        throw StateError(
+          'Background server exited after opening port $port (exit code $lateExitCode).',
+        );
+      }
+      return;
+    } on Object catch (error) {
+      lastError = error;
+      await Future<void>.delayed(const Duration(milliseconds: 200));
+    }
+  }
+  throw StateError(
+    'Timed out waiting for local server on port $port: $lastError',
+  );
+}
+
+Future<int?> _pollExitCode(Process process) async {
+  try {
+    return await process.exitCode.timeout(Duration.zero);
+  } on TimeoutException {
+    return null;
+  }
+}
+
+String _formatScenarioList(List<LocalE2eScenario> scenarios) {
+  final buffer = StringBuffer()
+    ..writeln('Local-only E2E scenarios:')
+    ..writeln('');
+  for (final group in LocalE2eScenarioGroup.values) {
+    buffer.writeln('${group.label}:');
+    for (final scenario in scenarios.where((item) => item.group == group)) {
+      final deviceHint = scenario.requiresDevice ? ' --device <device>' : '';
+      buffer.writeln('  ${scenario.name}$deviceHint');
+      buffer.writeln('    ${scenario.description}');
+    }
+    buffer.writeln('');
+  }
+  buffer.writeln(
+    'Run with: dart run tool/testing/run_local_e2e.dart --scenario <name> --dry-run',
+  );
+  return buffer.toString();
+}
+
+String _formatDryRun(
+  LocalE2eScenario scenario,
+  List<LocalE2eCommandStep> steps,
+) {
+  final buffer = StringBuffer()
+    ..writeln('Scenario: ${scenario.name}')
+    ..writeln('Group: ${scenario.group.label}')
+    ..writeln('Description: ${scenario.description}')
+    ..writeln('')
+    ..writeln('Commands:');
+  for (final step in steps) {
+    buffer.writeln('- ${step.description}:');
+    buffer.writeln('  ${step.toDisplayString()}');
+  }
+  return buffer.toString();
+}
+
+String _usage() {
+  return '''Usage: dart run tool/testing/run_local_e2e.dart [options]
+
+Options:
+  --list                         List available local-only scenarios.
+  --scenario <name>              Scenario to run or dry-run.
+  --dry-run                      Print commands without executing them.
+  --device <device>              Flutter device id for device scenarios (default: macos).
+  --port <port>                  Local web server port (default: 7358).
+  --python <path>                Python executable for helper scripts (default: python3).
+  --model-url <url>              Model URL for real-model web smoke.
+  --expect <text>                Expected response text for real-model web smoke.
+  --skip-build                   Reuse an existing Flutter web build where supported.
+  -h, --help                     Show this help.
+''';
+}
+
+String _shellQuote(String value) {
+  if (value.isEmpty) {
+    return "''";
+  }
+  final safe = RegExp(r'^[A-Za-z0-9_@%+=:,./-]+$');
+  if (safe.hasMatch(value)) {
+    return value;
+  }
+  return "'${value.replaceAll("'", "'\\''")}'";
+}
+
+class _ParsedArgs {
+  const _ParsedArgs({
+    required this.list,
+    required this.help,
+    required this.dryRun,
+    required this.device,
+    required this.port,
+    required this.python,
+    required this.expect,
+    required this.skipBuild,
+    this.scenario,
+    this.modelUrl,
+  });
+
+  final bool list;
+  final bool help;
+  final bool dryRun;
+  final String? scenario;
+  final String device;
+  final int port;
+  final String python;
+  final String? modelUrl;
+  final String expect;
+  final bool skipBuild;
+
+  factory _ParsedArgs.parse(List<String> args) {
+    var list = false;
+    var help = false;
+    var dryRun = false;
+    var device = 'macos';
+    var port = 7358;
+    var python = 'python3';
+    var expect = '4';
+    var skipBuild = false;
+    String? scenario;
+    String? modelUrl;
+
+    for (var index = 0; index < args.length; index++) {
+      final arg = args[index];
+      switch (arg) {
+        case '--list':
+          list = true;
+        case '--help' || '-h':
+          help = true;
+        case '--dry-run':
+          dryRun = true;
+        case '--skip-build':
+          skipBuild = true;
+        case '--scenario':
+          scenario = _readValue(args, ++index, arg);
+        case '--device':
+          device = _readValue(args, ++index, arg);
+        case '--port':
+          port = int.parse(_readValue(args, ++index, arg));
+        case '--python':
+          python = _readValue(args, ++index, arg);
+        case '--model-url':
+          modelUrl = _readValue(args, ++index, arg);
+        case '--expect':
+          expect = _readValue(args, ++index, arg);
+        default:
+          throw ArgumentError('Unknown option: $arg');
+      }
+    }
+
+    return _ParsedArgs(
+      list: list,
+      help: help,
+      dryRun: dryRun,
+      scenario: scenario,
+      device: device,
+      port: port,
+      python: python,
+      modelUrl: modelUrl,
+      expect: expect,
+      skipBuild: skipBuild,
+    );
+  }
+
+  static String _readValue(List<String> args, int index, String option) {
+    if (index >= args.length) {
+      throw ArgumentError('Missing value for $option');
+    }
+    return args[index];
+  }
+}
+
+Future<void> main(List<String> args) async {
+  LocalE2eResult result;
+  try {
+    result = await runLocalE2e(args);
+  } on FormatException catch (error) {
+    result = LocalE2eResult(64, stderr: '${error.message}\n');
+  } on ArgumentError catch (error) {
+    result = LocalE2eResult(64, stderr: '$error\n');
+  }
+
+  if (result.stdout.isNotEmpty) {
+    stdout.write(result.stdout);
+  }
+  if (result.stderr.isNotEmpty) {
+    stderr.write(result.stderr);
+  }
+  exitCode = result.exitCode;
+}

--- a/website/docs/changelog/recent-releases.md
+++ b/website/docs/changelog/recent-releases.md
@@ -7,6 +7,15 @@ For canonical full release notes, use:
 
 - [`CHANGELOG.md`](https://github.com/leehack/llamadart/blob/main/CHANGELOG.md)
 
+## Unreleased
+
+- Added `tool/testing/run_local_e2e.dart` as a discovery and orchestration
+  entry point for heavyweight local-only Dart E2E, Flutter device, and
+  Web/Playwright smoke scenarios.
+- Documented that real-model/device/WebGPU scenarios remain skipped from
+  default CI and should be opted into explicitly with `--list` and `--dry-run`
+  first.
+
 ## 0.6.14
 
 - Updated the default WebGPU bridge asset pin to


### PR DESCRIPTION
## Summary
- add a local-only E2E scenario runner that discovers Dart, Flutter device, and Web smoke scenarios
- document the opt-in workflow in README/CONTRIBUTING/AGENTS and changelog docs
- add unit coverage for scenario listing, dry-runs, unknown scenarios, port conflicts, and background startup failures

Closes #130

## Verification
- `dart format --output=none --set-exit-if-changed .`
- `dart analyze`
- `dart test`
- `npm run build` in `website/`
- `dart run tool/testing/run_local_e2e.dart --list`
- `dart run tool/testing/run_local_e2e.dart --scenario root-native-tool-e2e --dry-run`
- `dart run tool/testing/run_local_e2e.dart --scenario qwen35-multimodal-macos-repro --dry-run`
- `dart run tool/testing/run_local_e2e.dart --scenario chat-app-model-cache --device macos --dry-run`
- `dart run tool/testing/run_local_e2e.dart --scenario bridge-smoke --dry-run`
- `dart run tool/testing/run_local_e2e.dart --scenario webgpu-multimodal-regression --port 9123 --python /custom/python --skip-build --dry-run`
- `dart run tool/testing/run_local_e2e.dart --scenario chat-app-web-real-model-smoke --python /custom/python --model-url http://127.0.0.1:7358/models/tiny.gguf --expect ok --dry-run`

## Notes
- No llama.cpp/native/WebGPU asset version bump is included.
- Heavy real-model/device/WebGPU scenarios remain opt-in/local-only and are not added to default CI.
