### PR TITLE
Speed up CI workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -58,27 +58,21 @@ jobs:
     steps:
       - uses: actions/checkout@v6
 
-      - name: Setup Flutter
-        uses: subosito/flutter-action@v2
-        with:
-          channel: 'stable'
-          cache: true
-
       - name: Setup Node
         uses: actions/setup-node@v6
         with:
           node-version: '20'
+          cache: npm
+          cache-dependency-path: website/package-lock.json
 
       - name: Install dependencies
-        run: |
-          flutter pub get
-          (cd website && npm ci)
+        run: (cd website && npm ci)
 
       - name: Build documentation site
         run: ./tool/docs/build_site.sh
 
   test-linux-coverage:
-    name: Test Linux & Web (with Coverage)
+    name: Test Linux VM (with Coverage)
     runs-on: ubuntu-latest
     timeout-minutes: 45
     steps:
@@ -99,9 +93,6 @@ jobs:
       - name: Run VM tests (with coverage)
         run: dart test -p vm -j 1 --exclude-tags local-only --coverage=coverage
 
-      - name: Run Browser tests
-        run: dart test -p chrome --exclude-tags local-only
-
       - name: Format coverage
         run: |
           dart pub global run coverage:format_coverage --lcov --in=coverage/test --out=coverage/lcov.info --report-on=lib --check-ignore
@@ -116,6 +107,35 @@ jobs:
           name: codecov-umbrella
           fail_ci_if_error: true
           token: ${{ secrets.CODECOV_TOKEN }}
+
+  test-web:
+    name: Test Web (Chrome)
+    runs-on: ubuntu-latest
+    timeout-minutes: 25
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Setup Flutter
+        uses: subosito/flutter-action@v2
+        with:
+          channel: 'stable'
+          cache: true
+
+      - name: Install dependencies
+        run: flutter pub get
+
+      - name: Run Browser tests
+        run: dart test -p chrome --exclude-tags local-only
+
+  test-linux-web:
+    name: Test Linux & Web (with Coverage)
+    runs-on: ubuntu-latest
+    needs:
+      - test-linux-coverage
+      - test-web
+    steps:
+      - name: Confirm Linux coverage and Web tests passed
+        run: echo "Linux VM coverage and Chrome tests passed."
 
   test-other-os:
     name: Test Native (${{ matrix.os }})


### PR DESCRIPTION
## Summary

- Split Chrome tests into a separate CI job so they run in parallel with the VM coverage job.
- Keep VM coverage generation, LCOV formatting, threshold checking, and Codecov upload unchanged.
- Trim the docs build job by removing unnecessary Flutter setup and enabling npm cache for the website lockfile.
- Add an aggregate `Test Linux & Web (with Coverage)` job that depends on both VM coverage and Chrome tests, preserving the old check name for branch protection.

## Validation

- `git diff --check`
- `ruby -e "require 'yaml'; YAML.load_file('.github/workflows/ci.yml'); puts 'yaml ok'"`