### PR TITLE
fix: relax WebGPU batch defaults for multimodal loads

### DIFF
--- a/lib/src/backends/webgpu/webgpu_backend.dart
+++ b/lib/src/backends/webgpu/webgpu_backend.dart
@@ -610,24 +610,32 @@ class WebGpuLlamaBackend
     return attempts;
   }
 
-  ({int nBatch, int nUbatch}) _resolveWebBatchSizes({
+  ({int? nBatch, int? nUbatch}) _resolveWebBatchSizes({
     required String url,
     required ModelParams params,
     required int contextSize,
+    required int gpuLayers,
   }) {
     final normalizedUrl = url.toLowerCase();
     final isQwen35Small =
         normalizedUrl.contains('qwen3.5-0.8b') ||
         normalizedUrl.contains('qwen_qwen3.5-0.8b');
-    final shouldUseQwen35SmallTuning =
-        params.batchSize <= 0 &&
-        params.microBatchSize <= 0 &&
+    final isGemma4 = normalizedUrl.contains('gemma-4');
+    final hasExplicitBatchSizes =
+        params.batchSize > 0 || params.microBatchSize > 0;
+    final shouldUseWebGpuDefaults =
+        !hasExplicitBatchSizes &&
         params.preferredBackend != GpuBackend.cpu &&
-        params.gpuLayers != 0 &&
-        isQwen35Small;
+        gpuLayers != 0;
+    final shouldUseQwen35SmallTuning = shouldUseWebGpuDefaults && isQwen35Small;
+    final shouldUseBridgeBatchDefaults = shouldUseWebGpuDefaults && isGemma4;
 
     if (shouldUseQwen35SmallTuning) {
       return (nBatch: 32, nUbatch: 8);
+    }
+
+    if (shouldUseBridgeBatchDefaults) {
+      return (nBatch: null, nUbatch: null);
     }
 
     final resolved = resolveModelContextBatchSizes(params, contextSize);
@@ -929,6 +937,7 @@ class WebGpuLlamaBackend
         url: url,
         params: params,
         contextSize: attempt.contextSize,
+        gpuLayers: attempt.gpuLayers,
       );
       LlamaWebGpuBridge? bridgeForAttempt;
       bool? forceRemoteFetchBackend;

--- a/test/integration/backends/webgpu/webgpu_engine_multimodal_browser_integration_test.dart
+++ b/test/integration/backends/webgpu/webgpu_engine_multimodal_browser_integration_test.dart
@@ -21,6 +21,8 @@ void main() {
     List<int>? lastStateSaveTokens;
     String? lastStateLoadPath;
     int? lastStateLoadCapacity;
+    int? lastLoadNBatch;
+    int? lastLoadNUbatch;
 
     setUp(() {
       bridge = JSObject();
@@ -30,10 +32,22 @@ void main() {
       lastStateSaveTokens = null;
       lastStateLoadPath = null;
       lastStateLoadCapacity = null;
+      lastLoadNBatch = null;
+      lastLoadNUbatch = null;
 
       bridge.setProperty(
         'loadModelFromUrl'.toJS,
         ((String url, JSObject? config) {
+          if (config != null) {
+            final nBatch = config.getProperty('nBatch'.toJS);
+            final nUbatch = config.getProperty('nUbatch'.toJS);
+            lastLoadNBatch = nBatch.isA<JSNumber>()
+                ? (nBatch as JSNumber).toDartInt
+                : null;
+            lastLoadNUbatch = nUbatch.isA<JSNumber>()
+                ? (nUbatch as JSNumber).toDartInt
+                : null;
+          }
           return Future<void>.value().toJS;
         }).toJS,
       );
@@ -212,6 +226,41 @@ void main() {
 
     tearDown(() async {
       await engine.dispose();
+    });
+
+    test('WebGPU load leaves Gemma 4 batches to bridge defaults', () async {
+      await engine.loadModelFromUrl(
+        'https://example.com/gemma-4-E2B-it-Q4_K_S.gguf',
+        modelParams: const ModelParams(contextSize: 4096, gpuLayers: 99),
+      );
+
+      expect(lastLoadNBatch, isNull);
+      expect(lastLoadNUbatch, isNull);
+    });
+
+    test('WebGPU load keeps Qwen3.5 0.8B browser-safe batch tuning', () async {
+      await engine.loadModelFromUrl(
+        'https://example.com/Qwen3.5-0.8B-Q4_K_M.gguf',
+        modelParams: const ModelParams(contextSize: 4096, gpuLayers: 99),
+      );
+
+      expect(lastLoadNBatch, 32);
+      expect(lastLoadNUbatch, 8);
+    });
+
+    test('WebGPU load forwards explicit batch sizing', () async {
+      await engine.loadModelFromUrl(
+        'https://example.com/gemma-4-E2B-it-Q4_K_S.gguf',
+        modelParams: const ModelParams(
+          contextSize: 4096,
+          gpuLayers: 99,
+          batchSize: 128,
+          microBatchSize: 64,
+        ),
+      );
+
+      expect(lastLoadNBatch, 128);
+      expect(lastLoadNUbatch, 64);
     });
 
     test('LlamaEngine create forwards multimodal audio parts', () async {

--- a/test/unit/backends/webgpu/webgpu_backend_test.dart
+++ b/test/unit/backends/webgpu/webgpu_backend_test.dart
@@ -675,6 +675,37 @@ void main() {
       },
     );
 
+    test('Gemma 4 CPU fallback uses cascaded batch sizes', () async {
+      var loadCallCount = 0;
+      bridge.setProperty(
+        'loadModelFromUrl'.toJS,
+        ((String url, JSObject? config) {
+          loadCallCount += 1;
+          recordLoadConfig(config);
+
+          if (loadCallCount == 1) {
+            final error = JSObject();
+            error.setProperty(
+              'message'.toJS,
+              'array buffer allocation failed'.toJS,
+            );
+            return _rejectPromise(error);
+          }
+          return Future<void>.value().toJS;
+        }).toJS,
+      );
+
+      await backend.modelLoadFromUrl(
+        'https://example.com/gemma-4-E2B-it-Q4_K_S.gguf',
+        const ModelParams(contextSize: 4096, gpuLayers: 99),
+      );
+
+      expect(requestedContextSizes, <int>[4096, 4096]);
+      expect(requestedBatchSizes, <int>[4096]);
+      expect(requestedMicroBatchSizes, <int>[4096]);
+      expect(lastRequestedGpuLayers, 0);
+    });
+
     test('streams generated tokens from bridge callback', () async {
       await backend.modelLoadFromUrl(
         'https://example.com/model.gguf',


### PR DESCRIPTION
## Summary
- Leave Gemma 4 WebGPU batch sizing unset on actual GPU attempts so the JS bridge/wasm runtime can use its internal defaults instead of forcing `nBatch == contextSize`.
- Preserve the existing Qwen3.5 0.8B browser-safe `32/8` batch tuning.
- Keep CPU fallback attempts on cascaded context-sized batches by resolving against the effective load attempt `gpuLayers`, preventing encoder/CPU fallback regressions.
- Add browser/unit coverage for Gemma 4 bridge defaults, Qwen tuning, explicit batch forwarding, and Gemma 4 CPU fallback batch resolution.

## Root cause
The Dart WebGPU backend was resolving default `nBatch` / `nUbatch` from the requested context size and forwarding those values for Gemma 4 web loads. For larger multimodal models this can force large batch allocations (for example 4096) in the web worker/wasm runtime, causing WebGPU loader stalls or memory pressure.

## Verification
- `flutter analyze lib/src/backends/webgpu/webgpu_backend.dart test/unit/backends/webgpu/webgpu_backend_test.dart test/integration/backends/webgpu/webgpu_engine_multimodal_browser_integration_test.dart`
- `dart test -p chrome test/unit/backends/webgpu/webgpu_backend_test.dart test/integration/backends/webgpu/webgpu_engine_multimodal_browser_integration_test.dart`
- `dart test -p chrome --exclude-tags local-only`
- Browser smoke matrix against the rebuilt chat app bundle:
  - Qwen3.5 0.8B GPU/WebGPU worker: loaded model + mmproj and generated text
  - Qwen3.5 0.8B CPU worker: loaded model + mmproj and generated text
  - Gemma 4 E2B GPU/WebGPU worker: loaded model + mmproj and generated text
  - Gemma 4 E2B CPU worker: loaded model + mmproj and generated text
- GitHub Actions CI on PR head `5456362d4be0dcea831d9852346a503a296ff451`: all checks passed

## Notes
- Web builds still require remote model/projector URLs; this does not add local web asset support.
- A direct main-thread Gemma CPU probe with `disableWorker: true` was not used as the app path; the worker CPU fallback path passed.