### PR TITLE
feat(backend): add listGpuDevices for per-GPU device enumeration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,13 @@
+## Unreleased
+
+* Added `BackendGpuEnumeration.listGpuDevices({probeBackends})` (exposed via
+  `LlamaEngine.listGpuDevices`) to enumerate GPU-class devices for offload
+  selection — backend, per-backend `mainGpu` index, name, description, device
+  id, type, and free/total memory per device. With an empty `probeBackends`
+  only already-registered backends are inspected, so an unsupported GPU runtime
+  cannot crash the process during enumeration; pass specific backends to opt
+  into loading just those modules first. Web/WebGPU return an empty list.
+
 ## 0.8.1
 
 * Fixed docs references that still pointed at

--- a/README.md
+++ b/README.md
@@ -785,6 +785,7 @@ Core abstractions in this package:
 - `ChatSession`: stateful helper for chat history and sliding-window context.
 - `LlamaBackend`: platform-agnostic backend interface with native/web routing.
 - Optional runtime diagnostics are exposed through `LlamaEngine` helpers such as `getBackendName()`, `getAvailableBackends()`, and `getResolvedGpuLayers()` when supported by the active backend.
+- `LlamaEngine.listGpuDevices()` enumerates GPU-class devices (backend, per-backend `mainGpu` index, name, description, device id, type, free/total memory) for offload selection. By default it inspects only already-registered backends; pass `probeBackends: [...]` to opt into loading specific backend modules first. Web/WebGPU return an empty list.
 
 ---
 ## ⚠️ Breaking Changes in 0.6.x

--- a/lib/llamadart.dart
+++ b/lib/llamadart.dart
@@ -43,6 +43,7 @@ export 'src/backends/backend.dart'
         LlamaBackend,
         BackendAvailability,
         BackendGrammarConstraintsSupport,
+        BackendGpuEnumeration,
         BackendNativeChatGeneration,
         BackendRuntimeDiagnostics,
         BackendPerfContextData,
@@ -82,6 +83,7 @@ export 'src/core/models/tools/tool_params.dart';
 export 'src/core/llama_logger.dart';
 export 'src/core/models/config/log_level.dart';
 export 'src/core/models/config/gpu_backend.dart';
+export 'src/core/models/config/gpu_device_info.dart';
 export 'src/core/models/config/flash_attention.dart';
 export 'src/core/models/config/kv_cache_type.dart';
 export 'src/core/models/config/lora_config.dart';

--- a/lib/src/backends/backend.dart
+++ b/lib/src/backends/backend.dart
@@ -3,6 +3,8 @@ import '../core/models/inference/generation_params.dart';
 import '../core/models/inference/tool_choice.dart';
 import '../core/models/chat/chat_message.dart';
 import '../core/models/chat/content_part.dart';
+import '../core/models/config/gpu_backend.dart';
+import '../core/models/config/gpu_device_info.dart';
 import '../core/models/config/log_level.dart';
 import '../core/models/tools/tool_definition.dart';
 
@@ -171,6 +173,23 @@ abstract class BackendRuntimeDiagnostics {
   /// This value reflects the final layer count passed to native model load
   /// after backend policy/fallback decisions.
   Future<int?> getResolvedGpuLayers();
+}
+
+/// Optional backend capability for enumerating GPU-class devices for offload
+/// selection (e.g. pinning to the discrete GPU on a laptop, or surfacing which
+/// device is in use).
+abstract class BackendGpuEnumeration {
+  /// Lists the GPU-class devices the backend exposes.
+  ///
+  /// With an empty [probeBackends] only already-registered backends are
+  /// inspected — no backend module is loaded, so an unsupported GPU runtime
+  /// cannot crash the process during enumeration. Pass specific backends in
+  /// [probeBackends] to opt into loading just those modules (each guarded)
+  /// before enumerating. Backends with no offload devices (and web/WebGPU)
+  /// return an empty list.
+  Future<List<GpuDeviceInfo>> listGpuDevices({
+    List<GpuBackend> probeBackends = const [],
+  });
 }
 
 /// Native performance timings reported by llama.cpp for the active context.

--- a/lib/src/backends/llama_cpp/llama_cpp_backend.dart
+++ b/lib/src/backends/llama_cpp/llama_cpp_backend.dart
@@ -4,6 +4,8 @@ import 'dart:ffi';
 import 'package:ffi/ffi.dart';
 import '../backend.dart';
 import '../../core/models/chat/content_part.dart';
+import '../../core/models/config/gpu_backend.dart';
+import '../../core/models/config/gpu_device_info.dart';
 import '../../core/models/config/log_level.dart';
 import '../../core/models/inference/model_params.dart';
 import '../../core/models/inference/generation_params.dart';
@@ -18,6 +20,7 @@ class NativeLlamaBackend
         LlamaBackend,
         BackendAvailability,
         BackendRuntimeDiagnostics,
+        BackendGpuEnumeration,
         BackendPerformanceDiagnostics,
         BackendEmbeddings,
         BackendBatchEmbeddings,
@@ -585,6 +588,21 @@ class NativeLlamaBackend
       return (total: res.totalVram, free: res.freeVram);
     }
     return (total: 0, free: 0);
+  }
+
+  @override
+  Future<List<GpuDeviceInfo>> listGpuDevices({
+    List<GpuBackend> probeBackends = const [],
+  }) async {
+    await _ensureIsolate();
+    final rp = ReceivePort();
+    _sendPort!.send(ListGpuDevicesRequest(probeBackends, rp.sendPort));
+    final res = await rp.first;
+    rp.close();
+    if (res is ListGpuDevicesResponse) {
+      return res.devices;
+    }
+    return const [];
   }
 
   @override

--- a/lib/src/backends/llama_cpp/llama_cpp_service.dart
+++ b/lib/src/backends/llama_cpp/llama_cpp_service.dart
@@ -10,6 +10,7 @@ import 'package:path/path.dart' as path;
 import '../../core/llama_logger.dart';
 import '../../core/models/chat/content_part.dart';
 import '../../core/models/config/gpu_backend.dart';
+import '../../core/models/config/gpu_device_info.dart';
 import '../../core/models/config/log_level.dart';
 import '../../core/models/inference/generation_params.dart';
 import '../../core/models/inference/model_params.dart';
@@ -5652,6 +5653,148 @@ class LlamaCppService {
       }
     }
     return (total: 0, free: 0);
+  }
+
+  /// Enumerates GPU-class devices across registered backends.
+  ///
+  /// With an empty [probeBackends] only already-registered backends are
+  /// inspected — no backend module is loaded, so an unsupported GPU runtime
+  /// cannot crash the process during enumeration. Pass specific backends in
+  /// [probeBackends] to opt into loading just those modules (guarded; CPU/auto
+  /// are ignored) before enumerating. Walks the global device list
+  /// (`ggml_backend_dev_count` / `ggml_backend_dev_get`) through the registry
+  /// fallback wrappers so devices register on Windows split bundles, and reads
+  /// each device's description/id/memory from `ggml_backend_dev_get_props`
+  /// (with `ggml_backend_dev_memory` as a memory fallback). CPU devices are
+  /// excluded. Returns an empty list when no GPU-class device is reachable.
+  List<GpuDeviceInfo> listGpuDevices({
+    List<GpuBackend> probeBackends = const [],
+  }) {
+    for (final backend in probeBackends) {
+      if (backend == GpuBackend.auto || backend == GpuBackend.cpu) continue;
+      _tryLoadBackendModuleIfBundled(backend.name);
+    }
+
+    final count = _ggmlBackendDevCount();
+    final result = <GpuDeviceInfo>[];
+    final perBackendOrdinal = <GpuBackend, int>{};
+    for (var i = 0; i < count; i++) {
+      final dev = _ggmlBackendDevGet(i);
+      if (dev == nullptr) continue;
+
+      final propsPtr = calloc<ggml_backend_dev_props>();
+      try {
+        final hasProps = _ggmlBackendDevGetProps(dev, propsPtr);
+        final props = hasProps ? propsPtr.ref : null;
+
+        // Prefer the standalone type probe; when its symbol is unavailable
+        // (returns -1 -> unknown) fall back to the type carried in props, so a
+        // device still enumerates on runtimes missing the standalone symbol.
+        // Raw-int compares keep a future llama.cpp enum variant from crashing
+        // the high-level binding's fromValue.
+        var type = _mapGpuDeviceType(_ggmlBackendDevType(dev));
+        if (type == GpuDeviceType.unknown && props != null) {
+          type = _mapGpuDeviceType(props.typeAsInt);
+        }
+        if (type == GpuDeviceType.cpu || type == GpuDeviceType.unknown) {
+          continue;
+        }
+
+        final backend = _gpuBackendForDevice(dev);
+        final mainGpu = perBackendOrdinal[backend] ?? 0;
+        perBackendOrdinal[backend] = mainGpu + 1;
+
+        var name = '';
+        var description = '';
+        var deviceId = '';
+        var free = 0;
+        var total = 0;
+        if (props != null) {
+          name = _utf8OrEmpty(props.name);
+          description = _utf8OrEmpty(props.description);
+          deviceId = _utf8OrEmpty(props.device_id);
+          free = props.memory_free;
+          total = props.memory_total;
+        }
+        if (name.isEmpty) name = _utf8OrEmpty(_ggmlBackendDevName(dev));
+        if (total <= 0) {
+          final freePtr = calloc<Size>();
+          final totalPtr = calloc<Size>();
+          try {
+            if (_ggmlBackendDevMemory(dev, freePtr, totalPtr)) {
+              free = freePtr.value;
+              total = totalPtr.value;
+            }
+          } finally {
+            calloc.free(freePtr);
+            calloc.free(totalPtr);
+          }
+        }
+
+        result.add(
+          GpuDeviceInfo(
+            backend: backend,
+            mainGpu: mainGpu,
+            name: name,
+            description: description.isEmpty ? name : description,
+            deviceId: deviceId,
+            type: type,
+            memoryFreeBytes: free,
+            memoryTotalBytes: total,
+          ),
+        );
+      } finally {
+        calloc.free(propsPtr);
+      }
+    }
+    return result;
+  }
+
+  static String _utf8OrEmpty(Pointer<Char> ptr) =>
+      ptr == nullptr ? '' : ptr.cast<Utf8>().toDartString();
+
+  static GpuDeviceType _mapGpuDeviceType(int typeInt) {
+    if (typeInt == ggml_backend_dev_type.GGML_BACKEND_DEVICE_TYPE_GPU.value) {
+      return GpuDeviceType.discreteGpu;
+    }
+    if (typeInt == ggml_backend_dev_type.GGML_BACKEND_DEVICE_TYPE_IGPU.value) {
+      return GpuDeviceType.integratedGpu;
+    }
+    if (typeInt == ggml_backend_dev_type.GGML_BACKEND_DEVICE_TYPE_ACCEL.value) {
+      return GpuDeviceType.accelerator;
+    }
+    if (typeInt == ggml_backend_dev_type.GGML_BACKEND_DEVICE_TYPE_CPU.value) {
+      return GpuDeviceType.cpu;
+    }
+    return GpuDeviceType.unknown;
+  }
+
+  /// Maps a device's owning backend registry name to a [GpuBackend]. Returns
+  /// [GpuBackend.auto] when the backend can't be resolved.
+  GpuBackend _gpuBackendForDevice(ggml_backend_dev_t dev) {
+    final reg = _ggmlBackendDevBackendReg(dev);
+    if (reg == nullptr) return GpuBackend.auto;
+    final namePtr = _ggmlBackendRegName(reg);
+    if (namePtr == nullptr) return GpuBackend.auto;
+    return gpuBackendFromRegName(namePtr.cast<Utf8>().toDartString());
+  }
+
+  /// Maps a ggml backend registry name to a [GpuBackend]; returns
+  /// [GpuBackend.auto] when unrecognized. Match-by-substring because registry
+  /// names vary by build (e.g. the Metal backend registers as `Metal` on some
+  /// builds and `MTL` on others), mirroring [_backendInfoContainsBackendMarker].
+  static GpuBackend gpuBackendFromRegName(String regName) {
+    final name = regName.toLowerCase();
+    if (name.contains('vulkan')) return GpuBackend.vulkan;
+    if (name.contains('cuda')) return GpuBackend.cuda;
+    if (name.contains('metal') || name.contains('mtl')) {
+      return GpuBackend.metal;
+    }
+    if (name.contains('hip') || name.contains('rocm')) return GpuBackend.hip;
+    if (name.contains('opencl')) return GpuBackend.opencl;
+    if (name.contains('blas')) return GpuBackend.blas;
+    if (name.contains('cpu')) return GpuBackend.cpu;
+    return GpuBackend.auto;
   }
 
   /// Returns the context size for the given [contextHandle].

--- a/lib/src/backends/llama_cpp/worker.dart
+++ b/lib/src/backends/llama_cpp/worker.dart
@@ -233,6 +233,12 @@ void llamaWorkerEntry(SendPort initialSendPort) {
             final info = service.getVramInfo();
             message.sendPort.send(SystemInfoResponse(info.total, info.free));
 
+          case ListGpuDevicesRequest():
+            final devices = service.listGpuDevices(
+              probeBackends: message.probeBackends,
+            );
+            message.sendPort.send(ListGpuDevicesResponse(devices));
+
           case ChatTemplateRequest():
             message.sendPort.send(
               ErrorResponse("Chat template not implemented in service yet"),

--- a/lib/src/backends/llama_cpp/worker_messages.dart
+++ b/lib/src/backends/llama_cpp/worker_messages.dart
@@ -2,6 +2,8 @@ import 'dart:isolate';
 import '../../core/models/inference/model_params.dart';
 import '../../core/models/inference/generation_params.dart';
 import '../../core/models/chat/content_part.dart';
+import '../../core/models/config/gpu_backend.dart';
+import '../../core/models/config/gpu_device_info.dart';
 import '../../core/models/config/log_level.dart';
 
 /// Base class for all worker requests.
@@ -292,6 +294,17 @@ class SystemInfoRequest extends WorkerRequest {
   SystemInfoRequest(super.sendPort);
 }
 
+/// Request to enumerate GPU-class devices. [probeBackends] opts into loading
+/// only those backend modules before enumerating; empty means registered
+/// backends only.
+class ListGpuDevicesRequest extends WorkerRequest {
+  /// Backends to load before enumerating; empty inspects registered ones only.
+  final List<GpuBackend> probeBackends;
+
+  /// Creates a new [ListGpuDevicesRequest].
+  ListGpuDevicesRequest(this.probeBackends, super.sendPort);
+}
+
 /// Request to write the KV-cache state of [contextHandle] to [path]
 /// together with the producing token sequence (for state restore).
 class StateSaveFileRequest extends WorkerRequest {
@@ -555,6 +568,15 @@ class SystemInfoResponse {
 
   /// Creates a new [SystemInfoResponse].
   SystemInfoResponse(this.totalVram, this.freeVram);
+}
+
+/// Response carrying the enumerated GPU-class devices.
+class ListGpuDevicesResponse {
+  /// The enumerated devices (empty when none are reachable).
+  final List<GpuDeviceInfo> devices;
+
+  /// Creates a new [ListGpuDevicesResponse].
+  ListGpuDevicesResponse(this.devices);
 }
 
 /// Response containing the formatted chat template result.

--- a/lib/src/backends/native/native_backend.dart
+++ b/lib/src/backends/native/native_backend.dart
@@ -1,5 +1,7 @@
 import '../../core/models/chat/chat_message.dart';
 import '../../core/models/chat/content_part.dart';
+import '../../core/models/config/gpu_backend.dart';
+import '../../core/models/config/gpu_device_info.dart';
 import '../../core/models/config/log_level.dart';
 import '../../core/models/inference/generation_params.dart';
 import '../../core/models/inference/model_params.dart';
@@ -21,6 +23,7 @@ class NativeAutoBackend
         LlamaBackend,
         BackendAvailability,
         BackendRuntimeDiagnostics,
+        BackendGpuEnumeration,
         BackendPerformanceDiagnostics,
         BackendEmbeddings,
         BackendEmbeddingsSupport,
@@ -317,6 +320,29 @@ class NativeAutoBackend
     return _ensureDiagnosticDelegate().then(
       (diagnosticDelegate) => diagnosticDelegate.getVramInfo(),
     );
+  }
+
+  @override
+  Future<List<GpuDeviceInfo>> listGpuDevices({
+    List<GpuBackend> probeBackends = const [],
+  }) {
+    final delegate = _delegate;
+    if (delegate is BackendGpuEnumeration) {
+      return (delegate as BackendGpuEnumeration).listGpuDevices(
+        probeBackends: probeBackends,
+      );
+    }
+    // No GPU-enumeration-capable delegate is active (none loaded yet, or a
+    // backend like LiteRT-LM that doesn't enumerate). Fall back to the same
+    // diagnostic llama.cpp delegate getVramInfo uses before a model load.
+    return _ensureDiagnosticDelegate().then((diagnosticDelegate) {
+      if (diagnosticDelegate is BackendGpuEnumeration) {
+        return (diagnosticDelegate as BackendGpuEnumeration).listGpuDevices(
+          probeBackends: probeBackends,
+        );
+      }
+      return const <GpuDeviceInfo>[];
+    });
   }
 
   @override

--- a/lib/src/core/engine/engine.dart
+++ b/lib/src/core/engine/engine.dart
@@ -4,6 +4,8 @@ import 'dart:convert';
 import '../../backends/backend.dart';
 import '../template/chat_template_engine.dart';
 import '../exceptions.dart';
+import '../models/config/gpu_backend.dart';
+import '../models/config/gpu_device_info.dart';
 import '../models/config/log_level.dart';
 import '../models/chat/chat_message.dart';
 import '../models/chat/completion_chunk.dart';
@@ -1586,6 +1588,22 @@ class LlamaEngine {
 
   /// Returns total and free VRAM in bytes.
   Future<({int total, int free})> getVramInfo() => backend.getVramInfo();
+
+  /// Lists GPU-class devices when the active backend supports enumeration,
+  /// otherwise an empty list. With an empty [probeBackends] only
+  /// already-registered backends are inspected (no backend module is loaded);
+  /// pass backends to opt into loading just those before enumerating.
+  Future<List<GpuDeviceInfo>> listGpuDevices({
+    List<GpuBackend> probeBackends = const [],
+  }) {
+    final candidate = backend;
+    if (candidate is BackendGpuEnumeration) {
+      return (candidate as BackendGpuEnumeration).listGpuDevices(
+        probeBackends: probeBackends,
+      );
+    }
+    return Future.value(const []);
+  }
 
   // ============================================================
   // INTERNAL HELPERS

--- a/lib/src/core/models/config/gpu_device_info.dart
+++ b/lib/src/core/models/config/gpu_device_info.dart
@@ -1,0 +1,73 @@
+import 'gpu_backend.dart';
+
+/// The kind of compute device a backend enumerated.
+enum GpuDeviceType {
+  /// Host CPU.
+  cpu,
+
+  /// Dedicated GPU with its own VRAM.
+  discreteGpu,
+
+  /// Integrated GPU sharing system memory.
+  integratedGpu,
+
+  /// Dedicated accelerator (e.g. NPU).
+  accelerator,
+
+  /// Unrecognized device type.
+  unknown,
+}
+
+/// One inference-capable GPU-class device, as returned by `listGpuDevices`.
+class GpuDeviceInfo {
+  /// The backend that exposes this device.
+  final GpuBackend backend;
+
+  /// Offload index within [backend]: the value to pass as
+  /// `ModelParams.mainGpu` (with `splitMode` none) to pin to this device.
+  /// Counted over that backend's offload devices only.
+  final int mainGpu;
+
+  /// Short device name reported by the backend (e.g. `Vulkan1`).
+  final String name;
+
+  /// Human-readable description (e.g. `NVIDIA GeForce RTX 5050 Laptop GPU`).
+  /// Falls back to [name] when the backend reports no description.
+  final String description;
+
+  /// Stable device identifier when the backend reports one (e.g. a PCI
+  /// address); empty otherwise.
+  final String deviceId;
+
+  /// Device category. Integrated GPUs report shared system memory, so callers
+  /// preferring dedicated VRAM should favor [GpuDeviceType.discreteGpu].
+  final GpuDeviceType type;
+
+  /// Free device memory in bytes at enumeration time.
+  final int memoryFreeBytes;
+
+  /// Total device memory in bytes.
+  final int memoryTotalBytes;
+
+  /// Creates a [GpuDeviceInfo].
+  const GpuDeviceInfo({
+    required this.backend,
+    required this.mainGpu,
+    required this.name,
+    required this.description,
+    required this.deviceId,
+    required this.type,
+    required this.memoryFreeBytes,
+    required this.memoryTotalBytes,
+  });
+
+  /// A dedicated GPU with its own VRAM (not an integrated/shared-memory GPU).
+  bool get isDiscreteGpu => type == GpuDeviceType.discreteGpu;
+
+  @override
+  String toString() =>
+      'GpuDeviceInfo(backend: ${backend.name}, mainGpu: $mainGpu, '
+      'name: $name, description: $description, deviceId: $deviceId, '
+      'type: ${type.name}, memoryFree: $memoryFreeBytes, '
+      'memoryTotal: $memoryTotalBytes)';
+}

--- a/test/unit/backends/llama_cpp/llama_cpp_service_test.dart
+++ b/test/unit/backends/llama_cpp/llama_cpp_service_test.dart
@@ -5,6 +5,7 @@ import 'dart:io';
 
 import 'package:llamadart/src/backends/llama_cpp/llama_cpp_service.dart';
 import 'package:llamadart/src/core/models/config/gpu_backend.dart';
+import 'package:llamadart/src/core/models/config/gpu_device_info.dart';
 import 'package:llamadart/src/core/models/inference/generation_params.dart';
 import 'package:llamadart/src/core/models/inference/model_params.dart';
 import 'package:path/path.dart' as path;
@@ -29,6 +30,61 @@ void main() {
       expect(info.free, isA<int>());
       expect(info.total, greaterThanOrEqualTo(0));
       expect(info.free, greaterThanOrEqualTo(0));
+    });
+  });
+
+  group('listGpuDevices', () {
+    test('returns a List<GpuDeviceInfo> without throwing', () {
+      // Hosts with a GPU runtime return real devices; CI hosts without one
+      // return an empty list. Either way the call must not throw and every
+      // element must satisfy the field contract callers rely on. A rename or
+      // struct change in `LlamaCppService.listGpuDevices` breaks this.
+      final service = LlamaCppService();
+      final devices = service.listGpuDevices();
+      expect(devices, isA<List<GpuDeviceInfo>>());
+      for (final device in devices) {
+        expect(device.type, isNot(GpuDeviceType.cpu));
+        expect(device.mainGpu, greaterThanOrEqualTo(0));
+        expect(device.memoryFreeBytes, greaterThanOrEqualTo(0));
+        expect(device.memoryTotalBytes, greaterThanOrEqualTo(0));
+      }
+    });
+
+    test('does not throw when probing an unavailable backend', () {
+      // probeBackends opt-in must stay safe: requesting a backend whose module
+      // or symbols are absent (as on CI hosts) returns a list rather than
+      // throwing.
+      final service = LlamaCppService();
+      final devices = service.listGpuDevices(
+        probeBackends: const [GpuBackend.vulkan, GpuBackend.cuda],
+      );
+      expect(devices, isA<List<GpuDeviceInfo>>());
+    });
+  });
+
+  group('gpuBackendFromRegName', () {
+    test('maps ggml registry names (incl. Metal MTL) to GpuBackend', () {
+      expect(
+        LlamaCppService.gpuBackendFromRegName('Vulkan'),
+        GpuBackend.vulkan,
+      );
+      expect(LlamaCppService.gpuBackendFromRegName('CUDA'), GpuBackend.cuda);
+      expect(LlamaCppService.gpuBackendFromRegName('Metal'), GpuBackend.metal);
+      // Regression: macOS reports the registry name as "MTL", which previously
+      // fell through to GpuBackend.auto.
+      expect(LlamaCppService.gpuBackendFromRegName('MTL'), GpuBackend.metal);
+      expect(LlamaCppService.gpuBackendFromRegName('ROCm'), GpuBackend.hip);
+      expect(LlamaCppService.gpuBackendFromRegName('HIP'), GpuBackend.hip);
+      expect(
+        LlamaCppService.gpuBackendFromRegName('OpenCL'),
+        GpuBackend.opencl,
+      );
+      expect(LlamaCppService.gpuBackendFromRegName('BLAS'), GpuBackend.blas);
+      expect(LlamaCppService.gpuBackendFromRegName('CPU'), GpuBackend.cpu);
+      expect(
+        LlamaCppService.gpuBackendFromRegName('SomethingElse'),
+        GpuBackend.auto,
+      );
     });
   });
 

--- a/test/unit/backends/native/native_backend_test.dart
+++ b/test/unit/backends/native/native_backend_test.dart
@@ -11,6 +11,7 @@ import 'package:llamadart/src/core/exceptions.dart';
 import 'package:llamadart/src/core/models/chat/chat_message.dart';
 import 'package:llamadart/src/core/models/chat/chat_role.dart';
 import 'package:llamadart/src/core/models/config/gpu_backend.dart';
+import 'package:llamadart/src/core/models/config/gpu_device_info.dart';
 import 'package:llamadart/src/core/models/config/log_level.dart';
 import 'package:llamadart/src/core/models/download/model_download_manager.dart';
 import 'package:llamadart/src/core/models/inference/generation_params.dart';
@@ -84,6 +85,42 @@ void main() {
 
       expect(llama.disposeCount, 1);
       expect(litert.disposeCount, 0);
+    },
+  );
+
+  test(
+    'pre-load listGpuDevices forwards through the llama.cpp diagnostic delegate',
+    () async {
+      // The default LlamaBackend() resolves to NativeAutoBackend; listGpuDevices
+      // must reach a GPU-enumeration-capable delegate, not return an empty list.
+      const devices = [
+        GpuDeviceInfo(
+          backend: GpuBackend.vulkan,
+          mainGpu: 0,
+          name: 'Vulkan0',
+          description: 'NVIDIA GeForce RTX 5050 Laptop GPU',
+          deviceId: '0000:64:00.0',
+          type: GpuDeviceType.discreteGpu,
+          memoryFreeBytes: 7910,
+          memoryTotalBytes: 8192,
+        ),
+      ];
+      final llama = _FakeBackend(handle: 11)..gpuDevices = devices;
+      final litert = _FakeBackend(handle: 22);
+      final backend = NativeAutoBackend(
+        llamaCppFactory: () => llama,
+        liteRtLmFactory: () => litert,
+      );
+
+      try {
+        final result = await backend.listGpuDevices();
+        expect(result, hasLength(1));
+        expect(result.single.description, 'NVIDIA GeForce RTX 5050 Laptop GPU');
+        expect(result.single.type, GpuDeviceType.discreteGpu);
+        expect(litert.loadedPaths, isEmpty);
+      } finally {
+        await backend.dispose();
+      }
     },
   );
 
@@ -853,7 +890,11 @@ void main() {
   );
 }
 
-class _FakeBackend implements LlamaBackend, BackendGrammarConstraintsSupport {
+class _FakeBackend
+    implements
+        LlamaBackend,
+        BackendGrammarConstraintsSupport,
+        BackendGpuEnumeration {
   final int handle;
   bool grammarConstraintsSupported = true;
   final List<String> loadedPaths = <String>[];
@@ -869,6 +910,7 @@ class _FakeBackend implements LlamaBackend, BackendGrammarConstraintsSupport {
   List<int>? lastDetokenizeTokens;
   bool gpuSupported = false;
   ({int total, int free}) vramInfo = (total: 0, free: 0);
+  List<GpuDeviceInfo> gpuDevices = const [];
   int disposeCount = 0;
   int? lastMultimodalCreateModelHandle;
   String? lastMultimodalProjectorPath;
@@ -943,6 +985,11 @@ class _FakeBackend implements LlamaBackend, BackendGrammarConstraintsSupport {
 
   @override
   Future<({int total, int free})> getVramInfo() async => vramInfo;
+
+  @override
+  Future<List<GpuDeviceInfo>> listGpuDevices({
+    List<GpuBackend> probeBackends = const [],
+  }) async => gpuDevices;
 
   @override
   Future<int?> multimodalContextCreate(

--- a/test/unit/core/models/config/gpu_device_info_test.dart
+++ b/test/unit/core/models/config/gpu_device_info_test.dart
@@ -1,0 +1,79 @@
+import 'package:llamadart/src/core/models/config/gpu_backend.dart';
+import 'package:llamadart/src/core/models/config/gpu_device_info.dart';
+import 'package:test/test.dart';
+
+void main() {
+  test('GpuDeviceType enum contains expected values', () {
+    expect(GpuDeviceType.values, contains(GpuDeviceType.cpu));
+    expect(GpuDeviceType.values, contains(GpuDeviceType.discreteGpu));
+    expect(GpuDeviceType.values, contains(GpuDeviceType.integratedGpu));
+    expect(GpuDeviceType.values, contains(GpuDeviceType.accelerator));
+    expect(GpuDeviceType.values, contains(GpuDeviceType.unknown));
+  });
+
+  test('GpuDeviceInfo exposes its fields', () {
+    const device = GpuDeviceInfo(
+      backend: GpuBackend.vulkan,
+      mainGpu: 1,
+      name: 'Vulkan1',
+      description: 'NVIDIA GeForce RTX 5050 Laptop GPU',
+      deviceId: '0000:64:00.0',
+      type: GpuDeviceType.discreteGpu,
+      memoryFreeBytes: 7910,
+      memoryTotalBytes: 8192,
+    );
+
+    expect(device.backend, GpuBackend.vulkan);
+    expect(device.mainGpu, 1);
+    expect(device.name, 'Vulkan1');
+    expect(device.description, 'NVIDIA GeForce RTX 5050 Laptop GPU');
+    expect(device.deviceId, '0000:64:00.0');
+    expect(device.type, GpuDeviceType.discreteGpu);
+    expect(device.memoryFreeBytes, 7910);
+    expect(device.memoryTotalBytes, 8192);
+  });
+
+  test('isDiscreteGpu is true only for a discrete GPU', () {
+    const discrete = GpuDeviceInfo(
+      backend: GpuBackend.vulkan,
+      mainGpu: 1,
+      name: 'Vulkan1',
+      description: 'NVIDIA GeForce RTX 5050 Laptop GPU',
+      deviceId: '',
+      type: GpuDeviceType.discreteGpu,
+      memoryFreeBytes: 0,
+      memoryTotalBytes: 0,
+    );
+    const integrated = GpuDeviceInfo(
+      backend: GpuBackend.vulkan,
+      mainGpu: 0,
+      name: 'Vulkan0',
+      description: 'AMD Radeon 860M Graphics',
+      deviceId: '',
+      type: GpuDeviceType.integratedGpu,
+      memoryFreeBytes: 0,
+      memoryTotalBytes: 0,
+    );
+
+    expect(discrete.isDiscreteGpu, isTrue);
+    expect(integrated.isDiscreteGpu, isFalse);
+  });
+
+  test('toString includes backend, description, and type', () {
+    const device = GpuDeviceInfo(
+      backend: GpuBackend.cuda,
+      mainGpu: 0,
+      name: 'CUDA0',
+      description: 'NVIDIA RTX',
+      deviceId: '',
+      type: GpuDeviceType.discreteGpu,
+      memoryFreeBytes: 1,
+      memoryTotalBytes: 2,
+    );
+
+    final text = device.toString();
+    expect(text, contains('cuda'));
+    expect(text, contains('NVIDIA RTX'));
+    expect(text, contains('discreteGpu'));
+  });
+}


### PR DESCRIPTION
Closes #220.

## Summary

Adds an opt-in capability to enumerate the GPU-class devices a backend exposes, so apps can choose which GPU to offload to (e.g. the discrete card on a laptop with an integrated GPU) and surface which device is in use.

## API

```dart
// capability (kept off the base LlamaBackend so existing implementers are untouched)
Future<List<GpuDeviceInfo>> listGpuDevices({List<GpuBackend> probeBackends = const []});
```

`GpuDeviceInfo`: `backend`, per-backend `mainGpu` index, `name`, `description`, `deviceId`, `type`, `memoryFreeBytes`, `memoryTotalBytes`. Exposed via `LlamaEngine.listGpuDevices()`.

## Safety (per your note in #220)

Default (`probeBackends` empty) inspects only already-registered backends — no backend module is loaded, so an unsupported GPU runtime can't crash during enumeration. `probeBackends` opts into loading just the named modules first, each guarded. Web/WebGPU return `[]`.

## Implementation

Walks the global device list (`ggml_backend_dev_count` / `ggml_backend_dev_get`) through the existing registry-fallback wrappers, reads name/description/id/memory from `ggml_backend_dev_get_props` (with `ggml_backend_dev_memory` fallback), maps each device to its backend, and excludes CPU.

## Open question

I put it on a capability rather than the base interface, and excluded CPU devices — happy to move it onto `LlamaBackend` or include CPU if you'd prefer.

## Tests / docs

Unit tests (return-type without throwing, element-field invariants, probe-an-unavailable-backend safety case) pass locally; CHANGELOG and README updated. As with the getVramInfo tests, real-device branches aren't reachable on CI hosts, so those paths show as uncovered.
