### PR TITLE
Prepare llamadart 0.7.2 platform metadata release

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -236,9 +236,16 @@ jobs:
         run: flutter pub get
 
       - name: Download parity model
+        shell: bash
+        env:
+          HF_TOKEN: ${{ secrets.HF_TOKEN }}
         run: |
           mkdir -p "$RUNNER_TEMP/models"
-          curl --retry 5 --retry-all-errors --retry-delay 3 --location \
+          curl_args=(--fail --location --retry 8 --retry-all-errors --retry-delay 10)
+          if [[ -n "${HF_TOKEN:-}" ]]; then
+            curl_args+=(--header "Authorization: Bearer $HF_TOKEN")
+          fi
+          curl "${curl_args[@]}" \
             "https://huggingface.co/Qwen/Qwen2.5-0.5B-Instruct-GGUF/resolve/main/qwen2.5-0.5b-instruct-q4_k_m.gguf?download=true" \
             --output "$RUNNER_TEMP/models/qwen2.5-0.5b-instruct-q4_k_m.gguf"
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+## 0.7.2
+
+* Added explicit pub.dev platform metadata for Android, iOS, Linux, macOS, web,
+  and Windows. This keeps the package listing aligned with the actual
+  cross-platform runtime support even though Flutter plugin registration is
+  only needed for Darwin app integration.
+
 ## 0.7.1
 
 * **Apple native runtime packaging**:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: llamadart
 description: Dart and Flutter local LLM inference with llama.cpp GGUF and LiteRT-LM across native platforms and web.
-version: 0.7.1
+version: 0.7.2
 homepage: https://github.com/leehack/llamadart
 repository: https://github.com/leehack/llamadart
 issue_tracker: https://github.com/leehack/llamadart/issues
@@ -10,6 +10,16 @@ topics:
   - inference
   - gguf
   - litert
+
+# Pub.dev platform support is broader than the Flutter plugin registrar
+# declarations below, which are only needed for Darwin app integration.
+platforms:
+  android:
+  ios:
+  linux:
+  macos:
+  web:
+  windows:
 
 environment:
   sdk: ^3.10.7


### PR DESCRIPTION
Bumps llamadart to 0.7.2 and adds explicit pub.dev platform metadata for Android, iOS, Linux, macOS, web, and Windows. Validation: dart pub publish --dry-run reports 0 warnings.