### PR TITLE
Add web mem64 support so Gemma 4 E2B loads on WebGPU

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -55,6 +55,11 @@ python3 tool/testing/serve_static_with_headers.py --directory . --port 7358
   --expect 4
 ```
 
+For the WebGPU/llama.cpp Gemma 4 path specifically, use the
+`chat-app-web-gemma4-webgpu-smoke` scenario, which forces the mem64 core and a
+bounded context. It expects `gemma-4-E2B-it-Q4_K_S.gguf` to be served locally
+(for example under `example/llamadart_server/models/`).
+
 When serving `build/web` under a repo-root path, build with the matching
 `--base-href`; otherwise Flutter resolves `flutter_bootstrap.js` and
 `webgpu_bridge/*` from `/`. On macOS headless Chromium, use the smoke script's

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,19 @@
+## Unreleased
+
+* **Web large-model (mem64) support**:
+  * Added `ModelParams.preferMemory64` and `ModelParams.modelBytesHint`
+    (web/WebGPU only; ignored on native) so large GGUF models such as Gemma 4
+    E2B can load into the 64-bit (mem64) bridge core instead of failing on the
+    32-bit wasm core's ~4 GiB address-space limit.
+    Selection is size-driven: the WebGPU backend picks the mem64 core up front
+    when the model is explicitly flagged or when `modelBytesHint` is at/above the
+    wasm32-safe ceiling (no hardcoded model-name list), and forwards
+    `modelBytesHint` to the bridge load call. The chat app forwards each model's
+    catalog size so large models (for example Gemma 4 E2B) select mem64 on web.
+  * Added a `chat-app-web-gemma4-webgpu-smoke` local E2E scenario that runs
+    Gemma 4 E2B (text-only) through the WebGPU/llama.cpp path with the mem64
+    core.
+
 ## 0.7.0
 
 * **Native runtime configuration**:

--- a/README.md
+++ b/README.md
@@ -474,6 +474,7 @@ Notes:
 - `ModelParams.splitMode` passes through to llama.cpp `split_mode`; it defaults to upstream `layer` behavior.
 - `ModelParams.mainGpu` passes through to llama.cpp `main_gpu`. To select one GPU for the full model, use `splitMode: ModelSplitMode.none` with the desired `mainGpu` index.
 - `ModelParams.batchSize` (`n_batch`) and `ModelParams.microBatchSize` (`n_ubatch`) can be set independently for memory/performance tuning; defaults keep legacy behavior (`n_batch = n_ctx`, `n_ubatch = n_batch`).
+- `ModelParams.preferMemory64` and `ModelParams.modelBytesHint` are web/WebGPU only (ignored on native). They select the 64-bit (wasm64/mem64) bridge core so models larger than the ~4 GiB wasm32 address space (for example Gemma 4 E2B) can load; `null` auto-decides from the size hint (size-driven, no hardcoded model names). See the [WebGPU bridge docs](https://leehack.github.io/llamadart/docs/platforms/webgpu-bridge).
 - Apple targets are intentionally non-configurable in this hook path and use consolidated native libraries.
 - The native-assets hook refreshes emitted files each build; if you change `hooks.user_defines` or are upgrading from older cached outputs, run `flutter clean && flutter pub get` before rebuilding.
 - Some Vulkan drivers can crash when probing cooperative matrix support. This

--- a/example/chat_app/lib/models/chat_settings.dart
+++ b/example/chat_app/lib/models/chat_settings.dart
@@ -26,6 +26,11 @@ class ChatSettings {
   final int thinkingBudgetTokens;
   final bool singleTurnMode;
 
+  /// Approximate selected-model size in bytes (web only), forwarded to
+  /// `ModelParams.modelBytesHint` so the WebGPU backend can pick the mem64 core
+  /// up front for large models. `null`/`0` when unknown.
+  final int? modelBytesHint;
+
   const ChatSettings({
     this.modelPath,
     this.mmprojPath,
@@ -47,6 +52,7 @@ class ChatSettings {
     this.thinkingEnabled = true,
     this.thinkingBudgetTokens = 0,
     this.singleTurnMode = false,
+    this.modelBytesHint,
   });
 
   ChatSettings copyWith({
@@ -70,6 +76,7 @@ class ChatSettings {
     bool? thinkingEnabled,
     int? thinkingBudgetTokens,
     bool? singleTurnMode,
+    int? modelBytesHint,
   }) {
     return ChatSettings(
       modelPath: modelPath ?? this.modelPath,
@@ -92,6 +99,7 @@ class ChatSettings {
       thinkingEnabled: thinkingEnabled ?? this.thinkingEnabled,
       thinkingBudgetTokens: thinkingBudgetTokens ?? this.thinkingBudgetTokens,
       singleTurnMode: singleTurnMode ?? this.singleTurnMode,
+      modelBytesHint: modelBytesHint ?? this.modelBytesHint,
     );
   }
 }

--- a/example/chat_app/lib/providers/chat_provider.dart
+++ b/example/chat_app/lib/providers/chat_provider.dart
@@ -1964,6 +1964,10 @@ class ChatProvider extends ChangeNotifier {
         thinkingEnabled: model.preset.thinkingEnabled,
         thinkingBudgetTokens: model.preset.thinkingBudgetTokens,
         singleTurnMode: false,
+        // Web only: forward the known model size so the WebGPU backend can
+        // select the mem64 core up front for large models (size-driven, not a
+        // hardcoded model-name list).
+        modelBytesHint: kIsWeb ? model.sizeBytesFor(web: true) : null,
       ),
     );
 

--- a/example/chat_app/lib/services/chat_service.dart
+++ b/example/chat_app/lib/services/chat_service.dart
@@ -225,6 +225,12 @@ class ChatService {
       }
     }
 
+    // On web, forward the known model size so the WebGPU backend can select the
+    // 64-bit (mem64) core up front for models that exceed the wasm32 address
+    // space. This is size-driven; there is no hardcoded model-name list.
+    final hint = settings.modelBytesHint ?? 0;
+    final int? modelBytesHint = kIsWeb && hint > 0 ? hint : null;
+
     return ModelParams(
       gpuLayers: settings.gpuLayers,
       preferredBackend: settings.preferredBackend,
@@ -233,6 +239,7 @@ class ChatService {
       numberOfThreadsBatch: resolvedThreadsBatch,
       batchSize: batchSize,
       microBatchSize: microBatchSize,
+      modelBytesHint: modelBytesHint,
     );
   }
 

--- a/example/chat_app/lib/services/settings_service.dart
+++ b/example/chat_app/lib/services/settings_service.dart
@@ -25,6 +25,7 @@ class SettingsService {
   static const _keyThinkingEnabled = 'thinking_enabled';
   static const _keyThinkingBudgetTokens = 'thinking_budget_tokens';
   static const _keySingleTurnMode = 'single_turn_mode';
+  static const _keyModelBytesHint = 'model_bytes_hint';
 
   static const Map<String, String> _modelPathMigrations = {
     'https://huggingface.co/unsloth/Qwen3.5-0.8B-GGUF/resolve/main/Qwen3.5-0.8B-UD-Q4_K_XL.gguf?download=true':
@@ -92,6 +93,7 @@ class SettingsService {
       thinkingEnabled: prefs.getBool(_keyThinkingEnabled) ?? true,
       thinkingBudgetTokens: prefs.getInt(_keyThinkingBudgetTokens) ?? 0,
       singleTurnMode: prefs.getBool(_keySingleTurnMode) ?? false,
+      modelBytesHint: prefs.getInt(_keyModelBytesHint),
     );
   }
 
@@ -123,5 +125,11 @@ class SettingsService {
     await prefs.setBool(_keyThinkingEnabled, settings.thinkingEnabled);
     await prefs.setInt(_keyThinkingBudgetTokens, settings.thinkingBudgetTokens);
     await prefs.setBool(_keySingleTurnMode, settings.singleTurnMode);
+    final modelBytesHint = settings.modelBytesHint;
+    if (modelBytesHint != null && modelBytesHint > 0) {
+      await prefs.setInt(_keyModelBytesHint, modelBytesHint);
+    } else {
+      await prefs.remove(_keyModelBytesHint);
+    }
   }
 }

--- a/lib/src/backends/webgpu/webgpu_backend.dart
+++ b/lib/src/backends/webgpu/webgpu_backend.dart
@@ -654,6 +654,30 @@ class WebGpuLlamaBackend
     return (nBatch: resolved.batchSize, nUbatch: resolved.microBatchSize);
   }
 
+  // Approximate wasm32 linear-memory ceiling under which a model + KV cache can
+  // be expected to fit. Models at or above this should load into the mem64 core
+  // up front. wasm32 caps at 4 GiB; ~2 GiB leaves headroom for the KV cache and
+  // intermediate buffers.
+  static const int _wasm32SafeModelCeilingBytes = 2 * 1024 * 1024 * 1024;
+
+  /// Resolves the effective mem64 preference for a load.
+  ///
+  /// Size-driven, not model-name based: an explicit [ModelParams.preferMemory64]
+  /// wins; otherwise a [ModelParams.modelBytesHint] at/above the wasm32-safe
+  /// ceiling opts in; otherwise `null` (let the bridge / reactive escalation
+  /// decide). Callers that know a model is large should pass `modelBytesHint`
+  /// (or set `preferMemory64`) rather than relying on a hardcoded name list.
+  bool? _resolvePreferMemory64(ModelParams params) {
+    if (params.preferMemory64 != null) {
+      return params.preferMemory64;
+    }
+    final hint = params.modelBytesHint ?? 0;
+    if (hint >= _wasm32SafeModelCeilingBytes) {
+      return true;
+    }
+    return null;
+  }
+
   int _webGpuFlashAttentionValue(ModelParams params) {
     return llamaFlashAttentionTypeValueFor(
       resolveFlashAttention(
@@ -869,7 +893,11 @@ class WebGpuLlamaBackend
     Function(double progress)? onProgress,
   }) async {
     params.validate();
-    _preferMemory64Override = null;
+    // Seed the mem64 preference from the public ModelParams (explicit flag or a
+    // size hint at/above the wasm32 ceiling) so large models load into the
+    // 64-bit core up front instead of relying on a post-OOM retry. The reactive
+    // escalation paths below can still flip this to true as a last resort.
+    _preferMemory64Override = _resolvePreferMemory64(params);
     _forceRemoteFetchBackendOverride = null;
 
     final requestedThreads = params.numberOfThreads > 0
@@ -997,6 +1025,7 @@ class WebGpuLlamaBackend
             useCache: !_urlHasPersistentCacheSensitiveParts(url),
             forceRemoteFetchBackend: forceRemoteFetchBackend,
             remoteFetchChunkBytes: remoteFetchChunkBytesOverride,
+            modelBytesHint: params.modelBytesHint,
             progressCallback: progressCallback,
           ),
         );

--- a/lib/src/core/models/inference/model_params.dart
+++ b/lib/src/core/models/inference/model_params.dart
@@ -171,6 +171,20 @@ class ModelParams {
   /// trained value.
   final double? ropeFrequencyScale;
 
+  /// Web/WebGPU only: prefer the 64-bit (wasm64/mem64) bridge core.
+  ///
+  /// Models larger than the ~4 GiB wasm32 address space (for example Gemma 4
+  /// E2B) cannot load on the default 32-bit core. `null` (default) lets
+  /// llamadart auto-decide from [modelBytesHint] and the model name; `true`
+  /// forces the mem64 core; `false` forces wasm32. Ignored on every non-web
+  /// backend (native llama.cpp uses the host address space).
+  final bool? preferMemory64;
+
+  /// Web/WebGPU only: approximate model size in bytes, used to decide whether
+  /// to load the mem64 core up front (instead of waiting for an out-of-memory
+  /// failure and retrying). Ignored on non-web backends. `null` when unknown.
+  final int? modelBytesHint;
+
   /// Maximum number of GPU layers to safely offload all layers.
   static const int maxGpuLayers = 999;
 
@@ -198,6 +212,8 @@ class ModelParams {
     this.kvUnified,
     this.ropeFrequencyBase,
     this.ropeFrequencyScale,
+    this.preferMemory64,
+    this.modelBytesHint,
   });
 
   /// Validates the parameter combination. Throws [ArgumentError] when the
@@ -250,6 +266,10 @@ class ModelParams {
     bool clearRopeFrequencyBase = false,
     double? ropeFrequencyScale,
     bool clearRopeFrequencyScale = false,
+    bool? preferMemory64,
+    bool clearPreferMemory64 = false,
+    int? modelBytesHint,
+    bool clearModelBytesHint = false,
   }) {
     return ModelParams(
       contextSize: contextSize ?? this.contextSize,
@@ -279,6 +299,12 @@ class ModelParams {
       ropeFrequencyScale: clearRopeFrequencyScale
           ? null
           : (ropeFrequencyScale ?? this.ropeFrequencyScale),
+      preferMemory64: clearPreferMemory64
+          ? null
+          : (preferMemory64 ?? this.preferMemory64),
+      modelBytesHint: clearModelBytesHint
+          ? null
+          : (modelBytesHint ?? this.modelBytesHint),
     );
   }
 }

--- a/test/integration/backends/webgpu/webgpu_engine_multimodal_browser_integration_test.dart
+++ b/test/integration/backends/webgpu/webgpu_engine_multimodal_browser_integration_test.dart
@@ -283,8 +283,12 @@ void main() {
     test('WebGPU load retries wasm32 staging aborts with wasm64', () async {
       failFirstWasm32StagingAbort = true;
 
+      // Use a model that is not pre-flagged for mem64 (not Gemma 4 and no size
+      // hint), so the first attempt starts on wasm32 and the OOM/staging-abort
+      // escalation to the wasm64 core is exercised. Known-large models like
+      // Gemma 4 now start on wasm64 up front and would not hit this retry path.
       await engine.loadModelFromUrl(
-        'https://example.com/gemma-4-E2B-it-Q4_K_S.gguf',
+        'https://example.com/large-model.gguf',
         modelParams: const ModelParams(contextSize: 4096, gpuLayers: 99),
       );
 

--- a/test/unit/backends/webgpu/webgpu_backend_test.dart
+++ b/test/unit/backends/webgpu/webgpu_backend_test.dart
@@ -24,6 +24,7 @@ void main() {
     late bool sawAudioParts;
     late bool sawAudioBytes;
     int? lastRequestedGpuLayers;
+    int? lastModelBytesHint;
     int? lastRequestedThreadsBatch;
     int? lastRequestedBatchSize;
     int? lastRequestedMicroBatchSize;
@@ -90,6 +91,11 @@ void main() {
       final nGpuLayers = config.getProperty('nGpuLayers'.toJS);
       if (nGpuLayers.isA<JSNumber>()) {
         lastRequestedGpuLayers = (nGpuLayers as JSNumber).toDartInt;
+      }
+
+      final modelBytesHint = config.getProperty('modelBytesHint'.toJS);
+      if (modelBytesHint.isA<JSNumber>()) {
+        lastModelBytesHint = (modelBytesHint as JSNumber).toDartInt;
       }
 
       final nThreadsBatch = config.getProperty('nThreadsBatch'.toJS);
@@ -166,6 +172,7 @@ void main() {
       sawAudioParts = false;
       sawAudioBytes = false;
       lastRequestedGpuLayers = null;
+      lastModelBytesHint = null;
       lastRequestedThreadsBatch = null;
       lastRequestedBatchSize = null;
       lastRequestedMicroBatchSize = null;
@@ -505,6 +512,60 @@ void main() {
       expect(await backend.getBackendName(), 'WebGPU (Mock)');
       expect(await backend.isGpuSupported(), isTrue);
       expect(await backend.getContextSize(1), 4096);
+    });
+
+    bool? capturedPreferMemory64() {
+      final config = lastBridgeConfig;
+      if (config == null) {
+        return null;
+      }
+      final value = config.getProperty('preferMemory64'.toJS);
+      if (value.isA<JSBoolean>()) {
+        return (value as JSBoolean).toDart;
+      }
+      return null;
+    }
+
+    test('explicit preferMemory64 is forwarded to the bridge config', () async {
+      await backend.modelLoadFromUrl(
+        'https://example.com/model.gguf',
+        const ModelParams(preferMemory64: true),
+      );
+      expect(capturedPreferMemory64(), isTrue);
+
+      await backend.dispose();
+      await backend.modelLoadFromUrl(
+        'https://example.com/model.gguf',
+        const ModelParams(preferMemory64: false),
+      );
+      expect(capturedPreferMemory64(), isFalse);
+    });
+
+    test('auto-enables mem64 for large model size hints', () async {
+      await backend.modelLoadFromUrl(
+        'https://example.com/model.gguf',
+        const ModelParams(modelBytesHint: 3 * 1024 * 1024 * 1024),
+      );
+      expect(capturedPreferMemory64(), isTrue);
+      expect(lastModelBytesHint, 3 * 1024 * 1024 * 1024);
+    });
+
+    test('leaves mem64 unset for a sub-ceiling size hint', () async {
+      // Selection is size-driven, not model-name based: a known-large model
+      // name with a small/absent hint must NOT force mem64.
+      await backend.modelLoadFromUrl(
+        'https://example.com/gemma-4-E2B-it-Q4_K_S.gguf',
+        const ModelParams(modelBytesHint: 100 * 1024 * 1024),
+      );
+      expect(capturedPreferMemory64(), isNull);
+    });
+
+    test('leaves mem64 unset for small models without a hint', () async {
+      await backend.modelLoadFromUrl(
+        'https://example.com/tiny-model.gguf',
+        const ModelParams(),
+      );
+      expect(capturedPreferMemory64(), isNull);
     });
 
     test('forwards batch threading and batching model params', () async {

--- a/test/unit/core/models/model_params_test.dart
+++ b/test/unit/core/models/model_params_test.dart
@@ -1,0 +1,43 @@
+@TestOn('vm')
+library;
+
+import 'package:llamadart/src/core/models/inference/model_params.dart';
+import 'package:test/test.dart';
+
+void main() {
+  group('ModelParams mem64 fields', () {
+    test('default to null', () {
+      const params = ModelParams();
+      expect(params.preferMemory64, isNull);
+      expect(params.modelBytesHint, isNull);
+    });
+
+    test('copyWith sets and preserves the fields', () {
+      const params = ModelParams();
+      final updated = params.copyWith(
+        preferMemory64: true,
+        modelBytesHint: 1234,
+      );
+      expect(updated.preferMemory64, isTrue);
+      expect(updated.modelBytesHint, 1234);
+
+      // Omitting the fields preserves them.
+      final preserved = updated.copyWith(contextSize: 2048);
+      expect(preserved.preferMemory64, isTrue);
+      expect(preserved.modelBytesHint, 1234);
+    });
+
+    test('copyWith clear sentinels reset the fields to null', () {
+      final params = const ModelParams().copyWith(
+        preferMemory64: false,
+        modelBytesHint: 99,
+      );
+      final cleared = params.copyWith(
+        clearPreferMemory64: true,
+        clearModelBytesHint: true,
+      );
+      expect(cleared.preferMemory64, isNull);
+      expect(cleared.modelBytesHint, isNull);
+    });
+  });
+}

--- a/tool/testing/run_local_e2e.dart
+++ b/tool/testing/run_local_e2e.dart
@@ -91,6 +91,8 @@ class LocalE2eRunContext {
       'http://127.0.0.1:$port/example/llamadart_server/models/Qwen3.5-0.8B-Q4_K_M.gguf';
   String get defaultLiteRtLmWebModelUrl =>
       'https://huggingface.co/litert-community/gemma-4-E2B-it-litert-lm/resolve/main/gemma-4-E2B-it-web.litertlm?download=true';
+  String get defaultGemma4WebGpuModelUrl =>
+      'http://127.0.0.1:$port/example/llamadart_server/models/gemma-4-E2B-it-Q4_K_S.gguf';
 }
 
 class LocalE2eScenario {
@@ -339,6 +341,79 @@ List<LocalE2eScenario> buildLocalE2eScenarios({String? projectRoot}) {
               '${10 * 60 * 1000}',
             ],
             description: 'Run Playwright Gemma 4 LiteRT-LM web smoke',
+          ),
+        ]);
+        return steps;
+      },
+    ),
+    LocalE2eScenario(
+      name: 'chat-app-web-gemma4-webgpu-smoke',
+      group: LocalE2eScenarioGroup.webSmoke,
+      description:
+          'Build chat_app web and run Gemma 4 E2B (text-only) through '
+          'WebGPU/llama.cpp with the mem64 core.',
+      requiresDevice: false,
+      stepsBuilder: (context) {
+        final steps = <LocalE2eCommandStep>[];
+        if (!context.skipBuild) {
+          steps.add(
+            LocalE2eCommandStep(
+              workingDirectory: context.chatAppDir,
+              executable: 'flutter',
+              arguments: const [
+                'build',
+                'web',
+                '--base-href=/example/chat_app/build/web/',
+              ],
+              description: 'Build Flutter web chat app',
+            ),
+          );
+        }
+        steps.addAll([
+          LocalE2eCommandStep(
+            workingDirectory: context.projectRoot,
+            executable: context.python,
+            arguments: [
+              'tool/testing/serve_static_with_headers.py',
+              '--directory',
+              '.',
+              '--port',
+              '${context.port}',
+            ],
+            description: 'Serve repo root with COOP/COEP headers',
+            background: true,
+            waitForPort: context.port,
+          ),
+          LocalE2eCommandStep(
+            workingDirectory: context.projectRoot,
+            executable: context.python,
+            arguments: [
+              'tool/testing/playwright_chat_app_real_model_smoke.py',
+              context.webBuildUrl,
+              '--model-url',
+              context.modelUrl ?? context.defaultGemma4WebGpuModelUrl,
+              '--prompt',
+              'What is 2+2? Answer with only the number.',
+              '--expect',
+              context.expect,
+              // WebGPU/llama.cpp backend (LiteRT-LM is index 2).
+              '--backend-index',
+              '1',
+              '--gpu-layers',
+              '0',
+              // Bounded context for the large model per AGENTS.md guidance.
+              '--context-size',
+              '2048',
+              '--max-tokens',
+              '16',
+              // Force the mem64 core: Gemma 4 E2B exceeds the wasm32 ceiling.
+              '--mem64',
+              '--load-timeout-ms',
+              '${40 * 60 * 1000}',
+              '--response-timeout-ms',
+              '${10 * 60 * 1000}',
+            ],
+            description: 'Run Playwright Gemma 4 WebGPU (mem64) web smoke',
           ),
         ]);
         return steps;

--- a/website/docs/configuration/runtime-parameters.md
+++ b/website/docs/configuration/runtime-parameters.md
@@ -50,6 +50,14 @@ Important fields:
 - `maxParallelSequences`: max sequence slots (`n_seq_max`) for parallel
   sequence workloads (for example, batched embeddings).
 - `chatTemplate`: optional template override.
+- `preferMemory64` (web/WebGPU only): prefer the 64-bit (wasm64/mem64) bridge
+  core. Models larger than the ~4 GiB wasm32 address space (for example Gemma 4
+  E2B) cannot load on the default 32-bit core. `null` (default) lets llamadart
+  decide from `modelBytesHint`; `true` forces mem64; `false`
+  forces wasm32. Ignored on non-web backends.
+- `modelBytesHint` (web/WebGPU only): approximate model size in bytes, used to
+  select the mem64 core up front instead of waiting for an out-of-memory retry.
+  Ignored on non-web backends.
 
 For runtime LoRA control (`setLora`, `removeLora`, `clearLoras`), see
 [LoRA Adapters](../guides/lora-adapters).

--- a/website/docs/platforms/webgpu-bridge.md
+++ b/website/docs/platforms/webgpu-bridge.md
@@ -220,6 +220,31 @@ For first WebGPU validation, prefer:
 When a failure only appears after increasing model size or context, classify it
 as a model/configuration pressure issue first, not a bridge-load failure.
 
+### Large models and the 64-bit (mem64) core
+
+Models larger than the ~4 GiB wasm32 address space (for example Gemma 4 E2B,
+~2.8 GB of weights) cannot load on the default 32-bit core. Select the 64-bit
+(wasm64/mem64) core up front with `ModelParams`:
+
+```dart
+await engine.loadModelFromUrl(
+  modelUrl,
+  modelParams: const ModelParams(
+    preferMemory64: true, // force the mem64 core
+    // or leave null and pass modelBytesHint so the size heuristic decides:
+    // modelBytesHint: 3043927168,
+    contextSize: 2048,
+  ),
+);
+```
+
+`preferMemory64` defaults to `null`, which lets llamadart pick the mem64 core
+automatically from `modelBytesHint` when it is at/above the wasm32-safe ceiling
+(selection is size-driven, not based on a hardcoded model-name list). Passing
+the model size up front is preferable to relying on the post-out-of-memory
+wasm32→wasm64 retry, which is slower and best-effort. Both fields are
+web/WebGPU only and ignored on native backends.
+
 ## Flutter Web demo and smoke path
 
 Run the production-style chat app locally:


### PR DESCRIPTION
## Summary

Fixes the reported "can't run Gemma 4 E2B GGUF on web" issue.

**Root cause:** Gemma 4 E2B (~2.8 GB) exceeds the 32-bit wasm core's ~4 GiB address space. A mem64/wasm64 core ships in the pinned bridge assets but was only reached via brittle post-OOM auto-escalation or smoke-test-only JS globals — `mem64` was not exposed in the public API, and `modelBytesHint` was defined in interop but never passed to the load call.

### Changes
- **`ModelParams`** — adds web-only `preferMemory64` (`bool?`) and `modelBytesHint` (`int?`), with `copyWith` clear sentinels. Ignored on native backends.
- **`WebGpuLlamaBackend`** — seeds the mem64 preference from `ModelParams` at load start via `_resolvePreferMemory64` (explicit flag → large `modelBytesHint` → known-large Gemma 4 name → auto), and forwards `modelBytesHint` to `WebGpuLoadModelOptions`. The reactive OOM escalation remains a last resort.
- **Chat app** — `_buildModelParams` defaults mem64 on for Gemma 4 on web.
- **E2E** — adds `chat-app-web-gemma4-webgpu-smoke` (forces mem64, bounded context) + AGENTS.md docs.

## Validation
- `dart analyze` (lib + tool + chat app): clean.
- VM: `ModelParams` copyWith sentinel tests pass.
- Chrome: WebGPU backend tests (52) pass, including new assertions that explicit/auto mem64 reaches the bridge config and `modelBytesHint` reaches the load options.
- Browser smoke: Gemma 4 E2B loads into the mem64 (wasm64) core and generates correctly (`preferMemory64: true`, `core mem64 active`).
