### PR TITLE
Fix cross-isolate cancel/dispose lifecycle bugs (native & LiteRT-LM)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,22 @@
+## Unreleased
+
+* **Cancellation / disposal lifecycle fixes** (native & LiteRT-LM):
+  * Fixed a cross-isolate use-after-free where the llama.cpp generation cancel
+    token was freed in `onCancel` while the worker isolate could still poll it.
+    The token is now freed only after the worker's terminal response, or after
+    the worker is killed during `dispose`.
+  * The llama.cpp worker now waits for an in-flight generation to emit its
+    terminal response before disposing native resources and exiting, so
+    cancelling/disposing mid-generation no longer abandons the consumer stream.
+  * The LiteRT-LM worker no longer deletes the engine/conversation while a
+    native call may still be running (it skips the native dispose when the
+    in-flight request has not settled), avoiding a use-after-free on teardown.
+  * The LiteRT-LM streaming path no longer leaks the `NativeCallable`, stream
+    proxy, and message buffer when a generation is cancelled, and guards stream
+    writes against a closed controller.
+  * The LiteRT-LM backend no longer sends a generation request to a closed
+    response port when cancellation races isolate startup.
+
 ## 0.7.0
 
 * **Native runtime configuration**:

--- a/lib/src/backends/litert_lm/litert_lm_backend.dart
+++ b/lib/src/backends/litert_lm/litert_lm_backend.dart
@@ -200,10 +200,17 @@ class LiteRtLmBackend
         unawaited(() async {
           try {
             await _ensureIsolate();
-            if (cleanedUp) {
+            // Re-check after the await: a cancel during _ensureIsolate() runs
+            // cleanup(), which closes the response port and may clear
+            // _sendPort. Capture the port and guard in one synchronous step so
+            // we never send a generate request to a closed port (which would
+            // orphan a generation on the worker) or dereference a null port.
+            final sendPort = _sendPort;
+            if (cleanedUp || sendPort == null) {
+              cleanup();
               return;
             }
-            _sendPort!.send(
+            sendPort.send(
               LiteRtLmGenerateRequest(
                 contextHandle,
                 prompt,

--- a/lib/src/backends/litert_lm/litert_lm_runtime.dart
+++ b/lib/src/backends/litert_lm/litert_lm_runtime.dart
@@ -606,12 +606,12 @@ class LiteRtLmRuntimeClient {
   Stream<String> _generateStreaming(String prompt) {
     final bindings = _requireBindings();
     final conversation = _requireConversation();
-    final controller = StreamController<String>(onCancel: cancel);
     final messagePtr = _messageJson(prompt).toNativeUtf8();
     Pointer<Void> callbackData = nullptr;
     var cleanedUp = false;
 
     late final NativeCallable<_StreamCallbackNative> callable;
+    late final StreamController<String> controller;
     void cleanup() {
       if (cleanedUp) {
         return;
@@ -625,6 +625,20 @@ class LiteRtLmRuntimeClient {
       calloc.free(messagePtr);
     }
 
+    controller = StreamController<String>(
+      onCancel: () {
+        // Signal the native side to stop, but do NOT run cleanup() here:
+        // closing the NativeCallable while the runtime may still invoke it is
+        // unsafe. cancellation drives the runtime to deliver a terminal
+        // CANCELLED/error callback, and cleanup() runs from there (below). A
+        // timer-based backstop is deliberately avoided: closing the callable
+        // while a later native callback is still possible would crash. If the
+        // runtime never delivers a terminal callback the callback resources
+        // leak, which is preferable to a use-after-free.
+        cancel();
+      },
+    );
+
     callable = NativeCallable<_StreamCallbackNative>.listener((
       Pointer<Void> data,
       Pointer<Char> chunk,
@@ -635,10 +649,14 @@ class LiteRtLmRuntimeClient {
         final error = errorMessage.cast<Utf8>().toDartString();
         _proxyFreeString?.call(errorMessage);
         if (error.startsWith('CANCELLED')) {
-          unawaited(controller.close());
+          if (!controller.isClosed) {
+            unawaited(controller.close());
+          }
         } else {
-          controller.addError(StateError(error));
-          unawaited(controller.close());
+          if (!controller.isClosed) {
+            controller.addError(StateError(error));
+            unawaited(controller.close());
+          }
         }
         cleanup();
         return;
@@ -648,13 +666,15 @@ class LiteRtLmRuntimeClient {
         final raw = chunk.cast<Utf8>().toDartString();
         _proxyFreeString?.call(chunk);
         final text = _extractText(raw);
-        if (text.isNotEmpty) {
+        if (text.isNotEmpty && !controller.isClosed) {
           controller.add(text);
         }
       }
 
       if (isFinal) {
-        unawaited(controller.close());
+        if (!controller.isClosed) {
+          unawaited(controller.close());
+        }
         cleanup();
       }
     });

--- a/lib/src/backends/litert_lm/worker.dart
+++ b/lib/src/backends/litert_lm/worker.dart
@@ -20,6 +20,7 @@ void runLiteRtLmWorkerForTesting(
   SendPort initialSendPort,
   LiteRtLmService service, {
   bool exitOnDispose = true,
+  Duration disposeTimeout = const Duration(seconds: 5),
 }) {
   final receivePort = ReceivePort();
   initialSendPort.send(receivePort.sendPort);
@@ -33,17 +34,24 @@ void runLiteRtLmWorkerForTesting(
     if (message is LiteRtLmDisposeRequest) {
       shuttingDown = true;
       service.cancelGeneration();
+      var requestSettled = true;
       try {
-        await activeRequest.timeout(const Duration(seconds: 5));
+        await activeRequest.timeout(disposeTimeout);
       } on TimeoutException {
-        // Teardown continues below; the isolate is exited after the response.
+        // The in-flight native call (e.g. a blocking send_message) may still be
+        // executing. Deleting the engine/conversation now would be a
+        // use-after-free, so skip the native dispose and let the isolate/
+        // process teardown reclaim the (bounded) native memory instead.
+        requestSettled = false;
       } catch (_) {
-        // Request errors are reported to their original listeners.
+        // Request errored but is settled; safe to dispose.
       }
-      try {
-        service.dispose();
-      } catch (_) {
-        // Ignore errors during dispose.
+      if (requestSettled) {
+        try {
+          service.dispose();
+        } catch (_) {
+          // Ignore errors during dispose.
+        }
       }
       message.sendPort.send(LiteRtLmDoneResponse());
       receivePort.close();

--- a/lib/src/backends/llama_cpp/llama_cpp_backend.dart
+++ b/lib/src/backends/llama_cpp/llama_cpp_backend.dart
@@ -27,6 +27,7 @@ class NativeLlamaBackend
   final ReceivePort _responsesPort = ReceivePort();
   Pointer<Int8>? _activeCancelToken;
   void Function()? _activeGenerationCleanup;
+  void Function()? _activeFreeToken;
 
   bool _isReady = false;
   LlamaLogLevel _currentLogLevel = LlamaLogLevel.warn;
@@ -173,22 +174,46 @@ class NativeLlamaBackend
     cancelToken.value = 0;
     _activeCancelToken = cancelToken;
 
-    var cleanedUp = false;
-    void cleanup() {
-      if (cleanedUp) {
+    // The cancel token is shared with the worker isolate, which polls it every
+    // decode iteration. It must only be freed once the worker has stopped
+    // reading it. Cleanup is split in two: detachAndClose() runs eagerly on
+    // cancel and only tears down the Dart-side controller, while freeToken()
+    // frees the native token and closes the response port. The only safe times
+    // to free are when the worker proves it has stopped: a terminal
+    // DoneResponse/ErrorResponse (the worker breaks its decode loop on seeing
+    // the cancel flag and then emits one), or dispose() freeing it after
+    // killing the worker isolate. A timer-based backstop is deliberately
+    // avoided: it could fire mid-decode (e.g. during a slow prompt eval) and
+    // reintroduce the use-after-free. Worst case (a wedged worker that never
+    // responds and is never disposed) leaks a single byte, which is acceptable.
+    var tokenFreed = false;
+    late final void Function() freeToken;
+    freeToken = () {
+      if (tokenFreed) {
         return;
       }
-      cleanedUp = true;
-
+      tokenFreed = true;
       rp.close();
-      if (!controller.isClosed) {
-        unawaited(controller.close());
-      }
       malloc.free(cancelToken);
       if (_activeCancelToken == cancelToken) {
         _activeCancelToken = null;
       }
-      if (_activeGenerationCleanup == cleanup) {
+      if (_activeFreeToken == freeToken) {
+        _activeFreeToken = null;
+      }
+    };
+    _activeFreeToken = freeToken;
+
+    var detached = false;
+    void detachAndClose() {
+      if (detached) {
+        return;
+      }
+      detached = true;
+      if (!controller.isClosed) {
+        unawaited(controller.close());
+      }
+      if (_activeGenerationCleanup == detachAndClose) {
         _activeGenerationCleanup = null;
       }
     }
@@ -196,10 +221,13 @@ class NativeLlamaBackend
     controller = StreamController<List<int>>(
       onCancel: () {
         cancelGeneration();
-        cleanup();
+        // Close the Dart side immediately, but keep the response port open and
+        // the native token alive so the worker can observe the cancel flag and
+        // emit its terminal response, at which point freeToken() runs.
+        detachAndClose();
       },
     );
-    _activeGenerationCleanup = cleanup;
+    _activeGenerationCleanup = detachAndClose;
 
     _sendPort!.send(
       GenerateRequest(
@@ -214,12 +242,18 @@ class NativeLlamaBackend
 
     rp.listen((msg) {
       if (msg is TokenResponse) {
-        controller.add(msg.bytes);
+        if (!controller.isClosed) {
+          controller.add(msg.bytes);
+        }
       } else if (msg is DoneResponse) {
-        cleanup();
+        detachAndClose();
+        freeToken();
       } else if (msg is ErrorResponse) {
-        controller.addError(Exception(msg.message));
-        cleanup();
+        if (!controller.isClosed) {
+          controller.addError(Exception(msg.message));
+        }
+        detachAndClose();
+        freeToken();
       }
     });
 
@@ -467,6 +501,12 @@ class NativeLlamaBackend
 
   @override
   Future<void> dispose() async {
+    // Signal any in-flight generation to stop and close the Dart side, but do
+    // not free the shared cancel token yet: the worker may still poll it. The
+    // worker awaits the in-flight generation before acking the dispose, so its
+    // terminal response normally frees the token first. After killing the
+    // worker (below) the token is provably unread, so freeing it there is safe
+    // and idempotent (guarded by the freeToken tokenFreed flag).
     _activeCancelToken?.value = 1;
     _activeGenerationCleanup?.call();
 
@@ -478,8 +518,11 @@ class NativeLlamaBackend
     }
     _isolate?.kill();
     _responsesPort.close();
+    // Worker is gone; free the token if a terminal response did not already.
+    _activeFreeToken?.call();
     _activeCancelToken = null;
     _activeGenerationCleanup = null;
+    _activeFreeToken = null;
     _isReady = false;
   }
 

--- a/lib/src/backends/llama_cpp/worker.dart
+++ b/lib/src/backends/llama_cpp/worker.dart
@@ -15,9 +15,24 @@ void llamaWorkerEntry(SendPort initialSendPort) {
   // Service
   final service = LlamaCppService();
   var isInitialized = false;
+  var shuttingDown = false;
+
+  // Tracks the currently running generation so dispose can wait for it to emit
+  // its terminal response (and stop reading the shared native cancel token)
+  // before tearing the isolate down. Without this, Isolate.exit() abandons an
+  // in-flight generate with no DoneResponse, hanging the consumer's stream.
+  Future<void> activeGenerate = Future<void>.value();
 
   receivePort.listen((message) async {
     if (message is DisposeRequest) {
+      shuttingDown = true;
+      // Let any in-flight generation observe the cancel flag and finish
+      // emitting its terminal response before we dispose native resources.
+      try {
+        await activeGenerate.timeout(const Duration(seconds: 5));
+      } catch (_) {
+        // Timed out or errored; proceed with teardown regardless.
+      }
       try {
         service.dispose();
       } catch (e) {
@@ -40,6 +55,9 @@ void llamaWorkerEntry(SendPort initialSendPort) {
 
     // Requests
     if (message is WorkerRequest) {
+      if (shuttingDown) {
+        return;
+      }
       try {
         switch (message) {
           case ModelLoadRequest():
@@ -69,36 +87,42 @@ void llamaWorkerEntry(SendPort initialSendPort) {
             message.sendPort.send(DoneResponse());
 
           case GenerateRequest():
-            try {
-              final stream = service.generate(
-                message.contextHandle,
-                message.prompt,
-                message.params,
-                message.cancelTokenAddress,
-                parts: message.parts,
-              );
+            // Capture the generation future so a concurrent DisposeRequest can
+            // await its terminal response before tearing down the isolate.
+            final generateFuture = () async {
+              try {
+                final stream = service.generate(
+                  message.contextHandle,
+                  message.prompt,
+                  message.params,
+                  message.cancelTokenAddress,
+                  parts: message.parts,
+                );
 
-              final batcher = NativeTokenStreamBatcher(
-                tokenThreshold: message.params.streamBatchTokenThreshold,
-                byteThreshold: message.params.streamBatchByteThreshold,
-              );
+                final batcher = NativeTokenStreamBatcher(
+                  tokenThreshold: message.params.streamBatchTokenThreshold,
+                  byteThreshold: message.params.streamBatchByteThreshold,
+                );
 
-              await for (final tokens in stream) {
-                final readyChunks = batcher.add(tokens);
-                for (final chunk in readyChunks) {
-                  message.sendPort.send(TokenResponse(chunk));
+                await for (final tokens in stream) {
+                  final readyChunks = batcher.add(tokens);
+                  for (final chunk in readyChunks) {
+                    message.sendPort.send(TokenResponse(chunk));
+                  }
                 }
-              }
 
-              final finalChunk = batcher.flush();
-              if (finalChunk != null) {
-                message.sendPort.send(TokenResponse(finalChunk));
-              }
+                final finalChunk = batcher.flush();
+                if (finalChunk != null) {
+                  message.sendPort.send(TokenResponse(finalChunk));
+                }
 
-              message.sendPort.send(DoneResponse());
-            } catch (e) {
-              message.sendPort.send(ErrorResponse(e.toString()));
-            }
+                message.sendPort.send(DoneResponse());
+              } catch (e) {
+                message.sendPort.send(ErrorResponse(e.toString()));
+              }
+            }();
+            activeGenerate = generateFuture;
+            await generateFuture;
 
           case EmbedRequest():
             final embedding = service.embed(

--- a/test/e2e/backends/cancel_dispose_e2e_test.dart
+++ b/test/e2e/backends/cancel_dispose_e2e_test.dart
@@ -1,0 +1,133 @@
+@TestOn('vm')
+@Tags(['local-only', 'e2e'])
+@Timeout(Duration(minutes: 5))
+library;
+
+import 'dart:io';
+
+import 'package:llamadart/llamadart.dart';
+import 'package:path/path.dart' as path;
+import 'package:test/test.dart';
+
+/// Real-native regression coverage for the cross-isolate cancel/dispose
+/// lifecycle fixes (cancel-token use-after-free and dispose abandoning an
+/// in-flight generation). These exercise the actual worker isolate + FFI path,
+/// so they are local-only and require a small GGUF in `models/`.
+void main() {
+  final candidates = <String>[
+    'functiongemma-270m-it-Q4_K_M.gguf',
+    'Llama-3.2-1B-Instruct-Q4_K_M.gguf',
+    'llama3.2-1b.gguf',
+  ];
+
+  String? resolveModel() {
+    final modelsDir = Directory(path.join(Directory.current.path, 'models'));
+    for (final name in candidates) {
+      final file = File(path.join(modelsDir.path, name));
+      if (file.existsSync()) {
+        return file.path;
+      }
+    }
+    return null;
+  }
+
+  group('cancel/dispose lifecycle (native)', () {
+    late String modelPath;
+
+    setUpAll(() {
+      final resolved = resolveModel();
+      if (resolved == null) {
+        markTestSkipped(
+          'No local GGUF found in models/ for cancel/dispose e2e',
+        );
+      }
+      modelPath = resolved ?? '';
+    });
+
+    Future<LlamaEngine> loadEngine() async {
+      final engine = LlamaEngine(LlamaBackend());
+      await engine.loadModel(
+        modelPath,
+        modelParams: const ModelParams(
+          contextSize: 512,
+          gpuLayers: 0,
+          numberOfThreads: 2,
+          numberOfThreadsBatch: 2,
+        ),
+      );
+      return engine;
+    }
+
+    test('cancel mid-stream then regenerate does not crash', () async {
+      if (modelPath.isEmpty) {
+        return;
+      }
+      final engine = await loadEngine();
+      try {
+        // Start a generation and cancel it after the first emitted chunk. The
+        // cancel token must survive until the worker stops reading it; a UAF or
+        // double free would crash the VM here.
+        final stream = engine.create([
+          LlamaChatMessage.fromText(
+            role: LlamaChatRole.user,
+            text: 'Write a long story about a robot.',
+          ),
+        ], params: const GenerationParams(maxTokens: 256));
+
+        var received = 0;
+        final sub = stream.listen((_) => received += 1);
+        await Future<void>.delayed(const Duration(milliseconds: 300));
+        engine.cancelGeneration();
+        await sub.cancel();
+
+        // A second generation on the same engine must still succeed.
+        final buffer = StringBuffer();
+        await for (final chunk in engine.create([
+          LlamaChatMessage.fromText(
+            role: LlamaChatRole.user,
+            text: 'Say hello.',
+          ),
+        ], params: const GenerationParams(maxTokens: 16))) {
+          if (chunk.choices.isNotEmpty) {
+            buffer.write(chunk.choices.first.delta.content ?? '');
+          }
+        }
+        expect(buffer.toString(), isNotEmpty);
+        expect(received, greaterThanOrEqualTo(0));
+      } finally {
+        await engine.dispose();
+      }
+    });
+
+    test('dispose while a generation is in flight completes cleanly', () async {
+      if (modelPath.isEmpty) {
+        return;
+      }
+      final engine = await loadEngine();
+      var disposed = false;
+      try {
+        final stream = engine.create([
+          LlamaChatMessage.fromText(
+            role: LlamaChatRole.user,
+            text: 'Write a very long story about the ocean.',
+          ),
+        ], params: const GenerationParams(maxTokens: 512));
+
+        final sub = stream.listen((_) {}, onError: (_) {});
+        await Future<void>.delayed(const Duration(milliseconds: 300));
+
+        // Dispose mid-generation. The worker must let the in-flight generation
+        // emit its terminal response (so the token is freed) before tearing the
+        // isolate down. This should complete promptly without hanging.
+        await engine.dispose().timeout(const Duration(seconds: 15));
+        disposed = true;
+        await sub.cancel();
+      } finally {
+        if (!disposed) {
+          await engine.dispose();
+        }
+      }
+      expect(disposed, isTrue);
+    });
+  });
+}

--- a/test/unit/backends/litert_lm/worker_test.dart
+++ b/test/unit/backends/litert_lm/worker_test.dart
@@ -556,6 +556,70 @@ void main() {
       }
     });
 
+    test(
+      'skips native dispose when an in-flight request has not settled',
+      () async {
+        final service = _DisposeTrackingBlockingService();
+        final worker = await _startWorkerInCurrentIsolate(
+          service,
+          disposeTimeout: const Duration(milliseconds: 50),
+        );
+
+        final generationPort = ReceivePort();
+        try {
+          worker.sendPort.send(
+            LiteRtLmGenerateRequest(
+              1,
+              'hello',
+              const GenerationParams(),
+              generationPort.sendPort,
+            ),
+          );
+          await service.generateStarted.future;
+
+          final disposePort = ReceivePort();
+          worker.sendPort.send(LiteRtLmDisposeRequest(disposePort.sendPort));
+          final ack = await disposePort.first.timeout(
+            const Duration(seconds: 2),
+          );
+          disposePort.close();
+
+          expect(ack, isA<LiteRtLmDoneResponse>());
+          // The blocking generation never settled, so the worker must not
+          // delete native handles out from under the in-flight native call.
+          expect(service.disposeCalled, isFalse);
+        } finally {
+          generationPort.close();
+        }
+      },
+    );
+
+    test(
+      'disposes native resources when the in-flight request settles',
+      () async {
+        final service = _DisposeTrackingStreamingService();
+        final worker = await _startWorkerInCurrentIsolate(service);
+
+        final responses = await _collectGenerationResponses(
+          worker.sendPort,
+          (sendPort) => LiteRtLmGenerateRequest(
+            1,
+            'hello',
+            const GenerationParams(),
+            sendPort,
+          ),
+        );
+        expect(responses.last, isA<LiteRtLmDoneResponse>());
+
+        final disposePort = ReceivePort();
+        worker.sendPort.send(LiteRtLmDisposeRequest(disposePort.sendPort));
+        await disposePort.first.timeout(const Duration(seconds: 2));
+        disposePort.close();
+
+        expect(service.disposeCalled, isTrue);
+      },
+    );
+
     test('routes performance and multimodal capability responses', () async {
       final service = _FeatureLiteRtLmService();
       final worker = await _startWorkerInCurrentIsolate(service);
@@ -643,13 +707,15 @@ Future<({Isolate isolate, SendPort sendPort})> _spawnWorker() async {
 }
 
 Future<({Isolate? isolate, SendPort sendPort})> _startWorkerInCurrentIsolate(
-  LiteRtLmService service,
-) async {
+  LiteRtLmService service, {
+  Duration disposeTimeout = const Duration(seconds: 5),
+}) async {
   final receivePort = ReceivePort();
   runLiteRtLmWorkerForTesting(
     receivePort.sendPort,
     service,
     exitOnDispose: false,
+    disposeTimeout: disposeTimeout,
   );
   final sendPort = await receivePort.first as SendPort;
   receivePort.close();
@@ -805,6 +871,54 @@ class _ThrowingGenerationLiteRtLmService extends LiteRtLmService {
     List<LlamaContentPart>? parts,
   }) async* {
     throw StateError('generation failed');
+  }
+}
+
+class _DisposeTrackingBlockingService extends LiteRtLmService {
+  final Completer<void> generateStarted = Completer<void>();
+  final Completer<void> _releaseGeneration = Completer<void>();
+  bool disposeCalled = false;
+
+  @override
+  Stream<List<int>> generate(
+    int contextHandle,
+    String prompt,
+    GenerationParams params, {
+    List<LlamaContentPart>? parts,
+  }) async* {
+    if (!generateStarted.isCompleted) {
+      generateStarted.complete();
+    }
+    // Block forever; cancellation does not release this in the test, so the
+    // worker's dispose wait must time out.
+    await _releaseGeneration.future;
+  }
+
+  @override
+  void cancelGeneration() {}
+
+  @override
+  void dispose() {
+    disposeCalled = true;
+  }
+}
+
+class _DisposeTrackingStreamingService extends LiteRtLmService {
+  bool disposeCalled = false;
+
+  @override
+  Stream<List<int>> generate(
+    int contextHandle,
+    String prompt,
+    GenerationParams params, {
+    List<LlamaContentPart>? parts,
+  }) async* {
+    yield const [1];
+  }
+
+  @override
+  void dispose() {
+    disposeCalled = true;
   }
 }
 

--- a/test/unit/backends/llama_cpp/llama_cpp_backend_test.dart
+++ b/test/unit/backends/llama_cpp/llama_cpp_backend_test.dart
@@ -140,6 +140,40 @@ void main() {
       },
     );
 
+    test(
+      'cancel defers token free until the terminal worker response',
+      () async {
+        final subscription = backend
+            .generate(1, 'pending', const GenerationParams())
+            .listen((_) {});
+        await Future<void>.delayed(Duration.zero);
+
+        final generateRequest = harness.received
+            .whereType<GenerateRequest>()
+            .last;
+
+        // Cancelling closes the Dart side but must NOT free the shared cancel
+        // token yet, because the worker may still be polling it.
+        await subscription.cancel();
+        expect(backend.cancelGenerationCalled, isTrue);
+
+        // The worker observes the cancel flag and emits its terminal response,
+        // which is when the token is finally freed. A double free here would
+        // crash the VM.
+        generateRequest.sendPort.send(DoneResponse());
+        await Future<void>.delayed(Duration.zero);
+
+        // The backend remains healthy: a subsequent generation still streams.
+        final chunks = await backend
+            .generate(1, 'ok', const GenerationParams())
+            .toList();
+        expect(chunks, <List<int>>[
+          <int>[65],
+          <int>[66],
+        ]);
+      },
+    );
+
     test('diagnostic and multimodal endpoints route correctly', () async {
       expect(await backend.getBackendName(), 'CPU');
       expect(await backend.getAvailableBackends(), 'CPU, METAL');


### PR DESCRIPTION
## Summary

Fixes a cluster of **cross-isolate use-after-free and resource-leak bugs** in the cancellation/disposal paths. Unifying principle: a terminal worker/native response is the only safe signal that the worker has stopped touching shared native resources (cancel token, conversation, `NativeCallable`), so native frees are deferred until that signal while the Dart-side controller is torn down eagerly.

### Fixes
- **llama.cpp cancel-token UAF** — the token was `malloc.free`'d in `onCancel` while the worker isolate still polled it. It is now freed only on the worker's terminal `DoneResponse`/`ErrorResponse`, or by `dispose()` after the worker isolate is killed. No timer backstop (a timer could fire mid-decode and reintroduce the UAF); worst case is a 1-byte leak if a worker wedges and is never disposed.
- **llama.cpp worker dispose** — awaits the in-flight generation's terminal response before `service.dispose()`/`Isolate.exit()`, so cancel/dispose mid-generation no longer abandons the consumer stream.
- **LiteRT-LM worker dispose** — skips the native engine/conversation delete when the in-flight request has not settled (timeout), avoiding deleting handles under a live native call. Dispose timeout is injectable for tests.
- **LiteRT-LM streaming runtime** — `onCancel` no longer leaks the `NativeCallable`/proxy/message buffer; `cleanup()` runs only from the terminal native callback (cancellation drives a terminal CANCELLED/error callback), never on a timer; controller writes are guarded against a closed stream.
- **LiteRT-LM backend** — captures the send port and re-guards `cleanedUp` synchronously before sending, so a cancel racing `_ensureIsolate()` never targets a closed response port.

## Validation
- `dart analyze` (lib + test): clean.
- VM unit tests: llama.cpp two-phase-free regression, LiteRT-LM dispose-gating — pass.
- Local-only real-native e2e (`test/e2e/backends/cancel_dispose_e2e_test.dart`): cancel→regenerate (no UAF/crash) and dispose-in-flight (clean, no hang) — pass.

Addresses the Copilot review feedback by removing the timer backstops that could fire before the worker/native side had actually stopped.
