### PR TITLE
Prefer local native bundles when explicitly enabled

### DIFF
--- a/hook/build.dart
+++ b/hook/build.dart
@@ -199,24 +199,6 @@ Future<Directory> _acquireBundleDirectory({
   final archivePath = path.join(cacheDir, archiveName);
   final archiveFile = File(archivePath);
 
-  final cachedLibraryPaths = _collectDynamicLibraryPaths(extractedDir);
-  if (cachedLibraryPaths.isNotEmpty &&
-      _isBundleLayoutCompatible(
-        bundle: bundle,
-        libraryPaths: cachedLibraryPaths,
-        log: log,
-      )) {
-    log.info('Using cached native bundle: ${extractedDir.path}');
-    return extractedDir;
-  }
-
-  if (cachedLibraryPaths.isNotEmpty) {
-    log.warning('Cached native bundle appears stale; refreshing: $bundle');
-    if (extractedDir.existsSync()) {
-      await extractedDir.delete(recursive: true);
-    }
-  }
-
   if (allowLegacyLocalBundles) {
     final localCandidates = _localBundleCandidates(
       packageRoot: packageRoot,
@@ -236,6 +218,24 @@ Future<Directory> _acquireBundleDirectory({
         );
         return candidate;
       }
+    }
+  }
+
+  final cachedLibraryPaths = _collectDynamicLibraryPaths(extractedDir);
+  if (cachedLibraryPaths.isNotEmpty &&
+      _isBundleLayoutCompatible(
+        bundle: bundle,
+        libraryPaths: cachedLibraryPaths,
+        log: log,
+      )) {
+    log.info('Using cached native bundle: ${extractedDir.path}');
+    return extractedDir;
+  }
+
+  if (cachedLibraryPaths.isNotEmpty) {
+    log.warning('Cached native bundle appears stale; refreshing: $bundle');
+    if (extractedDir.existsSync()) {
+      await extractedDir.delete(recursive: true);
     }
   }
 


### PR DESCRIPTION
## Summary
- prefer legacy local native bundle directories before the downloaded cache when `LLAMADART_ALLOW_LEGACY_LOCAL_BUNDLES=true`
- keep normal package behavior unchanged when the env var is not set

## Why
This makes it easier to test replacement native binaries from `llamadart-native` PRs without clearing `.dart_tool/llamadart/native_bundles` first. It is useful for validating leehack/llamadart-native#15 against iOS issue reports before publishing a new native release.

## Validation
- `dart format hook/build.dart`
- `dart test -p vm test/unit/hook/build_hook_integration_test.dart test/unit/hook/build_hook_android_integration_test.dart test/unit/hook/build_hook_linux_integration_test.dart`
- `git diff --check`

Related: leehack/llamadart#169
