### PR TITLE
fix: recover webgpu multimodal model loads

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 ## Unreleased
 
+* **WebGPU and chat app fixes**:
+  * Improved browser recovery for large remote WebGPU model/projector loads by
+    retrying wasm32 model-staging aborts with the wasm64 core before surfacing
+    memory-pressure failures.
+  * Improved the runnable chat app's web remote-model startup path so model
+    assets are prefetched into browser cache when available, browser
+    `CacheStorage` failures fall back to direct network loading, and
+    credentialed/signed model URLs skip persistent browser cache storage.
 * **Model download UX**:
   * Improved the runnable chat app's mobile download behavior so lifecycle
     pauses no longer deliberately cancel active foreground downloads; the app

--- a/README.md
+++ b/README.md
@@ -344,7 +344,7 @@ The default web backend uses `WebGpuLlamaBackend` as a router for WebGPU and CPU
   - [`leehack/llama-web-bridge-assets`](https://github.com/leehack/llama-web-bridge-assets)
 - `example/chat_app` prefers vendored local bridge assets on localhost for dev/runtime validation, and otherwise prefers pinned jsDelivr assets with local fallback.
 - Web embeddings require bridge assets with embedding APIs (`v0.1.7` or newer).
-- Browser Cache Storage is used for repeated model loads when `useCache` is enabled (default).
+- Browser Cache Storage is used for repeated model loads when `useCache` is enabled (default). Signed or credentialed model URLs bypass persistent cache storage and load directly so secret-bearing URL parts are not stored as browser cache request keys.
 - `loadMultimodalProjector` is supported on web for URL-based model/mmproj assets.
 - `supportsVision` and `supportsAudio` reflect loaded projector capabilities.
 - LoRA runtime adapters are not currently supported on web.

--- a/doc/webgpu_bridge.md
+++ b/doc/webgpu_bridge.md
@@ -47,6 +47,11 @@ web backend load options).
 
 - First load of a model URL fetches from network and stores into cache.
 - Subsequent loads of the same URL can be served from cache.
+- Model URLs with userinfo, query strings, or fragments are treated as
+  credential-sensitive; `llamadart` passes `useCache: false` so the bridge loads
+  them directly with no persistent Cache Storage request key.
+- Multimodal projector loads are direct bridge fetches and should not rely on
+  model Cache Storage for reuse.
 - Cache behavior/availability depends on browser storage quota and private mode
   policies.
 

--- a/example/chat_app/lib/providers/chat_provider.dart
+++ b/example/chat_app/lib/providers/chat_provider.dart
@@ -3,6 +3,7 @@ import 'dart:io';
 import 'dart:math' as math;
 import 'dart:ui' as ui;
 
+import 'package:dio/dio.dart';
 import 'package:file_picker/file_picker.dart';
 import 'package:flutter/foundation.dart';
 import 'package:llamadart/llamadart.dart';
@@ -18,6 +19,7 @@ import '../services/chat_session_service.dart';
 import '../services/conversation_state_service.dart';
 import '../services/runtime_profile_service.dart';
 import '../services/settings_service.dart';
+import '../services/model_service_base.dart' as model_service;
 import '../services/tool_declaration_service.dart';
 import '../utils/backend_utils.dart';
 
@@ -54,8 +56,10 @@ class ChatProvider extends ChangeNotifier {
   final ConversationStateService _conversationStateService;
   final RuntimeProfileService _runtimeProfileService;
   final SettingsService _settingsService;
+  final model_service.ModelService _modelService;
   final AssistantOutputService _assistantOutputService;
   final ToolDeclarationService _toolDeclarationService;
+  final bool _enableWebModelPrefetch;
 
   final List<ChatMessage> _messages = [];
   final List<LlamaContentPart> _stagedParts = [];
@@ -85,6 +89,8 @@ class ChatProvider extends ChangeNotifier {
   ChatFormat? _detectedChatFormat;
   String? _error;
   Timer? _settingsSaveDebounce;
+  CancelToken? _activeModelPrefetchCancelToken;
+  bool _isDisposed = false;
 
   // Telemetry
   int _contextLimit = 2048;
@@ -203,9 +209,11 @@ class ChatProvider extends ChangeNotifier {
     ConversationStateService? conversationStateService,
     RuntimeProfileService? runtimeProfileService,
     SettingsService? settingsService,
+    model_service.ModelService? modelService,
     AssistantOutputService? assistantOutputService,
     ToolDeclarationService? toolDeclarationService,
     ChatSettings? initialSettings,
+    bool? enableWebModelPrefetch,
   }) : _chatService = chatService ?? ChatService(),
        _chatGenerationService =
            chatGenerationService ?? const ChatGenerationService(),
@@ -215,10 +223,12 @@ class ChatProvider extends ChangeNotifier {
        _runtimeProfileService =
            runtimeProfileService ?? const RuntimeProfileService(),
        _settingsService = settingsService ?? SettingsService(),
+       _modelService = modelService ?? model_service.ModelService(),
        _assistantOutputService =
            assistantOutputService ?? const AssistantOutputService(),
        _toolDeclarationService =
            toolDeclarationService ?? const ToolDeclarationService(),
+       _enableWebModelPrefetch = enableWebModelPrefetch ?? kIsWeb,
        _settings = initialSettings ?? const ChatSettings() {
     _createInitialConversation();
     _rebuildDeclaredToolsFromSettings();
@@ -468,8 +478,179 @@ class ChatProvider extends ChangeNotifier {
     notifyListeners();
   }
 
+  bool _isRemoteUrl(String? value) {
+    if (value == null || value.isEmpty) {
+      return false;
+    }
+    final uri = Uri.tryParse(value);
+    return uri != null && (uri.scheme == 'http' || uri.scheme == 'https');
+  }
+
+  bool _hasPersistentCacheSensitiveUrlParts(String? value) {
+    if (!_isRemoteUrl(value)) {
+      return false;
+    }
+    final uri = Uri.parse(value!);
+    return uri.userInfo.isNotEmpty ||
+        uri.query.isNotEmpty ||
+        uri.fragment.isNotEmpty;
+  }
+
+  bool _webCachePrefetchWouldPersistSensitiveUrl() {
+    return _hasPersistentCacheSensitiveUrlParts(_settings.modelPath);
+  }
+
+  String _filenameFromPathOrUrl(
+    String value, {
+    String fallback = 'model.gguf',
+  }) {
+    final uri = Uri.tryParse(value);
+    final path = (uri?.hasScheme ?? false) ? uri!.path : value;
+    final normalized = path.replaceAll('\\', '/');
+    final pieces = normalized.split('/').where((part) => part.isNotEmpty);
+    final filename = pieces.isEmpty ? fallback : pieces.last;
+    return filename.isEmpty ? fallback : filename;
+  }
+
+  DownloadableModel? _downloadableModelForCurrentSettings() {
+    final modelPath = _settings.modelPath;
+    if (!_isRemoteUrl(modelPath)) {
+      return null;
+    }
+
+    return DownloadableModel(
+      name: _filenameFromPathOrUrl(modelPath!),
+      description: 'Chat startup model cache prefetch',
+      url: modelPath,
+      filename: _filenameFromPathOrUrl(modelPath),
+      sizeBytes: 0,
+    );
+  }
+
+  void _cancelActiveModelPrefetch() {
+    final cancelToken = _activeModelPrefetchCancelToken;
+    if (cancelToken != null && !cancelToken.isCancelled) {
+      cancelToken.cancel('Model prefetch cancelled');
+    }
+    _activeModelPrefetchCancelToken = null;
+  }
+
+  Future<bool> _prefetchWebRemoteModelIfNeeded(
+    void Function(double value, {String? backendLabel, bool forceNotify})
+    updateLoadingUi,
+  ) async {
+    if (!_enableWebModelPrefetch || !_isRemoteUrl(_settings.modelPath)) {
+      return false;
+    }
+    if (_webCachePrefetchWouldPersistSensitiveUrl()) {
+      updateLoadingUi(
+        0.14,
+        backendLabel:
+            'Browser cache skipped for credentialed URL; loading from network...',
+        forceNotify: true,
+      );
+      return false;
+    }
+    if (_modelService is! model_service.WebCachePrefetchModelService) {
+      return false;
+    }
+    final prefetchService =
+        _modelService as model_service.WebCachePrefetchModelService;
+    if (!await prefetchService.supportsWebCachePrefetch()) {
+      return false;
+    }
+
+    final model = _downloadableModelForCurrentSettings();
+    if (model == null) {
+      return false;
+    }
+
+    final cancelToken = CancelToken();
+    _activeModelPrefetchCancelToken = cancelToken;
+    final modelsDir = await _modelService.getModelsDirectory();
+    Object? downloadError;
+    var completed = false;
+
+    try {
+      updateLoadingUi(
+        0.14,
+        backendLabel: 'Downloading model 0%',
+        forceNotify: true,
+      );
+
+      await _modelService.downloadModel(
+        model: model,
+        modelsDir: modelsDir,
+        cancelToken: cancelToken,
+        onProgress: (progress) {
+          if (cancelToken.isCancelled || _isDisposed) {
+            return;
+          }
+          final normalized = progress.clamp(0.0, 1.0);
+          updateLoadingUi(
+            0.14 + (normalized * 0.58),
+            backendLabel:
+                'Downloading model ${(normalized * 100).toStringAsFixed(0)}%',
+            forceNotify: normalized >= 1.0,
+          );
+        },
+        onProgressDetail: (progress) {
+          if (cancelToken.isCancelled || _isDisposed) {
+            return;
+          }
+          final normalized = progress.overallProgress.clamp(0.0, 1.0);
+          updateLoadingUi(
+            0.14 + (normalized * 0.58),
+            backendLabel:
+                'Downloading model ${(normalized * 100).toStringAsFixed(0)}%',
+            forceNotify: normalized >= 1.0,
+          );
+        },
+        onSuccess: (_) {
+          completed = true;
+        },
+        onError: (error) {
+          downloadError = error;
+        },
+      );
+    } finally {
+      if (identical(_activeModelPrefetchCancelToken, cancelToken)) {
+        _activeModelPrefetchCancelToken = null;
+      }
+    }
+
+    if (cancelToken.isCancelled) {
+      throw DioException(
+        requestOptions: RequestOptions(path: 'web-cache-prefetch'),
+        type: DioExceptionType.cancel,
+        message: 'Model prefetch cancelled',
+      );
+    }
+    if (downloadError != null) {
+      if (_isNonFatalWebCachePrefetchFailure(downloadError!)) {
+        updateLoadingUi(
+          0.14,
+          backendLabel: 'Browser cache unavailable; loading from network...',
+          forceNotify: true,
+        );
+        return false;
+      }
+      throw downloadError!;
+    }
+    if (!completed) {
+      throw Exception('Model download did not complete.');
+    }
+
+    updateLoadingUi(
+      0.72,
+      backendLabel: 'Preparing WebGPU runtime...',
+      forceNotify: true,
+    );
+    return true;
+  }
+
   Future<void> loadModel() async {
-    if (_isInitializing) return;
+    if (_isDisposed || _isInitializing) return;
     if (_settings.modelPath == null || _settings.modelPath!.isEmpty) {
       _error = 'Model path not set. Please configure in settings.';
       _syncActiveConversationSnapshot(touchUpdatedAt: false);
@@ -504,6 +685,9 @@ class ChatProvider extends ChangeNotifier {
       String? backendLabel,
       bool forceNotify = false,
     }) {
+      if (_isDisposed) {
+        return;
+      }
       final double clamped = value.clamp(0.0, 1.0);
       var changed = false;
 
@@ -558,17 +742,35 @@ class ChatProvider extends ChangeNotifier {
 
       await _chatService.engine.setDartLogLevel(_settings.logLevel);
       await _chatService.engine.setNativeLogLevel(_settings.nativeLogLevel);
+      if (_chatService.engine.isReady) {
+        await _chatService.unloadModel();
+      }
       updateLoadingUi(0.14);
+
+      final prefetchedWebModel = await _prefetchWebRemoteModelIfNeeded(
+        updateLoadingUi,
+      );
+      final modelLoadStart = prefetchedWebModel ? 0.72 : 0.14;
+      final modelLoadSpan = prefetchedWebModel ? 0.12 : 0.7;
+      if (prefetchedWebModel) {
+        updateLoadingUi(
+          modelLoadStart,
+          backendLabel: 'Loading model into memory...',
+          forceNotify: true,
+        );
+      }
+
       await _chatService.init(
         _settings,
         eagerLoadMultimodalProjector: eagerLoadMmproj,
         onProgress: (progress) {
           final normalized = progress.clamp(0.0, 1.0);
-          final staged = 0.14 + (normalized * 0.7);
+          final staged = modelLoadStart + (normalized * modelLoadSpan);
           updateLoadingUi(
             staged,
-            backendLabel:
-                'Loading model ${(normalized * 100).toStringAsFixed(0)}%',
+            backendLabel: prefetchedWebModel
+                ? 'Loading model into memory ${(normalized * 100).toStringAsFixed(0)}%'
+                : 'Loading model ${(normalized * 100).toStringAsFixed(0)}%',
           );
         },
       );
@@ -669,9 +871,13 @@ class ChatProvider extends ChangeNotifier {
       _syncActiveConversationSnapshot(touchUpdatedAt: false);
       updateLoadingUi(1.0, forceNotify: true);
     } catch (e, stackTrace) {
-      debugPrint('Error loading model: $e');
+      if (_isDisposed) {
+        return;
+      }
+      final displayError = _formatDisplayError(e);
+      debugPrint('Error loading model: $displayError');
       debugPrint(stackTrace.toString());
-      _error = _formatDisplayError(e);
+      _error = displayError;
       _loadedModelPath = null;
       _loadedMmprojPath = null;
       _supportsVision = false;
@@ -679,12 +885,53 @@ class ChatProvider extends ChangeNotifier {
       _mmprojLoaded = false;
     } finally {
       _isInitializing = false;
-      notifyListeners();
+      if (!_isDisposed) {
+        notifyListeners();
+      }
     }
   }
 
+  bool _isNonFatalWebCachePrefetchFailure(Object error) {
+    final normalized = error.toString().toLowerCase();
+    if (normalized.contains('browser cache prefetch skipped') &&
+        normalized.contains('credentialed')) {
+      return true;
+    }
+    final mentionsCache =
+        normalized.contains('browser cache') ||
+        normalized.contains('cachestorage') ||
+        normalized.contains('cache storage') ||
+        normalized.contains('model cache') ||
+        normalized.contains('quota');
+    final mentionsStoreFailure =
+        normalized.contains('failed to store') ||
+        normalized.contains('store_failed') ||
+        normalized.contains('storage') ||
+        normalized.contains('quota') ||
+        normalized.contains('quotaexceeded');
+    return mentionsCache && mentionsStoreFailure;
+  }
+
+  String _redactPotentiallySensitiveUrls(String text) {
+    final urlPattern = RegExp(r'''https?:\/\/[^\s\])}>"']+''');
+    return text.replaceAllMapped(urlPattern, (match) {
+      final value = match.group(0)!;
+      final uri = Uri.tryParse(value);
+      if (uri == null || !uri.hasScheme || uri.host.isEmpty) {
+        return value;
+      }
+      final redacted = Uri(
+        scheme: uri.scheme,
+        host: uri.host,
+        port: uri.hasPort ? uri.port : null,
+        path: uri.path,
+      );
+      return redacted.toString();
+    });
+  }
+
   String _formatDisplayError(Object error) {
-    final raw = error.toString().trim();
+    final raw = _redactPotentiallySensitiveUrls(error.toString().trim());
     const prefixes = <String>['LlamaException: ', 'Exception: '];
     for (final prefix in prefixes) {
       if (raw.startsWith(prefix)) {
@@ -1616,6 +1863,7 @@ class ChatProvider extends ChangeNotifier {
 
   Future<void> unloadModel() async {
     stopGeneration();
+    _cancelActiveModelPrefetch();
     _session?.reset();
     _session = null;
     await _chatService.unloadModel();
@@ -1853,10 +2101,12 @@ class ChatProvider extends ChangeNotifier {
 
   @override
   void dispose() {
+    _isDisposed = true;
     _settingsSaveDebounce?.cancel();
     _settingsSaveDebounce = null;
     unawaited(_settingsService.saveSettings(_settings));
     stopGeneration();
+    _cancelActiveModelPrefetch();
     _session?.reset();
     _session = null;
     unawaited(_chatService.dispose());
@@ -1872,6 +2122,7 @@ class ChatProvider extends ChangeNotifier {
     try {
       await _saveSettingsNow();
       stopGeneration();
+      _cancelActiveModelPrefetch();
       _session?.reset();
       _session = null;
       _isLoaded = false;

--- a/example/chat_app/lib/services/model_service_base.dart
+++ b/example/chat_app/lib/services/model_service_base.dart
@@ -150,6 +150,10 @@ class ModelDownloadProgressTracker {
   }
 }
 
+abstract class WebCachePrefetchModelService {
+  Future<bool> supportsWebCachePrefetch();
+}
+
 abstract class ModelService {
   factory ModelService() => createModelService();
 

--- a/example/chat_app/lib/services/model_service_web.dart
+++ b/example/chat_app/lib/services/model_service_web.dart
@@ -8,7 +8,7 @@ import 'package:shared_preferences/shared_preferences.dart';
 import '../models/downloadable_model.dart';
 import 'model_service_base.dart';
 
-class ModelServiceWeb implements ModelService {
+class ModelServiceWeb implements ModelService, WebCachePrefetchModelService {
   static const String _downloadedModelsKey = 'web_cached_models';
   static const String _modelCacheName = 'llamadart-webgpu-model-cache-v1';
   static const String _hfToken = String.fromEnvironment('HF_TOKEN');
@@ -110,6 +110,25 @@ class ModelServiceWeb implements ModelService {
       includeMmproj: mmprojUrl != null,
       providedTotalBytes: model.sizeBytes > 0 ? model.sizeBytes : null,
     );
+    if (_remoteSourcesFor(
+      model,
+    ).any((source) => _hasPersistentCacheSensitiveUrlParts(source.url))) {
+      onError(
+        UnsupportedError(
+          'Browser cache prefetch skipped for credentialed remote URL; load the model directly to avoid storing sensitive URL parts.',
+        ),
+      );
+      return;
+    }
+    if (!_hasCacheStorageApi()) {
+      onError(
+        UnsupportedError(
+          'Browser CacheStorage is unavailable; remote models can still be loaded directly.',
+        ),
+      );
+      return;
+    }
+
     final bridge = _tryCreateBridge();
 
     try {
@@ -221,10 +240,59 @@ class ModelServiceWeb implements ModelService {
     }
   }
 
+  @override
+  Future<bool> supportsWebCachePrefetch() async {
+    if (!_hasCacheStorageApi()) {
+      return false;
+    }
+
+    final bridge = _tryCreateBridge();
+    if (bridge == null) {
+      return false;
+    }
+
+    try {
+      final prefetchMember = bridge.getProperty<JSAny?>(
+        'prefetchModelToCache'.toJS,
+      );
+      return prefetchMember != null && prefetchMember.isA<JSFunction>();
+    } finally {
+      try {
+        final disposePromise = bridge.dispose();
+        if (disposePromise != null) {
+          await disposePromise.toDart;
+        }
+      } catch (_) {
+        // best-effort bridge disposal
+      }
+    }
+  }
+
   bool _looksLikePrefetchUnavailable(dynamic error) {
     final normalized = '$error'.toLowerCase();
     return normalized.contains('prefetchmodeltocache') &&
         normalized.contains('not a function');
+  }
+
+  bool _hasCacheStorageApi() {
+    try {
+      final caches = globalContext.getProperty<JSAny?>('caches'.toJS);
+      if (caches == null || !caches.isA<JSObject>()) {
+        return false;
+      }
+      final openMember = (caches as JSObject).getProperty<JSAny?>('open'.toJS);
+      return openMember != null && openMember.isA<JSFunction>();
+    } catch (_) {
+      return false;
+    }
+  }
+
+  bool _hasPersistentCacheSensitiveUrlParts(String value) {
+    final uri = Uri.tryParse(value);
+    return uri != null &&
+        (uri.userInfo.isNotEmpty ||
+            uri.query.isNotEmpty ||
+            uri.fragment.isNotEmpty);
   }
 
   _WebModelCacheBridge? _tryCreateBridge() {

--- a/example/chat_app/test/unit_test.dart
+++ b/example/chat_app/test/unit_test.dart
@@ -1,9 +1,15 @@
+import 'dart:async';
+
+import 'package:dio/dio.dart';
 import 'package:flutter/foundation.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:llamadart/llamadart.dart';
 import 'package:llamadart_chat_example/providers/chat_provider.dart';
 import 'package:llamadart_chat_example/models/chat_settings.dart';
 import 'package:llamadart_chat_example/models/downloadable_model.dart';
+import 'package:llamadart_chat_example/services/chat_service.dart';
+import 'package:llamadart_chat_example/services/model_service_base.dart'
+    as app_model_service;
 
 import 'mocks.dart';
 
@@ -55,6 +61,204 @@ void main() {
       expect(mockEngine.initialized, isTrue);
       expect(provider.maxGenerationTokens, greaterThan(0));
     });
+
+    test(
+      'web remote load prefetches model before runtime load and shows download stage',
+      () async {
+        final webEngine = MockLlamaEngine();
+        final modelService = _RecordingModelService();
+        final webProvider = ChatProvider(
+          chatService: ChatService(engine: webEngine),
+          settingsService: mockSettingsService,
+          modelService: modelService,
+          enableWebModelPrefetch: true,
+          initialSettings: const ChatSettings(
+            modelPath: 'https://example.com/models/tiny.gguf',
+            mmprojPath: 'https://example.com/models/mmproj.gguf',
+          ),
+        );
+        addTearDown(webProvider.dispose);
+
+        final labels = <String>[];
+        final progress = <double>[];
+        webProvider.addListener(() {
+          labels.add(webProvider.activeBackend);
+          progress.add(webProvider.loadingProgress);
+        });
+
+        await webProvider.loadModel();
+
+        expect(modelService.downloadCalls, 1);
+        expect(modelService.lastModel?.url, webProvider.settings.modelPath);
+        expect(modelService.lastModel?.mmprojUrl, isNull);
+        expect(webEngine.lastLoadedModelUrl, webProvider.settings.modelPath);
+        expect(webProvider.isLoaded, isTrue);
+        expect(webProvider.error, isNull);
+        expect(labels, contains('Downloading model 50%'));
+        expect(labels, contains('Preparing WebGPU runtime...'));
+        expect(labels, contains('Loading model into memory...'));
+        expect(progress.any((value) => value > 0.14 && value < 0.72), isTrue);
+      },
+    );
+
+    test('web remote load skips cache prefetch for credentialed urls', () async {
+      final webEngine = MockLlamaEngine();
+      final modelService = _RecordingModelService();
+      final webProvider = ChatProvider(
+        chatService: ChatService(engine: webEngine),
+        settingsService: mockSettingsService,
+        modelService: modelService,
+        enableWebModelPrefetch: true,
+        initialSettings: const ChatSettings(
+          modelPath:
+              'https://user:pass@example.com/models/tiny.gguf?token=secret#frag',
+          mmprojPath: 'https://example.com/models/mmproj.gguf?sig=secret',
+        ),
+      );
+      addTearDown(webProvider.dispose);
+
+      final labels = <String>[];
+      webProvider.addListener(() {
+        labels.add(webProvider.activeBackend);
+      });
+
+      await webProvider.loadModel();
+
+      expect(modelService.downloadCalls, 0);
+      expect(webEngine.lastLoadedModelUrl, webProvider.settings.modelPath);
+      expect(webProvider.isLoaded, isTrue);
+      expect(webProvider.error, isNull);
+      expect(
+        labels,
+        contains(
+          'Browser cache skipped for credentialed URL; loading from network...',
+        ),
+      );
+    });
+
+    test(
+      'web remote load skips prefetch when cache bridge is unavailable',
+      () async {
+        final webEngine = MockLlamaEngine();
+        final modelService = _RecordingModelService(supportsPrefetch: false);
+        final webProvider = ChatProvider(
+          chatService: ChatService(engine: webEngine),
+          settingsService: mockSettingsService,
+          modelService: modelService,
+          enableWebModelPrefetch: true,
+          initialSettings: const ChatSettings(
+            modelPath: 'https://example.com/models/tiny.gguf',
+          ),
+        );
+        addTearDown(webProvider.dispose);
+
+        await webProvider.loadModel();
+
+        expect(modelService.downloadCalls, 0);
+        expect(webEngine.lastLoadedModelUrl, webProvider.settings.modelPath);
+        expect(webProvider.isLoaded, isTrue);
+        expect(webProvider.error, isNull);
+      },
+    );
+
+    test(
+      'web remote load falls back to network when browser cache storage fails',
+      () async {
+        final webEngine = MockLlamaEngine();
+        final modelService = _RecordingModelService(
+          downloadError: Exception(
+            'Failed to store prefetched model in browser cache.',
+          ),
+        );
+        final webProvider = ChatProvider(
+          chatService: ChatService(engine: webEngine),
+          settingsService: mockSettingsService,
+          modelService: modelService,
+          enableWebModelPrefetch: true,
+          initialSettings: const ChatSettings(
+            modelPath: 'https://example.com/models/tiny.gguf',
+          ),
+        );
+        addTearDown(webProvider.dispose);
+
+        final labels = <String>[];
+        webProvider.addListener(() {
+          labels.add(webProvider.activeBackend);
+        });
+
+        await webProvider.loadModel();
+
+        expect(modelService.downloadCalls, 1);
+        expect(webEngine.lastLoadedModelUrl, webProvider.settings.modelPath);
+        expect(webProvider.isLoaded, isTrue);
+        expect(webProvider.error, isNull);
+        expect(
+          labels,
+          contains('Browser cache unavailable; loading from network...'),
+        );
+      },
+    );
+
+    test(
+      'web prefetch failure redacts signed urls from user-facing error',
+      () async {
+        final webProvider = ChatProvider(
+          chatService: ChatService(engine: MockLlamaEngine()),
+          settingsService: mockSettingsService,
+          modelService: _RecordingModelService(
+            downloadError: DioException(
+              requestOptions: RequestOptions(
+                path: 'https://example.com/models/tiny.gguf?token=secret',
+              ),
+              message:
+                  'Failed https://user:pass@example.com/models/tiny.gguf?token=secret#frag',
+            ),
+          ),
+          enableWebModelPrefetch: true,
+          initialSettings: const ChatSettings(
+            modelPath: 'https://example.com/models/tiny.gguf',
+          ),
+        );
+        addTearDown(webProvider.dispose);
+
+        await webProvider.loadModel();
+
+        expect(webProvider.isLoaded, isFalse);
+        expect(webProvider.error, isNotNull);
+        expect(
+          webProvider.error,
+          contains('https://example.com/models/tiny.gguf'),
+        );
+        expect(webProvider.error, isNot(contains('token=secret')));
+        expect(webProvider.error, isNot(contains('user:pass')));
+        expect(webProvider.error, isNot(contains('#frag')));
+      },
+    );
+
+    test(
+      'web reload unloads existing runtime before prefetch can fail',
+      () async {
+        final webEngine = _UnloadRecordingEngine()..initialized = true;
+        final webProvider = ChatProvider(
+          chatService: ChatService(engine: webEngine),
+          settingsService: mockSettingsService,
+          modelService: _RecordingModelService(
+            downloadError: Exception('offline'),
+          ),
+          enableWebModelPrefetch: true,
+          initialSettings: const ChatSettings(
+            modelPath: 'https://example.com/models/tiny.gguf',
+          ),
+        );
+        addTearDown(webProvider.dispose);
+
+        await webProvider.loadModel();
+
+        expect(webEngine.unloadModelCalls, 1);
+        expect(webEngine.initialized, isFalse);
+        expect(webProvider.isLoaded, isFalse);
+      },
+    );
 
     test('loadConfiguredMmproj attaches projector to loaded model', () async {
       await provider.loadModel();
@@ -834,6 +1038,67 @@ class _MacFallbackEstimateEngine extends MockLlamaEngine {
 
   @override
   Future<String> getAvailableBackends() async => 'CPU, METAL';
+}
+
+class _UnloadRecordingEngine extends MockLlamaEngine {
+  int unloadModelCalls = 0;
+
+  @override
+  Future<void> unloadModel() async {
+    unloadModelCalls += 1;
+    initialized = false;
+  }
+}
+
+class _RecordingModelService
+    implements
+        app_model_service.ModelService,
+        app_model_service.WebCachePrefetchModelService {
+  _RecordingModelService({this.supportsPrefetch = true, this.downloadError});
+
+  final bool supportsPrefetch;
+  final Object? downloadError;
+  int downloadCalls = 0;
+  DownloadableModel? lastModel;
+
+  @override
+  Future<bool> supportsWebCachePrefetch() async => supportsPrefetch;
+
+  @override
+  Future<String> getModelsDirectory() async => 'browser-cache';
+
+  @override
+  Future<Set<String>> getDownloadedModels(
+    List<DownloadableModel> models,
+  ) async {
+    return <String>{};
+  }
+
+  @override
+  Future<void> downloadModel({
+    required DownloadableModel model,
+    required String modelsDir,
+    required CancelToken cancelToken,
+    required Function(double progress) onProgress,
+    Function(app_model_service.ModelDownloadProgress progress)?
+    onProgressDetail,
+    required Function(String filename) onSuccess,
+    required Function(dynamic error) onError,
+  }) async {
+    downloadCalls += 1;
+    lastModel = model;
+    if (downloadError != null) {
+      onError(downloadError);
+      return;
+    }
+    onProgress(0.0);
+    onProgress(0.5);
+    onProgress(1.0);
+    onSuccess(model.filename);
+  }
+
+  @override
+  Future<void> deleteModel(String modelsDir, DownloadableModel model) async {}
 }
 
 class _FunctionGemmaRawCallTextEngine extends MockLlamaEngine {

--- a/lib/src/backends/webgpu/webgpu_backend.dart
+++ b/lib/src/backends/webgpu/webgpu_backend.dart
@@ -567,6 +567,18 @@ class WebGpuLlamaBackend
         lowered.contains('error 138');
   }
 
+  bool _urlHasPersistentCacheSensitiveParts(String value) {
+    final uri = Uri.tryParse(value);
+    if (uri == null ||
+        (uri.scheme != 'http' && uri.scheme != 'https') ||
+        uri.host.isEmpty) {
+      return false;
+    }
+    return uri.userInfo.isNotEmpty ||
+        uri.query.isNotEmpty ||
+        uri.fragment.isNotEmpty;
+  }
+
   List<({int contextSize, int gpuLayers})> _buildLoadAttempts({
     required int requestedContextSize,
     required int requestedGpuLayers,
@@ -982,7 +994,7 @@ class WebGpuLlamaBackend
             ropeFrequencyScale: params.ropeFrequencyScale,
             splitMode: params.splitMode.llamaCppValue,
             mainGpu: params.mainGpu,
-            useCache: true,
+            useCache: !_urlHasPersistentCacheSensitiveParts(url),
             forceRemoteFetchBackend: forceRemoteFetchBackend,
             remoteFetchChunkBytes: remoteFetchChunkBytesOverride,
             progressCallback: progressCallback,
@@ -1052,6 +1064,10 @@ class WebGpuLlamaBackend
             _isThreadConstructorFailure(e) ||
             runtimeNotes.contains('thread_constructor_failed') ||
             runtimeNotes.contains('threads_capped_no_coi');
+        final wasm32ModelStagingFailed =
+            coreVariant == 'wasm32' && fsWriteFailed;
+        final memoryPressureFailure =
+            _isLikelyMemoryPressureError(e) || wasm32ModelStagingFailed;
         final forceRemoteFetchRequested = forceRemoteFetchBackend == true;
 
         if (remoteFetchAborted) {
@@ -1083,12 +1099,12 @@ class WebGpuLlamaBackend
             !retriedWithWasm64 &&
             !wasm64InteropKnownBroken &&
             coreVariant == 'wasm32' &&
-            _isLikelyMemoryPressureError(e) &&
+            memoryPressureFailure &&
             !runtimeNotes.contains('model_fetch_backend_skipped_small');
 
         final canRetry =
             index < loadAttempts.length - 1 &&
-            _isLikelyMemoryPressureError(e) &&
+            memoryPressureFailure &&
             !(fsWriteFailed && coreVariant == 'wasm64');
 
         await _safeDisposeBridge();

--- a/test/integration/backends/webgpu/webgpu_engine_multimodal_browser_integration_test.dart
+++ b/test/integration/backends/webgpu/webgpu_engine_multimodal_browser_integration_test.dart
@@ -23,6 +23,10 @@ void main() {
     int? lastStateLoadCapacity;
     int? lastLoadNBatch;
     int? lastLoadNUbatch;
+    bool? lastLoadUseCache;
+    var modelLoadCallCount = 0;
+    var failFirstWasm32StagingAbort = false;
+    late List<bool?> bridgePreferMemory64Values;
 
     setUp(() {
       bridge = JSObject();
@@ -34,10 +38,15 @@ void main() {
       lastStateLoadCapacity = null;
       lastLoadNBatch = null;
       lastLoadNUbatch = null;
+      lastLoadUseCache = null;
+      modelLoadCallCount = 0;
+      failFirstWasm32StagingAbort = false;
+      bridgePreferMemory64Values = <bool?>[];
 
       bridge.setProperty(
         'loadModelFromUrl'.toJS,
         ((String url, JSObject? config) {
+          modelLoadCallCount += 1;
           if (config != null) {
             final nBatch = config.getProperty('nBatch'.toJS);
             final nUbatch = config.getProperty('nUbatch'.toJS);
@@ -47,6 +56,15 @@ void main() {
             lastLoadNUbatch = nUbatch.isA<JSNumber>()
                 ? (nUbatch as JSNumber).toDartInt
                 : null;
+            final useCache = config.getProperty('useCache'.toJS);
+            lastLoadUseCache = useCache.isA<JSBoolean>()
+                ? (useCache as JSBoolean).toDart
+                : null;
+          }
+          if (failFirstWasm32StagingAbort && modelLoadCallCount == 1) {
+            return Future<void>.error(
+              Exception('Aborted(). Build with -sASSERTIONS for more info.'),
+            ).toJS;
           }
           return Future<void>.value().toJS;
         }).toJS,
@@ -197,6 +215,17 @@ void main() {
         (() {
           final meta = JSObject();
           meta.setProperty('general.architecture'.toJS, 'llama'.toJS);
+          if (failFirstWasm32StagingAbort && modelLoadCallCount == 1) {
+            meta.setProperty(
+              'llamadart.webgpu.core_variant'.toJS,
+              'wasm32'.toJS,
+            );
+            meta.setProperty(
+              'llamadart.webgpu.runtime_notes'.toJS,
+              'core_wasm32_active;core_abort;model_fs_write_loaded:1073741824;model_fs_write_abort'
+                  .toJS,
+            );
+          }
           return meta;
         }).toJS,
       );
@@ -219,7 +248,19 @@ void main() {
       );
 
       backend = WebGpuLlamaBackend(
-        bridgeFactory: ([config]) => bridge as LlamaWebGpuBridge,
+        bridgeFactory: ([config]) {
+          if (config == null) {
+            bridgePreferMemory64Values.add(null);
+          } else {
+            final rawPreferMemory64 = config.getProperty('preferMemory64'.toJS);
+            bridgePreferMemory64Values.add(
+              rawPreferMemory64.isA<JSBoolean>()
+                  ? (rawPreferMemory64 as JSBoolean).toDart
+                  : null,
+            );
+          }
+          return bridge as LlamaWebGpuBridge;
+        },
       );
       engine = LlamaEngine(backend);
     });
@@ -236,6 +277,19 @@ void main() {
 
       expect(lastLoadNBatch, isNull);
       expect(lastLoadNUbatch, isNull);
+      expect(lastLoadUseCache, isTrue);
+    });
+
+    test('WebGPU load retries wasm32 staging aborts with wasm64', () async {
+      failFirstWasm32StagingAbort = true;
+
+      await engine.loadModelFromUrl(
+        'https://example.com/gemma-4-E2B-it-Q4_K_S.gguf',
+        modelParams: const ModelParams(contextSize: 4096, gpuLayers: 99),
+      );
+
+      expect(modelLoadCallCount, 2);
+      expect(bridgePreferMemory64Values, <bool?>[null, true]);
     });
 
     test('WebGPU load keeps Qwen3.5 0.8B browser-safe batch tuning', () async {
@@ -261,6 +315,15 @@ void main() {
 
       expect(lastLoadNBatch, 128);
       expect(lastLoadNUbatch, 64);
+    });
+
+    test('WebGPU load disables cache for signed URLs', () async {
+      await engine.loadModelFromUrl(
+        'https://example.com/gemma-4-E2B-it-Q4_K_S.gguf?token=secret',
+        modelParams: const ModelParams(contextSize: 4096, gpuLayers: 99),
+      );
+
+      expect(lastLoadUseCache, isFalse);
     });
 
     test('LlamaEngine create forwards multimodal audio parts', () async {

--- a/website/docs/examples/chat-app.md
+++ b/website/docs/examples/chat-app.md
@@ -65,6 +65,15 @@ status panel exposes the active bridge/core variant, fallback reason, model
 source, cache state, and runtime notes so you can distinguish browser capability
 problems from model/configuration pressure.
 
+When the model path is a remote HTTP(S) URL, the web app tries to prefetch the
+model into browser cache before handing it to the bridge. If `CacheStorage` is
+unavailable, quota-limited, or rejects the write, startup falls back to direct
+network loading instead of failing the model load. Signed or otherwise
+credentialed model URLs with userinfo, query strings, or fragments bypass
+persistent browser cache storage so credentials are not stored as cache request
+keys. Web multimodal projectors are fetched directly by the bridge and are not
+part of the chat startup cache prefetch.
+
 For reliable large GGUF loads, serve the app with COOP/COEP headers so
 `window.crossOriginIsolated === true`. A built smoke path is documented in
 [WebGPU Bridge](../platforms/webgpu-bridge); it uses

--- a/website/docs/platforms/webgpu-bridge.md
+++ b/website/docs/platforms/webgpu-bridge.md
@@ -196,7 +196,10 @@ failure:
 - Legacy Safari bridge assets force CPU fallback unless adaptive Safari GPU probe
   support is present or `window.__llamadartAllowSafariWebGpu = true` is set.
 - wasm64/wasm32 and remote-fetch loader retries can happen automatically when
-  bridge metadata indicates an interop or memory-pressure problem.
+  bridge metadata indicates an interop or memory-pressure problem. Large
+  wasm32 model-staging aborts, including virtual-filesystem write aborts during
+  remote model/projector setup, are treated as memory pressure and retried with
+  the wasm64 core when available.
 
 Fallback is not silent success for every unsupported condition. If the bridge
 cannot load, the browser blocks worker threads, or the model exceeds browser


### PR DESCRIPTION
## Summary
- retry wasm32 WebGPU model staging aborts with the wasm64 core so large browser models such as Gemma 4 can recover instead of failing during MEMFS writes
- keep chat-app web startup functional when CacheStorage is missing or rejects large model entries by falling back to direct network loads
- skip persistent browser cache prefetch for credentialed/signed URLs so query/userinfo/fragment secrets are not stored as CacheStorage request keys
- add regression coverage for Gemma/Qwen WebGPU batch defaults, wasm64 escalation, cache fallback, credentialed URL cache-skip, and signed URL redaction

## Existing issue check
- Searched existing issues/PRs for `Gemma 4 WebGPU mmproj`, `Qwen 3.5 WebGPU projector`, and `CacheStorage web model`.
- No open dedicated issue found. This is a follow-up to the web multimodal regression work after #162.

## Production-readiness scope
- Users can load remote web models/projectors through the Flutter chat app even when browser CacheStorage is unavailable or cannot store the model.
- Large wasm32 staging failures now enter the existing wasm64 fallback path for browser WebGPU loads.
- Credentialed/signed model URLs are still loaded directly, but they are not sent through the persistent browser prefetch/cache path.
- Unsupported/missing browser cache paths fail open to direct runtime/network loading with a user-facing progress note instead of a fatal load screen.

## Test Plan
- [x] `dart format lib/src/backends/webgpu/webgpu_backend.dart test/integration/backends/webgpu/webgpu_engine_multimodal_browser_integration_test.dart example/chat_app/lib/providers/chat_provider.dart example/chat_app/lib/services/model_service_base.dart example/chat_app/lib/services/model_service_web.dart example/chat_app/test/unit_test.dart`
- [x] `flutter analyze lib/src/backends/webgpu/webgpu_backend.dart test/integration/backends/webgpu/webgpu_engine_multimodal_browser_integration_test.dart example/chat_app/lib/providers/chat_provider.dart example/chat_app/lib/services/model_service_base.dart example/chat_app/lib/services/model_service_web.dart example/chat_app/test/unit_test.dart`
- [x] `(cd example/chat_app && flutter test test/unit_test.dart)`
- [x] `dart test -p chrome test/integration/backends/webgpu/webgpu_engine_multimodal_browser_integration_test.dart`
- [x] `git diff --check`
- [x] static diff scan for hardcoded secrets/dangerous exec/raw URL logs

## Manual smoke evidence
- Direct browser bridge matrix from the local verification pass loaded Qwen 3.5 0.8B + projector on both GPU/WebGPU worker and CPU worker paths.
- Direct browser bridge matrix loaded Gemma 4 E2B + projector with the wasm64 runtime path.
- Flutter chat-app UI smoke completed Qwen 3.5 remote load and token generation while browser cache storage failed, confirming direct-network fallback.

## Review Notes
- Independent pre-PR review found a privacy blocker: signed URLs could be persisted by browser prefetch/cache keys. This branch now skips persistent cache prefetch for URLs with userinfo/query/fragment and covers that behavior in unit tests.

## Reviewer follow-up
- Copilot flagged that `ModelServiceWeb.downloadModel` could still persist credentialed URLs when called outside `ChatProvider`.
- Fixed in `d6b8033` by adding the same userinfo/query/fragment guard inside `ModelServiceWeb` before any CacheStorage prefetch or marker writes.
- Latest head `d6b8033` CI is green and the Copilot thread was replied to and resolved.
