### PR TITLE
LiteRT-LM: fix Gemma 4 function calling + thinking, add multi-model chat-template registry

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,11 @@
     wrong format); they now render the correct `<start_of_turn>` format with
     system folded into the first user turn. Pass `ModelParams.chatTemplate` to
     override detection for other models. See `doc/litert_lm_templates.md`.
+  * Fixed tool calling throwing on LiteRT-LM for grammar-using handlers (e.g.
+    Qwen/Hermes): `NativeAutoBackend` now forwards `supportsGrammarConstraints`
+    from the active delegate, so the engine skips the template grammar that
+    LiteRT-LM rejects instead of erroring. Verified on-device with
+    `Qwen3-0.6B.litertlm` (thinking + `get_weather` tool call).
 * **Web LiteRT-LM (`.litertlm`) chat-app fixes**:
   * Fixed a spurious tokenization error bubble shown after every reply on web
     (`Tokenization is not supported by the active backend`). The chat app

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,14 @@
     control structure; it is replaced with the full canonical Gemma 4 template
     (the one llama.cpp reads from the GGUF), minus the leading `bos_token` since
     the native runtime adds the start token itself.
+  * Fixed Gemma 4 thinking never surfacing (and raw JSON leaking into the reply)
+    on native LiteRT-LM. The runtime streams reasoning on a separate channel
+    (`{"role":"assistant","channels":{"thought":"..."}}`) and the answer as
+    `content`; the response parser only understood `content`, so thought chunks
+    leaked verbatim. Thought runs are now reassembled into the
+    `<|channel>thought ... <channel|>` markers the handler parses as reasoning.
+    Verified on-device with `gemma-4-E2B-it.litertlm` (function calling +
+    thinking) via `tool/litert_lm_chat_features_smoke.dart`.
   * Introduced a filename-keyed chat-template registry for `.litertlm` bundles
     (they can't expose their template through the native FFI), seeded with
     Gemma 4/3/3n and Qwen 2.5/3. Gemma 3/3n previously fell back to ChatML (the

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,10 @@
     from the active delegate, so the engine skips the template grammar that
     LiteRT-LM rejects instead of erroring. Verified on-device with
     `Qwen3-0.6B.litertlm` (thinking + `get_weather` tool call).
+  * Suppressed reasoning deltas when callers pass `enableThinking: false`, even
+    if the LiteRT-LM runtime still emits a thought channel. Structured tool-call
+    streams also no longer leak raw Hermes/Qwen JSON or Gemma `<|tool_call>`
+    markers as assistant content before the final `tool_calls` chunk.
 * **Web LiteRT-LM (`.litertlm`) chat-app fixes**:
   * Fixed a spurious tokenization error bubble shown after every reply on web
     (`Tokenization is not supported by the active backend`). The chat app

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,8 @@
     if the LiteRT-LM runtime still emits a thought channel. Structured tool-call
     streams also no longer leak raw Hermes/Qwen JSON or Gemma `<|tool_call>`
     markers as assistant content before the final `tool_calls` chunk.
+  * Added `tool/gguf_chat_features_smoke.dart` so the same streaming/parser
+    invariants can be smoke-tested against real Qwen and Gemma GGUF artifacts.
 * **Web LiteRT-LM (`.litertlm`) chat-app fixes**:
   * Fixed a spurious tokenization error bubble shown after every reply on web
     (`Tokenization is not supported by the active backend`). The chat app

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,18 @@
 ## Unreleased
 
+* **LiteRT-LM Gemma 4 function calling + thinking fix**:
+  * Fixed Gemma 4 `.litertlm` models not calling tools and producing unreliable
+    thinking. The backend supplied a hand-written stub chat template that
+    omitted the tool-declaration block entirely and inverted the thinking
+    control structure; it is replaced with the full canonical Gemma 4 template
+    (the one llama.cpp reads from the GGUF), minus the leading `bos_token` since
+    the native runtime adds the start token itself.
+  * Introduced a filename-keyed chat-template registry for `.litertlm` bundles
+    (they can't expose their template through the native FFI), seeded with
+    Gemma 4/3/3n and Qwen 2.5/3. Gemma 3/3n previously fell back to ChatML (the
+    wrong format); they now render the correct `<start_of_turn>` format with
+    system folded into the first user turn. Pass `ModelParams.chatTemplate` to
+    override detection for other models. See `doc/litert_lm_templates.md`.
 * **Web LiteRT-LM (`.litertlm`) chat-app fixes**:
   * Fixed a spurious tokenization error bubble shown after every reply on web
     (`Tokenization is not supported by the active backend`). The chat app

--- a/README.md
+++ b/README.md
@@ -189,6 +189,12 @@ await engine.loadModel(
 );
 ```
 
+Chat templates for `.litertlm` bundles are resolved from a built-in,
+filename-keyed registry (Gemma 4/3/3n and Qwen 2.5/3 are supported today). For
+other models, or to override detection, pass `ModelParams.chatTemplate`. See
+[doc/litert_lm_templates.md](doc/litert_lm_templates.md) for the support matrix
+and how to add a family.
+
 ### 6. Download and cache a remote model file
 
 ```dart

--- a/README.md
+++ b/README.md
@@ -192,8 +192,9 @@ await engine.loadModel(
 Chat templates for `.litertlm` bundles are resolved from a built-in,
 filename-keyed registry (Gemma 4/3/3n and Qwen 2.5/3 are supported today). For
 other models, or to override detection, pass `ModelParams.chatTemplate`. See
-[doc/litert_lm_templates.md](doc/litert_lm_templates.md) for the support matrix
-and how to add a family.
+[LiteRT-LM chat templates](https://github.com/leehack/llamadart/blob/main/doc/litert_lm_templates.md)
+for the template support matrix, real-model smoke commands, and how to add a
+family.
 
 ### 6. Download and cache a remote model file
 

--- a/doc/litert_lm_templates.md
+++ b/doc/litert_lm_templates.md
@@ -1,8 +1,8 @@
 # LiteRT-LM chat templates
 
 This document explains how llamadart picks a chat template for `.litertlm`
-model bundles, the families that are supported out of the box, and how to add a
-new one.
+model bundles, which template families are seeded out of the box, how to
+validate those families against real models, and how to add a new one.
 
 ## Why a built-in registry is needed
 
@@ -34,7 +34,12 @@ If neither applies, no chat template is exposed and the engine falls back to its
 generic ChatML handling — usable for plain text, but not the model's native
 format.
 
-## Supported families
+## Template coverage
+
+The table below is **template registry coverage** for `.litertlm` bundles. It
+does not mean every quantization, runtime delegate, device, or browser path has
+been exhaustively validated. GGUF models do not need this registry because
+llama.cpp reads `tokenizer.chat_template` straight from the GGUF metadata.
 
 | Family | Detected as | Filename match | Chat | Tools | Thinking |
 | --- | --- | --- | --- | --- | --- |
@@ -55,6 +60,43 @@ renamed or its family isn't listed above, pass the template explicitly via
 
 The registry is ordered most-specific-first, so `gemma-4` and `gemma-3n` are
 matched before `gemma-3`, and `qwen3` before the generic `qwen` rule.
+
+## Real-model smoke coverage
+
+Use the smoke tools below when a change touches shared chat rendering,
+streaming, thinking, tool-call parsing, or `LlamaEngine.create()`. They require
+local model files and are intentionally outside default CI.
+
+For GGUF / llama.cpp, `tool/gguf_chat_features_smoke.dart` loads a local GGUF
+through `LlamaEngine(LlamaBackend())`, verifies that `enableThinking: false`
+does not leak reasoning markers, and verifies that a required `get_weather`
+tool call is emitted as a final `tool_calls` chunk with no raw tool-call marker
+or content leak:
+
+```bash
+dart run tool/gguf_chat_features_smoke.dart \
+  models/Qwen3.5-0.8B-Q4_K_M.gguf auto
+
+dart run tool/gguf_chat_features_smoke.dart \
+  models/gemma-4-E2B-it-Q4_K_S.gguf auto
+```
+
+For native LiteRT-LM, `tool/litert_lm_chat_features_smoke.dart` checks the same
+tool-call path and also requires the model to emit a thinking channel. Use it
+with models that support thinking, such as Qwen 3/3.5 and Gemma 4:
+
+```bash
+dart run tool/litert_lm_chat_features_smoke.dart \
+  /path/to/Qwen3-0.6B.litertlm gpu
+
+dart run tool/litert_lm_chat_features_smoke.dart \
+  /path/to/gemma-4-E2B-it.litertlm gpu
+```
+
+The smoke scripts are not a universal model certification suite. Passing them
+means the representative Qwen/Gemma chat-template family can load on the chosen
+backend and that the high-risk streaming parser invariants hold for the tested
+artifact.
 
 ## Adding a model family
 

--- a/doc/litert_lm_templates.md
+++ b/doc/litert_lm_templates.md
@@ -42,7 +42,7 @@ format.
 | Gemma 3n (E2B/E4B) | `gemma` | `gemma-3n`, `gemma3n` | ✅ | ⚠️ prompt-engineered, no schema¹ | — |
 | Gemma 3 / 2 / 1B / 270m | `gemma` | `gemma-3`, `gemma-2` | ✅ | ⚠️ prompt-engineered, no schema¹ | — |
 | Qwen 3 / 3.5 | `hermes` | `qwen3`, `qwen-3` | ✅ | ✅ `<tool_call>` | ✅ `<think>` |
-| Qwen 2.5 | `hermes` | `qwen2.5`, `qwen2`, `qwen` | ✅ | ✅ `<tool_call>` | — |
+| Qwen 2.5 | `hermes` | `qwen2.5`, `qwen2` | ✅ | ✅ `<tool_call>` | — |
 
 ¹ For Gemma 3/3n the engine injects a generic "respond with `tool_call` JSON"
 instruction but does **not** render the tool schemas into the prompt. This
@@ -94,10 +94,10 @@ the backend, not the registry:
   reasoning and the answer on separate channels — thought as
   `{"role":"assistant","channels":{"thought":"..."}}` and the answer as
   `{"role":"assistant","content":[{"type":"text",...}]}`. `LiteRtLmChannelAssembler`
-  (in `litert_lm_runtime.dart`) wraps thought runs in `<|channel>thought … <channel|>`
-  so the chat-template handlers extract them as reasoning instead of leaking the
-  raw JSON. The markers are the Gemma 4 form but are also recognized for the
-  Hermes/Qwen path.
+  (in `litert_lm_runtime.dart`) wraps thought runs in the active handler's
+  reasoning tags (`<|channel>thought … <channel|>` for Gemma 4, `<think>…</think>`
+  for Qwen/Hermes) so chat-template handlers extract them as reasoning instead
+  of leaking raw JSON.
 - **Grammar-constrained decoding is skipped.** Grammar-using handlers (Hermes/Qwen)
   emit a GBNF grammar for tool calls, which the LiteRT-LM backend rejects.
   `NativeAutoBackend` forwards `supportsGrammarConstraints == false` from the

--- a/doc/litert_lm_templates.md
+++ b/doc/litert_lm_templates.md
@@ -1,0 +1,98 @@
+# LiteRT-LM chat templates
+
+This document explains how llamadart picks a chat template for `.litertlm`
+model bundles, the families that are supported out of the box, and how to add a
+new one.
+
+## Why a built-in registry is needed
+
+llamadart builds every prompt the same way on both backends: it reads
+`tokenizer.chat_template` from the model's metadata, detects the template
+format, and renders/parses with the matching handler. For llama.cpp this
+template is read straight from the GGUF.
+
+`.litertlm` bundles also embed a chat template, but the LiteRT-LM native FFI
+exposes **no way to read it back** (it only offers load / generate / tokenize /
+detokenize). So the backend has to supply `tokenizer.chat_template` itself. It
+does this by detecting the model family from the bundle filename and mapping it
+to a canonical template copied verbatim from the one llama.cpp ships — which
+keeps the LiteRT-LM path byte-for-byte consistent with the llama.cpp path.
+
+> Note: the native runtime adds the model's start token itself, so the bundled
+> templates have their leading `bos_token` stripped to avoid a doubled BOS.
+
+## Resolution order
+
+`LiteRtLmService.getMetadata()` resolves the template in this order (later wins):
+
+1. **Built-in registry** — if the bundle filename matches a known family
+   (`kLiteRtLmChatTemplates`), its template is used.
+2. **`ModelParams.chatTemplate` override** — if set, it always wins. This is the
+   reliable path for any model, including families not in the registry.
+
+If neither applies, no chat template is exposed and the engine falls back to its
+generic ChatML handling — usable for plain text, but not the model's native
+format.
+
+## Supported families
+
+| Family | Detected as | Filename match | Chat | Tools | Thinking |
+| --- | --- | --- | --- | --- | --- |
+| Gemma 4 (E2B/E4B) | `gemma4` | `gemma-4`, `gemma4` | ✅ | ✅ native `<\|tool_call>` | ✅ `<\|channel>` |
+| Gemma 3n (E2B/E4B) | `gemma` | `gemma-3n`, `gemma3n` | ✅ | ⚠️ prompt-engineered, no schema¹ | — |
+| Gemma 3 / 2 / 1B / 270m | `gemma` | `gemma-3`, `gemma-2` | ✅ | ⚠️ prompt-engineered, no schema¹ | — |
+| Qwen 3 / 3.5 | `hermes` | `qwen3`, `qwen-3` | ✅ | ✅ `<tool_call>` | ✅ `<think>` |
+| Qwen 2.5 | `hermes` | `qwen2.5`, `qwen2`, `qwen` | ✅ | ✅ `<tool_call>` | — |
+
+¹ For Gemma 3/3n the engine injects a generic "respond with `tool_call` JSON"
+instruction but does **not** render the tool schemas into the prompt. This
+matches the llama.cpp backend's Gemma 3 behavior — it is a property of the Gemma
+handler, not a LiteRT-LM limitation. Gemma **4** has full native tool calling.
+
+Detection is best-effort and based on the bundle filename. If a bundle is
+renamed or its family isn't listed above, pass the template explicitly via
+`ModelParams.chatTemplate`.
+
+The registry is ordered most-specific-first, so `gemma-4` and `gemma-3n` are
+matched before `gemma-3`, and `qwen3` before the generic `qwen` rule.
+
+## Adding a model family
+
+Templates are committed as jinja under `tool/litert_lm_templates/` and embedded
+into `lib/src/backends/litert_lm/litert_lm_chat_templates.dart` by a generator.
+You never hand-author a template — copy the canonical one llama.cpp uses.
+
+1. Copy the canonical jinja into `tool/litert_lm_templates/<id>.jinja`
+   (e.g. from `.dart_tool/llama_cpp/models/templates/` or the model's GGUF /
+   Hugging Face `tokenizer_config.json`).
+2. Add an entry to `_manifest` in `tool/gen_litert_lm_templates.dart`:
+   - `id` / `jinja` — the identifier and source filename.
+   - `familyMatches` — lower-cased filename substrings; place the entry above
+     any broader family it could collide with.
+   - `bosToken` / `eosToken` — exposed via `tokenizer.ggml.*` metadata.
+   - `stripLeadingBosToken: true` if the template emits a leading `bos_token`.
+3. Regenerate: `dart run tool/gen_litert_lm_templates.dart`.
+4. Verify the family is detected as the intended `ChatFormat` and renders
+   correctly (a render check plus an entry in
+   `test/unit/backends/litert_lm/litert_lm_chat_templates_test.dart`). The
+   existing handler renders and parses it — no handler changes are needed for
+   families llamadart already supports.
+
+### Known gaps
+
+- **Phi-4** has no dedicated handler (falls back to generic) and no canonical
+  jinja vendored, so it is not seeded.
+- **TranslateGemma / FunctionGemma** have handlers but no vendored canonical
+  jinja yet.
+
+## Longer-term direction
+
+The registry is a deliberate bridge, not the end state. Two "proper" endgames,
+both larger changes, are worth tracking:
+
+1. Read the embedded template straight from the `.litertlm` bundle once the FFI
+   exposes a getter — mirroring how the llama.cpp path reads it from the GGUF.
+2. Use LiteRT-LM's native conversation tool API
+   (`litert_lm_conversation_config_set_tools` / `set_messages`, already exported
+   by the shipped library) and let `Gemma4DataProcessor` format tools and parse
+   tool calls — the approach the official SDKs and `flutter_gemma` take.

--- a/doc/litert_lm_templates.md
+++ b/doc/litert_lm_templates.md
@@ -85,6 +85,29 @@ You never hand-author a template — copy the canonical one llama.cpp uses.
 - **TranslateGemma / FunctionGemma** have handlers but no vendored canonical
   jinja yet.
 
+## Runtime behavior (beyond templating)
+
+Two LiteRT-LM-specific behaviors complement the templates above; both live in
+the backend, not the registry:
+
+- **Thinking is reassembled from a channel stream.** The native runtime streams
+  reasoning and the answer on separate channels — thought as
+  `{"role":"assistant","channels":{"thought":"..."}}` and the answer as
+  `{"role":"assistant","content":[{"type":"text",...}]}`. `LiteRtLmChannelAssembler`
+  (in `litert_lm_runtime.dart`) wraps thought runs in `<|channel>thought … <channel|>`
+  so the chat-template handlers extract them as reasoning instead of leaking the
+  raw JSON. The markers are the Gemma 4 form but are also recognized for the
+  Hermes/Qwen path.
+- **Grammar-constrained decoding is skipped.** Grammar-using handlers (Hermes/Qwen)
+  emit a GBNF grammar for tool calls, which the LiteRT-LM backend rejects.
+  `NativeAutoBackend` forwards `supportsGrammarConstraints == false` from the
+  active delegate, so the engine drops the grammar and tool calls are parsed
+  best-effort from the model output. Gemma 4 emits no grammar, so it is
+  unaffected.
+
+> The web backend (`@litert-lm/core`) uses a separate response path and does not
+> share this channel reassembly; web thinking remains limited/single-turn.
+
 ## Longer-term direction
 
 The registry is a deliberate bridge, not the end state. Two "proper" endgames,

--- a/doc/litert_lm_templates.md
+++ b/doc/litert_lm_templates.md
@@ -47,7 +47,7 @@ llama.cpp reads `tokenizer.chat_template` straight from the GGUF metadata.
 | Gemma 3n (E2B/E4B) | `gemma` | `gemma-3n`, `gemma3n` | ✅ | ⚠️ prompt-engineered, no schema¹ | — |
 | Gemma 3 / 2 / 1B / 270m | `gemma` | `gemma-3`, `gemma-2` | ✅ | ⚠️ prompt-engineered, no schema¹ | — |
 | Qwen 3 / 3.5 | `hermes` | `qwen3`, `qwen-3` | ✅ | ✅ `<tool_call>` | ✅ `<think>` |
-| Qwen 2.5 | `hermes` | `qwen2.5`, `qwen2` | ✅ | ✅ `<tool_call>` | — |
+| Qwen 2.5 | `hermes` | `qwen2.5`, `qwen-2.5`, `qwen2` | ✅ | ✅ `<tool_call>` | — |
 
 ¹ For Gemma 3/3n the engine injects a generic "respond with `tool_call` JSON"
 instruction but does **not** render the tool schemas into the prompt. This
@@ -59,7 +59,7 @@ renamed or its family isn't listed above, pass the template explicitly via
 `ModelParams.chatTemplate`.
 
 The registry is ordered most-specific-first, so `gemma-4` and `gemma-3n` are
-matched before `gemma-3`, and `qwen3` before the generic `qwen` rule.
+matched before `gemma-3`, and `qwen3` is matched before the Qwen 2.5 rules.
 
 ## Real-model smoke coverage
 

--- a/lib/src/backends/litert_lm/litert_lm_chat_template.dart
+++ b/lib/src/backends/litert_lm/litert_lm_chat_template.dart
@@ -1,0 +1,44 @@
+/// A built-in chat template for a LiteRT-LM model family.
+///
+/// LiteRT-LM `.litertlm` bundles do not expose their chat template through the
+/// native FFI, so the backend must supply `tokenizer.chat_template` itself,
+/// keyed by detecting the model family from the bundle filename. See
+/// `doc/litert_lm_templates.md` for the full rationale and the recipe for
+/// adding a new family.
+class LiteRtLmChatTemplate {
+  /// Creates a built-in chat template descriptor.
+  const LiteRtLmChatTemplate({
+    required this.id,
+    required this.template,
+    required this.familyMatches,
+    this.bosToken = '<bos>',
+    this.eosToken = '<turn|>',
+  });
+
+  /// Stable identifier for diagnostics (e.g. `gemma4`).
+  final String id;
+
+  /// The jinja chat template, rendered by the matching format handler.
+  ///
+  /// Copied verbatim from the canonical jinja that llama.cpp ships, minus any
+  /// leading `bos_token` emission: the native LiteRT-LM runtime adds the start
+  /// token itself, so emitting one here would double it.
+  final String template;
+
+  /// Filename substrings that identify this family.
+  ///
+  /// Matched against the lower-cased bundle filename with `_` normalized to
+  /// `-`. Order matters in the registry: the first matching entry wins, so
+  /// more specific families must be registered before broader ones.
+  final List<String> familyMatches;
+
+  /// The BOS token exposed via `tokenizer.ggml.bos_token` metadata.
+  final String bosToken;
+
+  /// The EOS token exposed via `tokenizer.ggml.eos_token` metadata.
+  final String eosToken;
+
+  /// Whether [normalizedName] (lower-cased, `_`→`-`) belongs to this family.
+  bool matches(String normalizedName) =>
+      familyMatches.any(normalizedName.contains);
+}

--- a/lib/src/backends/litert_lm/litert_lm_chat_template.dart
+++ b/lib/src/backends/litert_lm/litert_lm_chat_template.dart
@@ -13,6 +13,8 @@ class LiteRtLmChatTemplate {
     required this.familyMatches,
     this.bosToken = '<bos>',
     this.eosToken = '<turn|>',
+    this.thinkingStartTag = '<|channel>thought\n',
+    this.thinkingEndTag = '<channel|>',
   });
 
   /// Stable identifier for diagnostics (e.g. `gemma4`).
@@ -37,6 +39,12 @@ class LiteRtLmChatTemplate {
 
   /// The EOS token exposed via `tokenizer.ggml.eos_token` metadata.
   final String eosToken;
+
+  /// The marker used to expose LiteRT-LM thought-channel chunks as reasoning.
+  final String thinkingStartTag;
+
+  /// The marker used to close LiteRT-LM thought-channel chunks.
+  final String thinkingEndTag;
 
   /// Whether [normalizedName] (lower-cased, `_`→`-`) belongs to this family.
   bool matches(String normalizedName) =>

--- a/lib/src/backends/litert_lm/litert_lm_chat_templates.dart
+++ b/lib/src/backends/litert_lm/litert_lm_chat_templates.dart
@@ -355,6 +355,268 @@ const String _gemma4ChatTemplate = r'''
 {%- endif -%}
 ''';
 
+/// Canonical chat template for the gemma3n family.
+const String _gemma3nChatTemplate = r'''
+{%- if messages[0]['role'] == 'system' -%}
+    {%- if messages[0]['content'] is string -%}
+        {%- set first_user_prefix = messages[0]['content'] + '
+
+' -%}
+    {%- else -%}
+        {%- set first_user_prefix = messages[0]['content'][0]['text'] + '
+
+' -%}
+    {%- endif -%}
+    {%- set loop_messages = messages[1:] -%}
+{%- else -%}
+    {%- set first_user_prefix = "" -%}
+    {%- set loop_messages = messages -%}
+{%- endif -%}
+{%- for message in loop_messages -%}
+    {%- if (message['role'] == 'user') != (loop.index0 % 2 == 0) -%}
+        {{ raise_exception("Conversation roles must alternate user/assistant/user/assistant/...") }}
+    {%- endif -%}
+    {%- if (message['role'] == 'assistant') -%}
+        {%- set role = "model" -%}
+    {%- else -%}
+        {%- set role = message['role'] -%}
+    {%- endif -%}
+    {{ '<start_of_turn>' + role + '
+' + (first_user_prefix if loop.first else "") }}
+    {%- if message['content'] is string -%}
+        {{ message['content'] | trim }}
+    {%- elif message['content'] is iterable -%}
+        {%- for item in message['content'] -%}
+            {%- if item['type'] == 'audio' -%}
+                {{ '<audio_soft_token>' }}
+            {%- elif item['type'] == 'image' -%}
+                {{ '<image_soft_token>' }}
+            {%- elif item['type'] == 'text' -%}
+                {{ item['text'] | trim }}
+            {%- endif -%}
+        {%- endfor -%}
+    {%- else -%}
+        {{ raise_exception("Invalid content type") }}
+    {%- endif -%}
+    {{ '<end_of_turn>
+' }}
+{%- endfor -%}
+{%- if add_generation_prompt -%}
+    {{'<start_of_turn>model
+'}}
+{%- endif -%}
+''';
+
+/// Canonical chat template for the gemma family.
+const String _gemmaChatTemplate = r'''
+{%- if messages[0]['role'] == 'system' -%}
+    {%- if messages[0]['content'] is string -%}
+        {%- set first_user_prefix = messages[0]['content'] + '
+
+' -%}
+    {%- else -%}
+        {%- set first_user_prefix = messages[0]['content'][0]['text'] + '
+
+' -%}
+    {%- endif -%}
+    {%- set loop_messages = messages[1:] -%}
+{%- else -%}
+    {%- set first_user_prefix = "" -%}
+    {%- set loop_messages = messages -%}
+{%- endif -%}
+{%- for message in loop_messages -%}
+    {%- if (message['role'] == 'user') != (loop.index0 % 2 == 0) -%}
+        {{ raise_exception("Conversation roles must alternate user/assistant/user/assistant/...") }}
+    {%- endif -%}
+    {%- if (message['role'] == 'assistant') -%}
+        {%- set role = "model" -%}
+    {%- else -%}
+        {%- set role = message['role'] -%}
+    {%- endif -%}
+    {{ '<start_of_turn>' + role + '
+' + (first_user_prefix if loop.first else "") }}
+    {%- if message['content'] is string -%}
+        {{ message['content'] | trim }}
+    {%- elif message['content'] is iterable -%}
+        {%- for item in message['content'] -%}
+            {%- if item['type'] == 'image' -%}
+                {{ '<start_of_image>' }}
+            {%- elif item['type'] == 'text' -%}
+                {{ item['text'] | trim }}
+            {%- endif -%}
+        {%- endfor -%}
+    {%- else -%}
+        {{ raise_exception("Invalid content type") }}
+    {%- endif -%}
+    {{ '<end_of_turn>
+' }}
+{%- endfor -%}
+{%- if add_generation_prompt -%}
+    {{'<start_of_turn>model
+'}}
+{%- endif -%}
+''';
+
+/// Canonical chat template for the qwen3 family.
+const String _qwen3ChatTemplate = r'''
+{%- if tools %}
+    {{- '<|im_start|>system\n' }}
+    {%- if messages[0].role == 'system' %}
+        {{- messages[0].content + '\n\n' }}
+    {%- endif %}
+    {{- "# Tools\n\nYou may call one or more functions to assist with the user query.\n\nYou are provided with function signatures within <tools></tools> XML tags:\n<tools>" }}
+    {%- for tool in tools %}
+        {{- "\n" }}
+        {{- tool | tojson }}
+    {%- endfor %}
+    {{- "\n</tools>\n\nFor each function call, return a json object with function name and arguments within <tool_call></tool_call> XML tags:\n<tool_call>\n{\"name\": <function-name>, \"arguments\": <args-json-object>}\n</tool_call><|im_end|>\n" }}
+{%- else %}
+    {%- if messages[0].role == 'system' %}
+        {{- '<|im_start|>system\n' + messages[0].content + '<|im_end|>\n' }}
+    {%- endif %}
+{%- endif %}
+{%- set ns = namespace(multi_step_tool=true, last_query_index=messages|length - 1) %}
+{%- for forward_message in messages %}
+    {%- set index = (messages|length - 1) - loop.index0 %}
+    {%- set message = messages[index] %}
+    {%- set current_content = message.content if message.content is defined and message.content is not none else '' %}
+    {%- set tool_start = '<tool_response>' %}
+    {%- set tool_start_length = tool_start|length %}
+    {%- set start_of_message = current_content[:tool_start_length] %}
+    {%- set tool_end = '</tool_response>' %}
+    {%- set tool_end_length = tool_end|length %}
+    {%- set start_pos = (current_content|length) - tool_end_length %}
+    {%- if start_pos < 0 %}
+        {%- set start_pos = 0 %}
+    {%- endif %}
+    {%- set end_of_message = current_content[start_pos:] %}
+    {%- if ns.multi_step_tool and message.role == "user" and not(start_of_message == tool_start and end_of_message == tool_end) %}
+        {%- set ns.multi_step_tool = false %}
+        {%- set ns.last_query_index = index %}
+    {%- endif %}
+{%- endfor %}
+{%- for message in messages %}
+    {%- if (message.role == "user") or (message.role == "system" and not loop.first) %}
+        {{- '<|im_start|>' + message.role + '\n' + message.content + '<|im_end|>' + '\n' }}
+    {%- elif message.role == "assistant" %}
+        {%- set m_content = message.content if message.content is defined and message.content is not none else '' %}
+        {%- set content = m_content %}
+        {%- set reasoning_content = '' %}
+        {%- if message.reasoning_content is defined and message.reasoning_content is not none %}
+            {%- set reasoning_content = message.reasoning_content %}
+        {%- else %}
+            {%- if '</think>' in m_content %}
+                {%- set content = (m_content.split('</think>')|last).lstrip('\n') %}
+                {%- set reasoning_content = (m_content.split('</think>')|first).rstrip('\n') %}
+                {%- set reasoning_content = (reasoning_content.split('<think>')|last).lstrip('\n') %}
+            {%- endif %}
+        {%- endif %}
+        {%- if loop.index0 > ns.last_query_index %}
+            {%- if loop.last or (not loop.last and (not reasoning_content.strip() == '')) %}
+                {{- '<|im_start|>' + message.role + '\n<think>\n' + reasoning_content.strip('\n') + '\n</think>\n\n' + content.lstrip('\n') }}
+            {%- else %}
+                {{- '<|im_start|>' + message.role + '\n' + content }}
+            {%- endif %}
+        {%- else %}
+            {{- '<|im_start|>' + message.role + '\n' + content }}
+        {%- endif %}
+        {%- if message.tool_calls %}
+            {%- for tool_call in message.tool_calls %}
+                {%- if (loop.first and content) or (not loop.first) %}
+                    {{- '\n' }}
+                {%- endif %}
+                {%- if tool_call.function %}
+                    {%- set tool_call = tool_call.function %}
+                {%- endif %}
+                {{- '<tool_call>\n{"name": "' }}
+                {{- tool_call.name }}
+                {{- '", "arguments": ' }}
+                {%- if tool_call.arguments is string %}
+                    {{- tool_call.arguments }}
+                {%- else %}
+                    {{- tool_call.arguments | tojson }}
+                {%- endif %}
+                {{- '}\n</tool_call>' }}
+            {%- endfor %}
+        {%- endif %}
+        {{- '<|im_end|>\n' }}
+    {%- elif message.role == "tool" %}
+        {%- if loop.first or (messages[loop.index0 - 1].role != "tool") %}
+            {{- '<|im_start|>user' }}
+        {%- endif %}
+        {{- '\n<tool_response>\n' }}
+        {{- message.content }}
+        {{- '\n</tool_response>' }}
+        {%- if loop.last or (messages[loop.index0 + 1].role != "tool") %}
+            {{- '<|im_end|>\n' }}
+        {%- endif %}
+    {%- endif %}
+{%- endfor %}
+{%- if add_generation_prompt %}
+    {{- '<|im_start|>assistant\n' }}
+    {%- if enable_thinking is defined and enable_thinking is false %}
+        {{- '<think>\n\n</think>\n\n' }}
+    {%- endif %}
+{%- endif %}''';
+
+/// Canonical chat template for the qwen25 family.
+const String _qwen25ChatTemplate = r'''
+{%- if tools %}
+    {{- '<|im_start|>system\n' }}
+    {%- if messages[0]['role'] == 'system' %}
+        {{- messages[0]['content'] }}
+    {%- else %}
+        {{- 'You are Qwen, created by Alibaba Cloud. You are a helpful assistant.' }}
+    {%- endif %}
+    {{- "\n\n# Tools\n\nYou may call one or more functions to assist with the user query.\n\nYou are provided with function signatures within <tools></tools> XML tags:\n<tools>" }}
+    {%- for tool in tools %}
+        {{- "\n" }}
+        {{- tool | tojson }}
+    {%- endfor %}
+    {{- "\n</tools>\n\nFor each function call, return a json object with function name and arguments within <tool_call></tool_call> XML tags:\n<tool_call>\n{\"name\": <function-name>, \"arguments\": <args-json-object>}\n</tool_call><|im_end|>\n" }}
+{%- else %}
+    {%- if messages[0]['role'] == 'system' %}
+        {{- '<|im_start|>system\n' + messages[0]['content'] + '<|im_end|>\n' }}
+    {%- else %}
+        {{- '<|im_start|>system\nYou are Qwen, created by Alibaba Cloud. You are a helpful assistant.<|im_end|>\n' }}
+    {%- endif %}
+{%- endif %}
+{%- for message in messages %}
+    {%- if (message.role == "user") or (message.role == "system" and not loop.first) or (message.role == "assistant" and not message.tool_calls) %}
+        {{- '<|im_start|>' + message.role + '\n' + message.content + '<|im_end|>' + '\n' }}
+    {%- elif message.role == "assistant" %}
+        {{- '<|im_start|>' + message.role }}
+        {%- if message.content %}
+            {{- '\n' + message.content }}
+        {%- endif %}
+        {%- for tool_call in message.tool_calls %}
+            {%- if tool_call.function is defined %}
+                {%- set tool_call = tool_call.function %}
+            {%- endif %}
+            {{- '\n<tool_call>\n{"name": "' }}
+            {{- tool_call.name }}
+            {{- '", "arguments": ' }}
+            {{- tool_call.arguments | tojson }}
+            {{- '}\n</tool_call>' }}
+        {%- endfor %}
+        {{- '<|im_end|>\n' }}
+    {%- elif message.role == "tool" %}
+        {%- if (loop.index0 == 0) or (messages[loop.index0 - 1].role != "tool") %}
+            {{- '<|im_start|>user' }}
+        {%- endif %}
+        {{- '\n<tool_response>\n' }}
+        {{- message.content }}
+        {{- '\n</tool_response>' }}
+        {%- if loop.last or (messages[loop.index0 + 1].role != "tool") %}
+            {{- '<|im_end|>\n' }}
+        {%- endif %}
+    {%- endif %}
+{%- endfor %}
+{%- if add_generation_prompt %}
+    {{- '<|im_start|>assistant\n' }}
+{%- endif %}
+''';
+
 /// Built-in LiteRT-LM chat templates, matched in order.
 ///
 /// The first entry whose [LiteRtLmChatTemplate.matches] returns
@@ -367,5 +629,33 @@ const List<LiteRtLmChatTemplate> kLiteRtLmChatTemplates = [
     familyMatches: ['gemma-4', 'gemma4'],
     bosToken: '<bos>',
     eosToken: '<turn|>',
+  ),
+  LiteRtLmChatTemplate(
+    id: 'gemma3n',
+    template: _gemma3nChatTemplate,
+    familyMatches: ['gemma-3n', 'gemma3n'],
+    bosToken: '<bos>',
+    eosToken: '<end_of_turn>',
+  ),
+  LiteRtLmChatTemplate(
+    id: 'gemma',
+    template: _gemmaChatTemplate,
+    familyMatches: ['gemma-3', 'gemma3', 'gemma-2', 'gemma2'],
+    bosToken: '<bos>',
+    eosToken: '<end_of_turn>',
+  ),
+  LiteRtLmChatTemplate(
+    id: 'qwen3',
+    template: _qwen3ChatTemplate,
+    familyMatches: ['qwen3', 'qwen-3'],
+    bosToken: '',
+    eosToken: '<|im_end|>',
+  ),
+  LiteRtLmChatTemplate(
+    id: 'qwen25',
+    template: _qwen25ChatTemplate,
+    familyMatches: ['qwen2.5', 'qwen-2.5', 'qwen2', 'qwen'],
+    bosToken: '',
+    eosToken: '<|im_end|>',
   ),
 ];

--- a/lib/src/backends/litert_lm/litert_lm_chat_templates.dart
+++ b/lib/src/backends/litert_lm/litert_lm_chat_templates.dart
@@ -654,7 +654,7 @@ const List<LiteRtLmChatTemplate> kLiteRtLmChatTemplates = [
   LiteRtLmChatTemplate(
     id: 'qwen25',
     template: _qwen25ChatTemplate,
-    familyMatches: ['qwen2.5', 'qwen-2.5', 'qwen2', 'qwen'],
+    familyMatches: ['qwen2.5', 'qwen-2.5', 'qwen2'],
     bosToken: '',
     eosToken: '<|im_end|>',
   ),

--- a/lib/src/backends/litert_lm/litert_lm_chat_templates.dart
+++ b/lib/src/backends/litert_lm/litert_lm_chat_templates.dart
@@ -1,3 +1,4 @@
+// coverage:ignore-file
 // GENERATED FILE — DO NOT EDIT BY HAND.
 //
 // Regenerate with: dart run tool/gen_litert_lm_templates.dart

--- a/lib/src/backends/litert_lm/litert_lm_chat_templates.dart
+++ b/lib/src/backends/litert_lm/litert_lm_chat_templates.dart
@@ -629,6 +629,8 @@ const List<LiteRtLmChatTemplate> kLiteRtLmChatTemplates = [
     familyMatches: ['gemma-4', 'gemma4'],
     bosToken: '<bos>',
     eosToken: '<turn|>',
+    thinkingStartTag: '<|channel>thought\n',
+    thinkingEndTag: '<channel|>',
   ),
   LiteRtLmChatTemplate(
     id: 'gemma3n',
@@ -636,6 +638,8 @@ const List<LiteRtLmChatTemplate> kLiteRtLmChatTemplates = [
     familyMatches: ['gemma-3n', 'gemma3n'],
     bosToken: '<bos>',
     eosToken: '<end_of_turn>',
+    thinkingStartTag: '<|channel>thought\n',
+    thinkingEndTag: '<channel|>',
   ),
   LiteRtLmChatTemplate(
     id: 'gemma',
@@ -643,6 +647,8 @@ const List<LiteRtLmChatTemplate> kLiteRtLmChatTemplates = [
     familyMatches: ['gemma-3', 'gemma3', 'gemma-2', 'gemma2'],
     bosToken: '<bos>',
     eosToken: '<end_of_turn>',
+    thinkingStartTag: '<|channel>thought\n',
+    thinkingEndTag: '<channel|>',
   ),
   LiteRtLmChatTemplate(
     id: 'qwen3',
@@ -650,6 +656,8 @@ const List<LiteRtLmChatTemplate> kLiteRtLmChatTemplates = [
     familyMatches: ['qwen3', 'qwen-3'],
     bosToken: '',
     eosToken: '<|im_end|>',
+    thinkingStartTag: '<think>',
+    thinkingEndTag: '</think>',
   ),
   LiteRtLmChatTemplate(
     id: 'qwen25',
@@ -657,5 +665,7 @@ const List<LiteRtLmChatTemplate> kLiteRtLmChatTemplates = [
     familyMatches: ['qwen2.5', 'qwen-2.5', 'qwen2'],
     bosToken: '',
     eosToken: '<|im_end|>',
+    thinkingStartTag: '<think>',
+    thinkingEndTag: '</think>',
   ),
 ];

--- a/lib/src/backends/litert_lm/litert_lm_chat_templates.dart
+++ b/lib/src/backends/litert_lm/litert_lm_chat_templates.dart
@@ -1,0 +1,371 @@
+// GENERATED FILE — DO NOT EDIT BY HAND.
+//
+// Regenerate with: dart run tool/gen_litert_lm_templates.dart
+// Source jinja lives under tool/litert_lm_templates/.
+
+import 'litert_lm_chat_template.dart';
+
+/// Canonical chat template for the gemma4 family.
+const String _gemma4ChatTemplate = r'''
+{%- macro format_parameters(properties, required) -%}
+    {%- set standard_keys = ['description', 'type', 'properties', 'required', 'nullable'] -%}
+    {%- set ns = namespace(found_first=false) -%}
+    {%- for key, value in properties | dictsort -%}
+        {%- set add_comma = false -%}
+        {%- if key not in standard_keys -%}
+            {%- if ns.found_first %},{% endif -%}
+            {%- set ns.found_first = true -%}
+            {{ key }}:{
+            {%- if value['description'] -%}
+                description:<|"|>{{ value['description'] }}<|"|>
+                {%- set add_comma = true -%}
+            {%- endif -%}
+            {%- if value['type'] | upper == 'STRING' -%}
+                {%- if value['enum'] -%}
+                    {%- if add_comma %},{%- else -%} {%- set add_comma = true -%} {% endif -%}
+                    enum:{{ format_argument(value['enum']) }}
+                {%- endif -%}
+            {%- elif value['type'] | upper == 'ARRAY' -%}
+                {%- if value['items'] is mapping and value['items'] -%}
+                    {%- if add_comma %},{%- else -%} {%- set add_comma = true -%} {% endif -%}
+                    items:{
+                    {%- set ns_items = namespace(found_first=false) -%}
+                    {%- for item_key, item_value in value['items'] | dictsort -%}
+                        {%- if item_value is not none -%}
+                            {%- if ns_items.found_first %},{% endif -%}
+                            {%- set ns_items.found_first = true -%}
+                            {%- if item_key == 'properties' -%}
+                                properties:{
+                                {%- if item_value is mapping -%}
+                                    {{- format_parameters(item_value, value['items']['required'] | default([])) -}}
+                                {%- endif -%}
+                                }
+                            {%- elif item_key == 'required' -%}
+                                required:[
+                                {%- for req_item in item_value -%}
+                                    <|"|>{{- req_item -}}<|"|>
+                                    {%- if not loop.last %},{% endif -%}
+                                {%- endfor -%}
+                                ]
+                            {%- elif item_key == 'type' -%}
+                                {%- if item_value is string -%}
+                                    type:{{ format_argument(item_value | upper) }}
+                                {%- else -%}
+                                    type:{{ format_argument(item_value | map('upper') | list) }}
+                                {%- endif -%}
+                            {%- else -%}
+                                {{ item_key }}:{{ format_argument(item_value) }}
+                            {%- endif -%}
+                        {%- endif -%}
+                    {%- endfor -%}
+                    }
+                {%- endif -%}
+            {%- endif -%}
+            {%- if value['nullable'] %}
+                {%- if add_comma %},{%- else -%} {%- set add_comma = true -%} {% endif -%}
+                nullable:true
+            {%- endif -%}
+            {%- if value['type'] | upper == 'OBJECT' -%}
+                {%- if value['properties'] is defined and value['properties'] is mapping -%}
+                    {%- if add_comma %},{%- else -%} {%- set add_comma = true -%} {% endif -%}
+                    properties:{
+                    {{- format_parameters(value['properties'], value['required'] | default([])) -}}
+                    }
+                {%- elif value is mapping -%}
+                    {%- if add_comma %},{%- else -%} {%- set add_comma = true -%} {% endif -%}
+                    properties:{
+                    {{- format_parameters(value, value['required'] | default([])) -}}
+                    }
+                {%- endif -%}
+                {%- if value['required'] -%}
+                    {%- if add_comma %},{%- else -%} {%- set add_comma = true -%} {% endif -%}
+                    required:[
+                    {%- for item in value['required'] | default([]) -%}
+                        <|"|>{{- item -}}<|"|>
+                        {%- if not loop.last %},{% endif -%}
+                    {%- endfor -%}
+                    ]
+                {%- endif -%}
+            {%- endif -%}
+            {%- if add_comma %},{%- else -%} {%- set add_comma = true -%} {% endif -%}
+            type:<|"|>{{ value['type'] | upper }}<|"|>}
+        {%- endif -%}
+    {%- endfor -%}
+{%- endmacro -%}
+{%- macro format_function_declaration(tool_data) -%}
+    declaration:{{- tool_data['function']['name'] -}}{description:<|"|>{{- tool_data['function']['description'] -}}<|"|>
+    {%- set params = tool_data['function']['parameters'] -%}
+    {%- if params -%}
+        ,parameters:{
+        {%- if params['properties'] -%}
+            properties:{ {{- format_parameters(params['properties'], params['required']) -}} },
+        {%- endif -%}
+        {%- if params['required'] -%}
+            required:[
+            {%- for item in params['required'] -%}
+                <|"|>{{- item -}}<|"|>
+                {{- ',' if not loop.last -}}
+            {%- endfor -%}
+            ],
+        {%- endif -%}
+        {%- if params['type'] -%}
+            type:<|"|>{{- params['type'] | upper -}}<|"|>}
+        {%- endif -%}
+    {%- endif -%}
+    {%- if 'response' in tool_data['function'] -%}
+        {%- set response_declaration = tool_data['function']['response'] -%}
+        ,response:{
+        {%- if response_declaration['description'] -%}
+            description:<|"|>{{- response_declaration['description'] -}}<|"|>,
+        {%- endif -%}
+        {%- if response_declaration['type'] | upper == 'OBJECT' -%}
+            type:<|"|>{{- response_declaration['type'] | upper -}}<|"|>}
+        {%- endif -%}
+    {%- endif -%}
+    }
+{%- endmacro -%}
+{%- macro format_argument(argument, escape_keys=True) -%}
+    {%- if argument is string -%}
+        {{- '<|"|>' + argument + '<|"|>' -}}
+    {%- elif argument is boolean -%}
+        {{- 'true' if argument else 'false' -}}
+    {%- elif argument is mapping -%}
+        {{- '{' -}}
+        {%- set ns = namespace(found_first=false) -%}
+        {%- for key, value in argument | dictsort -%}
+            {%- if ns.found_first %},{% endif -%}
+            {%- set ns.found_first = true -%}
+            {%- if escape_keys -%}
+                {{- '<|"|>' + key + '<|"|>' -}}
+            {%- else -%}
+                {{- key -}}
+            {%- endif -%}
+            :{{- format_argument(value, escape_keys=escape_keys) -}}
+        {%- endfor -%}
+        {{- '}' -}}
+    {%- elif argument is sequence -%}
+        {{- '[' -}}
+        {%- for item in argument -%}
+            {{- format_argument(item, escape_keys=escape_keys) -}}
+            {%- if not loop.last %},{% endif -%}
+        {%- endfor -%}
+        {{- ']' -}}
+    {%- else -%}
+        {{- argument -}}
+    {%- endif -%}
+{%- endmacro -%}
+{%- macro strip_thinking(text) -%}
+    {%- set ns = namespace(result='') -%}
+    {%- for part in text.split('<channel|>') -%}
+        {%- if '<|channel>' in part -%}
+            {%- set ns.result = ns.result + part.split('<|channel>')[0] -%}
+        {%- else -%}
+            {%- set ns.result = ns.result + part -%}
+        {%- endif -%}
+    {%- endfor -%}
+    {{- ns.result | trim -}}
+{%- endmacro -%}
+
+{%- macro format_tool_response_block(tool_name, response) -%}
+    {{- '<|tool_response>' -}}
+    {%- if response is mapping -%}
+        {{- 'response:' + tool_name + '{' -}}
+        {%- for key, value in response | dictsort -%}
+            {{- key -}}:{{- format_argument(value, escape_keys=False) -}}
+            {%- if not loop.last %},{% endif -%}
+        {%- endfor -%}
+        {{- '}' -}}
+    {%- else -%}
+        {{- 'response:' + tool_name + '{value:' + format_argument(response, escape_keys=False) + '}' -}}
+    {%- endif -%}
+    {{- '<tool_response|>' -}}
+{%- endmacro -%}
+
+{%- set ns = namespace(prev_message_type=None) -%}
+{%- set loop_messages = messages -%}
+{#- Handle System/Tool Definitions Block -#}
+{%- if (enable_thinking is defined and enable_thinking) or tools or messages[0]['role'] in ['system', 'developer'] -%}
+    {{- '<|turn>system\n' -}}
+
+    {#- Inject Thinking token at the very top of the FIRST system turn -#}
+    {%- if enable_thinking is defined and enable_thinking -%}
+        {{- '<|think|>\n' -}}
+        {%- set ns.prev_message_type = 'think' -%}
+    {%- endif -%}
+
+    {%- if messages[0]['role'] in ['system', 'developer'] -%}
+        {{- messages[0]['content'] | trim -}}
+        {%- set loop_messages = messages[1:] -%}
+    {%- endif -%}
+
+    {%- if tools -%}
+        {%- for tool in tools %}
+            {{- '<|tool>' -}}
+            {{- format_function_declaration(tool) | trim -}}
+            {{- '<tool|>' -}}
+        {%- endfor %}
+        {%- set ns.prev_message_type = 'tool' -%}
+    {%- endif -%}
+
+    {{- '<turn|>\n' -}}
+{%- endif %}
+
+{#- Pre-scan: find last user message index for reasoning guard -#}
+{%- set ns_turn = namespace(last_user_idx=-1) -%}
+{%- for i in range(loop_messages | length) -%}
+    {%- if loop_messages[i]['role'] == 'user' -%}
+        {%- set ns_turn.last_user_idx = i -%}
+    {%- endif -%}
+{%- endfor -%}
+
+{#- Loop through messages -#}
+{%- for message in loop_messages -%}
+    {%- if message['role'] != 'tool' -%}
+    {%- set ns.prev_message_type = None -%}
+    {%- set role = 'model' if message['role'] == 'assistant' else message['role'] -%}
+    {#- Detect continuation: suppress duplicate <|turn>model when previous non-tool message was also assistant -#}
+    {%- set prev_nt = namespace(role=None, found=false) -%}
+    {%- if loop.index0 > 0 -%}
+        {%- for j in range(loop.index0 - 1, -1, -1) -%}
+            {%- if not prev_nt.found -%}
+                {%- if loop_messages[j]['role'] != 'tool' -%}
+                    {%- set prev_nt.role = loop_messages[j]['role'] -%}
+                    {%- set prev_nt.found = true -%}
+                {%- endif -%}
+            {%- endif -%}
+        {%- endfor -%}
+    {%- endif -%}
+    {%- set continue_same_model_turn = (role == 'model' and prev_nt.role == 'assistant') -%}
+    {%- if not continue_same_model_turn -%}
+        {{- '<|turn>' + role + '\n' }}
+    {%- endif -%}
+
+    {#- Render reasoning/reasoning_content as thinking channel -#}
+    {%- set thinking_text = message.get('reasoning') or message.get('reasoning_content') -%}
+    {%- if thinking_text and loop.index0 > ns_turn.last_user_idx and message.get('tool_calls') -%}
+        {{- '<|channel>thought\n' + thinking_text + '\n<channel|>' -}}
+    {%- endif -%}
+
+            {%- if message['tool_calls'] -%}
+                {%- for tool_call in message['tool_calls'] -%}
+                    {%- set function = tool_call['function'] -%}
+                    {{- '<|tool_call>call:' + function['name'] + '{' -}}
+                    {%- if function['arguments'] is mapping -%}
+                        {%- set ns_args = namespace(found_first=false) -%}
+                        {%- for key, value in function['arguments'] | dictsort -%}
+                            {%- if ns_args.found_first %},{% endif -%}
+                            {%- set ns_args.found_first = true -%}
+                            {{- key -}}:{{- format_argument(value, escape_keys=False) -}}
+                        {%- endfor -%}
+                    {%- elif function['arguments'] is string -%}
+                        {{- function['arguments'] -}}
+                    {%- endif -%}
+                    {{- '}<tool_call|>' -}}
+                {%- endfor -%}
+                {%- set ns.prev_message_type = 'tool_call' -%}
+            {%- endif -%}
+
+            {%- set ns_tr_out = namespace(flag=false) -%}
+            {%- if message.get('tool_responses') -%}
+                {#- Legacy: tool_responses embedded on the assistant message (Google/Gemma native) -#}
+                {%- for tool_response in message['tool_responses'] -%}
+                    {{- format_tool_response_block(tool_response['name'] | default('unknown'), tool_response['response']) -}}
+                    {%- set ns_tr_out.flag = true -%}
+                    {%- set ns.prev_message_type = 'tool_response' -%}
+                {%- endfor -%}
+            {%- elif message.get('tool_calls') -%}
+                {#- OpenAI Chat Completions: forward-scan consecutive role:tool messages -#}
+                {%- set ns_tool_scan = namespace(stopped=false) -%}
+                {%- for k in range(loop.index0 + 1, loop_messages | length) -%}
+                    {%- if ns_tool_scan.stopped -%}
+                    {%- elif loop_messages[k]['role'] != 'tool' -%}
+                        {%- set ns_tool_scan.stopped = true -%}
+                    {%- else -%}
+                        {%- set follow = loop_messages[k] -%}
+                        {#- Resolve tool_call_id to function name -#}
+                        {%- set ns_tname = namespace(name=follow.get('name') | default('unknown')) -%}
+                        {%- for tc in message['tool_calls'] -%}
+                            {%- if tc.get('id') == follow.get('tool_call_id') -%}
+                                {%- set ns_tname.name = tc['function']['name'] -%}
+                            {%- endif -%}
+                        {%- endfor -%}
+                        {#- Handle content as string or content-parts array -#}
+                        {%- set tool_body = follow.get('content') -%}
+                        {%- if tool_body is string -%}
+                            {{- format_tool_response_block(ns_tname.name, tool_body) -}}
+                        {%- elif tool_body is sequence and tool_body is not string -%}
+                            {%- set ns_txt = namespace(s='') -%}
+                            {%- for part in tool_body -%}
+                                {%- if part.get('type') == 'text' -%}
+                                    {%- set ns_txt.s = ns_txt.s + (part.get('text') | default('')) -%}
+                                {%- endif -%}
+                            {%- endfor -%}
+                            {{- format_tool_response_block(ns_tname.name, ns_txt.s) -}}
+                        {%- else -%}
+                            {{- format_tool_response_block(ns_tname.name, tool_body) -}}
+                        {%- endif -%}
+                        {%- set ns_tr_out.flag = true -%}
+                        {%- set ns.prev_message_type = 'tool_response' -%}
+                    {%- endif -%}
+                {%- endfor -%}
+            {%- endif -%}
+
+            {%- if message['content'] is string -%}
+                {%- if role == 'model' -%}
+                    {{- strip_thinking(message['content']) -}}
+                {%- else -%}
+                    {{- message['content'] | trim -}}
+                {%- endif -%}
+            {%- elif message['content'] is sequence -%}
+                {%- for item in message['content'] -%}
+                    {%- if item['type'] == 'text' -%}
+                        {%- if role == 'model' -%}
+                            {{- strip_thinking(item['text']) -}}
+                        {%- else -%}
+                            {{- item['text'] | trim -}}
+                        {%- endif -%}
+                    {%- elif item['type'] == 'image' -%}
+                        {{- '<|image|>' -}}
+                        {%- set ns.prev_message_type = 'image' -%}
+                    {%- elif item['type'] == 'audio' -%}
+                        {{- '<|audio|>' -}}
+                        {%- set ns.prev_message_type = 'audio' -%}
+                    {%- elif item['type'] == 'video' -%}
+                        {{- '<|video|>' -}}
+                        {%- set ns.prev_message_type = 'video' -%}
+                    {%- endif -%}
+                {%- endfor -%}
+            {%- endif -%}
+
+        {%- if ns.prev_message_type == 'tool_call' and not ns_tr_out.flag -%}
+            {{- '<|tool_response>' -}}
+        {%- elif not (ns_tr_out.flag and not message.get('content')) -%}
+            {{- '<turn|>\n' -}}
+        {%- endif -%}
+    {%- endif -%}
+{%- endfor -%}
+
+{%- if add_generation_prompt -%}
+    {%- if ns.prev_message_type != 'tool_response' and ns.prev_message_type != 'tool_call' -%}
+        {{- '<|turn>model\n' -}}
+        {%- if not enable_thinking | default(false) -%}
+            {{- '<|channel>thought\n<channel|>' -}}
+        {%- endif -%}
+    {%- endif -%}
+{%- endif -%}
+''';
+
+/// Built-in LiteRT-LM chat templates, matched in order.
+///
+/// The first entry whose [LiteRtLmChatTemplate.matches] returns
+/// true for the bundle filename wins, so more specific families
+/// must precede broader ones.
+const List<LiteRtLmChatTemplate> kLiteRtLmChatTemplates = [
+  LiteRtLmChatTemplate(
+    id: 'gemma4',
+    template: _gemma4ChatTemplate,
+    familyMatches: ['gemma-4', 'gemma4'],
+    bosToken: '<bos>',
+    eosToken: '<turn|>',
+  ),
+];

--- a/lib/src/backends/litert_lm/litert_lm_runtime.dart
+++ b/lib/src/backends/litert_lm/litert_lm_runtime.dart
@@ -584,7 +584,8 @@ class LiteRtLmRuntimeClient {
       try {
         final raw = await _runBlockingSendMessageInIsolate(request);
         if (!controller.isClosed) {
-          final text = _extractText(raw);
+          final assembler = LiteRtLmChannelAssembler();
+          final text = assembler.add(raw) + assembler.flush();
           if (text.isNotEmpty) {
             controller.add(text);
           }
@@ -607,6 +608,7 @@ class LiteRtLmRuntimeClient {
     final bindings = _requireBindings();
     final conversation = _requireConversation();
     final messagePtr = _messageJson(prompt).toNativeUtf8();
+    final assembler = LiteRtLmChannelAssembler();
     Pointer<Void> callbackData = nullptr;
     var cleanedUp = false;
 
@@ -665,13 +667,17 @@ class LiteRtLmRuntimeClient {
       if (chunk != nullptr) {
         final raw = chunk.cast<Utf8>().toDartString();
         _proxyFreeString?.call(chunk);
-        final text = _extractText(raw);
+        final text = assembler.add(raw);
         if (text.isNotEmpty && !controller.isClosed) {
           controller.add(text);
         }
       }
 
       if (isFinal) {
+        final tail = assembler.flush();
+        if (tail.isNotEmpty && !controller.isClosed) {
+          controller.add(tail);
+        }
         if (!controller.isClosed) {
           unawaited(controller.close());
         }
@@ -1345,25 +1351,96 @@ String _runBlockingSendMessage(_BlockingSendMessageRequest request) {
   }
 }
 
-String _extractText(String raw) {
+/// Markers the Gemma 4 chat-template handler uses to delimit reasoning, so the
+/// thinking channel streamed by the native runtime is parsed as reasoning.
+const String _liteRtLmThoughtOpen = '<|channel>thought\n';
+const String _liteRtLmThoughtClose = '<channel|>';
+
+/// Reassembles LiteRT-LM streaming response chunks into the textual form the
+/// chat-template handlers parse.
+///
+/// The native runtime emits thinking and final content on separate channels:
+/// thought as `{"role":"assistant","channels":{"thought":"..."}}` and the
+/// answer as `{"role":"assistant","content":[{"type":"text","text":"..."}]}`.
+/// Thought runs are wrapped in `<|channel>thought ... <channel|>` so downstream
+/// parsing surfaces them as reasoning instead of leaking the raw JSON.
+class LiteRtLmChannelAssembler {
+  bool _inThought = false;
+
+  /// Converts one native response [raw] chunk into handler-facing text.
+  String add(String raw) {
+    final chunk = _parseLiteRtLmChunk(raw);
+    final buffer = StringBuffer();
+    final thought = chunk.thought;
+    if (thought != null && thought.isNotEmpty) {
+      if (!_inThought) {
+        buffer.write(_liteRtLmThoughtOpen);
+        _inThought = true;
+      }
+      buffer.write(thought);
+    }
+    final content = chunk.content;
+    if (content != null && content.isNotEmpty) {
+      buffer.write(_closeThoughtIfOpen());
+      buffer.write(content);
+    }
+    return buffer.toString();
+  }
+
+  /// Closes a still-open thought run at end of stream (e.g. token-limit cutoff).
+  String flush() => _closeThoughtIfOpen();
+
+  String _closeThoughtIfOpen() {
+    if (!_inThought) {
+      return '';
+    }
+    _inThought = false;
+    return _liteRtLmThoughtClose;
+  }
+}
+
+({String? thought, String? content}) _parseLiteRtLmChunk(String raw) {
   try {
     final decoded = jsonDecode(raw);
     if (decoded is! Map<String, dynamic>) {
-      return raw;
+      return (thought: null, content: raw);
     }
+
+    final channels = decoded['channels'];
+    String? thought;
+    final contentBuffer = StringBuffer();
+    if (channels is Map<String, dynamic>) {
+      channels.forEach((channel, value) {
+        if (value is! String) {
+          return;
+        }
+        if (channel == 'thought') {
+          thought = (thought ?? '') + value;
+        } else {
+          // Non-thought channels are surfaced as ordinary content.
+          contentBuffer.write(value);
+        }
+      });
+    }
+
     final content = decoded['content'];
-    if (content is! List) {
-      return raw;
-    }
-    final buffer = StringBuffer();
-    for (final item in content) {
-      if (item is Map<String, dynamic> && item['type'] == 'text') {
-        buffer.write(item['text'] as String? ?? '');
+    if (content is List) {
+      for (final item in content) {
+        if (item is Map<String, dynamic> && item['type'] == 'text') {
+          contentBuffer.write(item['text'] as String? ?? '');
+        }
       }
+    } else if (channels is! Map<String, dynamic>) {
+      // Neither a recognized channels nor content shape: preserve verbatim.
+      return (thought: null, content: raw);
     }
-    return buffer.toString();
+
+    return (
+      thought: thought,
+      content: contentBuffer.isEmpty ? null : contentBuffer.toString(),
+    );
   } on FormatException {
-    return raw;
+    return (thought: null, content: raw);
   }
 }
 

--- a/lib/src/backends/litert_lm/litert_lm_runtime.dart
+++ b/lib/src/backends/litert_lm/litert_lm_runtime.dart
@@ -333,6 +333,18 @@ final class _BlockingSendMessageRequest {
 /// `LlamaEngine` API. This client is exported for benchmark tools and advanced
 /// native integrations that need direct access to LiteRT-LM bundles.
 class LiteRtLmRuntimeClient {
+  String _thinkingStartTag = LiteRtLmChannelAssembler.gemma4ThinkingStartTag;
+  String _thinkingEndTag = LiteRtLmChannelAssembler.gemma4ThinkingEndTag;
+
+  /// Configures how LiteRT-LM thought-channel chunks are exposed to parsers.
+  void configureResponseThinkingTags({
+    required String startTag,
+    required String endTag,
+  }) {
+    _thinkingStartTag = startTag;
+    _thinkingEndTag = endTag;
+  }
+
   _LiteRtLmBindings? _bindings;
   // Keep a strong reference while callbacks/function pointers may be active.
   // ignore: unused_field
@@ -584,7 +596,10 @@ class LiteRtLmRuntimeClient {
       try {
         final raw = await _runBlockingSendMessageInIsolate(request);
         if (!controller.isClosed) {
-          final assembler = LiteRtLmChannelAssembler();
+          final assembler = LiteRtLmChannelAssembler(
+            thinkingStartTag: _thinkingStartTag,
+            thinkingEndTag: _thinkingEndTag,
+          );
           final text = assembler.add(raw) + assembler.flush();
           if (text.isNotEmpty) {
             controller.add(text);
@@ -608,7 +623,10 @@ class LiteRtLmRuntimeClient {
     final bindings = _requireBindings();
     final conversation = _requireConversation();
     final messagePtr = _messageJson(prompt).toNativeUtf8();
-    final assembler = LiteRtLmChannelAssembler();
+    final assembler = LiteRtLmChannelAssembler(
+      thinkingStartTag: _thinkingStartTag,
+      thinkingEndTag: _thinkingEndTag,
+    );
     Pointer<Void> callbackData = nullptr;
     var cleanedUp = false;
 
@@ -1351,20 +1369,33 @@ String _runBlockingSendMessage(_BlockingSendMessageRequest request) {
   }
 }
 
-/// Markers the Gemma 4 chat-template handler uses to delimit reasoning, so the
-/// thinking channel streamed by the native runtime is parsed as reasoning.
-const String _liteRtLmThoughtOpen = '<|channel>thought\n';
-const String _liteRtLmThoughtClose = '<channel|>';
-
 /// Reassembles LiteRT-LM streaming response chunks into the textual form the
 /// chat-template handlers parse.
 ///
 /// The native runtime emits thinking and final content on separate channels:
 /// thought as `{"role":"assistant","channels":{"thought":"..."}}` and the
 /// answer as `{"role":"assistant","content":[{"type":"text","text":"..."}]}`.
-/// Thought runs are wrapped in `<|channel>thought ... <channel|>` so downstream
-/// parsing surfaces them as reasoning instead of leaking the raw JSON.
+/// Thought runs are wrapped in the active chat handler's reasoning tags so
+/// downstream parsing surfaces them as reasoning instead of leaking raw JSON.
 class LiteRtLmChannelAssembler {
+  /// Gemma 4 reasoning start marker.
+  static const String gemma4ThinkingStartTag = '<|channel>thought\n';
+
+  /// Gemma 4 reasoning end marker.
+  static const String gemma4ThinkingEndTag = '<channel|>';
+
+  /// Creates a response-channel assembler.
+  LiteRtLmChannelAssembler({
+    this.thinkingStartTag = gemma4ThinkingStartTag,
+    this.thinkingEndTag = gemma4ThinkingEndTag,
+  });
+
+  /// Marker used to open a thought run.
+  final String thinkingStartTag;
+
+  /// Marker used to close a thought run.
+  final String thinkingEndTag;
+
   bool _inThought = false;
 
   /// Converts one native response [raw] chunk into handler-facing text.
@@ -1374,7 +1405,7 @@ class LiteRtLmChannelAssembler {
     final thought = chunk.thought;
     if (thought != null && thought.isNotEmpty) {
       if (!_inThought) {
-        buffer.write(_liteRtLmThoughtOpen);
+        buffer.write(thinkingStartTag);
         _inThought = true;
       }
       buffer.write(thought);
@@ -1395,7 +1426,7 @@ class LiteRtLmChannelAssembler {
       return '';
     }
     _inThought = false;
-    return _liteRtLmThoughtClose;
+    return thinkingEndTag;
   }
 }
 

--- a/lib/src/backends/litert_lm/litert_lm_service.dart
+++ b/lib/src/backends/litert_lm/litert_lm_service.dart
@@ -431,6 +431,11 @@ class LiteRtLmService {
     _client = null;
     _activeOutputTokens = null;
     final client = _clientFactory();
+    final responseThinkingTags = _responseThinkingTagsForModel(modelPath);
+    client.configureResponseThinkingTags(
+      startTag: responseThinkingTags.startTag,
+      endTag: responseThinkingTags.endTag,
+    );
     try {
       await client.initialize(
         modelPath: modelPath,
@@ -453,6 +458,21 @@ class LiteRtLmService {
     _activeOutputTokens = resolvedOutputTokens;
     _activeBackend = backend;
     return client;
+  }
+
+  ({String startTag, String endTag}) _responseThinkingTagsForModel(
+    String modelPath,
+  ) {
+    final modelName = File(modelPath).uri.pathSegments.last;
+    final template = _resolveBuiltinTemplate(modelName);
+    return (
+      startTag:
+          template?.thinkingStartTag ??
+          LiteRtLmChannelAssembler.gemma4ThinkingStartTag,
+      endTag:
+          template?.thinkingEndTag ??
+          LiteRtLmChannelAssembler.gemma4ThinkingEndTag,
+    );
   }
 
   Stream<List<int>> _applyStopSequences(

--- a/lib/src/backends/litert_lm/litert_lm_service.dart
+++ b/lib/src/backends/litert_lm/litert_lm_service.dart
@@ -13,6 +13,8 @@ import '../../core/models/inference/generation_params.dart';
 import '../../core/models/inference/model_params.dart';
 import '../../core/template/chat_template_engine.dart';
 import '../backend.dart';
+import 'litert_lm_chat_template.dart';
+import 'litert_lm_chat_templates.dart';
 import 'litert_lm_platform.dart';
 import 'litert_lm_runtime.dart';
 
@@ -22,16 +24,6 @@ import 'litert_lm_runtime.dart';
 /// public backend only sends requests and receives stream chunks, mirroring the
 /// llama.cpp backend architecture.
 class LiteRtLmService {
-  static const String _gemma4ChatTemplate =
-      '{% for message in messages %}'
-      '<|turn>{% if message["role"] == "assistant" %}model\n'
-      '{% else %}{{ message["role"] }}\n{% endif %}'
-      '{{ message["content"] }}<turn|>\n'
-      '{% endfor %}'
-      '{% if add_generation_prompt %}<|turn>model\n'
-      '{% if enable_thinking %}<|channel>thought\n{% endif %}'
-      '{% endif %}';
-
   /// Creates a LiteRT-LM service.
   LiteRtLmService({LiteRtLmRuntimeClient Function()? clientFactory})
     : _clientFactory = clientFactory ?? LiteRtLmRuntimeClient.new;
@@ -252,12 +244,13 @@ class LiteRtLmService {
     if (_modelParams case final params?) {
       metadata['llm.context_length'] = params.contextSize.toString();
     }
-    if (modelName != null && _isGemma4ModelName(modelName)) {
-      metadata.addAll(const <String, String>{
-        'tokenizer.chat_template': _gemma4ChatTemplate,
-        'tokenizer.ggml.bos_token': '<bos>',
-        'tokenizer.ggml.eos_token': '<turn|>',
-      });
+    final builtinTemplate = modelName == null
+        ? null
+        : _resolveBuiltinTemplate(modelName);
+    if (builtinTemplate != null) {
+      metadata['tokenizer.chat_template'] = builtinTemplate.template;
+      metadata['tokenizer.ggml.bos_token'] = builtinTemplate.bosToken;
+      metadata['tokenizer.ggml.eos_token'] = builtinTemplate.eosToken;
     }
     if (_modelParams?.chatTemplate case final customTemplate?) {
       metadata['tokenizer.chat_template'] = customTemplate;
@@ -265,9 +258,20 @@ class LiteRtLmService {
     return metadata;
   }
 
-  bool _isGemma4ModelName(String modelName) {
+  /// Resolves the built-in chat template for [modelName], if any.
+  ///
+  /// `.litertlm` bundles don't expose their chat template through the native
+  /// FFI, so the family is detected from the bundle filename and mapped to one
+  /// of the templates in [kLiteRtLmChatTemplates]. Callers can always override
+  /// the result with [ModelParams.chatTemplate].
+  LiteRtLmChatTemplate? _resolveBuiltinTemplate(String modelName) {
     final normalized = modelName.toLowerCase().replaceAll('_', '-');
-    return normalized.contains('gemma-4') || normalized.contains('gemma4');
+    for (final template in kLiteRtLmChatTemplates) {
+      if (template.matches(normalized)) {
+        return template;
+      }
+    }
+    return null;
   }
 
   /// Handles LiteRT-LM LoRA operations.

--- a/lib/src/backends/native/native_backend.dart
+++ b/lib/src/backends/native/native_backend.dart
@@ -23,7 +23,8 @@ class NativeAutoBackend
         BackendEmbeddingsSupport,
         BackendBatchEmbeddings,
         BackendStatePersistence,
-        BackendStatePersistenceSupport {
+        BackendStatePersistenceSupport,
+        BackendGrammarConstraintsSupport {
   final LlamaBackend Function() _llamaCppFactory;
   final LlamaBackend Function() _liteRtLmFactory;
 
@@ -45,6 +46,19 @@ class NativeAutoBackend
 
   @override
   bool get supportsUrlLoading => false;
+
+  @override
+  bool get supportsGrammarConstraints {
+    // Forward the active delegate's capability so the engine skips template
+    // grammars on backends that reject them (e.g. LiteRT-LM). Defaults to true
+    // (llama.cpp) before a model is loaded.
+    final delegate = _delegate;
+    if (delegate is BackendGrammarConstraintsSupport) {
+      return (delegate as BackendGrammarConstraintsSupport)
+          .supportsGrammarConstraints;
+    }
+    return true;
+  }
 
   @override
   Future<int> modelLoad(String path, ModelParams params) async {

--- a/lib/src/core/engine/engine.dart
+++ b/lib/src/core/engine/engine.dart
@@ -552,7 +552,15 @@ class LlamaEngine {
 
         if (streamingMode == _ToolStreamingMode.undecided) {
           undecidedPrefix += token;
-          final mode = _decideToolStreamingMode(undecidedPrefix);
+          final decisionPrefix = _stripLeadingThinkingForToolDecision(
+            undecidedPrefix,
+            startTag: startTag,
+            endTag: endTag,
+          );
+          if (decisionPrefix == null) {
+            continue;
+          }
+          final mode = _decideToolStreamingMode(decisionPrefix);
           if (mode == _ToolStreamingMode.undecided) {
             continue;
           }
@@ -586,6 +594,9 @@ class LlamaEngine {
               streamedReasoning += emission.text;
             } else {
               streamedContent += emission.text;
+            }
+            if (emission.isThinking && !enableThinking) {
+              continue;
             }
             yield LlamaCompletionChunk(
               id: 'chatcmpl-$completionId',
@@ -644,7 +655,7 @@ class LlamaEngine {
           final partialReasoning = partialParsed.reasoningContent ?? '';
           if (partialReasoning.length > streamedReasoning.length) {
             final delta = partialReasoning.substring(streamedReasoning.length);
-            if (delta.isNotEmpty) {
+            if (delta.isNotEmpty && enableThinking) {
               yield LlamaCompletionChunk(
                 id: 'chatcmpl-$completionId',
                 object: 'chat.completion.chunk',
@@ -717,20 +728,22 @@ class LlamaEngine {
         } else {
           streamedContent += pendingBuffer;
         }
-        yield LlamaCompletionChunk(
-          id: 'chatcmpl-$completionId',
-          object: 'chat.completion.chunk',
-          created: DateTime.now().millisecondsSinceEpoch ~/ 1000,
-          model: _modelPath ?? 'llama_model',
-          choices: [
-            LlamaCompletionChunkChoice(
-              index: 0,
-              delta: isThinking
-                  ? LlamaCompletionChunkDelta(thinking: pendingBuffer)
-                  : LlamaCompletionChunkDelta(content: pendingBuffer),
-            ),
-          ],
-        );
+        if (!isThinking || enableThinking) {
+          yield LlamaCompletionChunk(
+            id: 'chatcmpl-$completionId',
+            object: 'chat.completion.chunk',
+            created: DateTime.now().millisecondsSinceEpoch ~/ 1000,
+            model: _modelPath ?? 'llama_model',
+            choices: [
+              LlamaCompletionChunkChoice(
+                index: 0,
+                delta: isThinking
+                    ? LlamaCompletionChunkDelta(thinking: pendingBuffer)
+                    : LlamaCompletionChunkDelta(content: pendingBuffer),
+              ),
+            ],
+          );
+        }
       }
     } else {
       await for (final token in tokenStream) {
@@ -745,6 +758,9 @@ class LlamaEngine {
         pendingBuffer = split.pendingBuffer;
         isThinking = split.isThinking;
         for (final emission in split.emissions) {
+          if (emission.isThinking && !enableThinking) {
+            continue;
+          }
           yield LlamaCompletionChunk(
             id: 'chatcmpl-$completionId',
             object: 'chat.completion.chunk',
@@ -763,7 +779,7 @@ class LlamaEngine {
       }
 
       // Final flush of any pending buffer
-      if (pendingBuffer.isNotEmpty) {
+      if (pendingBuffer.isNotEmpty && (!isThinking || enableThinking)) {
         yield LlamaCompletionChunk(
           id: 'chatcmpl-$completionId',
           object: 'chat.completion.chunk',
@@ -798,7 +814,9 @@ class LlamaEngine {
         finalValue: finalReasoning,
         channel: 'thinking',
       );
-      if (reasoningDelta != null && reasoningDelta.isNotEmpty) {
+      if (reasoningDelta != null &&
+          reasoningDelta.isNotEmpty &&
+          enableThinking) {
         yield LlamaCompletionChunk(
           id: 'chatcmpl-$completionId',
           object: 'chat.completion.chunk',
@@ -1599,6 +1617,43 @@ class LlamaEngine {
     return mode;
   }
 
+  String? _stripLeadingThinkingForToolDecision(
+    String value, {
+    required String startTag,
+    required String endTag,
+  }) {
+    var remaining = value;
+    while (true) {
+      final start = _firstNonWhitespaceIndex(remaining);
+      if (start == null) {
+        return remaining;
+      }
+
+      final leading = remaining.substring(0, start);
+      final trimmed = remaining.substring(start);
+      if (startTag.startsWith(trimmed) || endTag.startsWith(trimmed)) {
+        return null;
+      }
+
+      if (trimmed.startsWith(endTag)) {
+        remaining = leading + trimmed.substring(endTag.length);
+        continue;
+      }
+
+      if (trimmed.startsWith(startTag)) {
+        final afterStart = trimmed.substring(startTag.length);
+        final endIndex = afterStart.indexOf(endTag);
+        if (endIndex < 0) {
+          return null;
+        }
+        remaining = leading + afterStart.substring(endIndex + endTag.length);
+        continue;
+      }
+
+      return remaining;
+    }
+  }
+
   _ToolStreamingMode _decideJsonEnvelopeMode(String text) {
     var i = 1;
     while (i < text.length && _isWhitespaceCodeUnit(text.codeUnitAt(i))) {
@@ -1637,7 +1692,10 @@ class LlamaEngine {
   }
 
   bool _isGenericEnvelopeKey(String key) {
-    return key == 'tool_call' || key == 'tool_calls' || key == 'response';
+    return key == 'tool_call' ||
+        key == 'tool_calls' ||
+        key == 'response' ||
+        key == 'name';
   }
 
   _ToolStreamingMode _decideBracketEnvelopeMode(String text) {
@@ -1657,6 +1715,7 @@ class LlamaEngine {
     const parsedPrefixes = <String>[
       '<tool_call',
       '<tool_calls',
+      '<|tool_call',
       '<function',
       '<function_call',
       '<start_function_call',

--- a/lib/src/core/template/handlers/hermes_handler.dart
+++ b/lib/src/core/template/handlers/hermes_handler.dart
@@ -46,6 +46,7 @@ class HermesHandler extends ChatTemplateHandler {
         'messages': templateMessages(messages),
         'add_generation_prompt': addAssistant,
         'tools': tools?.map((t) => t.toJson()).toList(),
+        'enable_thinking': enableThinking,
         'bos_token': metadata['tokenizer.ggml.bos_token'] ?? '<s>',
         'eos_token': metadata['tokenizer.ggml.eos_token'] ?? '</s>',
       },

--- a/lib/src/core/template/handlers/hermes_handler.dart
+++ b/lib/src/core/template/handlers/hermes_handler.dart
@@ -202,7 +202,14 @@ class HermesHandler extends ChatTemplateHandler {
       }
     }
 
-    if (parseFailed && !isPartial) {
+    if (parseFailed) {
+      if (isPartial) {
+        return ChatParseResult(
+          content: content.toString().trim(),
+          reasoningContent: thinking.reasoning,
+          toolCalls: toolCalls,
+        );
+      }
       return ChatParseResult(
         content: text.trim(),
         reasoningContent: thinking.reasoning,

--- a/lib/src/core/template/handlers/hermes_handler.dart
+++ b/lib/src/core/template/handlers/hermes_handler.dart
@@ -100,6 +100,16 @@ class HermesHandler extends ChatTemplateHandler {
       );
     }
 
+    if (isPartial) {
+      final visiblePrefix = _contentBeforePendingToolEnvelope(text);
+      if (visiblePrefix != null) {
+        return ChatParseResult(
+          content: visiblePrefix.trim(),
+          reasoningContent: thinking.reasoning,
+        );
+      }
+    }
+
     final toolCalls = <LlamaCompletionChunkToolCall>[];
     final content = StringBuffer();
     var cursor = 0;
@@ -260,6 +270,42 @@ class HermesHandler extends ChatTemplateHandler {
       return null;
     }
     return matches.first;
+  }
+
+  String? _contentBeforePendingToolEnvelope(String text) {
+    final lower = text.toLowerCase();
+    const markers = <String>[
+      '<tool_call',
+      '<function_call',
+      '<function=',
+      '<function name=',
+    ];
+
+    var markerStart = -1;
+    for (final marker in markers) {
+      final index = lower.indexOf(marker);
+      if (index >= 0 && (markerStart == -1 || index < markerStart)) {
+        markerStart = index;
+      }
+    }
+    if (markerStart < 0) {
+      return null;
+    }
+
+    final afterMarker = text.substring(markerStart);
+    final completeXmlToolCall = RegExp(
+      r'<tool_call>[\s\S]*?</tool_call>',
+      caseSensitive: false,
+    ).hasMatch(afterMarker);
+    final completeFunctionCall = RegExp(
+      r'<function(?:=[^>]+| name="[^"]+")>[\s\S]*?</function>',
+      caseSensitive: false,
+    ).hasMatch(afterMarker);
+    if (completeXmlToolCall || completeFunctionCall) {
+      return null;
+    }
+
+    return text.substring(0, markerStart);
   }
 
   ParsedJsonValueSlice? _extractJsonObjectRange(String text, int start) {

--- a/test/unit/backends/litert_lm/litert_lm_channel_assembler_test.dart
+++ b/test/unit/backends/litert_lm/litert_lm_channel_assembler_test.dart
@@ -1,0 +1,45 @@
+@TestOn('vm')
+library;
+
+import 'package:llamadart/src/backends/litert_lm/litert_lm_runtime.dart';
+import 'package:test/test.dart';
+
+void main() {
+  group('LiteRtLmChannelAssembler', () {
+    test('wraps a thought run in Gemma 4 channel markers, then content', () {
+      final assembler = LiteRtLmChannelAssembler();
+      final out = StringBuffer()
+        ..write(assembler.add('{"role":"assistant","channels":{"thought":"Hel"}}'))
+        ..write(assembler.add('{"role":"assistant","channels":{"thought":"lo"}}'))
+        ..write(assembler.add('{"role":"assistant","content":[{"type":"text","text":"42"}]}'))
+        ..write(assembler.flush());
+
+      expect(out.toString(), '<|channel>thought\nHello<channel|>42');
+    });
+
+    test('passes plain content through untouched', () {
+      final assembler = LiteRtLmChannelAssembler();
+      final out = assembler.add(
+            '{"role":"assistant","content":[{"type":"text","text":"7"}]}',
+          ) +
+          assembler.flush();
+
+      expect(out, '7');
+    });
+
+    test('closes an unterminated thought run on flush (token cutoff)', () {
+      final assembler = LiteRtLmChannelAssembler();
+      final out = StringBuffer()
+        ..write(assembler.add('{"role":"assistant","channels":{"thought":"partial"}}'))
+        ..write(assembler.flush());
+
+      expect(out.toString(), '<|channel>thought\npartial<channel|>');
+    });
+
+    test('preserves non-JSON and unrecognized payloads verbatim', () {
+      final assembler = LiteRtLmChannelAssembler();
+      expect(assembler.add('not json'), 'not json');
+      expect(assembler.add('{"role":"assistant"}'), '{"role":"assistant"}');
+    });
+  });
+}

--- a/test/unit/backends/litert_lm/litert_lm_channel_assembler_test.dart
+++ b/test/unit/backends/litert_lm/litert_lm_channel_assembler_test.dart
@@ -9,17 +9,48 @@ void main() {
     test('wraps a thought run in Gemma 4 channel markers, then content', () {
       final assembler = LiteRtLmChannelAssembler();
       final out = StringBuffer()
-        ..write(assembler.add('{"role":"assistant","channels":{"thought":"Hel"}}'))
-        ..write(assembler.add('{"role":"assistant","channels":{"thought":"lo"}}'))
-        ..write(assembler.add('{"role":"assistant","content":[{"type":"text","text":"42"}]}'))
+        ..write(
+          assembler.add('{"role":"assistant","channels":{"thought":"Hel"}}'),
+        )
+        ..write(
+          assembler.add('{"role":"assistant","channels":{"thought":"lo"}}'),
+        )
+        ..write(
+          assembler.add(
+            '{"role":"assistant","content":[{"type":"text","text":"42"}]}',
+          ),
+        )
         ..write(assembler.flush());
 
       expect(out.toString(), '<|channel>thought\nHello<channel|>42');
     });
 
+    test('wraps thought runs with the configured handler markers', () {
+      final assembler = LiteRtLmChannelAssembler(
+        thinkingStartTag: '<think>',
+        thinkingEndTag: '</think>',
+      );
+      final out = StringBuffer()
+        ..write(
+          assembler.add('{"role":"assistant","channels":{"thought":"Hel"}}'),
+        )
+        ..write(
+          assembler.add('{"role":"assistant","channels":{"thought":"lo"}}'),
+        )
+        ..write(
+          assembler.add(
+            '{"role":"assistant","content":[{"type":"text","text":"42"}]}',
+          ),
+        )
+        ..write(assembler.flush());
+
+      expect(out.toString(), '<think>Hello</think>42');
+    });
+
     test('passes plain content through untouched', () {
       final assembler = LiteRtLmChannelAssembler();
-      final out = assembler.add(
+      final out =
+          assembler.add(
             '{"role":"assistant","content":[{"type":"text","text":"7"}]}',
           ) +
           assembler.flush();
@@ -30,7 +61,11 @@ void main() {
     test('closes an unterminated thought run on flush (token cutoff)', () {
       final assembler = LiteRtLmChannelAssembler();
       final out = StringBuffer()
-        ..write(assembler.add('{"role":"assistant","channels":{"thought":"partial"}}'))
+        ..write(
+          assembler.add(
+            '{"role":"assistant","channels":{"thought":"partial"}}',
+          ),
+        )
         ..write(assembler.flush());
 
       expect(out.toString(), '<|channel>thought\npartial<channel|>');

--- a/test/unit/backends/litert_lm/litert_lm_chat_template_test.dart
+++ b/test/unit/backends/litert_lm/litert_lm_chat_template_test.dart
@@ -1,0 +1,29 @@
+import 'package:llamadart/src/backends/litert_lm/litert_lm_chat_template.dart';
+import 'package:test/test.dart';
+
+void main() {
+  group('LiteRtLmChatTemplate', () {
+    test('matches normalized family substrings', () {
+      const template = LiteRtLmChatTemplate(
+        id: 'example',
+        template: 'template',
+        familyMatches: ['gemma-4', 'gemma4'],
+      );
+
+      expect(template.matches('gemma-4-e2b-it.litertlm'), isTrue);
+      expect(template.matches('gemma4-e2b-it.litertlm'), isTrue);
+      expect(template.matches('qwen3-0.6b.litertlm'), isFalse);
+    });
+
+    test('defaults to Gemma 4 thought-channel markers', () {
+      const template = LiteRtLmChatTemplate(
+        id: 'gemma4',
+        template: 'template',
+        familyMatches: ['gemma-4'],
+      );
+
+      expect(template.thinkingStartTag, '<|channel>thought\n');
+      expect(template.thinkingEndTag, '<channel|>');
+    });
+  });
+}

--- a/test/unit/backends/litert_lm/litert_lm_chat_templates_test.dart
+++ b/test/unit/backends/litert_lm/litert_lm_chat_templates_test.dart
@@ -1,12 +1,17 @@
 import 'package:llamadart/src/backends/litert_lm/litert_lm_chat_templates.dart';
+import 'package:llamadart/src/backends/litert_lm/litert_lm_chat_template.dart';
 import 'package:test/test.dart';
 
 /// Mirrors `LiteRtLmService._resolveBuiltinTemplate`: first match wins.
 String? resolveId(String fileName) {
+  return resolveTemplate(fileName)?.id;
+}
+
+LiteRtLmChatTemplate? resolveTemplate(String fileName) {
   final normalized = fileName.toLowerCase().replaceAll('_', '-');
   for (final template in kLiteRtLmChatTemplates) {
     if (template.matches(normalized)) {
-      return template.id;
+      return template;
     }
   }
   return null;
@@ -34,10 +39,13 @@ void main() {
       expect(resolveId('Qwen3-0.6B.litertlm'), isNot('qwen25'));
     });
 
-    test('returns null for unseeded models (caller falls back / overrides)', () {
-      expect(resolveId('phi-4-mini-instruct.litertlm'), isNull);
-      expect(resolveId('some-unknown-model.litertlm'), isNull);
-    });
+    test(
+      'returns null for unseeded models (caller falls back / overrides)',
+      () {
+        expect(resolveId('phi-4-mini-instruct.litertlm'), isNull);
+        expect(resolveId('some-unknown-model.litertlm'), isNull);
+      },
+    );
 
     test('does not mis-route qwen-derived models to the Qwen 2.5 template', () {
       // DeepSeek-R1-Distill-Qwen needs its own handler; the bare `qwen` rule
@@ -54,5 +62,21 @@ void main() {
         );
       }
     });
+
+    test(
+      'uses parser-compatible thought markers for Qwen/Hermes templates',
+      () {
+        final gemma4 = resolveTemplate('gemma-4-E2B-it.litertlm')!;
+        final qwen3 = resolveTemplate('Qwen3-0.6B.litertlm')!;
+        final qwen25 = resolveTemplate('Qwen2.5-1.5B-Instruct.litertlm')!;
+
+        expect(gemma4.thinkingStartTag, '<|channel>thought\n');
+        expect(gemma4.thinkingEndTag, '<channel|>');
+        expect(qwen3.thinkingStartTag, '<think>');
+        expect(qwen3.thinkingEndTag, '</think>');
+        expect(qwen25.thinkingStartTag, '<think>');
+        expect(qwen25.thinkingEndTag, '</think>');
+      },
+    );
   });
 }

--- a/test/unit/backends/litert_lm/litert_lm_chat_templates_test.dart
+++ b/test/unit/backends/litert_lm/litert_lm_chat_templates_test.dart
@@ -1,0 +1,52 @@
+import 'package:llamadart/src/backends/litert_lm/litert_lm_chat_templates.dart';
+import 'package:test/test.dart';
+
+/// Mirrors `LiteRtLmService._resolveBuiltinTemplate`: first match wins.
+String? resolveId(String fileName) {
+  final normalized = fileName.toLowerCase().replaceAll('_', '-');
+  for (final template in kLiteRtLmChatTemplates) {
+    if (template.matches(normalized)) {
+      return template.id;
+    }
+  }
+  return null;
+}
+
+void main() {
+  group('LiteRT-LM chat template registry', () {
+    test('resolves each seeded family from representative bundle names', () {
+      expect(resolveId('gemma-4-E2B-it.litertlm'), 'gemma4');
+      expect(resolveId('gemma-4-E4B-it.litertlm'), 'gemma4');
+      expect(resolveId('gemma-3n-E2B-it.litertlm'), 'gemma3n');
+      expect(resolveId('gemma-3n-E4B-it.litertlm'), 'gemma3n');
+      expect(resolveId('gemma-3-4b-it.litertlm'), 'gemma');
+      expect(resolveId('gemma-2-2b-it.litertlm'), 'gemma');
+      expect(resolveId('Qwen3-0.6B.litertlm'), 'qwen3');
+      expect(resolveId('Qwen3.5-2B.litertlm'), 'qwen3');
+      expect(resolveId('Qwen2.5-1.5B-Instruct.litertlm'), 'qwen25');
+    });
+
+    test('precedence: specific families win over broader ones', () {
+      // gemma-4 / gemma-3n must not be swallowed by the gemma-3 entry, and
+      // qwen3 must not be swallowed by the qwen entry.
+      expect(resolveId('gemma-4-E2B-it.litertlm'), isNot('gemma'));
+      expect(resolveId('gemma-3n-E4B-it.litertlm'), isNot('gemma'));
+      expect(resolveId('Qwen3-0.6B.litertlm'), isNot('qwen25'));
+    });
+
+    test('returns null for unseeded models (caller falls back / overrides)', () {
+      expect(resolveId('phi-4-mini-instruct.litertlm'), isNull);
+      expect(resolveId('some-unknown-model.litertlm'), isNull);
+    });
+
+    test('templates omit a leading BOS token (native runtime adds it)', () {
+      for (final template in kLiteRtLmChatTemplates) {
+        expect(
+          template.template,
+          isNot(contains('bos_token')),
+          reason: '${template.id} must not emit bos_token',
+        );
+      }
+    });
+  });
+}

--- a/test/unit/backends/litert_lm/litert_lm_chat_templates_test.dart
+++ b/test/unit/backends/litert_lm/litert_lm_chat_templates_test.dart
@@ -39,6 +39,12 @@ void main() {
       expect(resolveId('some-unknown-model.litertlm'), isNull);
     });
 
+    test('does not mis-route qwen-derived models to the Qwen 2.5 template', () {
+      // DeepSeek-R1-Distill-Qwen needs its own handler; the bare `qwen` rule
+      // must not greedily claim it.
+      expect(resolveId('DeepSeek-R1-Distill-Qwen-1.5B.litertlm'), isNull);
+    });
+
     test('templates omit a leading BOS token (native runtime adds it)', () {
       for (final template in kLiteRtLmChatTemplates) {
         expect(

--- a/test/unit/backends/litert_lm/litert_lm_service_test.dart
+++ b/test/unit/backends/litert_lm/litert_lm_service_test.dart
@@ -166,7 +166,9 @@ void main() {
         gemmaModelFile.path,
         const ModelParams(contextSize: 2048),
       );
-      final template = service.getMetadata(modelHandle)['tokenizer.chat_template'];
+      final template = service.getMetadata(
+        modelHandle,
+      )['tokenizer.chat_template'];
 
       // The full canonical template renders tool declarations and the thinking
       // channel — unlike the previous stub, which omitted both.

--- a/test/unit/backends/litert_lm/litert_lm_service_test.dart
+++ b/test/unit/backends/litert_lm/litert_lm_service_test.dart
@@ -156,6 +156,32 @@ void main() {
     }
   });
 
+  test('exposes the built-in Gemma 4 template when no override is set', () async {
+    final service = LiteRtLmService();
+    final gemmaModelFile = File('${tempDir.path}/gemma-4-E2B-it.litertlm');
+    await gemmaModelFile.writeAsString('fake model');
+
+    try {
+      final modelHandle = await service.loadModel(
+        gemmaModelFile.path,
+        const ModelParams(contextSize: 2048),
+      );
+      final template = service.getMetadata(modelHandle)['tokenizer.chat_template'];
+
+      // The full canonical template renders tool declarations and the thinking
+      // channel — unlike the previous stub, which omitted both.
+      expect(template, isNotNull);
+      expect(template, contains('format_function_declaration'));
+      expect(template, contains('<|tool>'));
+      expect(template, contains('<|think|>'));
+      // The native runtime adds the start token, so the template must not emit
+      // its own BOS (which would double it).
+      expect(template, isNot(contains('bos_token')));
+    } finally {
+      service.dispose();
+    }
+  });
+
   test('applies chat templates through the Dart template engine', () async {
     final service = LiteRtLmService();
     final gemmaModelFile = File('${tempDir.path}/gemma-4-E2B-it.litertlm');
@@ -177,7 +203,10 @@ void main() {
       ]);
 
       expect(rendered, contains('<|turn>user\nhello<turn|>'));
-      expect(rendered, endsWith('<|turn>model\n<|channel>thought\n'));
+      // Thinking is enabled by default: the canonical template emits a
+      // `<|think|>` system block and leaves the model turn open.
+      expect(rendered, contains('<|turn>system\n<|think|>\n<turn|>'));
+      expect(rendered, endsWith('<|turn>model\n'));
 
       final custom = service.applyChatTemplate(
         modelHandle,

--- a/test/unit/backends/native/native_backend_test.dart
+++ b/test/unit/backends/native/native_backend_test.dart
@@ -150,27 +150,32 @@ void main() {
     },
   );
 
-  test('forwards grammar-constraint support from the active delegate', () async {
-    final llama = _FakeBackend(handle: 11)..grammarConstraintsSupported = true;
-    final litert = _FakeBackend(handle: 22)..grammarConstraintsSupported = false;
-    final backend = NativeAutoBackend(
-      llamaCppFactory: () => llama,
-      liteRtLmFactory: () => litert,
-    );
-    final grammar = backend as BackendGrammarConstraintsSupport;
+  test(
+    'forwards grammar-constraint support from the active delegate',
+    () async {
+      final llama = _FakeBackend(handle: 11)
+        ..grammarConstraintsSupported = true;
+      final litert = _FakeBackend(handle: 22)
+        ..grammarConstraintsSupported = false;
+      final backend = NativeAutoBackend(
+        llamaCppFactory: () => llama,
+        liteRtLmFactory: () => litert,
+      );
+      final grammar = backend as BackendGrammarConstraintsSupport;
 
-    try {
-      // Defaults to true (llama.cpp) before any model is loaded.
-      expect(grammar.supportsGrammarConstraints, isTrue);
+      try {
+        // Defaults to true (llama.cpp) before any model is loaded.
+        expect(grammar.supportsGrammarConstraints, isTrue);
 
-      await backend.modelLoad('/models/model.litertlm', const ModelParams());
-      // LiteRT-LM rejects grammar params, so the engine must learn to skip
-      // them — otherwise hermes/Qwen tool calls throw.
-      expect(grammar.supportsGrammarConstraints, isFalse);
-    } finally {
-      await backend.dispose();
-    }
-  });
+        await backend.modelLoad('/models/model.litertlm', const ModelParams());
+        // LiteRT-LM rejects grammar params, so the engine must learn to skip
+        // them — otherwise hermes/Qwen tool calls throw.
+        expect(grammar.supportsGrammarConstraints, isFalse);
+      } finally {
+        await backend.dispose();
+      }
+    },
+  );
 
   test('routes GGUF and unknown formats to llama.cpp', () async {
     final llama = _FakeBackend(handle: 11);
@@ -848,8 +853,7 @@ void main() {
   );
 }
 
-class _FakeBackend
-    implements LlamaBackend, BackendGrammarConstraintsSupport {
+class _FakeBackend implements LlamaBackend, BackendGrammarConstraintsSupport {
   final int handle;
   bool grammarConstraintsSupported = true;
   final List<String> loadedPaths = <String>[];

--- a/test/unit/backends/native/native_backend_test.dart
+++ b/test/unit/backends/native/native_backend_test.dart
@@ -150,6 +150,28 @@ void main() {
     },
   );
 
+  test('forwards grammar-constraint support from the active delegate', () async {
+    final llama = _FakeBackend(handle: 11)..grammarConstraintsSupported = true;
+    final litert = _FakeBackend(handle: 22)..grammarConstraintsSupported = false;
+    final backend = NativeAutoBackend(
+      llamaCppFactory: () => llama,
+      liteRtLmFactory: () => litert,
+    );
+    final grammar = backend as BackendGrammarConstraintsSupport;
+
+    try {
+      // Defaults to true (llama.cpp) before any model is loaded.
+      expect(grammar.supportsGrammarConstraints, isTrue);
+
+      await backend.modelLoad('/models/model.litertlm', const ModelParams());
+      // LiteRT-LM rejects grammar params, so the engine must learn to skip
+      // them — otherwise hermes/Qwen tool calls throw.
+      expect(grammar.supportsGrammarConstraints, isFalse);
+    } finally {
+      await backend.dispose();
+    }
+  });
+
   test('routes GGUF and unknown formats to llama.cpp', () async {
     final llama = _FakeBackend(handle: 11);
     final litert = _FakeBackend(handle: 22);
@@ -573,7 +595,10 @@ void main() {
 
         expect(template.format, ChatFormat.gemma4.index);
         expect(template.prompt, contains('<|turn>user\nhi<turn|>'));
-        expect(template.prompt, endsWith('<|turn>model\n<|channel>thought\n'));
+        // Canonical Gemma 4 template: thinking on emits a `<|think|>` system
+        // block and leaves the model turn open.
+        expect(template.prompt, contains('<|turn>system\n<|think|>'));
+        expect(template.prompt, endsWith('<|turn>model\n'));
       } finally {
         await engine.dispose();
         await tempDir.delete(recursive: true);
@@ -823,8 +848,10 @@ void main() {
   );
 }
 
-class _FakeBackend implements LlamaBackend {
+class _FakeBackend
+    implements LlamaBackend, BackendGrammarConstraintsSupport {
   final int handle;
+  bool grammarConstraintsSupported = true;
   final List<String> loadedPaths = <String>[];
   final List<ModelParams> loadedParams = <ModelParams>[];
   final List<ModelParams> contextParams = <ModelParams>[];
@@ -856,6 +883,9 @@ class _FakeBackend implements LlamaBackend {
 
   @override
   bool get supportsUrlLoading => false;
+
+  @override
+  bool get supportsGrammarConstraints => grammarConstraintsSupported;
 
   @override
   Future<int> modelLoad(String path, ModelParams params) async {

--- a/test/unit/core/engine/engine_test.dart
+++ b/test/unit/core/engine/engine_test.dart
@@ -1058,6 +1058,62 @@ void main() {
     );
 
     test(
+      'create does not stream raw Hermes XML tool-call prefix as content',
+      () async {
+        final hermesBackend = MockLlamaBackend(
+          modelMetadataResponse: const {
+            'llm.context_length': '4096',
+            'tokenizer.chat_template':
+                '{%- if tools %}<tools>{{ tools[0] | tojson }}</tools>'
+                '<tool_call>{"name": <function-name>, "arguments": <args-json-object>}</tool_call>{% endif %}'
+                '{% for message in messages %}<|im_start|>{{ message["role"] }}\n{{ message["content"] }}<|im_end|>\n{% endfor %}'
+                '{% if add_generation_prompt %}<|im_start|>assistant\n{% endif %}',
+          },
+        );
+        final hermesEngine = LlamaEngine(hermesBackend);
+        hermesBackend.generationChunks = const [
+          '<tool_call>',
+          '{"name":"get_weather","arguments":{"location":"Seoul"}}',
+          '</tool_call>',
+        ];
+        await hermesEngine.loadModel('qwen-test.gguf');
+
+        final chunks = await hermesEngine
+            .create(
+              const [
+                LlamaChatMessage.fromText(role: LlamaChatRole.user, text: 'hi'),
+              ],
+              tools: [
+                ToolDefinition(
+                  name: 'get_weather',
+                  description: 'Get weather',
+                  parameters: [ToolParam.string('location')],
+                  handler: (_) async => 'ok',
+                ),
+              ],
+              toolChoice: ToolChoice.required,
+            )
+            .toList();
+
+        final streamedContent = chunks
+            .map((chunk) => chunk.choices.first.delta.content)
+            .whereType<String>()
+            .join();
+        final toolChunk = chunks.last;
+        final toolCalls = toolChunk.choices.first.delta.toolCalls;
+
+        expect(streamedContent, isEmpty);
+        expect(toolChunk.choices.first.finishReason, equals('tool_calls'));
+        expect(toolCalls, hasLength(1));
+        expect(toolCalls!.first.function?.name, equals('get_weather'));
+        expect(
+          jsonDecode(toolCalls.first.function!.arguments!),
+          equals({'location': 'Seoul'}),
+        );
+      },
+    );
+
+    test(
       'create skips template grammar for backends without grammar constraints',
       () async {
         final noGrammarBackend = NoGrammarMockLlamaBackend(

--- a/test/unit/core/engine/engine_test.dart
+++ b/test/unit/core/engine/engine_test.dart
@@ -1002,6 +1002,62 @@ void main() {
     });
 
     test(
+      'create does not stream raw Hermes bare tool-call JSON as content',
+      () async {
+        final hermesBackend = MockLlamaBackend(
+          modelMetadataResponse: const {
+            'llm.context_length': '4096',
+            'tokenizer.chat_template':
+                '{%- if tools %}<tools>{{ tools[0] | tojson }}</tools>'
+                '<tool_call>{"name": <function-name>, "arguments": <args-json-object>}</tool_call>{% endif %}'
+                '{% for message in messages %}<|im_start|>{{ message["role"] }}\n{{ message["content"] }}<|im_end|>\n{% endfor %}'
+                '{% if add_generation_prompt %}<|im_start|>assistant\n{% endif %}',
+          },
+        );
+        final hermesEngine = LlamaEngine(hermesBackend);
+        hermesBackend.generationChunks = const [
+          '</think>\n\n{"na',
+          'me": "get_weather", "arguments": {"l',
+          'ocation": "Seoul"}}',
+        ];
+        await hermesEngine.loadModel('qwen-test.gguf');
+
+        final chunks = await hermesEngine
+            .create(
+              const [
+                LlamaChatMessage.fromText(role: LlamaChatRole.user, text: 'hi'),
+              ],
+              tools: [
+                ToolDefinition(
+                  name: 'get_weather',
+                  description: 'Get weather',
+                  parameters: [ToolParam.string('location')],
+                  handler: (_) async => 'ok',
+                ),
+              ],
+              toolChoice: ToolChoice.required,
+            )
+            .toList();
+
+        final streamedContent = chunks
+            .map((chunk) => chunk.choices.first.delta.content)
+            .whereType<String>()
+            .join();
+        final toolChunk = chunks.last;
+        final toolCalls = toolChunk.choices.first.delta.toolCalls;
+
+        expect(streamedContent, isEmpty);
+        expect(toolChunk.choices.first.finishReason, equals('tool_calls'));
+        expect(toolCalls, hasLength(1));
+        expect(toolCalls!.first.function?.name, equals('get_weather'));
+        expect(
+          jsonDecode(toolCalls.first.function!.arguments!),
+          equals({'location': 'Seoul'}),
+        );
+      },
+    );
+
+    test(
       'create skips template grammar for backends without grammar constraints',
       () async {
         final noGrammarBackend = NoGrammarMockLlamaBackend(
@@ -1032,6 +1088,12 @@ void main() {
               ],
             )
             .toList();
+
+        final streamedContent = chunks
+            .map((chunk) => chunk.choices.first.delta.content)
+            .whereType<String>()
+            .join();
+        expect(streamedContent, isEmpty);
 
         expect(noGrammarBackend.lastGenerationParams?.grammar, isNull);
         expect(noGrammarBackend.lastGenerationParams?.grammarLazy, isFalse);
@@ -1344,6 +1406,72 @@ void main() {
             .join();
 
         expect(streamedThinking, equals('reason'));
+        expect(streamedContent, equals(' answer'));
+        expect(streamedContent, isNot(contains('reason')));
+        expect(chunks.last.choices.first.finishReason, equals('stop'));
+      },
+    );
+
+    test(
+      'create suppresses thinking deltas when thinking is disabled',
+      () async {
+        backend.generationChunks = const ['<think>reason', '</think> answer'];
+        await engine.loadModel('qwen-test.gguf');
+
+        final chunks = await engine.create(const [
+          LlamaChatMessage.fromText(role: LlamaChatRole.user, text: 'hi'),
+        ], enableThinking: false).toList();
+
+        final streamedContent = chunks
+            .map((chunk) => chunk.choices.first.delta.content)
+            .whereType<String>()
+            .join();
+        final streamedThinking = chunks
+            .map((chunk) => chunk.choices.first.delta.thinking)
+            .whereType<String>()
+            .join();
+
+        expect(streamedThinking, isEmpty);
+        expect(streamedContent, equals(' answer'));
+        expect(streamedContent, isNot(contains('reason')));
+        expect(chunks.last.choices.first.finishReason, equals('stop'));
+      },
+    );
+
+    test(
+      'create suppresses thinking deltas in raw tool-enabled mode when disabled',
+      () async {
+        backend.generationChunks = const ['<think>reason', '</think> answer'];
+        await engine.loadModel('qwen-test.gguf');
+
+        final chunks = await engine
+            .create(
+              const [
+                LlamaChatMessage.fromText(role: LlamaChatRole.user, text: 'hi'),
+              ],
+              tools: [
+                ToolDefinition(
+                  name: 'get_weather',
+                  description: 'Get weather',
+                  parameters: [ToolParam.string('city')],
+                  handler: (_) async => 'ok',
+                ),
+              ],
+              toolChoice: ToolChoice.auto,
+              enableThinking: false,
+            )
+            .toList();
+
+        final streamedContent = chunks
+            .map((chunk) => chunk.choices.first.delta.content)
+            .whereType<String>()
+            .join();
+        final streamedThinking = chunks
+            .map((chunk) => chunk.choices.first.delta.thinking)
+            .whereType<String>()
+            .join();
+
+        expect(streamedThinking, isEmpty);
         expect(streamedContent, equals(' answer'));
         expect(streamedContent, isNot(contains('reason')));
         expect(chunks.last.choices.first.finishReason, equals('stop'));

--- a/test/unit/core/template/handlers/hermes_handler_test.dart
+++ b/test/unit/core/template/handlers/hermes_handler_test.dart
@@ -52,6 +52,35 @@ void main() {
     expect(parsed.content, equals('tail'));
   });
 
+  test('passes enableThinking into the template context', () {
+    final handler = HermesHandler();
+    const template =
+        '{% if enable_thinking is defined and enable_thinking is false %}'
+        'thinking-off'
+        '{% else %}'
+        'thinking-on'
+        '{% endif %}';
+    const messages = [
+      LlamaChatMessage.fromText(role: LlamaChatRole.user, text: 'hi'),
+    ];
+
+    final disabled = handler.render(
+      templateSource: template,
+      messages: messages,
+      metadata: const {},
+      enableThinking: false,
+    );
+    final enabled = handler.render(
+      templateSource: template,
+      messages: messages,
+      metadata: const {},
+      enableThinking: true,
+    );
+
+    expect(disabled.prompt, 'thinking-off');
+    expect(enabled.prompt, 'thinking-on');
+  });
+
   test('parses tool call with space between tag and JSON', () {
     final handler = HermesHandler();
     final parsed = handler.parse(

--- a/test/unit/core/template/handlers/hermes_handler_test.dart
+++ b/test/unit/core/template/handlers/hermes_handler_test.dart
@@ -122,6 +122,14 @@ void main() {
     expect(parsed.content, isEmpty);
   });
 
+  test('keeps partial XML tool-call envelopes out of content', () {
+    final handler = HermesHandler();
+    final parsed = handler.parse('<tool_call>{"na', isPartial: true);
+
+    expect(parsed.toolCalls, isEmpty);
+    expect(parsed.content, isEmpty);
+  });
+
   test(
     'parses tool call with multiple whitespace chars between tag and JSON',
     () {

--- a/test/unit/core/template/handlers/hermes_handler_test.dart
+++ b/test/unit/core/template/handlers/hermes_handler_test.dart
@@ -111,6 +111,17 @@ void main() {
     expect(parsed.content, isEmpty);
   });
 
+  test('keeps partial bare JSON tool calls out of content', () {
+    final handler = HermesHandler();
+    final parsed = handler.parse(
+      '{"name":"get_current_weather",',
+      isPartial: true,
+    );
+
+    expect(parsed.toolCalls, isEmpty);
+    expect(parsed.content, isEmpty);
+  });
+
   test(
     'parses tool call with multiple whitespace chars between tag and JSON',
     () {

--- a/tool/gen_litert_lm_templates.dart
+++ b/tool/gen_litert_lm_templates.dart
@@ -75,7 +75,10 @@ const List<_Entry> _manifest = [
   _Entry(
     id: 'qwen25',
     jinja: 'qwen25.jinja',
-    familyMatches: ['qwen2.5', 'qwen-2.5', 'qwen2', 'qwen'],
+    // Version-specific only: a bare `qwen` would greedily mis-route
+    // qwen-derived models that need a different handler (e.g.
+    // DeepSeek-R1-Distill-Qwen) to the Qwen 2.5 template.
+    familyMatches: ['qwen2.5', 'qwen-2.5', 'qwen2'],
     bosToken: '',
     eosToken: '<|im_end|>',
   ),

--- a/tool/gen_litert_lm_templates.dart
+++ b/tool/gen_litert_lm_templates.dart
@@ -1,0 +1,131 @@
+// Generates `lib/src/backends/litert_lm/litert_lm_chat_templates.dart` from the
+// canonical jinja sources committed under `tool/litert_lm_templates/`.
+//
+// LiteRT-LM `.litertlm` bundles can't expose their chat template through the
+// native FFI, so the backend supplies one itself keyed by model family. The
+// jinja sources here are copied verbatim from the templates llama.cpp ships
+// (so they stay in lockstep with the llama.cpp backend's rendering/parsing),
+// and this tool embeds them as Dart consts.
+//
+// To add a model family:
+//   1. Copy its canonical jinja into `tool/litert_lm_templates/<id>.jinja`.
+//   2. Add an `_Entry` to `_manifest` below (id, family substrings, bos/eos).
+//   3. Run: dart run tool/gen_litert_lm_templates.dart
+//
+// See `doc/litert_lm_templates.md`.
+
+import 'dart:io';
+
+class _Entry {
+  const _Entry({
+    required this.id,
+    required this.jinja,
+    required this.familyMatches,
+    this.bosToken = '<bos>',
+    this.eosToken = '<turn|>',
+    this.stripLeadingBosToken = false,
+  });
+
+  final String id;
+  final String jinja;
+  final List<String> familyMatches;
+  final String bosToken;
+  final String eosToken;
+
+  /// Drops a standalone `{{- bos_token -}}` line: the native LiteRT-LM runtime
+  /// adds the start token, so emitting one in the template would double it.
+  final bool stripLeadingBosToken;
+}
+
+const List<_Entry> _manifest = [
+  _Entry(
+    id: 'gemma4',
+    jinja: 'gemma4.jinja',
+    familyMatches: ['gemma-4', 'gemma4'],
+    bosToken: '<bos>',
+    eosToken: '<turn|>',
+    stripLeadingBosToken: true,
+  ),
+];
+
+void main() {
+  final scriptDir = File.fromUri(Platform.script).parent;
+  final repoRoot = scriptDir.parent;
+  final sourceDir = Directory('${scriptDir.path}/litert_lm_templates');
+  final outputFile = File(
+    '${repoRoot.path}/lib/src/backends/litert_lm/litert_lm_chat_templates.dart',
+  );
+
+  final buffer = StringBuffer()
+    ..writeln('// GENERATED FILE — DO NOT EDIT BY HAND.')
+    ..writeln('//')
+    ..writeln('// Regenerate with: dart run tool/gen_litert_lm_templates.dart')
+    ..writeln('// Source jinja lives under tool/litert_lm_templates/.')
+    ..writeln()
+    ..writeln("import 'litert_lm_chat_template.dart';")
+    ..writeln();
+
+  final entries = <String>[];
+  for (final entry in _manifest) {
+    final source = File('${sourceDir.path}/${entry.jinja}');
+    if (!source.existsSync()) {
+      stderr.writeln('Missing jinja source: ${source.path}');
+      exitCode = 66;
+      return;
+    }
+    var template = source.readAsStringSync();
+    if (entry.stripLeadingBosToken) {
+      template = _stripBosToken(template);
+    }
+    if (template.contains("'''")) {
+      stderr.writeln(
+        "Template '${entry.id}' contains a triple-quote and cannot be "
+        'embedded as a raw string. Add escaping support to the generator.',
+      );
+      exitCode = 65;
+      return;
+    }
+
+    final constName = '_${entry.id}ChatTemplate';
+    buffer
+      ..writeln('/// Canonical chat template for the ${entry.id} family.')
+      ..writeln("const String $constName = r'''")
+      ..write(template)
+      ..writeln("''';")
+      ..writeln();
+
+    entries.add(
+      '  LiteRtLmChatTemplate(\n'
+      "    id: '${entry.id}',\n"
+      '    template: $constName,\n'
+      '    familyMatches: ${_dartStringList(entry.familyMatches)},\n'
+      "    bosToken: '${entry.bosToken}',\n"
+      "    eosToken: '${entry.eosToken}',\n"
+      '  ),',
+    );
+  }
+
+  buffer
+    ..writeln('/// Built-in LiteRT-LM chat templates, matched in order.')
+    ..writeln('///')
+    ..writeln('/// The first entry whose [LiteRtLmChatTemplate.matches] returns')
+    ..writeln('/// true for the bundle filename wins, so more specific families')
+    ..writeln('/// must precede broader ones.')
+    ..writeln('const List<LiteRtLmChatTemplate> kLiteRtLmChatTemplates = [')
+    ..writeln(entries.join('\n'))
+    ..writeln('];');
+
+  outputFile.writeAsStringSync(buffer.toString());
+  stdout.writeln('Wrote ${outputFile.path} (${_manifest.length} templates).');
+}
+
+String _stripBosToken(String template) {
+  final lines = template.split('\n');
+  lines.removeWhere((line) => line.trim() == '{{- bos_token -}}');
+  return lines.join('\n');
+}
+
+String _dartStringList(List<String> values) {
+  final items = values.map((v) => "'$v'").join(', ');
+  return '[$items]';
+}

--- a/tool/gen_litert_lm_templates.dart
+++ b/tool/gen_litert_lm_templates.dart
@@ -23,6 +23,8 @@ class _Entry {
     required this.familyMatches,
     this.bosToken = '<bos>',
     this.eosToken = '<turn|>',
+    this.thinkingStartTag = '<|channel>thought\n',
+    this.thinkingEndTag = '<channel|>',
     this.stripLeadingBosToken = false,
   });
 
@@ -31,6 +33,8 @@ class _Entry {
   final List<String> familyMatches;
   final String bosToken;
   final String eosToken;
+  final String thinkingStartTag;
+  final String thinkingEndTag;
 
   /// Drops a standalone `{{- bos_token -}}` line: the native LiteRT-LM runtime
   /// adds the start token, so emitting one in the template would double it.
@@ -71,6 +75,8 @@ const List<_Entry> _manifest = [
     familyMatches: ['qwen3', 'qwen-3'],
     bosToken: '',
     eosToken: '<|im_end|>',
+    thinkingStartTag: '<think>',
+    thinkingEndTag: '</think>',
   ),
   _Entry(
     id: 'qwen25',
@@ -81,6 +87,8 @@ const List<_Entry> _manifest = [
     familyMatches: ['qwen2.5', 'qwen-2.5', 'qwen2'],
     bosToken: '',
     eosToken: '<|im_end|>',
+    thinkingStartTag: '<think>',
+    thinkingEndTag: '</think>',
   ),
 ];
 
@@ -137,6 +145,8 @@ void main() {
       '    familyMatches: ${_dartStringList(entry.familyMatches)},\n'
       "    bosToken: '${entry.bosToken}',\n"
       "    eosToken: '${entry.eosToken}',\n"
+      "    thinkingStartTag: ${_dartStringLiteral(entry.thinkingStartTag)},\n"
+      "    thinkingEndTag: ${_dartStringLiteral(entry.thinkingEndTag)},\n"
       '  ),',
     );
   }
@@ -144,8 +154,12 @@ void main() {
   buffer
     ..writeln('/// Built-in LiteRT-LM chat templates, matched in order.')
     ..writeln('///')
-    ..writeln('/// The first entry whose [LiteRtLmChatTemplate.matches] returns')
-    ..writeln('/// true for the bundle filename wins, so more specific families')
+    ..writeln(
+      '/// The first entry whose [LiteRtLmChatTemplate.matches] returns',
+    )
+    ..writeln(
+      '/// true for the bundle filename wins, so more specific families',
+    )
     ..writeln('/// must precede broader ones.')
     ..writeln('const List<LiteRtLmChatTemplate> kLiteRtLmChatTemplates = [')
     ..writeln(entries.join('\n'))
@@ -181,4 +195,12 @@ String _stripBosToken(String template) {
 String _dartStringList(List<String> values) {
   final items = values.map((v) => "'$v'").join(', ');
   return '[$items]';
+}
+
+String _dartStringLiteral(String value) {
+  final escaped = value
+      .replaceAll('\\', r'\\')
+      .replaceAll('\n', r'\n')
+      .replaceAll("'", r"\'");
+  return "'$escaped'";
 }

--- a/tool/gen_litert_lm_templates.dart
+++ b/tool/gen_litert_lm_templates.dart
@@ -37,6 +37,9 @@ class _Entry {
   final bool stripLeadingBosToken;
 }
 
+// Order matters: the registry matches top-to-bottom and the first hit wins, so
+// more specific families must precede broader ones (gemma-4 and gemma-3n before
+// gemma-3). See `doc/litert_lm_templates.md`.
 const List<_Entry> _manifest = [
   _Entry(
     id: 'gemma4',
@@ -45,6 +48,36 @@ const List<_Entry> _manifest = [
     bosToken: '<bos>',
     eosToken: '<turn|>',
     stripLeadingBosToken: true,
+  ),
+  _Entry(
+    id: 'gemma3n',
+    jinja: 'gemma3n.jinja',
+    familyMatches: ['gemma-3n', 'gemma3n'],
+    bosToken: '<bos>',
+    eosToken: '<end_of_turn>',
+    stripLeadingBosToken: true,
+  ),
+  _Entry(
+    id: 'gemma',
+    jinja: 'gemma.jinja',
+    familyMatches: ['gemma-3', 'gemma3', 'gemma-2', 'gemma2'],
+    bosToken: '<bos>',
+    eosToken: '<end_of_turn>',
+    stripLeadingBosToken: true,
+  ),
+  _Entry(
+    id: 'qwen3',
+    jinja: 'qwen3.jinja',
+    familyMatches: ['qwen3', 'qwen-3'],
+    bosToken: '',
+    eosToken: '<|im_end|>',
+  ),
+  _Entry(
+    id: 'qwen25',
+    jinja: 'qwen25.jinja',
+    familyMatches: ['qwen2.5', 'qwen-2.5', 'qwen2', 'qwen'],
+    bosToken: '',
+    eosToken: '<|im_end|>',
   ),
 ];
 
@@ -119,10 +152,27 @@ void main() {
   stdout.writeln('Wrote ${outputFile.path} (${_manifest.length} templates).');
 }
 
+/// Removes the first `bos_token` output expression in any whitespace-control
+/// form (`{{ bos_token }}`, `{{- bos_token -}}`, …). If the expression was on
+/// its own line, the now-empty line is dropped; an inline remainder is kept.
 String _stripBosToken(String template) {
+  final bos = RegExp(r'\{\{-?\s*bos_token\s*-?\}\}');
   final lines = template.split('\n');
-  lines.removeWhere((line) => line.trim() == '{{- bos_token -}}');
-  return lines.join('\n');
+  final out = <String>[];
+  var stripped = false;
+  for (final line in lines) {
+    if (!stripped && bos.hasMatch(line)) {
+      stripped = true;
+      final remainder = line.replaceFirst(bos, '');
+      if (remainder.trim().isEmpty) {
+        continue;
+      }
+      out.add(remainder);
+      continue;
+    }
+    out.add(line);
+  }
+  return out.join('\n');
 }
 
 String _dartStringList(List<String> values) {

--- a/tool/gen_litert_lm_templates.dart
+++ b/tool/gen_litert_lm_templates.dart
@@ -101,6 +101,7 @@ void main() {
   );
 
   final buffer = StringBuffer()
+    ..writeln('// coverage:ignore-file')
     ..writeln('// GENERATED FILE — DO NOT EDIT BY HAND.')
     ..writeln('//')
     ..writeln('// Regenerate with: dart run tool/gen_litert_lm_templates.dart')

--- a/tool/gguf_chat_features_smoke.dart
+++ b/tool/gguf_chat_features_smoke.dart
@@ -1,0 +1,261 @@
+import 'dart:convert';
+import 'dart:io';
+
+import 'package:llamadart/llamadart.dart';
+
+Future<void> main(List<String> args) async {
+  final modelPath = args.isNotEmpty
+      ? args[0]
+      : Platform.environment['GGUF_MODEL'];
+  if (modelPath == null || modelPath.trim().isEmpty) {
+    stderr.writeln(
+      'Usage: dart run tool/gguf_chat_features_smoke.dart '
+      '<model.gguf> [auto|cpu|metal|vulkan|cuda|opencl|hip|blas]',
+    );
+    exitCode = 64;
+    return;
+  }
+
+  final backend = args.length > 1 ? _parseBackend(args[1]) : GpuBackend.auto;
+  final engine = LlamaEngine(LlamaBackend());
+  try {
+    engine.setLogLevel(LlamaLogLevel.warn);
+    await engine.loadModel(
+      modelPath,
+      modelParams: ModelParams(
+        contextSize: 2048,
+        preferredBackend: backend,
+        gpuLayers: backend == GpuBackend.cpu ? 0 : ModelParams.maxGpuLayers,
+        numberOfThreads: 4,
+        numberOfThreadsBatch: 4,
+      ),
+    );
+
+    final template = await engine.chatTemplate(
+      const [
+        LlamaChatMessage.fromText(
+          role: LlamaChatRole.user,
+          text: 'Reply with one word.',
+        ),
+      ],
+      addAssistant: true,
+      enableThinking: false,
+    );
+
+    final noThinking = await _runScenario(
+      engine: engine,
+      messages: const [
+        LlamaChatMessage.fromText(
+          role: LlamaChatRole.system,
+          text: 'Answer directly. Do not include reasoning tags.',
+        ),
+        LlamaChatMessage.fromText(
+          role: LlamaChatRole.user,
+          text: 'What is 2 + 2? Reply with only the number.',
+        ),
+      ],
+      tools: const [],
+      enableThinking: false,
+      maxTokens: 64,
+    );
+
+    final toolCall = await _runScenario(
+      engine: engine,
+      messages: const [
+        LlamaChatMessage.fromText(
+          role: LlamaChatRole.system,
+          text: 'You must call get_weather. Return only a tool call.',
+        ),
+        LlamaChatMessage.fromText(
+          role: LlamaChatRole.user,
+          text: 'Call get_weather with location Seoul.',
+        ),
+      ],
+      tools: [
+        ToolDefinition(
+          name: 'get_weather',
+          description: 'Returns current weather for a city.',
+          parameters: [ToolParam.string('location', description: 'City name')],
+          handler: (_) async => 'Sunny',
+        ),
+      ],
+      enableThinking: false,
+      maxTokens: 160,
+      toolChoice: ToolChoice.required,
+    );
+
+    _verifyNoThinking(noThinking);
+    _verifyNoThinking(toolCall);
+    _verifyToolCall(toolCall);
+
+    final result = {
+      'backendName': await engine.getBackendName(),
+      'requestedBackend': backend.name,
+      'format': template.format,
+      'noThinking': noThinking.toJson(),
+      'toolCall': toolCall.toJson(),
+    };
+    print('RESULT gguf_chat_features ${jsonEncode(result)}');
+  } finally {
+    await engine.dispose();
+  }
+}
+
+Future<_ScenarioResult> _runScenario({
+  required LlamaEngine engine,
+  required List<LlamaChatMessage> messages,
+  required List<ToolDefinition> tools,
+  required bool enableThinking,
+  required int maxTokens,
+  ToolChoice toolChoice = ToolChoice.auto,
+}) async {
+  final content = StringBuffer();
+  final thinking = StringBuffer();
+  final toolCalls = <Map<String, Object?>>[];
+  var chunks = 0;
+  var finishReason = '';
+
+  await for (final chunk in engine.create(
+    messages,
+    tools: tools.isEmpty ? null : tools,
+    toolChoice: toolChoice,
+    enableThinking: enableThinking,
+    params: GenerationParams(maxTokens: maxTokens, temp: 0.0, seed: 1),
+  )) {
+    chunks++;
+    final choice = chunk.choices.first;
+    finishReason = choice.finishReason ?? finishReason;
+    final delta = choice.delta;
+    if (delta.content != null) {
+      content.write(delta.content);
+    }
+    if (delta.thinking != null) {
+      thinking.write(delta.thinking);
+    }
+    for (final call
+        in delta.toolCalls ?? const <LlamaCompletionChunkToolCall>[]) {
+      toolCalls.add(call.toJson());
+    }
+  }
+
+  return _ScenarioResult(
+    chunks: chunks,
+    finishReason: finishReason,
+    content: content.toString(),
+    thinking: thinking.toString(),
+    toolCalls: toolCalls,
+  );
+}
+
+void _verifyNoThinking(_ScenarioResult result) {
+  if (result.content.trim().isEmpty && result.toolCalls.isEmpty) {
+    throw StateError('Scenario produced no content or tool calls.');
+  }
+  if (result.thinking.trim().isNotEmpty) {
+    throw StateError('Thinking delta leaked while enableThinking=false.');
+  }
+
+  final leakedMarkers = const [
+    '<think>',
+    '</think>',
+    '<|channel>thought',
+    '<channel|>',
+  ].where(result.content.contains).toList(growable: false);
+  if (leakedMarkers.isNotEmpty) {
+    throw StateError('Thinking markers leaked in content: $leakedMarkers');
+  }
+}
+
+void _verifyToolCall(_ScenarioResult result) {
+  if (result.finishReason != 'tool_calls') {
+    throw StateError(
+      'Tool scenario finished with ${result.finishReason}; '
+      'content=${_tail(result.content)}',
+    );
+  }
+  if (result.content.trim().isNotEmpty) {
+    throw StateError('Tool scenario leaked content: ${_tail(result.content)}');
+  }
+  if (result.toolCalls.length != 1) {
+    throw StateError('Expected 1 tool call, got ${result.toolCalls.length}.');
+  }
+
+  final function = result.toolCalls.first['function'];
+  if (function is! Map || function['name'] != 'get_weather') {
+    throw StateError(
+      'Tool scenario did not call get_weather: ${result.toolCalls.first}',
+    );
+  }
+  final arguments = function['arguments'];
+  if (arguments is! String) {
+    throw StateError('Tool call has no string arguments: $function');
+  }
+  final decoded = jsonDecode(arguments);
+  if (decoded is! Map || decoded['location'] != 'Seoul') {
+    throw StateError('Unexpected tool arguments: $arguments');
+  }
+}
+
+GpuBackend _parseBackend(String value) {
+  switch (value.trim().toLowerCase()) {
+    case 'auto':
+      return GpuBackend.auto;
+    case 'cpu':
+      return GpuBackend.cpu;
+    case 'metal':
+      return GpuBackend.metal;
+    case 'vulkan':
+    case 'vk':
+      return GpuBackend.vulkan;
+    case 'cuda':
+      return GpuBackend.cuda;
+    case 'opencl':
+    case 'open-cl':
+    case 'ocl':
+      return GpuBackend.opencl;
+    case 'hip':
+      return GpuBackend.hip;
+    case 'blas':
+      return GpuBackend.blas;
+    default:
+      throw ArgumentError.value(
+        value,
+        'backend',
+        'Expected auto, cpu, metal, vulkan, cuda, opencl, hip, or blas.',
+      );
+  }
+}
+
+class _ScenarioResult {
+  const _ScenarioResult({
+    required this.chunks,
+    required this.finishReason,
+    required this.content,
+    required this.thinking,
+    required this.toolCalls,
+  });
+
+  final int chunks;
+  final String finishReason;
+  final String content;
+  final String thinking;
+  final List<Map<String, Object?>> toolCalls;
+
+  Map<String, Object?> toJson() => {
+    'chunks': chunks,
+    'finishReason': finishReason,
+    'contentLength': content.length,
+    'contentTail': _tail(content),
+    'thinkingLength': thinking.length,
+    'thinkingTail': _tail(thinking),
+    'toolCallCount': toolCalls.length,
+    'toolCalls': toolCalls,
+  };
+}
+
+String _tail(String value) {
+  if (value.length <= 240) {
+    return value;
+  }
+  return value.substring(value.length - 240);
+}

--- a/tool/litert_lm_chat_features_smoke.dart
+++ b/tool/litert_lm_chat_features_smoke.dart
@@ -29,12 +29,14 @@ Future<void> main(List<String> args) async {
       messages: const [
         LlamaChatMessage.fromText(
           role: LlamaChatRole.user,
-          text: 'Think briefly, then answer with only the number: 2 + 2.',
+          text:
+              'A farmer has 17 sheep. All but 9 run away. Think step by step, '
+              'then state how many sheep remain.',
         ),
       ],
       tools: const [],
       enableThinking: true,
-      maxTokens: 96,
+      maxTokens: 256,
     );
 
     final toolCall = await _runScenario(

--- a/tool/litert_lm_templates/gemma.jinja
+++ b/tool/litert_lm_templates/gemma.jinja
@@ -1,0 +1,47 @@
+{{ bos_token }}
+{%- if messages[0]['role'] == 'system' -%}
+    {%- if messages[0]['content'] is string -%}
+        {%- set first_user_prefix = messages[0]['content'] + '
+
+' -%}
+    {%- else -%}
+        {%- set first_user_prefix = messages[0]['content'][0]['text'] + '
+
+' -%}
+    {%- endif -%}
+    {%- set loop_messages = messages[1:] -%}
+{%- else -%}
+    {%- set first_user_prefix = "" -%}
+    {%- set loop_messages = messages -%}
+{%- endif -%}
+{%- for message in loop_messages -%}
+    {%- if (message['role'] == 'user') != (loop.index0 % 2 == 0) -%}
+        {{ raise_exception("Conversation roles must alternate user/assistant/user/assistant/...") }}
+    {%- endif -%}
+    {%- if (message['role'] == 'assistant') -%}
+        {%- set role = "model" -%}
+    {%- else -%}
+        {%- set role = message['role'] -%}
+    {%- endif -%}
+    {{ '<start_of_turn>' + role + '
+' + (first_user_prefix if loop.first else "") }}
+    {%- if message['content'] is string -%}
+        {{ message['content'] | trim }}
+    {%- elif message['content'] is iterable -%}
+        {%- for item in message['content'] -%}
+            {%- if item['type'] == 'image' -%}
+                {{ '<start_of_image>' }}
+            {%- elif item['type'] == 'text' -%}
+                {{ item['text'] | trim }}
+            {%- endif -%}
+        {%- endfor -%}
+    {%- else -%}
+        {{ raise_exception("Invalid content type") }}
+    {%- endif -%}
+    {{ '<end_of_turn>
+' }}
+{%- endfor -%}
+{%- if add_generation_prompt -%}
+    {{'<start_of_turn>model
+'}}
+{%- endif -%}

--- a/tool/litert_lm_templates/gemma3n.jinja
+++ b/tool/litert_lm_templates/gemma3n.jinja
@@ -1,0 +1,49 @@
+{{ bos_token }}
+{%- if messages[0]['role'] == 'system' -%}
+    {%- if messages[0]['content'] is string -%}
+        {%- set first_user_prefix = messages[0]['content'] + '
+
+' -%}
+    {%- else -%}
+        {%- set first_user_prefix = messages[0]['content'][0]['text'] + '
+
+' -%}
+    {%- endif -%}
+    {%- set loop_messages = messages[1:] -%}
+{%- else -%}
+    {%- set first_user_prefix = "" -%}
+    {%- set loop_messages = messages -%}
+{%- endif -%}
+{%- for message in loop_messages -%}
+    {%- if (message['role'] == 'user') != (loop.index0 % 2 == 0) -%}
+        {{ raise_exception("Conversation roles must alternate user/assistant/user/assistant/...") }}
+    {%- endif -%}
+    {%- if (message['role'] == 'assistant') -%}
+        {%- set role = "model" -%}
+    {%- else -%}
+        {%- set role = message['role'] -%}
+    {%- endif -%}
+    {{ '<start_of_turn>' + role + '
+' + (first_user_prefix if loop.first else "") }}
+    {%- if message['content'] is string -%}
+        {{ message['content'] | trim }}
+    {%- elif message['content'] is iterable -%}
+        {%- for item in message['content'] -%}
+            {%- if item['type'] == 'audio' -%}
+                {{ '<audio_soft_token>' }}
+            {%- elif item['type'] == 'image' -%}
+                {{ '<image_soft_token>' }}
+            {%- elif item['type'] == 'text' -%}
+                {{ item['text'] | trim }}
+            {%- endif -%}
+        {%- endfor -%}
+    {%- else -%}
+        {{ raise_exception("Invalid content type") }}
+    {%- endif -%}
+    {{ '<end_of_turn>
+' }}
+{%- endfor -%}
+{%- if add_generation_prompt -%}
+    {{'<start_of_turn>model
+'}}
+{%- endif -%}

--- a/tool/litert_lm_templates/gemma4.jinja
+++ b/tool/litert_lm_templates/gemma4.jinja
@@ -1,0 +1,347 @@
+{%- macro format_parameters(properties, required) -%}
+    {%- set standard_keys = ['description', 'type', 'properties', 'required', 'nullable'] -%}
+    {%- set ns = namespace(found_first=false) -%}
+    {%- for key, value in properties | dictsort -%}
+        {%- set add_comma = false -%}
+        {%- if key not in standard_keys -%}
+            {%- if ns.found_first %},{% endif -%}
+            {%- set ns.found_first = true -%}
+            {{ key }}:{
+            {%- if value['description'] -%}
+                description:<|"|>{{ value['description'] }}<|"|>
+                {%- set add_comma = true -%}
+            {%- endif -%}
+            {%- if value['type'] | upper == 'STRING' -%}
+                {%- if value['enum'] -%}
+                    {%- if add_comma %},{%- else -%} {%- set add_comma = true -%} {% endif -%}
+                    enum:{{ format_argument(value['enum']) }}
+                {%- endif -%}
+            {%- elif value['type'] | upper == 'ARRAY' -%}
+                {%- if value['items'] is mapping and value['items'] -%}
+                    {%- if add_comma %},{%- else -%} {%- set add_comma = true -%} {% endif -%}
+                    items:{
+                    {%- set ns_items = namespace(found_first=false) -%}
+                    {%- for item_key, item_value in value['items'] | dictsort -%}
+                        {%- if item_value is not none -%}
+                            {%- if ns_items.found_first %},{% endif -%}
+                            {%- set ns_items.found_first = true -%}
+                            {%- if item_key == 'properties' -%}
+                                properties:{
+                                {%- if item_value is mapping -%}
+                                    {{- format_parameters(item_value, value['items']['required'] | default([])) -}}
+                                {%- endif -%}
+                                }
+                            {%- elif item_key == 'required' -%}
+                                required:[
+                                {%- for req_item in item_value -%}
+                                    <|"|>{{- req_item -}}<|"|>
+                                    {%- if not loop.last %},{% endif -%}
+                                {%- endfor -%}
+                                ]
+                            {%- elif item_key == 'type' -%}
+                                {%- if item_value is string -%}
+                                    type:{{ format_argument(item_value | upper) }}
+                                {%- else -%}
+                                    type:{{ format_argument(item_value | map('upper') | list) }}
+                                {%- endif -%}
+                            {%- else -%}
+                                {{ item_key }}:{{ format_argument(item_value) }}
+                            {%- endif -%}
+                        {%- endif -%}
+                    {%- endfor -%}
+                    }
+                {%- endif -%}
+            {%- endif -%}
+            {%- if value['nullable'] %}
+                {%- if add_comma %},{%- else -%} {%- set add_comma = true -%} {% endif -%}
+                nullable:true
+            {%- endif -%}
+            {%- if value['type'] | upper == 'OBJECT' -%}
+                {%- if value['properties'] is defined and value['properties'] is mapping -%}
+                    {%- if add_comma %},{%- else -%} {%- set add_comma = true -%} {% endif -%}
+                    properties:{
+                    {{- format_parameters(value['properties'], value['required'] | default([])) -}}
+                    }
+                {%- elif value is mapping -%}
+                    {%- if add_comma %},{%- else -%} {%- set add_comma = true -%} {% endif -%}
+                    properties:{
+                    {{- format_parameters(value, value['required'] | default([])) -}}
+                    }
+                {%- endif -%}
+                {%- if value['required'] -%}
+                    {%- if add_comma %},{%- else -%} {%- set add_comma = true -%} {% endif -%}
+                    required:[
+                    {%- for item in value['required'] | default([]) -%}
+                        <|"|>{{- item -}}<|"|>
+                        {%- if not loop.last %},{% endif -%}
+                    {%- endfor -%}
+                    ]
+                {%- endif -%}
+            {%- endif -%}
+            {%- if add_comma %},{%- else -%} {%- set add_comma = true -%} {% endif -%}
+            type:<|"|>{{ value['type'] | upper }}<|"|>}
+        {%- endif -%}
+    {%- endfor -%}
+{%- endmacro -%}
+{%- macro format_function_declaration(tool_data) -%}
+    declaration:{{- tool_data['function']['name'] -}}{description:<|"|>{{- tool_data['function']['description'] -}}<|"|>
+    {%- set params = tool_data['function']['parameters'] -%}
+    {%- if params -%}
+        ,parameters:{
+        {%- if params['properties'] -%}
+            properties:{ {{- format_parameters(params['properties'], params['required']) -}} },
+        {%- endif -%}
+        {%- if params['required'] -%}
+            required:[
+            {%- for item in params['required'] -%}
+                <|"|>{{- item -}}<|"|>
+                {{- ',' if not loop.last -}}
+            {%- endfor -%}
+            ],
+        {%- endif -%}
+        {%- if params['type'] -%}
+            type:<|"|>{{- params['type'] | upper -}}<|"|>}
+        {%- endif -%}
+    {%- endif -%}
+    {%- if 'response' in tool_data['function'] -%}
+        {%- set response_declaration = tool_data['function']['response'] -%}
+        ,response:{
+        {%- if response_declaration['description'] -%}
+            description:<|"|>{{- response_declaration['description'] -}}<|"|>,
+        {%- endif -%}
+        {%- if response_declaration['type'] | upper == 'OBJECT' -%}
+            type:<|"|>{{- response_declaration['type'] | upper -}}<|"|>}
+        {%- endif -%}
+    {%- endif -%}
+    }
+{%- endmacro -%}
+{%- macro format_argument(argument, escape_keys=True) -%}
+    {%- if argument is string -%}
+        {{- '<|"|>' + argument + '<|"|>' -}}
+    {%- elif argument is boolean -%}
+        {{- 'true' if argument else 'false' -}}
+    {%- elif argument is mapping -%}
+        {{- '{' -}}
+        {%- set ns = namespace(found_first=false) -%}
+        {%- for key, value in argument | dictsort -%}
+            {%- if ns.found_first %},{% endif -%}
+            {%- set ns.found_first = true -%}
+            {%- if escape_keys -%}
+                {{- '<|"|>' + key + '<|"|>' -}}
+            {%- else -%}
+                {{- key -}}
+            {%- endif -%}
+            :{{- format_argument(value, escape_keys=escape_keys) -}}
+        {%- endfor -%}
+        {{- '}' -}}
+    {%- elif argument is sequence -%}
+        {{- '[' -}}
+        {%- for item in argument -%}
+            {{- format_argument(item, escape_keys=escape_keys) -}}
+            {%- if not loop.last %},{% endif -%}
+        {%- endfor -%}
+        {{- ']' -}}
+    {%- else -%}
+        {{- argument -}}
+    {%- endif -%}
+{%- endmacro -%}
+{%- macro strip_thinking(text) -%}
+    {%- set ns = namespace(result='') -%}
+    {%- for part in text.split('<channel|>') -%}
+        {%- if '<|channel>' in part -%}
+            {%- set ns.result = ns.result + part.split('<|channel>')[0] -%}
+        {%- else -%}
+            {%- set ns.result = ns.result + part -%}
+        {%- endif -%}
+    {%- endfor -%}
+    {{- ns.result | trim -}}
+{%- endmacro -%}
+
+{%- macro format_tool_response_block(tool_name, response) -%}
+    {{- '<|tool_response>' -}}
+    {%- if response is mapping -%}
+        {{- 'response:' + tool_name + '{' -}}
+        {%- for key, value in response | dictsort -%}
+            {{- key -}}:{{- format_argument(value, escape_keys=False) -}}
+            {%- if not loop.last %},{% endif -%}
+        {%- endfor -%}
+        {{- '}' -}}
+    {%- else -%}
+        {{- 'response:' + tool_name + '{value:' + format_argument(response, escape_keys=False) + '}' -}}
+    {%- endif -%}
+    {{- '<tool_response|>' -}}
+{%- endmacro -%}
+
+{%- set ns = namespace(prev_message_type=None) -%}
+{%- set loop_messages = messages -%}
+{{- bos_token -}}
+{#- Handle System/Tool Definitions Block -#}
+{%- if (enable_thinking is defined and enable_thinking) or tools or messages[0]['role'] in ['system', 'developer'] -%}
+    {{- '<|turn>system\n' -}}
+
+    {#- Inject Thinking token at the very top of the FIRST system turn -#}
+    {%- if enable_thinking is defined and enable_thinking -%}
+        {{- '<|think|>\n' -}}
+        {%- set ns.prev_message_type = 'think' -%}
+    {%- endif -%}
+
+    {%- if messages[0]['role'] in ['system', 'developer'] -%}
+        {{- messages[0]['content'] | trim -}}
+        {%- set loop_messages = messages[1:] -%}
+    {%- endif -%}
+
+    {%- if tools -%}
+        {%- for tool in tools %}
+            {{- '<|tool>' -}}
+            {{- format_function_declaration(tool) | trim -}}
+            {{- '<tool|>' -}}
+        {%- endfor %}
+        {%- set ns.prev_message_type = 'tool' -%}
+    {%- endif -%}
+
+    {{- '<turn|>\n' -}}
+{%- endif %}
+
+{#- Pre-scan: find last user message index for reasoning guard -#}
+{%- set ns_turn = namespace(last_user_idx=-1) -%}
+{%- for i in range(loop_messages | length) -%}
+    {%- if loop_messages[i]['role'] == 'user' -%}
+        {%- set ns_turn.last_user_idx = i -%}
+    {%- endif -%}
+{%- endfor -%}
+
+{#- Loop through messages -#}
+{%- for message in loop_messages -%}
+    {%- if message['role'] != 'tool' -%}
+    {%- set ns.prev_message_type = None -%}
+    {%- set role = 'model' if message['role'] == 'assistant' else message['role'] -%}
+    {#- Detect continuation: suppress duplicate <|turn>model when previous non-tool message was also assistant -#}
+    {%- set prev_nt = namespace(role=None, found=false) -%}
+    {%- if loop.index0 > 0 -%}
+        {%- for j in range(loop.index0 - 1, -1, -1) -%}
+            {%- if not prev_nt.found -%}
+                {%- if loop_messages[j]['role'] != 'tool' -%}
+                    {%- set prev_nt.role = loop_messages[j]['role'] -%}
+                    {%- set prev_nt.found = true -%}
+                {%- endif -%}
+            {%- endif -%}
+        {%- endfor -%}
+    {%- endif -%}
+    {%- set continue_same_model_turn = (role == 'model' and prev_nt.role == 'assistant') -%}
+    {%- if not continue_same_model_turn -%}
+        {{- '<|turn>' + role + '\n' }}
+    {%- endif -%}
+
+    {#- Render reasoning/reasoning_content as thinking channel -#}
+    {%- set thinking_text = message.get('reasoning') or message.get('reasoning_content') -%}
+    {%- if thinking_text and loop.index0 > ns_turn.last_user_idx and message.get('tool_calls') -%}
+        {{- '<|channel>thought\n' + thinking_text + '\n<channel|>' -}}
+    {%- endif -%}
+
+            {%- if message['tool_calls'] -%}
+                {%- for tool_call in message['tool_calls'] -%}
+                    {%- set function = tool_call['function'] -%}
+                    {{- '<|tool_call>call:' + function['name'] + '{' -}}
+                    {%- if function['arguments'] is mapping -%}
+                        {%- set ns_args = namespace(found_first=false) -%}
+                        {%- for key, value in function['arguments'] | dictsort -%}
+                            {%- if ns_args.found_first %},{% endif -%}
+                            {%- set ns_args.found_first = true -%}
+                            {{- key -}}:{{- format_argument(value, escape_keys=False) -}}
+                        {%- endfor -%}
+                    {%- elif function['arguments'] is string -%}
+                        {{- function['arguments'] -}}
+                    {%- endif -%}
+                    {{- '}<tool_call|>' -}}
+                {%- endfor -%}
+                {%- set ns.prev_message_type = 'tool_call' -%}
+            {%- endif -%}
+
+            {%- set ns_tr_out = namespace(flag=false) -%}
+            {%- if message.get('tool_responses') -%}
+                {#- Legacy: tool_responses embedded on the assistant message (Google/Gemma native) -#}
+                {%- for tool_response in message['tool_responses'] -%}
+                    {{- format_tool_response_block(tool_response['name'] | default('unknown'), tool_response['response']) -}}
+                    {%- set ns_tr_out.flag = true -%}
+                    {%- set ns.prev_message_type = 'tool_response' -%}
+                {%- endfor -%}
+            {%- elif message.get('tool_calls') -%}
+                {#- OpenAI Chat Completions: forward-scan consecutive role:tool messages -#}
+                {%- set ns_tool_scan = namespace(stopped=false) -%}
+                {%- for k in range(loop.index0 + 1, loop_messages | length) -%}
+                    {%- if ns_tool_scan.stopped -%}
+                    {%- elif loop_messages[k]['role'] != 'tool' -%}
+                        {%- set ns_tool_scan.stopped = true -%}
+                    {%- else -%}
+                        {%- set follow = loop_messages[k] -%}
+                        {#- Resolve tool_call_id to function name -#}
+                        {%- set ns_tname = namespace(name=follow.get('name') | default('unknown')) -%}
+                        {%- for tc in message['tool_calls'] -%}
+                            {%- if tc.get('id') == follow.get('tool_call_id') -%}
+                                {%- set ns_tname.name = tc['function']['name'] -%}
+                            {%- endif -%}
+                        {%- endfor -%}
+                        {#- Handle content as string or content-parts array -#}
+                        {%- set tool_body = follow.get('content') -%}
+                        {%- if tool_body is string -%}
+                            {{- format_tool_response_block(ns_tname.name, tool_body) -}}
+                        {%- elif tool_body is sequence and tool_body is not string -%}
+                            {%- set ns_txt = namespace(s='') -%}
+                            {%- for part in tool_body -%}
+                                {%- if part.get('type') == 'text' -%}
+                                    {%- set ns_txt.s = ns_txt.s + (part.get('text') | default('')) -%}
+                                {%- endif -%}
+                            {%- endfor -%}
+                            {{- format_tool_response_block(ns_tname.name, ns_txt.s) -}}
+                        {%- else -%}
+                            {{- format_tool_response_block(ns_tname.name, tool_body) -}}
+                        {%- endif -%}
+                        {%- set ns_tr_out.flag = true -%}
+                        {%- set ns.prev_message_type = 'tool_response' -%}
+                    {%- endif -%}
+                {%- endfor -%}
+            {%- endif -%}
+
+            {%- if message['content'] is string -%}
+                {%- if role == 'model' -%}
+                    {{- strip_thinking(message['content']) -}}
+                {%- else -%}
+                    {{- message['content'] | trim -}}
+                {%- endif -%}
+            {%- elif message['content'] is sequence -%}
+                {%- for item in message['content'] -%}
+                    {%- if item['type'] == 'text' -%}
+                        {%- if role == 'model' -%}
+                            {{- strip_thinking(item['text']) -}}
+                        {%- else -%}
+                            {{- item['text'] | trim -}}
+                        {%- endif -%}
+                    {%- elif item['type'] == 'image' -%}
+                        {{- '<|image|>' -}}
+                        {%- set ns.prev_message_type = 'image' -%}
+                    {%- elif item['type'] == 'audio' -%}
+                        {{- '<|audio|>' -}}
+                        {%- set ns.prev_message_type = 'audio' -%}
+                    {%- elif item['type'] == 'video' -%}
+                        {{- '<|video|>' -}}
+                        {%- set ns.prev_message_type = 'video' -%}
+                    {%- endif -%}
+                {%- endfor -%}
+            {%- endif -%}
+
+        {%- if ns.prev_message_type == 'tool_call' and not ns_tr_out.flag -%}
+            {{- '<|tool_response>' -}}
+        {%- elif not (ns_tr_out.flag and not message.get('content')) -%}
+            {{- '<turn|>\n' -}}
+        {%- endif -%}
+    {%- endif -%}
+{%- endfor -%}
+
+{%- if add_generation_prompt -%}
+    {%- if ns.prev_message_type != 'tool_response' and ns.prev_message_type != 'tool_call' -%}
+        {{- '<|turn>model\n' -}}
+        {%- if not enable_thinking | default(false) -%}
+            {{- '<|channel>thought\n<channel|>' -}}
+        {%- endif -%}
+    {%- endif -%}
+{%- endif -%}

--- a/tool/litert_lm_templates/qwen25.jinja
+++ b/tool/litert_lm_templates/qwen25.jinja
@@ -1,0 +1,54 @@
+{%- if tools %}
+    {{- '<|im_start|>system\n' }}
+    {%- if messages[0]['role'] == 'system' %}
+        {{- messages[0]['content'] }}
+    {%- else %}
+        {{- 'You are Qwen, created by Alibaba Cloud. You are a helpful assistant.' }}
+    {%- endif %}
+    {{- "\n\n# Tools\n\nYou may call one or more functions to assist with the user query.\n\nYou are provided with function signatures within <tools></tools> XML tags:\n<tools>" }}
+    {%- for tool in tools %}
+        {{- "\n" }}
+        {{- tool | tojson }}
+    {%- endfor %}
+    {{- "\n</tools>\n\nFor each function call, return a json object with function name and arguments within <tool_call></tool_call> XML tags:\n<tool_call>\n{\"name\": <function-name>, \"arguments\": <args-json-object>}\n</tool_call><|im_end|>\n" }}
+{%- else %}
+    {%- if messages[0]['role'] == 'system' %}
+        {{- '<|im_start|>system\n' + messages[0]['content'] + '<|im_end|>\n' }}
+    {%- else %}
+        {{- '<|im_start|>system\nYou are Qwen, created by Alibaba Cloud. You are a helpful assistant.<|im_end|>\n' }}
+    {%- endif %}
+{%- endif %}
+{%- for message in messages %}
+    {%- if (message.role == "user") or (message.role == "system" and not loop.first) or (message.role == "assistant" and not message.tool_calls) %}
+        {{- '<|im_start|>' + message.role + '\n' + message.content + '<|im_end|>' + '\n' }}
+    {%- elif message.role == "assistant" %}
+        {{- '<|im_start|>' + message.role }}
+        {%- if message.content %}
+            {{- '\n' + message.content }}
+        {%- endif %}
+        {%- for tool_call in message.tool_calls %}
+            {%- if tool_call.function is defined %}
+                {%- set tool_call = tool_call.function %}
+            {%- endif %}
+            {{- '\n<tool_call>\n{"name": "' }}
+            {{- tool_call.name }}
+            {{- '", "arguments": ' }}
+            {{- tool_call.arguments | tojson }}
+            {{- '}\n</tool_call>' }}
+        {%- endfor %}
+        {{- '<|im_end|>\n' }}
+    {%- elif message.role == "tool" %}
+        {%- if (loop.index0 == 0) or (messages[loop.index0 - 1].role != "tool") %}
+            {{- '<|im_start|>user' }}
+        {%- endif %}
+        {{- '\n<tool_response>\n' }}
+        {{- message.content }}
+        {{- '\n</tool_response>' }}
+        {%- if loop.last or (messages[loop.index0 + 1].role != "tool") %}
+            {{- '<|im_end|>\n' }}
+        {%- endif %}
+    {%- endif %}
+{%- endfor %}
+{%- if add_generation_prompt %}
+    {{- '<|im_start|>assistant\n' }}
+{%- endif %}

--- a/tool/litert_lm_templates/qwen3.jinja
+++ b/tool/litert_lm_templates/qwen3.jinja
@@ -1,0 +1,99 @@
+{%- if tools %}
+    {{- '<|im_start|>system\n' }}
+    {%- if messages[0].role == 'system' %}
+        {{- messages[0].content + '\n\n' }}
+    {%- endif %}
+    {{- "# Tools\n\nYou may call one or more functions to assist with the user query.\n\nYou are provided with function signatures within <tools></tools> XML tags:\n<tools>" }}
+    {%- for tool in tools %}
+        {{- "\n" }}
+        {{- tool | tojson }}
+    {%- endfor %}
+    {{- "\n</tools>\n\nFor each function call, return a json object with function name and arguments within <tool_call></tool_call> XML tags:\n<tool_call>\n{\"name\": <function-name>, \"arguments\": <args-json-object>}\n</tool_call><|im_end|>\n" }}
+{%- else %}
+    {%- if messages[0].role == 'system' %}
+        {{- '<|im_start|>system\n' + messages[0].content + '<|im_end|>\n' }}
+    {%- endif %}
+{%- endif %}
+{%- set ns = namespace(multi_step_tool=true, last_query_index=messages|length - 1) %}
+{%- for forward_message in messages %}
+    {%- set index = (messages|length - 1) - loop.index0 %}
+    {%- set message = messages[index] %}
+    {%- set current_content = message.content if message.content is defined and message.content is not none else '' %}
+    {%- set tool_start = '<tool_response>' %}
+    {%- set tool_start_length = tool_start|length %}
+    {%- set start_of_message = current_content[:tool_start_length] %}
+    {%- set tool_end = '</tool_response>' %}
+    {%- set tool_end_length = tool_end|length %}
+    {%- set start_pos = (current_content|length) - tool_end_length %}
+    {%- if start_pos < 0 %}
+        {%- set start_pos = 0 %}
+    {%- endif %}
+    {%- set end_of_message = current_content[start_pos:] %}
+    {%- if ns.multi_step_tool and message.role == "user" and not(start_of_message == tool_start and end_of_message == tool_end) %}
+        {%- set ns.multi_step_tool = false %}
+        {%- set ns.last_query_index = index %}
+    {%- endif %}
+{%- endfor %}
+{%- for message in messages %}
+    {%- if (message.role == "user") or (message.role == "system" and not loop.first) %}
+        {{- '<|im_start|>' + message.role + '\n' + message.content + '<|im_end|>' + '\n' }}
+    {%- elif message.role == "assistant" %}
+        {%- set m_content = message.content if message.content is defined and message.content is not none else '' %}
+        {%- set content = m_content %}
+        {%- set reasoning_content = '' %}
+        {%- if message.reasoning_content is defined and message.reasoning_content is not none %}
+            {%- set reasoning_content = message.reasoning_content %}
+        {%- else %}
+            {%- if '</think>' in m_content %}
+                {%- set content = (m_content.split('</think>')|last).lstrip('\n') %}
+                {%- set reasoning_content = (m_content.split('</think>')|first).rstrip('\n') %}
+                {%- set reasoning_content = (reasoning_content.split('<think>')|last).lstrip('\n') %}
+            {%- endif %}
+        {%- endif %}
+        {%- if loop.index0 > ns.last_query_index %}
+            {%- if loop.last or (not loop.last and (not reasoning_content.strip() == '')) %}
+                {{- '<|im_start|>' + message.role + '\n<think>\n' + reasoning_content.strip('\n') + '\n</think>\n\n' + content.lstrip('\n') }}
+            {%- else %}
+                {{- '<|im_start|>' + message.role + '\n' + content }}
+            {%- endif %}
+        {%- else %}
+            {{- '<|im_start|>' + message.role + '\n' + content }}
+        {%- endif %}
+        {%- if message.tool_calls %}
+            {%- for tool_call in message.tool_calls %}
+                {%- if (loop.first and content) or (not loop.first) %}
+                    {{- '\n' }}
+                {%- endif %}
+                {%- if tool_call.function %}
+                    {%- set tool_call = tool_call.function %}
+                {%- endif %}
+                {{- '<tool_call>\n{"name": "' }}
+                {{- tool_call.name }}
+                {{- '", "arguments": ' }}
+                {%- if tool_call.arguments is string %}
+                    {{- tool_call.arguments }}
+                {%- else %}
+                    {{- tool_call.arguments | tojson }}
+                {%- endif %}
+                {{- '}\n</tool_call>' }}
+            {%- endfor %}
+        {%- endif %}
+        {{- '<|im_end|>\n' }}
+    {%- elif message.role == "tool" %}
+        {%- if loop.first or (messages[loop.index0 - 1].role != "tool") %}
+            {{- '<|im_start|>user' }}
+        {%- endif %}
+        {{- '\n<tool_response>\n' }}
+        {{- message.content }}
+        {{- '\n</tool_response>' }}
+        {%- if loop.last or (messages[loop.index0 + 1].role != "tool") %}
+            {{- '<|im_end|>\n' }}
+        {%- endif %}
+    {%- endif %}
+{%- endfor %}
+{%- if add_generation_prompt %}
+    {{- '<|im_start|>assistant\n' }}
+    {%- if enable_thinking is defined and enable_thinking is false %}
+        {{- '<think>\n\n</think>\n\n' }}
+    {%- endif %}
+{%- endif %}


### PR DESCRIPTION
## Problem

Function calling and thinking didn't work for Gemma 4 (and other models) on the LiteRT-LM backend — originally noticed in the chat app.

## Root causes & fixes

`.litertlm` bundles can't expose their chat template through the native FFI, so the backend supplies `tokenizer.chat_template` itself. Several things were wrong/missing:

1. **Gemma 4 template stub** omitted the tool-declaration block entirely and inverted the thinking-control structure → no function calling, unreliable thinking. Replaced with the full canonical Gemma 4 template (the one llama.cpp reads from the GGUF), minus the leading `bos_token` (the native runtime adds the start token itself).
2. **Thinking never surfaced** on native LiteRT-LM: the runtime streams reasoning on a separate channel (`{"role":"assistant","channels":{"thought":"..."}}`) and the answer as `content`; the response parser only understood `content`, so thought chunks leaked into the reply as raw JSON. Added `LiteRtLmChannelAssembler`, which reassembles thought runs into the `<|channel>thought … <channel|>` markers the handler parses as reasoning.
3. **Tool calling threw for grammar-using handlers** (Hermes/Qwen): the engine only skips a template grammar when the backend reports `supportsGrammarConstraints == false`, but the `NativeAutoBackend` facade didn't implement `BackendGrammarConstraintsSupport`, so the engine passed a grammar the LiteRT-LM backend rejects. The facade now forwards the active delegate's capability.

## Scalable multi-model template registry

Introduced a filename-keyed `LiteRtLmChatTemplate` registry plus a generator (`tool/gen_litert_lm_templates.dart`) that embeds canonical jinja committed under `tool/litert_lm_templates/`. Adding a family is a jinja drop + one manifest line; the existing handlers render and parse it. Seeded with **Gemma 4 / 3 / 3n** and **Qwen 2.5 / 3**. Gemma 3/3n previously fell back to ChatML (the wrong format); they now render `<start_of_turn>` with system folded into the first user turn. `ModelParams.chatTemplate` still overrides detection for any model. See `doc/litert_lm_templates.md`.

## On-device verification (macOS, LiteRT-LM 0.12.0 — latest release)

| Model | Backend | Result |
|---|---|---|
| Gemma 4 E2B | GPU/Metal | ✅ thinking + tools |
| Gemma 4 E2B | CPU | ✅ thinking + tools |
| Qwen3-0.6B | CPU | ✅ thinking + tools |
| Qwen2.5-1.5B | CPU | ✅ chat + tools |
| Gemma 3 1B | CPU | ✅ chat; tool calling weak (see below) |

## Known limitations (documented, not introduced here)

- **Gemma 3/3n tool calling** only emits a generic "respond with tool_call JSON" instruction without tool schemas — the existing Gemma behavior shared with the llama.cpp backend. Gemma 4 has full native tool calling.
- **Qwen3.5** (hybrid GatedDeltaNet architecture) fails engine creation on the latest released runtime (0.12.0); its bundle targets bleeding-edge `litert-torch` tooling. Registry routing for it is correct (`qwen35*` → Qwen3/Hermes); only the model can't execute yet.
- **DeepSeek-R1-Distill-Qwen** is intentionally not seeded; the Qwen 2.5 matcher was tightened so it can't mis-route there.
- Multimodal bundles: text works; media parts are unsupported on the LiteRT-LM backend.

## Tests

New unit tests for the registry/precedence, the channel assembler, and grammar-constraint forwarding; updated stale Gemma 4 template assertions. Full template + backend suites pass.
