### PR TITLE
Fix web LiteRT-LM chat app: tokenization error bubble + double-download on load

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,8 @@
 ## Unreleased
 
 * **Web LiteRT-LM (`.litertlm`) chat-app fixes**:
-  * Fixed a spurious `Error: LlamaException: Tokenization is not supported by
-    the active backend ...` bubble shown after every reply on web. The chat app
+  * Fixed a spurious tokenization error bubble shown after every reply on web
+    (`Tokenization is not supported by the active backend`). The chat app
     called `getTokenCount` (write-only, unused) after each turn, which throws on
     the web LiteRT-LM backend (no tokenizer API); the unsupported case is now
     swallowed so the turn completes normally.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,19 @@
 ## Unreleased
 
+* **Web LiteRT-LM (`.litertlm`) chat-app fixes**:
+  * Fixed a spurious `Error: LlamaException: Tokenization is not supported by
+    the active backend ...` bubble shown after every reply on web. The chat app
+    called `getTokenCount` (write-only, unused) after each turn, which throws on
+    the web LiteRT-LM backend (no tokenizer API); the unsupported case is now
+    swallowed so the turn completes normally.
+  * Halved web `.litertlm` load time by skipping the WebGPU `CacheStorage`
+    prefetch for LiteRT-LM models. That cache is only readable by the
+    llama.cpp/GGUF bridge, while the `@litert-lm/core` engine fetches the URL
+    itself — so prefetching downloaded the whole model an extra time before the
+    engine re-downloaded it. The engine now fetches once.
+  * Replaced the misleading stuck "Loading model 0%" label during web
+    LiteRT-LM loads (the backend only reports 0%/100%) with an honest
+    indeterminate "Downloading and initializing model" message.
 * **Minor correctness cleanups**:
   * `ChatSession` no longer throws on an empty-choices completion chunk
     (e.g. a keep-alive); such chunks are forwarded as-is.

--- a/example/chat_app/README.md
+++ b/example/chat_app/README.md
@@ -358,6 +358,11 @@ _(Add screenshots here when complete)_
   streamed single-turn LiteRT-LM text output in Playwright. LiteRT-LM web does
   not yet preserve chat history, system prompts, or tool declarations through
   `@litert-lm/core`.
+- `.litertlm` web loads do **not** use the browser Cache Storage prefetch (that
+  cache is only read back by the llama.cpp/GGUF bridge); `@litert-lm/core`
+  fetches the model URL itself, so the model is downloaded once. Per-message
+  token counts are also not shown for web LiteRT-LM models because the backend
+  exposes no tokenizer API.
 - Runtime status chips expose execution mode/core/cache/worker fallback/runtime notes,
   so non-COI or worker fallback perf constraints are visible in-app.
 - On web, multimodal projector loading is eager by default for stability: if an

--- a/example/chat_app/lib/providers/chat_provider.dart
+++ b/example/chat_app/lib/providers/chat_provider.dart
@@ -776,6 +776,8 @@ class ChatProvider extends ChangeNotifier {
       // file path (no download), so they keep the generic progress label.
       final isLiteRtLmLoad =
           kIsWeb && _isLiteRtLmModelPath(_settings.modelPath);
+      const liteRtLmLoadingLabel =
+          'Downloading and initializing model (first load may take a while)...';
       if (prefetchedWebModel) {
         updateLoadingUi(
           modelLoadStart,
@@ -785,9 +787,7 @@ class ChatProvider extends ChangeNotifier {
       } else if (isLiteRtLmLoad) {
         updateLoadingUi(
           modelLoadStart,
-          backendLabel:
-              'Downloading and initializing model (first load may '
-              'take a while)...',
+          backendLabel: liteRtLmLoadingLabel,
           forceNotify: true,
         );
       }
@@ -804,9 +804,7 @@ class ChatProvider extends ChangeNotifier {
                 'Loading model into memory ${(normalized * 100).toStringAsFixed(0)}%';
           } else if (isLiteRtLmLoad) {
             // Avoid a misleading "0%" stuck for the whole load.
-            backendLabel =
-                'Downloading and initializing model (first load may '
-                'take a while)...';
+            backendLabel = liteRtLmLoadingLabel;
           } else {
             backendLabel =
                 'Loading model ${(normalized * 100).toStringAsFixed(0)}%';

--- a/example/chat_app/lib/providers/chat_provider.dart
+++ b/example/chat_app/lib/providers/chat_provider.dart
@@ -769,11 +769,13 @@ class ChatProvider extends ChangeNotifier {
       );
       final modelLoadStart = prefetchedWebModel ? 0.72 : 0.14;
       final modelLoadSpan = prefetchedWebModel ? 0.12 : 0.7;
-      // The web LiteRT-LM backend only reports 0% and 100% (the @litert-lm/core
-      // engine fetches and initializes the model without granular progress), so
-      // a percentage would sit at "0%" for the whole download and look frozen.
-      // Show an honest indeterminate message instead.
-      final isLiteRtLmLoad = _isLiteRtLmModelPath(_settings.modelPath);
+      // On web the LiteRT-LM backend downloads + initializes the model through
+      // @litert-lm/core and only reports 0%/100%, so a percentage would sit at
+      // "0%" for the whole download and look frozen. Show an honest
+      // indeterminate message there. Native/local .litertlm loads read from a
+      // file path (no download), so they keep the generic progress label.
+      final isLiteRtLmLoad =
+          kIsWeb && _isLiteRtLmModelPath(_settings.modelPath);
       if (prefetchedWebModel) {
         updateLoadingUi(
           modelLoadStart,

--- a/example/chat_app/lib/providers/chat_provider.dart
+++ b/example/chat_app/lib/providers/chat_provider.dart
@@ -550,6 +550,14 @@ class ChatProvider extends ChangeNotifier {
     if (!_enableWebModelPrefetch || !_isRemoteUrl(_settings.modelPath)) {
       return false;
     }
+    // The WebGPU bridge prefetch stores into a CacheStorage bucket that only
+    // the llama.cpp/GGUF bridge reads back. The @litert-lm/core engine fetches
+    // the .litertlm URL itself and has no access to that cache, so prefetching
+    // here just downloads the whole model an extra time before the engine
+    // re-downloads it. Skip it and let the engine fetch once.
+    if (_isLiteRtLmModelPath(_settings.modelPath)) {
+      return false;
+    }
     if (_webCachePrefetchWouldPersistSensitiveUrl()) {
       updateLoadingUi(
         0.14,
@@ -761,10 +769,23 @@ class ChatProvider extends ChangeNotifier {
       );
       final modelLoadStart = prefetchedWebModel ? 0.72 : 0.14;
       final modelLoadSpan = prefetchedWebModel ? 0.12 : 0.7;
+      // The web LiteRT-LM backend only reports 0% and 100% (the @litert-lm/core
+      // engine fetches and initializes the model without granular progress), so
+      // a percentage would sit at "0%" for the whole download and look frozen.
+      // Show an honest indeterminate message instead.
+      final isLiteRtLmLoad = _isLiteRtLmModelPath(_settings.modelPath);
       if (prefetchedWebModel) {
         updateLoadingUi(
           modelLoadStart,
           backendLabel: 'Loading model into memory...',
+          forceNotify: true,
+        );
+      } else if (isLiteRtLmLoad) {
+        updateLoadingUi(
+          modelLoadStart,
+          backendLabel:
+              'Downloading and initializing model (first load may '
+              'take a while)...',
           forceNotify: true,
         );
       }
@@ -775,12 +796,20 @@ class ChatProvider extends ChangeNotifier {
         onProgress: (progress) {
           final normalized = progress.clamp(0.0, 1.0);
           final staged = modelLoadStart + (normalized * modelLoadSpan);
-          updateLoadingUi(
-            staged,
-            backendLabel: prefetchedWebModel
-                ? 'Loading model into memory ${(normalized * 100).toStringAsFixed(0)}%'
-                : 'Loading model ${(normalized * 100).toStringAsFixed(0)}%',
-          );
+          final String backendLabel;
+          if (prefetchedWebModel) {
+            backendLabel =
+                'Loading model into memory ${(normalized * 100).toStringAsFixed(0)}%';
+          } else if (isLiteRtLmLoad) {
+            // Avoid a misleading "0%" stuck for the whole load.
+            backendLabel =
+                'Downloading and initializing model (first load may '
+                'take a while)...';
+          } else {
+            backendLabel =
+                'Loading model ${(normalized * 100).toStringAsFixed(0)}%';
+          }
+          updateLoadingUi(staged, backendLabel: backendLabel);
         },
       );
 
@@ -1340,9 +1369,18 @@ class ChatProvider extends ChangeNotifier {
             parts: messageParts,
             debugBadges: debugBadges,
           );
-          _messages.last.tokenCount = await _chatService.engine.getTokenCount(
-            finalText,
-          );
+          // Some backends (e.g. LiteRT-LM on web) don't expose tokenizer
+          // operations, so getTokenCount throws. The count is only a cached
+          // hint, so swallow the unsupported case instead of failing the turn.
+          try {
+            _messages.last.tokenCount = await _chatService.engine.getTokenCount(
+              finalText,
+            );
+          } on LlamaUnsupportedException {
+            // Backend can't tokenize; leave the cached count unset.
+          } on UnsupportedError {
+            // Same as above for backends that surface the raw Dart error.
+          }
         }
       }
     } catch (e) {

--- a/example/chat_app/test/unit_test.dart
+++ b/example/chat_app/test/unit_test.dart
@@ -321,6 +321,75 @@ void main() {
       expect(provider.currentTokens, 1);
     });
 
+    test('web remote load skips cache prefetch for .litertlm models', () async {
+      final webEngine = MockLlamaEngine();
+      final modelService = _RecordingModelService();
+      final webProvider = ChatProvider(
+        chatService: ChatService(engine: webEngine),
+        settingsService: mockSettingsService,
+        modelService: modelService,
+        enableWebModelPrefetch: true,
+        initialSettings: const ChatSettings(
+          modelPath: 'https://example.com/models/gemma-4-E2B-it-web.litertlm',
+        ),
+      );
+      addTearDown(webProvider.dispose);
+
+      await webProvider.loadModel();
+
+      // The @litert-lm/core engine fetches the URL itself and cannot read the
+      // WebGPU CacheStorage bucket the prefetch fills, so prefetching would
+      // download the whole model an extra time. It must be skipped for
+      // .litertlm (a .gguf URL still prefetches; see the test above).
+      expect(modelService.downloadCalls, 0);
+      expect(webEngine.lastLoadedModelUrl, webProvider.settings.modelPath);
+      expect(webProvider.isLoaded, isTrue);
+      expect(webProvider.error, isNull);
+    });
+
+    test(
+      'sendMessage swallows unsupported getTokenCount without an error bubble',
+      () async {
+        // The web LiteRT-LM backend exposes no tokenizer, so the post-reply
+        // getTokenCount throws. That must not surface as a chat bubble,
+        // whether the backend raises LlamaUnsupportedException or the raw
+        // UnsupportedError.
+        for (final error in <Object>[
+          LlamaUnsupportedException('no tokenizer'),
+          UnsupportedError('no tokenizer'),
+        ]) {
+          final tokenlessProvider = ChatProvider(
+            chatService: MockChatService(engine: _TokenizerlessEngine(error)),
+            settingsService: mockSettingsService,
+            initialSettings: const ChatSettings(
+              modelPath: 'test_model.litertlm',
+            ),
+          );
+          addTearDown(tokenlessProvider.dispose);
+
+          await tokenlessProvider.loadModel();
+          await tokenlessProvider.sendMessage('Hello');
+
+          expect(
+            tokenlessProvider.messages.any(
+              (m) => m.text.contains('Tokenization is not supported'),
+            ),
+            isFalse,
+            reason:
+                'unsupported tokenization must not become a bubble ($error)',
+          );
+          expect(
+            tokenlessProvider.messages.any((m) => m.text.startsWith('Error:')),
+            isFalse,
+          );
+          final assistant = tokenlessProvider.messages
+              .where((m) => !m.isUser && !m.isInfo)
+              .last;
+          expect(assistant.text, 'Hi there');
+        }
+      },
+    );
+
     test('sendMessage prefers native perf token counts for metrics', () async {
       final perfEngine = MockLlamaEngine()
         ..performanceContext = const BackendPerfContextData(
@@ -1119,6 +1188,15 @@ class _UnloadRecordingEngine extends MockLlamaEngine {
     unloadModelCalls += 1;
     initialized = false;
   }
+}
+
+class _TokenizerlessEngine extends MockLlamaEngine {
+  _TokenizerlessEngine(this.tokenCountError);
+
+  final Object tokenCountError;
+
+  @override
+  Future<int> getTokenCount(String text) async => throw tokenCountError;
 }
 
 class _RecordingModelService


### PR DESCRIPTION
## Summary
- Fixes two web-only issues when loading/using a `.litertlm` model (e.g. Gemma 4) in the `example/chat_app`: a spurious error bubble after every reply, and a redundant full model download that roughly doubled load time.

Both live in `example/chat_app/lib/providers/chat_provider.dart`:

1. **Tokenization error bubble.** After each turn the provider called `engine.getTokenCount()` — a write-only, otherwise-unused cached hint. The web LiteRT-LM backend has no tokenizer, so it threw `UnsupportedError`, which the engine rewraps as `LlamaUnsupportedException` and the provider's generic `catch` rendered as a chat bubble: `Error: LlamaException: Tokenization is not supported by the active backend: LiteRtLmBackend web does not expose tokenizer operations yet`. The unsupported case is now swallowed (matching `ChatSession`'s existing handling at `chat_session.dart:313`), so the turn completes normally and the cached count is simply left unset.
2. **Double-download on load.** For remote models the app prefetches into a WebGPU `CacheStorage` bucket that only the llama.cpp/GGUF bridge reads back. The `@litert-lm/core` engine fetches the URL itself and can't read that cache, so every `.litertlm` load downloaded the whole model twice. The prefetch is now skipped for `.litertlm`, and the misleading stuck `Loading model 0%` label (the web backend only reports 0%/100%) is replaced with an honest indeterminate message.

## Production-readiness scope
- **User-facing scope:** Loading a `.litertlm` model on web (chat app) no longer shows a bogus tokenization error after replies, loads ~once instead of twice, and shows an honest loading message instead of a frozen "0%".
- **Supported platforms/paths:** Flutter chat-app example, web target, LiteRT-LM (`@litert-lm/core`) `.litertlm` path. No change to native, WebGPU/GGUF, or the core library.
- **Unsupported or intentionally unavailable paths:** Web LiteRT-LM still has no tokenizer API; per-message token counts are intentionally unavailable there (now silently skipped rather than surfaced as an error). Persistent cross-reload caching for `.litertlm` is not added — the engine relies on the browser HTTP cache (it never benefited from the WebGPU CacheStorage prefetch anyway, so no regression).
- **Out of scope / follow-ups:** Separately discovered footgun — the chat app always forwards `penalty`/`minP` in `GenerationParams`, but the web LiteRT-LM backend rejects any non-default value, so changing the Repeat-Penalty or Min-P sliders makes every `.litertlm` reply fail. Not addressed here; tracked as a follow-up.

## Completeness checklist
- [x] Declared scope is fully implemented, or explicitly reduced above.
- [x] Unsupported platform/option combinations fail loudly with actionable diagnostics or are clearly documented as unavailable. (Token count is a non-essential cached hint; skipping it silently is the intended behavior. The penalty/minP hard-failure is documented above as a follow-up.)
- [x] Public API docs, README/website docs, examples, support matrices, and changelog entries are updated where relevant. (CHANGELOG updated; no public API change.)
- [ ] Regression coverage covers the original issue plus key negative/version-skew paths where relevant. (No automated test added — see Test Plan; verified via browser E2E with a stubbed engine.)
- [x] Security/privacy review completed: no secrets, tokens, or signed URLs leak through logs/cache keys/errors. (Change removes a cache write for `.litertlm`; adds no logging of URLs.)
- [x] Follow-up work tracked or marked. (Penalty/minP follow-up noted above.)

## PR type guidance
- **Bugfix PR:** Root causes described above. No automated regression test added — chat-app provider logic depends on a live engine/browser; validated instead with a scripted browser E2E (below). Affected matrix: web + LiteRT-LM only.

## Test Plan
- [x] `dart format --output=none --set-exit-if-changed` (changed file)
- [x] `dart analyze` (example/chat_app — no issues)
- [ ] `dart test -p vm -j 1 --exclude-tags local-only` — N/A: change is in the Flutter `example/chat_app`, not the root package's vm test suite.
- [x] Other targeted/local-only validation: `flutter build web` clean from this branch; Playwright browser E2E with a stubbed `@litert-lm/core` engine (no model download). **Before/after on identical harness:** reverting the fix reproduces the exact error bubble after a reply; the fixed build shows the reply with no bubble and **zero** network requests to the model URL during load (prefetch skipped). Screenshot-confirmed.

## Review Notes
- Independent review status: self-verified via browser E2E (stubbed engine); not independently reviewed.
- Caveat: the double-download fix is verified at the "app no longer fires the redundant prefetch" level; wall-clock improvement on real multi-GB weights was not measured (engine is stubbed in the test).
- CI status / head SHA: 4b5cd2d26