### PR TITLE
Prepare llamadart 0.6.15 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-## Unreleased
+## 0.6.15
 
 * **Fixes**:
   * Fixed GLM-OCR and other multimodal chat-template workarounds so image and
@@ -16,6 +16,10 @@
   * Documented that real-model/device/WebGPU scenarios remain skipped from
     default CI and should be opted into explicitly with `--list` and
     `--dry-run` first.
+* **Compatibility note**: no public API breaking changes in `0.6.15`;
+  existing `0.6.14` callers remain compatible. The chat-template changes fix
+  multimodal serialization behavior for affected templates, and the local E2E
+  runner is additive.
 
 ## 0.6.14
 

--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@
 
 ```yaml
 dependencies:
-  llamadart: ^0.6.14
+  llamadart: ^0.6.15
 ```
 
 ### 2. Run with defaults

--- a/example/chat_app/pubspec.lock
+++ b/example/chat_app/pubspec.lock
@@ -349,7 +349,7 @@ packages:
       path: "../.."
       relative: true
     source: path
-    version: "0.6.14"
+    version: "0.6.15"
   logging:
     dependency: transitive
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: llamadart
 description: A Dart/Flutter plugin for llama.cpp - run LLM inference on any platform using GGUF models
-version: 0.6.14
+version: 0.6.15
 homepage: https://github.com/leehack/llamadart
 repository: https://github.com/leehack/llamadart
 issue_tracker: https://github.com/leehack/llamadart/issues

--- a/website/docs/changelog/recent-releases.md
+++ b/website/docs/changelog/recent-releases.md
@@ -7,7 +7,7 @@ For canonical full release notes, use:
 
 - [`CHANGELOG.md`](https://github.com/leehack/llamadart/blob/main/CHANGELOG.md)
 
-## Unreleased
+## 0.6.15
 
 - Fixed GLM-OCR and other multimodal chat-template workarounds so image and
   audio content parts are preserved when tool-call normalization runs, system
@@ -23,6 +23,10 @@ For canonical full release notes, use:
 - Documented that real-model/device/WebGPU scenarios remain skipped from
   default CI and should be opted into explicitly with `--list` and `--dry-run`
   first.
+- Compatibility note: no public API breaking changes in `0.6.15`; existing
+  `0.6.14` callers remain compatible. The chat-template changes fix
+  multimodal serialization behavior for affected templates, and the local E2E
+  runner is additive.
 
 ## 0.6.14
 

--- a/website/docs/getting-started/installation.md
+++ b/website/docs/getting-started/installation.md
@@ -25,7 +25,7 @@ configurations.
 
 ```yaml
 dependencies:
-  llamadart: ^0.6.14
+  llamadart: ^0.6.15
 ```
 
 Then resolve packages:


### PR DESCRIPTION
## Summary
- bump llamadart to 0.6.15 for the release prep
- promote the accumulated changelog and website recent-release notes from Unreleased to 0.6.15
- update current install snippets and refresh the chat app lockfile for the local package version

## Release notes
- fixes GLM-OCR and other multimodal chat-template workaround serialization for media content, system prompts before leading media parts, and invalid tool-call serialization failures
- adds the local E2E discovery/orchestration entry point for heavyweight Dart, Flutter, and Web smoke scenarios
- hardens the llama.cpp chat/template E2E runner for current upstream target names and build requirements

## Validation
- `dart format --output=none --set-exit-if-changed .`
- `git diff --check`
- `dart analyze`
- `dart test`
- `./tool/docs/build_site.sh`
- `./tool/docs/validate_links.sh`
- `dart pub publish --dry-run` (0 warnings)
