### PR TITLE
Add contributor test matrix workflow

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -26,7 +26,14 @@
 - [ ] `dart format --output=none --set-exit-if-changed .`
 - [ ] `dart analyze`
 - [ ] `dart test -p vm -j 1 --exclude-tags local-only`
-- [ ] Other targeted/local-only validation: <!-- e.g. Chrome/WebGPU smoke, Flutter app E2E, docs build, N/A -->
+- [ ] `dart test -p chrome --exclude-tags local-only` <!-- N/A with reason if not relevant -->
+- [ ] Other targeted/local-only validation: <!-- Use `dart run tool/testing/test_matrix.dart --list`; e.g. WebGPU smoke, Flutter app E2E, docs build, N/A -->
+
+## Matrix Evidence
+<!-- Generate rows with `dart run tool/testing/test_matrix.dart --pr-template`; keep applicable rows and mark skipped rows N/A with a concrete reason. -->
+| Matrix row | Scope covered | Platform / model / backend | Result | Evidence / notes |
+| --- | --- | --- | --- | --- |
+|  |  |  |  |  |
 
 ## Review Notes
 - Independent review status: <!-- reviewer/tool/verdict, or N/A for trivial docs-only changes -->

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -30,6 +30,9 @@ dart run tool/testing/check_lcov_threshold.dart coverage/lcov.info 70
 Use the scenario runner as the discovery entry point for heavyweight manual checks:
 
 ```bash
+dart run tool/testing/test_matrix.dart --list
+dart run tool/testing/test_matrix.dart --pr-template
+dart run tool/testing/test_matrix.dart --tier platform
 dart run tool/testing/run_local_e2e.dart --list
 dart run tool/testing/run_local_e2e.dart --scenario <name> --dry-run
 dart run tool/testing/run_local_e2e.dart --scenario chat-app-model-cache --device macos
@@ -38,6 +41,20 @@ dart run tool/testing/run_local_e2e.dart --scenario chat-app-model-cache --devic
 Heavy scenarios remain skipped by default and out of CI unless explicitly requested.
 Use `--dry-run` before Web smoke scenarios to see the required build/server/
 Playwright steps and model URL defaults.
+
+When preparing or updating a PR, pick the applicable rows from
+`doc/testing_matrix.md` / `tool/testing/test_matrix.dart` and record evidence in
+the PR. Include row ID, exact command or CI workflow, platform/device, model,
+backend, PASS/FAIL/N/A status, and any log/artifact pointer. If a row cannot run
+locally, state why and whether CI, a manual device run, or a follow-up issue
+covers it.
+
+Representative local real-model feature smokes:
+
+```bash
+dart run tool/testing/run_local_e2e.dart --scenario gguf-chat-features-smoke --model-path models/Qwen3.5-0.8B-Q4_K_M.gguf --backend auto
+dart run tool/testing/run_local_e2e.dart --scenario litert-lm-chat-features-smoke --model-path /path/to/gemma-4-E2B-it.litertlm --backend auto
+```
 
 ### Local Chat App Web E2E
 Use the real chat app path for WebGPU bridge validation after bridge/runtime
@@ -276,6 +293,9 @@ make sure the PR template can honestly answer:
   out of scope.
 - **Platform matrix**: native, WebGPU, Flutter examples, docs-only, or other
   relevant paths are listed with actual validation evidence.
+- **Matrix evidence**: applicable rows from `tool/testing/test_matrix.dart` are
+  recorded with exact command, platform/device, model, backend, result, and
+  notes.
 - **Unsupported combinations**: unsupported platforms/options fail loudly with a
   typed/actionable error, disabled UI, or documented fallback; never report
   success for a path that is not implemented.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -116,6 +116,17 @@ Always verify paths in your environment before using them.
 
 We take testing seriously. CI enforces **>=70% line coverage on maintainable `lib/` code**. Auto-generated files are excluded when they are marked with `// coverage:ignore-file`.
 
+The authoritative contributor test matrix lives in
+[`doc/testing_matrix.md`](doc/testing_matrix.md) and
+`tool/testing/test_matrix.dart`. Use it to decide which runtime/model/feature
+rows apply to a PR and to generate the evidence table for the pull request:
+
+```bash
+dart run tool/testing/test_matrix.dart --list
+dart run tool/testing/test_matrix.dart --pr-template
+dart run tool/testing/test_matrix.dart --tier platform
+```
+
 ### 1. Unified Test Runner
 We use `dart_test.yaml` and `@TestOn` tags to manage multi-platform execution.
 Running `dart test` will run VM and Chrome-compatible tests. Tests tagged
@@ -130,6 +141,10 @@ dart run tool/testing/run_local_e2e.dart --list
 
 # Preview the commands for one scenario without running it
 dart run tool/testing/run_local_e2e.dart --scenario chat-app-model-cache --device macos --dry-run
+
+# Run representative local real-model feature smokes
+dart run tool/testing/run_local_e2e.dart --scenario gguf-chat-features-smoke --model-path models/Qwen3.5-0.8B-Q4_K_M.gguf --backend auto
+dart run tool/testing/run_local_e2e.dart --scenario litert-lm-chat-features-smoke --model-path /path/to/gemma-4-E2B-it.litertlm --backend auto
 
 # Run root local-only Dart E2E tests directly
 dart test --run-skipped -t local-only
@@ -239,6 +254,9 @@ Every non-trivial pull request should explain:
 - **User-facing scope**: what users can do after the PR merges.
 - **Supported platform matrix**: native, WebGPU, Flutter examples, docs-only, or
   any other relevant path.
+- **Matrix evidence**: applicable row IDs from `tool/testing/test_matrix.dart`,
+  including exact commands, CI workflow names, model/backend/device selections,
+  and PASS/FAIL/N/A status.
 - **Unsupported paths**: combinations that are intentionally unavailable must
   fail loudly with clear errors, disabled UI, or documented fallback behavior.
   They must not appear to succeed silently.

--- a/README.md
+++ b/README.md
@@ -915,6 +915,8 @@ Check out our [LoRA Training Notebook](https://github.com/leehack/llamadart/blob
 This project maintains a high standard of quality with **>=70% line coverage on maintainable `lib/` code** (auto-generated files marked with `// coverage:ignore-file` are excluded).
 
 - **Multi-Platform Testing**: `dart test` runs VM and Chrome-compatible suites automatically.
+- **Contributor Matrix**: `tool/testing/test_matrix.dart` lists essential,
+  targeted, and release validation rows for PR evidence.
 - **Local-Only Scenarios**: Slow E2E tests are tagged `local-only` and skipped by default; use `tool/testing/run_local_e2e.dart` to discover the root Dart, Flutter device, and Web smoke commands.
 - **CI/CD**: Automatic analysis, linting, and cross-platform test execution on every PR.
 
@@ -924,6 +926,11 @@ dart test
 
 # Discover local-only E2E scenarios
 dart run tool/testing/run_local_e2e.dart --list
+
+# Print the PR validation matrix and evidence table
+dart run tool/testing/test_matrix.dart --list
+dart run tool/testing/test_matrix.dart --pr-template
+dart run tool/testing/test_matrix.dart --tier platform
 
 # Run local-only E2E scenarios
 dart test --run-skipped -t local-only

--- a/doc/testing_matrix.md
+++ b/doc/testing_matrix.md
@@ -1,0 +1,159 @@
+# Contributor Test Matrix
+
+This repository uses a layered test matrix so contributors can validate the
+essential runtime, model, feature, and platform paths without forcing every pull
+request to run large local models or device-only checks.
+
+Use the matrix for every non-trivial PR:
+
+```bash
+dart run tool/testing/test_matrix.dart --list
+dart run tool/testing/test_matrix.dart --pr-template
+dart run tool/testing/test_matrix.dart --tier platform
+dart run tool/testing/run_local_e2e.dart --list
+```
+
+Copy the PR evidence table into the pull request, keep the rows that apply to
+the change, and mark skipped rows as `N/A` with a concrete reason.
+
+## Matrix Tiers
+
+| Tier | Meaning | Expected use |
+| --- | --- | --- |
+| `essential` | Cheap baseline package health checks. | Run for most code PRs and expect CI to cover them. |
+| `targeted` | Runtime/model/feature checks selected by touched code. | Run locally or cite the matching CI workflow when the PR touches that path. |
+| `platform` | Supported platform or architecture validation rows. | Use when a PR affects runtime packaging, native pins, backend selection, app launch, or release confidence for a platform. |
+| `release` | Device or representative smoke checks that are too heavy for every PR. | Run for release candidates, native bundle changes, or high-risk runtime changes. |
+
+## Evidence Standard
+
+Each PR should answer four questions:
+
+| Question | Evidence to include |
+| --- | --- |
+| What changed? | User-facing scope and touched runtime or feature path. |
+| Which rows apply? | Matrix row IDs from `tool/testing/test_matrix.dart`. |
+| What ran? | Exact command, CI workflow/check name, device, model, and backend. |
+| What happened? | PASS/FAIL/N/A plus failure logs, artifact links, or a reason for N/A. |
+
+Prefer exact model names and backend selections over broad phrases. For example:
+`Gemma 4 E2B GGUF, WebGPU/llama.cpp, mem64, gpuLayers=0, contextSize=2048`.
+
+## Essential Baseline
+
+The baseline rows are:
+
+```bash
+dart run tool/testing/test_matrix.dart --tier essential
+```
+
+For a typical code PR, include:
+
+- `static-format-analyze`
+- `root-vm`
+- `root-chrome` when shared, web, template, or public API code changed
+- `coverage-lib` when `lib/` behavior changed or coverage is in doubt
+
+Docs-only PRs can mark runtime rows `N/A`, but should run `docs-site` when docs
+or website files changed.
+
+## Targeted Runtime and Model Rows
+
+Pick targeted rows based on the touched surface:
+
+| Change area | Matrix rows to consider |
+| --- | --- |
+| Native-assets hook, runtime pin, bundle layout | `native-hook-bundles`, `litert-lm-engine-smoke`, and relevant `platform` rows such as `android-arm64-device-smoke` |
+| llama.cpp / GGUF generation, prompt reuse, context reuse | `native-prompt-reuse-parity`, `gguf-chat-features-smoke` |
+| Chat template, parser, tools, thinking extraction | `template-parity`, `gguf-chat-features-smoke`, `litert-lm-chat-features-smoke` |
+| LiteRT-LM native backend | `litert-lm-engine-smoke`, `litert-lm-chat-features-smoke` |
+| Web bridge bootstrap or interop | `web-bridge-smoke`, `web-real-model-smoke` |
+| WebGPU multimodal | `webgpu-multimodal-regression` |
+| Large WebGPU GGUF / wasm64 selection | `gemma4-webgpu-mem64` |
+| LiteRT-LM web / Gemma 4 web bundle | `gemma4-litert-web` |
+| Chat app model cache/download/projector | `chat-app-device-cache` |
+| Example app, CLI, or server package | `examples-tests` |
+
+## Coverage Map
+
+The matrix is designed to cover these essential axes:
+
+| Axis | Covered by |
+| --- | --- |
+| llama.cpp native GGUF | `root-vm`, `native-prompt-reuse-parity`, `gguf-chat-features-smoke` |
+| llama.cpp WebGPU GGUF | `web-bridge-smoke`, `web-real-model-smoke`, `webgpu-multimodal-regression`, `gemma4-webgpu-mem64` |
+| LiteRT-LM native `.litertlm` | `litert-lm-engine-smoke`, `litert-lm-chat-features-smoke`, `native-hook-bundles` |
+| LiteRT-LM web `.litertlm` | `gemma4-litert-web` |
+| Model families | Qwen 2.5 prompt reuse, Qwen 3/3.5 chat/multimodal, Gemma 4 tool/thinking/mem64/LiteRT-LM |
+| Feature paths | load/generate, prompt reuse, chat templates, streaming, tool calls, thinking, multimodal, model cache, native hook packaging |
+| Platforms | See `dart run tool/testing/test_matrix.dart --tier platform`; each supported family/architecture is marked as CI, local, manual/device, or hook-only. |
+
+## Platform Rows
+
+The platform tier is intentionally explicit about what is runtime-tested versus
+only hook/package-tested:
+
+```bash
+dart run tool/testing/test_matrix.dart --tier platform
+```
+
+| Platform target | Matrix row | Current evidence level |
+| --- | --- | --- |
+| Linux x64 | `linux-x64-ci-runtime` | CI runtime plus real-model smoke. |
+| Linux arm64 | `linux-arm64-runtime-smoke` | Local/self-hosted runtime row; hook coverage in `native-hook-bundles`. |
+| Windows x64 | `windows-x64-ci-runtime` | CI runtime plus LiteRT-LM smoke. |
+| Windows arm64 | `windows-arm64-hook-coverage` | Hook coverage; runtime proof needs Windows arm64 hardware. |
+| macOS arm64 | `macos-arm64-runtime-smoke` | Local/device runtime row. |
+| macOS x64 | `macos-x64-runtime-smoke` | Local/device runtime row. |
+| iOS arm64 device | `ios-arm64-device-smoke` | Manual/device runtime row. |
+| iOS arm64/x86_64 simulator | `ios-simulator-smoke` | Manual/simulator runtime row. |
+| Android arm64 | `android-arm64-device-smoke` | Manual/device runtime row and release smoke plan. |
+| Android x64 | `android-x64-emulator-smoke` | Manual/emulator runtime row. |
+| Web browser | `web-chrome-runtime-smoke` | Chrome CI plus local WebGPU/LiteRT-LM web smokes. |
+
+Rows that say `hook-only` must not be used as full runtime proof. They only show
+that package/bundle selection is covered; PR evidence still needs a hardware or
+emulator run when the runtime behavior itself is at risk.
+
+## Local Model Scenarios
+
+Real model checks are intentionally local-only. They can use the unified runner:
+
+```bash
+dart run tool/testing/run_local_e2e.dart --scenario gguf-chat-features-smoke \
+  --model-path models/Qwen3.5-0.8B-Q4_K_M.gguf \
+  --backend auto
+
+dart run tool/testing/run_local_e2e.dart --scenario litert-lm-chat-features-smoke \
+  --model-path /path/to/gemma-4-E2B-it.litertlm \
+  --backend auto
+```
+
+Use `--dry-run` first when a scenario starts servers, builds Flutter web, or
+requires local model URLs.
+
+## PR Evidence Template
+
+Generate the current template instead of hand-copying from this doc:
+
+```bash
+dart run tool/testing/test_matrix.dart --pr-template
+```
+
+Example filled row:
+
+| Matrix row | Scope covered | Platform / model / backend | Result | Evidence / notes |
+| --- | --- | --- | --- | --- |
+| `gguf-chat-features-smoke` | real GGUF chat/tool/thinking smoke | macOS arm64, Qwen3.5-0.8B-Q4_K_M.gguf, llama.cpp auto | PASS | `RESULT gguf_chat_features ...`, no thinking marker leak, one `get_weather` tool call |
+
+## Agentic Workflow
+
+When an agent creates or updates a PR:
+
+1. Run `dart run tool/testing/test_matrix.dart --list` and choose rows from the
+   touched surfaces.
+2. Run essential rows first, then targeted local-only rows with `--dry-run`
+   before heavy execution.
+3. If a row cannot run locally, record why and whether CI, device availability,
+   or a follow-up issue covers it.
+4. Paste or update the PR matrix evidence table before asking for review.

--- a/test/README.md
+++ b/test/README.md
@@ -24,6 +24,11 @@ dart test --run-skipped -t local-only
 # Enumerate repeatable local browser/device smoke scenarios
 dart run tool/testing/run_local_e2e.dart --list
 
+# Print the contributor validation matrix and PR evidence table
+dart run tool/testing/test_matrix.dart --list
+dart run tool/testing/test_matrix.dart --pr-template
+dart run tool/testing/test_matrix.dart --tier platform
+
 # Real Gemma 4 LiteRT-LM web smoke
 dart run tool/testing/run_local_e2e.dart --scenario chat-app-web-litert-gemma4-smoke
 

--- a/test/unit/tooling/run_local_e2e_test.dart
+++ b/test/unit/tooling/run_local_e2e_test.dart
@@ -16,6 +16,8 @@ void main() {
       expect(result.stdout, contains('root-template-e2e'));
       expect(result.stdout, contains('root-native-tool-e2e'));
       expect(result.stdout, contains('qwen35-multimodal-macos-repro'));
+      expect(result.stdout, contains('gguf-chat-features-smoke'));
+      expect(result.stdout, contains('litert-lm-chat-features-smoke'));
       expect(result.stdout, contains('webgpu-multimodal-regression'));
       expect(result.stdout, contains('chat-app-model-cache'));
       expect(result.stdout, contains('chat-app-web-real-model-smoke'));
@@ -109,6 +111,51 @@ void main() {
       expect(
         result.stdout,
         contains('tool/testing/playwright_chat_app_real_model_smoke.py'),
+      );
+    });
+
+    test(
+      'dry-runs GGUF chat feature smoke with model path and backend',
+      () async {
+        final result = await runLocalE2e(const [
+          '--scenario',
+          'gguf-chat-features-smoke',
+          '--model-path',
+          'models/Qwen3.5-0.8B-Q4_K_M.gguf',
+          '--backend',
+          'cpu',
+          '--dry-run',
+        ], projectRoot: '/repo');
+
+        expect(result.exitCode, 0);
+        expect(result.stdout, contains('gguf-chat-features-smoke'));
+        expect(
+          result.stdout,
+          contains(
+            'cd /repo && dart run tool/gguf_chat_features_smoke.dart '
+            'models/Qwen3.5-0.8B-Q4_K_M.gguf cpu',
+          ),
+        );
+      },
+    );
+
+    test('dry-runs LiteRT-LM chat feature smoke with model path', () async {
+      final result = await runLocalE2e(const [
+        '--scenario',
+        'litert-lm-chat-features-smoke',
+        '--model-path',
+        'models/gemma-4-E2B-it.litertlm',
+        '--dry-run',
+      ], projectRoot: '/repo');
+
+      expect(result.exitCode, 0);
+      expect(result.stdout, contains('litert-lm-chat-features-smoke'));
+      expect(
+        result.stdout,
+        contains(
+          'cd /repo && dart run tool/litert_lm_chat_features_smoke.dart '
+          'models/gemma-4-E2B-it.litertlm auto',
+        ),
       );
     });
 

--- a/test/unit/tooling/test_matrix_test.dart
+++ b/test/unit/tooling/test_matrix_test.dart
@@ -1,0 +1,78 @@
+@TestOn('vm')
+library;
+
+import 'package:test/test.dart';
+
+import '../../../tool/testing/test_matrix.dart';
+
+void main() {
+  group('test_matrix', () {
+    test('has unique row ids', () {
+      final ids = testMatrixRows.map((row) => row.id).toList();
+
+      expect(ids.toSet(), hasLength(ids.length));
+    });
+
+    test('has stable essential rows for baseline PR validation', () {
+      final ids = testMatrixRows.map((row) => row.id).toSet();
+
+      expect(ids, contains('static-format-analyze'));
+      expect(ids, contains('root-vm'));
+      expect(ids, contains('root-chrome'));
+      expect(ids, contains('coverage-lib'));
+    });
+
+    test('includes targeted local model smoke rows', () {
+      final ids = testMatrixRows.map((row) => row.id).toSet();
+
+      expect(ids, contains('gguf-chat-features-smoke'));
+      expect(ids, contains('litert-lm-chat-features-smoke'));
+      expect(ids, contains('web-real-model-smoke'));
+      expect(ids, contains('webgpu-multimodal-regression'));
+      expect(ids, contains('gemma4-webgpu-mem64'));
+    });
+
+    test('includes explicit platform coverage rows', () {
+      final ids = testMatrixRows.map((row) => row.id).toSet();
+
+      expect(ids, contains('linux-x64-ci-runtime'));
+      expect(ids, contains('linux-arm64-runtime-smoke'));
+      expect(ids, contains('windows-x64-ci-runtime'));
+      expect(ids, contains('windows-arm64-hook-coverage'));
+      expect(ids, contains('macos-arm64-runtime-smoke'));
+      expect(ids, contains('macos-x64-runtime-smoke'));
+      expect(ids, contains('ios-arm64-device-smoke'));
+      expect(ids, contains('ios-simulator-smoke'));
+      expect(ids, contains('android-arm64-device-smoke'));
+      expect(ids, contains('android-x64-emulator-smoke'));
+      expect(ids, contains('web-chrome-runtime-smoke'));
+    });
+
+    test('formats PR evidence template with matrix ids', () {
+      final template = formatPrEvidenceTemplate(tier: 'essential');
+
+      expect(template, contains('| Matrix row |'));
+      expect(template, contains('`root-vm`'));
+      expect(template, contains('PASS / FAIL / N/A'));
+      expect(template, isNot(contains('`android-arm64-device-smoke`')));
+    });
+
+    test('formats targeted matrix table with commands', () {
+      final table = formatTestMatrix(tier: 'targeted');
+
+      expect(table, contains('| ID | Tier | Mode |'));
+      expect(table, contains('gguf-chat-features-smoke'));
+      expect(table, contains('run_local_e2e.dart'));
+      expect(table, isNot(contains('static-format-analyze')));
+    });
+
+    test('formats platform matrix table separately from targeted rows', () {
+      final table = formatTestMatrix(tier: 'platform');
+
+      expect(table, contains('linux-x64-ci-runtime'));
+      expect(table, contains('ios-arm64-device-smoke'));
+      expect(table, contains('web-chrome-runtime-smoke'));
+      expect(table, isNot(contains('gguf-chat-features-smoke')));
+    });
+  });
+}

--- a/tool/testing/run_local_e2e.dart
+++ b/tool/testing/run_local_e2e.dart
@@ -70,7 +70,9 @@ class LocalE2eRunContext {
     required this.device,
     required this.port,
     required this.python,
+    required this.modelPath,
     required this.modelUrl,
+    required this.backend,
     required this.expect,
     required this.skipBuild,
   });
@@ -79,7 +81,9 @@ class LocalE2eRunContext {
   final String device;
   final int port;
   final String python;
+  final String? modelPath;
   final String? modelUrl;
+  final String backend;
   final String expect;
   final bool skipBuild;
 
@@ -177,6 +181,52 @@ List<LocalE2eScenario> buildLocalE2eScenarios({String? projectRoot}) {
           description: 'Qwen3.5 multimodal macOS repro E2E',
         ),
       ],
+    ),
+    LocalE2eScenario(
+      name: 'gguf-chat-features-smoke',
+      group: LocalE2eScenarioGroup.dartLocalOnly,
+      description:
+          'Run real GGUF chat, thinking-suppression, and tool-call smoke.',
+      requiresDevice: false,
+      stepsBuilder: (context) {
+        final arguments = <String>['run', 'tool/gguf_chat_features_smoke.dart'];
+        if (context.modelPath != null) {
+          arguments.add(context.modelPath!);
+          arguments.add(context.backend);
+        }
+        return [
+          LocalE2eCommandStep(
+            workingDirectory: context.projectRoot,
+            executable: 'dart',
+            arguments: arguments,
+            description: 'GGUF chat feature smoke',
+          ),
+        ];
+      },
+    ),
+    LocalE2eScenario(
+      name: 'litert-lm-chat-features-smoke',
+      group: LocalE2eScenarioGroup.dartLocalOnly,
+      description: 'Run real LiteRT-LM chat, thinking, and tool-call smoke.',
+      requiresDevice: false,
+      stepsBuilder: (context) {
+        final arguments = <String>[
+          'run',
+          'tool/litert_lm_chat_features_smoke.dart',
+        ];
+        if (context.modelPath != null) {
+          arguments.add(context.modelPath!);
+          arguments.add(context.backend);
+        }
+        return [
+          LocalE2eCommandStep(
+            workingDirectory: context.projectRoot,
+            executable: 'dart',
+            arguments: arguments,
+            description: 'LiteRT-LM chat feature smoke',
+          ),
+        ];
+      },
     ),
     LocalE2eScenario(
       name: 'webgpu-multimodal-regression',
@@ -493,7 +543,9 @@ Future<LocalE2eResult> runLocalE2e(
     device: parsed.device,
     port: parsed.port,
     python: parsed.pythonProvided ? parsed.python : _defaultPython(root),
+    modelPath: parsed.modelPath,
     modelUrl: parsed.modelUrl,
+    backend: parsed.backend,
     expect: parsed.expect,
     skipBuild: parsed.skipBuild,
   );
@@ -684,7 +736,9 @@ Options:
   --device <device>              Flutter device id for device scenarios (default: macos).
   --port <port>                  Local web server port (default: 7358).
   --python <path>                Python executable for helper scripts (default: repo Playwright venv, then python3).
+  --model-path <path>            Local model path for Dart local-only model scenarios.
   --model-url <url>              Model URL for real-model web smoke.
+  --backend <name>               Backend for local model scenarios (default: auto).
   --expect <text>                Expected response text for real-model web smoke.
   --skip-build                   Reuse an existing Flutter web build where supported.
   -h, --help                     Show this help.
@@ -711,9 +765,11 @@ class _ParsedArgs {
     required this.port,
     required this.python,
     required this.pythonProvided,
+    required this.backend,
     required this.expect,
     required this.skipBuild,
     this.scenario,
+    this.modelPath,
     this.modelUrl,
   });
 
@@ -725,7 +781,9 @@ class _ParsedArgs {
   final int port;
   final String python;
   final bool pythonProvided;
+  final String? modelPath;
   final String? modelUrl;
+  final String backend;
   final String expect;
   final bool skipBuild;
 
@@ -737,9 +795,11 @@ class _ParsedArgs {
     var port = 7358;
     var python = 'python3';
     var pythonProvided = false;
+    var backend = 'auto';
     var expect = '4';
     var skipBuild = false;
     String? scenario;
+    String? modelPath;
     String? modelUrl;
 
     for (var index = 0; index < args.length; index++) {
@@ -762,8 +822,12 @@ class _ParsedArgs {
         case '--python':
           python = _readValue(args, ++index, arg);
           pythonProvided = true;
+        case '--model-path':
+          modelPath = _readValue(args, ++index, arg);
         case '--model-url':
           modelUrl = _readValue(args, ++index, arg);
+        case '--backend':
+          backend = _readValue(args, ++index, arg);
         case '--expect':
           expect = _readValue(args, ++index, arg);
         default:
@@ -780,7 +844,9 @@ class _ParsedArgs {
       port: port,
       python: python,
       pythonProvided: pythonProvided,
+      modelPath: modelPath,
       modelUrl: modelUrl,
+      backend: backend,
       expect: expect,
       skipBuild: skipBuild,
     );

--- a/tool/testing/test_matrix.dart
+++ b/tool/testing/test_matrix.dart
@@ -19,7 +19,7 @@ class TestMatrixRow {
   /// One of `essential`, `targeted`, `platform`, or `release`.
   final String tier;
 
-  /// Where the row normally runs: CI, local, or manual/device.
+  /// Free-form descriptor for where the row normally runs.
   final String mode;
 
   /// Runtime, model, feature, or platform coverage represented by this row.
@@ -425,7 +425,7 @@ Options:
 ''';
 }
 
-Future<void> main(List<String> args) async {
+void main(List<String> args) {
   var list = true;
   var prTemplate = false;
   var tier = 'all';

--- a/tool/testing/test_matrix.dart
+++ b/tool/testing/test_matrix.dart
@@ -1,0 +1,467 @@
+#!/usr/bin/env dart
+
+import 'dart:io';
+
+/// A test matrix row that contributors can cite in pull request evidence.
+class TestMatrixRow {
+  const TestMatrixRow({
+    required this.id,
+    required this.tier,
+    required this.mode,
+    required this.covers,
+    required this.command,
+    required this.useWhen,
+  });
+
+  /// Stable row identifier used in PR evidence.
+  final String id;
+
+  /// One of `essential`, `targeted`, `platform`, or `release`.
+  final String tier;
+
+  /// Where the row normally runs: CI, local, or manual/device.
+  final String mode;
+
+  /// Runtime, model, feature, or platform coverage represented by this row.
+  final String covers;
+
+  /// Command, workflow, or checklist entry point.
+  final String command;
+
+  /// Selection rule for contributors and agents.
+  final String useWhen;
+}
+
+/// The canonical contributor-facing validation matrix.
+const List<TestMatrixRow> testMatrixRows = <TestMatrixRow>[
+  TestMatrixRow(
+    id: 'static-format-analyze',
+    tier: 'essential',
+    mode: 'CI + local',
+    covers: 'format, analyzer, web/native import boundaries',
+    command:
+        'dart format --output=none --set-exit-if-changed .; dart analyze; '
+        'dart run tool/testing/check_platform_boundaries.dart',
+    useWhen: 'Every non-trivial PR.',
+  ),
+  TestMatrixRow(
+    id: 'root-vm',
+    tier: 'essential',
+    mode: 'CI + local',
+    covers: 'native-safe unit/integration coverage on the Dart VM',
+    command: 'dart test -p vm -j 1 --exclude-tags local-only',
+    useWhen: 'Every code PR unless the change is docs-only.',
+  ),
+  TestMatrixRow(
+    id: 'root-chrome',
+    tier: 'essential',
+    mode: 'CI + local',
+    covers: 'browser-compatible unit/integration coverage',
+    command: 'dart test -p chrome --exclude-tags local-only',
+    useWhen: 'Every shared, web, template, or public API change.',
+  ),
+  TestMatrixRow(
+    id: 'coverage-lib',
+    tier: 'essential',
+    mode: 'CI + local',
+    covers: '>=70% line coverage for maintainable lib/ code',
+    command:
+        'dart test -p vm --coverage=coverage; '
+        'dart pub global run coverage:format_coverage --lcov '
+        '--in=coverage/test --out=coverage/lcov.info --report-on=lib '
+        '--check-ignore; '
+        'dart run tool/testing/check_lcov_threshold.dart coverage/lcov.info 70',
+    useWhen: 'Before merge when lib/ behavior changes or coverage is in doubt.',
+  ),
+  TestMatrixRow(
+    id: 'docs-site',
+    tier: 'targeted',
+    mode: 'CI + local',
+    covers: 'website build, docs metadata, generated docs routes',
+    command: './tool/docs/build_site.sh; ./tool/docs/validate_links.sh',
+    useWhen: 'Docs, README, website, migration, or changelog changes.',
+  ),
+  TestMatrixRow(
+    id: 'examples-tests',
+    tier: 'targeted',
+    mode: 'local',
+    covers: 'example package unit tests and Flutter app regressions',
+    command:
+        'Run tests in each touched example package, for example '
+        '(cd example/chat_app && flutter test).',
+    useWhen: 'Any example app, CLI, or server package change.',
+  ),
+  TestMatrixRow(
+    id: 'native-hook-bundles',
+    tier: 'targeted',
+    mode: 'CI + local',
+    covers: 'native-assets hook, bundle selection, runtime companions',
+    command: 'dart test -p vm -j 1 test/unit/hook --exclude-tags local-only',
+    useWhen:
+        'hook/build.dart, native bundle config, runtime selection, or pins.',
+  ),
+  TestMatrixRow(
+    id: 'native-prompt-reuse-parity',
+    tier: 'targeted',
+    mode: 'CI + local',
+    covers: 'real GGUF native prompt reuse parity with deterministic prompts',
+    command:
+        'CI job "Native Prompt Reuse Parity", or dart run '
+        'tool/testing/native_prompt_reuse_parity.dart --model <model.gguf> '
+        '--prompt-file tool/testing/prompts/native_prompt_reuse_ci_prompts.txt '
+        '--max-prompts 4 --runs 1 --max-tokens 64 --gpu-layers 0 '
+        '--fail-on-mismatch',
+    useWhen:
+        'Native prompt reuse, context reuse, generation stability changes.',
+  ),
+  TestMatrixRow(
+    id: 'gguf-chat-features-smoke',
+    tier: 'targeted',
+    mode: 'local-only',
+    covers:
+        'real GGUF llama.cpp chat, thinking suppression, streaming tool calls',
+    command:
+        'dart run tool/testing/run_local_e2e.dart --scenario '
+        'gguf-chat-features-smoke --model-path <model.gguf> --backend auto',
+    useWhen:
+        'Chat rendering, parser, tool calling, thinking, or GGUF feature work.',
+  ),
+  TestMatrixRow(
+    id: 'template-parity',
+    tier: 'targeted',
+    mode: 'local-only',
+    covers: 'vendored llama.cpp chat-template detection/render/parse parity',
+    command: 'tool/testing/run_template_parity_suites.sh',
+    useWhen: 'Template engine, handlers, grammar, or parser changes.',
+  ),
+  TestMatrixRow(
+    id: 'litert-lm-engine-smoke',
+    tier: 'targeted',
+    mode: 'CI + local',
+    covers: 'real .litertlm load/generate path on LiteRT-LM CPU runtime',
+    command:
+        'CI workflow "LiteRT-LM Smoke", or dart run '
+        'tool/litert_lm_engine_smoke.dart <model.litertlm> cpu '
+        '"What is 2+2? Answer only with the number." 16 1024',
+    useWhen: 'LiteRT-LM backend, hook companion libraries, or runtime pins.',
+  ),
+  TestMatrixRow(
+    id: 'litert-lm-chat-features-smoke',
+    tier: 'targeted',
+    mode: 'local-only',
+    covers:
+        'real .litertlm chat, thinking channel reassembly, streaming tool calls',
+    command:
+        'dart run tool/testing/run_local_e2e.dart --scenario '
+        'litert-lm-chat-features-smoke --model-path <model.litertlm> '
+        '--backend auto',
+    useWhen:
+        'LiteRT-LM chat templates, thinking, tool calling, or ChatSession work.',
+  ),
+  TestMatrixRow(
+    id: 'chat-app-device-cache',
+    tier: 'targeted',
+    mode: 'local-only',
+    covers: 'Flutter device model/mmproj download-cache-load flow',
+    command:
+        'dart run tool/testing/run_local_e2e.dart --scenario '
+        'chat-app-model-cache --device <macos|ios|android>',
+    useWhen:
+        'Chat app model lifecycle, cache, projector, or device UI changes.',
+  ),
+  TestMatrixRow(
+    id: 'web-bridge-smoke',
+    tier: 'targeted',
+    mode: 'local-only',
+    covers: 'WebGPU bridge bootstrap and fallback wiring',
+    command: 'dart run tool/testing/run_local_e2e.dart --scenario bridge-smoke',
+    useWhen: 'Bridge asset loading, web bootstrap, or web interop changes.',
+  ),
+  TestMatrixRow(
+    id: 'web-real-model-smoke',
+    tier: 'targeted',
+    mode: 'local-only',
+    covers: 'built Flutter web chat app with real GGUF model URL',
+    command:
+        'dart run tool/testing/run_local_e2e.dart --scenario '
+        'chat-app-web-real-model-smoke --model-url <model-url> --expect 4',
+    useWhen:
+        'Web chat app, web model loading, or WebGPU bridge runtime changes.',
+  ),
+  TestMatrixRow(
+    id: 'webgpu-multimodal-regression',
+    tier: 'targeted',
+    mode: 'local-only',
+    covers: 'CPU and WebGPU Qwen multimodal regression path',
+    command:
+        'dart run tool/testing/run_local_e2e.dart --scenario '
+        'webgpu-multimodal-regression',
+    useWhen: 'Multimodal, WebGPU prompt formatting, or image staging changes.',
+  ),
+  TestMatrixRow(
+    id: 'gemma4-webgpu-mem64',
+    tier: 'targeted',
+    mode: 'local-only',
+    covers: 'Gemma 4 E2B GGUF through web llama.cpp mem64 core',
+    command:
+        'dart run tool/testing/run_local_e2e.dart --scenario '
+        'chat-app-web-gemma4-webgpu-smoke',
+    useWhen: 'Large WebGPU models, mem64 selection, or Gemma 4 web GGUF work.',
+  ),
+  TestMatrixRow(
+    id: 'gemma4-litert-web',
+    tier: 'targeted',
+    mode: 'local-only',
+    covers: 'Gemma 4 web .litertlm through LiteRT-LM JS backend',
+    command:
+        'dart run tool/testing/run_local_e2e.dart --scenario '
+        'chat-app-web-litert-gemma4-smoke',
+    useWhen: 'LiteRT-LM web backend, web chat app, or Gemma 4 web bundle work.',
+  ),
+  TestMatrixRow(
+    id: 'linux-x64-ci-runtime',
+    tier: 'platform',
+    mode: 'CI + local',
+    covers:
+        'Linux x64 root VM tests, real GGUF prompt reuse, LiteRT-LM CPU smoke',
+    command:
+        'CI jobs "Test Linux & Web (with Coverage)", '
+        '"Native Prompt Reuse Parity", and '
+        '"LiteRT-LM Smoke / Native smoke (ubuntu-latest)".',
+    useWhen: 'Any native runtime or release change affecting Linux x64.',
+  ),
+  TestMatrixRow(
+    id: 'linux-arm64-runtime-smoke',
+    tier: 'platform',
+    mode: 'local/self-hosted',
+    covers: 'Linux arm64 native hook bundle plus llama.cpp/LiteRT-LM runtime',
+    command:
+        'On a Linux arm64 host: dart test -p vm -j 1 --exclude-tags '
+        'local-only; dart run tool/gguf_chat_features_smoke.dart '
+        '<model.gguf> cpu; dart run tool/litert_lm_engine_smoke.dart '
+        '<model.litertlm> cpu',
+    useWhen: 'Linux arm64 bundle, release, or runtime changes.',
+  ),
+  TestMatrixRow(
+    id: 'windows-x64-ci-runtime',
+    tier: 'platform',
+    mode: 'CI + local',
+    covers: 'Windows x64 VM tests, hook bundle validation, LiteRT-LM CPU smoke',
+    command:
+        'CI jobs "Test Native (windows-latest)" and '
+        '"LiteRT-LM Smoke / Native smoke (windows-latest)".',
+    useWhen: 'Any native runtime or release change affecting Windows x64.',
+  ),
+  TestMatrixRow(
+    id: 'windows-arm64-hook-coverage',
+    tier: 'platform',
+    mode: 'hook-only + manual/runtime',
+    covers:
+        'Windows arm64 bundle selection; runtime smoke requires Windows arm64 hardware',
+    command:
+        'dart test -p vm -j 1 test/unit/hook --exclude-tags local-only; '
+        'for runtime proof, run the GGUF local smoke on Windows arm64 hardware.',
+    useWhen: 'Windows arm64 bundle, hook, or release changes.',
+  ),
+  TestMatrixRow(
+    id: 'macos-arm64-runtime-smoke',
+    tier: 'platform',
+    mode: 'local/device',
+    covers: 'macOS arm64 llama.cpp CPU/Metal and LiteRT-LM CPU/GPU runtime',
+    command:
+        'On Apple Silicon: dart test -p vm -j 1 --exclude-tags local-only; '
+        'dart run tool/gguf_chat_features_smoke.dart <model.gguf> metal; '
+        'dart run tool/litert_lm_chat_features_smoke.dart '
+        '<model.litertlm> gpu',
+    useWhen: 'Apple Metal, macOS runtime, LiteRT-LM GPU, or release changes.',
+  ),
+  TestMatrixRow(
+    id: 'macos-x64-runtime-smoke',
+    tier: 'platform',
+    mode: 'local/device',
+    covers: 'macOS x64 llama.cpp CPU/Metal and LiteRT-LM CPU/GPU runtime',
+    command:
+        'On Intel macOS: dart test -p vm -j 1 --exclude-tags local-only; '
+        'dart run tool/gguf_chat_features_smoke.dart <model.gguf> metal; '
+        'dart run tool/litert_lm_chat_features_smoke.dart '
+        '<model.litertlm> gpu',
+    useWhen: 'macOS x64 native runtime, bundle, or release changes.',
+  ),
+  TestMatrixRow(
+    id: 'ios-arm64-device-smoke',
+    tier: 'platform',
+    mode: 'manual/device',
+    covers: 'iOS arm64 device bundle, app launch, model load, first tokens',
+    command:
+        'Run example/chat_app on an iOS device, load a known small model, '
+        'generate a short deterministic response, and record device/iOS/model.',
+    useWhen: 'iOS runtime, bundle, framework staging, or release changes.',
+  ),
+  TestMatrixRow(
+    id: 'ios-simulator-smoke',
+    tier: 'platform',
+    mode: 'manual/simulator',
+    covers:
+        'iOS arm64 simulator and x86_64 simulator bundle/framework staging paths',
+    command:
+        'Run example/chat_app on available iOS simulators; record simulator '
+        'architecture, model, backend, and whether model load/generation passed.',
+    useWhen: 'iOS simulator hook, framework staging, or release changes.',
+  ),
+  TestMatrixRow(
+    id: 'android-arm64-device-smoke',
+    tier: 'platform',
+    mode: 'manual/device',
+    covers:
+        'Android arm64 device load/generate, CPU profiles, crash signatures',
+    command: './scripts/android_runtime_smoke.sh --app-id <app-id>',
+    useWhen:
+        'Android arm64 runtime selection, CPU variants, native bundle changes, '
+        'or release candidates.',
+  ),
+  TestMatrixRow(
+    id: 'android-x64-emulator-smoke',
+    tier: 'platform',
+    mode: 'manual/emulator',
+    covers: 'Android x64 emulator bundle, app launch, model load/generate',
+    command:
+        'Run example/chat_app on an Android x64 emulator and record emulator '
+        'image, model, backend, and generation result.',
+    useWhen: 'Android x64 bundle, hook, or emulator-targeted changes.',
+  ),
+  TestMatrixRow(
+    id: 'web-chrome-runtime-smoke',
+    tier: 'platform',
+    mode: 'CI + local',
+    covers: 'Chrome browser-safe tests plus local WebGPU/LiteRT-LM web smokes',
+    command:
+        'dart test -p chrome --exclude-tags local-only; choose relevant web '
+        'rows: web-bridge-smoke, web-real-model-smoke, gemma4-webgpu-mem64, '
+        'or gemma4-litert-web.',
+    useWhen: 'Web backend, browser interop, WebGPU, or LiteRT-LM web changes.',
+  ),
+  TestMatrixRow(
+    id: 'android-release-device-pool',
+    tier: 'release',
+    mode: 'manual/device',
+    covers:
+        'Android old/modern arm64 runtime load, CPU profiles, crash signatures',
+    command:
+        'Run android-arm64-device-smoke on old and modern arm64 devices with '
+        'the cpu_profile full and compact configurations; see '
+        'doc/android_runtime_smoke_test_plan.md.',
+    useWhen:
+        'Android runtime selection, CPU variants, release candidates, or '
+        'native bundle changes affecting Android.',
+  ),
+  TestMatrixRow(
+    id: 'release-representative-smokes',
+    tier: 'release',
+    mode: 'manual/local',
+    covers: 'representative examples before publishing a package release',
+    command: 'Follow website/docs/maintainers/release-workflow.md.',
+    useWhen: 'Before tagging and publishing a release.',
+  ),
+];
+
+String formatTestMatrix({String tier = 'all'}) {
+  final rows = _filterRows(tier);
+  final buffer = StringBuffer()
+    ..writeln('| ID | Tier | Mode | Covers | Use when | Command |')
+    ..writeln('| --- | --- | --- | --- | --- | --- |');
+  for (final row in rows) {
+    buffer.writeln(
+      '| ${_cell(row.id)} | ${_cell(row.tier)} | ${_cell(row.mode)} | '
+      '${_cell(row.covers)} | ${_cell(row.useWhen)} | '
+      '`${_cell(row.command)}` |',
+    );
+  }
+  return buffer.toString();
+}
+
+String formatPrEvidenceTemplate({String tier = 'all'}) {
+  final rows = _filterRows(tier);
+  final buffer = StringBuffer()
+    ..writeln(
+      '| Matrix row | Scope covered | Platform / model / backend | Result | Evidence / notes |',
+    )
+    ..writeln('| --- | --- | --- | --- | --- |');
+  for (final row in rows) {
+    buffer.writeln(
+      '| `${_cell(row.id)}` | ${_cell(row.covers)} |  | PASS / FAIL / N/A |  |',
+    );
+  }
+  return buffer.toString();
+}
+
+List<TestMatrixRow> _filterRows(String tier) {
+  final normalized = tier.trim().toLowerCase();
+  if (normalized == 'all') {
+    return testMatrixRows;
+  }
+  final rows = testMatrixRows
+      .where((row) => row.tier == normalized)
+      .toList(growable: false);
+  if (rows.isEmpty) {
+    throw ArgumentError.value(
+      tier,
+      'tier',
+      'Expected all, essential, targeted, platform, or release.',
+    );
+  }
+  return rows;
+}
+
+String _cell(String value) => value.replaceAll('|', r'\|');
+
+String _usage() {
+  return '''Usage: dart run tool/testing/test_matrix.dart [options]
+
+Options:
+  --list                 Print the canonical test matrix (default).
+  --pr-template          Print a PR evidence table.
+  --tier <tier>          Filter by all, essential, targeted, platform, or release.
+  -h, --help             Show this help.
+''';
+}
+
+Future<void> main(List<String> args) async {
+  var list = true;
+  var prTemplate = false;
+  var tier = 'all';
+
+  try {
+    for (var index = 0; index < args.length; index++) {
+      final arg = args[index];
+      switch (arg) {
+        case '--list':
+          list = true;
+          prTemplate = false;
+        case '--pr-template':
+          prTemplate = true;
+          list = false;
+        case '--tier':
+          index++;
+          if (index >= args.length) {
+            throw ArgumentError('Missing value for --tier');
+          }
+          tier = args[index];
+        case '--help' || '-h':
+          stdout.write(_usage());
+          return;
+        default:
+          throw ArgumentError('Unknown option: $arg');
+      }
+    }
+
+    if (prTemplate) {
+      stdout.write(formatPrEvidenceTemplate(tier: tier));
+    } else if (list) {
+      stdout.write(formatTestMatrix(tier: tier));
+    }
+  } on Object catch (error) {
+    stderr.writeln(error);
+    stderr.write(_usage());
+    exitCode = 64;
+  }
+}

--- a/website/docs/maintainers/native-and-web-sync.md
+++ b/website/docs/maintainers/native-and-web-sync.md
@@ -39,6 +39,12 @@ WEBGPU_BRIDGE_ASSETS_TAG=<tag> ./scripts/fetch_webgpu_bridge_assets.sh
 
 ## Validation after sync
 
+Use the contributor matrix to choose exact rows and record PR evidence:
+
+```bash
+dart run tool/testing/test_matrix.dart --list
+```
+
 - Native: model load/generation smoke checks on relevant platforms.
 - Web: bridge load/fallback checks in `example/chat_app`.
 - Docs: ensure version/platform notes match newly pinned runtime behavior.

--- a/website/docs/maintainers/release-workflow.md
+++ b/website/docs/maintainers/release-workflow.md
@@ -9,6 +9,7 @@ Use this checklist when releasing `llamadart`.
 ## 1. Pre-release validation
 
 ```bash
+# Print release-tier rows for evidence planning; this does not run validation.
 dart run tool/testing/test_matrix.dart --tier release
 dart format --output=none --set-exit-if-changed .
 dart analyze

--- a/website/docs/maintainers/release-workflow.md
+++ b/website/docs/maintainers/release-workflow.md
@@ -9,6 +9,7 @@ Use this checklist when releasing `llamadart`.
 ## 1. Pre-release validation
 
 ```bash
+dart run tool/testing/test_matrix.dart --tier release
 dart format --output=none --set-exit-if-changed .
 dart analyze
 dart test


### PR DESCRIPTION
## Summary
- Add a canonical contributor test matrix tool and documentation for essential, targeted, platform, and release validation rows.
- Extend the local E2E runner with GGUF and LiteRT-LM real-model chat feature smoke scenarios.
- Update PR, contributor, README, test, maintainer, and agent guidance so PR authors can include matrix evidence.

## Production-readiness scope
- **User-facing scope:** contributors and agentic workflows can list applicable runtime/model/feature/platform validation rows and paste a standard evidence table into PRs.
- **Supported platforms/paths:** documentation rows cover Linux x64/arm64, Windows x64/arm64, macOS arm64/x64, iOS device/simulator, Android arm64/x64, and Web/Chrome with explicit CI/local/manual/hook-only evidence levels.
- **Unsupported or intentionally unavailable paths:** heavy model, WebGPU, and device scenarios remain local/manual evidence rows rather than default CI requirements.
- **Out of scope / follow-ups:** no CI workflow expansion in this PR.

## Completeness checklist
- [x] Declared scope is fully implemented, or explicitly reduced above.
- [x] Unsupported platform/option combinations fail loudly with actionable diagnostics or are clearly documented as unavailable.
- [x] Public API docs, README/website docs, examples, support matrices, and changelog entries are updated where relevant.
- [x] Regression coverage covers the original issue plus key negative/version-skew paths where relevant.
- [x] Security/privacy review completed: no secrets, bearer tokens, signed URLs, or raw secret-bearing paths leak through logs, cache keys, metadata, errors, or snapshots.
- [x] Follow-up work that is useful but not required for this PR is tracked in GitHub Issues, or explicitly marked "None" above.

## PR type guidance
- **Feature PR:** test/contributor workflow feature; includes docs, PR template, agent guidance, local runner scenarios, and unit coverage.
- **Bugfix PR:** N/A.
- **Docs-only PR:** N/A; includes tooling and tests.

## Test Plan
- [x] `dart format --output=none --set-exit-if-changed .` equivalent targeted format on changed Dart files: `dart format tool/testing/test_matrix.dart tool/testing/run_local_e2e.dart test/unit/tooling/test_matrix_test.dart test/unit/tooling/run_local_e2e_test.dart`
- [x] `dart analyze tool/testing/test_matrix.dart tool/testing/run_local_e2e.dart test/unit/tooling/test_matrix_test.dart test/unit/tooling/run_local_e2e_test.dart`
- [x] `dart test -p vm test/unit/tooling/run_local_e2e_test.dart test/unit/tooling/test_matrix_test.dart`
- [ ] `dart test -p chrome --exclude-tags local-only` N/A: no browser runtime behavior changed.
- [x] Other targeted/local-only validation: `dart run tool/testing/test_matrix.dart --tier platform`; `dart run tool/testing/test_matrix.dart --tier release`; `dart run tool/testing/run_local_e2e.dart --list`
- [x] Review fix validation: `dart analyze tool/testing/test_matrix.dart test/unit/tooling/test_matrix_test.dart`; `dart test -p vm test/unit/tooling/test_matrix_test.dart`; `dart run tool/testing/test_matrix.dart --tier release`

## Matrix Evidence
| Matrix row | Scope covered | Platform / model / backend | Result | Evidence / notes |
| --- | --- | --- | --- | --- |
| `static-format-analyze` | targeted Dart formatting/analyzer for changed tooling | local macOS, changed Dart files | PASS | `dart format ...`; `dart analyze ...`; no issues found |
| `root-vm` | unit coverage for matrix tool and local E2E runner | VM | PASS | `dart test -p vm test/unit/tooling/run_local_e2e_test.dart test/unit/tooling/test_matrix_test.dart`; 18 tests passed |
| `root-chrome` | browser-compatible unit/integration coverage | N/A | N/A | no browser runtime behavior changed |
| `gguf-chat-features-smoke` | real GGUF model smoke scenario wiring | dry-run/list coverage only | N/A | scenario added and unit-tested; no local GGUF model smoke run |
| `litert-lm-chat-features-smoke` | real LiteRT-LM model smoke scenario wiring | dry-run/list coverage only | N/A | scenario added and unit-tested; no local `.litertlm` model smoke run |
| `web-chrome-runtime-smoke` | browser platform matrix documentation | Chrome/Web matrix row | PASS | `dart run tool/testing/test_matrix.dart --tier platform` lists row and evidence mode |
| `android-release-device-pool` | release matrix documentation | Android old/modern device pool | PASS | `dart run tool/testing/test_matrix.dart --tier release` lists release row and smoke-plan pointer |

## Review Notes
- Independent review status: Copilot review comments addressed and all 3 review threads resolved.
- CI status / head SHA: CI passed for `4a3f06ff0` (workflow run 699).