### PR TITLE
Prepare 0.8.1 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-## Unreleased
+## 0.8.1
 
 * Fixed docs references that still pointed at
   `llamadart_litert_lm_flutter` `0.0.1` and

--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ JavaScript runtime.
 
 ```yaml
 dependencies:
-  llamadart: ^0.8.0
+  llamadart: ^0.8.1
 ```
 
 Flutter iOS/macOS apps that want Swift Package Manager-linked Apple
@@ -61,7 +61,7 @@ they ship:
 
 ```yaml
 dependencies:
-  llamadart: ^0.8.0
+  llamadart: ^0.8.1
   llamadart_llama_cpp_flutter: ^0.0.2 # GGUF / llama.cpp
   llamadart_litert_lm_flutter: ^0.0.2 # .litertlm / LiteRT-LM
 ```

--- a/example/chat_app/pubspec.lock
+++ b/example/chat_app/pubspec.lock
@@ -349,7 +349,7 @@ packages:
       path: "../.."
       relative: true
     source: path
-    version: "0.8.0"
+    version: "0.8.1"
   logging:
     dependency: transitive
     description:

--- a/packages/llamadart_litert_lm_flutter/README.md
+++ b/packages/llamadart_litert_lm_flutter/README.md
@@ -10,7 +10,7 @@ core package's native-assets fallback.
 
 ```yaml
 dependencies:
-  llamadart: ^0.8.0
+  llamadart: ^0.8.1
   llamadart_litert_lm_flutter: ^0.0.2
 ```
 

--- a/packages/llamadart_llama_cpp_flutter/README.md
+++ b/packages/llamadart_llama_cpp_flutter/README.md
@@ -9,7 +9,7 @@ core package's native-assets fallback.
 
 ```yaml
 dependencies:
-  llamadart: ^0.8.0
+  llamadart: ^0.8.1
   llamadart_llama_cpp_flutter: ^0.0.2
 ```
 

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: llamadart
 description: Dart and Flutter local LLM inference with llama.cpp GGUF and LiteRT-LM across native platforms and web.
-version: 0.8.0
+version: 0.8.1
 homepage: https://github.com/leehack/llamadart
 repository: https://github.com/leehack/llamadart
 issue_tracker: https://github.com/leehack/llamadart/issues

--- a/website/docs/changelog/recent-releases.md
+++ b/website/docs/changelog/recent-releases.md
@@ -7,7 +7,7 @@ For canonical full release notes, use:
 
 - [`CHANGELOG.md`](https://github.com/leehack/llamadart/blob/main/CHANGELOG.md)
 
-## Unreleased
+## 0.8.1
 
 - Fixed docs references that still pointed at
   `llamadart_litert_lm_flutter` `0.0.1` and

--- a/website/docs/getting-started/installation.md
+++ b/website/docs/getting-started/installation.md
@@ -27,7 +27,7 @@ In Xcode, set `IPHONEOS_DEPLOYMENT_TARGET = 16.4` or
 
 ```yaml
 dependencies:
-  llamadart: ^0.8.0
+  llamadart: ^0.8.1
 ```
 
 For Flutter iOS/macOS apps that should link Apple XCFrameworks through Swift
@@ -35,7 +35,7 @@ Package Manager, also add the runtime companion packages you need:
 
 ```yaml
 dependencies:
-  llamadart: ^0.8.0
+  llamadart: ^0.8.1
   llamadart_llama_cpp_flutter: ^0.0.2 # GGUF / llama.cpp
   llamadart_litert_lm_flutter: ^0.0.2 # .litertlm / LiteRT-LM
 ```


### PR DESCRIPTION
## Summary

- Bump `llamadart` to `0.8.1`.
- Move the current release notes from `Unreleased` to `0.8.1` in the root changelog and website recent releases page.
- Update current install snippets to `llamadart: ^0.8.1` and refresh the tracked chat app path lockfile.

## Issue closure

- Closed #189 as addressed by #205; native `.litertlm` media parts now route through LiteRT-LM Conversation message JSON, while projector-style multimodal APIs remain llama.cpp/WebGPU-oriented by design.

## Validation

- `dart format --output=none --set-exit-if-changed .`
- `dart analyze`
- `dart test -p vm -j 1 --exclude-tags local-only`
- `./tool/docs/validate_links.sh`
- `dart pub publish --dry-run` (`Package has 0 warnings.`)

## Release notes

This is a patch release prep for the post-`0.8.0` docs pin fix and native LiteRT-LM media input routing. Companion package versions are unchanged.