### PR TITLE
fix: improve mobile download lifecycle UX

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,15 @@
+## Unreleased
+
+* **Model download UX**:
+  * Improved the runnable chat app's mobile download behavior so lifecycle
+    pauses no longer deliberately cancel active foreground downloads; the app
+    now lets short screen-lock/background interruptions continue when the OS
+    permits and still keeps explicit pause/dispose cancellation paths.
+  * Added in-app and docs guidance for mobile large-model downloads, including
+    resumable partial files, foreground Dart lifecycle limits, and the need for
+    opt-in native background download/model-store integrations for robust
+    cross-app GGUF management.
+
 ## 0.6.15
 
 * **Fixes**:

--- a/example/chat_app/lib/screens/manage_models_screen.dart
+++ b/example/chat_app/lib/screens/manage_models_screen.dart
@@ -86,14 +86,11 @@ class _ManageModelsScreenState extends State<ManageModelsScreen>
 
   @override
   void didChangeAppLifecycleState(AppLifecycleState state) {
-    if (kIsWeb) {
-      return;
-    }
-
-    if (state == AppLifecycleState.paused ||
-        state == AppLifecycleState.hidden) {
-      _pauseActiveDownloads();
-    }
+    // Do not deliberately cancel active downloads on mobile background/sleep.
+    // The foreground Dart request may be suspended by the OS, but cancelling here
+    // guarantees a pause every time the screen locks. Let the transfer continue
+    // for short lifecycle interruptions and rely on resumable `.download` files
+    // when the OS eventually interrupts the socket.
   }
 
   Future<void> _initModelService() async {

--- a/example/chat_app/lib/widgets/model_card.dart
+++ b/example/chat_app/lib/widgets/model_card.dart
@@ -1,3 +1,4 @@
+import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
 import 'package:google_fonts/google_fonts.dart';
 import '../models/downloadable_model.dart';
@@ -46,6 +47,11 @@ class ModelCard extends StatelessWidget {
     const webLargeModelWarningThresholdBytes = 1900 * 1024 * 1024;
     final showWebLargeModelWarning =
         isWeb && model.sizeBytes >= webLargeModelWarningThresholdBytes;
+    final showMobileDownloadGuidance =
+        isDownloading &&
+        !isWeb &&
+        (defaultTargetPlatform == TargetPlatform.android ||
+            defaultTargetPlatform == TargetPlatform.iOS);
 
     return Container(
       decoration: BoxDecoration(
@@ -274,6 +280,17 @@ class ModelCard extends StatelessWidget {
                 downloadTransferLabel!,
                 style: TextStyle(
                   fontSize: 11,
+                  color: colorScheme.onSurfaceVariant,
+                ),
+              ),
+            ],
+            if (showMobileDownloadGuidance) ...[
+              const SizedBox(height: 6),
+              Text(
+                'Keep the app open until the download finishes. On phones, if Android or iOS interrupts it, starting again reuses the partial file when supported.',
+                style: TextStyle(
+                  fontSize: 11,
+                  height: 1.3,
                   color: colorScheme.onSurfaceVariant,
                 ),
               ),

--- a/example/chat_app/test/manage_models_screen_download_test.dart
+++ b/example/chat_app/test/manage_models_screen_download_test.dart
@@ -1,6 +1,7 @@
 import 'dart:async';
 
 import 'package:dio/dio.dart';
+import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:llamadart_chat_example/models/downloadable_model.dart';
@@ -19,32 +20,101 @@ void main() {
     testWidgets('pause button cancels the active controller download', (
       tester,
     ) async {
-      SharedPreferences.setMockInitialValues({});
-      final model = _remoteModel();
-      final modelService = _HoldingModelService();
+      debugDefaultTargetPlatformOverride = TargetPlatform.android;
+      try {
+        SharedPreferences.setMockInitialValues({});
+        final model = _remoteModel();
+        final modelService = _HoldingModelService();
 
-      await _pumpScreen(tester, modelService: modelService, models: [model]);
+        await _pumpScreen(tester, modelService: modelService, models: [model]);
 
-      expect(find.text(model.name), findsOneWidget);
-      expect(find.text('Download'), findsOneWidget);
+        expect(find.text(model.name), findsOneWidget);
+        expect(find.text('Download'), findsOneWidget);
 
-      await tester.tap(find.text('Download'));
-      await modelService.downloadStarted.future.timeout(_testTimeout);
-      await tester.pump();
+        await tester.tap(find.text('Download'));
+        await modelService.downloadStarted.future.timeout(_testTimeout);
+        await tester.pump();
 
-      expect(modelService.downloadCalls, 1);
-      expect(find.text('Downloading model'), findsOneWidget);
-      expect(find.text('25%'), findsOneWidget);
+        expect(modelService.downloadCalls, 1);
+        expect(find.text('Downloading model'), findsOneWidget);
+        expect(find.text('25%'), findsOneWidget);
+        expect(find.textContaining('Keep the app open'), findsOneWidget);
 
-      await tester.tap(find.byTooltip('Pause Download'));
-      await tester.pump(const Duration(milliseconds: 150));
-      await modelService.downloadCancelled.future.timeout(_testTimeout);
-      await tester.pump();
+        await tester.tap(find.byTooltip('Pause Download'));
+        await tester.pump(const Duration(milliseconds: 150));
+        await modelService.downloadCancelled.future.timeout(_testTimeout);
+        await tester.pump();
 
-      expect(modelService.lastCancelToken?.isCancelled, isTrue);
-      expect(find.text('Paused'), findsOneWidget);
-      expect(find.text('25%'), findsOneWidget);
-      expect(find.text('Resume Download'), findsOneWidget);
+        expect(modelService.lastCancelToken?.isCancelled, isTrue);
+        expect(find.text('Paused'), findsOneWidget);
+        expect(find.text('25%'), findsOneWidget);
+        expect(find.text('Resume Download'), findsOneWidget);
+      } finally {
+        debugDefaultTargetPlatformOverride = null;
+      }
+    });
+
+    testWidgets(
+      'mobile lifecycle pause does not deliberately cancel downloads',
+      (tester) async {
+        SharedPreferences.setMockInitialValues({});
+        final model = _remoteModel();
+        final modelService = _HoldingModelService();
+
+        await _pumpScreen(tester, modelService: modelService, models: [model]);
+
+        await tester.tap(find.text('Download'));
+        await modelService.downloadStarted.future.timeout(_testTimeout);
+        await tester.pump();
+
+        final state = tester.state(find.byType(ManageModelsScreen)) as dynamic;
+        state.didChangeAppLifecycleState(AppLifecycleState.paused);
+        await tester.pump(const Duration(milliseconds: 150));
+
+        expect(modelService.lastCancelToken?.isCancelled, isFalse);
+        expect(modelService.downloadCancelled.isCompleted, isFalse);
+        expect(find.text('Downloading model'), findsOneWidget);
+        expect(find.text('25%'), findsOneWidget);
+
+        state.didChangeAppLifecycleState(AppLifecycleState.hidden);
+        await tester.pump(const Duration(milliseconds: 150));
+
+        expect(modelService.lastCancelToken?.isCancelled, isFalse);
+        expect(modelService.downloadCancelled.isCompleted, isFalse);
+        expect(find.text('Downloading model'), findsOneWidget);
+        expect(find.text('25%'), findsOneWidget);
+
+        await tester.pumpWidget(const SizedBox.shrink());
+        await tester.pump(const Duration(milliseconds: 150));
+        await modelService.downloadCancelled.future.timeout(_testTimeout);
+      },
+    );
+
+    testWidgets('mobile download guidance is hidden on desktop platforms', (
+      tester,
+    ) async {
+      debugDefaultTargetPlatformOverride = TargetPlatform.macOS;
+      try {
+        SharedPreferences.setMockInitialValues({});
+        final model = _remoteModel();
+        final modelService = _HoldingModelService();
+
+        await _pumpScreen(tester, modelService: modelService, models: [model]);
+
+        await tester.tap(find.text('Download'));
+        await modelService.downloadStarted.future.timeout(_testTimeout);
+        await tester.pump();
+
+        expect(find.text('Downloading model'), findsOneWidget);
+        expect(find.text('25%'), findsOneWidget);
+        expect(find.textContaining('Keep the app open'), findsNothing);
+
+        await tester.pumpWidget(const SizedBox.shrink());
+        await tester.pump(const Duration(milliseconds: 150));
+        await modelService.downloadCancelled.future.timeout(_testTimeout);
+      } finally {
+        debugDefaultTargetPlatformOverride = null;
+      }
     });
 
     testWidgets('cancel and discard reports a paused cancellation', (

--- a/website/docs/examples/chat-app.md
+++ b/website/docs/examples/chat-app.md
@@ -36,6 +36,13 @@ flutter test
   clear ready/failure states come from the same package helper app code can
   reuse. The adapter keeps the example's platform-specific service layer for
   multi-asset model + `mmproj` downloads and browser cache behavior.
+- On mobile, active downloads are treated as foreground work: the app no longer
+  cancels them just because Android/iOS reports a lifecycle pause, and the card
+  tells users to keep the app open. If the OS interrupts the socket anyway, the
+  next foreground download attempt reuses the partial file when the server
+  honors Range resume. A true sleep-proof UX should be built as an opt-in native
+  background downloader/model-store manager and injected through
+  `ModelDownloadManager`.
 - Runtime backend preference and GPU layer controls.
 - Persistent settings and split Dart/native logging controls.
 - Tool-calling toggles and model capability badges.
@@ -68,6 +75,12 @@ against a small Qwen3.5 model.
 
 - Qwen3.5 `0.8B` and `2B` currently default to `CPU` on Android because that was
   the fastest verified path on the maintainer Pixel test device.
+- GGUF downloads in this example run through the app's foreground Dart process.
+  Keep the app visible/unlocked for the most reliable download. The app avoids
+  deliberately cancelling on screen lock, but Android can still suspend the
+  process; production apps that need guaranteed completion should use a
+  foreground service or system download integration behind a custom
+  `ModelDownloadManager`.
 - Runtime chips expose native llama.cpp timing breakdowns (`p_eval`, `eval`,
   `sample`, `reuse`) so Android CPU vs Vulkan comparisons are visible in-app.
 - For general model/backend tuning workflow, use

--- a/website/docs/guides/model-lifecycle.md
+++ b/website/docs/guides/model-lifecycle.md
@@ -290,12 +290,28 @@ strings, fragments, and userinfo are redacted from display strings and metadata.
 For Flutter apps, pass an app-controlled `cacheDirectory` from your storage
 strategy (for example an application-support or documents directory selected by
 `path_provider`). Surface progress/cancel controls in the UI, keep downloads
-serialized for large GGUF files, and expect OS backgrounding to interrupt active
-requests. The `.part` resume support lets a later foreground session continue
-when the server supports Range requests and exposes a safe validator or the
-caller supplies SHA-256. On Android, prefer app-private storage unless the app
-intentionally exposes model files to the user; on iOS, avoid cache directories
-that the OS may purge while a model is still needed.
+serialized for large GGUF files, and tell users to keep the app open for the
+foreground download. Do not cancel purely because the app receives a lifecycle
+pause: Android/iOS may allow short screen-lock or app-switch interruptions to
+continue, while an eager cancellation guarantees a pause on every lock.
+
+Foreground Dart HTTP requests are still not a substitute for native background
+downloads. If the OS suspends or kills the app, the request can fail later. The
+`.part` resume support lets a later foreground session continue when the server
+supports Range requests and exposes a safe validator or the caller supplies
+SHA-256. On Android, a robust always-continue UX needs an app-owned foreground
+service or system `DownloadManager` flow with a notification; on iOS, use
+background `URLSession` download tasks. Implement those policies in the app or
+an optional platform package that implements `ModelDownloadManager`, not in the
+core package.
+
+For shared device-level GGUF storage, keep the same separation: core
+`llamadart` exposes source identities, cache metadata, progress, cancellation,
+retry, and verification hooks; a future opt-in platform model-store package can
+decide how apps share files, metadata, permissions, pruning, and native
+background download execution. On Android, prefer app-private storage unless the
+app intentionally exposes model files to the user; on iOS, avoid cache
+directories that the OS may purge while a model is still needed.
 
 ## State persistence
 


### PR DESCRIPTION
## Summary
- stop the example chat app from deliberately cancelling active model downloads when the mobile app is paused/hidden
- add in-app guidance that foreground mobile downloads should stay open and can be resumed if interrupted
- document the boundary between foreground Dart downloads, resumable partial files, and future native/background downloader integrations

## Related
- Related to #160 for shared GGUF model management and optional platform-native background downloaders

## Test Plan
- [x] `flutter test test/manage_models_screen_download_test.dart`
- [x] `dart analyze lib/screens/manage_models_screen.dart lib/widgets/model_card.dart test/manage_models_screen_download_test.dart`
- [x] `git diff --check origin/main...HEAD`

## Notes
- This keeps the core package dependency-light and does not add platform wake-lock/background-service behavior.
- Explicit pause/discard and screen disposal still cancel active downloads; only automatic lifecycle pause cancellation was removed.


## Review Notes
- Addressed Copilot feedback by showing the mobile-specific download guidance only on Android/iOS, not desktop platforms.
- Added regression coverage that the mobile guidance is hidden on desktop platforms.
- Follow-up cleanup: softened the restart/resume wording so it does not promise a specific UI state after OS interruption, and covered both `paused` and `hidden` lifecycle states.
- Latest CI head: `df9bcb1816bf66ac3f7ef3731d640c99cea3d229`.
