### PR TITLE
Sync LiteRT-LM native 0.13.1-native.1

### DIFF
--- a/.github/workflows/sync_native_bindings.yml
+++ b/.github/workflows/sync_native_bindings.yml
@@ -73,7 +73,7 @@ jobs:
             - Updates `hook/build.dart` native release pins.
             - Syncs headers from the matching `llamadart-native` release header bundle.
             - Regenerates `lib/src/backends/llama_cpp/bindings.dart` via ffigen.
-            - Updates LiteRT-LM runtime archive checksums when `litert_lm_tag` is not `keep`.
+            - Updates LiteRT-LM Dart runtime version and archive checksums when `litert_lm_tag` is not `keep`.
             - Updates Apple SPM companion `Package.swift` binary target pins in `packages/`.
             - Bumps companion package patch versions and updates their README/CHANGELOG native pin notes when SPM pins change.
 
@@ -93,5 +93,6 @@ jobs:
             packages/llamadart_litert_lm_flutter/pubspec.yaml
             packages/llamadart_litert_lm_flutter/CHANGELOG.md
             packages/llamadart_litert_lm_flutter/README.md
+            lib/src/backends/litert_lm/litert_lm_runtime.dart
             lib/src/backends/llama_cpp/bindings.dart
           delete-branch: true

--- a/hook/build.dart
+++ b/hook/build.dart
@@ -24,7 +24,7 @@ const _cacheBaseDir = 'llamadart';
 const _bundleCacheDir = 'native_bundles';
 const _reportDir = 'llamadart_bin';
 const _allowLegacyLocalBundleEnv = 'LLAMADART_ALLOW_LEGACY_LOCAL_BUNDLES';
-const _litertLmVersion = '0.13.1';
+const _litertLmVersion = '0.13.1-native.1';
 const _litertLmNativeReleaseBaseUrl =
     'https://github.com/leehack/litert-lm-native/releases/download/'
     'v$_litertLmVersion';
@@ -37,7 +37,7 @@ final _litertLmBundles = Map.unmodifiable({
 const _litertLmBundleSpecs = <_LiteRtLmBundleSpec>[
   _LiteRtLmBundleSpec(
     'android-arm64',
-    sha256: '8d0c9434eec939b7ea961b78fa192e37df9090c0f8b576a0111ddf731f26cbab',
+    sha256: '2586a3f453a7722366210a00fd365401e84110d214e723083343fb60ac111a74',
     requiredLibraries: {
       'libGemmaModelConstraintProvider.so',
       'libLiteRt.so',
@@ -51,7 +51,7 @@ const _litertLmBundleSpecs = <_LiteRtLmBundleSpec>[
   ),
   _LiteRtLmBundleSpec(
     'android-x64',
-    sha256: '92e01daa31f0429e61288402a067e41279587f6c0e39deba34c15003f165ad77',
+    sha256: '5eb7950bbd3c237d93f9ffdcc34665da3433e15fedbd9b6e150519a6fb4b0ffc',
     requiredLibraries: {
       'libGemmaModelConstraintProvider.so',
       'libLiteRt.so',
@@ -65,35 +65,27 @@ const _litertLmBundleSpecs = <_LiteRtLmBundleSpec>[
   ),
   _LiteRtLmBundleSpec(
     'ios-arm64',
-    sha256: '6e9380c8ef265cfe9c9a2426cc0d9ced3d42889a3f6d6f1988362324e57337ec',
+    sha256: 'faad402a7d4671fa7ef9b67777ca6b05cdbf32d74dd8971ac630cc1e26a09868',
     requiredLibraries: {'LiteRtLm', 'CLiteRTLM'},
   ),
   _LiteRtLmBundleSpec(
     'ios-arm64-sim',
-    sha256: '6b13e49937d64507422371324a9f53aa15d98b57c001682e500ec39f17d0aaab',
+    sha256: '8a63cb8ab06a379cbeab4e3f26bf5671ed4372f9b8915654901b07989347d1a4',
     requiredLibraries: {'LiteRtLm', 'CLiteRTLM'},
   ),
   _LiteRtLmBundleSpec(
     'macos-arm64',
-    sha256: 'f0af7691402cc1f68e118a1232a3b977c420f3952231ebf5777c7a366c76e1e5',
-    requiredLibraries: {
-      'libGemmaModelConstraintProvider.dylib',
-      'libLiteRt.dylib',
-      'libLiteRtLm.dylib',
-      'libLiteRtMetalAccelerator.dylib',
-      'libLiteRtTopKMetalSampler.dylib',
-      'libLiteRtTopKWebGpuSampler.dylib',
-      'libLiteRtWebGpuAccelerator.dylib',
-    },
+    sha256: '52f564026617542f3e54589065dcf7d0e6f39e0da845655a9d9efad682477378',
+    requiredLibraries: {'libLiteRtLm.dylib', 'libCLiteRTLM_mac.dylib'},
   ),
   _LiteRtLmBundleSpec(
     'macos-x64',
-    sha256: 'a4dbbd992cf30d617ae2c1dffd5fea24ceb7c07fd655fc077a69df0f5c69318c',
-    requiredLibraries: {'libLiteRtLm.dylib'},
+    sha256: '29cd359545182575ffc7a0ba8231054a445c4993169a4e2d792ffbcef53c1ef1',
+    requiredLibraries: {'libLiteRtLm.dylib', 'libCLiteRTLM_mac.dylib'},
   ),
   _LiteRtLmBundleSpec(
     'linux-arm64',
-    sha256: '87b67cf7e0bddcbd62ffdfa4f206a040171384d297d4793eb6377dd2e57b10f6',
+    sha256: '737a4e7657e09487d9d124e2b80bb459415336960da717ea33430042e6fe9d5b',
     requiredLibraries: {
       'libGemmaModelConstraintProvider.so',
       'libLiteRt.so',
@@ -104,7 +96,7 @@ const _litertLmBundleSpecs = <_LiteRtLmBundleSpec>[
   ),
   _LiteRtLmBundleSpec(
     'linux-x64',
-    sha256: 'cb8625edabd364410923a821e111af443f31483c8be852cf6311c7a9df3e68df',
+    sha256: '592b9eb695d34cf9aadc4520c974aa52494b38e36f3a54a4431b2d1c149b06cf',
     requiredLibraries: {
       'libGemmaModelConstraintProvider.so',
       'libLiteRt.so',
@@ -115,7 +107,7 @@ const _litertLmBundleSpecs = <_LiteRtLmBundleSpec>[
   ),
   _LiteRtLmBundleSpec(
     'windows-x64',
-    sha256: '8a6dd70c4f286215a444294757c9ac6bd35d83f65413b5dd4bce3b7d52367a8f',
+    sha256: '14b5d61834eb8f49e1b6c9ba7f0b695e4a74aa7bd5e75d1084b62116934b2216',
     requiredLibraries: {
       'LiteRtLm.dll',
       'libGemmaModelConstraintProvider.dll',

--- a/lib/src/backends/litert_lm/litert_lm_runtime.dart
+++ b/lib/src/backends/litert_lm/litert_lm_runtime.dart
@@ -9,7 +9,7 @@ import 'package:path/path.dart' as path;
 
 import '../../core/models/inference/model_params.dart';
 
-const _litertLmVersion = '0.13.1';
+const _litertLmVersion = '0.13.1-native.1';
 const _litertLmLibDirEnv = 'LLAMADART_LITERT_LM_LIB_DIR';
 const _liteRtLmIosNativeAsset = 'package:llamadart/litert_lm_LiteRtLm';
 const _processLibraryCandidate = '<process>';
@@ -60,15 +60,13 @@ List<String> liteRtLmMacOsCacheDirectoryCandidatesForAbi(Abi abi) {
 List<String> liteRtLmMacOsRequiredLibrariesForAbi(Abi abi) {
   return switch (abi) {
     Abi.macosArm64 => const <String>[
-      'libGemmaModelConstraintProvider.dylib',
-      'libLiteRt.dylib',
       'libLiteRtLm.dylib',
-      'libLiteRtMetalAccelerator.dylib',
-      'libLiteRtTopKMetalSampler.dylib',
-      'libLiteRtTopKWebGpuSampler.dylib',
-      'libLiteRtWebGpuAccelerator.dylib',
+      'libCLiteRTLM_mac.dylib',
     ],
-    Abi.macosX64 => const <String>['libLiteRtLm.dylib'],
+    Abi.macosX64 => const <String>[
+      'libLiteRtLm.dylib',
+      'libCLiteRTLM_mac.dylib',
+    ],
     _ => const <String>[],
   };
 }
@@ -251,16 +249,11 @@ List<String> liteRtLmMacOsRequiredNativeSpmFilesForAbi(Abi abi) {
   return switch (abi) {
     Abi.macosArm64 => const <String>[
       'LiteRtLm.framework/Versions/A/LiteRtLm',
-      'libGemmaModelConstraintProvider.dylib',
-      'libLiteRt.dylib',
-      'libLiteRtMetalAccelerator.dylib',
-      'libLiteRtTopKMetalSampler.dylib',
-      'libLiteRtTopKWebGpuSampler.dylib',
-      'libLiteRtWebGpuAccelerator.dylib',
+      'libCLiteRTLM_mac.dylib',
     ],
     Abi.macosX64 => const <String>[
       'LiteRtLm.framework/Versions/A/LiteRtLm',
-      'libLiteRt.dylib',
+      'libCLiteRTLM_mac.dylib',
     ],
     _ => const <String>[],
   };
@@ -1225,10 +1218,7 @@ class LiteRtLmRuntimeClient {
             '${frameworksDir.path}/LiteRtLm.framework/Versions/A/LiteRtLm',
           ],
           companions: usesNativeSpmFramework
-              ? [
-                  for (final library in companions)
-                    '${frameworksDir.path}/$library',
-                ]
+              ? const []
               : [
                   for (final library in companions)
                     _macOsFrameworkBinaryPath(frameworksDir, library),

--- a/packages/llamadart_litert_lm_flutter/CHANGELOG.md
+++ b/packages/llamadart_litert_lm_flutter/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.0.2
+
+* Updated Apple SwiftPM native pin to `leehack/litert-lm-native@v0.13.1-native.1`.
+
 ## 0.0.1
 
 * Initial Flutter Apple SwiftPM companion package for `llamadart` LiteRT-LM /

--- a/packages/llamadart_litert_lm_flutter/README.md
+++ b/packages/llamadart_litert_lm_flutter/README.md
@@ -11,13 +11,13 @@ core package's native-assets fallback.
 ```yaml
 dependencies:
   llamadart: ^0.8.0
-  llamadart_litert_lm_flutter: ^0.0.1
+  llamadart_litert_lm_flutter: ^0.0.2
 ```
 
 This package has no runtime Dart API of its own. Import `package:llamadart`
 normally from the core package and use `LlamaBackend()` / `LlamaEngine` there.
 
-The Apple SwiftPM manifest pins `leehack/litert-lm-native@v0.13.1`.
+The Apple SwiftPM manifest pins `leehack/litert-lm-native@v0.13.1-native.1`.
 
 Source for this package lives in
 `packages/llamadart_litert_lm_flutter` in the

--- a/packages/llamadart_litert_lm_flutter/darwin/llamadart_litert_lm_flutter/Package.swift
+++ b/packages/llamadart_litert_lm_flutter/darwin/llamadart_litert_lm_flutter/Package.swift
@@ -4,7 +4,7 @@ import PackageDescription
 
 let packageRoot = URL(fileURLWithPath: #filePath).deletingLastPathComponent()
 let artifactsRoot = packageRoot.appendingPathComponent("Artifacts")
-let liteRtLmTag = "v0.13.1"
+let liteRtLmTag = "v0.13.1-native.1"
 
 func localArtifactPath(_ name: String) -> String? {
     let path = artifactsRoot.appendingPathComponent(name).path
@@ -47,68 +47,28 @@ let package = Package(
             repository: "leehack/litert-lm-native",
             artifactName: "litert-lm-native-apple-LiteRtLm-xcframework-\(liteRtLmTag).zip",
             tag: liteRtLmTag,
-            checksum: "6fa9169d7c93eb1b70dc537b35640e2652cd9ee139014251404d4e6b15ad2686"
+            checksum: "52cb28c84bd13e5a0eeaf5a081a3f24fa62375ede4134e5c6b87cbe624077247"
         ),
         nativeRepoBinaryTarget(
             name: "CLiteRTLM",
             repository: "leehack/litert-lm-native",
             artifactName: "litert-lm-native-apple-CLiteRTLM-xcframework-\(liteRtLmTag).zip",
             tag: liteRtLmTag,
-            checksum: "81880c7bf84586bc08820cc645a1c52869870676ff7de123ac0ba99c2e6820f7"
+            checksum: "6127981cbb3693b0f3f50d34e56e0969a1cb955744eb5fa53b46d9845152869f"
         ),
         nativeRepoBinaryTarget(
-            name: "GemmaModelConstraintProvider",
+            name: "CLiteRTLMMac",
             repository: "leehack/litert-lm-native",
-            artifactName: "litert-lm-native-apple-GemmaModelConstraintProvider-xcframework-\(liteRtLmTag).zip",
+            artifactName: "litert-lm-native-apple-CLiteRTLMMac-xcframework-\(liteRtLmTag).zip",
             tag: liteRtLmTag,
-            checksum: "d039fe952eb3187626b7950c42b35c6f7d16340ab8d1e6b1ff63a998022446f9"
-        ),
-        nativeRepoBinaryTarget(
-            name: "LiteRt",
-            repository: "leehack/litert-lm-native",
-            artifactName: "litert-lm-native-apple-LiteRt-xcframework-\(liteRtLmTag).zip",
-            tag: liteRtLmTag,
-            checksum: "0055e5483c0aff861a37a20c66e485051eb081fb2dbded5501ffdc2cc82d0df7"
-        ),
-        nativeRepoBinaryTarget(
-            name: "LiteRtMetalAccelerator",
-            repository: "leehack/litert-lm-native",
-            artifactName: "litert-lm-native-apple-LiteRtMetalAccelerator-xcframework-\(liteRtLmTag).zip",
-            tag: liteRtLmTag,
-            checksum: "5e3ce138a722cbc4730b8986db0134fcf64f6f486876c2a3bacd922f50fdebf3"
-        ),
-        nativeRepoBinaryTarget(
-            name: "LiteRtTopKMetalSampler",
-            repository: "leehack/litert-lm-native",
-            artifactName: "litert-lm-native-apple-LiteRtTopKMetalSampler-xcframework-\(liteRtLmTag).zip",
-            tag: liteRtLmTag,
-            checksum: "f9c4f5e62be9a9c8d69298f5196c213cef8760394262fd02da0c9b13580f08a7"
-        ),
-        nativeRepoBinaryTarget(
-            name: "LiteRtTopKWebGpuSampler",
-            repository: "leehack/litert-lm-native",
-            artifactName: "litert-lm-native-apple-LiteRtTopKWebGpuSampler-xcframework-\(liteRtLmTag).zip",
-            tag: liteRtLmTag,
-            checksum: "e99fc2aef67b24e6c024bed89fee36bf8cf8bb2870c2b48dfae9ba7f42c0dcd6"
-        ),
-        nativeRepoBinaryTarget(
-            name: "LiteRtWebGpuAccelerator",
-            repository: "leehack/litert-lm-native",
-            artifactName: "litert-lm-native-apple-LiteRtWebGpuAccelerator-xcframework-\(liteRtLmTag).zip",
-            tag: liteRtLmTag,
-            checksum: "9a3de6686d37cf06475b4fd8dfb094aaa8e3f55b1cbbdc60ae38e6eb8f5f1ba1"
+            checksum: "cf29ca8d0b50a6d15845414aeabf2d9d30039ae18f6dff6a7ad5c7051f21506f"
         ),
         .target(
             name: "llamadart_litert_lm_flutter",
             dependencies: [
                 "LiteRtLm",
                 .target(name: "CLiteRTLM", condition: .when(platforms: [.iOS])),
-                .target(name: "GemmaModelConstraintProvider", condition: .when(platforms: [.macOS])),
-                .target(name: "LiteRt", condition: .when(platforms: [.macOS])),
-                .target(name: "LiteRtMetalAccelerator", condition: .when(platforms: [.macOS])),
-                .target(name: "LiteRtTopKMetalSampler", condition: .when(platforms: [.macOS])),
-                .target(name: "LiteRtTopKWebGpuSampler", condition: .when(platforms: [.macOS])),
-                .target(name: "LiteRtWebGpuAccelerator", condition: .when(platforms: [.macOS]))
+                .target(name: "CLiteRTLMMac", condition: .when(platforms: [.macOS]))
             ],
             linkerSettings: [
                 .unsafeFlags(["-Xlinker", "-reexport_framework", "-Xlinker", "LiteRtLm"]),

--- a/packages/llamadart_litert_lm_flutter/pubspec.yaml
+++ b/packages/llamadart_litert_lm_flutter/pubspec.yaml
@@ -1,6 +1,6 @@
 name: llamadart_litert_lm_flutter
 description: Flutter Apple SwiftPM runtime companion package for llamadart LiteRT-LM support.
-version: 0.0.1
+version: 0.0.2
 repository: https://github.com/leehack/llamadart/tree/main/packages/llamadart_litert_lm_flutter
 homepage: https://github.com/leehack/llamadart
 issue_tracker: https://github.com/leehack/llamadart/issues

--- a/test/unit/backends/litert_lm/litert_lm_runtime_test.dart
+++ b/test/unit/backends/litert_lm/litert_lm_runtime_test.dart
@@ -167,16 +167,12 @@ void main() {
 
   test('macOS LiteRT-LM cache validation follows runtime ABI files', () {
     expect(liteRtLmMacOsRequiredLibrariesForAbi(Abi.macosArm64), const <String>[
-      'libGemmaModelConstraintProvider.dylib',
-      'libLiteRt.dylib',
       'libLiteRtLm.dylib',
-      'libLiteRtMetalAccelerator.dylib',
-      'libLiteRtTopKMetalSampler.dylib',
-      'libLiteRtTopKWebGpuSampler.dylib',
-      'libLiteRtWebGpuAccelerator.dylib',
+      'libCLiteRTLM_mac.dylib',
     ]);
     expect(liteRtLmMacOsRequiredLibrariesForAbi(Abi.macosX64), const <String>[
       'libLiteRtLm.dylib',
+      'libCLiteRTLM_mac.dylib',
     ]);
     expect(liteRtLmMacOsRequiredLibrariesForAbi(Abi.linuxX64), isEmpty);
   });
@@ -251,6 +247,10 @@ void main() {
     expect(liteRtLmIsMacOsCacheDirectoryForAbi(x64Dir, Abi.macosX64), isFalse);
 
     File('${x64Dir.path}/libLiteRtLm.dylib').createSync();
+
+    expect(liteRtLmIsMacOsCacheDirectoryForAbi(x64Dir, Abi.macosX64), isFalse);
+
+    File('${x64Dir.path}/libCLiteRTLM_mac.dylib').createSync();
 
     expect(liteRtLmIsMacOsCacheDirectoryForAbi(x64Dir, Abi.macosX64), isTrue);
     expect(liteRtLmIsMacOsCacheDirectoryForAbi(x64Dir, Abi.linuxX64), isFalse);

--- a/test/unit/hook/build_hook_litert_lm_integration_test.dart
+++ b/test/unit/hook/build_hook_litert_lm_integration_test.dart
@@ -25,6 +25,12 @@ void main() {
   final macosArm64LitertBundleDir = Directory(
     '.dart_tool/llamadart/litert_lm/$litertVersion/macos/arm64',
   );
+  final macosX64NativeBundleDir = Directory(
+    '.dart_tool/llamadart/native_bundles/$nativeTag/macos-x86_64/extracted',
+  );
+  final macosX64LitertBundleDir = Directory(
+    '.dart_tool/llamadart/litert_lm/$litertVersion/macos/x64',
+  );
   final iosDeviceNativeBundleDir = Directory(
     '.dart_tool/llamadart/native_bundles/$nativeTag/ios-arm64/extracted',
   );
@@ -50,6 +56,14 @@ void main() {
     (
       macosArm64LitertBundleDir,
       Directory('${macosArm64LitertBundleDir.path}.__litert_test'),
+    ),
+    (
+      macosX64NativeBundleDir,
+      Directory('${macosX64NativeBundleDir.path}.__litert_test'),
+    ),
+    (
+      macosX64LitertBundleDir,
+      Directory('${macosX64LitertBundleDir.path}.__litert_test'),
     ),
     (
       iosDeviceNativeBundleDir,
@@ -94,6 +108,13 @@ void main() {
     await _writeBundleLibraries(
       macosArm64LitertBundleDir,
       _macosArm64LiteRtLibraries,
+    );
+    await _writeBundleLibraries(macosX64NativeBundleDir, const [
+      'libllamadart.dylib',
+    ]);
+    await _writeBundleLibraries(
+      macosX64LitertBundleDir,
+      _macosX64LiteRtLibraries,
     );
     for (final directory in [
       iosDeviceNativeBundleDir,
@@ -182,29 +203,37 @@ void main() {
   test(
     'build hook keeps macOS LiteRT-LM libraries in the cache when requested',
     () async {
-      await testCodeBuildHook(
-        mainMethod: build_hook.main,
-        targetOS: OS.macOS,
-        targetArchitecture: Architecture.arm64,
-        userDefines: _allRuntimeUserDefines(),
-        check: (input, output) {
-          final codeAssets = output.assets.encodedAssets
-              .where((asset) => asset.isCodeAsset)
-              .map((asset) => asset.asCodeAsset)
-              .toList(growable: false);
+      for (final (architecture, expectedLibraries) in [
+        (Architecture.arm64, _macosArm64LiteRtLibraries),
+        (Architecture.x64, _macosX64LiteRtLibraries),
+      ]) {
+        await testCodeBuildHook(
+          mainMethod: build_hook.main,
+          targetOS: OS.macOS,
+          targetArchitecture: architecture,
+          userDefines: _allRuntimeUserDefines(),
+          check: (input, output) {
+            final codeAssets = output.assets.encodedAssets
+                .where((asset) => asset.isCodeAsset)
+                .map((asset) => asset.asCodeAsset)
+                .toList(growable: false);
 
-          final codeAssetIds = codeAssets.map((asset) => asset.id).toSet();
-          final emittedNames = codeAssets
-              .map((asset) => path.basename(asset.file!.toFilePath()))
-              .toSet();
+            final codeAssetIds = codeAssets.map((asset) => asset.id).toSet();
+            final emittedNames = codeAssets
+                .map((asset) => path.basename(asset.file!.toFilePath()))
+                .toSet();
 
-          expect(codeAssetIds, contains('package:llamadart/llamadart'));
-          expect(codeAssetIds.where((id) => id.contains('litert_lm')), isEmpty);
-          for (final library in _macosArm64LiteRtLibraries) {
-            expect(emittedNames, isNot(contains(library)));
-          }
-        },
-      );
+            expect(codeAssetIds, contains('package:llamadart/llamadart'));
+            expect(
+              codeAssetIds.where((id) => id.contains('litert_lm')),
+              isEmpty,
+            );
+            for (final library in expectedLibraries) {
+              expect(emittedNames, isNot(contains(library)));
+            }
+          },
+        );
+      }
     },
   );
 
@@ -705,16 +734,14 @@ const List<String> _iosLiteRtAssetNames = [
 ];
 
 const List<String> _macosArm64LiteRtLibraries = [
-  'libGemmaModelConstraintProvider.dylib',
-  'libLiteRt.dylib',
   'libLiteRtLm.dylib',
-  'libLiteRtMetalAccelerator.dylib',
-  'libLiteRtTopKMetalSampler.dylib',
-  'libLiteRtTopKWebGpuSampler.dylib',
-  'libLiteRtWebGpuAccelerator.dylib',
+  'libCLiteRTLM_mac.dylib',
 ];
 
-const List<String> _macosX64LiteRtLibraries = ['libLiteRtLm.dylib'];
+const List<String> _macosX64LiteRtLibraries = [
+  'libLiteRtLm.dylib',
+  'libCLiteRTLM_mac.dylib',
+];
 
 const List<String> _linuxLiteRtLibraries = [
   'libGemmaModelConstraintProvider.so',

--- a/test/unit/tooling/sync_native_release_pins_script_test.dart
+++ b/test/unit/tooling/sync_native_release_pins_script_test.dart
@@ -31,12 +31,27 @@ const _litertLmBundleSpecs = <_LiteRtLmBundleSpec>[
   ),
 ];
 ''');
+    final litertRuntimeDart = File(
+      path.join(
+        root.path,
+        'lib',
+        'src',
+        'backends',
+        'litert_lm',
+        'litert_lm_runtime.dart',
+      ),
+    );
+    await litertRuntimeDart.parent.create(recursive: true);
+    await litertRuntimeDart.writeAsString('''
+const _litertLmVersion = '1.0.0';
+''');
     await _writePackageSwift(
       root,
       'packages/llamadart_llama_cpp_flutter/darwin/'
           'llamadart_llama_cpp_flutter/Package.swift',
       'llamaCppTag',
       const ['llama'],
+      const {'llama': 'llamadart-native-apple-xcframework-\\(llamaCppTag).zip'},
     );
     await _writePackageSwift(
       root,
@@ -44,6 +59,10 @@ const _litertLmBundleSpecs = <_LiteRtLmBundleSpec>[
           'llamadart_litert_lm_flutter/Package.swift',
       'liteRtLmTag',
       _litertAppleTargets.keys,
+      {
+        for (final entry in _litertAppleTargets.entries)
+          entry.key: entry.value.$1.replaceAll('{tag}', '\\(liteRtLmTag)'),
+      },
     );
     await _writeCompanionDocs(
       root,
@@ -106,6 +125,11 @@ const _litertLmBundleSpecs = <_LiteRtLmBundleSpec>[
     expect(hook, contains("const _llamaCppTag = '$llamaTag';"));
     expect(hook, contains("const _litertLmVersion = '9.9.9';"));
     expect(hook, contains("sha256: '$litertRuntimeChecksum'"));
+    final litertRuntimeDartText = await litertRuntimeDart.readAsString();
+    expect(
+      litertRuntimeDartText,
+      contains("const _litertLmVersion = '9.9.9';"),
+    );
 
     final llamaSwift = await File(
       path.join(
@@ -224,6 +248,7 @@ Future<void> _writePackageSwift(
   String relativePath,
   String tagVariable,
   Iterable<String> targetNames,
+  Map<String, String> artifactNames,
 ) async {
   final file = File(path.join(root.path, relativePath));
   await file.parent.create(recursive: true);
@@ -235,6 +260,7 @@ let package = Package(
 ${targetNames.map((target) => '''
         nativeRepoBinaryTarget(
             name: "$target",
+            artifactName: "${artifactNames[target]}",
             checksum: "${_hex('0')}"
         ),
 ''').join()}
@@ -294,25 +320,8 @@ String _hex(String character) => List.filled(64, character).join();
 const Map<String, (String, String)> _litertAppleTargets = {
   'LiteRtLm': ('litert-lm-native-apple-LiteRtLm-xcframework-{tag}.zip', '3'),
   'CLiteRTLM': ('litert-lm-native-apple-CLiteRTLM-xcframework-{tag}.zip', '4'),
-  'GemmaModelConstraintProvider': (
-    'litert-lm-native-apple-GemmaModelConstraintProvider-xcframework-{tag}.zip',
+  'CLiteRTLMMac': (
+    'litert-lm-native-apple-CLiteRTLMMac-xcframework-{tag}.zip',
     '5',
-  ),
-  'LiteRt': ('litert-lm-native-apple-LiteRt-xcframework-{tag}.zip', '6'),
-  'LiteRtMetalAccelerator': (
-    'litert-lm-native-apple-LiteRtMetalAccelerator-xcframework-{tag}.zip',
-    '7',
-  ),
-  'LiteRtTopKMetalSampler': (
-    'litert-lm-native-apple-LiteRtTopKMetalSampler-xcframework-{tag}.zip',
-    '8',
-  ),
-  'LiteRtTopKWebGpuSampler': (
-    'litert-lm-native-apple-LiteRtTopKWebGpuSampler-xcframework-{tag}.zip',
-    '9',
-  ),
-  'LiteRtWebGpuAccelerator': (
-    'litert-lm-native-apple-LiteRtWebGpuAccelerator-xcframework-{tag}.zip',
-    'a',
   ),
 };

--- a/tool/native/sync_native_release_pins.py
+++ b/tool/native/sync_native_release_pins.py
@@ -25,28 +25,9 @@ DEFAULT_LITERT_LM_PACKAGE_SWIFT = (
     "packages/llamadart_litert_lm_flutter/darwin/"
     "llamadart_litert_lm_flutter/Package.swift"
 )
-
-LITERT_LM_APPLE_TARGETS = {
-    "LiteRtLm": "litert-lm-native-apple-LiteRtLm-xcframework-{tag}.zip",
-    "CLiteRTLM": "litert-lm-native-apple-CLiteRTLM-xcframework-{tag}.zip",
-    "GemmaModelConstraintProvider": (
-        "litert-lm-native-apple-GemmaModelConstraintProvider-"
-        "xcframework-{tag}.zip"
-    ),
-    "LiteRt": "litert-lm-native-apple-LiteRt-xcframework-{tag}.zip",
-    "LiteRtMetalAccelerator": (
-        "litert-lm-native-apple-LiteRtMetalAccelerator-xcframework-{tag}.zip"
-    ),
-    "LiteRtTopKMetalSampler": (
-        "litert-lm-native-apple-LiteRtTopKMetalSampler-xcframework-{tag}.zip"
-    ),
-    "LiteRtTopKWebGpuSampler": (
-        "litert-lm-native-apple-LiteRtTopKWebGpuSampler-xcframework-{tag}.zip"
-    ),
-    "LiteRtWebGpuAccelerator": (
-        "litert-lm-native-apple-LiteRtWebGpuAccelerator-xcframework-{tag}.zip"
-    ),
-}
+DEFAULT_LITERT_LM_RUNTIME_DART = (
+    "lib/src/backends/litert_lm/litert_lm_runtime.dart"
+)
 
 
 class ReleaseError(RuntimeError):
@@ -59,6 +40,7 @@ def main() -> int:
     hook_path = repo_root / args.hook_build
     llama_cpp_package_swift_path = repo_root / args.llama_cpp_package_swift
     litert_lm_package_swift_path = repo_root / args.litert_lm_package_swift
+    litert_lm_runtime_dart_path = repo_root / args.litert_lm_runtime_dart
 
     hook_text = hook_path.read_text(encoding="utf-8")
     pending_writes: dict[Path, str] = {}
@@ -131,6 +113,19 @@ def main() -> int:
             f"const _litertLmVersion = '{litert_version}';",
             "hook LiteRT-LM version",
         )
+        if not litert_lm_runtime_dart_path.exists():
+            raise ReleaseError(
+                f"Missing LiteRT-LM Dart runtime {litert_lm_runtime_dart_path}"
+            )
+        runtime_dart_text = litert_lm_runtime_dart_path.read_text(
+            encoding="utf-8"
+        )
+        pending_writes[litert_lm_runtime_dart_path] = replace_one(
+            runtime_dart_text,
+            r"const _litertLmVersion = '[^']+';",
+            f"const _litertLmVersion = '{litert_version}';",
+            "LiteRT-LM Dart runtime version",
+        )
         for bundle in litert_lm_bundle_names(hook_text):
             checksum = release_asset_checksum(
                 release,
@@ -146,6 +141,16 @@ def main() -> int:
             original_swift_text = litert_lm_package_swift_path.read_text(
                 encoding="utf-8"
             )
+            original_litert_lm_tag = swift_variable_value(
+                original_swift_text,
+                "liteRtLmTag",
+                "LiteRT-LM Package.swift tag",
+            )
+            apple_targets = swift_native_repo_binary_targets(
+                original_swift_text,
+                tag_variable="liteRtLmTag",
+                current_tag=original_litert_lm_tag,
+            )
             swift_text = original_swift_text
             swift_text = replace_one(
                 swift_text,
@@ -153,7 +158,7 @@ def main() -> int:
                 f'let liteRtLmTag = "{resolved_litert_lm_tag}"',
                 "LiteRT-LM Package.swift tag",
             )
-            for target_name, asset_template in LITERT_LM_APPLE_TARGETS.items():
+            for target_name, asset_template in apple_targets:
                 checksum = release_asset_checksum(
                     release,
                     asset_template.format(tag=resolved_litert_lm_tag),
@@ -230,6 +235,14 @@ def parse_args() -> argparse.Namespace:
         help=(
             "Path to the LiteRT-LM Flutter companion Package.swift relative "
             "to repo root. Skipped if the file does not exist."
+        ),
+    )
+    parser.add_argument(
+        "--litert-lm-runtime-dart",
+        default=DEFAULT_LITERT_LM_RUNTIME_DART,
+        help=(
+            "Path to the LiteRT-LM Dart runtime version pin relative "
+            "to repo root."
         ),
     )
     parser.add_argument(
@@ -395,6 +408,59 @@ def replace_swift_binary_target_checksum(
     if count != 1:
         raise ReleaseError(f"Could not replace Package.swift checksum for {target_name}")
     return updated
+
+
+def swift_variable_value(
+    swift_text: str,
+    variable_name: str,
+    description: str,
+) -> str:
+    match = re.search(
+        rf'\blet\s+{re.escape(variable_name)}\s*=\s*"([^"]+)"',
+        swift_text,
+    )
+    if not match:
+        raise ReleaseError(f"Could not read {description}")
+    return match.group(1)
+
+
+def swift_native_repo_binary_targets(
+    swift_text: str,
+    *,
+    tag_variable: str,
+    current_tag: str,
+) -> list[tuple[str, str]]:
+    pattern = re.compile(
+        r'nativeRepoBinaryTarget\(\s*name:\s*"(?P<name>[^"]+)"'
+        r'.*?artifactName:\s*"(?P<artifact_name>[^"]+)"'
+        r'.*?checksum:\s*"[0-9a-f]+"',
+        re.DOTALL,
+    )
+    targets: list[tuple[str, str]] = []
+    for match in pattern.finditer(swift_text):
+        artifact_template = swift_artifact_template(
+            match.group("artifact_name"),
+            tag_variable=tag_variable,
+            current_tag=current_tag,
+        )
+        targets.append((match.group("name"), artifact_template))
+    if not targets:
+        raise ReleaseError("Could not find nativeRepoBinaryTarget entries")
+    return targets
+
+
+def swift_artifact_template(
+    artifact_name: str,
+    *,
+    tag_variable: str,
+    current_tag: str,
+) -> str:
+    interpolated_tag = rf"\({tag_variable})"
+    if interpolated_tag in artifact_name:
+        return artifact_name.replace(interpolated_tag, "{tag}")
+    if current_tag in artifact_name:
+        return artifact_name.replace(current_tag, "{tag}")
+    return artifact_name
 
 
 def companion_package_root(package_swift_path: Path) -> Path:


### PR DESCRIPTION
## Summary

- Sync LiteRT-LM native runtime archives to `leehack/litert-lm-native@v0.13.1-native.1`.
- Update macOS runtime expectations for the consolidated `libLiteRtLm.dylib` + `libCLiteRTLM_mac.dylib` layout.
- Update the LiteRT-LM Flutter Apple SPM companion to the new three-artifact layout: `LiteRtLm`, `CLiteRTLM`, and `CLiteRTLMMac`.
- Avoid separately opening the macOS SPM companion dylib when `LiteRtLm.framework` already owns the upstream runtime, preventing duplicate LiteRT-LM registration.
- Fix `sync_native_release_pins.py` and the version-bump workflow so future LiteRT-LM bumps update Apple binary targets, archive checksums, companion metadata, and the Dart runtime pin together.
- Bump `llamadart_litert_lm_flutter` to `0.0.2` for the SPM pin change.

## Validation

- `python3 -m py_compile tool/native/sync_native_release_pins.py`
- `python3 tool/native/sync_native_release_pins.py --llama-cpp-tag keep --litert-lm-tag v0.13.1-native.1 --dry-run`
- `dart test test/unit/tooling/sync_native_release_pins_script_test.dart`
- `dart test test/unit/backends/litert_lm/litert_lm_runtime_test.dart test/unit/hook/build_hook_litert_lm_integration_test.dart`
- `dart analyze hook/build.dart lib/src/backends/litert_lm/litert_lm_runtime.dart test/unit/backends/litert_lm/litert_lm_runtime_test.dart test/unit/hook/build_hook_litert_lm_integration_test.dart test/unit/tooling/sync_native_release_pins_script_test.dart`
- `git diff --check`

## Manual Runtime Checks

Using `gemma-4-E2B-it.litertlm`:

- macOS Flutter/SPM CPU inference: passed, generated `4`.
- macOS Flutter/SPM GPU/Metal inference: passed, generated `4`.
- iOS simulator Flutter/SPM CPU inference: passed, generated `4`.
- iOS simulator GPU/Metal reached native engine creation but failed in LiteRT-LM Metal delegate setup with `texture binding has argument index 31 that is greater than 30`; this appears to be a simulator/runtime Metal limitation, not an SPM linking failure.

Note: full `dart analyze` still reports unrelated pre-existing example app dependency/import issues, so the targeted analyzer command above was used for this PR.
