### PR TITLE
Fix chat app generation failing on .litertlm models when Min-P/Repeat Penalty sliders changed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,14 @@
   * Added a `chat-app-web-gemma4-webgpu-smoke` local E2E scenario that runs
     Gemma 4 E2B (text-only) through the WebGPU/llama.cpp path with the mem64
     core.
+* **Web LiteRT-LM (`.litertlm`) chat-app generation fix**:
+  * Fixed every reply failing when the Repeat Penalty or Min-P slider was moved
+    while a `.litertlm` model was loaded. The chat app forwarded `minP`/`penalty`
+    to the LiteRT-LM web backend, which rejects any non-default llama.cpp-specific
+    `GenerationParams` with an `UnsupportedError`. The chat app now leaves
+    `minP`/`penalty` at their defaults for `.litertlm` models (the backend
+    supports only `maxTokens`, `temp`, `topK`, `topP`, `seed`, `stopSequences`);
+    other backends are unchanged.
 * **Web model download fixes (chat app example)**:
   * Fixed broken web downloads where the app silently reported success without
     caching any bytes when the WebGPU bridge runtime had not finished loading.

--- a/example/chat_app/lib/services/chat_generation_service.dart
+++ b/example/chat_app/lib/services/chat_generation_service.dart
@@ -46,15 +46,32 @@ class ChatGenerationService {
   static const int _tokenDeltaFlushBatchSize = 8;
 
   GenerationParams buildParams(ChatSettings settings) {
+    // The LiteRT-LM backend only supports a subset of generation options
+    // (maxTokens, temp, topK, topP, seed, stopSequences) and throws an
+    // UnsupportedError for llama.cpp-specific fields like minP/penalty when
+    // they differ from their defaults. For .litertlm models, leave those
+    // fields at their defaults so generation does not fail.
+    const defaults = GenerationParams();
+    final isLiteRtLm = _isLiteRtLmModel(settings.modelPath);
     return GenerationParams(
       maxTokens: settings.maxTokens,
       temp: settings.temperature,
       topK: settings.topK,
       topP: settings.topP,
-      minP: settings.minP,
-      penalty: settings.penalty,
+      minP: isLiteRtLm ? defaults.minP : settings.minP,
+      penalty: isLiteRtLm ? defaults.penalty : settings.penalty,
       stopSequences: const <String>[],
     );
+  }
+
+  bool _isLiteRtLmModel(String? modelPath) {
+    final normalized = (modelPath ?? '')
+        .split('?')
+        .first
+        .split('#')
+        .first
+        .toLowerCase();
+    return normalized.endsWith('.litertlm');
   }
 
   List<LlamaContentPart> buildChatParts({

--- a/example/chat_app/test/chat_generation_service_test.dart
+++ b/example/chat_app/test/chat_generation_service_test.dart
@@ -28,6 +28,31 @@ void main() {
       expect(params.stopSequences, isEmpty);
     });
 
+    test('omits unsupported minP/penalty for litert models', () {
+      const defaults = GenerationParams();
+      const settings = ChatSettings(
+        modelPath: '/models/gemma.litertlm',
+        maxTokens: 1234,
+        temperature: 0.4,
+        topK: 7,
+        topP: 0.8,
+        minP: 0.2,
+        penalty: 1.3,
+      );
+
+      final params = service.buildParams(settings);
+
+      // Supported options are still forwarded.
+      expect(params.maxTokens, 1234);
+      expect(params.temp, 0.4);
+      expect(params.topK, 7);
+      expect(params.topP, 0.8);
+      // minP/penalty fall back to defaults so the LiteRT-LM backend does not
+      // reject the request with an UnsupportedError.
+      expect(params.minP, defaults.minP);
+      expect(params.penalty, defaults.penalty);
+    });
+
     test('accumulates stream updates and metrics', () async {
       final updates = <GenerationStreamUpdate>[];
       final result = await service.consumeStream(


### PR DESCRIPTION
## Summary
- The LiteRT-LM web backend rejects any non-default `minP`/`penalty` (it only supports `maxTokens`, `temp`, `topK`, `topP`, `seed`, `stopSequences`). The chat app's `buildParams` always forwarded `minP`/`penalty` from settings, so moving the **Repeat Penalty** or **Min-P** slider while a `.litertlm` model was loaded made *every* reply fail with `Generation is not supported by the active backend: ... does not support llama.cpp-specific GenerationParams: minP, penalty`.
- `buildParams` now detects `.litertlm` models from `settings.modelPath` (mirroring the existing `_isLiteRtLmModel`/`_isLiteRtLmModelPath` helpers) and leaves `minP`/`penalty` at their `GenerationParams` defaults for those models. Supported options are forwarded unchanged for all backends.

## Production-readiness scope
- **User-facing scope:** Users can adjust Min-P / Repeat Penalty sliders with a `.litertlm` model loaded and still get replies; those two sliders are simply no-ops for LiteRT-LM (which doesn't support them) instead of breaking generation.
- **Supported platforms/paths:** Flutter chat app (`example/chat_app`), LiteRT-LM web backend. No library/native changes.
- **Unsupported or intentionally unavailable paths:** `minP`/`penalty` remain unsupported by the LiteRT-LM backend by design; the app now declines to send them rather than triggering the backend's `UnsupportedError`.
- **Out of scope / follow-ups:** A separate, pre-existing issue surfaces a "Tokenization is not supported" bubble after litert replies (`chat_provider.dart` calls `engine.getTokenCount` unconditionally). Being addressed in another session.

## Completeness checklist
- [x] Declared scope is fully implemented.
- [x] Unsupported option combinations no longer fail loudly mid-chat; unsupported sliders are silently left at defaults for litert only.
- [x] Regression coverage covers the original issue (litert path) plus the unchanged non-litert path.
- [x] No secrets/tokens involved.
- [x] Follow-up (tokenization bubble) noted above.

## PR type guidance
- **Bugfix PR:** root cause = `buildParams` forwarding `minP`/`penalty` for a backend that rejects non-defaults; fixed by zeroing them to defaults for `.litertlm`. Regression test added. Affected path: chat app + LiteRT-LM web.

## Test Plan
- [x] `dart format --output=none --set-exit-if-changed` (changed files)
- [x] `dart analyze` — clean in `example/chat_app`
- [x] `flutter test test/chat_generation_service_test.dart` — all pass (incl. new litert case)
- [x] Other: Chromium e2e via stubbed LiteRT-LM engine. With non-default `minP=0.2`/`penalty=1.3` the reply streams; an A/B control with the fix reverted reproduces the exact `GenerationParams: minP, penalty` rejection (no reply).

## Review Notes
- Independent review status: self-verified (unit + e2e A/B).
- The fix derives defaults from `const GenerationParams()` rather than hardcoding `0.0`/`1.1`, so it stays correct if those defaults change.