### PR TITLE
Fix FFI leaks and correctness bugs (multimodal, truncation, grammar, downloads)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,24 @@
+## Unreleased
+
+* **Memory-safety and correctness fixes**:
+  * Freed the multimodal prompt buffer and input-text struct on tokenize/eval
+    error paths instead of leaking them on every failed multimodal prompt.
+  * Fixed `ChatSession` history truncation to trim only on user-message turn
+    boundaries (so a user prompt is never split from its reply), and to warn
+    when even the most recent turn exceeds the context budget instead of
+    silently sending an over-limit prompt.
+  * JSON-schema-to-GBNF conversion now resolves `$ref`s nested inside other
+    `$ref` targets, and fails loudly on unresolvable/external `$ref`s rather
+    than emitting invalid grammar that the sampler rejects.
+  * Serialized multimodal projector load/unload so concurrent calls cannot
+    leak or double-free the native multimodal context.
+  * Added connection and idle-read timeouts to model downloads so a stalled
+    server surfaces a retryable error instead of hanging indefinitely.
+  * Restricted partial-download resume to cases with a stored validator
+    (ETag/Last-Modified) and cleared stale resume metadata on checksum
+    mismatch, avoiding wasted full re-downloads onto stale bytes.
+  * Closed a leaked handshake reply port in the native backend.
+
 ## 0.7.0
 
 * **Native runtime configuration**:

--- a/lib/src/backends/llama_cpp/llama_cpp_backend.dart
+++ b/lib/src/backends/llama_cpp/llama_cpp_backend.dart
@@ -48,10 +48,11 @@ class NativeLlamaBackend
       _sendPort = message;
       // Complete handshake
       _sendPort!.send(WorkerHandshake(_currentLogLevel));
-      // Sync log level
-      _sendPort!.send(
-        LogLevelRequest(_currentLogLevel, ReceivePort().sendPort),
-      );
+      // Sync log level, closing the reply port once acked so it does not leak
+      // (mirrors _ensureIsolate).
+      final logRp = ReceivePort();
+      _sendPort!.send(LogLevelRequest(_currentLogLevel, logRp.sendPort));
+      logRp.first.then((_) => logRp.close());
     }
   }
 

--- a/lib/src/backends/llama_cpp/llama_cpp_service.dart
+++ b/lib/src/backends/llama_cpp/llama_cpp_service.dart
@@ -3271,6 +3271,8 @@ class LlamaCppService {
     int initialTokens = 0;
     final bitmaps = malloc<Pointer<mtmd_bitmap>>(mediaParts.length);
     final chunks = _mtmdInputChunksInit();
+    Pointer<mtmd_input_text> inputText = nullptr;
+    Pointer<Utf8> promptPtr = nullptr;
 
     try {
       for (int i = 0; i < mediaParts.length; i++) {
@@ -3321,12 +3323,12 @@ class LlamaCppService {
         }
       }
 
-      final inputText = malloc<mtmd_input_text>();
+      inputText = malloc<mtmd_input_text>();
       final normalizedPrompt = _normalizeMtmdPromptMarkers(
         prompt,
         mediaParts.length,
       );
-      final promptPtr = normalizedPrompt.toNativeUtf8();
+      promptPtr = normalizedPrompt.toNativeUtf8();
       inputText.ref.text = promptPtr.cast();
 
       final bos = llama_vocab_bos(vocab);
@@ -3372,10 +3374,11 @@ class LlamaCppService {
       } else {
         throw Exception("mtmd_tokenize failed: $res");
       }
-
-      malloc.free(promptPtr);
-      malloc.free(inputText);
     } finally {
+      // Free in finally so a tokenize/eval failure above does not leak the
+      // prompt buffer or the input-text struct.
+      if (promptPtr != nullptr) malloc.free(promptPtr);
+      if (inputText != nullptr) malloc.free(inputText);
       for (int i = 0; i < mediaParts.length; i++) {
         if (bitmaps[i] != nullptr) _mtmdBitmapFree(bitmaps[i]);
       }

--- a/lib/src/core/engine/chat_session.dart
+++ b/lib/src/core/engine/chat_session.dart
@@ -2,6 +2,7 @@ import 'dart:async';
 import 'dart:convert';
 import 'engine.dart';
 import '../exceptions.dart';
+import '../llama_logger.dart';
 import '../models/chat/chat_message.dart';
 import '../models/chat/completion_chunk.dart';
 import '../models/chat/chat_role.dart';
@@ -241,16 +242,29 @@ class ChatSession {
     if (_history.isEmpty) return;
 
     final turnOffsets = _buildTurnOffsets();
-    if (turnOffsets.length <= 1) return;
 
     final fullTokenCount = await _getTemplateTokenCount(
       _buildMessagesFromOffset(0),
     );
     if (fullTokenCount < targetLimit) return;
 
+    if (turnOffsets.length <= 1) {
+      // Nothing older to trim (e.g. a single oversized user turn). Warn rather
+      // than silently sending an over-limit prompt the backend may truncate or
+      // reject.
+      LlamaLogger.instance.warn(
+        'ChatSession: the latest turn ($fullTokenCount tokens) exceeds the '
+        'context budget ($targetLimit tokens) and there are no older turns to '
+        'trim. The prompt may be truncated or rejected by the backend; reduce '
+        'the message size or increase the context window.',
+      );
+      return;
+    }
+
     int low = 1;
     int high = turnOffsets.length - 1;
     int bestDropCount = high;
+    var foundFit = false;
 
     while (low <= high) {
       final mid = (low + high) >> 1;
@@ -260,6 +274,7 @@ class ChatSession {
 
       if (tokenCount < targetLimit) {
         bestDropCount = mid;
+        foundFit = true;
         high = mid - 1;
       } else {
         low = mid + 1;
@@ -269,6 +284,18 @@ class ChatSession {
     final removeUntil = turnOffsets[bestDropCount];
     if (removeUntil > 0) {
       _history.removeRange(0, removeUntil);
+    }
+
+    if (!foundFit) {
+      // Even retaining only the most recent turn exceeds the budget. Do not
+      // silently send an over-limit prompt: warn so the oversize prompt (which
+      // the backend may truncate or reject) is at least diagnosable.
+      LlamaLogger.instance.warn(
+        'ChatSession: conversation still exceeds the context budget '
+        '($targetLimit tokens) after trimming to the most recent turn. The '
+        'prompt may be truncated or rejected by the backend; reduce the '
+        'message size or increase the context window.',
+      );
     }
   }
 
@@ -322,17 +349,19 @@ class ChatSession {
     return messages;
   }
 
+  // Returns the indices at which conversational turns begin, so history can be
+  // trimmed only on clean turn boundaries. A turn starts at a user message and
+  // includes the assistant/tool messages that follow it until the next user
+  // message. Anchoring on user messages (rather than blindly consuming the
+  // first message of each iteration) keeps a user prompt grouped with its reply
+  // even when the history does not start with a user message.
   List<int> _buildTurnOffsets() {
     final offsets = <int>[0];
-    int index = 0;
 
-    while (index < _history.length) {
-      index += 1;
-      while (index < _history.length &&
-          _history[index].role == LlamaChatRole.assistant) {
-        index += 1;
+    for (int i = 1; i < _history.length; i++) {
+      if (_history[i].role == LlamaChatRole.user) {
+        offsets.add(i);
       }
-      offsets.add(index);
     }
 
     return offsets;

--- a/lib/src/core/engine/engine.dart
+++ b/lib/src/core/engine/engine.dart
@@ -78,6 +78,9 @@ class LlamaEngine {
   int? _modelHandle;
   int? _contextHandle;
   int? _mmContextHandle;
+  // Serializes multimodal projector load/unload so concurrent calls cannot
+  // race the native create/free (which could leak or double-free the context).
+  Future<void> _mmLifecycle = Future<void>.value();
   bool _isReady = false;
   String? _modelPath;
   Map<String, String>? _cachedModelMetadata;
@@ -290,14 +293,28 @@ class LlamaEngine {
     }
   }
 
+  // Runs [action] after any in-flight multimodal lifecycle operation, so
+  // create/free of the multimodal context never overlap.
+  Future<T> _withMmLifecycle<T>(Future<T> Function() action) {
+    final result = _mmLifecycle.then((_) => action());
+    // Advance the chain on a swallowed copy so one failed operation doesn't
+    // wedge subsequent ones; the real result/error still flows to the caller.
+    _mmLifecycle = result.then((_) {}, onError: (_) {});
+    return result;
+  }
+
   /// Loads a multimodal projector model for vision/audio support.
-  Future<void> loadMultimodalProjector(String mmProjPath) async {
+  Future<void> loadMultimodalProjector(String mmProjPath) {
+    return _withMmLifecycle(() => _loadMultimodalProjectorLocked(mmProjPath));
+  }
+
+  Future<void> _loadMultimodalProjectorLocked(String mmProjPath) async {
     final mmProjName = _displayNameForSource(mmProjPath);
     LlamaLogger.instance.info('Loading multimodal projector: $mmProjName');
     _ensureReady(requireContext: false);
     try {
       if (_mmContextHandle != null) {
-        await unloadMultimodalProjector();
+        await _unloadMultimodalProjectorLocked();
       }
 
       _mmContextHandle = await backend.multimodalContextCreate(
@@ -321,15 +338,24 @@ class LlamaEngine {
   }
 
   /// Unloads the active multimodal projector while keeping the model loaded.
-  Future<void> unloadMultimodalProjector() async {
+  Future<void> unloadMultimodalProjector() {
+    return _withMmLifecycle(_unloadMultimodalProjectorLocked);
+  }
+
+  Future<void> _unloadMultimodalProjectorLocked() async {
     final mmContextHandle = _mmContextHandle;
     if (mmContextHandle == null) {
       return;
     }
 
     LlamaLogger.instance.info('Unloading multimodal projector');
-    _mmContextHandle = null;
+    // Free the native context before clearing the handle so a concurrent
+    // reader never observes a null handle while teardown is still in flight.
+    // Serialization via _withMmLifecycle prevents a double free.
     await backend.multimodalContextFree(mmContextHandle);
+    if (_mmContextHandle == mmContextHandle) {
+      _mmContextHandle = null;
+    }
   }
 
   /// Releases all allocated resources.
@@ -346,10 +372,11 @@ class LlamaEngine {
       await backend.contextFree(_contextHandle!);
       _contextHandle = null;
     }
-    if (_mmContextHandle != null) {
-      await backend.multimodalContextFree(_mmContextHandle!);
-      _mmContextHandle = null;
-    }
+    // Always queue the projector unload (even when no handle is set yet): a
+    // projector load may be in flight and not have assigned _mmContextHandle.
+    // Routing through the serialized lifecycle makes this wait behind that load
+    // and free the projector before the model handle is released.
+    await unloadMultimodalProjector();
     if (_modelHandle != null) {
       await backend.modelFree(_modelHandle!);
       _modelHandle = null;

--- a/lib/src/core/grammar/json_schema_converter.dart
+++ b/lib/src/core/grammar/json_schema_converter.dart
@@ -148,24 +148,25 @@ class JsonSchemaConverter {
       }
     } else if (node is Map<String, dynamic>) {
       final ref = node[r'$ref'] as String?;
-      if (ref != null && !_refs.containsKey(ref)) {
-        if (ref.startsWith('#/')) {
-          // Local ref
-          dynamic target = rootSchema;
-          final selectors = ref.substring(2).split('/');
-          for (final sel in selectors) {
-            if (target is Map<String, dynamic> && target.containsKey(sel)) {
-              target = target[sel];
-            } else {
-              throw StateError('Error resolving ref $ref: $sel not found');
-            }
+      if (ref != null && !_refs.containsKey(ref) && ref.startsWith('#/')) {
+        // Local ref
+        dynamic target = rootSchema;
+        final selectors = ref.substring(2).split('/');
+        for (final sel in selectors) {
+          if (target is Map<String, dynamic> && target.containsKey(sel)) {
+            target = target[sel];
+          } else {
+            throw StateError('Error resolving ref $ref: $sel not found');
           }
-          _refs[ref] = target;
         }
-      } else {
-        for (final value in node.values) {
-          resolveRefs(value, rootSchema);
-        }
+        _refs[ref] = target;
+        // Resolve refs nested inside the target as well.
+        resolveRefs(target, rootSchema);
+      }
+      // Always walk children so refs nested as siblings of a $ref (or inside an
+      // already-registered ref-bearing node) are resolved too.
+      for (final value in node.values) {
+        resolveRefs(value, rootSchema);
       }
     }
   }
@@ -174,6 +175,18 @@ class JsonSchemaConverter {
     var refFragment = ref.split('#').last;
     var refName =
         'ref${refFragment.replaceAll(RegExp(r'[^a-zA-Z0-9-]+'), '-')}';
+    // Fail loudly for unresolvable refs based on the ref itself, not the
+    // generated rule name. `resolveRefs` registers every local "#/..." ref in
+    // _refs up front, so a ref that is absent there (and not mid-resolution for
+    // cycles) is external/unresolvable. Checking the ref rather than the
+    // rule-name cache keeps this order-independent even when an external ref
+    // would collide with an already-emitted local rule name.
+    if (!_refs.containsKey(ref) && !_refsBeingResolved.contains(ref)) {
+      throw StateError(
+        'Cannot resolve \$ref "$ref": only local "#/..." references within '
+        'the same schema are supported.',
+      );
+    }
     if (!_rules.containsKey(refName) && !_refsBeingResolved.contains(ref)) {
       _refsBeingResolved.add(ref);
       final resolved = _refs[ref];

--- a/lib/src/platform/io/model_download_manager_io.dart
+++ b/lib/src/platform/io/model_download_manager_io.dart
@@ -603,11 +603,18 @@ class DefaultModelDownloadManager implements ModelDownloadManager {
         ? null
         : await _readPartMetadata(partMetadataFile);
     var existingBytes = 0;
+    // Only resume when we have a stored validator (ETag/Last-Modified) to send
+    // as If-Range. Resuming on sha256 alone risks appending a fresh tail onto
+    // stale leading bytes if the remote changed, wasting a full re-download
+    // before the checksum catches it.
+    final hasResumeValidator =
+        partMetadata != null &&
+        (partMetadata.etag != null || partMetadata.lastModified != null);
     final canResumePartial =
         partFile != null &&
         options.resume &&
         await partFile.exists() &&
-        (partMetadata != null || options.sha256 != null);
+        hasResumeValidator;
     if (canResumePartial) {
       existingBytes = await partFile.length();
     } else {
@@ -618,6 +625,7 @@ class DefaultModelDownloadManager implements ModelDownloadManager {
     }
 
     final client = HttpClient();
+    client.connectionTimeout = const Duration(seconds: 30);
     try {
       var requestUri = uri;
       late HttpClientResponse response;
@@ -645,7 +653,15 @@ class DefaultModelDownloadManager implements ModelDownloadManager {
           }
         }
 
-        response = await request.close();
+        // Bound the wait for response headers too: a server can accept the
+        // connection (passing connectionTimeout) yet never send headers, which
+        // would hang before the body idle-read timeout is even installed.
+        response = await request.close().timeout(
+          const Duration(seconds: 60),
+          onTimeout: () => throw const HttpException(
+            'Timed out waiting for download response headers.',
+          ),
+        );
         if (!_isRedirectStatus(response.statusCode)) {
           break;
         }
@@ -725,8 +741,21 @@ class DefaultModelDownloadManager implements ModelDownloadManager {
       );
       var receivedBytes = existingBytes;
       final totalBytes = _totalBytes(response, existingBytes);
+      // Guard against a server that accepts the connection then stalls: an idle
+      // read timeout surfaces as an IOException so the retry loop can react,
+      // instead of hanging indefinitely (cooperative cancel only fires when a
+      // chunk arrives).
+      final body = response.timeout(
+        const Duration(seconds: 60),
+        onTimeout: (sink) {
+          sink.addError(
+            const HttpException('Timed out waiting for download data.'),
+          );
+          sink.close();
+        },
+      );
       try {
-        await for (final chunk in response) {
+        await for (final chunk in body) {
           _throwIfCancelled(options);
           sink.add(chunk);
           receivedBytes += chunk.length;
@@ -747,6 +776,11 @@ class DefaultModelDownloadManager implements ModelDownloadManager {
         final actual = await _sha256File(downloadFile);
         if (actual != options.sha256) {
           await _deleteIfExists(downloadFile);
+          // Drop the stale validator too, so the next attempt restarts cleanly
+          // instead of resuming onto bytes we just rejected.
+          if (partMetadataFile != null) {
+            await _deleteIfExists(partMetadataFile);
+          }
           throw LlamaModelException(
             'Checksum mismatch for ${source.displayName}.',
           );

--- a/test/unit/core/engine/chat_session_test.dart
+++ b/test/unit/core/engine/chat_session_test.dart
@@ -165,6 +165,73 @@ void main() {
       expect(session.history.length, lessThan(40));
     });
 
+    test(
+      'truncation keeps turn boundaries when history starts with assistant',
+      () async {
+        backend.contextSize = 400;
+        session.maxContextTokens = 400;
+
+        // Pre-seed a leading assistant message (history does not start with a
+        // user turn). The old segmentation could strand this assistant or split
+        // a user/assistant pair; boundaries anchored at user messages must trim
+        // only on clean turn starts.
+        session.addMessage(
+          LlamaChatMessage.fromText(
+            role: LlamaChatRole.assistant,
+            text: 'seed ${List.filled(40, 'z').join()}',
+          ),
+        );
+        for (int i = 0; i < 20; i++) {
+          session.addMessage(
+            LlamaChatMessage.fromText(
+              role: LlamaChatRole.user,
+              text: 'U$i ${List.filled(40, 'x').join()}',
+            ),
+          );
+          session.addMessage(
+            LlamaChatMessage.fromText(
+              role: LlamaChatRole.assistant,
+              text: 'A$i ${List.filled(40, 'y').join()}',
+            ),
+          );
+        }
+
+        backend.queueResponse('ok');
+        await session.create(const []).drain();
+
+        // Trimming must have occurred, and the retained history must begin at a
+        // user turn boundary (never an orphaned assistant reply).
+        expect(session.history.length, lessThan(41));
+        expect(session.history.first.role, LlamaChatRole.user);
+      },
+    );
+
+    test('warns when a single oversized turn cannot be trimmed', () async {
+      final warnings = <String>[];
+      LlamaEngine.configureLogging(
+        level: LlamaLogLevel.warn,
+        handler: (record) {
+          if (record.level == LlamaLogLevel.warn) {
+            warnings.add(record.message);
+          }
+        },
+      );
+      try {
+        // Budget below the single turn's rendered token count, with no older
+        // turns to trim, must warn instead of silently sending it.
+        session.maxContextTokens = 140;
+        backend.queueResponse('ok');
+        await session.create([const LlamaTextContent('hello')]).drain();
+
+        expect(
+          warnings.any((w) => w.contains('no older turns to trim')),
+          isTrue,
+        );
+      } finally {
+        LlamaEngine.configureLogging(level: LlamaLogLevel.none);
+      }
+    });
+
     test('enforceContextLimit trims with bounded template passes', () async {
       backend.contextSize = 420;
       session.maxContextTokens = 420;

--- a/test/unit/core/grammar/json_schema_converter_test.dart
+++ b/test/unit/core/grammar/json_schema_converter_test.dart
@@ -184,6 +184,59 @@ void main() {
       expect(grammar, contains(r'\"city\"'));
     });
 
+    test(r'resolves a $ref nested inside another $ref target', () {
+      // Node has a $ref AND the target itself contains a nested $ref. The
+      // nested ref must be resolved (no dangling rule / invalid GBNF).
+      final grammar = JsonSchemaConverter.convert({
+        'type': 'object',
+        'properties': {
+          'person': {r'$ref': '#/definitions/Person'},
+        },
+        'required': ['person'],
+        'definitions': {
+          'Person': {
+            'type': 'object',
+            'properties': {
+              'home': {r'$ref': '#/definitions/Address'},
+            },
+            'required': ['home'],
+          },
+          'Address': {
+            'type': 'object',
+            'properties': {
+              'city': {'type': 'string'},
+            },
+            'required': ['city'],
+          },
+        },
+      });
+      expect(grammar, contains('root ::='));
+      expect(grammar, contains(r'\"home\"'));
+      expect(grammar, contains(r'\"city\"'));
+      // No rule may reference an undefined rule (dangling ref). Every "ref..."
+      // token used on a right-hand side must have its own definition.
+      final defined = RegExp(
+        r'^([A-Za-z0-9-]+) ::=',
+        multiLine: true,
+      ).allMatches(grammar).map((m) => m.group(1)).toSet();
+      final referenced = RegExp(
+        r'\bref[A-Za-z0-9-]+\b',
+      ).allMatches(grammar).map((m) => m.group(0)!).toSet();
+      expect(referenced.difference(defined), isEmpty);
+    });
+
+    test(r'throws on an unresolvable external $ref', () {
+      expect(
+        () => JsonSchemaConverter.convert({
+          'type': 'object',
+          'properties': {
+            'x': {r'$ref': 'https://example.com/schema.json#/X'},
+          },
+        }),
+        throwsA(isA<StateError>()),
+      );
+    });
+
     test('converts array type union', () {
       final grammar = JsonSchemaConverter.convert({
         'type': ['string', 'null'],


### PR DESCRIPTION
## Summary

Medium-severity FFI memory leaks and correctness bugs from the code review.

### Fixes
- **Multimodal prompt leak** — `promptPtr`/`inputText` are freed in `finally`, so a failed `mtmd` tokenize/eval no longer leaks native memory each attempt.
- **Chat-session truncation** — turn boundaries anchored at user messages so trimming never splits a user prompt from its reply; warns instead of silently sending an over-limit prompt when even the most recent turn exceeds the budget.
- **Grammar `$ref` resolution** — resolves `$ref`s nested inside other `$ref` targets and recurses into siblings; throws on unresolvable/external `$ref`s instead of emitting GBNF referencing an undefined rule.
- **Multimodal projector lifecycle** — load/unload serialized through a lifecycle lock with free-before-null ordering, preventing leak/double-free.
- **Download robustness** — HTTP connection + idle-read timeouts (retryable); partial-download resume restricted to cases with a stored validator; stale resume metadata cleared on checksum mismatch.
- **Native backend** — closes the leaked handshake log-level reply port.

## Validation
- `dart analyze` (lib + test): clean.
- Full VM unit suite (`--exclude-tags local-only`): 877 pass / 1 skip.
- New regression tests: nested `$ref` → valid GBNF + unresolvable `$ref` throws; assistant-leading history trims on a user boundary.
