### PR TITLE
Prepare 0.7.1 release

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -90,7 +90,31 @@ jobs:
       - name: Install Coverage tool
         run: dart pub global activate coverage
 
+      - name: Cache tiny GGUF test model
+        id: tiny-gguf-cache
+        uses: actions/cache@v5
+        with:
+          path: .dart_tool/test_models/stories15M.gguf
+          key: tiny-gguf-stories15M-${{ runner.os }}-v1
+
+      - name: Download tiny GGUF test model
+        if: steps.tiny-gguf-cache.outputs.cache-hit != 'true'
+        shell: bash
+        env:
+          HF_TOKEN: ${{ secrets.HF_TOKEN }}
+        run: |
+          mkdir -p .dart_tool/test_models
+          curl_args=(--fail --location --retry 8 --retry-all-errors --retry-delay 10)
+          if [[ -n "${HF_TOKEN:-}" ]]; then
+            curl_args+=(--header "Authorization: Bearer $HF_TOKEN")
+          fi
+          curl "${curl_args[@]}" \
+            "https://huggingface.co/ggml-org/tiny-llamas/resolve/main/stories15M.gguf" \
+            --output .dart_tool/test_models/stories15M.gguf
+
       - name: Run VM tests (with coverage)
+        env:
+          LLAMADART_TEST_MODELS_DIR: ${{ github.workspace }}/.dart_tool/test_models
         run: dart test -p vm -j 1 --exclude-tags local-only --coverage=coverage
 
       - name: Format coverage
@@ -158,9 +182,32 @@ jobs:
       - name: Install dependencies
         run: flutter pub get
 
+      - name: Cache tiny GGUF test model
+        id: tiny-gguf-cache
+        uses: actions/cache@v5
+        with:
+          path: .dart_tool/test_models/stories15M.gguf
+          key: tiny-gguf-stories15M-${{ runner.os }}-v1
+
+      - name: Download tiny GGUF test model
+        if: steps.tiny-gguf-cache.outputs.cache-hit != 'true'
+        shell: bash
+        env:
+          HF_TOKEN: ${{ secrets.HF_TOKEN }}
+        run: |
+          mkdir -p .dart_tool/test_models
+          curl_args=(--fail --location --retry 8 --retry-all-errors --retry-delay 10)
+          if [[ -n "${HF_TOKEN:-}" ]]; then
+            curl_args+=(--header "Authorization: Bearer $HF_TOKEN")
+          fi
+          curl "${curl_args[@]}" \
+            "https://huggingface.co/ggml-org/tiny-llamas/resolve/main/stories15M.gguf" \
+            --output .dart_tool/test_models/stories15M.gguf
+
       - name: Run native tests
         env:
           GGML_METAL_DEVICES: "0"
+          LLAMADART_TEST_MODELS_DIR: ${{ github.workspace }}/.dart_tool/test_models
         run: dart test -p vm -j 1 --exclude-tags local-only
 
   native-prompt-reuse-parity:

--- a/.pubignore
+++ b/.pubignore
@@ -34,6 +34,7 @@ third_party/bin/
 third_party/build-*/
 third_party/llama_cpp/
 third_party/Vulkan-Headers/
+darwin/llamadart/Artifacts/
 
 # Local bridge build/fetch outputs
 webgpu_bridge/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,21 +1,27 @@
-## Unreleased
+## 0.7.1
 
-* Added Flutter iOS/macOS Swift Package Manager integration for Apple native
-  runtimes. Flutter Apple apps now link the pinned `leehack/llamadart-native`
-  and `leehack/litert-lm-native` XCFramework artifacts through
-  `darwin/llamadart/Package.swift`.
-* Raised the Flutter Apple runtime floors to iOS 16.4 and macOS 14.0 to match
-  the published Apple XCFramework artifacts.
-* Disabled the legacy hook-managed Apple bundle path for Flutter iOS/macOS
-  builds so downstream App Store uploads no longer see wrapper/framework
-  `MinimumOSVersion` mismatches. Standalone Dart macOS keeps the native-assets
-  dylib fallback for compatibility.
-* Changed native build-hook defaults so Android continues to include both
-  `llama_cpp` and `litert_lm`, while iOS, macOS, Linux, and Windows default to
-  `llama_cpp` only. Apps that ship `.litertlm` models on non-Android native
-  targets should opt in with `llamadart_native_runtimes`.
-* Added native release pin automation so the maintainer sync workflow updates
-  Apple SPM checksums from the published native release asset digests.
+* **Apple native runtime packaging**:
+  * Added Flutter iOS/macOS Swift Package Manager integration so Apple apps link
+    the pinned `leehack/llamadart-native` and `leehack/litert-lm-native`
+    XCFramework artifacts through `darwin/llamadart/Package.swift`.
+  * Disabled the legacy hook-managed Apple bundle path for Flutter iOS/macOS
+    builds, avoiding wrapper/framework `MinimumOSVersion` mismatches in App
+    Store uploads. Standalone Dart macOS keeps the native-assets dylib fallback.
+  * Raised the Flutter Apple runtime floors to iOS 16.4 and macOS 14.0 to match
+    the published XCFramework artifacts.
+* **Runtime defaults and release automation**:
+  * Android native builds still include both `llama_cpp` and `litert_lm` by
+    default; iOS, macOS, Linux, and Windows now default to `llama_cpp` only.
+  * Added native release pin automation so the maintainer sync workflow updates
+    Apple SPM checksums from published native release asset digests.
+* **CI reliability**:
+  * Cached and retried tiny GGUF test-model downloads used by VM integration
+    tests so main-branch CI is less exposed to Hugging Face 429 rate limits.
+  * Excluded local SwiftPM artifact caches from pub archives; Flutter Apple
+    consumers still resolve the published remote XCFramework targets.
+* **Compatibility note**: no Dart API breaking changes. Flutter Apple apps must
+  target iOS 16.4/macOS 14.0 or newer, and non-Android native apps that ship
+  `.litertlm` models should opt in with `llamadart_native_runtimes`.
 
 ## 0.7.0
 

--- a/README.md
+++ b/README.md
@@ -26,7 +26,8 @@ JavaScript runtime.
   and web runtimes.
 - 🧩 **Model Format Routing**: `LlamaBackend()` loads GGUF models with
   llama.cpp and `.litertlm` bundles with LiteRT-LM on native and web targets.
-- 🛠️ **Zero Configuration**: Uses Pure Native Assets; no manual CMake or platform project edits.
+- 🛠️ **Zero Configuration**: Uses native assets and SwiftPM-managed Apple
+  XCFrameworks; no manual C++ build setup is required.
 - 📱 **Cross-Platform**: Android, iOS, macOS, Linux, Windows, and web.
 - ⚡ **GPU Acceleration**:
   - Apple: Metal
@@ -51,20 +52,21 @@ JavaScript runtime.
 
 ```yaml
 dependencies:
-  llamadart: ^0.7.0
+  llamadart: ^0.7.1
 ```
 
 ### 2. Run with defaults
 
 On first `dart run` / `flutter run`, `llamadart` will:
 1. Detect platform/architecture.
-2. Download the matching native runtime bundles from [`leehack/llamadart-native`](https://github.com/leehack/llamadart-native) and [`leehack/litert-lm-native`](https://github.com/leehack/litert-lm-native).
-3. Wire it into your app via native assets.
+2. Resolve matching native runtimes from [`leehack/llamadart-native`](https://github.com/leehack/llamadart-native) and [`leehack/litert-lm-native`](https://github.com/leehack/litert-lm-native).
+3. Wire them into your app through native assets, or through SwiftPM-linked
+   XCFrameworks for Flutter iOS/macOS builds.
 
 No manual binary download or C++ build steps are required.
 
-> iOS builds require a minimum deployment target of `16.4` or newer in your
-> Xcode project settings. If your app still uses CocoaPods, set the Podfile
+> Flutter Apple builds require deployment targets of iOS `16.4` or newer and
+> macOS `14.0` or newer. If an iOS app still uses CocoaPods, set the Podfile
 > platform to `16.4` or newer too.
 
 ### 3. Optional: choose native runtimes for package size

--- a/example/README.md
+++ b/example/README.md
@@ -207,7 +207,8 @@ example/
 
 - Dart SDK 3.10.7 or higher
 - For chat_app: Flutter 3.38.0 or higher
-- iOS builds require a minimum deployment target of 16.4 or newer
+- Flutter Apple builds require deployment targets of iOS 16.4 or newer and
+  macOS 14.0 or newer
 - Internet connection (for first run - downloads selected native runtime
   libraries)
 - At least 2GB RAM minimum, 4GB+ recommended

--- a/example/chat_app/README.md
+++ b/example/chat_app/README.md
@@ -28,8 +28,8 @@ flutter pub get
 flutter run
 ```
 
-If you run this app on iOS, set the Xcode project deployment target to `16.4`
-or newer first.
+If you run this app on Apple platforms, set the Xcode project deployment target
+to iOS `16.4` or macOS `14.0` or newer first.
 
 Unlike the smaller GGUF-only examples, this app intentionally opts into both
 native runtime families in `pubspec.yaml` so native `.litertlm` presets work on

--- a/example/chat_app/pubspec.lock
+++ b/example/chat_app/pubspec.lock
@@ -349,7 +349,7 @@ packages:
       path: "../.."
       relative: true
     source: path
-    version: "0.7.0"
+    version: "0.7.1"
   logging:
     dependency: transitive
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: llamadart
 description: Dart and Flutter local LLM inference with llama.cpp GGUF and LiteRT-LM across native platforms and web.
-version: 0.7.0
+version: 0.7.1
 homepage: https://github.com/leehack/llamadart
 repository: https://github.com/leehack/llamadart
 issue_tracker: https://github.com/leehack/llamadart/issues

--- a/test/integration/inference_smoke_test.dart
+++ b/test/integration/inference_smoke_test.dart
@@ -5,10 +5,9 @@ library;
 import 'dart:io';
 import 'dart:typed_data';
 import 'package:test/test.dart';
-import 'package:path/path.dart' as path;
-import 'package:http/http.dart' as http;
 import 'package:llamadart/llamadart.dart';
 import 'package:llamadart/src/backends/llama_cpp/llama_cpp_service.dart';
+import '../test_helper.dart';
 
 void main() {
   group('Inference Smoke Test (Desktop)', () {
@@ -22,31 +21,15 @@ void main() {
         LlamaCppService().setLogLevel(LlamaLogLevel.info);
         print('Backends: ${LlamaCppService().getBackendInfo()}');
 
-        // 2. Download Tiny Model
-        final modelUrl =
-            'https://huggingface.co/ggml-org/tiny-llamas/resolve/main/stories15M.gguf';
-        final dataDir = Directory(path.join(Directory.current.path, 'models'));
-        if (!dataDir.existsSync()) dataDir.createSync(recursive: true);
-
-        final modelPath = path.join(dataDir.path, 'test_model.gguf');
-        final modelFile = File(modelPath);
-
-        if (!modelFile.existsSync()) {
-          print('Downloading tiny model...');
-          final response = await http.get(Uri.parse(modelUrl));
-          if (response.statusCode != 200) {
-            fail('Failed to download model: ${response.statusCode}');
-          }
-          await modelFile.writeAsBytes(response.bodyBytes);
-          print('Model downloaded.');
-        }
+        // 2. Ensure tiny model
+        final modelFile = await TestHelper.getTestModel();
 
         // 3. Full Inference Pipeline Test
         final backend = LlamaBackend();
         final engine = LlamaEngine(backend);
         print('Loading model...');
         await engine.loadModel(
-          modelPath,
+          modelFile.path,
           modelParams: const ModelParams(
             contextSize: 128,
             gpuLayers: 0,

--- a/test/test_helper.dart
+++ b/test/test_helper.dart
@@ -1,3 +1,4 @@
+import 'dart:async';
 import 'dart:io';
 import 'package:http/http.dart' as http;
 import 'package:path/path.dart' as path;
@@ -6,31 +7,14 @@ class TestHelper {
   static const String modelUrl =
       'https://huggingface.co/ggml-org/tiny-llamas/resolve/main/stories15M.gguf';
   static const String modelFileName = 'stories15M.gguf';
+  static const String testModelsDirEnv = 'LLAMADART_TEST_MODELS_DIR';
 
   static Future<File> getTestModel() async {
-    final modelsDir = Directory(path.join(Directory.current.path, 'models'));
-    if (!modelsDir.existsSync()) {
-      modelsDir.createSync(recursive: true);
-    }
-
-    final modelFile = File(path.join(modelsDir.path, modelFileName));
-    if (modelFile.existsSync()) {
-      return modelFile;
-    }
-
-    print('Downloading test model from $modelUrl...');
-    final response = await http.get(Uri.parse(modelUrl));
-    if (response.statusCode != 200) {
-      throw Exception('Failed to download model: ${response.statusCode}');
-    }
-
-    await modelFile.writeAsBytes(response.bodyBytes);
-    print('Test model downloaded to ${modelFile.path}');
-    return modelFile;
+    return ensureModel(modelUrl, modelFileName);
   }
 
   static Future<File> ensureModel(String url, String filename) async {
-    final modelsDir = Directory(path.join(Directory.current.path, 'models'));
+    final modelsDir = _modelsDir();
     if (!modelsDir.existsSync()) {
       modelsDir.createSync(recursive: true);
     }
@@ -40,14 +24,137 @@ class TestHelper {
       return modelFile;
     }
 
-    print('Downloading model from $url...');
-    final response = await http.get(Uri.parse(url));
-    if (response.statusCode != 200) {
-      throw Exception('Failed to download model: ${response.statusCode}');
+    return _withDownloadLock(modelFile, () async {
+      if (modelFile.existsSync()) {
+        return modelFile;
+      }
+
+      print('Downloading model from $url...');
+      await _downloadToFile(url, modelFile);
+      print('Model downloaded to ${modelFile.path}');
+      return modelFile;
+    });
+  }
+
+  static Directory _modelsDir() {
+    final configuredDir = Platform.environment[testModelsDirEnv];
+    if (configuredDir != null && configuredDir.isNotEmpty) {
+      return Directory(configuredDir);
+    }
+    return Directory(path.join(Directory.current.path, 'models'));
+  }
+
+  static Future<void> _downloadToFile(String url, File target) async {
+    const maxAttempts = 5;
+    Object? lastError;
+
+    for (var attempt = 1; attempt <= maxAttempts; attempt++) {
+      try {
+        final response = await http
+            .get(Uri.parse(url), headers: _downloadHeaders(url))
+            .timeout(const Duration(seconds: 60));
+        if (response.statusCode == 200) {
+          final tempFile = File('${target.path}.tmp');
+          await tempFile.writeAsBytes(response.bodyBytes, flush: true);
+          await tempFile.rename(target.path);
+          return;
+        }
+
+        lastError = 'HTTP ${response.statusCode}';
+        if (!_shouldRetry(response.statusCode) || attempt == maxAttempts) {
+          break;
+        }
+        await _waitBeforeRetry(response, attempt, lastError);
+      } on TimeoutException catch (error) {
+        lastError = error;
+        if (attempt == maxAttempts) break;
+        await _waitBeforeRetry(null, attempt, lastError);
+      } on Exception catch (error) {
+        lastError = error;
+        if (attempt == maxAttempts) break;
+        await _waitBeforeRetry(null, attempt, lastError);
+      }
     }
 
-    await modelFile.writeAsBytes(response.bodyBytes);
-    print('Model downloaded to ${modelFile.path}');
-    return modelFile;
+    throw Exception(
+      'Failed to download model from $url after $maxAttempts attempts: '
+      '$lastError',
+    );
+  }
+
+  static Future<T> _withDownloadLock<T>(
+    File target,
+    Future<T> Function() action,
+  ) async {
+    final lockFile = File('${target.path}.download.lock');
+    var acquired = false;
+
+    try {
+      while (!acquired) {
+        try {
+          await lockFile.create(exclusive: true);
+          acquired = true;
+        } on FileSystemException {
+          if (!await _deleteStaleLock(lockFile)) {
+            await Future<void>.delayed(const Duration(milliseconds: 250));
+          }
+        }
+      }
+
+      return await action();
+    } finally {
+      if (acquired && lockFile.existsSync()) {
+        await lockFile.delete();
+      }
+    }
+  }
+
+  static Future<bool> _deleteStaleLock(File lockFile) async {
+    final stat = await lockFile.stat();
+    if (stat.type != FileSystemEntityType.file) {
+      return false;
+    }
+
+    final lockAge = DateTime.now().difference(stat.modified);
+    if (lockAge < const Duration(minutes: 15)) {
+      return false;
+    }
+
+    await lockFile.delete();
+    return true;
+  }
+
+  static Map<String, String> _downloadHeaders(String url) {
+    final uri = Uri.parse(url);
+    final token = Platform.environment['HF_TOKEN'];
+    if (uri.host.endsWith('huggingface.co') &&
+        token != null &&
+        token.isNotEmpty) {
+      return {'Authorization': 'Bearer $token'};
+    }
+    return const {};
+  }
+
+  static bool _shouldRetry(int statusCode) {
+    return statusCode == 408 ||
+        statusCode == 429 ||
+        (statusCode >= 500 && statusCode < 600);
+  }
+
+  static Future<void> _waitBeforeRetry(
+    http.Response? response,
+    int attempt,
+    Object? lastError,
+  ) async {
+    final retryAfter = response?.headers['retry-after'];
+    final retryAfterSeconds = int.tryParse(retryAfter ?? '');
+    final seconds = retryAfterSeconds != null
+        ? retryAfterSeconds.clamp(1, 60).toInt()
+        : attempt * 3;
+    print(
+      'Model download failed ($lastError); retrying in ${seconds}s '
+      '(attempt ${attempt + 1})...',
+    );
+    await Future<void>.delayed(Duration(seconds: seconds));
   }
 }

--- a/website/docs/changelog/recent-releases.md
+++ b/website/docs/changelog/recent-releases.md
@@ -7,6 +7,25 @@ For canonical full release notes, use:
 
 - [`CHANGELOG.md`](https://github.com/leehack/llamadart/blob/main/CHANGELOG.md)
 
+## 0.7.1
+
+- Added Flutter iOS/macOS Swift Package Manager integration so Apple apps link
+  pinned `leehack/llamadart-native` and `leehack/litert-lm-native`
+  XCFramework artifacts through `darwin/llamadart/Package.swift`.
+- Disabled the legacy hook-managed Apple bundle path for Flutter iOS/macOS
+  builds, avoiding wrapper/framework `MinimumOSVersion` mismatches in App Store
+  uploads.
+- Raised the Flutter Apple runtime floors to iOS 16.4 and macOS 14.0 to match
+  the published XCFramework artifacts.
+- Kept Android native builds on both `llama_cpp` and `litert_lm` by default;
+  iOS, macOS, Linux, and Windows now default to `llama_cpp` only. Non-Android
+  `.litertlm` apps should opt in with `llamadart_native_runtimes`.
+- Added native release pin automation for Apple SPM checksums, excluded local
+  SwiftPM artifact caches from pub archives, and hardened main-branch CI against
+  Hugging Face tiny-model download rate limits.
+- Compatibility note: no Dart API breaking changes. Flutter Apple apps must
+  target iOS 16.4/macOS 14.0 or newer.
+
 ## 0.7.0
 
 - Added LiteRT-LM as a first-class backend for native `.litertlm` bundles and

--- a/website/docs/examples/chat-app.md
+++ b/website/docs/examples/chat-app.md
@@ -17,8 +17,8 @@ flutter pub get
 flutter run
 ```
 
-If you run this example on iOS, set the project deployment target to `16.4` or
-newer before building.
+If you run this example on Apple platforms, set the project deployment target to
+iOS `16.4` or macOS `14.0` or newer before building.
 
 This example intentionally opts into both native runtime families in
 `pubspec.yaml` so native `.litertlm` presets work on supported targets. If your

--- a/website/docs/examples/overview.md
+++ b/website/docs/examples/overview.md
@@ -26,7 +26,8 @@ The repository ships multiple examples for different integration styles.
 
 - Dart SDK `>= 3.10.7`
 - Flutter SDK `>= 3.38.0` for Flutter examples
-- iOS example builds require a minimum deployment target of `16.4` or newer
+- Flutter Apple example builds require deployment targets of iOS `16.4` or
+  macOS `14.0` or newer
 - Internet on first run (runtime bundle resolution)
 - The Chat App opts into both `llama_cpp` and `litert_lm` native runtime
   families because it demonstrates GGUF and `.litertlm` models. The smaller

--- a/website/docs/getting-started/installation.md
+++ b/website/docs/getting-started/installation.md
@@ -1,31 +1,33 @@
 ---
 title: Installation
-description: Install llamadart, add the package to your app, and understand the native runtime bundle setup on first run.
+description: Install llamadart, add the package to your app, and understand the native runtime setup on first run.
 ---
 
 ## Prerequisites
 
 - Dart SDK `>= 3.10.7`
 - Flutter SDK `>= 3.38.0` (if you build Flutter apps)
-- iOS builds require a minimum deployment target of `16.4` or newer
+- Flutter iOS builds require a minimum deployment target of `16.4` or newer
+- Flutter macOS builds require a minimum deployment target of `14.0` or newer
 
-## iOS deployment target
+## Apple deployment targets
 
-If you build for iOS, set your app project to `16.4` or newer before running
-the app. If your app still uses CocoaPods, set the Podfile platform too.
+If you build a Flutter Apple app, set your app project deployment target before
+running the app. iOS needs `16.4` or newer; macOS needs `14.0` or newer. If
+your iOS app still uses CocoaPods, set the Podfile platform too.
 
 ```ruby
 platform :ios, '16.4'
 ```
 
-In Xcode, set `IPHONEOS_DEPLOYMENT_TARGET = 16.4` for the relevant Runner
-configurations.
+In Xcode, set `IPHONEOS_DEPLOYMENT_TARGET = 16.4` or
+`MACOSX_DEPLOYMENT_TARGET = 14.0` for the relevant Runner configurations.
 
 ## Add dependency
 
 ```yaml
 dependencies:
-  llamadart: ^0.7.0
+  llamadart: ^0.7.1
 ```
 
 Then resolve packages:
@@ -41,8 +43,10 @@ flutter pub get
 On the first `dart run` / `flutter run` for a native target, `llamadart`:
 
 1. Detects platform and architecture.
-2. Resolves the matching runtime bundle from `leehack/llamadart-native`.
-3. Wires native assets into your app process.
+2. Resolves matching runtime artifacts from `leehack/llamadart-native` and
+   `leehack/litert-lm-native`.
+3. Wires them into your app through native assets, or through SwiftPM-linked
+   XCFrameworks for Flutter iOS/macOS builds.
 
 No local C++ toolchain setup is required for consumers.
 

--- a/website/docs/maintainers/release-workflow.md
+++ b/website/docs/maintainers/release-workflow.md
@@ -42,6 +42,10 @@ version alignment:
   when the next unreleased change is documented.
 - Update `MIGRATION.md` if breaking behavior changed.
 - Keep docs pages aligned with new defaults/options.
+- Keep local SwiftPM artifact caches out of pub archives:
+  `darwin/llamadart/Artifacts/` is for local/offline SPM testing only, and
+  published packages should rely on the remote binary targets in
+  `darwin/llamadart/Package.swift`.
 
 ## 3. Publish flow
 

--- a/website/docs/platforms/support-matrix.md
+++ b/website/docs/platforms/support-matrix.md
@@ -42,8 +42,9 @@ runtime revision.
 | Web (browser) | N/A (JS bridge path) | N/A | Router: llama.cpp WebGPU/CPU for `.gguf`; LiteRT-LM JS for `.litertlm` URLs | Experimental; see [WebGPU Bridge](./webgpu-bridge) and LiteRT-LM web notes below |
 
 All iOS targets above require the consuming Flutter/Xcode project to use a
-minimum deployment target of `16.4` or newer. If the app still uses CocoaPods,
-set the Podfile platform to `16.4` or newer too.
+minimum deployment target of `16.4` or newer. Flutter macOS targets require
+macOS `14.0` or newer. If an iOS app still uses CocoaPods, set the Podfile
+platform to `16.4` or newer too.
 
 ## Model format routing
 


### PR DESCRIPTION
## Summary
- prepare 0.7.1 release metadata and concise release notes for Apple SPM runtime packaging
- harden main CI tiny GGUF model downloads with cache/retries and shared helper path
- update Apple deployment docs and exclude local SwiftPM Artifacts from pub archives

## CI failure addressed
- main CI was failing in VM integration tests because Hugging Face returned 429 while downloading stories15M.gguf
- CI now pre-caches the tiny GGUF model, retries transient downloads, and lets tests reuse LLAMADART_TEST_MODELS_DIR

## Validation
- flutter pub get
- (cd example/chat_app && flutter pub get)
- dart format --output=none --set-exit-if-changed .
- dart analyze
- LLAMADART_TEST_MODELS_DIR=.dart_tool/test_models dart test -p vm -j 1 --exclude-tags local-only
- dart test -p chrome --exclude-tags local-only
- ./tool/docs/build_site.sh
- ./tool/docs/validate_links.sh
- flutter pub publish --dry-run