### PR TITLE
Allow overriding native runtime source

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,17 @@
+## Unreleased
+
+* **Native runtime configuration**:
+  * Added `hooks.user_defines.llamadart.llamadart_native_tag`,
+    `llamadart_native_repository`, and `llamadart_native_path` so apps can test
+    a different compatible native runtime source without patching `llamadart`.
+  * Documented where to find available native release tags and how to confirm a
+    release includes the target bundle asset before overriding the default.
+  * Documented and logged that native source overrides do not regenerate Dart
+    FFI bindings or symbol lookups, so binaries must stay compatible with the
+    default native runtime revision.
+  * Updated the Windows runtime fallback scanner to discover custom GitHub and
+    local archive cache namespaces when `.dart_tool/lib` is unavailable.
+
 ## 0.6.17
 
 * **Native runtime sync**:

--- a/README.md
+++ b/README.md
@@ -57,12 +57,23 @@ No manual binary download or C++ build steps are required.
 > iOS builds require a minimum deployment target of `16.4` or newer in your
 > Xcode project / Podfile (for example `platform :ios, '16.4'`).
 
-### 3. Optional: choose backend modules per target (non-Apple)
+### 3. Optional: choose native source and backend modules
 
 ```yaml
 hooks:
   user_defines:
     llamadart:
+      # Optional. Defaults to llamadart's tested native runtime pin.
+      # Use a leehack/llamadart-native release tag when testing another build.
+      llamadart_native_tag: b9371
+
+      # Optional. GitHub repository slug or github.com URL.
+      llamadart_native_repository: leehack/llamadart-native
+
+      # Optional. Takes precedence over GitHub downloads when set.
+      # Relative paths are resolved from the pubspec defining this config.
+      # llamadart_native_path: ./native-bundles
+
       llamadart_native_backends:
         platforms:
           android-arm64:
@@ -73,6 +84,27 @@ hooks:
 ```
 
 If a requested module is unavailable for a target, `llamadart` logs a warning and falls back to target defaults.
+If `llamadart_native_tag` points at a release without a matching bundle asset,
+the native-assets hook fails while downloading that asset.
+
+Native source overrides are for compatibility testing. They do not regenerate
+Dart FFI bindings or symbol lookups, so the selected binary still must be ABI-
+and symbol-compatible with the default `leehack/llamadart-native@b9371` runtime.
+
+Available native tags are published on the
+[`leehack/llamadart-native` releases page](https://github.com/leehack/llamadart-native/releases).
+You can also list them with the GitHub CLI:
+
+```bash
+gh release list --repo leehack/llamadart-native --limit 20
+```
+
+Before overriding, confirm the release includes the asset for your target. The
+hook downloads files named `llamadart-native-<bundle>-<tag>.tar.gz`, for example
+`llamadart-native-windows-x64-b9371.tar.gz`.
+For local testing, `llamadart_native_path` may point directly at a bundle
+archive, at an extracted bundle directory, or at a directory containing
+`<tag>/<bundle>/`, `<bundle>/`, or the expected archive file.
 
 ### 4. Minimal first model load
 
@@ -219,7 +251,7 @@ persist chat messages separately when using the high-level chat API.
 <details>
 <summary>Full module matrix (available modules by target)</summary>
 
-Backend module matrix from pinned native tag `b9016`:
+Backend module matrix from the default native tag `b9371`:
 
 | Target | Available backend modules in bundle |
 |--------|-------------------------------------|
@@ -298,7 +330,14 @@ Selection precedence for Android arm64 CPU variants:
 
 Notes:
 
-- Module availability depends on the pinned native release bundle and may change when the native tag updates.
+- Module availability depends on the selected native release bundle and may
+  change when the native tag updates. Available tags are listed in
+  [`leehack/llamadart-native` releases](https://github.com/leehack/llamadart-native/releases).
+  The selected release must include `llamadart-native-<bundle>-<tag>.tar.gz`
+  for the target being built.
+- Native source overrides do not regenerate Dart FFI bindings or symbol
+  lookups, so the selected binary must remain compatible with the default
+  runtime revision.
 - Configurable targets always keep `cpu` bundled as a fallback.
 - Backend-owned runtime dependencies follow the selected backend module. For
   example, CUDA runtime DLLs (`cudart64_*`, `cublas64_*`, `cublaslt64_*`) are
@@ -329,7 +368,9 @@ Notes:
   before starting the process:
   `GGML_VK_DISABLE_COOPMAT=1` and `GGML_VK_DISABLE_COOPMAT2=1`.
 
-If you change `llamadart_native_backends`, run `flutter clean` once so stale native-asset outputs do not override new bundle selection.
+If you change `llamadart_native_tag`, `llamadart_native_repository`,
+`llamadart_native_path`, or `llamadart_native_backends`, run `flutter clean`
+once so stale native-asset outputs do not override new bundle selection.
 
 ---
 

--- a/hook/build.dart
+++ b/hook/build.dart
@@ -1,7 +1,9 @@
+import 'dart:convert';
 import 'dart:io';
 
 import 'package:archive/archive.dart';
 import 'package:code_assets/code_assets.dart';
+import 'package:crypto/crypto.dart';
 import 'package:hooks/hooks.dart';
 import 'package:http/http.dart' as http;
 import 'package:logging/logging.dart';
@@ -11,8 +13,6 @@ import 'package:llamadart/src/hook/native_bundle_config.dart';
 
 const _llamaCppTag = 'b9371';
 const _nativeRepoSlug = 'leehack/llamadart-native';
-const _baseUrl =
-    'https://github.com/$_nativeRepoSlug/releases/download/$_llamaCppTag';
 
 const _packageName = 'llamadart';
 const _thirdPartyDir = 'third_party';
@@ -27,6 +27,31 @@ const _dynamicLibraryExtensions = {'.so', '.dylib', '.dll'};
 final _windowsCudartPattern = RegExp(r'^cudart64(?:[_-]?\d+)?\.dll$');
 final _windowsCublasPattern = RegExp(r'^cublas64(?:[_-]?\d+)?\.dll$');
 final _linuxVersionedSoPattern = RegExp(r'\.so\.\d+$');
+final _nativeTagPattern = RegExp(r'^[A-Za-z0-9][A-Za-z0-9._-]*$');
+final _githubRepoSegmentPattern = RegExp(r'^[A-Za-z0-9_.-]+$');
+
+class _NativeBundleConfig {
+  final String tag;
+  final String repository;
+  final Uri? localPath;
+
+  const _NativeBundleConfig({
+    required this.tag,
+    required this.repository,
+    required this.localPath,
+  });
+
+  bool get usesOverride =>
+      tag != _llamaCppTag || repository != _nativeRepoSlug || localPath != null;
+
+  String get sourceLabel {
+    final pathUri = localPath;
+    if (pathUri != null) {
+      return 'local path ${pathUri.toFilePath()}';
+    }
+    return '$repository@$tag';
+  }
+}
 
 void main(List<String> args) async {
   Logger.root.level = Level.ALL;
@@ -66,9 +91,20 @@ void main(List<String> args) async {
 
     log.info('Hook Start: ${spec.bundle}');
 
+    final nativeConfig = _resolveNativeBundleConfig(input.userDefines);
+    log.info('Using native runtime source: ${nativeConfig.sourceLabel}');
+    if (nativeConfig.usesOverride) {
+      log.warning(
+        'Native runtime overrides do not regenerate Dart FFI bindings. '
+        'The selected binaries must stay ABI- and symbol-compatible with '
+        '$_nativeRepoSlug@$_llamaCppTag.',
+      );
+    }
+
     final pkgRoot = input.packageRoot.toFilePath();
     final bundleDir = await _acquireBundleDirectory(
       packageRoot: pkgRoot,
+      nativeConfig: nativeConfig,
       bundle: spec.bundle,
       log: log,
     );
@@ -179,25 +215,163 @@ String _dedupeAssetName(String base, Set<String> used) {
   return deduped;
 }
 
+_NativeBundleConfig _resolveNativeBundleConfig(
+  HookInputUserDefines userDefines,
+) {
+  return _NativeBundleConfig(
+    tag: _resolveNativeTag(userDefines[nativeTagUserDefineKey]),
+    repository: _resolveNativeRepository(
+      userDefines[nativeRepositoryUserDefineKey],
+    ),
+    localPath: _resolveNativePath(userDefines),
+  );
+}
+
+String _resolveNativeTag(Object? rawUserConfig) {
+  if (rawUserConfig == null) {
+    return _llamaCppTag;
+  }
+
+  if (rawUserConfig is! String) {
+    throw FormatException(
+      'hooks.user_defines.$_packageName.$nativeTagUserDefineKey must be a '
+      'string release tag such as $_llamaCppTag.',
+    );
+  }
+
+  final tag = rawUserConfig.trim();
+  if (tag.isEmpty) {
+    throw FormatException(
+      'hooks.user_defines.$_packageName.$nativeTagUserDefineKey must not be '
+      'empty.',
+    );
+  }
+  if (!_nativeTagPattern.hasMatch(tag)) {
+    throw FormatException(
+      'hooks.user_defines.$_packageName.$nativeTagUserDefineKey must be a '
+      'path-safe release tag such as $_llamaCppTag.',
+    );
+  }
+
+  return tag;
+}
+
+String _resolveNativeRepository(Object? rawUserConfig) {
+  if (rawUserConfig == null) {
+    return _nativeRepoSlug;
+  }
+
+  if (rawUserConfig is! String) {
+    throw FormatException(
+      'hooks.user_defines.$_packageName.$nativeRepositoryUserDefineKey must be '
+      'a GitHub repository slug such as $_nativeRepoSlug.',
+    );
+  }
+
+  final repository = _normalizeNativeRepository(rawUserConfig);
+  final segments = repository.split('/');
+  if (segments.length != 2 ||
+      segments.any((segment) => !_isValidGithubRepoSegment(segment))) {
+    throw FormatException(
+      'hooks.user_defines.$_packageName.$nativeRepositoryUserDefineKey must be '
+      'a GitHub repository slug such as $_nativeRepoSlug.',
+    );
+  }
+
+  return repository;
+}
+
+bool _isValidGithubRepoSegment(String segment) {
+  return _githubRepoSegmentPattern.hasMatch(segment) &&
+      segment != '.' &&
+      segment != '..';
+}
+
+String _normalizeNativeRepository(String value) {
+  final trimmed = value.trim();
+  if (trimmed.isEmpty) {
+    return trimmed;
+  }
+
+  final uri = Uri.tryParse(trimmed);
+  if (uri != null &&
+      (uri.scheme == 'https' || uri.scheme == 'http') &&
+      uri.host == 'github.com' &&
+      uri.pathSegments.length >= 2) {
+    final owner = uri.pathSegments[0];
+    final repo = uri.pathSegments[1].replaceFirst(RegExp(r'\.git$'), '');
+    return '$owner/$repo';
+  }
+
+  final gitPrefix = 'git@github.com:';
+  if (trimmed.startsWith(gitPrefix)) {
+    return trimmed
+        .substring(gitPrefix.length)
+        .replaceFirst(RegExp(r'\.git$'), '');
+  }
+
+  return trimmed.replaceFirst(RegExp(r'\.git$'), '');
+}
+
+Uri? _resolveNativePath(HookInputUserDefines userDefines) {
+  final rawUserConfig = userDefines[nativePathUserDefineKey];
+  if (rawUserConfig == null) {
+    return null;
+  }
+
+  if (rawUserConfig is! String) {
+    throw FormatException(
+      'hooks.user_defines.$_packageName.$nativePathUserDefineKey must be a '
+      'path string.',
+    );
+  }
+  if (rawUserConfig.trim().isEmpty) {
+    throw FormatException(
+      'hooks.user_defines.$_packageName.$nativePathUserDefineKey must not be '
+      'empty.',
+    );
+  }
+
+  final resolvedPath = userDefines.path(nativePathUserDefineKey);
+  if (resolvedPath == null || !resolvedPath.isScheme('file')) {
+    throw FormatException(
+      'hooks.user_defines.$_packageName.$nativePathUserDefineKey must resolve '
+      'to a local file path.',
+    );
+  }
+
+  return resolvedPath;
+}
+
 Future<Directory> _acquireBundleDirectory({
   required String packageRoot,
+  required _NativeBundleConfig nativeConfig,
   required String bundle,
   required Logger log,
 }) async {
   final allowLegacyLocalBundles = _isLegacyLocalBundleEnabled();
-
-  final cacheDir = path.join(
-    packageRoot,
-    _dartToolDir,
-    _cacheBaseDir,
-    _bundleCacheDir,
-    _llamaCppTag,
-    bundle,
+  final archiveName = 'llamadart-native-$bundle-${nativeConfig.tag}.tar.gz';
+  final cacheDir = _bundleCacheDirectory(
+    packageRoot: packageRoot,
+    nativeConfig: nativeConfig,
+    bundle: bundle,
   );
   final extractedDir = Directory(path.join(cacheDir, 'extracted'));
-  final archiveName = 'llamadart-native-$bundle-$_llamaCppTag.tar.gz';
   final archivePath = path.join(cacheDir, archiveName);
   final archiveFile = File(archivePath);
+
+  final localPath = nativeConfig.localPath;
+  if (localPath != null) {
+    return _acquireLocalBundleDirectory(
+      localPath: localPath,
+      nativeTag: nativeConfig.tag,
+      bundle: bundle,
+      archiveName: archiveName,
+      cacheDir: cacheDir,
+      extractedDir: extractedDir,
+      log: log,
+    );
+  }
 
   final cachedLibraryPaths = _collectDynamicLibraryPaths(extractedDir);
   if (cachedLibraryPaths.isNotEmpty &&
@@ -269,6 +443,8 @@ Future<Directory> _acquireBundleDirectory({
 
   if (!archiveFile.existsSync()) {
     await _downloadReleaseAsset(
+      repository: nativeConfig.repository,
+      nativeTag: nativeConfig.tag,
       assetName: archiveName,
       destinationPath: archivePath,
       log: log,
@@ -287,6 +463,183 @@ Future<Directory> _acquireBundleDirectory({
   )) {
     throw Exception('Downloaded bundle $archiveName is missing runtime deps.');
   }
+  return extractedDir;
+}
+
+String _bundleCacheDirectory({
+  required String packageRoot,
+  required _NativeBundleConfig nativeConfig,
+  required String bundle,
+}) {
+  final localPath = nativeConfig.localPath;
+  if (localPath != null) {
+    final digest = sha1.convert(utf8.encode(localPath.toString())).toString();
+    return path.join(
+      packageRoot,
+      _dartToolDir,
+      _cacheBaseDir,
+      _bundleCacheDir,
+      'local',
+      digest,
+      nativeConfig.tag,
+      bundle,
+    );
+  }
+
+  if (nativeConfig.repository == _nativeRepoSlug) {
+    return path.join(
+      packageRoot,
+      _dartToolDir,
+      _cacheBaseDir,
+      _bundleCacheDir,
+      nativeConfig.tag,
+      bundle,
+    );
+  }
+
+  final segments = nativeConfig.repository.split('/');
+  return path.join(
+    packageRoot,
+    _dartToolDir,
+    _cacheBaseDir,
+    _bundleCacheDir,
+    'github',
+    segments[0],
+    segments[1],
+    nativeConfig.tag,
+    bundle,
+  );
+}
+
+Future<Directory> _acquireLocalBundleDirectory({
+  required Uri localPath,
+  required String nativeTag,
+  required String bundle,
+  required String archiveName,
+  required String cacheDir,
+  required Directory extractedDir,
+  required Logger log,
+}) async {
+  final localFilePath = localPath.toFilePath();
+
+  final directArchive = File(localFilePath);
+  if (directArchive.existsSync()) {
+    return _extractLocalBundleArchive(
+      archivePath: directArchive.path,
+      bundle: bundle,
+      cacheDir: cacheDir,
+      extractedDir: extractedDir,
+      log: log,
+    );
+  }
+
+  for (final candidatePath in _localPathDirectoryCandidates(
+    localPath: localFilePath,
+    nativeTag: nativeTag,
+    bundle: bundle,
+  )) {
+    final candidate = Directory(candidatePath);
+    final candidatePaths = _collectDynamicLibraryPaths(candidate);
+    if (candidatePaths.isNotEmpty &&
+        _isBundleLayoutCompatible(
+          bundle: bundle,
+          libraryPaths: candidatePaths,
+          log: log,
+        )) {
+      log.info('Using local native bundle directory: ${candidate.path}');
+      return candidate;
+    }
+  }
+
+  for (final candidatePath in _localPathArchiveCandidates(
+    localPath: localFilePath,
+    nativeTag: nativeTag,
+    bundle: bundle,
+    archiveName: archiveName,
+  )) {
+    final candidate = File(candidatePath);
+    if (!candidate.existsSync()) {
+      continue;
+    }
+    return _extractLocalBundleArchive(
+      archivePath: candidate.path,
+      bundle: bundle,
+      cacheDir: cacheDir,
+      extractedDir: extractedDir,
+      log: log,
+    );
+  }
+
+  throw Exception(
+    'No compatible native bundle found at $localFilePath for $bundle. '
+    'Expected a directory containing dynamic libraries, a directory containing '
+    '$archiveName, or a direct path to a bundle archive.',
+  );
+}
+
+List<String> _localPathDirectoryCandidates({
+  required String localPath,
+  required String nativeTag,
+  required String bundle,
+}) {
+  return _dedupePaths([
+    path.join(localPath, nativeTag, bundle, 'extracted'),
+    path.join(localPath, nativeTag, bundle),
+    path.join(localPath, bundle, 'extracted'),
+    path.join(localPath, bundle),
+    path.join(localPath, 'extracted'),
+    localPath,
+  ]);
+}
+
+List<String> _localPathArchiveCandidates({
+  required String localPath,
+  required String nativeTag,
+  required String bundle,
+  required String archiveName,
+}) {
+  return _dedupePaths([
+    path.join(localPath, archiveName),
+    path.join(localPath, nativeTag, bundle, archiveName),
+    path.join(localPath, bundle, archiveName),
+  ]);
+}
+
+List<String> _dedupePaths(List<String> paths) {
+  final normalizedPaths = <String>[];
+  final seen = <String>{};
+  for (final entry in paths) {
+    final normalized = path.normalize(entry);
+    if (seen.add(normalized)) {
+      normalizedPaths.add(normalized);
+    }
+  }
+  return normalizedPaths;
+}
+
+Future<Directory> _extractLocalBundleArchive({
+  required String archivePath,
+  required String bundle,
+  required String cacheDir,
+  required Directory extractedDir,
+  required Logger log,
+}) async {
+  final extractedLibraryPaths = await _extractCachedArchive(
+    archivePath: archivePath,
+    extractedDir: extractedDir,
+    cacheDir: cacheDir,
+    log: log,
+  );
+  if (!_isBundleLayoutCompatible(
+    bundle: bundle,
+    libraryPaths: extractedLibraryPaths,
+    log: log,
+  )) {
+    throw Exception(
+      'Local bundle archive $archivePath is missing runtime deps.',
+    );
+  }
+  log.info('Using local native bundle archive: $archivePath');
   return extractedDir;
 }
 
@@ -493,11 +846,14 @@ Future<List<String>> _extractCachedArchive({
 }
 
 Future<void> _downloadReleaseAsset({
+  required String repository,
+  required String nativeTag,
   required String assetName,
   required String destinationPath,
   required Logger log,
 }) async {
-  final url = '$_baseUrl/$assetName';
+  final url =
+      'https://github.com/$repository/releases/download/$nativeTag/$assetName';
   log.info('Downloading native bundle: $url');
 
   final destination = File(destinationPath);

--- a/lib/src/backends/llama_cpp/llama_cpp_service.dart
+++ b/lib/src/backends/llama_cpp/llama_cpp_service.dart
@@ -914,7 +914,8 @@ class LlamaCppService {
   ///    `LLAMADART_BACKEND_MODULE_DIR`)
   /// 2. Directory of resolved executable (if it looks like a native bundle)
   /// 3. Current working directory (if it looks like a native bundle)
-  /// 4. Hook cache under `.dart_tool/llamadart/native_bundles/*/windows-*/`
+  /// 4. Hook cache under `.dart_tool/llamadart/native_bundles`, including
+  ///    default, custom GitHub, and local archive cache namespaces.
   /// 5. Directory of resolved executable (best-effort fallback)
   static String? resolveWindowsBackendModuleDirectory({
     required String resolvedExecutablePath,
@@ -1055,63 +1056,99 @@ class LlamaCppService {
     String cacheRootPath, {
     String? preferredBundleName,
   }) {
-    final cacheRoot = Directory(cacheRootPath);
-    List<Directory> tagDirectories;
-    try {
-      tagDirectories = cacheRoot.listSync().whereType<Directory>().toList(
-        growable: false,
-      );
-    } catch (_) {
-      return null;
+    final bundleDirs = _windowsBundleDirectoriesFromCache(
+      cacheRootPath,
+      preferredBundleName: preferredBundleName,
+    );
+
+    for (final bundleDir in bundleDirs) {
+      final extractedDir = path.join(bundleDir.path, 'extracted');
+      if (_containsWindowsNativeModules(extractedDir)) {
+        return extractedDir;
+      }
+      if (_containsWindowsNativeModules(bundleDir.path)) {
+        return bundleDir.path;
+      }
     }
+
+    return null;
+  }
+
+  static List<Directory> _windowsBundleDirectoriesFromCache(
+    String cacheRootPath, {
+    String? preferredBundleName,
+  }) {
+    final cacheRoot = Directory(cacheRootPath);
+    final tagDirectories = <Directory>[];
+
+    void addDefaultTags(Directory root) {
+      for (final child in _listChildDirectories(root)) {
+        final name = path.basename(child.path);
+        if (name == 'github' || name == 'local') {
+          continue;
+        }
+        tagDirectories.add(child);
+      }
+    }
+
+    void addGitHubTags(Directory root) {
+      final githubRoot = Directory(path.join(root.path, 'github'));
+      for (final ownerDir in _listChildDirectories(githubRoot)) {
+        for (final repoDir in _listChildDirectories(ownerDir)) {
+          tagDirectories.addAll(_listChildDirectories(repoDir));
+        }
+      }
+    }
+
+    void addLocalTags(Directory root) {
+      final localRoot = Directory(path.join(root.path, 'local'));
+      for (final digestDir in _listChildDirectories(localRoot)) {
+        tagDirectories.addAll(_listChildDirectories(digestDir));
+      }
+    }
+
+    addDefaultTags(cacheRoot);
+    addGitHubTags(cacheRoot);
+    addLocalTags(cacheRoot);
 
     tagDirectories.sort(
       (a, b) => path.basename(b.path).compareTo(path.basename(a.path)),
     );
 
+    final candidates = <Directory>[];
     for (final tagDirectory in tagDirectories) {
-      final bundleDirs = <Directory>[];
       if (preferredBundleName != null) {
         final preferred = Directory(
           path.join(tagDirectory.path, preferredBundleName),
         );
         if (preferred.existsSync()) {
-          bundleDirs.add(preferred);
+          candidates.add(preferred);
         }
       }
 
-      try {
-        final otherWindowsBundles = tagDirectory
-            .listSync()
-            .whereType<Directory>()
-            .where(
-              (directory) =>
-                  path.basename(directory.path).startsWith('windows-'),
-            )
-            .toList(growable: false);
-        bundleDirs.addAll(otherWindowsBundles);
-      } catch (_) {
-        // Ignore and continue with what we have.
-      }
-
-      final seen = <String>{};
-      for (final bundleDir in bundleDirs) {
-        final normalizedBundle = path.normalize(bundleDir.path);
-        if (!seen.add(normalizedBundle)) {
-          continue;
-        }
-
-        final extractedDir = path.join(bundleDir.path, 'extracted');
-        if (_containsWindowsNativeModules(extractedDir)) {
-          return extractedDir;
-        }
-        if (_containsWindowsNativeModules(bundleDir.path)) {
-          return bundleDir.path;
+      for (final directory in _listChildDirectories(tagDirectory)) {
+        if (path.basename(directory.path).startsWith('windows-')) {
+          candidates.add(directory);
         }
       }
     }
 
-    return null;
+    final seen = <String>{};
+    return candidates
+        .where((directory) {
+          return seen.add(path.normalize(directory.path));
+        })
+        .toList(growable: false);
+  }
+
+  static List<Directory> _listChildDirectories(Directory directory) {
+    try {
+      return directory.listSync().whereType<Directory>().toList(
+        growable: false,
+      );
+    } catch (_) {
+      return const <Directory>[];
+    }
   }
 
   static bool _containsWindowsNativeModules(String directoryPath) {

--- a/lib/src/hook/native_bundle_config.dart
+++ b/lib/src/hook/native_bundle_config.dart
@@ -4,6 +4,9 @@ import 'package:code_assets/code_assets.dart';
 import 'package:path/path.dart' as path;
 
 const String nativeBackendUserDefineKey = 'llamadart_native_backends';
+const String nativeTagUserDefineKey = 'llamadart_native_tag';
+const String nativeRepositoryUserDefineKey = 'llamadart_native_repository';
+const String nativePathUserDefineKey = 'llamadart_native_path';
 
 const Set<String> _coreLibraries = {
   'llamadart',

--- a/test/unit/backends/llama_cpp/llama_cpp_service_test.dart
+++ b/test/unit/backends/llama_cpp/llama_cpp_service_test.dart
@@ -706,6 +706,65 @@ void main() {
       expect(path.normalize(resolved!), path.normalize(extractedDir.path));
     });
 
+    test('finds custom GitHub hook cache namespace', () {
+      final extractedDir = Directory(
+        path.join(
+          tempRoot.path,
+          '.dart_tool',
+          'llamadart',
+          'native_bundles',
+          'github',
+          'example',
+          'native-fork',
+          'b8095',
+          'windows-x64',
+          'extracted',
+        ),
+      )..createSync(recursive: true);
+      _createWindowsBundleMarkerFiles(extractedDir.path);
+
+      final resolved = LlamaCppService.resolveWindowsBackendModuleDirectory(
+        resolvedExecutablePath: path.join(
+          tempRoot.path,
+          'dart-sdk',
+          'dart.exe',
+        ),
+        currentDirectoryPath: tempRoot.path,
+        environment: const {},
+      );
+
+      expect(path.normalize(resolved!), path.normalize(extractedDir.path));
+    });
+
+    test('finds local archive hook cache namespace', () {
+      final extractedDir = Directory(
+        path.join(
+          tempRoot.path,
+          '.dart_tool',
+          'llamadart',
+          'native_bundles',
+          'local',
+          '0123456789abcdef',
+          'b8095',
+          'windows-x64',
+          'extracted',
+        ),
+      )..createSync(recursive: true);
+      _createWindowsBundleMarkerFiles(extractedDir.path);
+
+      final resolved = LlamaCppService.resolveWindowsBackendModuleDirectory(
+        resolvedExecutablePath: path.join(
+          tempRoot.path,
+          'dart-sdk',
+          'dart.exe',
+        ),
+        currentDirectoryPath: tempRoot.path,
+        environment: const {},
+      );
+
+      expect(path.normalize(resolved!), path.normalize(extractedDir.path));
+    });
+
     test('prefers .dart_tool/lib when suffixed native assets are present', () {
       final dartToolLibDir = Directory(
         path.join(tempRoot.path, '.dart_tool', 'lib'),

--- a/test/unit/hook/build_hook_integration_test.dart
+++ b/test/unit/hook/build_hook_integration_test.dart
@@ -1,10 +1,12 @@
 @TestOn('vm')
 library;
 
+import 'dart:convert';
 import 'dart:io';
 
 import 'package:archive/archive.dart';
 import 'package:code_assets/code_assets.dart';
+import 'package:crypto/crypto.dart';
 import 'package:hooks/hooks.dart';
 import 'package:path/path.dart' as path;
 import 'package:test/test.dart';
@@ -175,6 +177,336 @@ void main() {
       },
     );
   });
+
+  test('build hook uses pubspec native tag override', () async {
+    const overrideTag = 'b0000-hook-test';
+    final overrideCacheDir = Directory(
+      '.dart_tool/llamadart/native_bundles/$overrideTag/windows-x64',
+    );
+    final overrideBundleDir = Directory(
+      path.join(overrideCacheDir.path, 'extracted'),
+    );
+    final overrideBackupDir = Directory(
+      '${overrideCacheDir.path}.__hook_test_backup',
+    );
+
+    if (overrideBackupDir.existsSync()) {
+      await overrideBackupDir.delete(recursive: true);
+    }
+    if (overrideCacheDir.existsSync()) {
+      await overrideCacheDir.rename(overrideBackupDir.path);
+    }
+
+    try {
+      await _writeBundleLibraries(overrideBundleDir, const [
+        'llamadart-windows-x64.dll',
+        'llama-windows-x64.dll',
+        'ggml-windows-x64.dll',
+        'ggml-base-windows-x64.dll',
+        'ggml-cpu-windows-x64.dll',
+        'ggml-opencl-windows-x64.dll',
+      ]);
+
+      final userDefines = PackageUserDefines(
+        workspacePubspec: PackageUserDefinesSource(
+          defines: {
+            'llamadart_native_tag': overrideTag,
+            'llamadart_native_backends': {
+              'platforms': {
+                'windows-x64': ['opencl'],
+              },
+            },
+          },
+          basePath: Directory.current.uri,
+        ),
+      );
+
+      await testCodeBuildHook(
+        mainMethod: build_hook.main,
+        targetOS: OS.windows,
+        targetArchitecture: Architecture.x64,
+        userDefines: userDefines,
+        check: (input, output) {
+          final codeAssets = output.assets.encodedAssets
+              .where((asset) => asset.isCodeAsset)
+              .map((asset) => asset.asCodeAsset)
+              .toList(growable: false);
+
+          final emittedNames = codeAssets
+              .map((asset) => path.basename(asset.file!.toFilePath()))
+              .toSet();
+
+          expect(emittedNames, contains('ggml-opencl-windows-x64.dll'));
+          expect(emittedNames, isNot(contains('ggml-vulkan-windows-x64.dll')));
+        },
+      );
+    } finally {
+      if (overrideCacheDir.existsSync()) {
+        await overrideCacheDir.delete(recursive: true);
+      }
+      if (overrideBackupDir.existsSync()) {
+        await overrideBackupDir.rename(overrideCacheDir.path);
+      }
+    }
+  });
+
+  test('build hook uses custom GitHub repository cache namespace', () async {
+    const overrideTag = 'b0000-repo-test';
+    const customRepository = 'example/native-fork';
+    final repoCacheRoot = Directory(
+      '.dart_tool/llamadart/native_bundles/github/example/native-fork',
+    );
+    final overrideBundleDir = Directory(
+      path.join(repoCacheRoot.path, overrideTag, 'windows-x64', 'extracted'),
+    );
+    final overrideBackupDir = Directory(
+      '${repoCacheRoot.path}.__hook_test_backup',
+    );
+
+    if (overrideBackupDir.existsSync()) {
+      await overrideBackupDir.delete(recursive: true);
+    }
+    if (repoCacheRoot.existsSync()) {
+      await repoCacheRoot.rename(overrideBackupDir.path);
+    }
+
+    try {
+      await _writeBundleLibraries(overrideBundleDir, const [
+        'llamadart-windows-x64.dll',
+        'llama-windows-x64.dll',
+        'ggml-windows-x64.dll',
+        'ggml-base-windows-x64.dll',
+        'ggml-cpu-windows-x64.dll',
+        'ggml-opencl-windows-x64.dll',
+      ]);
+
+      final userDefines = PackageUserDefines(
+        workspacePubspec: PackageUserDefinesSource(
+          defines: {
+            'llamadart_native_tag': overrideTag,
+            'llamadart_native_repository':
+                'https://github.com/$customRepository',
+            'llamadart_native_backends': {
+              'platforms': {
+                'windows-x64': ['opencl'],
+              },
+            },
+          },
+          basePath: Directory.current.uri,
+        ),
+      );
+
+      await testCodeBuildHook(
+        mainMethod: build_hook.main,
+        targetOS: OS.windows,
+        targetArchitecture: Architecture.x64,
+        userDefines: userDefines,
+        check: (input, output) {
+          final emittedNames = _emittedFileNames(output);
+
+          expect(emittedNames, contains('ggml-opencl-windows-x64.dll'));
+          expect(emittedNames, isNot(contains('ggml-vulkan-windows-x64.dll')));
+        },
+      );
+    } finally {
+      if (repoCacheRoot.existsSync()) {
+        await repoCacheRoot.delete(recursive: true);
+      }
+      if (overrideBackupDir.existsSync()) {
+        await overrideBackupDir.rename(repoCacheRoot.path);
+      }
+    }
+  });
+
+  test('build hook uses local native path directory', () async {
+    const localRootPath = '.dart_tool/llamadart_hook_test_local_dir';
+    final localRoot = Directory(localRootPath);
+    final localBundleDir = Directory(path.join(localRoot.path, 'windows-x64'));
+
+    if (localRoot.existsSync()) {
+      await localRoot.delete(recursive: true);
+    }
+
+    try {
+      await _writeBundleLibraries(localBundleDir, const [
+        'llamadart-windows-x64.dll',
+        'llama-windows-x64.dll',
+        'ggml-windows-x64.dll',
+        'ggml-base-windows-x64.dll',
+        'ggml-cpu-windows-x64.dll',
+        'ggml-opencl-windows-x64.dll',
+      ]);
+
+      final userDefines = PackageUserDefines(
+        workspacePubspec: PackageUserDefinesSource(
+          defines: {
+            'llamadart_native_path': localRootPath,
+            'llamadart_native_backends': {
+              'platforms': {
+                'windows-x64': ['opencl'],
+              },
+            },
+          },
+          basePath: Directory.current.uri,
+        ),
+      );
+
+      await testCodeBuildHook(
+        mainMethod: build_hook.main,
+        targetOS: OS.windows,
+        targetArchitecture: Architecture.x64,
+        userDefines: userDefines,
+        check: (input, output) {
+          final emittedNames = _emittedFileNames(output);
+
+          expect(emittedNames, contains('ggml-opencl-windows-x64.dll'));
+          expect(emittedNames, isNot(contains('ggml-vulkan-windows-x64.dll')));
+        },
+      );
+    } finally {
+      if (localRoot.existsSync()) {
+        await localRoot.delete(recursive: true);
+      }
+    }
+  });
+
+  test('build hook uses local native path archive', () async {
+    const overrideTag = 'b0000-local-archive';
+    const localRootPath = '.dart_tool/llamadart_hook_test_local_archive';
+    final localRoot = Directory(localRootPath);
+    final archiveFile = File(
+      path.join(
+        localRoot.path,
+        'llamadart-native-windows-x64-$overrideTag.tar.gz',
+      ),
+    );
+    final localCacheRoot = Directory(
+      _localPathCacheRoot(
+        localRootPath: localRootPath,
+        nativeTag: overrideTag,
+        bundle: 'windows-x64',
+      ),
+    );
+
+    if (localRoot.existsSync()) {
+      await localRoot.delete(recursive: true);
+    }
+    if (localCacheRoot.existsSync()) {
+      await localCacheRoot.delete(recursive: true);
+    }
+
+    try {
+      await _writeBundleArchive(
+        archiveFile: archiveFile,
+        files: const [
+          'llamadart-windows-x64.dll',
+          'llama-windows-x64.dll',
+          'ggml-windows-x64.dll',
+          'ggml-base-windows-x64.dll',
+          'ggml-cpu-windows-x64.dll',
+          'ggml-opencl-windows-x64.dll',
+        ],
+      );
+
+      final userDefines = PackageUserDefines(
+        workspacePubspec: PackageUserDefinesSource(
+          defines: {
+            'llamadart_native_tag': overrideTag,
+            'llamadart_native_path': localRootPath,
+            'llamadart_native_backends': {
+              'platforms': {
+                'windows-x64': ['opencl'],
+              },
+            },
+          },
+          basePath: Directory.current.uri,
+        ),
+      );
+
+      await testCodeBuildHook(
+        mainMethod: build_hook.main,
+        targetOS: OS.windows,
+        targetArchitecture: Architecture.x64,
+        userDefines: userDefines,
+        check: (input, output) {
+          final emittedNames = _emittedFileNames(output);
+
+          expect(emittedNames, contains('ggml-opencl-windows-x64.dll'));
+          expect(emittedNames, isNot(contains('ggml-vulkan-windows-x64.dll')));
+        },
+      );
+    } finally {
+      if (localRoot.existsSync()) {
+        await localRoot.delete(recursive: true);
+      }
+      if (localCacheRoot.existsSync()) {
+        await localCacheRoot.delete(recursive: true);
+      }
+    }
+  });
+
+  test('build hook rejects path-unsafe native tag override', () async {
+    final userDefines = PackageUserDefines(
+      workspacePubspec: PackageUserDefinesSource(
+        defines: const {'llamadart_native_tag': '../bad'},
+        basePath: Directory.current.uri,
+      ),
+    );
+
+    await expectLater(
+      testCodeBuildHook(
+        mainMethod: build_hook.main,
+        targetOS: OS.windows,
+        targetArchitecture: Architecture.x64,
+        userDefines: userDefines,
+        check: (input, output) {},
+      ),
+      throwsA(
+        isA<FormatException>().having(
+          (error) => error.message,
+          'message',
+          contains('path-safe release tag'),
+        ),
+      ),
+    );
+  });
+
+  test('build hook rejects invalid native repository override', () async {
+    final userDefines = PackageUserDefines(
+      workspacePubspec: PackageUserDefinesSource(
+        defines: const {'llamadart_native_repository': '../bad'},
+        basePath: Directory.current.uri,
+      ),
+    );
+
+    await expectLater(
+      testCodeBuildHook(
+        mainMethod: build_hook.main,
+        targetOS: OS.windows,
+        targetArchitecture: Architecture.x64,
+        userDefines: userDefines,
+        check: (input, output) {},
+      ),
+      throwsA(
+        isA<FormatException>().having(
+          (error) => error.message,
+          'message',
+          contains('GitHub repository slug'),
+        ),
+      ),
+    );
+  });
+}
+
+Set<String> _emittedFileNames(BuildOutput output) {
+  final codeAssets = output.assets.encodedAssets
+      .where((asset) => asset.isCodeAsset)
+      .map((asset) => asset.asCodeAsset)
+      .toList(growable: false);
+
+  return codeAssets
+      .map((asset) => path.basename(asset.file!.toFilePath()))
+      .toSet();
 }
 
 String _readHookNativeTag() {
@@ -214,4 +546,22 @@ Future<void> _writeBundleArchive({
 
   await archiveFile.parent.create(recursive: true);
   await archiveFile.writeAsBytes(gzBytes);
+}
+
+String _localPathCacheRoot({
+  required String localRootPath,
+  required String nativeTag,
+  required String bundle,
+}) {
+  final localRootUri = Directory.current.uri.resolve(localRootPath);
+  final digest = sha1.convert(utf8.encode(localRootUri.toString())).toString();
+  return path.join(
+    '.dart_tool',
+    'llamadart',
+    'native_bundles',
+    'local',
+    digest,
+    nativeTag,
+    bundle,
+  );
 }

--- a/website/docs/getting-started/installation.md
+++ b/website/docs/getting-started/installation.md
@@ -46,14 +46,26 @@ On the first `dart run` / `flutter run` for a native target, `llamadart`:
 
 No local C++ toolchain setup is required for consumers.
 
-## Optional backend selection (non-Apple)
+## Optional native source and backend selection
 
-You can configure backend modules per target in your `pubspec.yaml`:
+You can configure the native runtime source and backend modules per target in
+your `pubspec.yaml`:
 
 ```yaml
 hooks:
   user_defines:
     llamadart:
+      # Optional. Defaults to llamadart's tested native runtime pin.
+      # Use a leehack/llamadart-native release tag when testing another build.
+      llamadart_native_tag: b9371
+
+      # Optional. GitHub repository slug or github.com URL.
+      llamadart_native_repository: leehack/llamadart-native
+
+      # Optional. Takes precedence over GitHub downloads when set.
+      # Relative paths are resolved from the pubspec defining this config.
+      # llamadart_native_path: ./native-bundles
+
       llamadart_native_backends:
         platforms:
           android-arm64:
@@ -63,9 +75,30 @@ hooks:
           windows-x64: [vulkan, cuda]
 ```
 
-Module availability is platform/arch specific and tied to the pinned native
-bundle tag. See [Platform & Backend Matrix](../platforms/support-matrix) for
-the current per-target module list.
+Module availability is platform/arch specific and tied to the selected native
+bundle tag. If `llamadart_native_tag` points at a release without a matching
+bundle asset, the native-assets hook fails while downloading that asset. See
+[Platform & Backend Matrix](../platforms/support-matrix) for the current
+per-target module list.
+
+Native source overrides are for compatibility testing. They do not regenerate
+Dart FFI bindings or symbol lookups, so the selected binary still must be ABI-
+and symbol-compatible with the default `leehack/llamadart-native@b9371` runtime.
+
+Available native tags are published on the
+[`leehack/llamadart-native` releases page](https://github.com/leehack/llamadart-native/releases).
+You can also list them with the GitHub CLI:
+
+```bash
+gh release list --repo leehack/llamadart-native --limit 20
+```
+
+Before overriding, confirm the release includes the asset for your target. The
+hook downloads files named `llamadart-native-<bundle>-<tag>.tar.gz`, for example
+`llamadart-native-windows-x64-b9371.tar.gz`.
+For local testing, `llamadart_native_path` may point directly at a bundle
+archive, at an extracted bundle directory, or at a directory containing
+`<tag>/<bundle>/`, `<bundle>/`, or the expected archive file.
 
 For `android-arm64`, CPU variant policy is configurable:
 

--- a/website/docs/platforms/support-matrix.md
+++ b/website/docs/platforms/support-matrix.md
@@ -6,8 +6,21 @@ description: Check which native and web backends are supported by llamadart and 
 This page combines platform support and backend-module configuration for
 `llamadart`.
 
-The native-assets hook currently pins `llamadart-native` tag `b9016`
-(`hook/build.dart`). Module availability below is for that pinned tag.
+The native-assets hook defaults to `llamadart-native` tag `b9371`
+(`hook/build.dart`). Apps can override the GitHub source with
+`hooks.user_defines.llamadart.llamadart_native_tag` and
+`hooks.user_defines.llamadart.llamadart_native_repository`, or use a local
+bundle source with `hooks.user_defines.llamadart.llamadart_native_path`. Module
+availability below is for the default tag.
+
+Available override tags are published on the
+[`leehack/llamadart-native` releases page](https://github.com/leehack/llamadart-native/releases)
+or via `gh release list --repo leehack/llamadart-native --limit 20`.
+The selected release must include a bundle asset named
+`llamadart-native-<bundle>-<tag>.tar.gz` for the target being built.
+Native source overrides do not regenerate Dart FFI bindings or symbol lookups,
+so the selected binary must remain ABI- and symbol-compatible with the default
+runtime revision.
 
 ## Platform/architecture coverage
 
@@ -45,7 +58,7 @@ minimum deployment target of `16.4` or newer (for example
   a web load failure as a package bug. The [WebGPU Bridge](./webgpu-bridge)
   page has the browser-console probe and Flutter Web smoke-test path.
 
-## Current module availability by bundle (`b9016`)
+## Current module availability by bundle (`b9371`)
 
 | Bundle key | Available backend modules in bundle |
 | --- | --- |
@@ -81,12 +94,27 @@ targets, but Apple targets are non-configurable in
 
 ## Configuring native backend modules
 
-Use `hooks.user_defines.llamadart.llamadart_native_backends`:
+Use `hooks.user_defines.llamadart.llamadart_native_tag` and
+`hooks.user_defines.llamadart.llamadart_native_repository` to test another
+GitHub release source,
+`hooks.user_defines.llamadart.llamadart_native_path` to use a local source, and
+`hooks.user_defines.llamadart.llamadart_native_backends` to select split backend
+modules:
 
 ```yaml
 hooks:
   user_defines:
     llamadart:
+      # Optional. Defaults to llamadart's tested native runtime pin.
+      llamadart_native_tag: b9371
+
+      # Optional. GitHub repository slug or github.com URL.
+      llamadart_native_repository: leehack/llamadart-native
+
+      # Optional. Takes precedence over GitHub downloads when set.
+      # Relative paths are resolved from the pubspec defining this config.
+      # llamadart_native_path: ./native-bundles
+
       llamadart_native_backends:
         platforms:
           android-arm64:
@@ -160,8 +188,20 @@ no valid entries remain, selection falls back to `cpu_profile` (or default
 - `windows-x64` performs extra runtime dependency validation:
   - `cuda` requires `cudart` and `cublas` DLLs.
   - `blas` requires OpenBLAS DLL.
-- If you change `llamadart_native_backends`, run `flutter clean` once to clear
-  stale native-asset outputs.
+- If `llamadart_native_tag` points at a release without a matching bundle asset,
+  the native-assets hook fails while downloading that asset.
+- Available override values are `leehack/llamadart-native` release tags, not
+  `llamadart` package versions.
+- `llamadart_native_repository` accepts a GitHub `owner/repo` slug or
+  `https://github.com/owner/repo` URL.
+- `llamadart_native_path` takes precedence over GitHub downloads and can point
+  directly at an archive, at an extracted bundle directory, or at a directory
+  containing `<tag>/<bundle>/`, `<bundle>/`, or the expected archive file.
+- Native source overrides do not regenerate Dart FFI bindings or symbol
+  lookups, so they are only safe with compatible native binaries.
+- If you change `llamadart_native_tag`, `llamadart_native_repository`,
+  `llamadart_native_path`, or `llamadart_native_backends`, run `flutter clean`
+  once to clear stale native-asset outputs.
 
 ## Vulkan cooperative matrix driver crashes
 


### PR DESCRIPTION
## Summary

- Add `hooks.user_defines.llamadart.llamadart_native_tag`, `llamadart_native_repository`, and `llamadart_native_path` so apps can test compatible native runtime binaries without patching `llamadart`.
- Keep the default `leehack/llamadart-native@b9371` behavior and cache path unchanged, while isolating custom GitHub repositories and local-path archives/directories in separate cache namespaces.
- Update the Windows runtime fallback scanner so namespaced custom GitHub and local archive caches remain discoverable when `.dart_tool/lib` is unavailable.
- Log and document that native source overrides do not regenerate Dart FFI bindings or symbol lookups, so selected binaries must stay ABI- and symbol-compatible with the default runtime revision.
- Expand README and website docs with where to find available `llamadart-native` tags and the expected release asset/archive layout.

## Validation

- `dart test -p vm test/unit/backends/llama_cpp/llama_cpp_service_test.dart test/unit/hook`
- `dart test -p vm test/unit`
- `dart analyze`
- `dart format --output=none --set-exit-if-changed lib/src/backends/llama_cpp/llama_cpp_service.dart test/unit/backends/llama_cpp/llama_cpp_service_test.dart hook/build.dart lib/src/hook/native_bundle_config.dart test/unit/hook/build_hook_integration_test.dart`
- `git diff --check`
- `dart test --run-skipped -t local-only test/e2e/tooling/native_tool_e2e_test.dart`
- Disposable consumer app smoke: `llamadart_native_tag` + `llamadart_native_path` direct archive override from real `pubspec.yaml`, then `dart run` and native runtime load
- Disposable consumer app smoke: `llamadart_native_tag` + `llamadart_native_repository` custom cache namespace from real `pubspec.yaml`, then `dart run` and native runtime load
- Self-reviewed cache selection, repository validation, local archive/directory handling, stale-cache behavior, and Windows runtime fallback discovery