### PR TITLE
Prepare release 0.6.17

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,15 @@
+## 0.6.17
+
+* **Native runtime sync**:
+  * Updated native hook pinning and regenerated bindings through
+    `leehack/llamadart-native@b9371`, picking up llama.cpp `b9371`.
+  * Picked up the Apple mobile Metal stability fix that disables Metal
+    residency sets on iOS/tvOS/visionOS native bundles, avoiding affected
+    device context-creation failures such as `MTLLibraryErrorDomain Code=3`.
+* **Compatibility note**: no public API breaking changes in `0.6.17`;
+  existing `0.6.16` callers remain compatible. The release only refreshes
+  the pinned native runtime and generated low-level bindings.
+
 ## 0.6.16
 
 * **Native runtime diagnostics**:

--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@
 
 ```yaml
 dependencies:
-  llamadart: ^0.6.16
+  llamadart: ^0.6.17
 ```
 
 ### 2. Run with defaults

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: llamadart
 description: A Dart/Flutter plugin for llama.cpp - run LLM inference on any platform using GGUF models
-version: 0.6.16
+version: 0.6.17
 homepage: https://github.com/leehack/llamadart
 repository: https://github.com/leehack/llamadart
 issue_tracker: https://github.com/leehack/llamadart/issues

--- a/website/docs/changelog/recent-releases.md
+++ b/website/docs/changelog/recent-releases.md
@@ -7,6 +7,16 @@ For canonical full release notes, use:
 
 - [`CHANGELOG.md`](https://github.com/leehack/llamadart/blob/main/CHANGELOG.md)
 
+## 0.6.17
+
+- Synced native hook pinning and regenerated bindings through
+  `leehack/llamadart-native@b9371`, picking up llama.cpp `b9371`.
+- Picked up the Apple mobile Metal stability fix that disables Metal residency
+  sets on iOS/tvOS/visionOS native bundles, avoiding affected device
+  context-creation failures such as `MTLLibraryErrorDomain Code=3`.
+- Compatibility note: no public API breaking changes in `0.6.17`; existing
+  `0.6.16` callers remain compatible.
+
 ## 0.6.16
 
 - Fixed native `getVramInfo()` so llama.cpp GPU-class backend devices can

--- a/website/docs/getting-started/installation.md
+++ b/website/docs/getting-started/installation.md
@@ -25,7 +25,7 @@ configurations.
 
 ```yaml
 dependencies:
-  llamadart: ^0.6.16
+  llamadart: ^0.6.17
 ```
 
 Then resolve packages:


### PR DESCRIPTION
## Summary
- bump package version and install snippets to `0.6.17`
- add `0.6.17` changelog and recent-release notes for the native `b9371` sync
- call out the Apple mobile Metal residency fix included in the new native bundle

## Validation
- `dart format --output=none --set-exit-if-changed .`
- `dart analyze`
- `dart test -p vm -j 1 --exclude-tags local-only`
- `./tool/docs/build_site.sh`
- `./tool/docs/validate_links.sh`
- `flutter pub publish --dry-run`