### PR TITLE
Fix iOS LiteRT-LM model loading (load frameworks by absolute path)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -46,6 +46,20 @@
   * Replaced the misleading stuck "Loading model 0%" label during web
     LiteRT-LM loads (the backend only reports 0%/100%) with an honest
     indeterminate "Downloading and initializing model" message.
+* **Fixed iOS LiteRT-LM model loading**:
+  * `.litertlm` models failed to load on iOS device and simulator with
+    `Failed to load dynamic library 'package:llamadart/litert_lm_LiteRtLm'`.
+    The loader passed the `package:llamadart/...` native-asset id straight to
+    `DynamicLibrary.open`, which does not resolve native-asset ids (only
+    `@Native` externals do), so it reached `dlopen` verbatim and never loaded;
+    the bare `libLiteRtLm.dylib` fallback is not on any iOS search path either.
+  * iOS now loads the embedded `LiteRtLm`/`StreamProxy` frameworks by their
+    absolute bundle path (`<App>.app/Frameworks/<Name>.framework/<Name>`,
+    resolved from the executable), matching the macOS approach. This also lets
+    the StreamProxy `RTLD_GLOBAL` preload and the isolate re-open receive a real
+    path, so streaming generation works on iOS instead of silently falling back.
+  * `_openFirstAvailable*` now report every candidate's error, so future load
+    failures name the actual reason rather than only the last fallback.
 * **Minor correctness cleanups**:
   * `ChatSession` no longer throws on an empty-choices completion chunk
     (e.g. a keep-alive); such chunks are forwarded as-is.

--- a/README.md
+++ b/README.md
@@ -330,8 +330,9 @@ FFI path is validated on Android, iOS, macOS, Linux, and Windows. Web
 `.litertlm` URLs route to the official `@litert-lm/core` JavaScript runtime,
 which is an early-preview text-in/text-out API and currently supports
 web-compatible Gemma 4 LiteRT-LM model variants. iOS LiteRT-LM bundles are
-derived from upstream `CLiteRTLM.xcframework` slices and loaded from bundled
-native-asset identifiers for device and simulator builds. Native LiteRT-LM
+derived from upstream `CLiteRTLM.xcframework` slices, embedded as app
+frameworks, and loaded by their absolute bundle path for device and simulator
+builds. Native LiteRT-LM
 generation works through the same high-level `LlamaEngine` and `ChatSession`
 APIs, including native tokenization and detokenization for exact token counts.
 On native targets, thinking and tool-call parsing run through the same

--- a/lib/src/backends/litert_lm/litert_lm_runtime.dart
+++ b/lib/src/backends/litert_lm/litert_lm_runtime.dart
@@ -946,7 +946,10 @@ class LiteRtLmRuntimeClient {
 
     if (libraries.proxyCandidates.isNotEmpty) {
       try {
-        final proxyLibrary = _openFirstAvailable(libraries.proxyCandidates);
+        final proxyLibrary = _openFirstAvailable(
+          libraries.proxyCandidates,
+          description: 'StreamProxy library',
+        );
         final loadGlobal = proxyLibrary
             .lookupFunction<_LoadGlobalNative, _LoadGlobalDart>(
               'stream_proxy_load_global',
@@ -984,7 +987,10 @@ class LiteRtLmRuntimeClient {
       }
     }
 
-    final liteRtLm = _openFirstAvailableWithPath(libraries.liteRtLmCandidates);
+    final liteRtLm = _openFirstAvailableWithPath(
+      libraries.liteRtLmCandidates,
+      description: 'LiteRT-LM library',
+    );
     _liteRtLmLibraryPath = liteRtLm.path;
     _bindings = _LiteRtLmBindings(liteRtLm.library);
   }
@@ -1125,13 +1131,20 @@ class LiteRtLmRuntimeClient {
     return null;
   }
 
-  DynamicLibrary _openFirstAvailable(List<String> candidates) {
-    return _openFirstAvailableWithPath(candidates).library;
+  DynamicLibrary _openFirstAvailable(
+    List<String> candidates, {
+    required String description,
+  }) {
+    return _openFirstAvailableWithPath(
+      candidates,
+      description: description,
+    ).library;
   }
 
   ({String path, DynamicLibrary library}) _openFirstAvailableWithPath(
-    List<String> candidates,
-  ) {
+    List<String> candidates, {
+    required String description,
+  }) {
     final errors = <String>[];
     for (final candidate in candidates) {
       try {
@@ -1141,7 +1154,7 @@ class LiteRtLmRuntimeClient {
       }
     }
     throw ArgumentError(
-      'Failed to load any LiteRT-LM library candidate:\n${errors.join('\n')}',
+      'Failed to load any $description candidate:\n${errors.join('\n')}',
     );
   }
 

--- a/lib/src/backends/litert_lm/litert_lm_runtime.dart
+++ b/lib/src/backends/litert_lm/litert_lm_runtime.dart
@@ -120,7 +120,10 @@ String liteRtLmIosFrameworkBinaryPath(String frameworksDirPath, String name) {
 /// dlopen and never loads. When [frameworksDirPath] is known, the absolute path
 /// to the embedded framework binary is preferred; the native-asset id and bare
 /// `libLiteRtLm.dylib` remain as last-resort fallbacks for the error message.
-List<String> liteRtLmIosLibraryCandidates(Abi abi, {String? frameworksDirPath}) {
+List<String> liteRtLmIosLibraryCandidates(
+  Abi abi, {
+  String? frameworksDirPath,
+}) {
   final fallbacks = liteRtLmIosLibraryCandidatesForAbi(abi);
   if (fallbacks.isEmpty) {
     return const <String>[];

--- a/lib/src/backends/litert_lm/litert_lm_runtime.dart
+++ b/lib/src/backends/litert_lm/litert_lm_runtime.dart
@@ -105,6 +105,49 @@ List<String> liteRtLmIosStreamProxyCandidatesForAbi(Abi abi) {
   };
 }
 
+/// Path to an embedded iOS framework binary
+/// (`<Frameworks>/<name>.framework/<name>`).
+///
+/// iOS frameworks are flat, unlike the versioned macOS layout.
+String liteRtLmIosFrameworkBinaryPath(String frameworksDirPath, String name) {
+  return '$frameworksDirPath/$name.framework/$name';
+}
+
+/// Ordered LiteRT-LM library load candidates for iOS.
+///
+/// `DynamicLibrary.open` does not resolve Dart native-asset ids (only `@Native`
+/// externals do), so the `package:llamadart/...` id is passed verbatim to
+/// dlopen and never loads. When [frameworksDirPath] is known, the absolute path
+/// to the embedded framework binary is preferred; the native-asset id and bare
+/// `libLiteRtLm.dylib` remain as last-resort fallbacks for the error message.
+List<String> liteRtLmIosLibraryCandidates(Abi abi, {String? frameworksDirPath}) {
+  final fallbacks = liteRtLmIosLibraryCandidatesForAbi(abi);
+  if (fallbacks.isEmpty) {
+    return const <String>[];
+  }
+  return <String>[
+    if (frameworksDirPath != null)
+      liteRtLmIosFrameworkBinaryPath(frameworksDirPath, 'LiteRtLm'),
+    ...fallbacks,
+  ];
+}
+
+/// Ordered StreamProxy load candidates for iOS. See [liteRtLmIosLibraryCandidates].
+List<String> liteRtLmIosStreamProxyCandidates(
+  Abi abi, {
+  String? frameworksDirPath,
+}) {
+  final fallbacks = liteRtLmIosStreamProxyCandidatesForAbi(abi);
+  if (fallbacks.isEmpty) {
+    return const <String>[];
+  }
+  return <String>[
+    if (frameworksDirPath != null)
+      liteRtLmIosFrameworkBinaryPath(frameworksDirPath, 'StreamProxy'),
+    ...fallbacks,
+  ];
+}
+
 /// Internal helper used by the LiteRT-LM runtime to validate extracted
 /// native-assets cache directories.
 List<String> liteRtLmRequiredLibrariesForAbi(Abi abi) {
@@ -964,9 +1007,21 @@ class LiteRtLmRuntimeClient {
       );
     }
     if (Platform.isIOS && (abi == Abi.iosArm64 || abi == Abi.iosX64)) {
+      // The LiteRT-LM frameworks are embedded under
+      // `<App>.app/Frameworks/<Name>.framework/<Name>`. Resolving their absolute
+      // paths from the executable lets dlopen, the StreamProxy RTLD_GLOBAL
+      // preload, and the isolate re-open all receive a real path (the
+      // `package:` native-asset ids never load via `DynamicLibrary.open`).
+      final frameworksDirPath = _findIosAppFrameworksDir()?.path;
       return (
-        proxyCandidates: liteRtLmIosStreamProxyCandidatesForAbi(abi),
-        liteRtLmCandidates: liteRtLmIosLibraryCandidatesForAbi(abi),
+        proxyCandidates: liteRtLmIosStreamProxyCandidates(
+          abi,
+          frameworksDirPath: frameworksDirPath,
+        ),
+        liteRtLmCandidates: liteRtLmIosLibraryCandidates(
+          abi,
+          frameworksDirPath: frameworksDirPath,
+        ),
         companions: const [],
         directCallbackSupported: true,
       );
@@ -1068,29 +1123,23 @@ class LiteRtLmRuntimeClient {
   }
 
   DynamicLibrary _openFirstAvailable(List<String> candidates) {
-    Object? lastError;
-    for (final candidate in candidates) {
-      try {
-        return DynamicLibrary.open(candidate);
-      } catch (error) {
-        lastError = error;
-      }
-    }
-    throw ArgumentError('Failed to load any of $candidates: $lastError');
+    return _openFirstAvailableWithPath(candidates).library;
   }
 
   ({String path, DynamicLibrary library}) _openFirstAvailableWithPath(
     List<String> candidates,
   ) {
-    Object? lastError;
+    final errors = <String>[];
     for (final candidate in candidates) {
       try {
         return (path: candidate, library: DynamicLibrary.open(candidate));
       } catch (error) {
-        lastError = error;
+        errors.add('  - $candidate: $error');
       }
     }
-    throw ArgumentError('Failed to load any of $candidates: $lastError');
+    throw ArgumentError(
+      'Failed to load any LiteRT-LM library candidate:\n${errors.join('\n')}',
+    );
   }
 
   Directory? _findMacOsAppFrameworksDir() {
@@ -1114,6 +1163,24 @@ class LiteRtLmRuntimeClient {
       return frameworksDir;
     }
     return null;
+  }
+
+  /// Locates the `Frameworks` directory of the running iOS `.app` bundle when
+  /// it contains the embedded LiteRT-LM framework.
+  ///
+  /// iOS frameworks are flat (`<App>.app/Frameworks/<Name>.framework/<Name>`),
+  /// unlike the versioned macOS layout, and the executable lives directly in
+  /// the bundle root (`<App>.app/<Executable>`).
+  Directory? _findIosAppFrameworksDir() {
+    final executable = File(Platform.resolvedExecutable);
+    final frameworksDir = Directory('${executable.parent.path}/Frameworks');
+    if (!frameworksDir.existsSync()) {
+      return null;
+    }
+    final liteRtLm = File(
+      liteRtLmIosFrameworkBinaryPath(frameworksDir.path, 'LiteRtLm'),
+    );
+    return liteRtLm.existsSync() ? frameworksDir : null;
   }
 
   Directory? _findMacOsLiteRtLmCacheDir() {

--- a/test/unit/backends/litert_lm/litert_lm_runtime_test.dart
+++ b/test/unit/backends/litert_lm/litert_lm_runtime_test.dart
@@ -79,7 +79,11 @@ void main() {
     expect(liteRtLmCacheDirectoryCandidatesForAbi(Abi.androidArm64), isEmpty);
   });
 
-  test('LiteRT-LM iOS lookup prefers bundled native asset identifiers', () {
+  test('LiteRT-LM iOS fallback identifiers are the native-asset id + dylib', () {
+    // These are last-resort fallbacks only: `DynamicLibrary.open` cannot
+    // resolve the `package:` native-asset id, and the bare dylib is not on any
+    // iOS search path. The absolute framework path (below) is what actually
+    // loads.
     expect(liteRtLmIosLibraryCandidatesForAbi(Abi.iosArm64), const <String>[
       'package:llamadart/litert_lm_LiteRtLm',
       'libLiteRtLm.dylib',
@@ -93,6 +97,50 @@ void main() {
       'libStreamProxy.dylib',
     ]);
     expect(liteRtLmIosLibraryCandidatesForAbi(Abi.macosArm64), isEmpty);
+  });
+
+  test('LiteRT-LM iOS lookup prefers the absolute embedded framework path', () {
+    // With the app Frameworks dir known, the absolute framework binary path is
+    // tried first, then the fallback identifiers.
+    expect(
+      liteRtLmIosLibraryCandidates(
+        Abi.iosArm64,
+        frameworksDirPath: '/App.app/Frameworks',
+      ),
+      const <String>[
+        '/App.app/Frameworks/LiteRtLm.framework/LiteRtLm',
+        'package:llamadart/litert_lm_LiteRtLm',
+        'libLiteRtLm.dylib',
+      ],
+    );
+    expect(
+      liteRtLmIosStreamProxyCandidates(
+        Abi.iosArm64,
+        frameworksDirPath: '/App.app/Frameworks',
+      ),
+      const <String>[
+        '/App.app/Frameworks/StreamProxy.framework/StreamProxy',
+        'package:llamadart/litert_lm_StreamProxy',
+        'libStreamProxy.dylib',
+      ],
+    );
+    // Without a Frameworks dir, only the fallback identifiers remain.
+    expect(liteRtLmIosLibraryCandidates(Abi.iosArm64), const <String>[
+      'package:llamadart/litert_lm_LiteRtLm',
+      'libLiteRtLm.dylib',
+    ]);
+    // Non-iOS ABIs have no iOS candidates regardless of a frameworks dir.
+    expect(
+      liteRtLmIosLibraryCandidates(
+        Abi.macosArm64,
+        frameworksDirPath: '/App.app/Frameworks',
+      ),
+      isEmpty,
+    );
+    expect(
+      liteRtLmIosFrameworkBinaryPath('/App.app/Frameworks', 'LiteRtLm'),
+      '/App.app/Frameworks/LiteRtLm.framework/LiteRtLm',
+    );
   });
 
   test('macOS LiteRT-LM cache validation follows runtime ABI files', () {


### PR DESCRIPTION
## Problem

Loading a `.litertlm` model on iOS (device **and** simulator) failed at generation time with:

```
Failed to load dynamic library 'package:llamadart/litert_lm_LiteRtLm':
dlopen(package:llamadart/litert_lm_LiteRtLm, 0x0001): ... (no such file)
```

The string `package:llamadart/litert_lm_LiteRtLm` was passed **verbatim to `dlopen`**. `DynamicLibrary.open` does **not** resolve Dart native-asset ids — only `@Native` externals do — so the `package:` candidate never loads, and the bare `libLiteRtLm.dylib` fallback isn't on any iOS search path. That left iOS with **no working candidate**, so it failed identically in debug, release, and on the simulator (it was never a stale install or a JIT-only issue).

The embedded frameworks were correctly bundled and signed at `<App>.app/Frameworks/<Name>.framework/<Name>` the whole time — the loader just never pointed `dlopen` at them.

## Fix

iOS now resolves the embedded `LiteRtLm` and `StreamProxy` frameworks by their **absolute bundle path**, computed from the executable's `Frameworks/` dir, mirroring what the macOS branch already does. Because the absolute path is the first candidate:

- the main `dlopen` succeeds,
- the StreamProxy `RTLD_GLOBAL` preload gets a real path (so **streaming generation works on iOS** instead of silently falling back to blocking),
- the isolate re-open gets a real path.

The `package:` id and bare dylib are kept as last-resort fallbacks. `_openFirstAvailable*` now report **every** candidate's error, which is what surfaced the literal-`package:`-to-`dlopen` bug in the first place.

## Verification

- Reproduced and fixed on the **iOS simulator** (iPad, arm64) via the LiteRT-LM benchmark harness — model loads and generates (prefill ~86 tok/s, decode ~27 tok/s).
- Confirmed working **on a physical iPad** (iOS 26.5) with Gemma 4 E2B.
- `dart analyze lib` clean; all LiteRT-LM unit tests pass, including new coverage asserting the absolute-framework-path-first candidate ordering.

## Notes

This is iOS-only behavior; Android/macOS/Linux/Windows load paths are unchanged. README and CHANGELOG updated.