### PR TITLE
Add chat app web runtime guards and PR previews

### DIFF
--- a/.github/workflows/chat_app_hf_pr_preview.yml
+++ b/.github/workflows/chat_app_hf_pr_preview.yml
@@ -1,0 +1,265 @@
+name: Chat App HF PR Preview
+
+on:
+  pull_request:
+    branches: [master, main]
+    types: [opened, reopened, synchronize, closed]
+    paths:
+      - "example/chat_app/**"
+      - "lib/**"
+      - "pubspec.yaml"
+      - "pubspec.lock"
+      - "scripts/fetch_webgpu_bridge_assets.sh"
+      - ".github/workflows/chat_app_hf_pr_preview.yml"
+
+permissions:
+  contents: read
+  issues: write
+  pull-requests: write
+
+concurrency:
+  group: chat-app-hf-pr-preview-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
+jobs:
+  preview:
+    name: Deploy chat app PR preview
+    runs-on: ubuntu-latest
+    timeout-minutes: 45
+    if: >-
+      ${{
+        github.event.pull_request.head.repo.full_name == github.repository &&
+        github.event.pull_request.user.login != 'dependabot[bot]'
+      }}
+    env:
+      HF_TOKEN: ${{ secrets.HF_TOKEN }}
+      HF_CHAT_APP_SPACE_REPO: ${{ vars.HF_CHAT_APP_SPACE_REPO }}
+      HF_CHAT_APP_PREVIEW_NAMESPACE: ${{ vars.HF_CHAT_APP_PREVIEW_NAMESPACE }}
+      PR_NUMBER: ${{ github.event.pull_request.number }}
+      PR_HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+    steps:
+      - name: Resolve Hugging Face preview target
+        id: target
+        run: |
+          if [ -z "$HF_TOKEN" ]; then
+            echo "error: set HF_TOKEN repository secret with write/create access to the preview Space namespace"
+            exit 1
+          fi
+
+          NAMESPACE="$HF_CHAT_APP_PREVIEW_NAMESPACE"
+          if [ -z "$NAMESPACE" ] && [ -n "$HF_CHAT_APP_SPACE_REPO" ]; then
+            NAMESPACE="${HF_CHAT_APP_SPACE_REPO%%/*}"
+          fi
+
+          if [ -z "$NAMESPACE" ]; then
+            echo "error: set HF_CHAT_APP_PREVIEW_NAMESPACE or HF_CHAT_APP_SPACE_REPO"
+            exit 1
+          fi
+
+          SPACE_NAME="llamadart-chat-pr-${PR_NUMBER}"
+          SPACE_REPO="${NAMESPACE}/${SPACE_NAME}"
+          SPACE_URL="https://huggingface.co/spaces/${SPACE_REPO}"
+          APP_HOST="$(printf '%s-%s' "$NAMESPACE" "$SPACE_NAME" | tr '[:upper:]' '[:lower:]')"
+          APP_URL="https://${APP_HOST}.static.hf.space"
+
+          {
+            echo "HF_PREVIEW_NAMESPACE=$NAMESPACE"
+            echo "SPACE_NAME=$SPACE_NAME"
+            echo "SPACE_REPO=$SPACE_REPO"
+            echo "SPACE_URL=$SPACE_URL"
+            echo "APP_URL=$APP_URL"
+          } >> "$GITHUB_ENV"
+
+          {
+            echo "space_repo=$SPACE_REPO"
+            echo "space_url=$SPACE_URL"
+            echo "app_url=$APP_URL"
+          } >> "$GITHUB_OUTPUT"
+
+      - uses: actions/checkout@v6
+        if: ${{ github.event.action != 'closed' }}
+        with:
+          ref: ${{ github.event.pull_request.head.sha }}
+
+      - name: Setup Flutter
+        if: ${{ github.event.action != 'closed' }}
+        uses: subosito/flutter-action@v2
+        with:
+          channel: stable
+          cache: true
+
+      - name: Install chat app dependencies
+        if: ${{ github.event.action != 'closed' }}
+        run: |
+          (cd example/chat_app && flutter pub get)
+
+      - name: Fetch pinned web bridge assets
+        if: ${{ github.event.action != 'closed' }}
+        run: ./scripts/fetch_webgpu_bridge_assets.sh
+
+      - name: Build chat app web
+        if: ${{ github.event.action != 'closed' }}
+        run: |
+          (cd example/chat_app && flutter build web --release)
+
+      - name: Install Hugging Face Hub client
+        run: python3 -m pip install --upgrade huggingface_hub
+
+      - name: Prepare static Space payload
+        if: ${{ github.event.action != 'closed' }}
+        run: |
+          rm -rf hf-space-sync
+          mkdir -p hf-space-sync
+
+          rsync -a --delete \
+            "example/chat_app/build/web/" "hf-space-sync/"
+
+          {
+            printf '%s\n' '---'
+            printf '%s\n' "title: llamadart chat app PR ${PR_NUMBER}"
+            printf '%s\n' 'sdk: static'
+            printf '%s\n' 'app_file: index.html'
+            printf '%s\n' 'custom_headers:'
+            printf '%s\n' '  cross-origin-embedder-policy: require-corp'
+            printf '%s\n' '  cross-origin-opener-policy: same-origin'
+            printf '%s\n' '  cross-origin-resource-policy: cross-origin'
+            printf '%s\n' '---'
+            printf '%s\n' ''
+            printf '%s\n' "llamadart chat app preview for PR ${PR_NUMBER}."
+          } > "hf-space-sync/README.md"
+
+      - name: Create or update preview Space
+        if: ${{ github.event.action != 'closed' }}
+        run: |
+          python3 - <<'PY'
+          import os
+
+          from huggingface_hub import HfApi
+
+          api = HfApi(token=os.environ["HF_TOKEN"])
+          space_repo = os.environ["SPACE_REPO"]
+          pr_number = os.environ["PR_NUMBER"]
+          head_sha = os.environ["PR_HEAD_SHA"]
+
+          api.create_repo(
+              repo_id=space_repo,
+              repo_type="space",
+              space_sdk="static",
+              exist_ok=True,
+              private=False,
+          )
+          api.upload_folder(
+              repo_id=space_repo,
+              repo_type="space",
+              folder_path="hf-space-sync",
+              revision="main",
+              delete_patterns="*",
+              commit_message=f"deploy PR #{pr_number} {head_sha[:7]}",
+          )
+          PY
+
+      - name: Delete preview Space
+        if: ${{ github.event.action == 'closed' }}
+        run: |
+          python3 - <<'PY'
+          import os
+
+          from huggingface_hub import HfApi
+          from huggingface_hub.errors import HfHubHTTPError
+
+          api = HfApi(token=os.environ["HF_TOKEN"])
+          try:
+              api.delete_repo(
+                  repo_id=os.environ["SPACE_REPO"],
+                  repo_type="space",
+              )
+          except HfHubHTTPError as error:
+              if getattr(error.response, "status_code", None) != 404:
+                  raise
+          PY
+
+      - name: Comment preview URL
+        if: ${{ github.event.action != 'closed' }}
+        uses: actions/github-script@v8
+        env:
+          APP_URL: ${{ steps.target.outputs.app_url }}
+          SPACE_URL: ${{ steps.target.outputs.space_url }}
+          SPACE_REPO: ${{ steps.target.outputs.space_repo }}
+          PR_HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+        with:
+          script: |
+            const marker = '<!-- llamadart-chat-app-hf-pr-preview -->';
+            const shortSha = process.env.PR_HEAD_SHA.slice(0, 7);
+            const body = [
+              marker,
+              `Chat app preview deployed for \`${shortSha}\`.`,
+              '',
+              `- App: ${process.env.APP_URL}`,
+              `- Space: ${process.env.SPACE_URL}`,
+              `- Repo: \`${process.env.SPACE_REPO}\``,
+            ].join('\n');
+
+            const {owner, repo} = context.repo;
+            const issue_number = context.issue.number;
+            const comments = await github.paginate(
+              github.rest.issues.listComments,
+              {owner, repo, issue_number, per_page: 100},
+            );
+            const existing = comments.find((comment) =>
+              comment.user?.type === 'Bot' && comment.body?.includes(marker)
+            );
+
+            if (existing) {
+              await github.rest.issues.updateComment({
+                owner,
+                repo,
+                comment_id: existing.id,
+                body,
+              });
+            } else {
+              await github.rest.issues.createComment({
+                owner,
+                repo,
+                issue_number,
+                body,
+              });
+            }
+
+      - name: Comment preview removal
+        if: ${{ github.event.action == 'closed' }}
+        uses: actions/github-script@v8
+        env:
+          SPACE_REPO: ${{ steps.target.outputs.space_repo }}
+        with:
+          script: |
+            const marker = '<!-- llamadart-chat-app-hf-pr-preview -->';
+            const body = [
+              marker,
+              `Chat app preview removed for \`${process.env.SPACE_REPO}\`.`,
+            ].join('\n');
+
+            const {owner, repo} = context.repo;
+            const issue_number = context.issue.number;
+            const comments = await github.paginate(
+              github.rest.issues.listComments,
+              {owner, repo, issue_number, per_page: 100},
+            );
+            const existing = comments.find((comment) =>
+              comment.user?.type === 'Bot' && comment.body?.includes(marker)
+            );
+
+            if (existing) {
+              await github.rest.issues.updateComment({
+                owner,
+                repo,
+                comment_id: existing.id,
+                body,
+              });
+            } else {
+              await github.rest.issues.createComment({
+                owner,
+                repo,
+                issue_number,
+                body,
+              });
+            }

--- a/example/chat_app/README.md
+++ b/example/chat_app/README.md
@@ -367,9 +367,10 @@ _(Add screenshots here when complete)_
   `@litert-lm/core`.
 - `.litertlm` web loads do **not** use the browser Cache Storage prefetch (that
   cache is only read back by the llama.cpp/GGUF bridge); `@litert-lm/core`
-  fetches the model URL itself, so the model is downloaded once. Per-message
-  token counts are also not shown for web LiteRT-LM models because the backend
-  exposes no tokenizer API.
+  fetches the model URL itself. Browser HTTP cache may avoid some network
+  transfer, but engine creation still has to initialize the large model and GPU
+  resources on each load. Per-message token counts are also not shown for web
+  LiteRT-LM models because the backend exposes no tokenizer API.
 - Runtime status chips expose execution mode/core/cache/worker fallback/runtime notes,
   so non-COI or worker fallback perf constraints are visible in-app.
 - On web, multimodal projector loading is eager by default for stability: if an

--- a/example/chat_app/README.md
+++ b/example/chat_app/README.md
@@ -64,6 +64,13 @@ flutter test --run-skipped -t local-only \
      `litert-lm-native` runtime. Web builds load web-compatible `.litertlm`
      URLs through `@litert-lm/core`; `web/index.html` sets a default module URL
      that apps can override with `window.__llamadartLiteRtLmModuleUrl`.
+   - LiteRT-LM Web is currently a single-turn text runtime. Because
+     `@litert-lm/core` accepts one prompt string and applies its own chat
+     wrapper internally, the chat app cannot pass structured chat history,
+     tool declarations, tool choice, or thinking-budget/template controls to
+     web `.litertlm` models. The app disables Function Calling and Thinking
+     controls for this runtime; use GGUF/WebGPU or native LiteRT-LM when those
+     structured controls are required.
    - The Gemma 4 E2B LiteRT-LM preset uses the native `.litertlm` bundle on
      Android/iOS/macOS/Linux/Windows and the `-web.litertlm` bundle on Flutter
      Web.
@@ -390,6 +397,24 @@ _(Add screenshots here when complete)_
 - Manual dispatch can override target Space via `space_repo` input and deploy a specific ref via `deploy_ref`.
 - The workflow-generated Space `README.md` already injects required COI headers
   for large-model web runtime support.
+
+### Hugging Face PR preview deployment (CI)
+
+- Workflow: `.github/workflows/chat_app_hf_pr_preview.yml`
+- Triggered for same-repository pull requests that touch the chat app, package
+  sources, or the web bridge asset script.
+- Creates or updates a per-PR static Space named
+  `llamadart-chat-pr-<number>` and comments the preview URL on the PR.
+- Deletes the preview Space when the PR is closed.
+- Required repository secret: `HF_TOKEN` with write/create access to the preview
+  namespace.
+- Optional repository variable: `HF_CHAT_APP_PREVIEW_NAMESPACE`. If omitted,
+  the workflow uses the owner portion of `HF_CHAT_APP_SPACE_REPO`.
+- Fork PRs are skipped so repository secrets are not exposed to untrusted code.
+- The automated PR workflow becomes available after the workflow file exists on
+  the base branch. For a one-off preview before that, manually dispatch
+  `.github/workflows/chat_app_hf_static_deploy.yml` with `space_repo` set to a
+  temporary Space and `deploy_ref` set to the branch or commit to preview.
 
 If deploying outside this workflow, set this frontmatter in Space README (all
 lowercase):

--- a/example/chat_app/integration_test/litert_lm_chat_service_e2e_test.dart
+++ b/example/chat_app/integration_test/litert_lm_chat_service_e2e_test.dart
@@ -49,7 +49,7 @@ void main() {
           modelPath: resolvedModelPath,
           preferredBackend: _preferredBackendFromEnvironment(),
           gpuLayers: ModelParams.maxGpuLayers,
-          contextSize: 1024,
+          contextSize: 2048,
           maxTokens: 16,
           nativeLogLevel: LlamaLogLevel.warn,
         ),
@@ -60,12 +60,17 @@ void main() {
 
       final thinkingSession = ChatSession(
         chatService.engine,
-        maxContextTokens: 1024,
+        maxContextTokens: 2048,
       );
       final thinkingChunks = await thinkingSession
           .create(
-            [LlamaTextContent('What is 2+2? Answer only with the number.')],
-            params: const GenerationParams(maxTokens: 16, seed: 1),
+            [
+              LlamaTextContent(
+                'A farmer has 17 sheep. All but 9 run away. Think step by '
+                'step, then state how many sheep remain.',
+              ),
+            ],
+            params: const GenerationParams(maxTokens: 256, temp: 0, seed: 1),
             enableThinking: true,
           )
           .toList();
@@ -77,7 +82,7 @@ void main() {
 
       final toolSession = ChatSession(
         chatService.engine,
-        maxContextTokens: 1024,
+        maxContextTokens: 2048,
         systemPrompt: 'You must call get_weather. Return only a tool call.',
       );
       final toolChunks = await toolSession

--- a/example/chat_app/lib/providers/chat_provider.dart
+++ b/example/chat_app/lib/providers/chat_provider.dart
@@ -86,6 +86,7 @@ class ChatProvider extends ChangeNotifier {
   bool _supportsVision = false;
   bool _supportsAudio = false;
   bool _templateSupportsTools = true;
+  bool _thinkingControlsSupported = true;
   ChatFormat? _detectedChatFormat;
   String? _error;
   Timer? _settingsSaveDebounce;
@@ -139,6 +140,7 @@ class ChatProvider extends ChangeNotifier {
   bool get supportsVision => _supportsVision;
   bool get supportsAudio => _supportsAudio;
   bool get templateSupportsTools => _templateSupportsTools;
+  bool get thinkingControlsSupported => _thinkingControlsSupported;
   String? get error => _error;
   double get temperature => _settings.temperature;
   int get topK => _settings.topK;
@@ -366,6 +368,8 @@ class ChatProvider extends ChangeNotifier {
       _supportsVision = false;
       _supportsAudio = false;
       _mmprojLoaded = false;
+      _templateSupportsTools = true;
+      _thinkingControlsSupported = true;
       _runtimeGpuLayers = null;
       _runtimeThreads = null;
       _runtimeThreadPoolSize = null;
@@ -682,6 +686,8 @@ class ChatProvider extends ChangeNotifier {
     _supportsVision = false;
     _supportsAudio = false;
     _mmprojLoaded = false;
+    _templateSupportsTools = true;
+    _thinkingControlsSupported = true;
     _runtimeGpuLayers = null;
     _runtimeThreads = null;
     _runtimeThreadPoolSize = null;
@@ -860,6 +866,7 @@ class ChatProvider extends ChangeNotifier {
       _supportsAudio =
           runtimeSupportsAudio ||
           (!_mmprojLoaded && inferredCapabilities.supportsAudio);
+      _updateThinkingControlSupport(metadata);
       _updateToolTemplateSupport(metadata);
       updateLoadingUi(0.9);
 
@@ -921,6 +928,8 @@ class ChatProvider extends ChangeNotifier {
       _supportsVision = false;
       _supportsAudio = false;
       _mmprojLoaded = false;
+      _templateSupportsTools = true;
+      _thinkingControlsSupported = true;
     } finally {
       _isInitializing = false;
       if (!_isDisposed) {
@@ -1884,6 +1893,13 @@ class ChatProvider extends ChangeNotifier {
   }
 
   void updateToolsEnabled(bool value) {
+    if (value && !_templateSupportsTools) {
+      _addInfoMessage(
+        'Tool calling is unavailable for this loaded runtime/template.',
+      );
+      notifyListeners();
+      return;
+    }
     _updateSettings(_settings.copyWith(toolsEnabled: value));
   }
 
@@ -1915,6 +1931,13 @@ class ChatProvider extends ChangeNotifier {
   }
 
   void updateThinkingEnabled(bool value) {
+    if (value && !_thinkingControlsSupported) {
+      _addInfoMessage(
+        'Thinking controls are unavailable for this loaded runtime.',
+      );
+      notifyListeners();
+      return;
+    }
     _updateSettings(_settings.copyWith(thinkingEnabled: value));
   }
 
@@ -1946,6 +1969,8 @@ class ChatProvider extends ChangeNotifier {
     _supportsVision = false;
     _supportsAudio = false;
     _mmprojLoaded = false;
+    _templateSupportsTools = true;
+    _thinkingControlsSupported = true;
     _runtimeGpuLayers = null;
     _runtimeThreads = null;
     _runtimeThreadPoolSize = null;
@@ -2017,7 +2042,43 @@ class ChatProvider extends ChangeNotifier {
     }
   }
 
+  bool _isSingleTurnTextOnlyRuntime(Map<String, String> metadata) {
+    final structuredChat = metadata['llamadart.litert_lm_web.structured_chat']
+        ?.trim()
+        .toLowerCase();
+    final chatScope = metadata['llamadart.litert_lm_web.chat_scope']
+        ?.trim()
+        .toLowerCase();
+    return structuredChat == 'false' || chatScope == 'single-turn-text';
+  }
+
+  void _updateThinkingControlSupport(Map<String, String> metadata) {
+    _thinkingControlsSupported = !_isSingleTurnTextOnlyRuntime(metadata);
+    if (_thinkingControlsSupported || !_settings.thinkingEnabled) {
+      return;
+    }
+
+    _settings = _settings.copyWith(thinkingEnabled: false);
+    unawaited(_saveSettingsNow());
+    _addInfoMessage(
+      'Thinking controls disabled for this runtime: LiteRT-LM Web currently exposes single-turn text generation only.',
+    );
+  }
+
   void _updateToolTemplateSupport(Map<String, String> metadata) {
+    if (_isSingleTurnTextOnlyRuntime(metadata)) {
+      _detectedChatFormat = ChatFormat.contentOnly;
+      _templateSupportsTools = false;
+      if (_settings.toolsEnabled) {
+        _settings = _settings.copyWith(toolsEnabled: false);
+        unawaited(_saveSettingsNow());
+      }
+      _addInfoMessage(
+        'Tool calling disabled for this runtime: LiteRT-LM Web currently exposes single-turn text generation only. Use GGUF/WebGPU or a native LiteRT-LM target for structured tool calls.',
+      );
+      return;
+    }
+
     final toolTemplate = metadata['tokenizer.chat_template.tool_use'];
     final defaultTemplate = metadata['tokenizer.chat_template'];
 

--- a/example/chat_app/lib/screens/manage_models_screen.dart
+++ b/example/chat_app/lib/screens/manage_models_screen.dart
@@ -816,13 +816,11 @@ class _ManageModelsScreenState extends State<ManageModelsScreen>
     }
 
     if (kIsWeb && model.sizeBytes >= _webLargeModelWarningBytes) {
+      final warningMessage = _isLiteRtLmWebModel(model)
+          ? 'Large LiteRT-LM web model selected. Browser memory limits may still block engine initialization.'
+          : 'Large web model selected. Download/cache can complete, but browser memory limits may still block loading.';
       ScaffoldMessenger.of(context).showSnackBar(
-        const SnackBar(
-          duration: Duration(seconds: 4),
-          content: Text(
-            'Large web model selected. Download/cache can complete, but browser memory limits may still block loading.',
-          ),
-        ),
+        SnackBar(duration: Duration(seconds: 4), content: Text(warningMessage)),
       );
     }
 
@@ -1027,6 +1025,10 @@ class _ManageModelsScreenState extends State<ManageModelsScreen>
     }
     return model.multimodalProjectorSourceFor(web: true)
         is LocalModelAssetSource;
+  }
+
+  bool _isLiteRtLmWebModel(DownloadableModel model) {
+    return model.filenameFor(web: true).toLowerCase().endsWith('.litertlm');
   }
 
   String _resolveAssetLoadReference(ModelAssetSource source) {

--- a/example/chat_app/lib/screens/manage_models_screen.dart
+++ b/example/chat_app/lib/screens/manage_models_screen.dart
@@ -815,7 +815,7 @@ class _ManageModelsScreenState extends State<ManageModelsScreen>
       provider.updateMmprojPath('');
     }
 
-    if (kIsWeb && model.sizeBytes >= _webLargeModelWarningBytes) {
+    if (kIsWeb && model.sizeBytesFor(web: true) >= _webLargeModelWarningBytes) {
       final warningMessage = _isLiteRtLmWebModel(model)
           ? 'Large LiteRT-LM web model selected. Browser memory limits may still block engine initialization.'
           : 'Large web model selected. Download/cache can complete, but browser memory limits may still block loading.';

--- a/example/chat_app/lib/screens/manage_models_screen.dart
+++ b/example/chat_app/lib/screens/manage_models_screen.dart
@@ -1731,11 +1731,15 @@ class _ManageModelsScreenState extends State<ManageModelsScreen>
                     SwitchListTile.adaptive(
                       value: provider.toolsEnabled,
                       title: const Text('Function calling'),
-                      subtitle: const Text(
-                        'Allow the model to emit tool calls.',
+                      subtitle: Text(
+                        provider.templateSupportsTools
+                            ? 'Allow the model to emit tool calls.'
+                            : 'Unavailable for this loaded runtime/template.',
                       ),
                       contentPadding: EdgeInsets.zero,
-                      onChanged: provider.updateToolsEnabled,
+                      onChanged: provider.templateSupportsTools
+                          ? provider.updateToolsEnabled
+                          : null,
                     ),
                     Align(
                       alignment: Alignment.centerLeft,
@@ -1771,11 +1775,15 @@ class _ManageModelsScreenState extends State<ManageModelsScreen>
                     SwitchListTile.adaptive(
                       value: provider.thinkingEnabled,
                       title: const Text('Enable thinking output'),
-                      subtitle: const Text(
-                        'Sends thinking-disable hint to template handlers.',
+                      subtitle: Text(
+                        provider.thinkingControlsSupported
+                            ? 'Sends thinking-disable hint to template handlers.'
+                            : 'Unavailable for this loaded runtime.',
                       ),
                       contentPadding: EdgeInsets.zero,
-                      onChanged: provider.updateThinkingEnabled,
+                      onChanged: provider.thinkingControlsSupported
+                          ? provider.updateThinkingEnabled
+                          : null,
                     ),
                     const SizedBox(height: 10),
                     _LabeledSlider(
@@ -1787,8 +1795,11 @@ class _ManageModelsScreenState extends State<ManageModelsScreen>
                       max: 4096,
                       divisions: 64,
                       value: provider.thinkingBudgetTokens.toDouble(),
-                      onChanged: (value) =>
-                          provider.updateThinkingBudgetTokens(value.toInt()),
+                      onChanged: provider.thinkingControlsSupported
+                          ? (value) => provider.updateThinkingBudgetTokens(
+                              value.toInt(),
+                            )
+                          : null,
                     ),
                     SwitchListTile.adaptive(
                       value: provider.singleTurnMode,

--- a/example/chat_app/lib/widgets/chat_input.dart
+++ b/example/chat_app/lib/widgets/chat_input.dart
@@ -168,7 +168,7 @@ class _ChatInputState extends State<ChatInput> {
                               child: TextField(
                                 controller: widget.controller,
                                 focusNode: widget.focusNode,
-                                enabled: !isGenerating && isReady,
+                                enabled: isReady,
                                 maxLines: 6,
                                 minLines: 1,
                                 textCapitalization:

--- a/example/chat_app/lib/widgets/model_card.dart
+++ b/example/chat_app/lib/widgets/model_card.dart
@@ -186,7 +186,9 @@ class ModelCard extends StatelessWidget {
                 ),
               ),
               child: Text(
-                'Web warning: very large model. Download can succeed, but browser memory limits may still prevent loading.',
+                isWebLiteRtLmModel
+                    ? 'Web warning: very large LiteRT-LM model. Browser memory limits may still prevent engine initialization.'
+                    : 'Web warning: very large model. Download can succeed, but browser memory limits may still prevent loading.',
                 style: GoogleFonts.outfit(
                   fontSize: 12,
                   height: 1.3,

--- a/example/chat_app/lib/widgets/model_card.dart
+++ b/example/chat_app/lib/widgets/model_card.dart
@@ -45,6 +45,8 @@ class ModelCard extends StatelessWidget {
   Widget build(BuildContext context) {
     final colorScheme = Theme.of(context).colorScheme;
     const webLargeModelWarningThresholdBytes = 1900 * 1024 * 1024;
+    final isWebLiteRtLmModel = isWeb && _isLiteRtLmModel(model);
+    final canLoadModel = isDownloaded || isWebLiteRtLmModel;
     final showWebLargeModelWarning =
         isWeb && model.sizeBytes >= webLargeModelWarningThresholdBytes;
     final showMobileDownloadGuidance =
@@ -404,7 +406,7 @@ class ModelCard extends StatelessWidget {
             const SizedBox(height: 16),
             SizedBox(
               width: double.infinity,
-              child: isDownloaded
+              child: canLoadModel
                   ? FilledButton.icon(
                       onPressed: onSelect,
                       icon: Icon(
@@ -414,7 +416,11 @@ class ModelCard extends StatelessWidget {
                         size: 18,
                       ),
                       label: Text(
-                        isWeb
+                        isWebLiteRtLmModel
+                            ? (isSelected
+                                  ? 'Reload Web Model'
+                                  : 'Load Web Model')
+                            : isWeb
                             ? (isSelected
                                   ? 'Reload Cached Model'
                                   : 'Use Cached Model')
@@ -454,6 +460,10 @@ class ModelCard extends StatelessWidget {
         ],
       ),
     );
+  }
+
+  bool _isLiteRtLmModel(DownloadableModel model) {
+    return model.filenameFor(web: true).toLowerCase().endsWith('.litertlm');
   }
 
   Widget _buildMetaChip(

--- a/example/chat_app/lib/widgets/model_card.dart
+++ b/example/chat_app/lib/widgets/model_card.dart
@@ -47,8 +47,9 @@ class ModelCard extends StatelessWidget {
     const webLargeModelWarningThresholdBytes = 1900 * 1024 * 1024;
     final isWebLiteRtLmModel = isWeb && _isLiteRtLmModel(model);
     final canLoadModel = isDownloaded || isWebLiteRtLmModel;
+    final effectiveModelSizeBytes = model.sizeBytesFor(web: isWeb);
     final showWebLargeModelWarning =
-        isWeb && model.sizeBytes >= webLargeModelWarningThresholdBytes;
+        isWeb && effectiveModelSizeBytes >= webLargeModelWarningThresholdBytes;
     final showMobileDownloadGuidance =
         isDownloading &&
         !isWeb &&

--- a/example/chat_app/test/chat_input_test.dart
+++ b/example/chat_app/test/chat_input_test.dart
@@ -1,0 +1,69 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:llamadart/llamadart.dart';
+import 'package:llamadart_chat_example/models/chat_settings.dart';
+import 'package:llamadart_chat_example/providers/chat_provider.dart';
+import 'package:llamadart_chat_example/widgets/chat_input.dart';
+import 'package:provider/provider.dart';
+
+import 'mocks.dart';
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  testWidgets('composer stays editable while generation is running', (
+    tester,
+  ) async {
+    final provider = _GeneratingReadyProvider();
+    addTearDown(provider.dispose);
+
+    final controller = TextEditingController();
+    final focusNode = FocusNode();
+    addTearDown(controller.dispose);
+    addTearDown(focusNode.dispose);
+
+    await tester.pumpWidget(
+      ChangeNotifierProvider<ChatProvider>.value(
+        value: provider,
+        child: MaterialApp(
+          home: Scaffold(
+            body: ChatInput(
+              controller: controller,
+              focusNode: focusNode,
+              onSend: () {},
+            ),
+          ),
+        ),
+      ),
+    );
+
+    expect(tester.widget<TextField>(find.byType(TextField)).enabled, isTrue);
+
+    await tester.enterText(find.byType(TextField), 'draft next prompt');
+    expect(controller.text, 'draft next prompt');
+  });
+}
+
+class _GeneratingReadyProvider extends ChatProvider {
+  _GeneratingReadyProvider()
+    : super(
+        chatService: MockChatService(),
+        settingsService: MockSettingsService(),
+        initialSettings: const ChatSettings(modelPath: 'test_model.gguf'),
+      );
+
+  @override
+  bool get isGenerating => true;
+
+  @override
+  bool get isReady => true;
+
+  @override
+  bool get toolsEnabled => false;
+
+  @override
+  bool get canAttachMedia => false;
+
+  @override
+  List<LlamaContentPart> get stagedParts => const <LlamaContentPart>[];
+}

--- a/example/chat_app/test/model_card_test.dart
+++ b/example/chat_app/test/model_card_test.dart
@@ -1,0 +1,113 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:llamadart_chat_example/models/downloadable_model.dart';
+import 'package:llamadart_chat_example/widgets/model_card.dart';
+
+void main() {
+  testWidgets('web LiteRT-LM presets load directly instead of showing cache', (
+    tester,
+  ) async {
+    var selectCalls = 0;
+    var downloadCalls = 0;
+
+    await _pumpCard(
+      tester,
+      model: _litertLmModel(),
+      isWeb: true,
+      isDownloaded: false,
+      onSelect: () => selectCalls += 1,
+      onDownload: () => downloadCalls += 1,
+    );
+
+    expect(find.text('Load Web Model'), findsOneWidget);
+    expect(find.text('Cache Model'), findsNothing);
+
+    await tester.tap(find.text('Load Web Model'));
+    await tester.pump();
+
+    expect(selectCalls, 1);
+    expect(downloadCalls, 0);
+  });
+
+  testWidgets('web GGUF presets still show the cache action before download', (
+    tester,
+  ) async {
+    var selectCalls = 0;
+    var downloadCalls = 0;
+
+    await _pumpCard(
+      tester,
+      model: _ggufModel(),
+      isWeb: true,
+      isDownloaded: false,
+      onSelect: () => selectCalls += 1,
+      onDownload: () => downloadCalls += 1,
+    );
+
+    expect(find.text('Cache Model'), findsOneWidget);
+    expect(find.text('Load Web Model'), findsNothing);
+
+    await tester.tap(find.text('Cache Model'));
+    await tester.pump();
+
+    expect(selectCalls, 0);
+    expect(downloadCalls, 1);
+  });
+}
+
+Future<void> _pumpCard(
+  WidgetTester tester, {
+  required DownloadableModel model,
+  required bool isWeb,
+  required bool isDownloaded,
+  required VoidCallback onSelect,
+  required VoidCallback onDownload,
+}) async {
+  await tester.pumpWidget(
+    MaterialApp(
+      home: Scaffold(
+        body: SingleChildScrollView(
+          child: ModelCard(
+            model: model,
+            isDownloaded: isDownloaded,
+            isDownloading: false,
+            progress: 0,
+            isWeb: isWeb,
+            isSelected: false,
+            gpuLayers: 0,
+            contextSize: 2048,
+            onGpuLayersChanged: (_) {},
+            onContextSizeChanged: (_) {},
+            onSelect: onSelect,
+            onDownload: onDownload,
+            onDelete: () {},
+          ),
+        ),
+      ),
+    ),
+  );
+}
+
+DownloadableModel _litertLmModel() {
+  return const DownloadableModel(
+    name: 'LiteRT-LM Test Model',
+    description: 'Fake LiteRT-LM model for widget tests.',
+    url: 'https://example.com/model.litertlm',
+    filename: 'model.litertlm',
+    webModelSource: RemoteModelAssetSource(
+      url: 'https://example.com/model-web.litertlm?download=true',
+      filename: 'model-web.litertlm',
+    ),
+    sizeBytes: 10,
+  );
+}
+
+DownloadableModel _ggufModel() {
+  return const DownloadableModel(
+    name: 'GGUF Test Model',
+    description: 'Fake GGUF model for widget tests.',
+    url: 'https://example.com/model.gguf',
+    filename: 'model.gguf',
+    sizeBytes: 10,
+  );
+}

--- a/example/chat_app/test/model_card_test.dart
+++ b/example/chat_app/test/model_card_test.dart
@@ -53,6 +53,21 @@ void main() {
     expect(selectCalls, 0);
     expect(downloadCalls, 1);
   });
+
+  testWidgets('web large warning uses web model size when available', (
+    tester,
+  ) async {
+    await _pumpCard(
+      tester,
+      model: _largeNativeSmallWebLiteRtLmModel(),
+      isWeb: true,
+      isDownloaded: false,
+      onSelect: () {},
+      onDownload: () {},
+    );
+
+    expect(find.textContaining('very large LiteRT-LM'), findsNothing);
+  });
 }
 
 Future<void> _pumpCard(
@@ -109,5 +124,21 @@ DownloadableModel _ggufModel() {
     url: 'https://example.com/model.gguf',
     filename: 'model.gguf',
     sizeBytes: 10,
+  );
+}
+
+DownloadableModel _largeNativeSmallWebLiteRtLmModel() {
+  return const DownloadableModel(
+    name: 'LiteRT-LM Test Model',
+    description: 'Fake LiteRT-LM model for widget tests.',
+    url: 'https://example.com/model.litertlm',
+    filename: 'model.litertlm',
+    webSizeBytes: 1200 * 1024 * 1024,
+    webModelSource: RemoteModelAssetSource(
+      url: 'https://example.com/model-web.litertlm?download=true',
+      filename: 'model-web.litertlm',
+      sizeBytes: 1200 * 1024 * 1024,
+    ),
+    sizeBytes: 2400 * 1024 * 1024,
   );
 }

--- a/example/chat_app/test/unit_test.dart
+++ b/example/chat_app/test/unit_test.dart
@@ -63,6 +63,54 @@ void main() {
     });
 
     test(
+      'loadModel disables structured controls for LiteRT-LM web metadata',
+      () async {
+        final initialSettings = const ChatSettings(
+          modelPath: 'https://example.com/gemma-4-web.litertlm',
+          toolsEnabled: true,
+          thinkingEnabled: true,
+        );
+        final settingsService = MockSettingsService()
+          ..settings = initialSettings;
+        final liteRtWebProvider = ChatProvider(
+          chatService: MockChatService(
+            engine: _MetadataEngine(const {
+              'general.architecture': 'litert-lm',
+              'llamadart.litert_lm_web.chat_scope': 'single-turn-text',
+              'llamadart.litert_lm_web.structured_chat': 'false',
+              'tokenizer.chat_template':
+                  '{% for message in messages %}{% if loop.last %}{{ message["content"] }}{% endif %}{% endfor %}',
+            }),
+          ),
+          settingsService: settingsService,
+          initialSettings: initialSettings,
+        );
+        addTearDown(liteRtWebProvider.dispose);
+
+        await liteRtWebProvider.loadModel();
+
+        expect(liteRtWebProvider.templateSupportsTools, isFalse);
+        expect(liteRtWebProvider.thinkingControlsSupported, isFalse);
+        expect(liteRtWebProvider.settings.toolsEnabled, isFalse);
+        expect(liteRtWebProvider.settings.thinkingEnabled, isFalse);
+        expect(
+          liteRtWebProvider.messages.map((message) => message.text),
+          contains(
+            contains(
+              'LiteRT-LM Web currently exposes single-turn text generation only',
+            ),
+          ),
+        );
+
+        liteRtWebProvider.updateToolsEnabled(true);
+        liteRtWebProvider.updateThinkingEnabled(true);
+
+        expect(liteRtWebProvider.settings.toolsEnabled, isFalse);
+        expect(liteRtWebProvider.settings.thinkingEnabled, isFalse);
+      },
+    );
+
+    test(
       'web remote load prefetches model before runtime load and shows download stage',
       () async {
         final webEngine = MockLlamaEngine();
@@ -936,6 +984,15 @@ void main() {
       expect(result, '  hello world  '); // MockChatService doesn't trim
     });
   });
+}
+
+class _MetadataEngine extends MockLlamaEngine {
+  final Map<String, String> metadata;
+
+  _MetadataEngine(this.metadata);
+
+  @override
+  Future<Map<String, String>> getMetadata() async => metadata;
 }
 
 class _JsonResponseEngine extends MockLlamaEngine {


### PR DESCRIPTION
## Summary

- Disable tool calling and thinking controls when the loaded runtime is LiteRT-LM Web single-turn text generation.
- Keep the chat composer editable while generation is running so users can draft the next prompt.
- Add a Hugging Face Static Space PR-preview workflow for same-repo chat app PRs and document the setup.
- Clarify the README distinction between LiteRT-LM Web single-turn text and native LiteRT-LM structured controls.
- Update the macOS LiteRT-LM ChatService E2E so it exercises the same native thinking/tool-call path with a realistic context and prompt budget.

## Why

LiteRT-LM Web currently exposes `@litert-lm/core` as single-string generation, so the chat app cannot pass structured messages, tool declarations, or thinking controls through that runtime. The UI now reflects that limitation instead of presenting controls that cannot work on web LiteRT.

Native LiteRT-LM is different: the Dart/native path can exercise thinking deltas and structured tool calls. The macOS app E2E needs to load the model through the app-owned download path rather than an arbitrary host filesystem path, because the macOS app sandbox can block direct `/opt/...` model access.

## Validation

- `flutter analyze`
- `flutter test --reporter compact`
- `flutter build web --release`
- Browser-level smoke against the built static bundle: `tool/testing/playwright_chat_app_mock_smoke.py http://127.0.0.1:7358/?llamadart_mock_bridge=echo`
- Browser-level smoke against HF PR preview: `tool/testing/playwright_chat_app_mock_smoke.py https://leehack-llamadart-chat-pr-192.static.hf.space/?llamadart_mock_bridge=echo`
- Native LiteRT feature smoke: `dart run tool/litert_lm_chat_features_smoke.dart .dart_tool/litert_lm_models/gemma-4-E2B-it.litertlm cpu`
- macOS chat app LiteRT E2E with app-downloaded Gemma 4 model: `flutter test --run-skipped -t local-only integration_test/litert_lm_chat_service_e2e_test.dart -d macos --dart-define=LITERT_LM_MODEL_URL=http://127.0.0.1:8765/gemma-4-E2B-it.litertlm --dart-define=LITERT_LM_E2E_BACKEND=cpu`
- Workflow YAML parse check
- `git diff --check`

## Notes

The PR-preview workflow posts the Static Space URL back to the PR comment. The current preview is https://leehack-llamadart-chat-pr-192.static.hf.space.