### PR TITLE
Low-severity correctness cleanups

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,20 @@
+## Unreleased
+
+* **Minor correctness cleanups**:
+  * `ChatSession` no longer throws on an empty-choices completion chunk
+    (e.g. a keep-alive); such chunks are forwarded as-is.
+  * Thinking extraction now strips multiple `<think>` blocks instead of leaking
+    the second and later blocks into user-visible content.
+  * `LlamaEngine.generate` wraps unexpected backend errors in
+    `LlamaInferenceException` so callers catching `LlamaException` see the
+    documented error type.
+  * Fallback tool-call ids are derived from the tool call's logical index
+    rather than its list position.
+  * Loose tool-call parsing tolerates a language token without a trailing
+    delimiter in code fences, and keeps commas inside quoted argument values.
+  * Array grammar generation validates `minItems`/`maxItems` bounds and bounds
+    download restart recursion.
+
 ## 0.7.0
 
 * **Native runtime configuration**:

--- a/lib/src/core/engine/chat_session.dart
+++ b/lib/src/core/engine/chat_session.dart
@@ -149,6 +149,12 @@ class ChatSession {
       enableThinking: enableThinking,
       chatTemplateKwargs: chatTemplateKwargs,
     )) {
+      // Guard against an empty-choices chunk (e.g. a keep-alive) which would
+      // otherwise throw "Bad state: No element" mid-stream.
+      if (chunk.choices.isEmpty) {
+        yield chunk;
+        continue;
+      }
       final delta = chunk.choices.first.delta;
       if (delta.content != null) fullContent += delta.content!;
       if (delta.thinking != null) fullThinking += delta.thinking!;

--- a/lib/src/core/engine/engine.dart
+++ b/lib/src/core/engine/engine.dart
@@ -828,8 +828,11 @@ class LlamaEngine {
           .map(
             (entry) => LlamaCompletionChunkToolCall(
               index: entry.value.index,
+              // Base the fallback id on the tool call's logical index (not the
+              // list position) so the id stays consistent with the index that
+              // downstream consumers key tool-call builders by.
               id: (entry.value.id == null || entry.value.id!.isEmpty)
-                  ? 'call_${entry.key}'
+                  ? 'call_${entry.value.index}'
                   : entry.value.id,
               type: entry.value.type,
               function: entry.value.function,
@@ -1019,6 +1022,16 @@ class LlamaEngine {
       }
     } on UnsupportedError catch (error) {
       throw _unsupportedBackendOperation('Generation', error);
+    } on LlamaException {
+      rethrow;
+    } catch (error, stackTrace) {
+      // Wrap raw backend failures so callers catching LlamaException (the
+      // documented error contract) don't see unexpected error types escape,
+      // while preserving the original backend stack trace.
+      Error.throwWithStackTrace(
+        LlamaInferenceException('Generation failed', error),
+        stackTrace,
+      );
     }
   }
 

--- a/lib/src/core/grammar/json_schema_converter.dart
+++ b/lib/src/core/grammar/json_schema_converter.dart
@@ -463,6 +463,18 @@ String _buildRepetition(
   int? maxItems, {
   String separatorRule = '',
 }) {
+  // Validate bounds before formatting: a malformed schema with min > max (or a
+  // negative count) would otherwise emit invalid GBNF like `rule{2,1}`.
+  final normalizedMin = minItems < 0 ? 0 : minItems;
+  if (maxItems != null && maxItems < normalizedMin) {
+    // Generic wording: this helper backs both array minItems/maxItems and
+    // string minLength/maxLength repetition.
+    throw StateError(
+      'Invalid repetition bounds: maximum ($maxItems) must be >= minimum '
+      '($normalizedMin) and non-negative.',
+    );
+  }
+  minItems = normalizedMin;
   if (maxItems != null && maxItems == 0) return '';
   if (minItems == 0 && maxItems != null && maxItems == 1) return '$itemRule?';
 

--- a/lib/src/core/template/thinking_utils.dart
+++ b/lib/src/core/template/thinking_utils.dart
@@ -14,6 +14,24 @@ ThinkingExtraction extractThinking(
   String endTag = '</think>',
   bool thinkingForcedOpen = false,
 }) {
+  final result = _extractThinking(
+    text,
+    startTag: startTag,
+    endTag: endTag,
+    thinkingForcedOpen: thinkingForcedOpen,
+  );
+  // Trim only the overall content ends here, once. The recursion keeps content
+  // raw so whitespace between stripped thinking blocks (e.g. the space in
+  // "Hello<think>x</think> world<think>y</think>!") is preserved.
+  return (content: result.content.trim(), reasoning: result.reasoning);
+}
+
+ThinkingExtraction _extractThinking(
+  String text, {
+  required String startTag,
+  required String endTag,
+  bool thinkingForcedOpen = false,
+}) {
   final startIdx = text.indexOf(startTag);
   final endIdx = text.indexOf(endTag);
 
@@ -26,7 +44,7 @@ ThinkingExtraction extractThinking(
           .replaceAll(r'\n', '\n')
           .replaceAll(r'\r', '\r')
           .trim();
-      final content = text.substring(endIdx + endTag.length).trim();
+      final content = text.substring(endIdx + endTag.length);
       return (
         content: content,
         reasoning: reasoning.isEmpty ? null : reasoning,
@@ -49,7 +67,11 @@ ThinkingExtraction extractThinking(
         .trim();
     final remaining = text.substring(endIdx + endTag.length);
     // Recursively parse the rest to find more thinking tags if any
-    final rest = extractThinking(remaining, startTag: startTag, endTag: endTag);
+    final rest = _extractThinking(
+      remaining,
+      startTag: startTag,
+      endTag: endTag,
+    );
     return (
       content: rest.content,
       reasoning:
@@ -62,7 +84,7 @@ ThinkingExtraction extractThinking(
 
   if (nextEndIdx == -1) {
     // Still thinking — everything after startTag is reasoning
-    final before = text.substring(0, startIdx).trim();
+    final before = text.substring(0, startIdx);
     final reasoning = text
         .substring(afterStart)
         .replaceAll(r'\n', '\n')
@@ -79,9 +101,20 @@ ThinkingExtraction extractThinking(
       .trim();
   final before = text.substring(0, startIdx);
   final after = text.substring(nextEndIdx + endTag.length);
-  final content = (before + after).trim();
+  // Recurse into the remainder so additional <think> blocks are also stripped
+  // (mirrors the pre-opened branch above), instead of leaking them into
+  // user-visible content. Content is kept raw; the public wrapper trims once.
+  final rest = _extractThinking(after, startTag: startTag, endTag: endTag);
+  final content = before + rest.content;
+  final reasoningParts = <String>[
+    if (reasoning.isNotEmpty) reasoning,
+    if (rest.reasoning != null && rest.reasoning!.isNotEmpty) rest.reasoning!,
+  ];
 
-  return (content: content, reasoning: reasoning.isEmpty ? null : reasoning);
+  return (
+    content: content,
+    reasoning: reasoningParts.isEmpty ? null : reasoningParts.join('\n'),
+  );
 }
 
 /// Strips all thinking tags and content from text, returning only the

--- a/lib/src/core/template/tool_call_fallback_parser.dart
+++ b/lib/src/core/template/tool_call_fallback_parser.dart
@@ -340,6 +340,35 @@ LlamaCompletionChunkToolCall? _parseFunctionCallSyntax(String input) {
   );
 }
 
+/// Splits `key=value` argument lists on top-level commas only, leaving commas
+/// inside single/double-quoted values intact (e.g. `note='a, b'`).
+List<String> _splitArgsRespectingQuotes(String raw) {
+  final parts = <String>[];
+  final buffer = StringBuffer();
+  String? quote;
+  for (var i = 0; i < raw.length; i++) {
+    final ch = raw[i];
+    if (quote != null) {
+      buffer.write(ch);
+      if (ch == quote) {
+        quote = null;
+      }
+    } else if (ch == '"' || ch == "'") {
+      quote = ch;
+      buffer.write(ch);
+    } else if (ch == ',') {
+      parts.add(buffer.toString());
+      buffer.clear();
+    } else {
+      buffer.write(ch);
+    }
+  }
+  if (buffer.isNotEmpty) {
+    parts.add(buffer.toString());
+  }
+  return parts;
+}
+
 Map<String, dynamic>? _parseFunctionArguments(String raw) {
   if (raw.trim().isEmpty) {
     return const <String, dynamic>{};
@@ -351,7 +380,7 @@ Map<String, dynamic>? _parseFunctionArguments(String raw) {
   }
 
   final result = <String, dynamic>{};
-  final pairs = raw.split(',');
+  final pairs = _splitArgsRespectingQuotes(raw);
   for (final rawPair in pairs) {
     final pair = rawPair.trim();
     if (pair.isEmpty) {
@@ -405,7 +434,12 @@ Map<String, dynamic>? _parseFunctionArguments(String raw) {
 }
 
 String _stripToolFence(String input) {
-  final fenced = RegExp(r'^```(?:tool_code|tool|json)?\s*([\s\S]*?)\s*```$');
+  // Require a whitespace boundary after the optional language token so a
+  // payload like ```jsonify{...} does not get "json" consumed as the language
+  // (which would leave "ify{...}" as the body and corrupt the JSON).
+  final fenced = RegExp(
+    r'^```(?:(?:tool_code|tool|json)(?=\s))?\s*([\s\S]*?)\s*```$',
+  );
   final match = fenced.firstMatch(input);
   if (match == null) {
     return input;

--- a/lib/src/platform/io/model_download_manager_io.dart
+++ b/lib/src/platform/io/model_download_manager_io.dart
@@ -592,8 +592,17 @@ class DefaultModelDownloadManager implements ModelDownloadManager {
     Uri uri,
     File finalFile,
     File? partFile,
-    ModelDownloadProgressCallback? onProgress,
-  ) async {
+    ModelDownloadProgressCallback? onProgress, {
+    int restartDepth = 0,
+  }) async {
+    // Bound the restart recursion (validator-mismatch / HTTP 416 restarts) so a
+    // server that keeps flapping its validator cannot drive unbounded recursion
+    // or repeated full re-downloads.
+    if (restartDepth > 3) {
+      throw LlamaModelException(
+        'Exceeded download restart attempts for ${source.displayName}.',
+      );
+    }
     await finalFile.parent.create(recursive: true);
     final downloadFile = partFile ?? File('${finalFile.path}.download');
     final partMetadataFile = partFile == null
@@ -686,6 +695,7 @@ class DefaultModelDownloadManager implements ModelDownloadManager {
             finalFile,
             partFile,
             onProgress,
+            restartDepth: restartDepth + 1,
           );
         }
       } else if (existingBytes > 0 && statusCode == HttpStatus.ok) {
@@ -708,6 +718,7 @@ class DefaultModelDownloadManager implements ModelDownloadManager {
           finalFile,
           partFile,
           onProgress,
+          restartDepth: restartDepth + 1,
         );
       } else if (statusCode != HttpStatus.ok) {
         throw LlamaModelException(

--- a/test/unit/core/template/thinking_utils_test.dart
+++ b/test/unit/core/template/thinking_utils_test.dart
@@ -8,6 +8,22 @@ void main() {
     expect(result.content, 'Answer');
   });
 
+  test('extractThinking strips multiple think blocks', () {
+    final result = extractThinking(
+      '<think>first</think>A<think>second</think>B',
+    );
+    expect(result.content, 'AB');
+    expect(result.reasoning, 'first\nsecond');
+  });
+
+  test('extractThinking preserves whitespace between stripped blocks', () {
+    final result = extractThinking(
+      'Hello<think>x</think> world<think>y</think>!',
+    );
+    expect(result.content, 'Hello world!');
+    expect(result.reasoning, 'x\ny');
+  });
+
   test('isThinkingForcedOpen detects trailing think tag', () {
     expect(isThinkingForcedOpen('<think>\n'), isTrue);
     expect(isThinkingForcedOpen('hello'), isFalse);

--- a/test/unit/core/template/tool_call_fallback_parser_test.dart
+++ b/test/unit/core/template/tool_call_fallback_parser_test.dart
@@ -48,6 +48,17 @@ void main() {
       );
     });
 
+    test('keeps commas inside quoted function argument values', () {
+      final parsed = parseToolCallsFromLooseText(
+        "send_note(to='Alice', body='hello, world')",
+      );
+
+      expect(parsed.toolCalls, hasLength(1));
+      final args = jsonDecode(parsed.toolCalls.first.function!.arguments!);
+      expect(args, containsPair('to', 'Alice'));
+      expect(args, containsPair('body', 'hello, world'));
+    });
+
     test('does not coerce bare weather-like alias', () {
       final parsed = parseToolCallsFromLooseText('weatherlookup');
 


### PR DESCRIPTION
## Summary

Final batch from the code review — low-severity correctness cleanups.

- **ChatSession** tolerates an empty-`choices` completion chunk (forwards it instead of throwing).
- **thinking_utils** recurses into the remainder so multiple `<think>` blocks are fully stripped.
- **LlamaEngine.generate** wraps unexpected backend errors in `LlamaInferenceException`.
- **Fallback tool-call id** derived from the tool call's logical `index`, not list position.
- **Loose tool-call parsing**: code-fence regex requires a delimiter after the language token; argument splitting respects quotes (commas inside `'a, b'` preserved).
- **JSON-schema→GBNF** validates `minItems`/`maxItems` bounds.
- **Download manager** bounds `_downloadOnce` restart recursion.

## Validation
- `dart analyze` (lib + test): clean.
- Full VM unit suite (`--exclude-tags local-only`): 876 pass / 1 skip.
- New regression tests: multi-block thinking extraction; quote-aware tool-argument parsing.
