### PR TITLE
fix: support North Code Cohere2 tool templates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## Unreleased
+
+* Added Cohere2 MoE / North Code chat-template detection and parsing so
+  `<|START_TEXT|>` responses and `<|START_ACTION|>` tool-call arrays are
+  handled separately from older Command-R templates.
+
 ## 0.8.1
 
 * Fixed docs references that still pointed at

--- a/lib/src/core/engine/engine.dart
+++ b/lib/src/core/engine/engine.dart
@@ -1852,7 +1852,12 @@ class LlamaEngine {
     if (marker.startsWith(upper)) {
       return _ToolStreamingMode.undecided;
     }
+    // Some Command/Cohere-family templates (including North Mini Code) emit
+    // bare action arrays instead of the documented <|START_ACTION|> wrapper.
+    return _decideBareActionArrayEnvelopeMode(text);
+  }
 
+  _ToolStreamingMode _decideBareActionArrayEnvelopeMode(String text) {
     var i = 1;
     while (i < text.length && _isWhitespaceCodeUnit(text.codeUnitAt(i))) {
       i++;
@@ -1875,22 +1880,58 @@ class LlamaEngine {
       return _ToolStreamingMode.raw;
     }
 
-    final keyFragment = text.substring(i);
-    const commandActionKeys = <String>[
-      '"tool_name"',
-      '"tool_call_id"',
-      '"parameters"',
-    ];
-    for (final key in commandActionKeys) {
-      if (keyFragment.startsWith(key)) {
-        return _ToolStreamingMode.parsed;
-      }
-      if (key.startsWith(keyFragment)) {
-        return _ToolStreamingMode.undecided;
-      }
+    final key = _readLeadingJsonObjectKey(text, i);
+    if (!key.complete) {
+      return _ToolStreamingMode.undecided;
+    }
+    if (key.value == null) {
+      return _ToolStreamingMode.raw;
     }
 
-    return _ToolStreamingMode.raw;
+    i = key.nextIndex;
+    while (i < text.length && _isWhitespaceCodeUnit(text.codeUnitAt(i))) {
+      i++;
+    }
+    if (i >= text.length) {
+      return _ToolStreamingMode.undecided;
+    }
+    if (text.codeUnitAt(i) != 0x3A) {
+      return _ToolStreamingMode.raw;
+    }
+
+    return _isCommandBareActionKey(key.value!)
+        ? _ToolStreamingMode.parsed
+        : _ToolStreamingMode.raw;
+  }
+
+  ({bool complete, String? value, int nextIndex}) _readLeadingJsonObjectKey(
+    String text,
+    int quoteIndex,
+  ) {
+    final buffer = StringBuffer();
+    var i = quoteIndex + 1;
+    while (i < text.length) {
+      final ch = text.codeUnitAt(i);
+      if (ch == 0x22) {
+        return (complete: true, value: buffer.toString(), nextIndex: i + 1);
+      }
+      if (ch == 0x5C) {
+        if (i + 1 >= text.length) {
+          return (complete: false, value: null, nextIndex: i);
+        }
+        buffer.writeCharCode(text.codeUnitAt(i + 1));
+        i += 2;
+        continue;
+      }
+      buffer.writeCharCode(ch);
+      i++;
+    }
+
+    return (complete: false, value: null, nextIndex: text.length);
+  }
+
+  bool _isCommandBareActionKey(String key) {
+    return key == 'tool_name' || key == 'tool_call_id';
   }
 
   _ToolStreamingMode _decideXmlEnvelopeMode(String text) {

--- a/lib/src/core/engine/engine.dart
+++ b/lib/src/core/engine/engine.dart
@@ -1852,6 +1852,44 @@ class LlamaEngine {
     if (marker.startsWith(upper)) {
       return _ToolStreamingMode.undecided;
     }
+
+    var i = 1;
+    while (i < text.length && _isWhitespaceCodeUnit(text.codeUnitAt(i))) {
+      i++;
+    }
+    if (i >= text.length) {
+      return _ToolStreamingMode.undecided;
+    }
+    if (text.codeUnitAt(i) != 0x7B) {
+      return _ToolStreamingMode.raw;
+    }
+
+    i++;
+    while (i < text.length && _isWhitespaceCodeUnit(text.codeUnitAt(i))) {
+      i++;
+    }
+    if (i >= text.length) {
+      return _ToolStreamingMode.undecided;
+    }
+    if (text.codeUnitAt(i) != 0x22) {
+      return _ToolStreamingMode.raw;
+    }
+
+    final keyFragment = text.substring(i);
+    const commandActionKeys = <String>[
+      '"tool_name"',
+      '"tool_call_id"',
+      '"parameters"',
+    ];
+    for (final key in commandActionKeys) {
+      if (keyFragment.startsWith(key)) {
+        return _ToolStreamingMode.parsed;
+      }
+      if (key.startsWith(keyFragment)) {
+        return _ToolStreamingMode.undecided;
+      }
+    }
+
     return _ToolStreamingMode.raw;
   }
 
@@ -1861,6 +1899,8 @@ class LlamaEngine {
       '<tool_call',
       '<tool_calls',
       '<|tool_call',
+      '<|start_action|>',
+      '<|start_text|>',
       '<function',
       '<function_call',
       '<start_function_call',

--- a/lib/src/core/template/chat_format.dart
+++ b/lib/src/core/template/chat_format.dart
@@ -113,6 +113,10 @@ enum ChatFormat {
 
   /// Ministral 3 reasoning format with `[TOOL_CALLS]name[ARGS]{...}`.
   ministral,
+
+  /// Cohere2 MoE / North Code — `<|START_TEXT|>` content or
+  /// `<|START_ACTION|>` JSON tool arrays after thinking.
+  cohere2Moe,
 }
 
 /// Detects the [ChatFormat] by scanning a Jinja template source string
@@ -135,6 +139,13 @@ ChatFormat detectChatFormat(String? templateSource) {
   // DeepSeek R1
   if (templateSource.contains('<｜tool▁calls▁begin｜>')) {
     return ChatFormat.deepseekR1;
+  }
+
+  // Cohere2 MoE / North Code. Check before Command R7B because both use
+  // <|START_ACTION|>, but START_TEXT is unique to the newer North template.
+  if (templateSource.contains('<|START_TEXT|>') &&
+      templateSource.contains('<|START_ACTION|>')) {
+    return ChatFormat.cohere2Moe;
   }
 
   // Command R7B

--- a/lib/src/core/template/chat_template_engine.dart
+++ b/lib/src/core/template/chat_template_engine.dart
@@ -80,6 +80,7 @@ class ChatTemplateEngine {
     ChatFormat.deepseekV3,
     ChatFormat.deepseekR1,
     ChatFormat.commandR7B,
+    ChatFormat.cohere2Moe,
     ChatFormat.glm45,
     ChatFormat.hermes,
   };

--- a/lib/src/core/template/chat_template_engine.dart
+++ b/lib/src/core/template/chat_template_engine.dart
@@ -12,6 +12,7 @@ import 'chat_format.dart';
 import 'chat_parse_result.dart';
 import 'peg_chat_parser.dart';
 import 'chat_template_handler.dart';
+import 'handlers/cohere2_moe_handler.dart';
 import 'handlers/command_r7b_handler.dart';
 import 'handlers/deepseek_r1_handler.dart';
 import 'handlers/deepseek_v3_handler.dart';
@@ -528,6 +529,8 @@ class ChatTemplateEngine {
         return Gemma4Handler();
       case ChatFormat.commandR7B:
         return CommandR7BHandler();
+      case ChatFormat.cohere2Moe:
+        return Cohere2MoeHandler();
       case ChatFormat.granite:
         return GraniteHandler();
       case ChatFormat.glm45:

--- a/lib/src/core/template/handlers/cohere2_moe_handler.dart
+++ b/lib/src/core/template/handlers/cohere2_moe_handler.dart
@@ -1,0 +1,20 @@
+import '../chat_format.dart';
+import 'command_r7b_handler.dart';
+
+/// Handler for Cohere2 MoE / North Code templates.
+///
+/// This format is similar to Command-R action blocks, but content responses are
+/// wrapped in `<|START_TEXT|>...<|END_TEXT|>` instead of
+/// `<|START_RESPONSE|>...<|END_RESPONSE|>`.
+class Cohere2MoeHandler extends CommandR7BHandler {
+  @override
+  ChatFormat get format => ChatFormat.cohere2Moe;
+
+  @override
+  List<String> get additionalStops => ['<|END_TEXT|>'];
+
+  @override
+  List<String> getStops({bool hasTools = false, bool enableThinking = true}) {
+    return [...additionalStops, if (hasTools) '<|END_ACTION|>'];
+  }
+}

--- a/lib/src/core/template/handlers/command_r7b_handler.dart
+++ b/lib/src/core/template/handlers/command_r7b_handler.dart
@@ -326,6 +326,8 @@ class CommandR7BHandler extends ChatTemplateHandler {
           toolCalls: calls,
         );
       }
+
+      searchEnd = markerStart;
     }
 
     return null;

--- a/lib/src/core/template/handlers/command_r7b_handler.dart
+++ b/lib/src/core/template/handlers/command_r7b_handler.dart
@@ -2,10 +2,13 @@ import 'package:dinja/dinja.dart';
 
 import '../../models/chat/chat_message.dart';
 import '../../models/chat/chat_template_result.dart';
+import '../../models/chat/completion_chunk.dart';
+import '../../models/inference/tool_choice.dart';
 import '../../models/tools/tool_definition.dart';
 import '../chat_format.dart';
 import '../chat_parse_result.dart';
 import '../chat_template_handler.dart';
+import '../template_internal_metadata.dart';
 import '../thinking_utils.dart';
 import '../tool_call_parsing_utils.dart';
 
@@ -58,6 +61,9 @@ class CommandR7BHandler extends ChatTemplateHandler {
             metadata['tokenizer.ggml.bos_token'] ?? '<|START_OF_TURN_TOKEN|>',
         'eos_token':
             metadata['tokenizer.ggml.eos_token'] ?? '<|END_OF_TURN_TOKEN|>',
+        'enable_thinking': enableThinking,
+        'reasoning': enableThinking,
+        'skip_thinking': !enableThinking,
       },
     );
 
@@ -72,11 +78,13 @@ class CommandR7BHandler extends ChatTemplateHandler {
     }
 
     final hasTools = tools != null && tools.isNotEmpty;
+    final toolChoice = metadata[internalToolChoiceMetadataKey];
+    final toolChoiceRequired = toolChoice == ToolChoice.required.name;
     return LlamaChatTemplateResult(
       prompt: prompt,
       format: format.index,
       grammar: buildGrammar(tools),
-      grammarLazy: hasTools,
+      grammarLazy: hasTools && !toolChoiceRequired,
       thinkingForcedOpen: thinkingForcedOpen,
       additionalStops: getStops(
         hasTools: hasTools,
@@ -103,17 +111,41 @@ class CommandR7BHandler extends ChatTemplateHandler {
     );
     final text = thinking.content;
 
+    const startAction = '<|START_ACTION|>';
+    const endAction = '<|END_ACTION|>';
+    const startText = '<|START_TEXT|>';
+    const endText = '<|END_TEXT|>';
+    const startResponse = '<|START_RESPONSE|>';
+    const endResponse = '<|END_RESPONSE|>';
+
+    final textStart = text.indexOf(startText);
+    if (textStart != -1) {
+      final prelude = text.substring(0, textStart);
+      final bodyStart = textStart + startText.length;
+      final textEnd = text.indexOf(endText, bodyStart);
+      final bodyEnd = textEnd == -1 ? text.length : textEnd;
+      final trailing = textEnd == -1
+          ? ''
+          : text.substring(textEnd + endText.length).trim();
+      if (trailing.isNotEmpty) {
+        return ChatParseResult(
+          content: text.trim(),
+          reasoningContent: thinking.reasoning,
+        );
+      }
+
+      return ChatParseResult(
+        content: '$prelude${text.substring(bodyStart, bodyEnd)}'.trim(),
+        reasoningContent: thinking.reasoning,
+      );
+    }
+
     if (!parseToolCalls) {
       return ChatParseResult(
         content: text.trim(),
         reasoningContent: thinking.reasoning,
       );
     }
-
-    const startAction = '<|START_ACTION|>';
-    const endAction = '<|END_ACTION|>';
-    const startResponse = '<|START_RESPONSE|>';
-    const endResponse = '<|END_RESPONSE|>';
 
     final actionStart = text.indexOf(startAction);
     if (actionStart != -1) {
@@ -123,15 +155,19 @@ class CommandR7BHandler extends ChatTemplateHandler {
         afterStart,
         0,
       );
-      if (jsonSlice == null || jsonSlice.value is! List) {
+      if (jsonSlice == null) {
         return ChatParseResult(
           content: text.trim(),
           reasoningContent: thinking.reasoning,
         );
       }
 
+      final decodedCalls = jsonSlice.value is List
+          ? jsonSlice.value
+          : <Object?>[jsonSlice.value];
+
       final toolCalls = ToolCallParsingUtils.parseToolCallArray(
-        jsonSlice.value,
+        decodedCalls,
         nameKeys: const <String>['tool_name'],
         argumentKeys: const <String>['parameters'],
         idKeys: const <String>['tool_call_id'],
@@ -169,6 +205,15 @@ class CommandR7BHandler extends ChatTemplateHandler {
         content: prelude.trim(),
         reasoningContent: thinking.reasoning,
         toolCalls: toolCalls,
+      );
+    }
+
+    final bareToolCalls = _parseBareActionPayload(text.trim());
+    if (bareToolCalls != null) {
+      return ChatParseResult(
+        content: bareToolCalls.content,
+        reasoningContent: thinking.reasoning,
+        toolCalls: bareToolCalls.toolCalls,
       );
     }
 
@@ -226,10 +271,64 @@ class CommandR7BHandler extends ChatTemplateHandler {
     }
 
     final choiceRule = 'tool-choice ::= ${toolChoices.join(' | ')}';
+    final actionArray =
+        'action-array ::= "[" space tool-choice ("," space tool-choice)* space "]"';
     final root =
-        'root ::= "<|START_ACTION|>" space tool-choice "<|END_ACTION|>" (space "<|START_ACTION|>" space tool-choice "<|END_ACTION|>" )*';
+        'root ::= "<|START_ACTION|>" space action-array space "<|END_ACTION|>" | action-array';
 
-    return [root, choiceRule, ...toolRules, _commonGbnfRules()].join('\n');
+    return [
+      root,
+      actionArray,
+      choiceRule,
+      ...toolRules,
+      _commonGbnfRules(),
+    ].join('\n');
+  }
+
+  _CommandBareActionPayload? _parseBareActionPayload(String text) {
+    if (text.isEmpty) {
+      return null;
+    }
+
+    var searchEnd = text.length;
+    while (searchEnd > 0) {
+      final markerStart = text.lastIndexOf('[', searchEnd - 1);
+      if (markerStart == -1) {
+        break;
+      }
+
+      final jsonSlice = ToolCallParsingUtils.extractLeadingJsonValue(
+        text,
+        markerStart,
+      );
+      searchEnd = markerStart;
+      if (jsonSlice == null) {
+        continue;
+      }
+
+      if (text.substring(jsonSlice.end).trim().isNotEmpty) {
+        continue;
+      }
+
+      final decodedCalls = jsonSlice.value is List
+          ? jsonSlice.value
+          : <Object?>[jsonSlice.value];
+      final calls = ToolCallParsingUtils.parseToolCallArray(
+        decodedCalls,
+        nameKeys: const <String>['tool_name'],
+        argumentKeys: const <String>['parameters'],
+        idKeys: const <String>['tool_call_id'],
+        assignFallbackIds: false,
+      );
+      if (calls != null && calls.isNotEmpty) {
+        return _CommandBareActionPayload(
+          content: text.substring(0, markerStart).trim(),
+          toolCalls: calls,
+        );
+      }
+    }
+
+    return null;
   }
 
   String _sanitizeName(String name) =>
@@ -282,4 +381,14 @@ value ::= string | number | boolean | null | arr | obj
 arr ::= "[" space (value ("," space value)*)? space "]"
 obj ::= "{" space (string ":" space value ("," space string ":" space value)*)? space "}"''';
   }
+}
+
+class _CommandBareActionPayload {
+  const _CommandBareActionPayload({
+    required this.content,
+    required this.toolCalls,
+  });
+
+  final String content;
+  final List<LlamaCompletionChunkToolCall> toolCalls;
 }

--- a/test/unit/core/engine/engine_test.dart
+++ b/test/unit/core/engine/engine_test.dart
@@ -1819,6 +1819,89 @@ void main() {
       expect(chunks.last.choices.first.finishReason, equals('stop'));
     });
 
+    test('create streams raw bracket text when tools are enabled', () async {
+      backend.generationChunks = const ['  ["', 'note', '"]\n'];
+      await engine.loadModel('qwen-test.gguf');
+
+      final chunks = await engine
+          .create(
+            const [
+              LlamaChatMessage.fromText(role: LlamaChatRole.user, text: 'hi'),
+            ],
+            tools: [
+              ToolDefinition(
+                name: 'get_weather',
+                description: 'Get weather',
+                parameters: [ToolParam.string('city')],
+                handler: (_) async => 'ok',
+              ),
+            ],
+            toolChoice: ToolChoice.auto,
+          )
+          .toList();
+
+      final contentChunks = chunks
+          .where((chunk) => chunk.choices.first.delta.content != null)
+          .toList();
+      final streamedContent = contentChunks
+          .map((chunk) => chunk.choices.first.delta.content!)
+          .join();
+
+      expect(streamedContent, equals('  ["note"]\n'));
+      expect(contentChunks, hasLength(3));
+      expect(chunks.last.choices.first.finishReason, equals('stop'));
+    });
+
+    test('create parses Cohere bare action arrays as tool calls', () async {
+      final cohereBackend = MockLlamaBackend(
+        modelMetadataResponse: const {
+          'llm.context_length': '4096',
+          'tokenizer.chat_template':
+              '{% for message in messages %}{{ message["content"] }}{% endfor %}'
+              '{% if add_generation_prompt %}<|START_TEXT|>{% endif %}'
+              '{# <|START_ACTION|> #}',
+        },
+      );
+      final cohereEngine = LlamaEngine(cohereBackend);
+      cohereBackend.generationChunks = const [
+        '[{"tool_name"',
+        ':"get_weather","parameters":{"city":"Seoul"}}]',
+      ];
+      await cohereEngine.loadModel('north-code-test.gguf');
+
+      final chunks = await cohereEngine
+          .create(
+            const [
+              LlamaChatMessage.fromText(role: LlamaChatRole.user, text: 'hi'),
+            ],
+            tools: [
+              ToolDefinition(
+                name: 'get_weather',
+                description: 'Get weather',
+                parameters: [ToolParam.string('city')],
+                handler: (_) async => 'ok',
+              ),
+            ],
+            toolChoice: ToolChoice.auto,
+          )
+          .toList();
+
+      final streamedContent = chunks
+          .map((chunk) => chunk.choices.first.delta.content)
+          .whereType<String>()
+          .join();
+      final toolChunk = chunks.last;
+      final toolCalls = toolChunk.choices.first.delta.toolCalls;
+
+      expect(streamedContent, isEmpty);
+      expect(toolChunk.choices.first.finishReason, equals('tool_calls'));
+      expect(toolCalls, hasLength(1));
+      expect(toolCalls!.first.function?.name, equals('get_weather'));
+      expect(jsonDecode(toolCalls.first.function!.arguments!), {
+        'city': 'Seoul',
+      });
+    });
+
     test('create streams raw xml text when tools are enabled', () async {
       backend.generationChunks = const ['  <div', '>hello', '</div>\n'];
       await engine.loadModel('qwen-test.gguf');

--- a/test/unit/core/template/chat_format_test.dart
+++ b/test/unit/core/template/chat_format_test.dart
@@ -40,6 +40,13 @@ void main() {
       expect(format, equals(ChatFormat.contentOnly));
     });
 
+    test('detects Cohere2 MoE / North Code before older Command-R', () {
+      const source =
+          '<|START_THINKING|><|END_THINKING|><|START_TEXT|>{{ content }}<|END_TEXT|><|START_ACTION|>[]<|END_ACTION|>';
+      final format = detectChatFormat(source);
+      expect(format, equals(ChatFormat.cohere2Moe));
+    });
+
     test('detects GPT-OSS format', () {
       const source = '<|start|>assistant<|channel|>final<|message|>';
       final format = detectChatFormat(source);

--- a/test/unit/core/template/chat_template_engine_test.dart
+++ b/test/unit/core/template/chat_template_engine_test.dart
@@ -75,6 +75,7 @@ void main() {
         ChatFormat.llama3BuiltinTools:
             TemplateToolCallSerialization.normalizeOnly,
         ChatFormat.commandR7B: TemplateToolCallSerialization.normalizeOnly,
+        ChatFormat.cohere2Moe: TemplateToolCallSerialization.normalizeOnly,
         ChatFormat.glm45: TemplateToolCallSerialization.normalizeOnly,
         ChatFormat.minimaxM2: TemplateToolCallSerialization.normalizeOnly,
         ChatFormat.qwen3CoderXml: TemplateToolCallSerialization.normalizeOnly,

--- a/test/unit/core/template/chat_template_engine_test.dart
+++ b/test/unit/core/template/chat_template_engine_test.dart
@@ -454,6 +454,21 @@ void main() {
       expect(result.format, equals(ChatFormat.contentOnly.index));
     });
 
+    test('uses content-only schema routing for Cohere2 MoE templates', () {
+      const template =
+          '<|START_TEXT|>{{ messages[0]["content"] }}<|END_TEXT|>'
+          '<|START_ACTION|>[]<|END_ACTION|>';
+
+      final result = ChatTemplateEngine.render(
+        templateSource: template,
+        messages: grammarMessages,
+        metadata: const {},
+        responseFormat: const {'type': 'json_object'},
+      );
+
+      expect(result.format, equals(ChatFormat.contentOnly.index));
+    });
+
     test('disables lazy grammar for required tool choice when needed', () {
       const template =
           '<tool_call>\n<function=\n<function>\n<parameters>\n<parameter=\n{{ messages[0]["content"] }}';

--- a/test/unit/core/template/handlers/cohere2_moe_handler_test.dart
+++ b/test/unit/core/template/handlers/cohere2_moe_handler_test.dart
@@ -1,0 +1,35 @@
+import 'package:llamadart/src/core/models/chat/chat_message.dart';
+import 'package:llamadart/src/core/models/chat/chat_role.dart';
+import 'package:llamadart/src/core/models/tools/tool_definition.dart';
+import 'package:llamadart/src/core/template/chat_format.dart';
+import 'package:llamadart/src/core/template/chat_template_engine.dart';
+import 'package:llamadart/src/core/template/handlers/cohere2_moe_handler.dart';
+import 'package:test/test.dart';
+
+void main() {
+  test('Cohere2MoeHandler exposes North Code stops and format', () {
+    final handler = Cohere2MoeHandler();
+
+    expect(handler.format, ChatFormat.cohere2Moe);
+    expect(handler.getStops(hasTools: false), contains('<|END_TEXT|>'));
+    expect(handler.getStops(hasTools: true), contains('<|END_ACTION|>'));
+  });
+
+  test('ChatTemplateEngine routes START_TEXT templates to Cohere2MoeHandler', () {
+    const template =
+        '{{ bos_token }}{% for message in messages %}<|START_OF_TURN_TOKEN|><|USER_TOKEN|>{{ message.content }}<|END_OF_TURN_TOKEN|>{% endfor %}{% if add_generation_prompt %}<|START_OF_TURN_TOKEN|><|CHATBOT_TOKEN|>{% if enable_thinking %}<|START_THINKING|>{% else %}<|START_THINKING|><|END_THINKING|>{% endif %}{% endif %}<|START_TEXT|>{{ content }}<|END_TEXT|><|START_ACTION|>[]<|END_ACTION|>';
+    final rendered = ChatTemplateEngine.render(
+      templateSource: template,
+      messages: const [
+        LlamaChatMessage.fromText(role: LlamaChatRole.user, text: 'hello'),
+      ],
+      metadata: const {'tokenizer.ggml.bos_token': '<s>'},
+      tools: const <ToolDefinition>[],
+      enableThinking: false,
+    );
+
+    expect(rendered.format, ChatFormat.cohere2Moe.index);
+    expect(rendered.prompt, contains('<|END_THINKING|>'));
+    expect(rendered.additionalStops, contains('<|END_TEXT|>'));
+  });
+}

--- a/test/unit/core/template/handlers/command_r7b_handler_test.dart
+++ b/test/unit/core/template/handlers/command_r7b_handler_test.dart
@@ -120,6 +120,21 @@ void main() {
     expect(jsonDecode(parsed.toolCalls.first.function!.arguments!), isEmpty);
   });
 
+  test('parses trailing action arrays after earlier bracketed text', () {
+    final handler = CommandR7BHandler();
+    final parsed = handler.parse(
+      'Review [workspace] first.'
+      '[{"tool_name":"inspect_project","parameters":{"paths":["lib","test"]}}]',
+    );
+
+    expect(parsed.content, equals('Review [workspace] first.'));
+    expect(parsed.toolCalls, hasLength(1));
+    expect(parsed.toolCalls.first.function?.name, equals('inspect_project'));
+    expect(jsonDecode(parsed.toolCalls.first.function!.arguments!), {
+      'paths': ['lib', 'test'],
+    });
+  });
+
   test('keeps bare single-object action-like JSON as content', () {
     final handler = CommandR7BHandler();
     const input =
@@ -142,11 +157,11 @@ void main() {
     expect(parsed.toolCalls, isEmpty);
   });
 
-  test('preserves START_TEXT prelude spacing', () {
+  test('preserves prelude spacing before Cohere2 MoE START_TEXT content', () {
     final handler = CommandR7BHandler();
-    final parsed = handler.parse('Prelude <|START_TEXT|>body<|END_TEXT|>');
+    final parsed = handler.parse('Summary: <|START_TEXT|>all set<|END_TEXT|>');
 
-    expect(parsed.content, equals('Prelude body'));
+    expect(parsed.content, equals('Summary: all set'));
     expect(parsed.toolCalls, isEmpty);
   });
 

--- a/test/unit/core/template/handlers/command_r7b_handler_test.dart
+++ b/test/unit/core/template/handlers/command_r7b_handler_test.dart
@@ -33,7 +33,9 @@ void main() {
     expect(rendered.grammar, isNotNull);
     expect(rendered.grammarLazy, isTrue);
     expect(rendered.additionalStops, contains('<|END_ACTION|>'));
-    expect(rendered.grammarTriggers, isNotEmpty);
+    expect(rendered.grammarTriggers.map((trigger) => trigger.value), [
+      '<|START_ACTION|>',
+    ]);
 
     final parsed = handler.parse(
       '<|START_THINKING|>reasoning<|END_THINKING|>'
@@ -56,6 +58,15 @@ void main() {
     );
     expect(noToolParse.toolCalls, isEmpty);
     expect(noToolParse.content, contains('<|START_ACTION|>'));
+
+    final noToolTextParse = handler.parse(
+      '<|START_THINKING|>reasoning<|END_THINKING|>'
+      '<|START_TEXT|>plain answer<|END_TEXT|>',
+      parseToolCalls: false,
+    );
+    expect(noToolTextParse.reasoningContent, equals('reasoning'));
+    expect(noToolTextParse.content, equals('plain answer'));
+    expect(noToolTextParse.toolCalls, isEmpty);
   });
 
   test('parses action block with whitespace before end marker', () {
@@ -70,6 +81,128 @@ void main() {
       jsonDecode(parsed.toolCalls.first.function!.arguments!),
       containsPair('city', 'Seoul'),
     );
+  });
+
+  test('parses North/Cohere single-object action block', () {
+    final handler = CommandR7BHandler();
+    final parsed = handler.parse(
+      '<|START_ACTION|>{"tool_call_id":"0","tool_name":"inspect_project","parameters":{}}<|END_ACTION|>',
+    );
+
+    expect(parsed.content, isEmpty);
+    expect(parsed.toolCalls, hasLength(1));
+    expect(parsed.toolCalls.first.id, equals('0'));
+    expect(parsed.toolCalls.first.function?.name, equals('inspect_project'));
+    expect(jsonDecode(parsed.toolCalls.first.function!.arguments!), isEmpty);
+  });
+
+  test('parses bare North/Cohere action arrays', () {
+    final handler = CommandR7BHandler();
+    final parsed = handler.parse(
+      '[{"tool_name":"inspect_project","parameters":{}}]',
+    );
+
+    expect(parsed.content, isEmpty);
+    expect(parsed.toolCalls, hasLength(1));
+    expect(parsed.toolCalls.first.function?.name, equals('inspect_project'));
+    expect(jsonDecode(parsed.toolCalls.first.function!.arguments!), isEmpty);
+  });
+
+  test('parses trailing North/Cohere action arrays after prelude text', () {
+    final handler = CommandR7BHandler();
+    final parsed = handler.parse(
+      'I should inspect first.[{"tool_name":"inspect_project","parameters":{}}]',
+    );
+
+    expect(parsed.content, equals('I should inspect first.'));
+    expect(parsed.toolCalls, hasLength(1));
+    expect(parsed.toolCalls.first.function?.name, equals('inspect_project'));
+    expect(jsonDecode(parsed.toolCalls.first.function!.arguments!), isEmpty);
+  });
+
+  test('keeps bare single-object action-like JSON as content', () {
+    final handler = CommandR7BHandler();
+    const input =
+        'Use this object as an example: {"tool_name":"inspect_project","parameters":{}}';
+
+    final parsed = handler.parse(input);
+
+    expect(parsed.toolCalls, isEmpty);
+    expect(parsed.content, equals(input));
+  });
+
+  test('parses Cohere2 MoE START_TEXT content after thinking', () {
+    final handler = CommandR7BHandler();
+    final parsed = handler.parse(
+      'I am thinking<|END_THINKING|><|START_TEXT|>Hello, world!\nWhat\'s up?<|END_TEXT|>',
+    );
+
+    expect(parsed.reasoningContent, equals('I am thinking'));
+    expect(parsed.content, equals('Hello, world!\nWhat\'s up?'));
+    expect(parsed.toolCalls, isEmpty);
+  });
+
+  test('preserves START_TEXT prelude spacing', () {
+    final handler = CommandR7BHandler();
+    final parsed = handler.parse('Prelude <|START_TEXT|>body<|END_TEXT|>');
+
+    expect(parsed.content, equals('Prelude body'));
+    expect(parsed.toolCalls, isEmpty);
+  });
+
+  test('parses Cohere2 MoE START_TEXT content when tools are available', () {
+    final handler = CommandR7BHandler();
+    final parsed = handler.parse(
+      '<|END_THINKING|><|START_TEXT|>No tool needed.<|END_TEXT|>',
+    );
+
+    expect(parsed.reasoningContent, isNull);
+    expect(parsed.content, equals('No tool needed.'));
+    expect(parsed.toolCalls, isEmpty);
+  });
+
+  test('grammar emits North/Cohere array-shaped action blocks', () {
+    final handler = CommandR7BHandler();
+    final tools = [
+      ToolDefinition(
+        name: 'inspect_project',
+        description: 'Inspect project',
+        parameters: const [],
+        handler: _noop,
+      ),
+    ];
+
+    final grammar = handler.buildGrammar(tools)!;
+
+    expect(grammar, contains('"<|START_ACTION|>"'));
+    expect(grammar, contains('action-array ::= "["'));
+    expect(grammar, contains('| action-array'));
+    expect(grammar, contains('"["'));
+    expect(grammar, contains('tool_name'));
+    expect(grammar, contains('inspect_project'));
+    expect(grammar, contains('"<|END_ACTION|>"'));
+  });
+
+  test('grammar preserves required tool argument properties', () {
+    final handler = CommandR7BHandler();
+    final tools = [
+      ToolDefinition(
+        name: 'write_file',
+        description: 'Write file',
+        parameters: [
+          ToolParam.string('path', required: true),
+          ToolParam.string('content', required: true),
+        ],
+        handler: _noop,
+      ),
+    ];
+
+    final grammar = handler.buildGrammar(tools)!;
+
+    expect(grammar, contains('write-file-args ::= "{"'));
+    expect(grammar, contains('"\\"path\\": " space string'));
+    expect(grammar, contains('"\\"content\\": " space string'));
+    expect(grammar, isNot(contains('write-file-args ::= "{" space "}"')));
   });
 
   test('keeps malformed action block as content', () {

--- a/website/docs/changelog/recent-releases.md
+++ b/website/docs/changelog/recent-releases.md
@@ -7,6 +7,12 @@ For canonical full release notes, use:
 
 - [`CHANGELOG.md`](https://github.com/leehack/llamadart/blob/main/CHANGELOG.md)
 
+## Unreleased
+
+- Added Cohere2 MoE / North Code chat-template detection and parsing so
+  `<|START_TEXT|>` responses and `<|START_ACTION|>` tool-call arrays are
+  handled separately from older Command-R templates.
+
 ## 0.8.1
 
 - Fixed docs references that still pointed at


### PR DESCRIPTION
## Summary
- Add a dedicated Cohere2 MoE / North Code chat-template route for templates that use `<|START_TEXT|>` and `<|START_ACTION|>` markers.
- Parse `<|START_TEXT|>...<|END_TEXT|>` responses separately from `<|START_ACTION|>[...]<|END_ACTION|>` tool calls, including safe handling when tool parsing is disabled.
- Keep Command/Cohere tool-call grammar array-shaped while avoiding the unsafe global `[` lazy grammar trigger; bare bracket-leading content remains streamed as raw text unless it looks like a Command/Cohere action array.

## Existing issue check
No matching existing issue or PR found for `Cohere2 MoE`, `North Code`, `START_TEXT START_ACTION`, `North Mini Code`, or `CommandR7B START_ACTION`.

## Review fixes
- Preserved START_TEXT prelude spacing by trimming only the final combined text.
- Narrowed bracket-leading structured streaming to actual Command/Cohere-like action arrays (`tool_name` / `tool_call_id` object keys), so normal JSON arrays and bracketed markdown stream as plain content.
- Changed bare action-array parsing to search from the end of the output and added coverage for earlier bracketed text.
- Added engine-level regression tests for raw bracket content vs Cohere bare action arrays.

## Merge-base refresh
- Merged current `origin/main` into this PR after `main` moved through #221 and #222.
- Resolved the `CHANGELOG.md` conflict by keeping both the GPU enumeration entry from `main` and the Cohere2 MoE / North Code entry from this PR.

## Latest pushed head
- `31ae2e19a12fd7eb2e35ee0b64c07ede75a5a512`

## Test Plan
- [x] `git diff --check`
- [x] `git diff --cached --check`
- [x] `dart format --output=none --set-exit-if-changed lib/llamadart.dart lib/src/backends/backend.dart lib/src/backends/llama_cpp/llama_cpp_backend.dart lib/src/backends/llama_cpp/llama_cpp_service.dart lib/src/backends/llama_cpp/worker.dart lib/src/backends/llama_cpp/worker_messages.dart lib/src/backends/native/native_backend.dart lib/src/core/engine/engine.dart lib/src/core/models/config/gpu_device_info.dart lib/src/core/template/chat_format.dart lib/src/core/template/chat_template_engine.dart lib/src/core/template/handlers/cohere2_moe_handler.dart lib/src/core/template/handlers/command_r7b_handler.dart test/unit/backends/llama_cpp/llama_cpp_service_test.dart test/unit/backends/native/native_backend_test.dart test/unit/core/models/config/gpu_device_info_test.dart test/unit/core/engine/engine_test.dart test/unit/core/template/chat_format_test.dart test/unit/core/template/chat_template_engine_test.dart test/unit/core/template/handlers/cohere2_moe_handler_test.dart test/unit/core/template/handlers/command_r7b_handler_test.dart`
- [x] `dart analyze lib/llamadart.dart lib/src/backends/backend.dart lib/src/backends/llama_cpp/llama_cpp_backend.dart lib/src/backends/llama_cpp/llama_cpp_service.dart lib/src/backends/llama_cpp/worker.dart lib/src/backends/llama_cpp/worker_messages.dart lib/src/backends/native/native_backend.dart lib/src/core/engine/engine.dart lib/src/core/models/config/gpu_device_info.dart lib/src/core/template/chat_format.dart lib/src/core/template/chat_template_engine.dart lib/src/core/template/handlers/cohere2_moe_handler.dart lib/src/core/template/handlers/command_r7b_handler.dart test/unit/backends/llama_cpp/llama_cpp_service_test.dart test/unit/backends/native/native_backend_test.dart test/unit/core/models/config/gpu_device_info_test.dart test/unit/core/engine/engine_test.dart test/unit/core/template/chat_format_test.dart test/unit/core/template/chat_template_engine_test.dart test/unit/core/template/handlers/cohere2_moe_handler_test.dart test/unit/core/template/handlers/command_r7b_handler_test.dart`
- [x] `dart test -p vm test/unit/core/engine/engine_test.dart test/unit/core/template/chat_format_test.dart test/unit/core/template/chat_template_engine_test.dart test/unit/core/template/handlers/cohere2_moe_handler_test.dart test/unit/core/template/handlers/command_r7b_handler_test.dart test/unit/core/models/config/gpu_device_info_test.dart test/unit/backends/llama_cpp/llama_cpp_service_test.dart test/unit/backends/native/native_backend_test.dart`
- [x] `dart test -p chrome test/unit/core/engine/engine_test.dart test/unit/core/template/chat_format_test.dart test/unit/core/template/chat_template_engine_test.dart test/unit/core/template/handlers/cohere2_moe_handler_test.dart test/unit/core/template/handlers/command_r7b_handler_test.dart`
- [x] GitHub Actions CI for `31ae2e1` passed: Analyze and Lint, Linux VM with coverage, Web Chrome, native macOS and Windows, companion packages, docs build, native prompt reuse parity.
- [x] Chat app PR preview deployed for `31ae2e1`.

## Notes
- Broad root `dart analyze` can report pre-existing example/package resolution failures under example paths in some local checkouts; the changed package/template files analyze cleanly and CI's full Analyze and Lint job passed.
- The initial Copilot review produced three actionable comments; all are fixed and all review threads are resolved.
