### PR TITLE
Prepare llamadart 0.6.16 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-## Unreleased
+## 0.6.16
 
 * **WebGPU and chat app fixes**:
   * Improved browser recovery for large remote WebGPU model/projector loads by
@@ -17,6 +17,9 @@
     resumable partial files, foreground Dart lifecycle limits, and the need for
     opt-in native background download/model-store integrations for robust
     cross-app GGUF management.
+* **Compatibility note**: no public API breaking changes in `0.6.16`;
+  existing `0.6.15` callers remain compatible. The changes improve WebGPU
+  browser recovery and chat app download lifecycle behavior.
 
 ## 0.6.15
 

--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@
 
 ```yaml
 dependencies:
-  llamadart: ^0.6.15
+  llamadart: ^0.6.16
 ```
 
 ### 2. Run with defaults

--- a/example/chat_app/pubspec.lock
+++ b/example/chat_app/pubspec.lock
@@ -349,7 +349,7 @@ packages:
       path: "../.."
       relative: true
     source: path
-    version: "0.6.15"
+    version: "0.6.16"
   logging:
     dependency: transitive
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: llamadart
 description: A Dart/Flutter plugin for llama.cpp - run LLM inference on any platform using GGUF models
-version: 0.6.15
+version: 0.6.16
 homepage: https://github.com/leehack/llamadart
 repository: https://github.com/leehack/llamadart
 issue_tracker: https://github.com/leehack/llamadart/issues

--- a/website/docs/changelog/recent-releases.md
+++ b/website/docs/changelog/recent-releases.md
@@ -7,6 +7,26 @@ For canonical full release notes, use:
 
 - [`CHANGELOG.md`](https://github.com/leehack/llamadart/blob/main/CHANGELOG.md)
 
+## 0.6.16
+
+- Improved browser recovery for large remote WebGPU model/projector loads by
+  retrying wasm32 model-staging aborts with the wasm64 core before surfacing
+  memory-pressure failures.
+- Improved the runnable chat app's web remote-model startup path so model assets
+  are prefetched into browser cache when available, browser `CacheStorage`
+  failures fall back to direct network loading, and credentialed/signed model
+  URLs skip persistent browser cache storage.
+- Improved the runnable chat app's mobile download behavior so lifecycle pauses
+  no longer deliberately cancel active foreground downloads; the app now lets
+  short screen-lock/background interruptions continue when the OS permits and
+  still keeps explicit pause/dispose cancellation paths.
+- Added in-app and docs guidance for mobile large-model downloads, including
+  resumable partial files, foreground Dart lifecycle limits, and the need for
+  opt-in native background download/model-store integrations for robust
+  cross-app GGUF management.
+- Compatibility note: no public API breaking changes in `0.6.16`; existing
+  `0.6.15` callers remain compatible.
+
 ## 0.6.15
 
 - Fixed GLM-OCR and other multimodal chat-template workarounds so image and

--- a/website/docs/getting-started/installation.md
+++ b/website/docs/getting-started/installation.md
@@ -25,7 +25,7 @@ configurations.
 
 ```yaml
 dependencies:
-  llamadart: ^0.6.15
+  llamadart: ^0.6.16
 ```
 
 Then resolve packages:


### PR DESCRIPTION
## Summary
- Bump `llamadart` to `0.6.16` and align current install snippets plus the chat app path lockfile.
- Merge the latest `main` changes, including native `getVramInfo()` VRAM diagnostics, into the release branch.
- Move the accumulated release notes into a `0.6.16` changelog section with a compatibility note and no empty `Unreleased` section.
- Mirror the `0.6.16` highlights in the current docs recent releases page.

## Validation
- `dart format --output=none --set-exit-if-changed .`
- `dart analyze`
- `dart test -p vm -j 1 --exclude-tags local-only`
- `./tool/docs/build_site.sh`
- `./tool/docs/validate_links.sh`
- `flutter pub publish --dry-run` (`0 warnings`)
