### PR TITLE
Fix macOS LiteRT-LM runtime packaging

### DIFF
--- a/.github/workflows/litert_lm_smoke.yml
+++ b/.github/workflows/litert_lm_smoke.yml
@@ -12,6 +12,7 @@ on:
       - "lib/src/hook/**"
       - "pubspec.*"
       - "tool/litert_lm_engine_smoke.dart"
+      - "tool/litert_lm_library_smoke.dart"
   pull_request:
     branches: [master, main]
     paths:
@@ -22,6 +23,7 @@ on:
       - "lib/src/hook/**"
       - "pubspec.*"
       - "tool/litert_lm_engine_smoke.dart"
+      - "tool/litert_lm_library_smoke.dart"
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
@@ -34,12 +36,13 @@ jobs:
     timeout-minutes: 35
     strategy:
       fail-fast: false
+      max-parallel: 1
       matrix:
         include:
           - os: ubuntu-latest
-            litert_lib_dir: .dart_tool/llamadart/litert_lm/0.12.0/linux/x64
+            litert_lib_subdir: linux/x64
           - os: windows-latest
-            litert_lib_dir: .dart_tool/llamadart/litert_lm/0.12.0/windows/x64
+            litert_lib_subdir: windows/x64
 
     steps:
       - uses: actions/checkout@v6
@@ -50,47 +53,112 @@ jobs:
           channel: stable
           cache: true
 
-      - name: Install dependencies
-        run: flutter pub get
-
-      - name: Download tiny LiteRT-LM model
+      - name: Enable LiteRT-LM runtime for smoke
         shell: bash
         run: |
           set -euo pipefail
-          mkdir -p "$RUNNER_TEMP/models"
-          PYTHON_BIN=python3
-          if ! command -v python3 >/dev/null 2>&1; then
-            PYTHON_BIN=python
-          fi
-          "$PYTHON_BIN" - <<'PY'
-          import os
-          import pathlib
-          import time
-          import urllib.request
+          python3 - <<'PY'
+          from pathlib import Path
 
-          url = "https://huggingface.co/litert-community/Qwen3-0.6B/resolve/main/Qwen3-0.6B.litertlm?download=true"
-          destination = pathlib.Path(os.environ["RUNNER_TEMP"]) / "models" / "Qwen3-0.6B.litertlm"
-          last_error = None
-          for attempt in range(1, 6):
-              try:
-                  urllib.request.urlretrieve(url, destination)
-                  break
-              except Exception as error:
-                  last_error = error
-                  if attempt == 5:
-                      raise
-                  time.sleep(3 * attempt)
-          print(f"Downloaded {destination} ({destination.stat().st_size} bytes)")
+          pubspec = Path("pubspec.yaml")
+          text = pubspec.read_text()
+          if "\nhooks:" in text or text.startswith("hooks:"):
+              raise SystemExit(
+                  "pubspec.yaml already contains hooks; update the "
+                  "LiteRT-LM smoke workflow to merge the CI user_defines."
+              )
+          pubspec.write_text(text.rstrip() + """
+
+          hooks:
+            user_defines:
+              llamadart:
+                llamadart_native_runtimes: [litert_lm]
+          """)
           PY
 
-      - name: Run LiteRT-LM engine smoke
+      - name: Resolve LiteRT-LM runtime version
+        id: litert-version
+        shell: bash
+        run: |
+          set -euo pipefail
+          version="$(python3 - <<'PY'
+          import pathlib
+          import re
+
+          text = pathlib.Path("hook/build.dart").read_text()
+          match = re.search(r"const _litertLmVersion = '([^']+)';", text)
+          if not match:
+              raise SystemExit("Could not locate _litertLmVersion")
+          print(match.group(1))
+          PY
+          )"
+          echo "version=$version" >> "$GITHUB_OUTPUT"
+
+      - name: Install dependencies
+        run: flutter pub get
+
+      - name: Run LiteRT-LM library smoke
         shell: bash
         env:
-          LLAMADART_LITERT_LM_LIB_DIR: ${{ github.workspace }}/${{ matrix.litert_lib_dir }}
+          LLAMADART_LITERT_LM_LIB_DIR: ${{ github.workspace }}/.dart_tool/llamadart/litert_lm/${{ steps.litert-version.outputs.version }}/${{ matrix.litert_lib_subdir }}
+        run: dart run tool/litert_lm_library_smoke.dart
+
+      - name: Cache tiny LiteRT-LM model
+        uses: actions/cache@v5
+        with:
+          path: .dart_tool/litert_lm_models/Qwen3-0.6B.litertlm
+          key: litert-lm-smoke-qwen3-0.6b-${{ runner.os }}-v1
+
+      - name: Download tiny LiteRT-LM model
+        id: download-model
+        continue-on-error: true
+        shell: bash
+        env:
+          HF_TOKEN: ${{ secrets.HF_TOKEN }}
+        run: |
+          set -euo pipefail
+          model_path=".dart_tool/litert_lm_models/Qwen3-0.6B.litertlm"
+          model_url="https://huggingface.co/litert-community/Qwen3-0.6B/resolve/main/Qwen3-0.6B.litertlm?download=true"
+          mkdir -p "$(dirname "$model_path")"
+          if [ -s "$model_path" ]; then
+            echo "Using cached $model_path ($(wc -c < "$model_path") bytes)"
+            exit 0
+          fi
+          tmp_path="${model_path}.tmp"
+          rm -f "$tmp_path"
+          curl_args=(
+            --fail
+            --location
+            --retry 8
+            --retry-all-errors
+            --retry-delay 15
+            --retry-max-time 600
+            --connect-timeout 30
+            --output "$tmp_path"
+          )
+          if [ -n "${HF_TOKEN:-}" ]; then
+            curl_args+=(--header "Authorization: Bearer ${HF_TOKEN}")
+          fi
+          curl "${curl_args[@]}" "$model_url"
+          mv "$tmp_path" "$model_path"
+          echo "Downloaded $model_path ($(wc -c < "$model_path") bytes)"
+
+      - name: Run LiteRT-LM engine smoke
+        if: steps.download-model.outcome == 'success'
+        shell: bash
+        env:
+          LLAMADART_LITERT_LM_LIB_DIR: ${{ github.workspace }}/.dart_tool/llamadart/litert_lm/${{ steps.litert-version.outputs.version }}/${{ matrix.litert_lib_subdir }}
+          LITERT_LM_MODEL_PATH: ${{ github.workspace }}/.dart_tool/litert_lm_models/Qwen3-0.6B.litertlm
         run: |
           dart run tool/litert_lm_engine_smoke.dart \
-            "$RUNNER_TEMP/models/Qwen3-0.6B.litertlm" \
+            "$LITERT_LM_MODEL_PATH" \
             cpu \
             "What is 2+2? Answer only with the number." \
             16 \
             1024
+
+      - name: Note skipped LiteRT-LM engine smoke
+        if: steps.download-model.outcome != 'success'
+        shell: bash
+        run: |
+          echo "::warning::Skipped LiteRT-LM engine smoke because the external model download failed. The library/native-asset smoke already passed."

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+## Unreleased
+
+* Changed native build-hook defaults so Android continues to include both
+  `llama_cpp` and `litert_lm`, while iOS, macOS, Linux, and Windows default to
+  `llama_cpp` only. Apps that ship `.litertlm` models on non-Android native
+  targets should opt in with `llamadart_native_runtimes`.
+
 ## 0.7.0
 
 * **LiteRT-LM backend and runtime selection**:

--- a/README.md
+++ b/README.md
@@ -68,13 +68,15 @@ No manual binary download or C++ build steps are required.
 
 ### 3. Optional: choose native runtimes for package size
 
-By default, native builds include both runtime families where available:
+By default, Android native builds include both runtime families where available:
 
 - `llama_cpp` for GGUF models.
 - `litert_lm` for `.litertlm` model bundles.
 
-Use `llamadart_native_runtimes` when an app only ships one model format and
-you want to avoid bundling the other runtime family:
+Other native targets default to `llama_cpp` only. Use
+`llamadart_native_runtimes` when an app needs a different package-size /
+model-format tradeoff, such as enabling LiteRT-LM for desktop/iOS or shipping
+only `.litertlm` models:
 
 ```yaml
 hooks:
@@ -83,7 +85,8 @@ hooks:
       llamadart_native_runtimes: [llama_cpp] # or [litert_lm]
 ```
 
-The setting also supports per-target overrides:
+The setting also supports per-OS and exact target overrides. Exact target keys
+override OS keys:
 
 ```yaml
 hooks:
@@ -92,9 +95,13 @@ hooks:
       llamadart_native_runtimes:
         runtimes: [llama_cpp, litert_lm]
         platforms:
+          ios: [llama_cpp]
+          macos: [llama_cpp, litert_lm]
           android-arm64: [litert_lm]
           linux-x64: [llama_cpp]
 ```
+
+Use `all` or `both` to include every runtime family for a target.
 
 ### 4. Optional: choose llama.cpp backend modules per target
 
@@ -173,12 +180,12 @@ web-compatible `.litertlm` URLs through the LiteRT-LM JavaScript runtime.
 Android callers can opt into the LiteRT-LM NPU delegate through `ModelParams`:
 
 Sandboxed macOS apps must stage LiteRT-LM companion dylibs inside the `.app`
-bundle. The chat app example includes a `Prepare LiteRT-LM Frameworks` Xcode
-build phase that copies the pinned LiteRT-LM runtime into
-`Contents/Frameworks`. Standalone desktop VM tools also search the extracted
-`.dart_tool/llamadart/litert_lm/<version>/<platform>/<arch>` cache; set
-`LLAMADART_LITERT_LM_LIB_DIR` to that directory for custom CI or launcher
-layouts.
+bundle. The chat app example includes a `Prepare LiteRT-LM Runtime` Xcode build
+phase that copies the pinned LiteRT-LM runtime into
+`Contents/Frameworks/LiteRtLmRuntime`. Standalone desktop VM tools also search
+the extracted `.dart_tool/llamadart/litert_lm/<version>/<platform>/<arch>`
+cache; set `LLAMADART_LITERT_LM_LIB_DIR` to that directory for custom CI or
+launcher layouts.
 
 ```dart
 await engine.loadModel(
@@ -458,8 +465,10 @@ Notes:
   lookups, so the selected binary must remain compatible with the default
   runtime revision.
 - `llamadart_native_runtimes` controls whole native runtime families:
-  `llama_cpp`, `litert_lm`, or both. Use it to trim package size when an app
-  only ships GGUF or only ships `.litertlm` models.
+  `llama_cpp`, `litert_lm`, or both. Use it globally, per OS, or per exact
+  target to enable LiteRT-LM outside Android or to trim package size when an
+  app only ships GGUF or only ships `.litertlm` models. Android includes
+  LiteRT-LM by default; other native targets default to `llama_cpp` only.
 - `llamadart_native_backends` controls llama.cpp module files inside the
   `llama_cpp` runtime family. It does not affect LiteRT-LM assets.
 - Configurable targets always keep `cpu` bundled as a fallback.
@@ -485,7 +494,10 @@ Notes:
 - `ModelParams.mainGpu` passes through to llama.cpp `main_gpu`. To select one GPU for the full model, use `splitMode: ModelSplitMode.none` with the desired `mainGpu` index.
 - `ModelParams.batchSize` (`n_batch`) and `ModelParams.microBatchSize` (`n_ubatch`) can be set independently for memory/performance tuning; defaults keep legacy behavior (`n_batch = n_ctx`, `n_ubatch = n_batch`).
 - `ModelParams.preferMemory64` and `ModelParams.modelBytesHint` are web/WebGPU only (ignored on native). They select the 64-bit (wasm64/mem64) bridge core so models larger than the ~4 GiB wasm32 address space (for example Gemma 4 E2B) can load; `null` auto-decides from the size hint (size-driven, no hardcoded model names). See the [WebGPU bridge docs](https://leehack.github.io/llamadart/docs/platforms/webgpu-bridge).
-- Apple targets are intentionally non-configurable in this hook path and use consolidated native libraries.
+- Apple targets use consolidated llama.cpp native libraries, so
+  `llamadart_native_backends` does not split Apple backend modules. Use
+  `llamadart_native_runtimes` to include or exclude the llama.cpp or LiteRT-LM
+  runtime families on Apple targets.
 - The native-assets hook refreshes emitted files each build; if you change `hooks.user_defines` or are upgrading from older cached outputs, run `flutter clean && flutter pub get` before rebuilding.
 - Some Vulkan drivers can crash when probing cooperative matrix support. This
   is a driver-side failure in the Vulkan property query path, not a llamadart
@@ -656,7 +668,7 @@ Current pinned runtime artifacts:
 | Runtime path | Published artifact |
 |--------------|--------------------|
 | Native llama.cpp / GGUF | `leehack/llamadart-native@b9371` |
-| Native LiteRT-LM / `.litertlm` | `leehack/litert-lm-native@v0.12.0` |
+| Native LiteRT-LM / `.litertlm` | `leehack/litert-lm-native@v0.13.1` |
 | Web llama.cpp / GGUF | `leehack/llama-web-bridge-assets@v0.1.16` |
 | Web LiteRT-LM / `.litertlm` | App-provided `@litert-lm/core` module URL; the chat app defaults to jsDelivr `@litert-lm/core/+esm` |
 

--- a/example/README.md
+++ b/example/README.md
@@ -37,6 +37,7 @@ A Flutter UI application showing:
 - Model configuration
 - Settings persistence
 - Streaming text generation
+- GGUF plus LiteRT-LM `.litertlm` model routing
 - Material Design UI
 
 **Best for:** Real-world Flutter integration
@@ -161,7 +162,9 @@ See HuggingFace for more: https://huggingface.co/models?search=gguf
 
 ## Model Formats
 
-llamadart supports GGUF format models (converted for llama.cpp).
+Most examples use GGUF models through the llama.cpp runtime. The Flutter
+`chat_app` also demonstrates LiteRT-LM `.litertlm` models and explicitly opts
+into the `litert_lm` native runtime family for supported native targets.
 
 ## Architecture
 
@@ -205,7 +208,8 @@ example/
 - Dart SDK 3.10.7 or higher
 - For chat_app: Flutter 3.38.0 or higher
 - iOS builds require a minimum deployment target of 16.4 or newer
-- Internet connection (for first run - downloads native libraries)
+- Internet connection (for first run - downloads selected native runtime
+  libraries)
 - At least 2GB RAM minimum, 4GB+ recommended
 
 ## Platform Compatibility

--- a/example/chat_app/README.md
+++ b/example/chat_app/README.md
@@ -31,6 +31,11 @@ flutter run
 If you run this app on iOS, set the project deployment target to `16.4` or
 newer first (for example `platform :ios, '16.4'` in `ios/Podfile`).
 
+Unlike the smaller GGUF-only examples, this app intentionally opts into both
+native runtime families in `pubspec.yaml` so native `.litertlm` presets work on
+supported targets. If you copy this app and only ship GGUF models, set
+`llamadart_native_runtimes` to `[llama_cpp]` to reduce bundle size.
+
 ### 1.1 Run Tests
 ```bash
 cd example/chat_app
@@ -60,10 +65,11 @@ flutter test --run-skipped -t local-only \
      not audio support, so the chat UI keeps image input enabled and audio input
      disabled for this model.
    - LiteRT-LM `.litertlm` presets, when present, use the same model library
-     flow. Native builds load cached local bundle paths through the
-     `litert-lm-native` runtime. Web builds load web-compatible `.litertlm`
-     URLs through `@litert-lm/core`; `web/index.html` sets a default module URL
-     that apps can override with `window.__llamadartLiteRtLmModuleUrl`.
+     flow. The example `pubspec.yaml` enables the `litert_lm` native runtime
+     family for supported native targets, while Web builds load web-compatible
+     `.litertlm` URLs through `@litert-lm/core`; `web/index.html` sets a
+     default module URL that apps can override with
+     `window.__llamadartLiteRtLmModuleUrl`.
    - LiteRT-LM Web is currently a single-turn text runtime. Because
      `@litert-lm/core` accepts one prompt string and applies its own chat
      wrapper internally, the chat app cannot pass structured chat history,
@@ -72,8 +78,10 @@ flutter test --run-skipped -t local-only \
      controls for this runtime; use GGUF/WebGPU or native LiteRT-LM when those
      structured controls are required.
    - The Gemma 4 E2B LiteRT-LM preset uses the native `.litertlm` bundle on
-     Android/iOS/macOS/Linux/Windows and the `-web.litertlm` bundle on Flutter
-     Web.
+     Android, iOS arm64/arm64 simulator, macOS, Linux, and Windows x64; it uses
+     the `-web.litertlm` bundle on Flutter Web. iOS x86_64 simulator and
+     Windows arm64 are kept GGUF-only because no matching LiteRT-LM native
+     bundle is published.
 
 ### 3. Advanced Configuration (Optional)
 1. Tap the settings icon (⚙️) in the app bar.
@@ -215,10 +223,14 @@ _(Add screenshots here when complete)_
 ## Troubleshooting
 
 **"Failed to load library" or "Native asset not found" on first run:**
-- Ensure you have an active internet connection. The `llamadart` build hook needs to download the pre-compiled `llama.cpp` binary for your platform.
+- Ensure you have an active internet connection. The `llamadart` build hook needs to download the selected native runtime bundles for your platform.
 - Check the console for download progress logs.
 - If behind a proxy, ensure Dart/Flutter can access GitHub.
-- If you recently changed native backend config and are upgrading from an older build cache, run a one-time `flutter clean`.
+- If a native `.litertlm` load fails, confirm `pubspec.yaml` includes
+  `litert_lm` for your target. This example does that for supported native
+  targets and keeps iOS x86_64 simulator / Windows arm64 GGUF-only.
+- If you recently changed native backend or runtime config and are upgrading
+  from an older build cache, run a one-time `flutter clean`.
 
 **"Model file not found" error:**
 - Ensure you have successfully downloaded a model from the selection screen.

--- a/example/chat_app/macos/Runner.xcodeproj/project.pbxproj
+++ b/example/chat_app/macos/Runner.xcodeproj/project.pbxproj
@@ -240,7 +240,7 @@
 				33CC10EB2044A3C60003C045 /* Resources */,
 				33CC110E2044A8840003C045 /* Bundle Framework */,
 				3399D490228B24CF009A79C7 /* ShellScript */,
-				A17E2C1B5C7747D5A3C40A23 /* Prepare LiteRT-LM Frameworks */,
+				A17E2C1B5C7747D5A3C40A23 /* Prepare LiteRT-LM Runtime */,
 				684C686447A55F16132EB20D /* [CP] Embed Pods Frameworks */,
 			);
 			buildRules = (
@@ -406,7 +406,7 @@
 			shellPath = /bin/sh;
 			shellScript = "\"$FLUTTER_ROOT\"/packages/flutter_tools/bin/macos_assemble.sh && touch Flutter/ephemeral/tripwire";
 		};
-		A17E2C1B5C7747D5A3C40A23 /* Prepare LiteRT-LM Frameworks */ = {
+		A17E2C1B5C7747D5A3C40A23 /* Prepare LiteRT-LM Runtime */ = {
 			isa = PBXShellScriptBuildPhase;
 			alwaysOutOfDate = 1;
 			buildActionMask = 2147483647;
@@ -416,7 +416,7 @@
 			);
 			inputPaths = (
 			);
-			name = "Prepare LiteRT-LM Frameworks";
+			name = "Prepare LiteRT-LM Runtime";
 			outputFileListPaths = (
 			);
 			outputPaths = (

--- a/example/chat_app/pubspec.yaml
+++ b/example/chat_app/pubspec.yaml
@@ -36,3 +36,15 @@ dev_dependencies:
   http: any
 flutter:
   uses-material-design: true
+
+hooks:
+  user_defines:
+    llamadart:
+      # The chat example intentionally demonstrates both GGUF and .litertlm
+      # model flows. Smaller examples rely on the package defaults.
+      llamadart_native_runtimes:
+        runtimes: [llama_cpp, litert_lm]
+        platforms:
+          # LiteRT-LM native bundles are not published for these targets.
+          ios-x86_64-sim: [llama_cpp]
+          windows-arm64: [llama_cpp]

--- a/hook/build.dart
+++ b/hook/build.dart
@@ -22,20 +22,19 @@ const _cacheBaseDir = 'llamadart';
 const _bundleCacheDir = 'native_bundles';
 const _reportDir = 'llamadart_bin';
 const _allowLegacyLocalBundleEnv = 'LLAMADART_ALLOW_LEGACY_LOCAL_BUNDLES';
-const _litertLmVersion = '0.12.0';
+const _litertLmVersion = '0.13.1';
 const _litertLmNativeReleaseBaseUrl =
     'https://github.com/leehack/litert-lm-native/releases/download/'
     'v$_litertLmVersion';
 const _litertLmCacheDir = 'litert_lm';
-const _litertLmChecksumFileName = '.llamadart_litert_lm.sha256';
 
-const _litertLmBundles = <String, _LiteRtLmBundleSpec>{
-  'android-arm64': _LiteRtLmBundleSpec(
-    directoryName: 'android/arm64',
-    archiveName: 'litert-lm-native-runtime-android-arm64-v0.12.0.tar.gz',
-    sha256: '1d4332e740aca7bb3d23af20d94fb16193803e8997138a87633e8de4a096a026',
-    releaseBaseUrl: _litertLmNativeReleaseBaseUrl,
-    sourcePrefix: 'android/arm64',
+final _litertLmBundles = Map.unmodifiable({
+  for (final bundle in _litertLmBundleSpecs) bundle.bundle: bundle,
+});
+
+const _litertLmBundleSpecs = <_LiteRtLmBundleSpec>[
+  _LiteRtLmBundleSpec(
+    'android-arm64',
     requiredLibraries: {
       'libGemmaModelConstraintProvider.so',
       'libLiteRt.so',
@@ -45,16 +44,10 @@ const _litertLmBundles = <String, _LiteRtLmBundleSpec>{
       'libLiteRtTopKOpenClSampler.so',
       'libLiteRtTopKWebGpuSampler.so',
       'libLiteRtWebGpuAccelerator.so',
-      'libStreamProxy.so',
     },
-    emitAllLibraries: true,
   ),
-  'android-x64': _LiteRtLmBundleSpec(
-    directoryName: 'android/x64',
-    archiveName: 'litert-lm-native-runtime-android-x64-v0.12.0.tar.gz',
-    sha256: 'b59cb34a83d5e3b8c467fe9b670a7f810fe956f1b47b524271008546bc31c655',
-    releaseBaseUrl: _litertLmNativeReleaseBaseUrl,
-    sourcePrefix: 'android/x64',
+  _LiteRtLmBundleSpec(
+    'android-x64',
     requiredLibraries: {
       'libGemmaModelConstraintProvider.so',
       'libLiteRt.so',
@@ -64,40 +57,18 @@ const _litertLmBundles = <String, _LiteRtLmBundleSpec>{
       'libLiteRtTopKOpenClSampler.so',
       'libLiteRtTopKWebGpuSampler.so',
       'libLiteRtWebGpuAccelerator.so',
-      'libStreamProxy.so',
     },
-    emitAllLibraries: true,
   ),
-  'ios-arm64': _LiteRtLmBundleSpec(
-    directoryName: 'ios/arm64',
-    archiveName: 'litert-lm-native-runtime-ios-arm64-v0.12.0.tar.gz',
-    sha256: 'd1c48c085f901baac67097209814e25a84dfa61d79644a8fe6d125d6ab39c3c3',
-    releaseBaseUrl: _litertLmNativeReleaseBaseUrl,
-    sourcePrefix: 'ios/arm64',
-    requiredLibraries: {'libLiteRtLm.dylib', 'libStreamProxy.dylib'},
+  _LiteRtLmBundleSpec(
+    'ios-arm64',
+    requiredLibraries: {'LiteRtLm', 'CLiteRTLM'},
   ),
-  'ios-arm64-sim': _LiteRtLmBundleSpec(
-    directoryName: 'ios/arm64-sim',
-    archiveName: 'litert-lm-native-runtime-ios-arm64-sim-v0.12.0.tar.gz',
-    sha256: '9ae754eb6a0e9d6ff51caa94864b24b520b7e73c46a46091b8a44f99b7a4aef6',
-    releaseBaseUrl: _litertLmNativeReleaseBaseUrl,
-    sourcePrefix: 'ios/arm64-sim',
-    requiredLibraries: {'libLiteRtLm.dylib', 'libStreamProxy.dylib'},
+  _LiteRtLmBundleSpec(
+    'ios-arm64-sim',
+    requiredLibraries: {'LiteRtLm', 'CLiteRTLM'},
   ),
-  'ios-x64-sim': _LiteRtLmBundleSpec(
-    directoryName: 'ios/x64-sim',
-    archiveName: 'litert-lm-native-runtime-ios-x64-sim-v0.12.0.tar.gz',
-    sha256: 'be573217169878cb5d79b70084730c5a2978230cc6d1b96144f694249e2027e0',
-    releaseBaseUrl: _litertLmNativeReleaseBaseUrl,
-    sourcePrefix: 'ios/x64-sim',
-    requiredLibraries: {'libLiteRtLm.dylib', 'libStreamProxy.dylib'},
-  ),
-  'macos-arm64': _LiteRtLmBundleSpec(
-    directoryName: 'macos/arm64',
-    archiveName: 'litert-lm-native-runtime-macos-arm64-v0.12.0.tar.gz',
-    sha256: '6fe694ccc895c904b173f2952b73b7698097eda18d8bff0210ea9fcf10ca3da9',
-    releaseBaseUrl: _litertLmNativeReleaseBaseUrl,
-    sourcePrefix: 'macos/arm64',
+  _LiteRtLmBundleSpec(
+    'macos-arm64',
     requiredLibraries: {
       'libGemmaModelConstraintProvider.dylib',
       'libLiteRt.dylib',
@@ -106,66 +77,40 @@ const _litertLmBundles = <String, _LiteRtLmBundleSpec>{
       'libLiteRtTopKMetalSampler.dylib',
       'libLiteRtTopKWebGpuSampler.dylib',
       'libLiteRtWebGpuAccelerator.dylib',
-      'libStreamProxy.dylib',
     },
   ),
-  'macos-x64': _LiteRtLmBundleSpec(
-    directoryName: 'macos/x64',
-    archiveName: 'litert-lm-native-runtime-macos-x64-v0.12.0.tar.gz',
-    sha256: '8b54daaf55d6cb2570b7a667891c71bba1578a5875d8c2b7230c2185b2e88bf4',
-    releaseBaseUrl: _litertLmNativeReleaseBaseUrl,
-    sourcePrefix: 'macos/x64',
-    requiredLibraries: {'libLiteRtLm.dylib', 'libStreamProxy.dylib'},
-  ),
-  'linux-arm64': _LiteRtLmBundleSpec(
-    directoryName: 'linux/arm64',
-    archiveName: 'litert-lm-native-runtime-linux-arm64-v0.12.0.tar.gz',
-    sha256: 'd0546e0f769b1156f973051dfd928d8f4448e0db9465d57386cf0490192651c1',
-    releaseBaseUrl: _litertLmNativeReleaseBaseUrl,
-    sourcePrefix: 'linux/arm64',
+  _LiteRtLmBundleSpec('macos-x64', requiredLibraries: {'libLiteRtLm.dylib'}),
+  _LiteRtLmBundleSpec(
+    'linux-arm64',
     requiredLibraries: {
       'libGemmaModelConstraintProvider.so',
       'libLiteRt.so',
       'libLiteRtLm.so',
       'libLiteRtTopKWebGpuSampler.so',
       'libLiteRtWebGpuAccelerator.so',
-      'libStreamProxy.so',
     },
-    emitAllLibraries: true,
   ),
-  'linux-x64': _LiteRtLmBundleSpec(
-    directoryName: 'linux/x64',
-    archiveName: 'litert-lm-native-runtime-linux-x64-v0.12.0.tar.gz',
-    sha256: 'e508e545d7be417895071c47612fd4fd5da842b05864f0776c98c2c67ad223e9',
-    releaseBaseUrl: _litertLmNativeReleaseBaseUrl,
-    sourcePrefix: 'linux/x64',
+  _LiteRtLmBundleSpec(
+    'linux-x64',
     requiredLibraries: {
       'libGemmaModelConstraintProvider.so',
       'libLiteRt.so',
       'libLiteRtLm.so',
       'libLiteRtTopKWebGpuSampler.so',
       'libLiteRtWebGpuAccelerator.so',
-      'libStreamProxy.so',
     },
-    emitAllLibraries: true,
   ),
-  'windows-x64': _LiteRtLmBundleSpec(
-    directoryName: 'windows/x64',
-    archiveName: 'litert-lm-native-runtime-windows-x64-v0.12.0.tar.gz',
-    sha256: '4c6ff1b3affd37c49c4d45538fdd2f376cc065a85a1339ca6c166e2b542072df',
-    releaseBaseUrl: _litertLmNativeReleaseBaseUrl,
-    sourcePrefix: 'windows/x64',
+  _LiteRtLmBundleSpec(
+    'windows-x64',
     requiredLibraries: {
       'LiteRtLm.dll',
-      'StreamProxy.dll',
       'libGemmaModelConstraintProvider.dll',
       'libLiteRt.dll',
       'libLiteRtTopKWebGpuSampler.dll',
       'libLiteRtWebGpuAccelerator.dll',
     },
-    emitAllLibraries: true,
   ),
-};
+];
 
 const _dynamicLibraryExtensions = {'.so', '.dylib', '.dll'};
 final _windowsCudartPattern = RegExp(r'^cudart64(?:[_-]?\d+)?\.dll$');
@@ -198,23 +143,25 @@ class _NativeBundleConfig {
 }
 
 class _LiteRtLmBundleSpec {
-  final String directoryName;
-  final String archiveName;
-  final String? sha256;
-  final String releaseBaseUrl;
-  final String? sourcePrefix;
+  final String bundle;
   final Set<String> requiredLibraries;
-  final bool emitAllLibraries;
 
-  const _LiteRtLmBundleSpec({
-    required this.directoryName,
-    required this.archiveName,
-    required this.sha256,
-    required this.releaseBaseUrl,
-    this.sourcePrefix,
-    required this.requiredLibraries,
-    this.emitAllLibraries = false,
-  });
+  const _LiteRtLmBundleSpec(this.bundle, {required this.requiredLibraries});
+
+  String get archiveName =>
+      'litert-lm-native-runtime-$bundle-v$_litertLmVersion.tar.gz';
+
+  String get directoryName {
+    final separator = bundle.indexOf('-');
+    if (separator < 0) {
+      return bundle;
+    }
+    return '${bundle.substring(0, separator)}/${bundle.substring(separator + 1)}';
+  }
+
+  String get releaseUrl => '$_litertLmNativeReleaseBaseUrl/$archiveName';
+
+  String get sourcePrefix => directoryName;
 }
 
 void main(List<String> args) async {
@@ -407,6 +354,12 @@ Future<void> _emitLiteRtLmAssets({
 }) async {
   final bundleSpec = _liteRtLmBundleSpecForCode(code);
   if (bundleSpec == null) {
+    log.warning(
+      'LiteRT-LM runtime is not available for '
+      '${_liteRtLmTargetLabel(code)}; no LiteRT-LM assets will be bundled. '
+      'Configure $nativeRuntimesUserDefineKey to exclude litert_lm for this '
+      'target.',
+    );
     return;
   }
 
@@ -415,7 +368,18 @@ Future<void> _emitLiteRtLmAssets({
     bundleSpec: bundleSpec,
     log: log,
   );
-  final libraryPaths = _collectDynamicLibraryPaths(bundleDir);
+  if (code.targetOS == OS.macOS) {
+    log.info(
+      'Keeping macOS LiteRT-LM libraries in the hook cache at '
+      '${bundleDir.path}; the runtime loads them directly to avoid Flutter '
+      'rewriting upstream install names during app bundling.',
+    );
+    return;
+  }
+  final libraryPaths = _collectDynamicLibraryPaths(
+    bundleDir,
+    additionalFileNames: bundleSpec.requiredLibraries,
+  );
   if (libraryPaths.isEmpty) {
     log.warning('LiteRT-LM bundle had no dynamic libraries.');
     return;
@@ -431,13 +395,6 @@ Future<void> _emitLiteRtLmAssets({
     }
     final destinationPath = path.join(reportDirPath, fileName);
     await File(sourcePath).copy(destinationPath);
-    if (!_shouldEmitLiteRtLmCodeAsset(code, bundleSpec, fileName)) {
-      log.info(
-        'Copied LiteRT-LM companion `$fileName` without reporting it '
-        'as a native asset.',
-      );
-      continue;
-    }
     final assetName = _dedupeAssetName(
       _liteRtLmAssetName(fileName),
       usedAssetNames,
@@ -457,24 +414,6 @@ Future<void> _emitLiteRtLmAssets({
   }
 }
 
-bool _shouldEmitLiteRtLmCodeAsset(
-  CodeConfig code,
-  _LiteRtLmBundleSpec bundleSpec,
-  String fileName,
-) {
-  if (code.targetOS == OS.macOS) {
-    // Upstream LiteRT-LM dylibs are not reliable Dart Native Assets on macOS:
-    // the JIT bundler rewrites install names, and some upstream dylibs do not
-    // tolerate that rewrite. Keep them in the hook cache and let the
-    // LiteRT-LM loader open them from there.
-    return false;
-  }
-  if (bundleSpec.emitAllLibraries) {
-    return true;
-  }
-  return true;
-}
-
 _LiteRtLmBundleSpec? _liteRtLmBundleSpecForCode(CodeConfig code) {
   switch (code.targetOS) {
     case OS.android:
@@ -488,7 +427,7 @@ _LiteRtLmBundleSpec? _liteRtLmBundleSpecForCode(CodeConfig code) {
       return switch (code.targetArchitecture) {
         Architecture.arm64 =>
           _litertLmBundles[isSimulator ? 'ios-arm64-sim' : 'ios-arm64'],
-        Architecture.x64 => _litertLmBundles['ios-x64-sim'],
+        Architecture.x64 => null,
         _ => null,
       };
     case OS.macOS:
@@ -511,6 +450,17 @@ _LiteRtLmBundleSpec? _liteRtLmBundleSpecForCode(CodeConfig code) {
     default:
       return null;
   }
+}
+
+String _liteRtLmTargetLabel(CodeConfig code) {
+  final architecture =
+      code.targetOS == OS.iOS && code.targetArchitecture == Architecture.x64
+      ? 'x86_64'
+      : code.targetArchitecture.name;
+  if (code.targetOS == OS.iOS && code.iOS.targetSdk == IOSSdk.iPhoneSimulator) {
+    return '${code.targetOS.name}-$architecture-sim';
+  }
+  return '${code.targetOS.name}-$architecture';
 }
 
 String _liteRtLmAssetName(String fileName) {
@@ -541,16 +491,15 @@ Future<Directory> _acquireLiteRtLmBundle({
 
   await Directory(cacheDir).create(recursive: true);
   final archiveFile = File(path.join(cacheDir, bundleSpec.archiveName));
-  final expectedSha256 = bundleSpec.sha256;
-  if (archiveFile.existsSync() && expectedSha256 != null) {
-    final digest = await _sha256File(archiveFile);
-    if (digest != expectedSha256) {
-      log.warning(
-        'Cached LiteRT-LM archive checksum mismatch; redownloading '
-        '${bundleSpec.archiveName}.',
-      );
-      await archiveFile.delete();
-    }
+  if (archiveFile.existsSync() &&
+      await _tryExtractLiteRtLmArchive(
+        archiveFile: archiveFile,
+        extractedDir: extractedDir,
+        bundleSpec: bundleSpec,
+        log: log,
+        allowRefresh: true,
+      )) {
+    return extractedDir;
   }
   if (!archiveFile.existsSync()) {
     await _downloadLiteRtLmArchive(
@@ -559,16 +508,24 @@ Future<Directory> _acquireLiteRtLmBundle({
       log: log,
     );
   }
-  if (expectedSha256 != null) {
-    final digest = await _sha256File(archiveFile);
-    if (digest != expectedSha256) {
-      throw Exception(
-        'LiteRT-LM archive checksum mismatch: expected '
-        '$expectedSha256, got $digest',
-      );
-    }
-  }
 
+  await _tryExtractLiteRtLmArchive(
+    archiveFile: archiveFile,
+    extractedDir: extractedDir,
+    bundleSpec: bundleSpec,
+    log: log,
+    allowRefresh: false,
+  );
+  return extractedDir;
+}
+
+Future<bool> _tryExtractLiteRtLmArchive({
+  required File archiveFile,
+  required Directory extractedDir,
+  required _LiteRtLmBundleSpec bundleSpec,
+  required Logger log,
+  required bool allowRefresh,
+}) async {
   if (extractedDir.existsSync()) {
     await extractedDir.delete(recursive: true);
   }
@@ -584,9 +541,7 @@ Future<Directory> _acquireLiteRtLmBundle({
         continue;
       }
       final fileName = path.basename(entry.name);
-      if (!_dynamicLibraryExtensions.contains(
-        path.extension(fileName).toLowerCase(),
-      )) {
+      if (!_isLiteRtLmRuntimeLibraryFileName(fileName, bundleSpec)) {
         continue;
       }
       await File(
@@ -610,17 +565,40 @@ Future<Directory> _acquireLiteRtLmBundle({
       );
     }
     await _flattenLiteRtLmDynamicLibraries(extractedDir, bundleSpec);
+  } catch (error) {
+    if (!allowRefresh) {
+      rethrow;
+    }
+    log.warning(
+      'Cached LiteRT-LM archive could not be extracted; redownloading '
+      '${bundleSpec.archiveName}: $error',
+    );
+    await archiveFile.delete();
+    if (extractedDir.existsSync()) {
+      await extractedDir.delete(recursive: true);
+    }
+    return false;
   }
   final missingLibraries = _missingLiteRtLmLibraries(extractedDir, bundleSpec);
   if (missingLibraries.isNotEmpty) {
+    if (allowRefresh) {
+      log.warning(
+        'Cached LiteRT-LM archive ${bundleSpec.archiveName} is missing '
+        'required libraries: ${missingLibraries.join(', ')}; redownloading.',
+      );
+      await archiveFile.delete();
+      if (extractedDir.existsSync()) {
+        await extractedDir.delete(recursive: true);
+      }
+      return false;
+    }
     throw Exception(
       'LiteRT-LM bundle ${bundleSpec.archiveName} is missing required '
       'libraries: ${missingLibraries.join(', ')}',
     );
   }
-  await _writeLiteRtLmChecksumMarker(extractedDir, expectedSha256);
   log.info('Extracted LiteRT-LM bundle to ${extractedDir.path}');
-  return extractedDir;
+  return true;
 }
 
 Future<void> _downloadLiteRtLmArchive({
@@ -628,9 +606,8 @@ Future<void> _downloadLiteRtLmArchive({
   required File destination,
   required Logger log,
 }) async {
-  final url = '${bundleSpec.releaseBaseUrl}/${bundleSpec.archiveName}';
-  log.info('Downloading LiteRT-LM bundle from $url');
-  final response = await http.get(Uri.parse(url));
+  log.info('Downloading LiteRT-LM bundle from ${bundleSpec.releaseUrl}');
+  final response = await http.get(Uri.parse(bundleSpec.releaseUrl));
   if (response.statusCode != 200) {
     throw Exception(
       'Failed to download LiteRT-LM bundle: HTTP ${response.statusCode}',
@@ -639,19 +616,12 @@ Future<void> _downloadLiteRtLmArchive({
   await destination.writeAsBytes(response.bodyBytes);
 }
 
-Future<String> _sha256File(File file) async {
-  return sha256.convert(await file.readAsBytes()).toString();
-}
-
 bool _isLiteRtLmEntrySelected(
   String entryName,
   _LiteRtLmBundleSpec bundleSpec,
 ) {
-  final sourcePrefix = bundleSpec.sourcePrefix;
-  if (sourcePrefix == null) {
-    return true;
-  }
   final normalized = path.posix.normalize(entryName);
+  final sourcePrefix = bundleSpec.sourcePrefix;
   return normalized == sourcePrefix || normalized.startsWith('$sourcePrefix/');
 }
 
@@ -660,9 +630,6 @@ Future<void> _flattenLiteRtLmDynamicLibraries(
   _LiteRtLmBundleSpec bundleSpec,
 ) async {
   final sourcePrefix = bundleSpec.sourcePrefix;
-  if (sourcePrefix == null) {
-    return;
-  }
   final nestedDir = Directory(
     path.joinAll([extractedDir.path, ...sourcePrefix.split('/')]),
   );
@@ -674,9 +641,7 @@ Future<void> _flattenLiteRtLmDynamicLibraries(
       continue;
     }
     final fileName = path.basename(entity.path);
-    if (!_dynamicLibraryExtensions.contains(
-      path.extension(fileName).toLowerCase(),
-    )) {
+    if (!_isLiteRtLmRuntimeLibraryFileName(fileName, bundleSpec)) {
       continue;
     }
     await entity.copy(path.join(extractedDir.path, fileName));
@@ -691,27 +656,7 @@ bool _liteRtLmBundleIsUsable(
   if (_missingLiteRtLmLibraries(directory, bundleSpec).isNotEmpty) {
     return false;
   }
-  final expectedSha256 = bundleSpec.sha256;
-  if (expectedSha256 == null) {
-    return true;
-  }
-  final checksumFile = File(
-    path.join(directory.path, _litertLmChecksumFileName),
-  );
-  return checksumFile.existsSync() &&
-      checksumFile.readAsStringSync().trim() == expectedSha256;
-}
-
-Future<void> _writeLiteRtLmChecksumMarker(
-  Directory directory,
-  String? sha256,
-) async {
-  if (sha256 == null) {
-    return;
-  }
-  await File(
-    path.join(directory.path, _litertLmChecksumFileName),
-  ).writeAsString('$sha256\n');
+  return true;
 }
 
 List<String> _missingLiteRtLmLibraries(
@@ -726,6 +671,16 @@ List<String> _missingLiteRtLmLibraries(
         return !File(path.join(directory.path, libraryName)).existsSync();
       })
       .toList(growable: false);
+}
+
+bool _isLiteRtLmRuntimeLibraryFileName(
+  String fileName,
+  _LiteRtLmBundleSpec bundleSpec,
+) {
+  return _dynamicLibraryExtensions.contains(
+        path.extension(fileName).toLowerCase(),
+      ) ||
+      bundleSpec.requiredLibraries.contains(fileName);
 }
 
 String _dedupeAssetName(String base, Set<String> used) {
@@ -1244,7 +1199,10 @@ List<String> _localBundleCandidates({
   return candidates;
 }
 
-List<String> _collectDynamicLibraryPaths(Directory directory) {
+List<String> _collectDynamicLibraryPaths(
+  Directory directory, {
+  Set<String> additionalFileNames = const {},
+}) {
   if (!directory.existsSync()) {
     return const [];
   }
@@ -1257,6 +1215,7 @@ List<String> _collectDynamicLibraryPaths(Directory directory) {
     final fileName = path.basename(entity.path).toLowerCase();
     final extension = path.extension(entity.path).toLowerCase();
     if (_dynamicLibraryExtensions.contains(extension) ||
+        additionalFileNames.contains(path.basename(entity.path)) ||
         _linuxVersionedSoPattern.hasMatch(fileName)) {
       paths.add(entity.path);
     }

--- a/lib/src/backends/litert_lm/litert_lm_runtime.dart
+++ b/lib/src/backends/litert_lm/litert_lm_runtime.dart
@@ -7,10 +7,9 @@ import 'dart:isolate';
 import 'package:ffi/ffi.dart';
 import 'package:path/path.dart' as path;
 
-const _litertLmVersion = '0.12.0';
+const _litertLmVersion = '0.13.1';
 const _litertLmLibDirEnv = 'LLAMADART_LITERT_LM_LIB_DIR';
 const _liteRtLmIosNativeAsset = 'package:llamadart/litert_lm_LiteRtLm';
-const _streamProxyIosNativeAsset = 'package:llamadart/litert_lm_StreamProxy';
 
 /// Builds a diagnostic for LiteRT-LM engine creation failures.
 ///
@@ -65,9 +64,8 @@ List<String> liteRtLmMacOsRequiredLibrariesForAbi(Abi abi) {
       'libLiteRtTopKMetalSampler.dylib',
       'libLiteRtTopKWebGpuSampler.dylib',
       'libLiteRtWebGpuAccelerator.dylib',
-      'libStreamProxy.dylib',
     ],
-    Abi.macosX64 => const <String>['libLiteRtLm.dylib', 'libStreamProxy.dylib'],
+    Abi.macosX64 => const <String>['libLiteRtLm.dylib'],
     _ => const <String>[],
   };
 }
@@ -89,18 +87,7 @@ List<String> liteRtLmCacheDirectoryCandidatesForAbi(Abi abi) {
 List<String> liteRtLmIosLibraryCandidatesForAbi(Abi abi) {
   return switch (abi) {
     Abi.iosArm64 ||
-    Abi.iosX64 => const <String>[_liteRtLmIosNativeAsset, 'libLiteRtLm.dylib'],
-    _ => const <String>[],
-  };
-}
-
-/// Internal helper used by the LiteRT-LM runtime to locate iOS StreamProxy.
-List<String> liteRtLmIosStreamProxyCandidatesForAbi(Abi abi) {
-  return switch (abi) {
-    Abi.iosArm64 || Abi.iosX64 => const <String>[
-      _streamProxyIosNativeAsset,
-      'libStreamProxy.dylib',
-    ],
+    Abi.iosX64 => const <String>[_liteRtLmIosNativeAsset, 'LiteRtLm'],
     _ => const <String>[],
   };
 }
@@ -119,7 +106,7 @@ String liteRtLmIosFrameworkBinaryPath(String frameworksDirPath, String name) {
 /// externals do), so the `package:llamadart/...` id is passed verbatim to
 /// dlopen and never loads. When [frameworksDirPath] is known, the absolute path
 /// to the embedded framework binary is preferred; the native-asset id and bare
-/// `libLiteRtLm.dylib` remain as last-resort fallbacks for the error message.
+/// `LiteRtLm` remain as last-resort fallbacks for the error message.
 List<String> liteRtLmIosLibraryCandidates(
   Abi abi, {
   String? frameworksDirPath,
@@ -131,22 +118,6 @@ List<String> liteRtLmIosLibraryCandidates(
   return <String>[
     if (frameworksDirPath != null)
       liteRtLmIosFrameworkBinaryPath(frameworksDirPath, 'LiteRtLm'),
-    ...fallbacks,
-  ];
-}
-
-/// Ordered StreamProxy load candidates for iOS. See [liteRtLmIosLibraryCandidates].
-List<String> liteRtLmIosStreamProxyCandidates(
-  Abi abi, {
-  String? frameworksDirPath,
-}) {
-  final fallbacks = liteRtLmIosStreamProxyCandidatesForAbi(abi);
-  if (fallbacks.isEmpty) {
-    return const <String>[];
-  }
-  return <String>[
-    if (frameworksDirPath != null)
-      liteRtLmIosFrameworkBinaryPath(frameworksDirPath, 'StreamProxy'),
     ...fallbacks,
   ];
 }
@@ -163,7 +134,6 @@ List<String> liteRtLmRequiredLibrariesForAbi(Abi abi) {
       'libLiteRtLm.so',
       'libLiteRtTopKWebGpuSampler.so',
       'libLiteRtWebGpuAccelerator.so',
-      'libStreamProxy.so',
     ],
     Abi.linuxX64 => const <String>[
       'libGemmaModelConstraintProvider.so',
@@ -171,11 +141,9 @@ List<String> liteRtLmRequiredLibrariesForAbi(Abi abi) {
       'libLiteRtLm.so',
       'libLiteRtTopKWebGpuSampler.so',
       'libLiteRtWebGpuAccelerator.so',
-      'libStreamProxy.so',
     ],
     Abi.windowsX64 => const <String>[
       'LiteRtLm.dll',
-      'StreamProxy.dll',
       'libGemmaModelConstraintProvider.dll',
       'libLiteRt.dll',
       'libLiteRtTopKWebGpuSampler.dll',
@@ -202,12 +170,8 @@ List<String> liteRtLmMacOsRequiredFrameworksForAbi(Abi abi) {
           'LiteRtTopKWebGpuSampler',
       'LiteRtWebGpuAccelerator.framework/Versions/A/'
           'LiteRtWebGpuAccelerator',
-      'StreamProxy.framework/Versions/A/StreamProxy',
     ],
-    Abi.macosX64 => const <String>[
-      'LiteRtLm.framework/Versions/A/LiteRtLm',
-      'StreamProxy.framework/Versions/A/StreamProxy',
-    ],
+    Abi.macosX64 => const <String>['LiteRtLm.framework/Versions/A/LiteRtLm'],
     _ => const <String>[],
   };
 }
@@ -392,7 +356,7 @@ class LiteRtLmRuntimeClient {
   }
 
   _LiteRtLmBindings? _bindings;
-  // Keep a strong reference while callbacks/function pointers may be active.
+  // Keep a strong runtime-library reference while proxy function pointers are active.
   // ignore: unused_field
   DynamicLibrary? _proxyLibrary;
   _ProxyCreateDart? _proxyCreate;
@@ -944,59 +908,20 @@ class LiteRtLmRuntimeClient {
       }
     }
 
-    if (libraries.proxyCandidates.isNotEmpty) {
-      try {
-        final proxyLibrary = _openFirstAvailable(
-          libraries.proxyCandidates,
-          description: 'StreamProxy library',
-        );
-        final loadGlobal = proxyLibrary
-            .lookupFunction<_LoadGlobalNative, _LoadGlobalDart>(
-              'stream_proxy_load_global',
-            );
-        final liteRtLmLoadTarget = libraries.liteRtLmCandidates.first;
-        final liteRtLmName = liteRtLmLoadTarget.toNativeUtf8();
-        try {
-          final handle = loadGlobal(liteRtLmName);
-          if (handle == nullptr) {
-            throw StateError(
-              'Failed to load $liteRtLmLoadTarget with RTLD_GLOBAL',
-            );
-          }
-        } finally {
-          calloc.free(liteRtLmName);
-        }
-
-        _proxyCreate = proxyLibrary
-            .lookupFunction<_ProxyCreateNative, _ProxyCreateDart>(
-              'stream_proxy_create',
-            );
-        _proxyFreeString = proxyLibrary
-            .lookupFunction<_ProxyFreeStringNative, _ProxyFreeStringDart>(
-              'stream_proxy_free_string',
-            );
-        _proxyDelete = proxyLibrary
-            .lookupFunction<_ProxyDeleteNative, _ProxyDeleteDart>(
-              'stream_proxy_delete',
-            );
-        _proxyLibrary = proxyLibrary;
-      } catch (error) {
-        if (!libraries.directCallbackSupported) {
-          rethrow;
-        }
-      }
-    }
-
     final liteRtLm = _openFirstAvailableWithPath(
       libraries.liteRtLmCandidates,
       description: 'LiteRT-LM library',
     );
     _liteRtLmLibraryPath = liteRtLm.path;
+    _tryLoadEmbeddedStreamProxy(
+      liteRtLm.library,
+      liteRtLm.path,
+      libraries.directCallbackSupported,
+    );
     _bindings = _LiteRtLmBindings(liteRtLm.library);
   }
 
   ({
-    List<String> proxyCandidates,
     List<String> liteRtLmCandidates,
     List<String> companions,
     bool directCallbackSupported,
@@ -1006,10 +931,6 @@ class LiteRtLmRuntimeClient {
     if (Platform.isAndroid &&
         (abi == Abi.androidArm64 || abi == Abi.androidX64)) {
       return (
-        proxyCandidates: const [
-          'package:llamadart/litert_lm_StreamProxy',
-          'libStreamProxy.so',
-        ],
         liteRtLmCandidates: const ['libLiteRtLm.so'],
         companions: const [],
         directCallbackSupported: true,
@@ -1018,15 +939,11 @@ class LiteRtLmRuntimeClient {
     if (Platform.isIOS && (abi == Abi.iosArm64 || abi == Abi.iosX64)) {
       // The LiteRT-LM frameworks are embedded under
       // `<App>.app/Frameworks/<Name>.framework/<Name>`. Resolving their absolute
-      // paths from the executable lets dlopen, the StreamProxy RTLD_GLOBAL
-      // preload, and the isolate re-open all receive a real path (the
-      // `package:` native-asset ids never load via `DynamicLibrary.open`).
+      // paths from the executable lets dlopen and the isolate re-open receive a
+      // real path (the `package:` native-asset ids never load via
+      // `DynamicLibrary.open`).
       final frameworksDirPath = _findIosAppFrameworksDir()?.path;
       return (
-        proxyCandidates: liteRtLmIosStreamProxyCandidates(
-          abi,
-          frameworksDirPath: frameworksDirPath,
-        ),
         liteRtLmCandidates: liteRtLmIosLibraryCandidates(
           abi,
           frameworksDirPath: frameworksDirPath,
@@ -1037,14 +954,29 @@ class LiteRtLmRuntimeClient {
     }
     if (Platform.isMacOS && (abi == Abi.macosArm64 || abi == Abi.macosX64)) {
       final companions = _macOsCompanionLibrariesForAbi(abi);
+      final appLibraryDir = _findMacOsAppLibraryDir();
+      if (appLibraryDir != null) {
+        return (
+          liteRtLmCandidates: ['${appLibraryDir.path}/libLiteRtLm.dylib'],
+          companions: [
+            for (final library in companions) '${appLibraryDir.path}/$library',
+          ],
+          directCallbackSupported: true,
+        );
+      }
+      final cacheDir = _findMacOsLiteRtLmCacheDir();
+      if (cacheDir != null) {
+        return (
+          liteRtLmCandidates: ['${cacheDir.path}/libLiteRtLm.dylib'],
+          companions: [
+            for (final library in companions) '${cacheDir.path}/$library',
+          ],
+          directCallbackSupported: true,
+        );
+      }
       final frameworksDir = _findMacOsAppFrameworksDir();
       if (frameworksDir != null) {
         return (
-          proxyCandidates: [
-            '${frameworksDir.path}/StreamProxy.framework/Versions/A/StreamProxy',
-            'package:llamadart/litert_lm_StreamProxy',
-            'libStreamProxy.dylib',
-          ],
           liteRtLmCandidates: [
             '${frameworksDir.path}/LiteRtLm.framework/Versions/A/LiteRtLm',
           ],
@@ -1055,26 +987,7 @@ class LiteRtLmRuntimeClient {
           directCallbackSupported: true,
         );
       }
-      final cacheDir = _findMacOsLiteRtLmCacheDir();
-      if (cacheDir != null) {
-        return (
-          proxyCandidates: [
-            '${cacheDir.path}/libStreamProxy.dylib',
-            'package:llamadart/litert_lm_StreamProxy',
-            'libStreamProxy.dylib',
-          ],
-          liteRtLmCandidates: ['${cacheDir.path}/libLiteRtLm.dylib'],
-          companions: [
-            for (final library in companions) '${cacheDir.path}/$library',
-          ],
-          directCallbackSupported: true,
-        );
-      }
       return (
-        proxyCandidates: const [
-          'package:llamadart/litert_lm_StreamProxy',
-          'libStreamProxy.dylib',
-        ],
         liteRtLmCandidates: const ['libLiteRtLm.dylib'],
         companions: [for (final library in companions) library],
         directCallbackSupported: true,
@@ -1084,21 +997,12 @@ class LiteRtLmRuntimeClient {
       final cacheDir = _findLiteRtLmCacheDirForAbi(abi);
       if (cacheDir != null) {
         return (
-          proxyCandidates: [
-            '${cacheDir.path}/libStreamProxy.so',
-            'package:llamadart/litert_lm_StreamProxy',
-            'libStreamProxy.so',
-          ],
           liteRtLmCandidates: ['${cacheDir.path}/libLiteRtLm.so'],
           companions: _companionLibrariesForAbi(abi, cacheDir),
           directCallbackSupported: true,
         );
       }
       return (
-        proxyCandidates: const [
-          'package:llamadart/litert_lm_StreamProxy',
-          'libStreamProxy.so',
-        ],
         liteRtLmCandidates: const ['package:llamadart/litert_lm_LiteRtLm'],
         companions: const [],
         directCallbackSupported: true,
@@ -1108,37 +1012,18 @@ class LiteRtLmRuntimeClient {
       final cacheDir = _findLiteRtLmCacheDirForAbi(abi);
       if (cacheDir != null) {
         return (
-          proxyCandidates: [
-            '${cacheDir.path}/StreamProxy.dll',
-            'package:llamadart/litert_lm_StreamProxy',
-            'StreamProxy.dll',
-          ],
           liteRtLmCandidates: ['${cacheDir.path}/LiteRtLm.dll'],
           companions: _companionLibrariesForAbi(abi, cacheDir),
           directCallbackSupported: true,
         );
       }
       return (
-        proxyCandidates: const [
-          'package:llamadart/litert_lm_StreamProxy',
-          'StreamProxy.dll',
-        ],
         liteRtLmCandidates: const ['package:llamadart/litert_lm_LiteRtLm'],
         companions: const [],
         directCallbackSupported: true,
       );
     }
     return null;
-  }
-
-  DynamicLibrary _openFirstAvailable(
-    List<String> candidates, {
-    required String description,
-  }) {
-    return _openFirstAvailableWithPath(
-      candidates,
-      description: description,
-    ).library;
   }
 
   ({String path, DynamicLibrary library}) _openFirstAvailableWithPath(
@@ -1156,6 +1041,65 @@ class LiteRtLmRuntimeClient {
     throw ArgumentError(
       'Failed to load any $description candidate:\n${errors.join('\n')}',
     );
+  }
+
+  void _tryLoadEmbeddedStreamProxy(
+    DynamicLibrary liteRtLmLibrary,
+    String liteRtLmPath,
+    bool directCallbackSupported,
+  ) {
+    try {
+      _loadRuntimeGloballyIfAvailable(liteRtLmLibrary, liteRtLmPath);
+      final proxyCreate = liteRtLmLibrary
+          .lookupFunction<_ProxyCreateNative, _ProxyCreateDart>(
+            'stream_proxy_create',
+          );
+      final proxyFreeString = liteRtLmLibrary
+          .lookupFunction<_ProxyFreeStringNative, _ProxyFreeStringDart>(
+            'stream_proxy_free_string',
+          );
+      final proxyDelete = liteRtLmLibrary
+          .lookupFunction<_ProxyDeleteNative, _ProxyDeleteDart>(
+            'stream_proxy_delete',
+          );
+
+      _proxyCreate = proxyCreate;
+      _proxyFreeString = proxyFreeString;
+      _proxyDelete = proxyDelete;
+      _proxyLibrary = liteRtLmLibrary;
+    } catch (error) {
+      _proxyCreate = null;
+      _proxyFreeString = null;
+      _proxyDelete = null;
+      _proxyLibrary = null;
+      if (!directCallbackSupported) {
+        throw StateError(
+          'LiteRT-LM runtime does not export embedded StreamProxy symbols: '
+          '$error',
+        );
+      }
+    }
+  }
+
+  void _loadRuntimeGloballyIfAvailable(
+    DynamicLibrary liteRtLmLibrary,
+    String liteRtLmPath,
+  ) {
+    try {
+      final loadGlobal = liteRtLmLibrary
+          .lookupFunction<_LoadGlobalNative, _LoadGlobalDart>(
+            'stream_proxy_load_global',
+          );
+      final liteRtLmName = liteRtLmPath.toNativeUtf8();
+      try {
+        loadGlobal(liteRtLmName);
+      } finally {
+        calloc.free(liteRtLmName);
+      }
+    } catch (_) {
+      // Loading the already-open runtime globally is best-effort. The proxy
+      // functions themselves are resolved from the active LiteRtLm handle below.
+    }
   }
 
   Directory? _findMacOsAppFrameworksDir() {
@@ -1179,6 +1123,20 @@ class LiteRtLmRuntimeClient {
       return frameworksDir;
     }
     return null;
+  }
+
+  Directory? _findMacOsAppLibraryDir() {
+    final executable = File(Platform.resolvedExecutable);
+    final contentsDir = executable.parent.parent;
+    final libraryDir = Directory(
+      '${contentsDir.path}/Frameworks/LiteRtLmRuntime',
+    );
+    if (!libraryDir.existsSync()) {
+      return null;
+    }
+    return liteRtLmIsMacOsCacheDirectoryForAbi(libraryDir, Abi.current())
+        ? libraryDir
+        : null;
   }
 
   /// Locates the `Frameworks` directory of the running iOS `.app` bundle when
@@ -1246,22 +1204,17 @@ class LiteRtLmRuntimeClient {
 
   List<String> _macOsCompanionLibrariesForAbi(Abi abi) {
     return liteRtLmMacOsRequiredLibrariesForAbi(abi)
-        .where(
-          (library) =>
-              library != 'libLiteRtLm.dylib' &&
-              library != 'libStreamProxy.dylib',
-        )
+        .where((library) => library != 'libLiteRtLm.dylib')
         .toList(growable: false);
   }
 
   List<String> _companionLibrariesForAbi(Abi abi, Directory dir) {
     final liteRtLm = _liteRtLmLibraryFileNameForAbi(abi);
-    final streamProxy = _streamProxyLibraryFileNameForAbi(abi);
-    if (liteRtLm == null || streamProxy == null) {
+    if (liteRtLm == null) {
       return const <String>[];
     }
     return liteRtLmRequiredLibrariesForAbi(abi)
-        .where((library) => library != liteRtLm && library != streamProxy)
+        .where((library) => library != liteRtLm)
         .map((library) => '${dir.path}/$library')
         .toList(growable: false);
   }
@@ -1273,17 +1226,6 @@ class LiteRtLmRuntimeClient {
       Abi.linuxArm64 => 'libLiteRtLm.so',
       Abi.linuxX64 => 'libLiteRtLm.so',
       Abi.windowsX64 => 'LiteRtLm.dll',
-      _ => null,
-    };
-  }
-
-  String? _streamProxyLibraryFileNameForAbi(Abi abi) {
-    return switch (abi) {
-      Abi.macosArm64 => 'libStreamProxy.dylib',
-      Abi.macosX64 => 'libStreamProxy.dylib',
-      Abi.linuxArm64 => 'libStreamProxy.so',
-      Abi.linuxX64 => 'libStreamProxy.so',
-      Abi.windowsX64 => 'StreamProxy.dll',
       _ => null,
     };
   }

--- a/lib/src/hook/native_bundle_config.dart
+++ b/lib/src/hook/native_bundle_config.dart
@@ -11,10 +11,12 @@ const String nativeRuntimesUserDefineKey = 'llamadart_native_runtimes';
 const String nativeRuntimeLlamaCpp = 'llama_cpp';
 const String nativeRuntimeLiteRtLm = 'litert_lm';
 
-const List<String> defaultNativeRuntimes = [
+const List<String> allNativeRuntimes = [
   nativeRuntimeLlamaCpp,
   nativeRuntimeLiteRtLm,
 ];
+
+const List<String> defaultNativeRuntimes = [nativeRuntimeLlamaCpp];
 
 const Set<String> _coreLibraries = {
   'llamadart',
@@ -38,6 +40,28 @@ const Set<String> _knownBundleKeys = {
   'windows-x64',
 };
 
+const Set<String> _knownOsKeys = {
+  'android',
+  'ios',
+  'linux',
+  'macos',
+  'windows',
+};
+
+const Map<String, String> _bundleOsKeys = {
+  'android-arm64': 'android',
+  'android-x64': 'android',
+  'ios-arm64': 'ios',
+  'ios-arm64-sim': 'ios',
+  'ios-x86_64-sim': 'ios',
+  'linux-arm64': 'linux',
+  'linux-x64': 'linux',
+  'macos-arm64': 'macos',
+  'macos-x86_64': 'macos',
+  'windows-arm64': 'windows',
+  'windows-x64': 'windows',
+};
+
 const List<String> _platformSuffixes = [
   '-ios-x86_64-sim',
   '-ios-arm64-sim',
@@ -59,6 +83,21 @@ const Map<String, String> _bundleAliases = {
   'linux-x86_64': 'linux-x64',
   'macos-x64': 'macos-x86_64',
   'windows-x86_64': 'windows-x64',
+};
+
+const Map<String, String> _osAliases = {
+  'darwin': 'macos',
+  'mac': 'macos',
+  'mac-os': 'macos',
+  'macosx': 'macos',
+  'osx': 'macos',
+  'iphoneos': 'ios',
+  'iphonesimulator': 'ios',
+  'ios-sim': 'ios',
+  'ios-simulator': 'ios',
+  'win': 'windows',
+  'win32': 'windows',
+  'win64': 'windows',
 };
 
 const Map<String, String> _backendAliases = {
@@ -215,6 +254,20 @@ String canonicalizeBundleKey(String value) {
   return _bundleAliases[normalized] ?? normalized;
 }
 
+String _canonicalizePlatformKey(String value) {
+  final canonicalBundle = canonicalizeBundleKey(value);
+  if (_knownBundleKeys.contains(canonicalBundle)) {
+    return canonicalBundle;
+  }
+  return _osAliases[canonicalBundle] ?? canonicalBundle;
+}
+
+bool _isKnownPlatformConfigKey(String value) {
+  final canonical = _canonicalizePlatformKey(value);
+  return _knownBundleKeys.contains(canonical) ||
+      _knownOsKeys.contains(canonical);
+}
+
 Object? _platformConfigValueForBundle({
   required String bundle,
   required Object? rawUserConfig,
@@ -232,6 +285,16 @@ Object? _platformConfigValueForBundle({
   final canonicalBundle = canonicalizeBundleKey(bundle);
   for (final entry in platformsMap.entries) {
     if (canonicalizeBundleKey(entry.key) == canonicalBundle) {
+      return entry.value;
+    }
+  }
+
+  final osKey = _bundleOsKeys[canonicalBundle];
+  if (osKey == null) {
+    return null;
+  }
+  for (final entry in platformsMap.entries) {
+    if (_canonicalizePlatformKey(entry.key) == osKey) {
       return entry.value;
     }
   }
@@ -314,7 +377,7 @@ List<String> selectNativeRuntimesForBundle({
     rawUserConfig: rawUserConfig,
   );
   if (parsed == null) {
-    return defaultNativeRuntimes;
+    return defaultNativeRuntimesForBundle(bundle);
   }
 
   final invalid = parsed.invalid;
@@ -326,6 +389,14 @@ List<String> selectNativeRuntimesForBundle({
   }
 
   return parsed.runtimes;
+}
+
+List<String> defaultNativeRuntimesForBundle(String bundle) {
+  final canonicalBundle = canonicalizeBundleKey(bundle);
+  if (_bundleOsKeys[canonicalBundle] == 'android') {
+    return allNativeRuntimes;
+  }
+  return defaultNativeRuntimes;
 }
 
 List<String> selectBackendsForBundle({
@@ -401,7 +472,7 @@ _parseNativeRuntimeConfigForBundle({
   final root = _toStringMap(rawUserConfig);
   if (root == null) {
     return (
-      runtimes: defaultNativeRuntimes,
+      runtimes: defaultNativeRuntimesForBundle(bundle),
       invalid: [rawUserConfig.toString()],
     );
   }
@@ -432,15 +503,16 @@ _parseNativeRuntimeConfigForBundle({
   }
 
   final hasRuntimeShape =
-      root.keys.any(
-        (key) => _knownBundleKeys.contains(canonicalizeBundleKey(key)),
-      ) ||
+      root.keys.any(_isKnownPlatformConfigKey) ||
       _extractPlatformsMap(root) != null;
   if (hasRuntimeShape) {
     return null;
   }
 
-  return (runtimes: defaultNativeRuntimes, invalid: [rawUserConfig.toString()]);
+  return (
+    runtimes: defaultNativeRuntimesForBundle(bundle),
+    invalid: [rawUserConfig.toString()],
+  );
 }
 
 List<String> _androidCpuVariantsForProfile(String profile) {
@@ -735,9 +807,7 @@ Map<String, Object?>? _extractPlatformsMap(Map<String, Object?> root) {
   }
 
   // Backward-compatible shape: direct platform map.
-  final hasPlatformKeys = root.keys.any(
-    (key) => _knownBundleKeys.contains(canonicalizeBundleKey(key)),
-  );
+  final hasPlatformKeys = root.keys.any(_isKnownPlatformConfigKey);
   if (hasPlatformKeys) {
     return root;
   }
@@ -805,7 +875,7 @@ List<String> _parseBackendList(Object? value) {
       return;
     }
     if (normalized == 'all') {
-      for (final runtime in defaultNativeRuntimes) {
+      for (final runtime in allNativeRuntimes) {
         if (!result.contains(runtime)) {
           result.add(runtime);
         }

--- a/test/unit/backends/litert_lm/litert_lm_runtime_test.dart
+++ b/test/unit/backends/litert_lm/litert_lm_runtime_test.dart
@@ -79,25 +79,24 @@ void main() {
     expect(liteRtLmCacheDirectoryCandidatesForAbi(Abi.androidArm64), isEmpty);
   });
 
-  test('LiteRT-LM iOS fallback identifiers are the native-asset id + dylib', () {
-    // These are last-resort fallbacks only: `DynamicLibrary.open` cannot
-    // resolve the `package:` native-asset id, and the bare dylib is not on any
-    // iOS search path. The absolute framework path (below) is what actually
-    // loads.
-    expect(liteRtLmIosLibraryCandidatesForAbi(Abi.iosArm64), const <String>[
-      'package:llamadart/litert_lm_LiteRtLm',
-      'libLiteRtLm.dylib',
-    ]);
-    expect(liteRtLmIosLibraryCandidatesForAbi(Abi.iosX64), const <String>[
-      'package:llamadart/litert_lm_LiteRtLm',
-      'libLiteRtLm.dylib',
-    ]);
-    expect(liteRtLmIosStreamProxyCandidatesForAbi(Abi.iosArm64), const <String>[
-      'package:llamadart/litert_lm_StreamProxy',
-      'libStreamProxy.dylib',
-    ]);
-    expect(liteRtLmIosLibraryCandidatesForAbi(Abi.macosArm64), isEmpty);
-  });
+  test(
+    'LiteRT-LM iOS fallback identifiers are the native-asset id + binary',
+    () {
+      // These are last-resort fallbacks only: `DynamicLibrary.open` cannot
+      // resolve the `package:` native-asset id, and the bare dylib is not on any
+      // iOS search path. The absolute framework path (below) is what actually
+      // loads.
+      expect(liteRtLmIosLibraryCandidatesForAbi(Abi.iosArm64), const <String>[
+        'package:llamadart/litert_lm_LiteRtLm',
+        'LiteRtLm',
+      ]);
+      expect(liteRtLmIosLibraryCandidatesForAbi(Abi.iosX64), const <String>[
+        'package:llamadart/litert_lm_LiteRtLm',
+        'LiteRtLm',
+      ]);
+      expect(liteRtLmIosLibraryCandidatesForAbi(Abi.macosArm64), isEmpty);
+    },
+  );
 
   test('LiteRT-LM iOS lookup prefers the absolute embedded framework path', () {
     // With the app Frameworks dir known, the absolute framework binary path is
@@ -110,24 +109,13 @@ void main() {
       const <String>[
         '/App.app/Frameworks/LiteRtLm.framework/LiteRtLm',
         'package:llamadart/litert_lm_LiteRtLm',
-        'libLiteRtLm.dylib',
-      ],
-    );
-    expect(
-      liteRtLmIosStreamProxyCandidates(
-        Abi.iosArm64,
-        frameworksDirPath: '/App.app/Frameworks',
-      ),
-      const <String>[
-        '/App.app/Frameworks/StreamProxy.framework/StreamProxy',
-        'package:llamadart/litert_lm_StreamProxy',
-        'libStreamProxy.dylib',
+        'LiteRtLm',
       ],
     );
     // Without a Frameworks dir, only the fallback identifiers remain.
     expect(liteRtLmIosLibraryCandidates(Abi.iosArm64), const <String>[
       'package:llamadart/litert_lm_LiteRtLm',
-      'libLiteRtLm.dylib',
+      'LiteRtLm',
     ]);
     // Non-iOS ABIs have no iOS candidates regardless of a frameworks dir.
     expect(
@@ -152,11 +140,9 @@ void main() {
       'libLiteRtTopKMetalSampler.dylib',
       'libLiteRtTopKWebGpuSampler.dylib',
       'libLiteRtWebGpuAccelerator.dylib',
-      'libStreamProxy.dylib',
     ]);
     expect(liteRtLmMacOsRequiredLibrariesForAbi(Abi.macosX64), const <String>[
       'libLiteRtLm.dylib',
-      'libStreamProxy.dylib',
     ]);
     expect(liteRtLmMacOsRequiredLibrariesForAbi(Abi.linuxX64), isEmpty);
   });
@@ -168,11 +154,9 @@ void main() {
       'libLiteRtLm.so',
       'libLiteRtTopKWebGpuSampler.so',
       'libLiteRtWebGpuAccelerator.so',
-      'libStreamProxy.so',
     ]);
     expect(liteRtLmRequiredLibrariesForAbi(Abi.windowsX64), const <String>[
       'LiteRtLm.dll',
-      'StreamProxy.dll',
       'libGemmaModelConstraintProvider.dll',
       'libLiteRt.dll',
       'libLiteRtTopKWebGpuSampler.dll',
@@ -197,12 +181,10 @@ void main() {
             'LiteRtTopKWebGpuSampler',
         'LiteRtWebGpuAccelerator.framework/Versions/A/'
             'LiteRtWebGpuAccelerator',
-        'StreamProxy.framework/Versions/A/StreamProxy',
       ],
     );
     expect(liteRtLmMacOsRequiredFrameworksForAbi(Abi.macosX64), const <String>[
       'LiteRtLm.framework/Versions/A/LiteRtLm',
-      'StreamProxy.framework/Versions/A/StreamProxy',
     ]);
     expect(liteRtLmMacOsRequiredFrameworksForAbi(Abi.linuxX64), isEmpty);
   });
@@ -213,7 +195,6 @@ void main() {
 
     final arm64Dir = Directory('${root.path}/arm64')..createSync();
     File('${arm64Dir.path}/libLiteRtLm.dylib').createSync();
-    File('${arm64Dir.path}/libStreamProxy.dylib').createSync();
 
     expect(
       liteRtLmIsMacOsCacheDirectoryForAbi(arm64Dir, Abi.macosArm64),
@@ -232,11 +213,10 @@ void main() {
     );
 
     final x64Dir = Directory('${root.path}/x64')..createSync();
-    File('${x64Dir.path}/libLiteRtLm.dylib').createSync();
 
     expect(liteRtLmIsMacOsCacheDirectoryForAbi(x64Dir, Abi.macosX64), isFalse);
 
-    File('${x64Dir.path}/libStreamProxy.dylib').createSync();
+    File('${x64Dir.path}/libLiteRtLm.dylib').createSync();
 
     expect(liteRtLmIsMacOsCacheDirectoryForAbi(x64Dir, Abi.macosX64), isTrue);
     expect(liteRtLmIsMacOsCacheDirectoryForAbi(x64Dir, Abi.linuxX64), isFalse);
@@ -248,7 +228,6 @@ void main() {
 
     final linuxDir = Directory('${root.path}/linux')..createSync();
     File('${linuxDir.path}/libLiteRtLm.so').createSync();
-    File('${linuxDir.path}/libStreamProxy.so').createSync();
 
     expect(liteRtLmIsCacheDirectoryForAbi(linuxDir, Abi.linuxX64), isFalse);
 

--- a/test/unit/hook/build_hook_android_integration_test.dart
+++ b/test/unit/hook/build_hook_android_integration_test.dart
@@ -13,7 +13,6 @@ import '../../../hook/build.dart' as build_hook;
 void main() {
   final nativeTag = _readHookNativeTag();
   final litertVersion = _readHookLiteRtLmVersion();
-  final litertSha256 = _readLiteRtBundleSha256('android-arm64');
   final cacheRelativeDir =
       '.dart_tool/llamadart/native_bundles/$nativeTag/android-arm64';
   final bundleRelativePath = '$cacheRelativeDir/extracted';
@@ -47,11 +46,7 @@ void main() {
       await bundleDir.delete(recursive: true);
     }
     await _writeBundleLibraries(bundleDir, _androidArm64Libraries);
-    await _writeBundleLibraries(
-      litertBundleDir,
-      _androidLiteRtLibraries,
-      sha256: litertSha256,
-    );
+    await _writeBundleLibraries(litertBundleDir, _androidLiteRtLibraries);
   });
 
   tearDownAll(() async {
@@ -239,7 +234,6 @@ const List<String> _androidLiteRtLibraries = [
   'libLiteRtTopKOpenClSampler.so',
   'libLiteRtTopKWebGpuSampler.so',
   'libLiteRtWebGpuAccelerator.so',
-  'libStreamProxy.so',
 ];
 
 const List<String> _androidLiteRtAssetNames = [
@@ -251,7 +245,6 @@ const List<String> _androidLiteRtAssetNames = [
   'litert_lm_LiteRtTopKOpenClSampler',
   'litert_lm_LiteRtTopKWebGpuSampler',
   'litert_lm_LiteRtWebGpuAccelerator',
-  'litert_lm_StreamProxy',
 ];
 
 String _readHookNativeTag() {
@@ -274,33 +267,15 @@ String _readHookLiteRtLmVersion() {
   return match.group(1)!;
 }
 
-String _readLiteRtBundleSha256(String bundleKey) {
-  final source = File('hook/build.dart').readAsStringSync();
-  final escapedKey = RegExp.escape(bundleKey);
-  final match = RegExp(
-    "'$escapedKey':\\s*_LiteRtLmBundleSpec\\([\\s\\S]*?sha256:\\s*'([^']+)'",
-  ).firstMatch(source);
-  if (match == null) {
-    throw StateError('Could not locate LiteRT-LM checksum for $bundleKey');
-  }
-  return match.group(1)!;
-}
-
 Future<void> _writeBundleLibraries(
   Directory bundleDir,
-  List<String> fileNames, {
-  String? sha256,
-}) async {
+  List<String> fileNames,
+) async {
   if (bundleDir.existsSync()) {
     await bundleDir.delete(recursive: true);
   }
   await bundleDir.create(recursive: true);
   for (final name in fileNames) {
     await File(path.join(bundleDir.path, name)).writeAsString('fake-$name');
-  }
-  if (sha256 != null) {
-    await File(
-      path.join(bundleDir.path, '.llamadart_litert_lm.sha256'),
-    ).writeAsString('$sha256\n');
   }
 }

--- a/test/unit/hook/build_hook_integration_test.dart
+++ b/test/unit/hook/build_hook_integration_test.dart
@@ -16,7 +16,6 @@ import '../../../hook/build.dart' as build_hook;
 void main() {
   final nativeTag = _readHookNativeTag();
   final litertVersion = _readHookLiteRtLmVersion();
-  final litertSha256 = _readLiteRtBundleSha256('windows-x64');
   final cacheRelativeDir =
       '.dart_tool/llamadart/native_bundles/$nativeTag/windows-x64';
   final bundleRelativePath = '$cacheRelativeDir/extracted';
@@ -64,11 +63,7 @@ void main() {
       'cublas64_12.dll',
       'cublaslt64_12.dll',
     ]);
-    await _writeBundleLibraries(
-      litertBundleDir,
-      _windowsLiteRtLibraries,
-      sha256: litertSha256,
-    );
+    await _writeBundleLibraries(litertBundleDir, _windowsLiteRtLibraries);
 
     if (archiveFile.existsSync()) {
       await archiveFile.delete();
@@ -94,7 +89,7 @@ void main() {
   });
 
   test(
-    'build hook selects configured backend modules and emits primary asset',
+    'build hook selects configured backend modules without LiteRT-LM by default',
     () async {
       final userDefines = PackageUserDefines(
         workspacePubspec: PackageUserDefinesSource(
@@ -134,10 +129,13 @@ void main() {
           expect(emittedNames, contains('ggml-windows-x64.dll'));
           expect(emittedNames, contains('ggml-base-windows-x64.dll'));
           for (final library in _windowsLiteRtLibraries) {
-            expect(emittedNames, contains(library));
+            expect(emittedNames, isNot(contains(library)));
           }
           for (final assetName in _windowsLiteRtAssetNames) {
-            expect(codeAssetIds, contains('package:llamadart/$assetName'));
+            expect(
+              codeAssetIds,
+              isNot(contains('package:llamadart/$assetName')),
+            );
           }
           expect(emittedNames, isNot(contains('ggml-cuda-windows-x64.dll')));
           expect(emittedNames, isNot(contains('cudart64_12.dll')));
@@ -148,11 +146,102 @@ void main() {
     },
   );
 
+  test('build hook can emit both runtime families when requested', () async {
+    final userDefines = PackageUserDefines(
+      workspacePubspec: PackageUserDefinesSource(
+        defines: {
+          'llamadart_native_runtimes': ['all'],
+          'llamadart_native_backends': {
+            'platforms': {
+              'windows-x64': ['vulkan'],
+            },
+          },
+        },
+        basePath: Directory.current.uri,
+      ),
+    );
+
+    await testCodeBuildHook(
+      mainMethod: build_hook.main,
+      targetOS: OS.windows,
+      targetArchitecture: Architecture.x64,
+      userDefines: userDefines,
+      check: (input, output) {
+        final codeAssets = output.assets.encodedAssets
+            .where((asset) => asset.isCodeAsset)
+            .map((asset) => asset.asCodeAsset)
+            .toList(growable: false);
+
+        final codeAssetIds = codeAssets.map((asset) => asset.id).toSet();
+        final emittedNames = codeAssets
+            .map((asset) => path.basename(asset.file!.toFilePath()))
+            .toSet();
+
+        expect(codeAssetIds, contains('package:llamadart/llamadart'));
+        expect(emittedNames, contains('ggml-vulkan-windows-x64.dll'));
+        for (final library in _windowsLiteRtLibraries) {
+          expect(emittedNames, contains(library));
+        }
+        for (final assetName in _windowsLiteRtAssetNames) {
+          expect(codeAssetIds, contains('package:llamadart/$assetName'));
+        }
+      },
+    );
+  });
+
   test('build hook can emit llama.cpp runtime without LiteRT-LM', () async {
     final userDefines = PackageUserDefines(
       workspacePubspec: PackageUserDefinesSource(
         defines: {
           'llamadart_native_runtimes': ['llama_cpp'],
+          'llamadart_native_backends': {
+            'platforms': {
+              'windows-x64': ['vulkan'],
+            },
+          },
+        },
+        basePath: Directory.current.uri,
+      ),
+    );
+
+    await testCodeBuildHook(
+      mainMethod: build_hook.main,
+      targetOS: OS.windows,
+      targetArchitecture: Architecture.x64,
+      userDefines: userDefines,
+      check: (input, output) {
+        final codeAssets = output.assets.encodedAssets
+            .where((asset) => asset.isCodeAsset)
+            .map((asset) => asset.asCodeAsset)
+            .toList(growable: false);
+
+        final codeAssetIds = codeAssets.map((asset) => asset.id).toSet();
+        final emittedNames = codeAssets
+            .map((asset) => path.basename(asset.file!.toFilePath()))
+            .toSet();
+
+        expect(codeAssetIds, contains('package:llamadart/llamadart'));
+        expect(emittedNames, contains('ggml-vulkan-windows-x64.dll'));
+        for (final library in _windowsLiteRtLibraries) {
+          expect(emittedNames, isNot(contains(library)));
+        }
+        for (final assetName in _windowsLiteRtAssetNames) {
+          expect(codeAssetIds, isNot(contains('package:llamadart/$assetName')));
+        }
+      },
+    );
+  });
+
+  test('build hook supports OS-level runtime selection', () async {
+    final userDefines = PackageUserDefines(
+      workspacePubspec: PackageUserDefinesSource(
+        defines: {
+          'llamadart_native_runtimes': {
+            'runtimes': ['llama_cpp', 'litert_lm'],
+            'platforms': {
+              'windows': ['llama_cpp'],
+            },
+          },
           'llamadart_native_backends': {
             'platforms': {
               'windows-x64': ['vulkan'],
@@ -603,23 +692,10 @@ String _readHookLiteRtLmVersion() {
   return match.group(1)!;
 }
 
-String _readLiteRtBundleSha256(String bundleKey) {
-  final source = File('hook/build.dart').readAsStringSync();
-  final escapedKey = RegExp.escape(bundleKey);
-  final match = RegExp(
-    "'$escapedKey':\\s*_LiteRtLmBundleSpec\\([\\s\\S]*?sha256:\\s*'([^']+)'",
-  ).firstMatch(source);
-  if (match == null) {
-    throw StateError('Could not locate LiteRT-LM checksum for $bundleKey');
-  }
-  return match.group(1)!;
-}
-
 Future<void> _writeBundleLibraries(
   Directory bundleDir,
-  List<String> fileNames, {
-  String? sha256,
-}) async {
+  List<String> fileNames,
+) async {
   if (bundleDir.existsSync()) {
     await bundleDir.delete(recursive: true);
   }
@@ -627,16 +703,10 @@ Future<void> _writeBundleLibraries(
   for (final name in fileNames) {
     await File(path.join(bundleDir.path, name)).writeAsString('fake-$name');
   }
-  if (sha256 != null) {
-    await File(
-      path.join(bundleDir.path, '.llamadart_litert_lm.sha256'),
-    ).writeAsString('$sha256\n');
-  }
 }
 
 const List<String> _windowsLiteRtLibraries = [
   'LiteRtLm.dll',
-  'StreamProxy.dll',
   'libGemmaModelConstraintProvider.dll',
   'libLiteRt.dll',
   'libLiteRtTopKWebGpuSampler.dll',
@@ -645,7 +715,6 @@ const List<String> _windowsLiteRtLibraries = [
 
 const List<String> _windowsLiteRtAssetNames = [
   'litert_lm_LiteRtLm',
-  'litert_lm_StreamProxy',
   'litert_lm_GemmaModelConstraintProvider',
   'litert_lm_LiteRt',
   'litert_lm_LiteRtTopKWebGpuSampler',

--- a/test/unit/hook/build_hook_linux_integration_test.dart
+++ b/test/unit/hook/build_hook_linux_integration_test.dart
@@ -12,7 +12,6 @@ import '../../../hook/build.dart' as build_hook;
 void main() {
   final nativeTag = _readHookNativeTag();
   final litertVersion = _readHookLiteRtLmVersion();
-  final litertSha256 = _readLiteRtBundleSha256('linux-x64');
   final cacheRelativeDir =
       '.dart_tool/llamadart/native_bundles/$nativeTag/linux-x64';
   final bundleRelativePath = '$cacheRelativeDir/extracted';
@@ -53,11 +52,7 @@ void main() {
       'libggml-cpu.so',
       'libggml-vulkan.so',
     ]);
-    await _writeBundleLibraries(
-      litertBundleDir,
-      _linuxLiteRtLibraries,
-      sha256: litertSha256,
-    );
+    await _writeBundleLibraries(litertBundleDir, _linuxLiteRtLibraries);
   });
 
   tearDownAll(() async {
@@ -76,7 +71,7 @@ void main() {
   });
 
   test(
-    'build hook emits linux SONAME aliases for runtime dependencies',
+    'build hook emits linux SONAME aliases without LiteRT-LM by default',
     () async {
       await testCodeBuildHook(
         mainMethod: build_hook.main,
@@ -103,10 +98,13 @@ void main() {
           expect(emittedNames, contains('libggml-base.so'));
           expect(emittedNames, contains('libggml-base.so.0'));
           for (final library in _linuxLiteRtLibraries) {
-            expect(emittedNames, contains(library));
+            expect(emittedNames, isNot(contains(library)));
           }
           for (final assetName in _linuxLiteRtAssetNames) {
-            expect(codeAssetIds, contains('package:llamadart/$assetName'));
+            expect(
+              codeAssetIds,
+              isNot(contains('package:llamadart/$assetName')),
+            );
           }
         },
       );
@@ -134,25 +132,12 @@ String _readHookLiteRtLmVersion() {
   return match.group(1)!;
 }
 
-String _readLiteRtBundleSha256(String bundleKey) {
-  final source = File('hook/build.dart').readAsStringSync();
-  final escapedKey = RegExp.escape(bundleKey);
-  final match = RegExp(
-    "'$escapedKey':\\s*_LiteRtLmBundleSpec\\([\\s\\S]*?sha256:\\s*'([^']+)'",
-  ).firstMatch(source);
-  if (match == null) {
-    throw StateError('Could not locate LiteRT-LM checksum for $bundleKey');
-  }
-  return match.group(1)!;
-}
-
 const List<String> _linuxLiteRtLibraries = [
   'libGemmaModelConstraintProvider.so',
   'libLiteRt.so',
   'libLiteRtLm.so',
   'libLiteRtTopKWebGpuSampler.so',
   'libLiteRtWebGpuAccelerator.so',
-  'libStreamProxy.so',
 ];
 
 const List<String> _linuxLiteRtAssetNames = [
@@ -161,24 +146,17 @@ const List<String> _linuxLiteRtAssetNames = [
   'litert_lm_LiteRtLm',
   'litert_lm_LiteRtTopKWebGpuSampler',
   'litert_lm_LiteRtWebGpuAccelerator',
-  'litert_lm_StreamProxy',
 ];
 
 Future<void> _writeBundleLibraries(
   Directory bundleDir,
-  List<String> fileNames, {
-  String? sha256,
-}) async {
+  List<String> fileNames,
+) async {
   if (bundleDir.existsSync()) {
     await bundleDir.delete(recursive: true);
   }
   await bundleDir.create(recursive: true);
   for (final name in fileNames) {
     await File(path.join(bundleDir.path, name)).writeAsString('fake-$name');
-  }
-  if (sha256 != null) {
-    await File(
-      path.join(bundleDir.path, '.llamadart_litert_lm.sha256'),
-    ).writeAsString('$sha256\n');
   }
 }

--- a/test/unit/hook/build_hook_litert_lm_integration_test.dart
+++ b/test/unit/hook/build_hook_litert_lm_integration_test.dart
@@ -13,15 +13,17 @@ import '../../../hook/build.dart' as build_hook;
 void main() {
   final nativeTag = _readHookConst('_llamaCppTag');
   final litertVersion = _readHookConst('_litertLmVersion');
-  final linuxArm64LitertSha256 = _readLiteRtBundleSha256('linux-arm64');
-  final iosArm64LitertSha256 = _readLiteRtBundleSha256('ios-arm64');
-  final iosArm64SimLitertSha256 = _readLiteRtBundleSha256('ios-arm64-sim');
-  final iosX64SimLitertSha256 = _readLiteRtBundleSha256('ios-x64-sim');
   final nativeBundleDir = Directory(
     '.dart_tool/llamadart/native_bundles/$nativeTag/linux-arm64/extracted',
   );
   final litertBundleDir = Directory(
     '.dart_tool/llamadart/litert_lm/$litertVersion/linux/arm64',
+  );
+  final macosArm64NativeBundleDir = Directory(
+    '.dart_tool/llamadart/native_bundles/$nativeTag/macos-arm64/extracted',
+  );
+  final macosArm64LitertBundleDir = Directory(
+    '.dart_tool/llamadart/litert_lm/$litertVersion/macos/arm64',
   );
   final iosDeviceNativeBundleDir = Directory(
     '.dart_tool/llamadart/native_bundles/$nativeTag/ios-arm64/extracted',
@@ -38,12 +40,17 @@ void main() {
   final iosArm64SimLitertBundleDir = Directory(
     '.dart_tool/llamadart/litert_lm/$litertVersion/ios/arm64-sim',
   );
-  final iosX64SimLitertBundleDir = Directory(
-    '.dart_tool/llamadart/litert_lm/$litertVersion/ios/x64-sim',
-  );
   final backupPairs = [
     (nativeBundleDir, Directory('${nativeBundleDir.path}.__litert_test')),
     (litertBundleDir, Directory('${litertBundleDir.path}.__litert_test')),
+    (
+      macosArm64NativeBundleDir,
+      Directory('${macosArm64NativeBundleDir.path}.__litert_test'),
+    ),
+    (
+      macosArm64LitertBundleDir,
+      Directory('${macosArm64LitertBundleDir.path}.__litert_test'),
+    ),
     (
       iosDeviceNativeBundleDir,
       Directory('${iosDeviceNativeBundleDir.path}.__litert_test'),
@@ -64,10 +71,6 @@ void main() {
       iosArm64SimLitertBundleDir,
       Directory('${iosArm64SimLitertBundleDir.path}.__litert_test'),
     ),
-    (
-      iosX64SimLitertBundleDir,
-      Directory('${iosX64SimLitertBundleDir.path}.__litert_test'),
-    ),
   ];
 
   setUpAll(() async {
@@ -84,10 +87,13 @@ void main() {
       'libggml-base.so',
       'libggml-cpu.so',
     ]);
+    await _writeBundleLibraries(litertBundleDir, _linuxLiteRtLibraries);
+    await _writeBundleLibraries(macosArm64NativeBundleDir, const [
+      'libllamadart.dylib',
+    ]);
     await _writeBundleLibraries(
-      litertBundleDir,
-      _linuxLiteRtLibraries,
-      sha256: linuxArm64LitertSha256,
+      macosArm64LitertBundleDir,
+      _macosArm64LiteRtLibraries,
     );
     for (final directory in [
       iosDeviceNativeBundleDir,
@@ -99,21 +105,8 @@ void main() {
     for (final directory in [
       iosDeviceLitertBundleDir,
       iosArm64SimLitertBundleDir,
-      iosX64SimLitertBundleDir,
     ]) {
-      await _writeBundleLibraries(
-        directory,
-        const ['libLiteRtLm.dylib', 'libStreamProxy.dylib'],
-        sha256: switch (directory.path) {
-          final path when path == iosDeviceLitertBundleDir.path =>
-            iosArm64LitertSha256,
-          final path when path == iosArm64SimLitertBundleDir.path =>
-            iosArm64SimLitertSha256,
-          final path when path == iosX64SimLitertBundleDir.path =>
-            iosX64SimLitertSha256,
-          _ => null,
-        },
-      );
+      await _writeBundleLibraries(directory, _iosLiteRtLibraries);
     }
   });
 
@@ -130,7 +123,6 @@ void main() {
     _expectSpecLibraries(source, 'android-x64', _androidLiteRtLibraries);
     _expectSpecLibraries(source, 'ios-arm64', _iosLiteRtLibraries);
     _expectSpecLibraries(source, 'ios-arm64-sim', _iosLiteRtLibraries);
-    _expectSpecLibraries(source, 'ios-x64-sim', _iosLiteRtLibraries);
     _expectSpecLibraries(source, 'macos-arm64', _macosArm64LiteRtLibraries);
     _expectSpecLibraries(source, 'macos-x64', _macosX64LiteRtLibraries);
     _expectSpecLibraries(source, 'linux-arm64', _linuxLiteRtLibraries);
@@ -138,48 +130,72 @@ void main() {
     _expectSpecLibraries(source, 'windows-x64', _windowsLiteRtLibraries);
   });
 
-  test('build hook emits Linux arm64 LiteRT-LM runtime companions', () async {
-    await testCodeBuildHook(
-      mainMethod: build_hook.main,
-      targetOS: OS.linux,
-      targetArchitecture: Architecture.arm64,
-      check: (input, output) {
-        final codeAssets = output.assets.encodedAssets
-            .where((asset) => asset.isCodeAsset)
-            .map((asset) => asset.asCodeAsset)
-            .toList(growable: false);
+  test(
+    'build hook emits Linux arm64 LiteRT-LM runtime companions when requested',
+    () async {
+      await testCodeBuildHook(
+        mainMethod: build_hook.main,
+        targetOS: OS.linux,
+        targetArchitecture: Architecture.arm64,
+        userDefines: _allRuntimeUserDefines(),
+        check: (input, output) {
+          final codeAssets = output.assets.encodedAssets
+              .where((asset) => asset.isCodeAsset)
+              .map((asset) => asset.asCodeAsset)
+              .toList(growable: false);
 
-        final codeAssetIds = codeAssets.map((asset) => asset.id).toSet();
-        final emittedNames = codeAssets
-            .map((asset) => path.basename(asset.file!.toFilePath()))
-            .toSet();
+          final codeAssetIds = codeAssets.map((asset) => asset.id).toSet();
+          final emittedNames = codeAssets
+              .map((asset) => path.basename(asset.file!.toFilePath()))
+              .toSet();
 
-        expect(codeAssetIds, contains('package:llamadart/llamadart'));
-        for (final library in _linuxLiteRtLibraries) {
-          expect(emittedNames, contains(library));
-        }
-        for (final assetName in _linuxLiteRtAssetNames) {
-          expect(codeAssetIds, contains('package:llamadart/$assetName'));
-        }
-      },
-    );
-  });
+          expect(codeAssetIds, contains('package:llamadart/llamadart'));
+          for (final library in _linuxLiteRtLibraries) {
+            expect(emittedNames, contains(library));
+          }
+          for (final assetName in _linuxLiteRtAssetNames) {
+            expect(codeAssetIds, contains('package:llamadart/$assetName'));
+          }
+        },
+      );
+    },
+  );
+
+  test(
+    'build hook keeps macOS LiteRT-LM libraries in the cache when requested',
+    () async {
+      await testCodeBuildHook(
+        mainMethod: build_hook.main,
+        targetOS: OS.macOS,
+        targetArchitecture: Architecture.arm64,
+        userDefines: _allRuntimeUserDefines(),
+        check: (input, output) {
+          final codeAssets = output.assets.encodedAssets
+              .where((asset) => asset.isCodeAsset)
+              .map((asset) => asset.asCodeAsset)
+              .toList(growable: false);
+
+          final codeAssetIds = codeAssets.map((asset) => asset.id).toSet();
+          final emittedNames = codeAssets
+              .map((asset) => path.basename(asset.file!.toFilePath()))
+              .toSet();
+
+          expect(codeAssetIds, contains('package:llamadart/llamadart'));
+          expect(codeAssetIds.where((id) => id.contains('litert_lm')), isEmpty);
+          for (final library in _macosArm64LiteRtLibraries) {
+            expect(emittedNames, isNot(contains(library)));
+          }
+        },
+      );
+    },
+  );
 
   test('build hook can emit LiteRT-LM runtime without llama.cpp', () async {
-    final userDefines = PackageUserDefines(
-      workspacePubspec: PackageUserDefinesSource(
-        defines: {
-          'llamadart_native_runtimes': ['litert_lm'],
-        },
-        basePath: Directory.current.uri,
-      ),
-    );
-
     await testCodeBuildHook(
       mainMethod: build_hook.main,
       targetOS: OS.linux,
       targetArchitecture: Architecture.arm64,
-      userDefines: userDefines,
+      userDefines: _liteRtLmOnlyUserDefines(),
       check: (input, output) {
         final codeAssets = output.assets.encodedAssets
             .where((asset) => asset.isCodeAsset)
@@ -204,18 +220,19 @@ void main() {
   });
 
   test(
-    'build hook emits iOS device LiteRT-LM runtime and StreamProxy',
+    'build hook emits iOS device LiteRT-LM wrapper and upstream runtime',
     () async {
       await testCodeBuildHook(
         mainMethod: build_hook.main,
         targetOS: OS.iOS,
         targetArchitecture: Architecture.arm64,
         targetIOSSdk: IOSSdk.iPhoneOS,
+        userDefines: _allRuntimeUserDefines(),
         check: (input, output) {
           _expectLiteRtLmAssets(
             output.assets.encodedAssets,
-            liteRtLmFileName: 'libLiteRtLm.dylib',
-            streamProxyFileName: 'libStreamProxy.dylib',
+            liteRtLmFileName: 'LiteRtLm',
+            upstreamFileName: 'CLiteRTLM',
           );
         },
       );
@@ -223,18 +240,19 @@ void main() {
   );
 
   test(
-    'build hook emits iOS arm64 simulator LiteRT-LM runtime and StreamProxy',
+    'build hook emits iOS arm64 simulator wrapper and upstream runtime',
     () async {
       await testCodeBuildHook(
         mainMethod: build_hook.main,
         targetOS: OS.iOS,
         targetArchitecture: Architecture.arm64,
         targetIOSSdk: IOSSdk.iPhoneSimulator,
+        userDefines: _allRuntimeUserDefines(),
         check: (input, output) {
           _expectLiteRtLmAssets(
             output.assets.encodedAssets,
-            liteRtLmFileName: 'libLiteRtLm.dylib',
-            streamProxyFileName: 'libStreamProxy.dylib',
+            liteRtLmFileName: 'LiteRtLm',
+            upstreamFileName: 'CLiteRTLM',
           );
         },
       );
@@ -242,20 +260,45 @@ void main() {
   );
 
   test(
-    'build hook emits iOS x64 simulator LiteRT-LM runtime and StreamProxy',
+    'build hook excludes unavailable iOS simulator LiteRT-LM by default',
     () async {
       await testCodeBuildHook(
         mainMethod: build_hook.main,
         targetOS: OS.iOS,
         targetArchitecture: Architecture.x64,
         targetIOSSdk: IOSSdk.iPhoneSimulator,
-        check: (input, output) {
-          _expectLiteRtLmAssets(
-            output.assets.encodedAssets,
-            liteRtLmFileName: 'libLiteRtLm.dylib',
-            streamProxyFileName: 'libStreamProxy.dylib',
-          );
+        check: (_, output) {
+          final codeAssetIds = output.assets.encodedAssets
+              .where((asset) => asset.isCodeAsset)
+              .map((asset) => asset.asCodeAsset.id)
+              .toSet();
+
+          expect(codeAssetIds, contains('package:llamadart/llamadart'));
+          expect(codeAssetIds.where((id) => id.contains('litert_lm')), isEmpty);
         },
+      );
+    },
+  );
+
+  test(
+    'build hook fails when requested LiteRT-LM runtime is unavailable',
+    () async {
+      await expectLater(
+        testCodeBuildHook(
+          mainMethod: build_hook.main,
+          targetOS: OS.iOS,
+          targetArchitecture: Architecture.x64,
+          targetIOSSdk: IOSSdk.iPhoneSimulator,
+          userDefines: _allRuntimeUserDefines(),
+          check: (_, _) {},
+        ),
+        throwsA(
+          isA<Exception>().having(
+            (error) => error.toString(),
+            'message',
+            contains('LiteRT-LM runtime is not available for ios-x86_64-sim'),
+          ),
+        ),
       );
     },
   );
@@ -270,6 +313,24 @@ String _readHookConst(String name) {
   return match.group(1)!;
 }
 
+PackageUserDefines _liteRtLmOnlyUserDefines() => PackageUserDefines(
+  workspacePubspec: PackageUserDefinesSource(
+    defines: {
+      'llamadart_native_runtimes': ['litert_lm'],
+    },
+    basePath: Directory.current.uri,
+  ),
+);
+
+PackageUserDefines _allRuntimeUserDefines() => PackageUserDefines(
+  workspacePubspec: PackageUserDefinesSource(
+    defines: {
+      'llamadart_native_runtimes': ['all'],
+    },
+    basePath: Directory.current.uri,
+  ),
+);
+
 void _expectSpecLibraries(
   String source,
   String bundleKey,
@@ -277,7 +338,7 @@ void _expectSpecLibraries(
 ) {
   final escapedKey = RegExp.escape(bundleKey);
   final match = RegExp(
-    "'$escapedKey':\\s*_LiteRtLmBundleSpec\\([\\s\\S]*?"
+    "_LiteRtLmBundleSpec\\(\\s*'$escapedKey',[\\s\\S]*?"
     'requiredLibraries:\\s*\\{([\\s\\S]*?)\\},',
   ).firstMatch(source);
   if (match == null) {
@@ -298,13 +359,9 @@ const List<String> _androidLiteRtLibraries = [
   'libLiteRtTopKOpenClSampler.so',
   'libLiteRtTopKWebGpuSampler.so',
   'libLiteRtWebGpuAccelerator.so',
-  'libStreamProxy.so',
 ];
 
-const List<String> _iosLiteRtLibraries = [
-  'libLiteRtLm.dylib',
-  'libStreamProxy.dylib',
-];
+const List<String> _iosLiteRtLibraries = ['LiteRtLm', 'CLiteRTLM'];
 
 const List<String> _macosArm64LiteRtLibraries = [
   'libGemmaModelConstraintProvider.dylib',
@@ -314,13 +371,9 @@ const List<String> _macosArm64LiteRtLibraries = [
   'libLiteRtTopKMetalSampler.dylib',
   'libLiteRtTopKWebGpuSampler.dylib',
   'libLiteRtWebGpuAccelerator.dylib',
-  'libStreamProxy.dylib',
 ];
 
-const List<String> _macosX64LiteRtLibraries = [
-  'libLiteRtLm.dylib',
-  'libStreamProxy.dylib',
-];
+const List<String> _macosX64LiteRtLibraries = ['libLiteRtLm.dylib'];
 
 const List<String> _linuxLiteRtLibraries = [
   'libGemmaModelConstraintProvider.so',
@@ -328,7 +381,6 @@ const List<String> _linuxLiteRtLibraries = [
   'libLiteRtLm.so',
   'libLiteRtTopKWebGpuSampler.so',
   'libLiteRtWebGpuAccelerator.so',
-  'libStreamProxy.so',
 ];
 
 const List<String> _linuxLiteRtAssetNames = [
@@ -337,29 +389,15 @@ const List<String> _linuxLiteRtAssetNames = [
   'litert_lm_LiteRtLm',
   'litert_lm_LiteRtTopKWebGpuSampler',
   'litert_lm_LiteRtWebGpuAccelerator',
-  'litert_lm_StreamProxy',
 ];
 
 const List<String> _windowsLiteRtLibraries = [
   'LiteRtLm.dll',
-  'StreamProxy.dll',
   'libGemmaModelConstraintProvider.dll',
   'libLiteRt.dll',
   'libLiteRtTopKWebGpuSampler.dll',
   'libLiteRtWebGpuAccelerator.dll',
 ];
-
-String _readLiteRtBundleSha256(String bundleKey) {
-  final source = File('hook/build.dart').readAsStringSync();
-  final escapedKey = RegExp.escape(bundleKey);
-  final match = RegExp(
-    "'$escapedKey':\\s*_LiteRtLmBundleSpec\\([\\s\\S]*?sha256:\\s*'([^']+)'",
-  ).firstMatch(source);
-  if (match == null) {
-    throw StateError('Could not locate LiteRT-LM checksum for $bundleKey');
-  }
-  return match.group(1)!;
-}
 
 Future<void> _backupDirectory(Directory directory, Directory backup) async {
   if (backup.existsSync()) {
@@ -381,9 +419,8 @@ Future<void> _restoreDirectory(Directory directory, Directory backup) async {
 
 Future<void> _writeBundleLibraries(
   Directory bundleDir,
-  List<String> fileNames, {
-  String? sha256,
-}) async {
+  List<String> fileNames,
+) async {
   if (bundleDir.existsSync()) {
     await bundleDir.delete(recursive: true);
   }
@@ -391,17 +428,12 @@ Future<void> _writeBundleLibraries(
   for (final name in fileNames) {
     await File(path.join(bundleDir.path, name)).writeAsString('fake-$name');
   }
-  if (sha256 != null) {
-    await File(
-      path.join(bundleDir.path, '.llamadart_litert_lm.sha256'),
-    ).writeAsString('$sha256\n');
-  }
 }
 
 void _expectLiteRtLmAssets(
   Iterable<EncodedAsset> encodedAssets, {
   required String liteRtLmFileName,
-  required String streamProxyFileName,
+  required String upstreamFileName,
 }) {
   final codeAssets = encodedAssets
       .where((asset) => asset.isCodeAsset)
@@ -415,7 +447,7 @@ void _expectLiteRtLmAssets(
 
   expect(codeAssetIds, contains('package:llamadart/llamadart'));
   expect(codeAssetIds, contains('package:llamadart/litert_lm_LiteRtLm'));
-  expect(codeAssetIds, contains('package:llamadart/litert_lm_StreamProxy'));
+  expect(codeAssetIds, contains('package:llamadart/litert_lm_CLiteRTLM'));
   expect(emittedNames, contains(liteRtLmFileName));
-  expect(emittedNames, contains(streamProxyFileName));
+  expect(emittedNames, contains(upstreamFileName));
 }

--- a/test/unit/hook/native_bundle_config_test.dart
+++ b/test/unit/hook/native_bundle_config_test.dart
@@ -128,12 +128,39 @@ void main() {
 
       expect(requested, ['vulkan']);
     });
+
+    test('supports OS-level platform map shape', () {
+      final requested = parseRequestedBackends(
+        bundle: 'linux-x64',
+        rawUserConfig: {
+          'platforms': {
+            'linux': ['vulkan'],
+          },
+        },
+      );
+
+      expect(requested, ['vulkan']);
+    });
+
+    test('uses exact target backend override before OS-level config', () {
+      final requested = parseRequestedBackends(
+        bundle: 'linux-x64',
+        rawUserConfig: {
+          'platforms': {
+            'linux': ['vulkan'],
+            'linux-x64': ['cuda'],
+          },
+        },
+      );
+
+      expect(requested, ['cuda']);
+    });
   });
 
   group('selectNativeRuntimesForBundle', () {
-    test('defaults to llama.cpp and LiteRT-LM', () {
+    test('defaults to llama.cpp and LiteRT-LM on Android', () {
       final selected = selectNativeRuntimesForBundle(
-        bundle: 'linux-x64',
+        bundle: 'android-arm64',
         rawUserConfig: null,
         warn: (_) {},
       );
@@ -141,10 +168,37 @@ void main() {
       expect(selected, [nativeRuntimeLlamaCpp, nativeRuntimeLiteRtLm]);
     });
 
+    test('defaults to llama.cpp on non-Android targets', () {
+      for (final bundle in [
+        'ios-arm64',
+        'linux-x64',
+        'macos-arm64',
+        'windows-x64',
+      ]) {
+        final selected = selectNativeRuntimesForBundle(
+          bundle: bundle,
+          rawUserConfig: null,
+          warn: (_) {},
+        );
+
+        expect(selected, [nativeRuntimeLlamaCpp], reason: bundle);
+      }
+    });
+
     test('parses global runtime list with aliases', () {
       final selected = selectNativeRuntimesForBundle(
         bundle: 'android-arm64',
         rawUserConfig: 'gguf, litert-lm',
+        warn: (_) {},
+      );
+
+      expect(selected, [nativeRuntimeLlamaCpp, nativeRuntimeLiteRtLm]);
+    });
+
+    test('parses all as both runtime families on non-Android targets', () {
+      final selected = selectNativeRuntimesForBundle(
+        bundle: 'linux-x64',
+        rawUserConfig: 'all',
         warn: (_) {},
       );
 
@@ -164,6 +218,86 @@ void main() {
       );
 
       expect(selected, [nativeRuntimeLiteRtLm]);
+    });
+
+    test('supports OS-level runtime override', () {
+      final rawUserConfig = {
+        'runtimes': ['llama_cpp', 'litert_lm'],
+        'platforms': {
+          'ios': ['llama_cpp'],
+        },
+      };
+
+      final deviceSelected = selectNativeRuntimesForBundle(
+        bundle: 'ios-arm64',
+        rawUserConfig: rawUserConfig,
+        warn: (_) {},
+      );
+      final simulatorSelected = selectNativeRuntimesForBundle(
+        bundle: 'ios-arm64-sim',
+        rawUserConfig: rawUserConfig,
+        warn: (_) {},
+      );
+      final macosSelected = selectNativeRuntimesForBundle(
+        bundle: 'macos-arm64',
+        rawUserConfig: rawUserConfig,
+        warn: (_) {},
+      );
+
+      expect(deviceSelected, [nativeRuntimeLlamaCpp]);
+      expect(simulatorSelected, [nativeRuntimeLlamaCpp]);
+      expect(macosSelected, [nativeRuntimeLlamaCpp, nativeRuntimeLiteRtLm]);
+    });
+
+    test('uses exact target runtime override before OS-level config', () {
+      final rawUserConfig = {
+        'runtimes': ['llama_cpp', 'litert_lm'],
+        'platforms': {
+          'ios': ['llama_cpp'],
+          'ios-arm64': ['litert_lm'],
+        },
+      };
+
+      final deviceSelected = selectNativeRuntimesForBundle(
+        bundle: 'ios-arm64',
+        rawUserConfig: rawUserConfig,
+        warn: (_) {},
+      );
+      final simulatorSelected = selectNativeRuntimesForBundle(
+        bundle: 'ios-arm64-sim',
+        rawUserConfig: rawUserConfig,
+        warn: (_) {},
+      );
+
+      expect(deviceSelected, [nativeRuntimeLiteRtLm]);
+      expect(simulatorSelected, [nativeRuntimeLlamaCpp]);
+    });
+
+    test('supports direct OS runtime map shape', () {
+      final rawUserConfig = {
+        'ios': ['llama_cpp'],
+        'macos': ['litert_lm'],
+      };
+
+      final iosSelected = selectNativeRuntimesForBundle(
+        bundle: 'ios-arm64-sim',
+        rawUserConfig: rawUserConfig,
+        warn: (_) {},
+      );
+      final macosSelected = selectNativeRuntimesForBundle(
+        bundle: 'macos-x86_64',
+        rawUserConfig: rawUserConfig,
+        warn: (_) {},
+      );
+      final linuxSelected = selectNativeRuntimesForBundle(
+        bundle: 'linux-x64',
+        rawUserConfig: rawUserConfig,
+        warn: (_) {},
+      );
+
+      expect(iosSelected, [nativeRuntimeLlamaCpp]);
+      expect(macosSelected, [nativeRuntimeLiteRtLm]);
+      expect(linuxSelected, [nativeRuntimeLlamaCpp]);
     });
 
     test('supports map platform shape with runtimes key', () {

--- a/test/unit/tooling/macos_litert_lm_prepare_app_script_test.dart
+++ b/test/unit/tooling/macos_litert_lm_prepare_app_script_test.dart
@@ -18,7 +18,6 @@ void main() {
 
         final libDir = Directory(path.join(root.path, 'litert'))..createSync();
         await File(path.join(libDir.path, 'libLiteRtLm.dylib')).create();
-        await File(path.join(libDir.path, 'libStreamProxy.dylib')).create();
 
         final appDir = Directory(path.join(root.path, 'Test.app'));
         final result = await _runPrepareApp(appDir, libDir, arch: 'arm64');
@@ -40,7 +39,7 @@ void main() {
     );
 
     test(
-      'installs the full arm64 companion framework set',
+      'installs the full arm64 companion library set',
       () async {
         final root = await Directory.systemTemp.createTemp(
           'litert_prepare_full_',
@@ -59,22 +58,26 @@ void main() {
         expect(result.stdout, contains('Prepared LiteRT-LM macOS'));
 
         final frameworksDir = path.join(appDir.path, 'Contents', 'Frameworks');
-        for (final framework in _arm64Frameworks) {
-          final binaryPath = path.join(
-            frameworksDir,
-            '$framework.framework',
-            'Versions',
-            'A',
-            framework,
+        final runtimeDir = path.join(frameworksDir, 'LiteRtLmRuntime');
+        for (final library in _arm64Libraries) {
+          final libraryPath = path.join(runtimeDir, library);
+          expect(File(libraryPath).existsSync(), isTrue, reason: library);
+        }
+        for (final framework in _oldFrameworks) {
+          expect(
+            Directory(
+              path.join(frameworksDir, '$framework.framework'),
+            ).existsSync(),
+            isFalse,
+            reason: framework,
           );
-          expect(File(binaryPath).existsSync(), isTrue, reason: framework);
         }
       },
       skip: Platform.isWindows ? 'requires bash and POSIX symlinks' : false,
     );
 
     test(
-      'installs the x64 runtime framework set',
+      'installs the x64 runtime library set',
       () async {
         final root = await Directory.systemTemp.createTemp(
           'litert_prepare_x64_',
@@ -92,22 +95,30 @@ void main() {
         expect(result.exitCode, 0, reason: result.stderr.toString());
 
         final frameworksDir = path.join(appDir.path, 'Contents', 'Frameworks');
-        for (final framework in _x64Frameworks) {
-          final binaryPath = path.join(
-            frameworksDir,
-            '$framework.framework',
-            'Versions',
-            'A',
-            framework,
-          );
-          expect(File(binaryPath).existsSync(), isTrue, reason: framework);
+        final runtimeDir = path.join(frameworksDir, 'LiteRtLmRuntime');
+        for (final library in _x64Libraries) {
+          final libraryPath = path.join(runtimeDir, library);
+          expect(File(libraryPath).existsSync(), isTrue, reason: library);
         }
         expect(
-          Directory(
-            path.join(frameworksDir, 'LiteRtMetalAccelerator.framework'),
+          File(
+            path.join(
+              frameworksDir,
+              'LiteRtLmRuntime',
+              'libLiteRtMetalAccelerator.dylib',
+            ),
           ).existsSync(),
           isFalse,
         );
+        for (final framework in _oldFrameworks) {
+          expect(
+            Directory(
+              path.join(frameworksDir, '$framework.framework'),
+            ).existsSync(),
+            isFalse,
+            reason: framework,
+          );
+        }
       },
       skip: Platform.isWindows ? 'requires bash and POSIX symlinks' : false,
     );
@@ -137,10 +148,9 @@ const List<String> _arm64Libraries = [
   'libLiteRtTopKMetalSampler.dylib',
   'libLiteRtTopKWebGpuSampler.dylib',
   'libLiteRtWebGpuAccelerator.dylib',
-  'libStreamProxy.dylib',
 ];
 
-const List<String> _arm64Frameworks = [
+const List<String> _oldFrameworks = [
   'GemmaModelConstraintProvider',
   'LiteRt',
   'LiteRtLm',
@@ -148,12 +158,6 @@ const List<String> _arm64Frameworks = [
   'LiteRtTopKMetalSampler',
   'LiteRtTopKWebGpuSampler',
   'LiteRtWebGpuAccelerator',
-  'StreamProxy',
 ];
 
-const List<String> _x64Libraries = [
-  'libLiteRtLm.dylib',
-  'libStreamProxy.dylib',
-];
-
-const List<String> _x64Frameworks = ['LiteRtLm', 'StreamProxy'];
+const List<String> _x64Libraries = ['libLiteRtLm.dylib'];

--- a/tool/litert_lm_library_smoke.dart
+++ b/tool/litert_lm_library_smoke.dart
@@ -1,0 +1,77 @@
+import 'dart:convert';
+import 'dart:ffi';
+import 'dart:io';
+
+import 'package:llamadart/src/backends/litert_lm/litert_lm_runtime.dart'
+    as runtime;
+
+const _liteRtLmAssetId = 'package:llamadart/litert_lm_LiteRtLm';
+const _litertLmLibDirEnv = 'LLAMADART_LITERT_LM_LIB_DIR';
+const _requiredSymbols = <String>[
+  'litert_lm_engine_settings_create',
+  'litert_lm_engine_create',
+  'litert_lm_engine_delete',
+  'stream_proxy_create',
+  'stream_proxy_free_string',
+  'stream_proxy_delete',
+];
+
+void main() {
+  if (!_isSupportedHost()) {
+    stderr.writeln(
+      'LiteRT-LM library smoke does not support ${Abi.current()}.',
+    );
+    exitCode = 64;
+    return;
+  }
+
+  final opened = _openLiteRtLmLibrary();
+  final library = opened.library;
+  for (final symbol in _requiredSymbols) {
+    library.lookup<NativeFunction<Void Function()>>(symbol);
+  }
+
+  print(
+    'RESULT litert_lm_library ${jsonEncode({'abi': Abi.current().toString(), 'library': opened.path, 'symbols': _requiredSymbols})}',
+  );
+}
+
+bool _isSupportedHost() {
+  final abi = Abi.current();
+  return (Platform.isLinux && (abi == Abi.linuxX64 || abi == Abi.linuxArm64)) ||
+      (Platform.isWindows && abi == Abi.windowsX64);
+}
+
+({String path, DynamicLibrary library}) _openLiteRtLmLibrary() {
+  final envDir = Platform.environment[_litertLmLibDirEnv];
+  if (envDir != null && envDir.isNotEmpty) {
+    final primary = _primaryLibraryFileName();
+    if (primary == null) {
+      throw UnsupportedError('LiteRT-LM does not support ${Abi.current()}.');
+    }
+
+    for (final companion
+        in runtime
+            .liteRtLmRequiredLibrariesForAbi(Abi.current())
+            .where((library) => library != primary)) {
+      DynamicLibrary.open('$envDir/$companion');
+    }
+
+    final path = '$envDir/$primary';
+    return (path: path, library: DynamicLibrary.open(path));
+  }
+
+  return (
+    path: _liteRtLmAssetId,
+    library: DynamicLibrary.open(_liteRtLmAssetId),
+  );
+}
+
+String? _primaryLibraryFileName() {
+  final abi = Abi.current();
+  return switch (abi) {
+    Abi.linuxArm64 || Abi.linuxX64 => 'libLiteRtLm.so',
+    Abi.windowsX64 => 'LiteRtLm.dll',
+    _ => null,
+  };
+}

--- a/tool/macos_fair_litert_vs_llamadart.sh
+++ b/tool/macos_fair_litert_vs_llamadart.sh
@@ -40,8 +40,7 @@ echo "== LiteRT-LM Metal =="
     "$APP/Contents/Frameworks/LiteRtWebGpuAccelerator.framework" \
     "$APP/Contents/Frameworks/LiteRt.framework" \
     "$APP/Contents/Frameworks/LiteRtLm.framework" \
-    "$APP/Contents/Frameworks/GemmaModelConstraintProvider.framework" \
-    "$APP/Contents/Frameworks/StreamProxy.framework"
+    "$APP/Contents/Frameworks/GemmaModelConstraintProvider.framework"
 
   flutter build macos --debug \
     -t lib/litert_lm_benchmark_app.dart \

--- a/tool/macos_litert_lm_prepare_app.sh
+++ b/tool/macos_litert_lm_prepare_app.sh
@@ -4,6 +4,7 @@ set -euo pipefail
 ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 APP_PATH="${1:?usage: $0 /path/to/App.app}"
 FRAMEWORKS_DIR="$APP_PATH/Contents/Frameworks"
+RUNTIME_DIR="$FRAMEWORKS_DIR/LiteRtLmRuntime"
 
 resolve_litert_arch() {
   local arch="${LLAMADART_LITERT_LM_ARCH:-$(uname -m)}"
@@ -33,13 +34,11 @@ required_libraries() {
         "libLiteRtMetalAccelerator.dylib" \
         "libLiteRtTopKMetalSampler.dylib" \
         "libLiteRtTopKWebGpuSampler.dylib" \
-        "libLiteRtWebGpuAccelerator.dylib" \
-        "libStreamProxy.dylib"
+        "libLiteRtWebGpuAccelerator.dylib"
       ;;
     x64)
       printf '%s\n' \
-        "libLiteRtLm.dylib" \
-        "libStreamProxy.dylib"
+        "libLiteRtLm.dylib"
       ;;
   esac
 }
@@ -78,8 +77,8 @@ resolve_litert_dir() {
   fi
 
   local candidates=(
-    "$ROOT_DIR/.dart_tool/llamadart/litert_lm/0.12.0/macos_$LITERT_ARCH"
-    "$ROOT_DIR/.dart_tool/llamadart/litert_lm/0.12.0/macos/$LITERT_ARCH"
+    "$ROOT_DIR/.dart_tool/llamadart/litert_lm/0.13.1/macos_$LITERT_ARCH"
+    "$ROOT_DIR/.dart_tool/llamadart/litert_lm/0.13.1/macos/$LITERT_ARCH"
   )
   local candidate
   for candidate in "${candidates[@]}"; do
@@ -93,85 +92,42 @@ resolve_litert_dir() {
   exit 2
 }
 
-install_framework() {
-  local source_path="$1"
-  local framework_name="$2"
-  local binary_name="$3"
-  local framework_dir="$FRAMEWORKS_DIR/$framework_name.framework"
-  local version_dir="$framework_dir/Versions/A"
-  local resources_dir="$version_dir/Resources"
+sign_if_needed() {
+  local target="$1"
+  if ! file "$target" | grep -q "Mach-O"; then
+    return
+  fi
 
-  rm -rf "$framework_dir"
-  mkdir -p "$resources_dir"
-  cp "$source_path" "$version_dir/$binary_name"
-  chmod +x "$version_dir/$binary_name"
-  ln -s A "$framework_dir/Versions/Current"
-  ln -s Versions/Current/Resources "$framework_dir/Resources"
-  ln -s "Versions/Current/$binary_name" "$framework_dir/$binary_name"
-  cat > "$resources_dir/Info.plist" <<EOF
-<?xml version="1.0" encoding="UTF-8"?>
-<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
-<plist version="1.0">
-<dict>
-  <key>CFBundleExecutable</key>
-  <string>$binary_name</string>
-  <key>CFBundleIdentifier</key>
-  <string>com.llamadart.litertlm.$framework_name</string>
-  <key>CFBundleName</key>
-  <string>$framework_name</string>
-  <key>CFBundlePackageType</key>
-  <string>FMWK</string>
-  <key>CFBundleShortVersionString</key>
-  <string>1.0</string>
-  <key>CFBundleVersion</key>
-  <string>1</string>
-</dict>
-</plist>
-EOF
+  local identity="${EXPANDED_CODE_SIGN_IDENTITY:-${CODE_SIGN_IDENTITY:--}}"
+  if [[ -z "$identity" ]]; then
+    identity="-"
+  fi
+  codesign --force --sign "$identity" --timestamp=none "$target" >/dev/null
+}
+
+install_library() {
+  local library="$1"
+  local target="$RUNTIME_DIR/$library"
+
+  cp "$LITERT_DIR/$library" "$target"
+  chmod +x "$target"
+  sign_if_needed "$target"
 }
 
 LITERT_DIR="$(resolve_litert_dir)"
 
-install_framework \
-  "$LITERT_DIR/libLiteRtLm.dylib" \
-  "LiteRtLm" \
-  "LiteRtLm"
+rm -rf "$RUNTIME_DIR"
+mkdir -p "$RUNTIME_DIR"
 
-install_framework \
-  "$LITERT_DIR/libStreamProxy.dylib" \
-  "StreamProxy" \
-  "StreamProxy"
+install_library "libLiteRtLm.dylib"
 
 if [[ "$LITERT_ARCH" == "arm64" ]]; then
-  install_framework \
-    "$LITERT_DIR/libLiteRt.dylib" \
-    "LiteRt" \
-    "LiteRt"
-
-  install_framework \
-    "$LITERT_DIR/libLiteRtMetalAccelerator.dylib" \
-    "LiteRtMetalAccelerator" \
-    "LiteRtMetalAccelerator"
-
-  install_framework \
-    "$LITERT_DIR/libGemmaModelConstraintProvider.dylib" \
-    "GemmaModelConstraintProvider" \
-    "GemmaModelConstraintProvider"
-
-  install_framework \
-    "$LITERT_DIR/libLiteRtTopKMetalSampler.dylib" \
-    "LiteRtTopKMetalSampler" \
-    "LiteRtTopKMetalSampler"
-
-  install_framework \
-    "$LITERT_DIR/libLiteRtTopKWebGpuSampler.dylib" \
-    "LiteRtTopKWebGpuSampler" \
-    "LiteRtTopKWebGpuSampler"
-
-  install_framework \
-    "$LITERT_DIR/libLiteRtWebGpuAccelerator.dylib" \
-    "LiteRtWebGpuAccelerator" \
-    "LiteRtWebGpuAccelerator"
+  install_library "libLiteRt.dylib"
+  install_library "libLiteRtMetalAccelerator.dylib"
+  install_library "libGemmaModelConstraintProvider.dylib"
+  install_library "libLiteRtTopKMetalSampler.dylib"
+  install_library "libLiteRtTopKWebGpuSampler.dylib"
+  install_library "libLiteRtWebGpuAccelerator.dylib"
 fi
 
-echo "Prepared LiteRT-LM macOS companion frameworks in $FRAMEWORKS_DIR"
+echo "Prepared LiteRT-LM macOS runtime libraries in $RUNTIME_DIR"

--- a/tool/testing/test_matrix.dart
+++ b/tool/testing/test_matrix.dart
@@ -138,7 +138,9 @@ const List<TestMatrixRow> testMatrixRows = <TestMatrixRow>[
     id: 'litert-lm-engine-smoke',
     tier: 'targeted',
     mode: 'CI + local',
-    covers: 'real .litertlm load/generate path on LiteRT-LM CPU runtime',
+    covers:
+        'LiteRT-LM native library load in CI, plus real .litertlm '
+        'load/generate path when the smoke model is available',
     command:
         'CI workflow "LiteRT-LM Smoke", or dart run '
         'tool/litert_lm_engine_smoke.dart <model.litertlm> cpu '
@@ -223,7 +225,8 @@ const List<TestMatrixRow> testMatrixRows = <TestMatrixRow>[
     tier: 'platform',
     mode: 'CI + local',
     covers:
-        'Linux x64 root VM tests, real GGUF prompt reuse, LiteRT-LM CPU smoke',
+        'Linux x64 root VM tests, real GGUF prompt reuse, LiteRT-LM native '
+        'library smoke, and opportunistic LiteRT-LM CPU engine smoke',
     command:
         'CI jobs "Test Linux & Web (with Coverage)", '
         '"Native Prompt Reuse Parity", and '
@@ -246,7 +249,9 @@ const List<TestMatrixRow> testMatrixRows = <TestMatrixRow>[
     id: 'windows-x64-ci-runtime',
     tier: 'platform',
     mode: 'CI + local',
-    covers: 'Windows x64 VM tests, hook bundle validation, LiteRT-LM CPU smoke',
+    covers:
+        'Windows x64 VM tests, hook bundle validation, LiteRT-LM native '
+        'library smoke, and opportunistic LiteRT-LM CPU engine smoke',
     command:
         'CI jobs "Test Native (windows-latest)" and '
         '"LiteRT-LM Smoke / Native smoke (windows-latest)".',

--- a/website/docs/examples/chat-app.md
+++ b/website/docs/examples/chat-app.md
@@ -20,6 +20,11 @@ flutter run
 If you run this example on iOS, set the project deployment target to `16.4` or
 newer before building.
 
+This example intentionally opts into both native runtime families in
+`pubspec.yaml` so native `.litertlm` presets work on supported targets. If your
+app only ships GGUF models, set `llamadart_native_runtimes` to `[llama_cpp]` to
+avoid bundling LiteRT-LM.
+
 ## Test
 
 ```bash
@@ -49,6 +54,9 @@ flutter test
 - Runtime-verified multimodal capability gating after `mmproj` load. The app
   hides unsupported attachment types even if a model family advertises broader
   multimodal support.
+- Native and web `.litertlm` routing through LiteRT-LM. Native LiteRT-LM is
+  enabled for supported targets; iOS x86_64 simulator and Windows arm64 remain
+  GGUF-only because no matching LiteRT-LM native bundle is published.
 
 ## Gemma 4 note
 

--- a/website/docs/examples/overview.md
+++ b/website/docs/examples/overview.md
@@ -28,3 +28,6 @@ The repository ships multiple examples for different integration styles.
 - Flutter SDK `>= 3.38.0` for Flutter examples
 - iOS example builds require a minimum deployment target of `16.4` or newer
 - Internet on first run (runtime bundle resolution)
+- The Chat App opts into both `llama_cpp` and `litert_lm` native runtime
+  families because it demonstrates GGUF and `.litertlm` models. The smaller
+  examples stay on the package defaults.

--- a/website/docs/guides/backend-selection.md
+++ b/website/docs/guides/backend-selection.md
@@ -84,10 +84,10 @@ bundle keys, module availability, and selector names.
 
 ## Package Size Controls
 
-Native apps include both runtime families by default where available, so one
-build can load GGUF and `.litertlm` models. If your app only ships one model
-format, opt into the matching runtime family with
-`llamadart_native_runtimes`:
+Android native apps include both runtime families by default where available, so
+one build can load GGUF and `.litertlm` models. Other native targets default to
+`llama_cpp` only. Use `llamadart_native_runtimes` when your app needs a
+different package-size / model-format tradeoff:
 
 ```yaml
 hooks:
@@ -108,6 +108,11 @@ hooks:
 `llamadart_native_backends` is a different switch: it filters llama.cpp module
 files such as Vulkan, CUDA, OpenCL, BLAS, and HIP inside the `llama_cpp`
 runtime. It does not enable or disable LiteRT-LM.
+
+`llamadart_native_runtimes` can also be configured per OS (`ios`, `macos`,
+`android`, `linux`, `windows`) or per exact target (`android-arm64`,
+`linux-x64`, etc.); exact target keys override OS keys. Use `all` or `both` to
+include every runtime family for a target.
 
 ## Parameter Differences
 

--- a/website/docs/platforms/native-build-hooks.md
+++ b/website/docs/platforms/native-build-hooks.md
@@ -51,8 +51,9 @@ GitHub Releases:
 - `leehack/llamadart-native` for llama.cpp / GGUF runtime libraries.
 - `leehack/litert-lm-native` for LiteRT-LM / `.litertlm` runtime libraries.
 
-Native builds include both runtime families by default when the target platform
-has both. Apps that only ship one model format can reduce package size with
+Android native builds include both runtime families by default when available.
+Other native targets default to `llama_cpp` only. Apps can enable LiteRT-LM on
+desktop/iOS, or reduce package size when they only ship one model format, with
 `hooks.user_defines.llamadart.llamadart_native_runtimes`:
 
 ```yaml
@@ -62,7 +63,8 @@ hooks:
       llamadart_native_runtimes: [llama_cpp] # or [litert_lm]
 ```
 
-The value can also be a per-platform map:
+The value can also be a per-OS or exact-target map. Exact target keys override
+OS keys:
 
 ```yaml
 hooks:
@@ -71,12 +73,15 @@ hooks:
       llamadart_native_runtimes:
         runtimes: [llama_cpp, litert_lm]
         platforms:
+          ios: [llama_cpp]
+          macos: [llama_cpp, litert_lm]
           android-arm64: [litert_lm]
           linux-x64: [llama_cpp]
 ```
 
 Use `llamadart_native_backends` separately to filter llama.cpp modules such as
 Vulkan, CUDA, OpenCL, BLAS, and HIP inside the `llama_cpp` runtime family.
+Use `all` or `both` to include every runtime family for a target.
 
 ### 3. Dynamic Linking
 Using `native_assets_cli`, the downloaded dynamic libraries (`.so`, `.dylib`,
@@ -91,10 +96,11 @@ The hook validates the full expected companion set after extraction so missing
 or stale `litert-lm-native` archives fail during the build rather than later at
 engine creation.
 
-On macOS, LiteRT-LM dylibs are staged as app-bundle frameworks instead of
-opened directly from `.dart_tool`, because sandboxed apps cannot open arbitrary
-files from the build cache. The example chat app includes an Xcode build phase
-that calls `tool/macos_litert_lm_prepare_app.sh` after Flutter embeds its
+On macOS, LiteRT-LM dylibs are copied into
+`Contents/Frameworks/LiteRtLmRuntime` instead of reported as native assets,
+because Flutter's macOS bundler can rewrite install names in a way the upstream
+dylibs do not tolerate. The example chat app includes an Xcode build phase that
+calls `tool/macos_litert_lm_prepare_app.sh` after Flutter embeds its
 frameworks.
 
 ### 4. Validation and fallback safeguards
@@ -106,9 +112,9 @@ frameworks.
   to defaults.
 - On `windows-x64`, the hook additionally validates CUDA/BLAS runtime
   dependencies before accepting a bundle.
-- LiteRT-LM archives are checksum-pinned separately from llama.cpp archives and
-  use a cache marker so stale extracted runtimes are re-extracted when the
-  pinned release digest changes.
+- LiteRT-LM archives are validated after extraction by checking the required
+  runtime libraries; corrupt or incomplete cached archives are refreshed before
+  the build continues.
 
 ## The `llamadart-native` Bridge Repo
 

--- a/website/docs/platforms/support-matrix.md
+++ b/website/docs/platforms/support-matrix.md
@@ -8,7 +8,7 @@ backend-module configuration for
 `llamadart`.
 
 The native-assets hook currently pins `llamadart-native` tag `b9371` and
-`litert-lm-native` release `v0.12.0` (`hook/build.dart`). Apps can override the
+`litert-lm-native` release `v0.13.1` (`hook/build.dart`). Apps can override the
 llama.cpp native GitHub source with
 `hooks.user_defines.llamadart.llamadart_native_tag` and
 `hooks.user_defines.llamadart.llamadart_native_repository`, or use a local
@@ -79,9 +79,10 @@ bundled:
 - `llama_cpp`: GGUF model support through llama.cpp.
 - `litert_lm`: `.litertlm` model support through LiteRT-LM.
 
-The default is both runtime families where the target platform has both. This
-maximizes format compatibility, but apps that only ship one model format can
-trim package size:
+Android defaults to both runtime families where available. Other native targets
+default to `llama_cpp` only; opt into `litert_lm` when those apps ship
+`.litertlm` bundles. Apps that only ship one model format can also trim package
+size:
 
 ```yaml
 hooks:
@@ -90,7 +91,8 @@ hooks:
       llamadart_native_runtimes: [llama_cpp]
 ```
 
-Per-platform overrides use the same bundle keys as the tables on this page:
+Per-platform overrides can use OS keys or the exact bundle keys from the tables
+on this page. Exact target keys override OS keys:
 
 ```yaml
 hooks:
@@ -99,16 +101,19 @@ hooks:
       llamadart_native_runtimes:
         runtimes: [llama_cpp, litert_lm]
         platforms:
+          ios: [llama_cpp]
+          macos: [llama_cpp, litert_lm]
           android-arm64: [litert_lm]
           linux-x64: [llama_cpp]
 ```
 
 Accepted aliases include `llama.cpp`, `gguf`, `litert`, and `litert-lm`.
+Use `all` or `both` to include every runtime family for a target.
 Explicitly selecting `litert_lm` for a target without a pinned LiteRT-LM
 runtime fails during the build hook instead of producing an app that cannot
 load `.litertlm` models.
 
-## LiteRT-LM runtime coverage (`v0.12.0`)
+## LiteRT-LM runtime coverage (`v0.13.1`)
 
 | Platform target | LiteRT-LM bundle key | Selectable backends | Status |
 | --- | --- | --- | --- |
@@ -116,7 +121,7 @@ load `.litertlm` models.
 | Android x64 | `android-x64` | `cpu`, `gpu`, `npu` | Supported for emulator/test targets |
 | iOS arm64 (device) | `ios-arm64` | `cpu` | Supported |
 | iOS arm64 (simulator) | `ios-arm64-sim` | `cpu` | Supported |
-| iOS x86_64 (simulator) | `ios-x64-sim` | `cpu` | Supported |
+| iOS x86_64 (simulator) | Not published | N/A | Unsupported; exclude `litert_lm` for this target |
 | macOS arm64 | `macos-arm64` | `cpu`, `gpu` | Supported |
 | macOS x86_64 | `macos-x64` | `cpu`, `gpu` | Supported |
 | Linux arm64 | `linux-arm64` | `cpu` | Supported |
@@ -264,7 +269,8 @@ no valid entries remain, selection falls back to `cpu_profile` (or default
 
 - Configurable targets start from defaults (`cpu`, `vulkan`) if available.
 - `llamadart_native_runtimes` controls whole native runtime families:
-  `llama_cpp`, `litert_lm`, or both.
+  `llama_cpp`, `litert_lm`, or both. Android defaults to both families; other
+  native targets default to `llama_cpp` only.
 - `llamadart_native_backends` controls only llama.cpp module files inside
   `llama_cpp`; it does not affect LiteRT-LM assets.
 - `cpu` is auto-added as fallback when present in the bundle.
@@ -285,7 +291,8 @@ no valid entries remain, selection falls back to `cpu_profile` (or default
   consolidated.
 - Sandboxed macOS apps must stage LiteRT-LM companion dylibs inside the app
   bundle. The example chat app does this with the
-  `Prepare LiteRT-LM Frameworks` Xcode build phase.
+  `Prepare LiteRT-LM Runtime` Xcode build phase, which copies dylibs into
+  `Contents/Frameworks/LiteRtLmRuntime`.
 - `windows-x64` performs extra runtime dependency validation:
   - `cuda` requires `cudart` and `cublas` DLLs.
   - `blas` requires OpenBLAS DLL.

--- a/website/versioned_docs/version-0.7.0/examples/chat-app.md
+++ b/website/versioned_docs/version-0.7.0/examples/chat-app.md
@@ -20,6 +20,11 @@ flutter run
 If you run this example on iOS, set the project deployment target to `16.4` or
 newer before building.
 
+This example intentionally opts into both native runtime families in
+`pubspec.yaml` so native `.litertlm` presets work on supported targets. If your
+app only ships GGUF models, set `llamadart_native_runtimes` to `[llama_cpp]` to
+avoid bundling LiteRT-LM.
+
 ## Test
 
 ```bash
@@ -49,6 +54,9 @@ flutter test
 - Runtime-verified multimodal capability gating after `mmproj` load. The app
   hides unsupported attachment types even if a model family advertises broader
   multimodal support.
+- Native and web `.litertlm` routing through LiteRT-LM. Native LiteRT-LM is
+  enabled for supported targets; iOS x86_64 simulator and Windows arm64 remain
+  GGUF-only because no matching LiteRT-LM native bundle is published.
 
 ## Gemma 4 note
 

--- a/website/versioned_docs/version-0.7.0/examples/overview.md
+++ b/website/versioned_docs/version-0.7.0/examples/overview.md
@@ -28,3 +28,6 @@ The repository ships multiple examples for different integration styles.
 - Flutter SDK `>= 3.38.0` for Flutter examples
 - iOS example builds require a minimum deployment target of `16.4` or newer
 - Internet on first run (runtime bundle resolution)
+- The Chat App opts into both `llama_cpp` and `litert_lm` native runtime
+  families because it demonstrates GGUF and `.litertlm` models. The smaller
+  examples stay on the package defaults.

--- a/website/versioned_docs/version-0.7.0/guides/backend-selection.md
+++ b/website/versioned_docs/version-0.7.0/guides/backend-selection.md
@@ -84,10 +84,10 @@ bundle keys, module availability, and selector names.
 
 ## Package Size Controls
 
-Native apps include both runtime families by default where available, so one
-build can load GGUF and `.litertlm` models. If your app only ships one model
-format, opt into the matching runtime family with
-`llamadart_native_runtimes`:
+Android native apps include both runtime families by default where available, so
+one build can load GGUF and `.litertlm` models. Other native targets default to
+`llama_cpp` only. Use `llamadart_native_runtimes` when your app needs a
+different package-size / model-format tradeoff:
 
 ```yaml
 hooks:
@@ -108,6 +108,11 @@ hooks:
 `llamadart_native_backends` is a different switch: it filters llama.cpp module
 files such as Vulkan, CUDA, OpenCL, BLAS, and HIP inside the `llama_cpp`
 runtime. It does not enable or disable LiteRT-LM.
+
+`llamadart_native_runtimes` can also be configured per OS (`ios`, `macos`,
+`android`, `linux`, `windows`) or per exact target (`android-arm64`,
+`linux-x64`, etc.); exact target keys override OS keys. Use `all` or `both` to
+include every runtime family for a target.
 
 ## Parameter Differences
 

--- a/website/versioned_docs/version-0.7.0/platforms/native-build-hooks.md
+++ b/website/versioned_docs/version-0.7.0/platforms/native-build-hooks.md
@@ -51,8 +51,9 @@ GitHub Releases:
 - `leehack/llamadart-native` for llama.cpp / GGUF runtime libraries.
 - `leehack/litert-lm-native` for LiteRT-LM / `.litertlm` runtime libraries.
 
-Native builds include both runtime families by default when the target platform
-has both. Apps that only ship one model format can reduce package size with
+Android native builds include both runtime families by default when available.
+Other native targets default to `llama_cpp` only. Apps can enable LiteRT-LM on
+desktop/iOS, or reduce package size when they only ship one model format, with
 `hooks.user_defines.llamadart.llamadart_native_runtimes`:
 
 ```yaml
@@ -62,7 +63,8 @@ hooks:
       llamadart_native_runtimes: [llama_cpp] # or [litert_lm]
 ```
 
-The value can also be a per-platform map:
+The value can also be a per-OS or exact-target map. Exact target keys override
+OS keys:
 
 ```yaml
 hooks:
@@ -71,12 +73,15 @@ hooks:
       llamadart_native_runtimes:
         runtimes: [llama_cpp, litert_lm]
         platforms:
+          ios: [llama_cpp]
+          macos: [llama_cpp, litert_lm]
           android-arm64: [litert_lm]
           linux-x64: [llama_cpp]
 ```
 
 Use `llamadart_native_backends` separately to filter llama.cpp modules such as
 Vulkan, CUDA, OpenCL, BLAS, and HIP inside the `llama_cpp` runtime family.
+Use `all` or `both` to include every runtime family for a target.
 
 ### 3. Dynamic Linking
 Using `native_assets_cli`, the downloaded dynamic libraries (`.so`, `.dylib`,
@@ -91,10 +96,11 @@ The hook validates the full expected companion set after extraction so missing
 or stale `litert-lm-native` archives fail during the build rather than later at
 engine creation.
 
-On macOS, LiteRT-LM dylibs are staged as app-bundle frameworks instead of
-opened directly from `.dart_tool`, because sandboxed apps cannot open arbitrary
-files from the build cache. The example chat app includes an Xcode build phase
-that calls `tool/macos_litert_lm_prepare_app.sh` after Flutter embeds its
+On macOS, LiteRT-LM dylibs are copied into
+`Contents/Frameworks/LiteRtLmRuntime` instead of reported as native assets,
+because Flutter's macOS bundler can rewrite install names in a way the upstream
+dylibs do not tolerate. The example chat app includes an Xcode build phase that
+calls `tool/macos_litert_lm_prepare_app.sh` after Flutter embeds its
 frameworks.
 
 ### 4. Validation and fallback safeguards
@@ -106,9 +112,9 @@ frameworks.
   to defaults.
 - On `windows-x64`, the hook additionally validates CUDA/BLAS runtime
   dependencies before accepting a bundle.
-- LiteRT-LM archives are checksum-pinned separately from llama.cpp archives and
-  use a cache marker so stale extracted runtimes are re-extracted when the
-  pinned release digest changes.
+- LiteRT-LM archives are validated after extraction by checking the required
+  runtime libraries; corrupt or incomplete cached archives are refreshed before
+  the build continues.
 
 ## The `llamadart-native` Bridge Repo
 

--- a/website/versioned_docs/version-0.7.0/platforms/support-matrix.md
+++ b/website/versioned_docs/version-0.7.0/platforms/support-matrix.md
@@ -8,7 +8,7 @@ backend-module configuration for
 `llamadart`.
 
 The native-assets hook currently pins `llamadart-native` tag `b9371` and
-`litert-lm-native` release `v0.12.0` (`hook/build.dart`). Apps can override the
+`litert-lm-native` release `v0.13.1` (`hook/build.dart`). Apps can override the
 llama.cpp native GitHub source with
 `hooks.user_defines.llamadart.llamadart_native_tag` and
 `hooks.user_defines.llamadart.llamadart_native_repository`, or use a local
@@ -79,9 +79,10 @@ bundled:
 - `llama_cpp`: GGUF model support through llama.cpp.
 - `litert_lm`: `.litertlm` model support through LiteRT-LM.
 
-The default is both runtime families where the target platform has both. This
-maximizes format compatibility, but apps that only ship one model format can
-trim package size:
+Android defaults to both runtime families where available. Other native targets
+default to `llama_cpp` only; opt into `litert_lm` when those apps ship
+`.litertlm` bundles. Apps that only ship one model format can also trim package
+size:
 
 ```yaml
 hooks:
@@ -90,7 +91,8 @@ hooks:
       llamadart_native_runtimes: [llama_cpp]
 ```
 
-Per-platform overrides use the same bundle keys as the tables on this page:
+Per-platform overrides can use OS keys or the exact bundle keys from the tables
+on this page. Exact target keys override OS keys:
 
 ```yaml
 hooks:
@@ -99,16 +101,19 @@ hooks:
       llamadart_native_runtimes:
         runtimes: [llama_cpp, litert_lm]
         platforms:
+          ios: [llama_cpp]
+          macos: [llama_cpp, litert_lm]
           android-arm64: [litert_lm]
           linux-x64: [llama_cpp]
 ```
 
 Accepted aliases include `llama.cpp`, `gguf`, `litert`, and `litert-lm`.
+Use `all` or `both` to include every runtime family for a target.
 Explicitly selecting `litert_lm` for a target without a pinned LiteRT-LM
 runtime fails during the build hook instead of producing an app that cannot
 load `.litertlm` models.
 
-## LiteRT-LM runtime coverage (`v0.12.0`)
+## LiteRT-LM runtime coverage (`v0.13.1`)
 
 | Platform target | LiteRT-LM bundle key | Selectable backends | Status |
 | --- | --- | --- | --- |
@@ -116,7 +121,7 @@ load `.litertlm` models.
 | Android x64 | `android-x64` | `cpu`, `gpu`, `npu` | Supported for emulator/test targets |
 | iOS arm64 (device) | `ios-arm64` | `cpu` | Supported |
 | iOS arm64 (simulator) | `ios-arm64-sim` | `cpu` | Supported |
-| iOS x86_64 (simulator) | `ios-x64-sim` | `cpu` | Supported |
+| iOS x86_64 (simulator) | Not published | N/A | Unsupported; exclude `litert_lm` for this target |
 | macOS arm64 | `macos-arm64` | `cpu`, `gpu` | Supported |
 | macOS x86_64 | `macos-x64` | `cpu`, `gpu` | Supported |
 | Linux arm64 | `linux-arm64` | `cpu` | Supported |
@@ -264,7 +269,8 @@ no valid entries remain, selection falls back to `cpu_profile` (or default
 
 - Configurable targets start from defaults (`cpu`, `vulkan`) if available.
 - `llamadart_native_runtimes` controls whole native runtime families:
-  `llama_cpp`, `litert_lm`, or both.
+  `llama_cpp`, `litert_lm`, or both. Android defaults to both families; other
+  native targets default to `llama_cpp` only.
 - `llamadart_native_backends` controls only llama.cpp module files inside
   `llama_cpp`; it does not affect LiteRT-LM assets.
 - `cpu` is auto-added as fallback when present in the bundle.
@@ -285,7 +291,8 @@ no valid entries remain, selection falls back to `cpu_profile` (or default
   consolidated.
 - Sandboxed macOS apps must stage LiteRT-LM companion dylibs inside the app
   bundle. The example chat app does this with the
-  `Prepare LiteRT-LM Frameworks` Xcode build phase.
+  `Prepare LiteRT-LM Runtime` Xcode build phase, which copies dylibs into
+  `Contents/Frameworks/LiteRtLmRuntime`.
 - `windows-x64` performs extra runtime dependency validation:
   - `cuda` requires `cudart` and `cublas` DLLs.
   - `blas` requires OpenBLAS DLL.


### PR DESCRIPTION
## Summary

- Update the LiteRT-LM native runtime pin to `leehack/litert-lm-native@v0.13.1`, where StreamProxy is merged into the LiteRT-LM artifacts instead of shipped as standalone libraries.
- Stop emitting macOS LiteRT-LM dylibs as Flutter native assets; keep them in the hook cache and copy/sign the original upstream dylibs into `Contents/Frameworks/LiteRtLmRuntime` for app bundles.
- Update the native runtime loader to prefer app-local macOS LiteRT-LM libraries, then cache/framework fallbacks.
- Simplify the LiteRT-LM hook metadata: derive archive names, release URLs, cache paths, and archive source prefixes from the bundle key, and validate caches by required libraries instead of maintaining per-archive SHA-256 markers.
- Add OS-level `llamadart_native_runtimes` overrides (`ios`, `macos`, `android`, `linux`, `windows`) with exact target keys taking precedence, and document the package-size config path.

## Validation

- `dart test test/unit/hook/build_hook_integration_test.dart test/unit/hook/build_hook_litert_lm_integration_test.dart test/unit/hook/native_bundle_config_test.dart`
- `dart test test/unit/backends/litert_lm/litert_lm_runtime_test.dart test/unit/tooling/macos_litert_lm_prepare_app_script_test.dart`
- `dart analyze`

Additional macOS runtime validation performed before the final parser/docs/hook-metadata extension:

- `dart run tool/macos_litert_lm_engine_smoke.dart .dart_tool/litert_lm_models/gemma-4-E2B-it.litertlm gpu`
- `flutter test --run-skipped -t local-only integration_test/litert_lm_chat_service_e2e_test.dart -d macos --dart-define=LITERT_LM_MODEL_URL=http://127.0.0.1:8765/gemma-4-E2B-it.litertlm --dart-define=LITERT_LM_E2E_BACKEND=cpu`
- `flutter test --run-skipped -t local-only integration_test/litert_lm_chat_service_e2e_test.dart -d macos --dart-define=LITERT_LM_MODEL_URL=http://127.0.0.1:8765/gemma-4-E2B-it.litertlm --dart-define=LITERT_LM_E2E_BACKEND=auto`
- `codesign --verify --deep --strict --verbose=2 build/macos/Build/Products/Debug/llamadart_chat_example.app`
