### PR TITLE
feat: support llama.cpp external MTP drafts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,13 @@
   * Extended local macOS and chat app benchmark outputs with the new
     diagnostics and added focused llama.cpp MTP smoke/benchmark tools for
     baseline-vs-MTP comparisons.
+* **llama.cpp MTP runtime support**:
+  * Added `SpeculativeDecodingConfig.mtp(draftModelPath: ...)` for llama.cpp
+    external draft-model MTP sessions, with draft model caching and cleanup
+    tied to the target model lifetime.
+  * Removed the Android Vulkan MTP allow-list dart define and the model-name
+    based Android Vulkan acceleration shortcut; Vulkan MTP now runs only when
+    callers explicitly request Vulkan plus MTP in runtime parameters.
 * **Structured output**:
   * Added `responseFormat` routing to `LlamaEngine.create(...)` for
     grammar-capable backends, deprecated the legacy `chatTemplate(...)`

--- a/README.md
+++ b/README.md
@@ -254,11 +254,24 @@ Higher `draftTokenMax` values can be faster on some models/devices, but they
 should be benchmarked with the target model because excess draft depth can add
 verification overhead.
 
-Android Vulkan MTP is currently disabled by default. The upstream llama.cpp
-`draft-mtp` backend-sampling path can abort Android Vulkan processes with
-`vk::DeviceLostError`; use CPU for Android MTP validation, or rebuild with
-`--dart-define=LLAMADART_ANDROID_VULKAN_ALLOW_MTP=true` only when reproducing
-or benchmarking that upstream path.
+For target/draft model pairs, pass the separate drafter GGUF with
+`draftModelPath`:
+
+```dart
+params: const GenerationParams(
+  maxTokens: 128,
+  speculativeDecodingConfig: SpeculativeDecodingConfig.mtp(
+    draftModelPath: 'path/to/draft-model.gguf',
+    draftTokenMax: 1,
+  ),
+),
+```
+
+Android Vulkan MTP is opt-in through the same runtime parameters: request
+`GpuBackend.vulkan` in `ModelParams` and pass
+`SpeculativeDecodingConfig.mtp(...)` in `GenerationParams`. Benchmark this
+combination on target devices because MTP can increase memory use and may be
+slower than baseline decoding for some draft/target model pairs.
 
 ### 6. Download and cache a remote model file
 
@@ -561,7 +574,7 @@ Notes:
 - `ModelParams.mainGpu` passes through to llama.cpp `main_gpu`. To select one GPU for the full model, use `splitMode: ModelSplitMode.none` with the desired `mainGpu` index.
 - `ModelParams.batchSize` (`n_batch`) and `ModelParams.microBatchSize` (`n_ubatch`) can be set independently for memory/performance tuning; defaults keep legacy behavior (`n_batch = n_ctx`, `n_ubatch = n_batch`).
 - `ModelParams.speculativeRollbackTokenMax` passes through to llama.cpp `n_rs_seq`. Keep the default `0` for normal generation; set it to at least the MTP draft token max when a llama.cpp MTP model needs bounded rollback snapshots, such as Qwen3.5 MTP.
-- Android Vulkan MTP is guarded by default because the upstream llama.cpp MTP backend-sampling path can crash the process. The debug-only escape hatch is `--dart-define=LLAMADART_ANDROID_VULKAN_ALLOW_MTP=true`.
+- Android Vulkan MTP is not enabled by default; it runs only when callers request both `GpuBackend.vulkan` and `SpeculativeDecodingConfig.mtp(...)`. Benchmark on target devices because MTP can increase memory use and may be slower than baseline decoding.
 - `ModelParams.preferMemory64` and `ModelParams.modelBytesHint` are web/WebGPU only (ignored on native). They select the 64-bit (wasm64/mem64) bridge core so models larger than the ~4 GiB wasm32 address space (for example Gemma 4 E2B) can load; `null` auto-decides from the size hint (size-driven, no hardcoded model names). See the [WebGPU bridge docs](https://leehack.github.io/llamadart/docs/platforms/webgpu-bridge).
 - Apple targets use consolidated llama.cpp native libraries, so
   `llamadart_native_backends` does not split Apple backend modules. Use

--- a/example/chat_app/lib/litert_lm_benchmark_app.dart
+++ b/example/chat_app/lib/litert_lm_benchmark_app.dart
@@ -234,6 +234,9 @@ class _LiteRtLmBenchmarkAppState extends State<LiteRtLmBenchmarkApp> {
   final _llamaModelPathController = TextEditingController(
     text: const String.fromEnvironment('LLAMADART_MODEL'),
   );
+  final _llamaDraftModelPathController = TextEditingController(
+    text: const String.fromEnvironment('LLAMADART_DRAFT_MODEL'),
+  );
   final _promptController = TextEditingController(
     text: const String.fromEnvironment(
       'LITERT_LM_PROMPT',
@@ -289,6 +292,7 @@ class _LiteRtLmBenchmarkAppState extends State<LiteRtLmBenchmarkApp> {
   void dispose() {
     _modelPathController.dispose();
     _llamaModelPathController.dispose();
+    _llamaDraftModelPathController.dispose();
     _promptController.dispose();
     super.dispose();
   }
@@ -299,6 +303,9 @@ class _LiteRtLmBenchmarkAppState extends State<LiteRtLmBenchmarkApp> {
     );
     final llamaModelPath = await resolveBenchmarkModelPathForApp(
       _llamaModelPathController.text,
+    );
+    final llamaDraftModelPath = await resolveBenchmarkModelPathForApp(
+      _llamaDraftModelPathController.text,
     );
     if (modelPath.isEmpty && llamaModelPath.isEmpty) {
       _append('Set LITERT_LM_MODEL and/or LLAMADART_MODEL.');
@@ -319,7 +326,12 @@ class _LiteRtLmBenchmarkAppState extends State<LiteRtLmBenchmarkApp> {
     }
     if (llamaModelPath.isNotEmpty) {
       try {
-        await _runLlamaDartBenchmark(llamaModelPath);
+        await _runLlamaDartBenchmark(
+          llamaModelPath,
+          draftModelPath: llamaDraftModelPath.isEmpty
+              ? null
+              : llamaDraftModelPath,
+        );
       } catch (error, stackTrace) {
         _append('ERROR llamadart: $error');
         _append(stackTrace.toString());
@@ -494,7 +506,10 @@ class _LiteRtLmBenchmarkAppState extends State<LiteRtLmBenchmarkApp> {
     };
   }
 
-  Future<void> _runLlamaDartBenchmark(String modelPath) async {
+  Future<void> _runLlamaDartBenchmark(
+    String modelPath, {
+    String? draftModelPath,
+  }) async {
     final engine = LlamaEngine(LlamaBackend());
     try {
       final backendPreference = resolveLlamaCppBenchmarkBackend(_llamaBackend);
@@ -502,6 +517,9 @@ class _LiteRtLmBenchmarkAppState extends State<LiteRtLmBenchmarkApp> {
       _append('=== llamadart / llama.cpp ===');
       _append('Initializing llamadart:');
       _append('  model: $modelPath');
+      if (draftModelPath != null) {
+        _append('  draft model: $draftModelPath');
+      }
       _append('  backend: ${llamaCppBenchmarkBackendLabel(backendPreference)}');
       final loadSw = Stopwatch()..start();
       await engine.loadModel(
@@ -528,7 +546,9 @@ class _LiteRtLmBenchmarkAppState extends State<LiteRtLmBenchmarkApp> {
                 maxTokens: _outputTokens,
                 seed: 1,
                 speculativeDecodingConfig: _speculative
-                    ? const SpeculativeDecodingConfig.mtp()
+                    ? SpeculativeDecodingConfig.mtp(
+                        draftModelPath: draftModelPath,
+                      )
                     : null,
               ),
             )
@@ -548,7 +568,7 @@ class _LiteRtLmBenchmarkAppState extends State<LiteRtLmBenchmarkApp> {
             maxTokens: _outputTokens,
             seed: 1,
             speculativeDecodingConfig: _speculative
-                ? const SpeculativeDecodingConfig.mtp()
+                ? SpeculativeDecodingConfig.mtp(draftModelPath: draftModelPath)
                 : null,
           ),
         )) {
@@ -600,6 +620,7 @@ class _LiteRtLmBenchmarkAppState extends State<LiteRtLmBenchmarkApp> {
         'requestedBackend': backendPreference.name,
         'backendName': backendName,
         'resolvedGpuLayers': resolvedGpuLayers,
+        'draftModelPath': draftModelPath,
         'targetDecodeTokens': _outputTokens,
         'speculativeDecoding': _speculative,
         'outputTokens': runsDetail.isEmpty

--- a/lib/src/backends/litert_lm/litert_lm_service.dart
+++ b/lib/src/backends/litert_lm/litert_lm_service.dart
@@ -874,6 +874,9 @@ class LiteRtLmService {
     if (config.minProbability != null) {
       unsupported.add('speculativeDecodingConfig.minProbability');
     }
+    if (config.draftModelPath != null) {
+      unsupported.add('speculativeDecodingConfig.draftModelPath');
+    }
   }
 
   int _defaultSamplerSeed() {

--- a/lib/src/backends/llama_cpp/llama_cpp_service.dart
+++ b/lib/src/backends/llama_cpp/llama_cpp_service.dart
@@ -256,6 +256,20 @@ external Pointer<llama_dart_mtp> _llamadartWrapperMtpInit(
   bool backendSampling,
 );
 
+@Native<_LlamaDartMtpInitNative>(
+  assetId: _llamadartWrapperAssetId,
+  symbol: 'llama_dart_mtp_init_with_draft_model',
+)
+external Pointer<llama_dart_mtp> _llamadartWrapperMtpInitWithDraftModel(
+  Pointer<llama_model> draftModel,
+  Pointer<llama_context> context,
+  llama_context_params contextParams,
+  int draftTokenMax,
+  int draftTokenMin,
+  double minProbability,
+  bool backendSampling,
+);
+
 @Native<_LlamaDartMtpFreeNative>(
   assetId: _llamadartWrapperAssetId,
   symbol: 'llama_dart_mtp_free',
@@ -340,11 +354,13 @@ class _LlamaCppMtpConfig {
     required this.draftTokenMax,
     required this.draftTokenMin,
     required this.minProbability,
+    required this.draftModelPath,
   });
 
   final int draftTokenMax;
   final int draftTokenMin;
   final double minProbability;
+  final String? draftModelPath;
 }
 
 /// Service responsible for managing Llama.cpp models and contexts.
@@ -364,11 +380,6 @@ class LlamaCppService {
     'LLAMADART_ANDROID_VULKAN_ALLOW_FLASH_ATTN',
     defaultValue: false,
   );
-  static const bool _androidVulkanAllowMtp = bool.fromEnvironment(
-    'LLAMADART_ANDROID_VULKAN_ALLOW_MTP',
-    defaultValue: false,
-  );
-
   static const int _maxStartupDiagnostics = 32;
   static const Map<String, int> _androidCpuVariantPriority = <String, int>{
     'android_armv9.2_2': 0,
@@ -438,6 +449,10 @@ class LlamaCppService {
   final Map<int, Map<String, double>> _activeLoras = {};
   final Map<int, String> _modelBackendNames = <int, String>{};
   final Map<int, int> _modelResolvedGpuLayers = <int, int>{};
+  final Map<int, ModelParams> _modelLoadParams = <int, ModelParams>{};
+  final Map<String, _LlamaModelWrapper> _mtpDraftModels =
+      <String, _LlamaModelWrapper>{};
+  final Map<int, Set<String>> _modelToMtpDraftModelKeys = <int, Set<String>>{};
 
   /// Refcount of in-flight `generate()` calls per context. A set would let the
   /// first completion clear the marker while another decode is still running.
@@ -512,43 +527,6 @@ class LlamaCppService {
         resolvedGpuLayers ?? resolveGpuLayersForLoad(modelParams);
     return modelParams.preferredBackend == GpuBackend.vulkan &&
         effectiveGpuLayers > 0;
-  }
-
-  /// Returns whether Android should enable the experimental Vulkan fast path
-  /// for the given local model file.
-  static bool shouldEnableExperimentalAndroidVulkanAcceleration(
-    String? modelPath, {
-    bool isAndroid = false,
-  }) {
-    if (!isAndroid || modelPath == null || modelPath.isEmpty) {
-      return false;
-    }
-
-    final normalized = path.basename(modelPath).toLowerCase();
-    return normalized.contains('qwen3.5-0.8b') ||
-        normalized.contains('qwen3.5-2b') ||
-        normalized.contains('qwen3.5-4b') ||
-        normalized.contains('qwen_qwen3.5-0.8b') ||
-        normalized.contains('qwen_qwen3.5-2b') ||
-        normalized.contains('qwen_qwen3.5-4b');
-  }
-
-  /// Returns whether Android Vulkan MTP should be rejected before generation.
-  ///
-  /// Upstream llama.cpp `draft-mtp` backend sampling currently can abort Android
-  /// Vulkan processes with `vk::DeviceLostError`. Keep the public feature usable
-  /// on CPU and other backends, but fail fast for this backend combination unless
-  /// explicitly enabled for debugging/benchmarking.
-  static bool shouldRejectAndroidVulkanMtp(
-    String? backendName, {
-    int? resolvedGpuLayers,
-    bool isAndroid = false,
-    bool allowMtp = false,
-  }) {
-    if (!isAndroid || allowMtp || (resolvedGpuLayers ?? 0) <= 0) {
-      return false;
-    }
-    return (backendName ?? '').toLowerCase().contains('vulkan');
   }
 
   /// Resolves effective context batch parameters.
@@ -1462,20 +1440,7 @@ class LlamaCppService {
   /// Returns a handle to the loaded model.
   /// Throws an [Exception] if the file does not exist or fails to load.
   int loadModel(String modelPath, ModelParams modelParams) {
-    final modelFile = File(modelPath);
-    if (!modelFile.existsSync()) {
-      throw Exception("File not found: $modelPath");
-    }
-    final modelFileSize = modelFile.lengthSync();
-    if (modelFileSize <= 0) {
-      throw Exception("Model file is empty: $modelPath");
-    }
-    if (!_looksLikeGguf(modelFile)) {
-      throw Exception(
-        "Model file does not appear to be GGUF: $modelPath. "
-        "Please verify the download completed correctly.",
-      );
-    }
+    final modelFileSize = _validateGgufModelFile(modelPath, 'Model');
 
     _applyConfiguredLogLevel();
     final effectiveBackend = resolvePreferredBackendForLoad(
@@ -1550,10 +1515,113 @@ class LlamaCppService {
     );
     _modelBackendNames[handle] = resolvedBackend;
     _modelResolvedGpuLayers[handle] = gpuLayers;
+    _modelLoadParams[handle] = modelParams;
     _activeBackendName = resolvedBackend;
     _activeResolvedGpuLayers = gpuLayers;
 
     return handle;
+  }
+
+  int _validateGgufModelFile(String modelPath, String label) {
+    final modelFile = File(modelPath);
+    if (!modelFile.existsSync()) {
+      throw Exception("$label file not found: $modelPath");
+    }
+    final modelFileSize = modelFile.lengthSync();
+    if (modelFileSize <= 0) {
+      throw Exception("$label file is empty: $modelPath");
+    }
+    if (!_looksLikeGguf(modelFile)) {
+      throw Exception(
+        "$label file does not appear to be GGUF: $modelPath. "
+        "Please verify the download completed correctly.",
+      );
+    }
+    return modelFileSize;
+  }
+
+  String _mtpDraftModelCacheKey(
+    int targetModelHandle,
+    String draftModelPath,
+    int resolvedGpuLayers,
+  ) {
+    final normalizedPath = File(draftModelPath).absolute.path;
+    return '$targetModelHandle\x00$normalizedPath\x00$resolvedGpuLayers';
+  }
+
+  _LlamaModelWrapper _loadMtpDraftModel(
+    int targetModelHandle,
+    String draftModelPath,
+  ) {
+    final modelFileSize = _validateGgufModelFile(
+      draftModelPath,
+      'MTP draft model',
+    );
+    final targetModelParams =
+        _modelLoadParams[targetModelHandle] ?? const ModelParams();
+    final targetBackendName = _modelBackendNames[targetModelHandle];
+    final effectiveBackend = targetBackendName == _backendDisplayName('cpu')
+        ? GpuBackend.cpu
+        : resolvePreferredBackendForLoad(
+            targetModelParams,
+            isAndroid: Platform.isAndroid,
+          );
+    final targetResolvedGpuLayers =
+        _modelResolvedGpuLayers[targetModelHandle] ??
+        resolveGpuLayersForLoad(
+          targetModelParams,
+          isAndroid: Platform.isAndroid,
+        );
+    final draftBackend = effectiveBackend;
+    final draftGpuLayers = targetResolvedGpuLayers;
+    final cacheKey = _mtpDraftModelCacheKey(
+      targetModelHandle,
+      draftModelPath,
+      draftGpuLayers,
+    );
+
+    final cached = _mtpDraftModels[cacheKey];
+    if (cached != null) {
+      return cached;
+    }
+
+    _prepareBackendsForModelLoad(draftBackend);
+
+    final modelPathPtr = draftModelPath.toNativeUtf8();
+    final mparams = llama_model_default_params();
+    final preferredDevices = _createPreferredDeviceList(draftBackend);
+    mparams.n_gpu_layers = draftGpuLayers;
+    mparams.split_modeAsInt = targetModelParams.splitMode.llamaCppValue;
+    mparams.main_gpu = targetModelParams.mainGpu;
+    applyModelParams(mparams, targetModelParams);
+    if (preferredDevices != null) {
+      mparams.devices = preferredDevices;
+    }
+
+    Pointer<llama_model> modelPtr = nullptr;
+    try {
+      modelPtr = llama_model_load_from_file(modelPathPtr.cast(), mparams);
+    } finally {
+      malloc.free(modelPathPtr);
+      if (preferredDevices != null) {
+        malloc.free(preferredDevices);
+      }
+    }
+
+    if (modelPtr == nullptr) {
+      final diagnostics = _backendDiagnostics();
+      throw Exception(
+        "Failed to load MTP draft model (size=$modelFileSize bytes, "
+        "path=$draftModelPath, diagnostics=$diagnostics)",
+      );
+    }
+
+    final wrapper = _LlamaModelWrapper(modelPtr, sourcePath: draftModelPath);
+    _mtpDraftModels[cacheKey] = wrapper;
+    _modelToMtpDraftModelKeys
+        .putIfAbsent(targetModelHandle, () => <String>{})
+        .add(cacheKey);
+    return wrapper;
   }
 
   String _resolveBackendNameForLoad({
@@ -2866,6 +2934,13 @@ class LlamaCppService {
 
     _modelBackendNames.remove(modelHandle);
     _modelResolvedGpuLayers.remove(modelHandle);
+    _modelLoadParams.remove(modelHandle);
+    final draftModelKeys = _modelToMtpDraftModelKeys.remove(modelHandle);
+    if (draftModelKeys != null) {
+      for (final key in draftModelKeys) {
+        _mtpDraftModels.remove(key)?.dispose();
+      }
+    }
     if (_modelBackendNames.isEmpty) {
       _activeBackendName = _backendDisplayName('cpu');
       _activeResolvedGpuLayers = 0;
@@ -2924,25 +2999,13 @@ class LlamaCppService {
       resolvedGpuLayers: resolvedModelGpuLayers,
       isAndroid: Platform.isAndroid,
     )) {
-      final enableExperimentalAcceleration =
-          shouldEnableExperimentalAndroidVulkanAcceleration(
-            model.sourcePath,
-            isAndroid: Platform.isAndroid,
-          );
-      final allowKqv =
-          _androidVulkanAllowKqvOffload || enableExperimentalAcceleration;
-      final allowOp =
-          _androidVulkanAllowOpOffload || enableExperimentalAcceleration;
-      final allowFlash =
-          _androidVulkanAllowFlashAttn || enableExperimentalAcceleration;
-
-      if (!allowKqv) {
+      if (!_androidVulkanAllowKqvOffload) {
         ctxParams.offload_kqv = false;
       }
-      if (!allowOp) {
+      if (!_androidVulkanAllowOpOffload) {
         ctxParams.op_offload = false;
       }
-      if (!allowFlash) {
+      if (!_androidVulkanAllowFlashAttn) {
         ctxParams.flash_attn_typeAsInt =
             llama_flash_attn_type.LLAMA_FLASH_ATTN_TYPE_DISABLED.value;
       }
@@ -3022,6 +3085,7 @@ class LlamaCppService {
     final draftTokenMax = speculativeConfig.draftTokenMax ?? 1;
     final draftTokenMin = speculativeConfig.draftTokenMin ?? 0;
     final minProbability = speculativeConfig.minProbability ?? 0.0;
+    final draftModelPath = speculativeConfig.draftModelPath;
 
     if (draftTokenMax <= 0) {
       throw RangeError.value(
@@ -3044,11 +3108,19 @@ class LlamaCppService {
         'must be between 0.0 and 1.0 for llama.cpp MTP',
       );
     }
+    if (draftModelPath != null && draftModelPath.trim().isEmpty) {
+      throw ArgumentError.value(
+        draftModelPath,
+        'draftModelPath',
+        'must be null or a non-empty path for llama.cpp MTP',
+      );
+    }
 
     return _LlamaCppMtpConfig(
       draftTokenMax: draftTokenMax,
       draftTokenMin: draftTokenMin,
       minProbability: minProbability,
+      draftModelPath: draftModelPath,
     );
   }
 
@@ -3092,21 +3164,6 @@ class LlamaCppService {
         params,
         hasMediaParts: hasMediaParts,
       );
-      if (mtpConfig != null &&
-          shouldRejectAndroidVulkanMtp(
-            _modelBackendNames[modelHandle],
-            resolvedGpuLayers: _modelResolvedGpuLayers[modelHandle],
-            isAndroid: Platform.isAndroid,
-            allowMtp: _androidVulkanAllowMtp,
-          )) {
-        throw UnsupportedError(
-          'llama.cpp MTP speculative decoding is disabled for Android Vulkan '
-          'because the upstream draft-mtp backend-sampling path can abort with '
-          'vk::DeviceLostError. Use the CPU backend, disable MTP, or rebuild '
-          'with LLAMADART_ANDROID_VULKAN_ALLOW_MTP=true for debugging.',
-        );
-      }
-
       // 1. Reset Context
       ctx = _resetContext(
         contextHandle,
@@ -3129,20 +3186,28 @@ class LlamaCppService {
 
       if (mtpConfig != null) {
         mtpApi = _resolveMtpApi();
-        mtpSession = mtpApi.init(
-          model.pointer,
-          ctx.pointer,
-          modelParams,
-          mtpConfig.draftTokenMax,
-          mtpConfig.draftTokenMin,
-          mtpConfig.minProbability,
-          true,
+        final draftModelPath = mtpConfig.draftModelPath;
+        final draftModel = draftModelPath == null
+            ? null
+            : _loadMtpDraftModel(modelHandle, draftModelPath);
+        mtpSession = mtpApi.initSession(
+          targetModel: model.pointer,
+          draftModel: draftModel?.pointer,
+          targetContext: ctx.pointer,
+          contextParams: modelParams,
+          draftTokenMax: mtpConfig.draftTokenMax,
+          draftTokenMin: mtpConfig.draftTokenMin,
+          minProbability: mtpConfig.minProbability,
+          backendSampling: true,
         );
         if (mtpSession == nullptr) {
+          final draftHint = draftModelPath == null
+              ? 'Use an MTP GGUF model'
+              : 'Verify the draft model is compatible with the target model';
           throw UnsupportedError(
             'llama.cpp MTP speculative decoding is not available for this '
-            'model/context. Use an MTP GGUF model, a native libllamadart build '
-            'that includes llama-common, and set '
+            'model/context. $draftHint, a native libllamadart build that '
+            'includes llama-common and external-draft MTP symbols, and set '
             'ModelParams.speculativeRollbackTokenMax >= draftTokenMax when the '
             'target architecture needs bounded rollback snapshots.',
           );
@@ -4276,6 +4341,7 @@ class LlamaCppService {
           if (stopSequences.any((s) => text.endsWith(s))) break;
         }
       }
+      if (generatedTokens >= params.maxTokens) break;
 
       batch.n_tokens = 1;
       batch.token[0] = selectedToken;
@@ -5167,8 +5233,14 @@ class LlamaCppService {
       m.dispose();
     }
     _models.clear();
+    for (final m in _mtpDraftModels.values) {
+      m.dispose();
+    }
+    _mtpDraftModels.clear();
+    _modelToMtpDraftModelKeys.clear();
     _modelBackendNames.clear();
     _modelResolvedGpuLayers.clear();
+    _modelLoadParams.clear();
     _activeBackendName = _backendDisplayName('cpu');
     _activeResolvedGpuLayers = 0;
     for (final m in _mtmdContexts.values) {
@@ -5737,6 +5809,7 @@ class _LazyGrammarConfig {
 
 class _MtpApi {
   final _LlamaDartMtpInitDart init;
+  final _LlamaDartMtpInitDart? initWithDraftModel;
   final _LlamaDartMtpFreeDart free;
   final _LlamaDartMtpGetDraftContextDart getDraftContext;
   final _LlamaDartMtpBeginDart begin;
@@ -5747,6 +5820,7 @@ class _MtpApi {
 
   const _MtpApi({
     required this.init,
+    required this.initWithDraftModel,
     required this.free,
     required this.getDraftContext,
     required this.begin,
@@ -5759,6 +5833,7 @@ class _MtpApi {
   factory _MtpApi.direct() {
     final api = _MtpApi(
       init: llama_dart_mtp_init,
+      initWithDraftModel: llama_dart_mtp_init_with_draft_model,
       free: llama_dart_mtp_free,
       getDraftContext: llama_dart_mtp_get_draft_context,
       begin: llama_dart_mtp_begin,
@@ -5775,6 +5850,7 @@ class _MtpApi {
     _llamadartWrapperMtpFree(nullptr.cast<llama_dart_mtp>());
     return _MtpApi(
       init: _llamadartWrapperMtpInit,
+      initWithDraftModel: _llamadartWrapperMtpInitWithDraftModel,
       free: _llamadartWrapperMtpFree,
       getDraftContext: _llamadartWrapperMtpGetDraftContext,
       begin: _llamadartWrapperMtpBegin,
@@ -5816,13 +5892,71 @@ class _MtpApi {
     }
   }
 
+  Pointer<llama_dart_mtp> initSession({
+    required Pointer<llama_model> targetModel,
+    required Pointer<llama_model>? draftModel,
+    required Pointer<llama_context> targetContext,
+    required llama_context_params contextParams,
+    required int draftTokenMax,
+    required int draftTokenMin,
+    required double minProbability,
+    required bool backendSampling,
+  }) {
+    final resolvedDraftModel = draftModel;
+    if (resolvedDraftModel == null) {
+      return init(
+        targetModel,
+        targetContext,
+        contextParams,
+        draftTokenMax,
+        draftTokenMin,
+        minProbability,
+        backendSampling,
+      );
+    }
+    final initWithDraft = initWithDraftModel;
+    if (initWithDraft == null) {
+      throw UnsupportedError(
+        'llama.cpp MTP draftModelPath requires a native libllamadart build '
+        'that exports llama_dart_mtp_init_with_draft_model.',
+      );
+    }
+    try {
+      return initWithDraft(
+        resolvedDraftModel,
+        targetContext,
+        contextParams,
+        draftTokenMax,
+        draftTokenMin,
+        minProbability,
+        backendSampling,
+      );
+    } on Object catch (error) {
+      throw UnsupportedError(
+        'llama.cpp MTP draftModelPath requires a native libllamadart build '
+        'that exports llama_dart_mtp_init_with_draft_model. Native lookup '
+        'failed: $error',
+      );
+    }
+  }
+
   static _MtpApi? tryLoad(DynamicLibrary library) {
     try {
+      _LlamaDartMtpInitDart? initWithDraftModel;
+      try {
+        initWithDraftModel = library
+            .lookupFunction<_LlamaDartMtpInitNative, _LlamaDartMtpInitDart>(
+              'llama_dart_mtp_init_with_draft_model',
+            );
+      } catch (_) {
+        initWithDraftModel = null;
+      }
       return _MtpApi(
         init: library
             .lookupFunction<_LlamaDartMtpInitNative, _LlamaDartMtpInitDart>(
               'llama_dart_mtp_init',
             ),
+        initWithDraftModel: initWithDraftModel,
         free: library
             .lookupFunction<_LlamaDartMtpFreeNative, _LlamaDartMtpFreeDart>(
               'llama_dart_mtp_free',

--- a/lib/src/core/models/inference/generation_params.dart
+++ b/lib/src/core/models/inference/generation_params.dart
@@ -68,12 +68,20 @@ class SpeculativeDecodingConfig {
   /// `null` lets the backend choose its default.
   final double? minProbability;
 
+  /// Optional draft model path for speculative decoding modes that use a
+  /// separate drafter model, such as llama.cpp `--model-draft` with
+  /// `draft-mtp`.
+  ///
+  /// Leave null for models that carry their own MTP layers.
+  final String? draftModelPath;
+
   /// Creates a backend-neutral speculative decoding configuration.
   const SpeculativeDecodingConfig({
     this.strategy = SpeculativeDecodingStrategy.backendDefault,
     this.draftTokenMax,
     this.draftTokenMin,
     this.minProbability,
+    this.draftModelPath,
   }) : assert(draftTokenMax == null || draftTokenMax >= 0),
        assert(draftTokenMin == null || draftTokenMin >= 0),
        assert(
@@ -86,13 +94,15 @@ class SpeculativeDecodingConfig {
     : strategy = SpeculativeDecodingStrategy.backendDefault,
       draftTokenMax = null,
       draftTokenMin = null,
-      minProbability = null;
+      minProbability = null,
+      draftModelPath = null;
 
   /// Enables multi-token prediction speculative decoding.
   const SpeculativeDecodingConfig.mtp({
     this.draftTokenMax,
     this.draftTokenMin,
     this.minProbability,
+    this.draftModelPath,
   }) : strategy = SpeculativeDecodingStrategy.mtp,
        assert(draftTokenMax == null || draftTokenMax >= 0),
        assert(draftTokenMin == null || draftTokenMin >= 0),

--- a/test/integration/backends/llama_cpp/native_symbol_integration_test.dart
+++ b/test/integration/backends/llama_cpp/native_symbol_integration_test.dart
@@ -12,6 +12,7 @@ const _llamadartWrapperAssetId = 'package:llamadart/llamadart_wrapper';
 
 const _mtpSymbols = [
   'llama_dart_mtp_init',
+  'llama_dart_mtp_init_with_draft_model',
   'llama_dart_mtp_free',
   'llama_dart_mtp_get_draft_context',
   'llama_dart_mtp_begin',
@@ -185,6 +186,18 @@ void main() {
 
       expect(
         llama_dart_mtp_init(
+          nullModel,
+          nullContext,
+          ctxParams,
+          1,
+          0,
+          0.0,
+          true,
+        ).address,
+        0,
+      );
+      expect(
+        llama_dart_mtp_init_with_draft_model(
           nullModel,
           nullContext,
           ctxParams,

--- a/test/unit/backends/litert_lm/litert_lm_service_test.dart
+++ b/test/unit/backends/litert_lm/litert_lm_service_test.dart
@@ -1661,6 +1661,7 @@ void main() {
           const GenerationParams(
             speculativeDecodingConfig: SpeculativeDecodingConfig.mtp(
               draftTokenMax: 3,
+              draftModelPath: 'draft.gguf',
             ),
           ),
         ),
@@ -1668,7 +1669,10 @@ void main() {
           isA<UnsupportedError>().having(
             (error) => error.message.toString(),
             'message',
-            contains('speculativeDecodingConfig.draftTokenMax'),
+            allOf(
+              contains('speculativeDecodingConfig.draftTokenMax'),
+              contains('speculativeDecodingConfig.draftModelPath'),
+            ),
           ),
         ),
       );

--- a/test/unit/backends/llama_cpp/llama_cpp_service_test.dart
+++ b/test/unit/backends/llama_cpp/llama_cpp_service_test.dart
@@ -32,47 +32,6 @@ void main() {
     });
   });
 
-  group('Android Vulkan MTP guard', () {
-    test('rejects Android Vulkan with GPU layers by default', () {
-      expect(
-        LlamaCppService.shouldRejectAndroidVulkanMtp(
-          'Vulkan',
-          resolvedGpuLayers: 999,
-          isAndroid: true,
-        ),
-        isTrue,
-      );
-    });
-
-    test('allows CPU and explicit debug override', () {
-      expect(
-        LlamaCppService.shouldRejectAndroidVulkanMtp(
-          'CPU',
-          resolvedGpuLayers: 0,
-          isAndroid: true,
-        ),
-        isFalse,
-      );
-      expect(
-        LlamaCppService.shouldRejectAndroidVulkanMtp(
-          'Vulkan',
-          resolvedGpuLayers: 999,
-          isAndroid: true,
-          allowMtp: true,
-        ),
-        isFalse,
-      );
-      expect(
-        LlamaCppService.shouldRejectAndroidVulkanMtp(
-          'Vulkan',
-          resolvedGpuLayers: 999,
-          isAndroid: false,
-        ),
-        isFalse,
-      );
-    });
-  });
-
   group('loadModel preflight validation', () {
     late Directory tempDir;
 
@@ -548,51 +507,6 @@ void main() {
         LlamaCppService.shouldUseConservativeAndroidVulkanContextConfig(
           params,
           resolvedGpuLayers: 0,
-          isAndroid: true,
-        ),
-        isFalse,
-      );
-    });
-  });
-
-  group('shouldEnableExperimentalAndroidVulkanAcceleration', () {
-    test('returns false off Android', () {
-      expect(
-        LlamaCppService.shouldEnableExperimentalAndroidVulkanAcceleration(
-          'Qwen3.5-0.8B-Q4_K_M.gguf',
-        ),
-        isFalse,
-      );
-    });
-
-    test('returns true for small Qwen3.5 models on Android', () {
-      expect(
-        LlamaCppService.shouldEnableExperimentalAndroidVulkanAcceleration(
-          '/data/user/0/app_flutter/models/Qwen3.5-0.8B-Q4_K_M.gguf',
-          isAndroid: true,
-        ),
-        isTrue,
-      );
-      expect(
-        LlamaCppService.shouldEnableExperimentalAndroidVulkanAcceleration(
-          '/data/user/0/app_flutter/models/Qwen3.5-2B-Q4_K_M.gguf',
-          isAndroid: true,
-        ),
-        isTrue,
-      );
-      expect(
-        LlamaCppService.shouldEnableExperimentalAndroidVulkanAcceleration(
-          '/data/user/0/app_flutter/models/Qwen3.5-4B-Q4_K_M.gguf',
-          isAndroid: true,
-        ),
-        isTrue,
-      );
-    });
-
-    test('returns false for unrelated models on Android', () {
-      expect(
-        LlamaCppService.shouldEnableExperimentalAndroidVulkanAcceleration(
-          '/data/user/0/app_flutter/models/Llama-3.2-3B.gguf',
           isAndroid: true,
         ),
         isFalse,

--- a/test/unit/core/models/inference/generation_params_test.dart
+++ b/test/unit/core/models/inference/generation_params_test.dart
@@ -12,6 +12,7 @@ void main() {
       speculativeDecoding: true,
       speculativeDecodingConfig: const SpeculativeDecodingConfig.mtp(
         draftTokenMax: 3,
+        draftModelPath: 'draft.gguf',
       ),
       reusePromptPrefix: false,
       streamBatchTokenThreshold: 4,
@@ -35,6 +36,10 @@ void main() {
       SpeculativeDecodingStrategy.mtp,
     );
     expect(updated.resolvedSpeculativeDecodingConfig?.draftTokenMax, 3);
+    expect(
+      updated.resolvedSpeculativeDecodingConfig?.draftModelPath,
+      'draft.gguf',
+    );
     expect(updated.reusePromptPrefix, isFalse);
     expect(updated.streamBatchTokenThreshold, 4);
     expect(updated.streamBatchByteThreshold, 256);

--- a/tool/litert_lm_pixel_benchmark.sh
+++ b/tool/litert_lm_pixel_benchmark.sh
@@ -18,6 +18,14 @@ if [[ ! -f "$DEFAULT_LLAMADART_MODEL" && -f "$SIBLING_LLAMADART_MODEL" ]]; then
 fi
 LOCAL_LLAMADART_MODEL="${LOCAL_LLAMADART_MODEL:-$DEFAULT_LLAMADART_MODEL}"
 DEVICE_LLAMADART_MODEL="${DEVICE_LLAMADART_MODEL:-$DEVICE_APP_FILES_DIR/$LLAMADART_MODEL_NAME}"
+LLAMADART_DRAFT_MODEL_NAME="${LLAMADART_DRAFT_MODEL_NAME:-mtp-gemma-4-E2B-it.gguf}"
+DEFAULT_LLAMADART_DRAFT_MODEL="$ROOT_DIR/models/$LLAMADART_DRAFT_MODEL_NAME"
+SIBLING_LLAMADART_DRAFT_MODEL="$(dirname "$ROOT_DIR")/llamadart/models/$LLAMADART_DRAFT_MODEL_NAME"
+if [[ ! -f "$DEFAULT_LLAMADART_DRAFT_MODEL" && -f "$SIBLING_LLAMADART_DRAFT_MODEL" ]]; then
+  DEFAULT_LLAMADART_DRAFT_MODEL="$SIBLING_LLAMADART_DRAFT_MODEL"
+fi
+LOCAL_LLAMADART_DRAFT_MODEL="${LOCAL_LLAMADART_DRAFT_MODEL:-$DEFAULT_LLAMADART_DRAFT_MODEL}"
+DEVICE_LLAMADART_DRAFT_MODEL="${DEVICE_LLAMADART_DRAFT_MODEL:-$DEVICE_APP_FILES_DIR/$LLAMADART_DRAFT_MODEL_NAME}"
 BACKEND="${BACKEND:-gpu}"
 LLAMADART_BACKEND="${LLAMADART_BACKEND:-auto}"
 TARGETS="${TARGETS:-litert_lm,llamadart}"
@@ -74,6 +82,12 @@ else
     exit 2
   fi
 fi
+LLAMADART_DRAFT_MODEL_DEFINE=""
+if [[ -f "$LOCAL_LLAMADART_DRAFT_MODEL" ]]; then
+  LLAMADART_DRAFT_MODEL_DEFINE="$DEVICE_LLAMADART_DRAFT_MODEL"
+elif [[ "$SPECULATIVE" == "true" ]]; then
+  echo "No GGUF draft model found for speculative llama.cpp: $LOCAL_LLAMADART_DRAFT_MODEL" >&2
+fi
 
 echo "Benchmark configuration:"
 echo "  device: $DEVICE"
@@ -87,6 +101,9 @@ echo "  log timeouts: LiteRT-LM=${LITERT_LM_LOG_TIMEOUT}s llamadart=${LLAMADART_
 echo "  LiteRT-LM model: $LOCAL_MODEL -> $DEVICE_MODEL"
 if [[ -n "$LLAMADART_MODEL_DEFINE" ]]; then
   echo "  GGUF model: $LOCAL_LLAMADART_MODEL -> $DEVICE_LLAMADART_MODEL"
+  if [[ -n "$LLAMADART_DRAFT_MODEL_DEFINE" ]]; then
+    echo "  GGUF draft model: $LOCAL_LLAMADART_DRAFT_MODEL -> $DEVICE_LLAMADART_DRAFT_MODEL"
+  fi
 else
   echo "  GGUF model: unavailable"
 fi
@@ -110,6 +127,7 @@ build_install_and_push() {
   local target="$1"
   local litert_model_define=""
   local llamadart_model_define=""
+  local llamadart_draft_model_define=""
 
   case "$target" in
     litert_lm)
@@ -121,10 +139,12 @@ build_install_and_push() {
         return 1
       fi
       llamadart_model_define="$DEVICE_LLAMADART_MODEL"
+      llamadart_draft_model_define="$LLAMADART_DRAFT_MODEL_DEFINE"
       ;;
     both)
       litert_model_define="$DEVICE_MODEL"
       llamadart_model_define="$LLAMADART_MODEL_DEFINE"
+      llamadart_draft_model_define="$LLAMADART_DRAFT_MODEL_DEFINE"
       ;;
     *)
       echo "Unknown TARGETS entry: $target" >&2
@@ -140,6 +160,7 @@ build_install_and_push() {
       --dart-define=BENCHMARK_AUTO_RUN=true \
       --dart-define="LITERT_LM_MODEL=$litert_model_define" \
       --dart-define="LLAMADART_MODEL=$llamadart_model_define" \
+      --dart-define="LLAMADART_DRAFT_MODEL=$llamadart_draft_model_define" \
       --dart-define="LITERT_LM_BACKEND=$BACKEND" \
       --dart-define="LLAMADART_BACKEND=$LLAMADART_BACKEND" \
       --dart-define="LITERT_LM_SPECULATIVE=$SPECULATIVE" \
@@ -161,6 +182,10 @@ build_install_and_push() {
   if [[ -n "$llamadart_model_define" ]]; then
     echo "Pushing GGUF model to $DEVICE_LLAMADART_MODEL"
     push_app_file "$LOCAL_LLAMADART_MODEL" "$LLAMADART_MODEL_NAME"
+  fi
+  if [[ -n "$llamadart_draft_model_define" ]]; then
+    echo "Pushing GGUF draft model to $DEVICE_LLAMADART_DRAFT_MODEL"
+    push_app_file "$LOCAL_LLAMADART_DRAFT_MODEL" "$LLAMADART_DRAFT_MODEL_NAME"
   fi
 }
 

--- a/tool/testing/gemma4_mtp_smoke.dart
+++ b/tool/testing/gemma4_mtp_smoke.dart
@@ -8,13 +8,16 @@ Future<void> main(List<String> args) async {
   if (modelPath.isEmpty) {
     stderr.writeln(
       'Usage: dart run tool/testing/gemma4_mtp_smoke.dart '
-      '<model.gguf> [max-tokens] [draft-token-max]',
+      '<model.gguf> [draft-model.gguf] [max-tokens] [draft-token-max]',
     );
     exitCode = 64;
     return;
   }
-  final maxTokens = args.length > 1 ? int.parse(args[1]) : 32;
-  final draftTokenMax = args.length > 2 ? int.parse(args[2]) : 1;
+  final draftModelPath = args.length > 1 && args[1].isNotEmpty && args[1] != '-'
+      ? args[1]
+      : null;
+  final maxTokens = args.length > 2 ? int.parse(args[2]) : 32;
+  final draftTokenMax = args.length > 3 ? int.parse(args[3]) : 1;
 
   final engine = LlamaEngine(LlamaBackend());
   const userPrompt =
@@ -59,6 +62,7 @@ Future<void> main(List<String> args) async {
           seed: 7,
           reusePromptPrefix: false,
           speculativeDecodingConfig: SpeculativeDecodingConfig.mtp(
+            draftModelPath: draftModelPath,
             draftTokenMax: draftTokenMax,
             draftTokenMin: 0,
             minProbability: 0.0,
@@ -76,6 +80,7 @@ Future<void> main(List<String> args) async {
       const JsonEncoder.withIndent('  ').convert({
         'backend': backendName,
         'model': modelPath,
+        'draftModel': draftModelPath,
         'maxTokens': maxTokens,
         'draftTokenMax': draftTokenMax,
         'baseline': baseline,

--- a/tool/testing/llama_cpp_mtp_benchmark.dart
+++ b/tool/testing/llama_cpp_mtp_benchmark.dart
@@ -8,7 +8,8 @@ Future<void> main(List<String> args) async {
   if (modelPath.isEmpty) {
     stderr.writeln(
       'Usage: dart run tool/testing/llama_cpp_mtp_benchmark.dart '
-      '<model.gguf> [max-tokens] [runs] [draft-token-max-list] [warmups]\n'
+      '<model.gguf> [draft-model.gguf|-] [max-tokens] [runs] '
+      '[draft-token-max-list] [warmups]\n'
       'Set LLAMADART_MTP_BENCHMARK_INSTRUCTION to override the prompt.\n'
       'Set LLAMADART_MTP_BENCHMARK_BACKEND to override the backend.\n'
       'Set LLAMADART_MTP_BENCHMARK_RAW_PROMPT=true to skip chat wrapping.',
@@ -17,12 +18,15 @@ Future<void> main(List<String> args) async {
     return;
   }
 
-  final maxTokens = args.length > 1 ? int.parse(args[1]) : 512;
-  final measuredRuns = args.length > 2 ? int.parse(args[2]) : 3;
-  final draftTokenMaxValues = args.length > 3
-      ? args[3].split(',').map(int.parse).toList(growable: false)
+  final draftModelPath = args.length > 1 && args[1].isNotEmpty && args[1] != '-'
+      ? args[1]
+      : null;
+  final maxTokens = args.length > 2 ? int.parse(args[2]) : 512;
+  final measuredRuns = args.length > 3 ? int.parse(args[3]) : 3;
+  final draftTokenMaxValues = args.length > 4
+      ? args[4].split(',').map(int.parse).toList(growable: false)
       : const <int>[1, 2, 3];
-  final warmupRuns = args.length > 4 ? int.parse(args[4]) : 1;
+  final warmupRuns = args.length > 5 ? int.parse(args[5]) : 1;
   final benchmarkInstruction =
       Platform.environment['LLAMADART_MTP_BENCHMARK_INSTRUCTION'] ??
       _defaultBenchmarkInstruction;
@@ -62,7 +66,10 @@ Future<void> main(List<String> args) async {
     final benchmarkCases = <_BenchmarkCase>[
       const _BenchmarkCase.baseline(),
       for (final draftTokenMax in draftTokenMaxValues)
-        _BenchmarkCase.mtp(draftTokenMax: draftTokenMax),
+        _BenchmarkCase.mtp(
+          draftModelPath: draftModelPath,
+          draftTokenMax: draftTokenMax,
+        ),
     ];
 
     final results = <_RunResult>[];
@@ -113,6 +120,7 @@ Future<void> main(List<String> args) async {
       const JsonEncoder.withIndent('  ').convert({
         'backend': backendName,
         'model': modelPath,
+        'draftModel': draftModelPath,
         'maxTokens': maxTokens,
         'measuredRuns': measuredRuns,
         'warmupRuns': warmupRuns,
@@ -347,10 +355,14 @@ class _BenchmarkCase {
     : name = 'baseline',
       speculativeDecodingConfig = null;
 
-  factory _BenchmarkCase.mtp({required int draftTokenMax}) {
+  factory _BenchmarkCase.mtp({
+    required String? draftModelPath,
+    required int draftTokenMax,
+  }) {
     return _BenchmarkCase._(
       'mtp_draft_$draftTokenMax',
       SpeculativeDecodingConfig.mtp(
+        draftModelPath: draftModelPath,
         draftTokenMax: draftTokenMax,
         draftTokenMin: 0,
         minProbability: 0.0,

--- a/website/docs/changelog/recent-releases.md
+++ b/website/docs/changelog/recent-releases.md
@@ -25,6 +25,14 @@ For canonical full release notes, use:
 - Extended the LiteRT-LM engine smoke tool with matching environment variables
   and documented the support decision for each candidate runtime knob.
 - Kept LiteRT-LM web rejecting these native-only settings explicitly.
+- Added llama.cpp MTP benchmark diagnostics and local smoke/benchmark tools so
+  baseline-vs-MTP runs can report decode timing, draft/accepted token counts,
+  draft verification timing, and acceptance rate.
+- Added `SpeculativeDecodingConfig.mtp(draftModelPath: ...)` for llama.cpp
+  external draft-model MTP sessions.
+- Removed the Android Vulkan MTP allow-list dart define and the model-name
+  based Android Vulkan acceleration shortcut. Vulkan MTP now runs only when
+  callers explicitly request Vulkan plus MTP in runtime parameters.
 
 ## 0.7.2
 

--- a/website/docs/configuration/runtime-parameters.md
+++ b/website/docs/configuration/runtime-parameters.md
@@ -90,6 +90,7 @@ const params = GenerationParams(
   penalty: 1.1,
   stopSequences: ['</s>'],
   speculativeDecoding: false,
+  speculativeDecodingConfig: null,
 );
 ```
 
@@ -99,9 +100,12 @@ Important fields:
 - `temp`: randomness.
 - `topK`, `topP`, `minP`: token filtering controls.
 - `penalty`: repeat penalty.
-- `speculativeDecoding`: opt-in backend-native speculative decoding. Native
-  LiteRT-LM honors this flag; llama.cpp, WebGPU, and LiteRT-LM web reject it
-  until their speculative paths are implemented.
+- `speculativeDecoding` / `speculativeDecodingConfig`: opt-in backend-native
+  speculative decoding. Native LiteRT-LM honors the legacy boolean flag.
+  llama.cpp supports `SpeculativeDecodingConfig.mtp(...)` for compatible MTP
+  GGUF models, including separate target/draft model pairs through
+  `draftModelPath`. WebGPU and LiteRT-LM web reject speculative decoding until
+  their speculative paths are implemented.
 - `seed`: deterministic replay when set.
 - `grammar`: constrained decoding with GBNF.
 

--- a/website/docs/guides/performance-tuning.md
+++ b/website/docs/guides/performance-tuning.md
@@ -110,9 +110,11 @@ Guidelines:
   `streamBatchTokenThreshold` and `streamBatchByteThreshold`.
 - Lower stream thresholds improve token-by-token UI granularity, while higher
   values improve throughput by reducing isolate message overhead.
-- Use `speculativeDecoding` only for native LiteRT-LM and benchmark your target
-  model/device before enabling it; the default remains off because it is not a
-  universal speedup.
+- Use speculative decoding only after benchmarking your target model/device; the
+  default remains off because it is not a universal speedup. Native LiteRT-LM
+  uses the legacy `speculativeDecoding` boolean, while llama.cpp MTP uses
+  `SpeculativeDecodingConfig.mtp(...)` and can optionally load a separate draft
+  GGUF through `draftModelPath`.
 - `reusePromptPrefix` is enabled by default for native generation; keep it on
   for multi-turn chats and repeated prompts, and validate parity for your
   target model/workload.


### PR DESCRIPTION
## Summary

Stacked on #215.

Adds llama.cpp external draft-model support via `SpeculativeDecodingConfig.mtp(draftModelPath: ...)`. The llama.cpp service now validates and caches draft GGUF models per target model, initializes MTP with `llama_dart_mtp_init_with_draft_model` when a draft model is supplied, and disposes cached draft models with the target model/service lifetime.

This also removes the Android Vulkan MTP allow-list dart define and the model-name based Android Vulkan acceleration shortcut. Vulkan MTP now runs only when callers explicitly request `GpuBackend.vulkan` and `SpeculativeDecodingConfig.mtp(...)` in runtime params.

Benchmark tooling, README, current website docs, and tests were updated for external draft paths.

## Validation

- `git diff --cached --check`
- `dart analyze lib test/unit/backends/litert_lm/litert_lm_service_test.dart test/unit/backends/llama_cpp/llama_cpp_service_test.dart test/unit/core/models/inference/generation_params_test.dart test/integration/backends/llama_cpp/native_symbol_integration_test.dart tool/testing/gemma4_mtp_smoke.dart tool/testing/llama_cpp_mtp_benchmark.dart`
- `dart test test/unit/backends/backend_test.dart test/unit/backends/llama_cpp/llama_cpp_service_test.dart test/unit/backends/litert_lm/litert_lm_service_test.dart test/unit/core/models/inference/generation_params_test.dart`
- `dart test test/integration/backends/llama_cpp/native_symbol_integration_test.dart`
- `flutter analyze lib/litert_lm_benchmark_app.dart` from `example/chat_app`
- `tool/docs/validate_links.sh` after `cd website && npm ci`