### PR TITLE
Update llama.cpp runtimes and fix Gemma 4 web batches

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 ## Unreleased
 
+* Updated the default llama.cpp native runtime pin to
+  `leehack/llamadart-native@b9694`, regenerated matching Dart FFI bindings,
+  refreshed the `llamadart_llama_cpp_flutter` Apple SwiftPM checksum, and
+  updated the default WebGPU bridge asset pin to
+  `leehack/llama-web-bridge-assets@v0.1.17` (llama.cpp `b9699`). The WebGPU
+  backend now caps unset large-model browser batches so Gemma 4 mem64 loads do
+  not fall back to context-sized compute buffers.
+
 * Added `BackendGpuEnumeration.listGpuDevices({probeBackends})` (exposed via
   `LlamaEngine.listGpuDevices`) to enumerate GPU-class devices for offload
   selection — backend, per-backend `mainGpu` index, name, description, device

--- a/README.md
+++ b/README.md
@@ -62,7 +62,7 @@ they ship:
 ```yaml
 dependencies:
   llamadart: ^0.8.1
-  llamadart_llama_cpp_flutter: ^0.0.2 # GGUF / llama.cpp
+  llamadart_llama_cpp_flutter: ^0.0.3 # GGUF / llama.cpp
   llamadart_litert_lm_flutter: ^0.0.2 # .litertlm / LiteRT-LM
 ```
 
@@ -131,7 +131,7 @@ hooks:
     llamadart:
       # Optional. Defaults to llamadart's tested native runtime pin.
       # Use a leehack/llamadart-native release tag when testing another build.
-      llamadart_native_tag: b9587
+      llamadart_native_tag: b9694
 
       # Optional. GitHub repository slug or github.com URL.
       llamadart_native_repository: leehack/llamadart-native
@@ -159,7 +159,7 @@ the native-assets hook fails while downloading that asset.
 
 Native source overrides are for compatibility testing. They do not regenerate
 Dart FFI bindings or symbol lookups, so the selected binary still must be ABI-
-and symbol-compatible with the default `leehack/llamadart-native@b9587` runtime.
+and symbol-compatible with the default `leehack/llamadart-native@b9694` runtime.
 
 Available native tags are published on the
 [`leehack/llamadart-native` releases page](https://github.com/leehack/llamadart-native/releases).
@@ -171,7 +171,7 @@ gh release list --repo leehack/llamadart-native --limit 20
 
 Before overriding, confirm the release includes the asset for your target. The
 hook downloads files named `llamadart-native-<bundle>-<tag>.tar.gz`, for example
-`llamadart-native-windows-x64-b9587.tar.gz`.
+`llamadart-native-windows-x64-b9694.tar.gz`.
 For local testing, `llamadart_native_path` may point directly at a bundle
 archive, at an extracted bundle directory, or at a directory containing
 `<tag>/<bundle>/`, `<bundle>/`, or the expected archive file.
@@ -456,7 +456,7 @@ the current strict structured-output boundary.
 <details>
 <summary>Full module matrix (available modules by target)</summary>
 
-Available llama.cpp module matrix from the default native tag `b9587`:
+Available llama.cpp module matrix from the default native tag `b9694`:
 
 | Target | Available backend modules in bundle |
 |--------|-------------------------------------|
@@ -768,11 +768,11 @@ Current pinned runtime artifacts:
 
 | Runtime path | Published artifact |
 |--------------|--------------------|
-| Native llama.cpp / GGUF | `leehack/llamadart-native@b9587` |
+| Native llama.cpp / GGUF | `leehack/llamadart-native@b9694` |
 | Native LiteRT-LM / `.litertlm` | `leehack/litert-lm-native@v0.13.1-native.1` |
-| Apple SPM llama.cpp / GGUF | `llamadart_llama_cpp_flutter` pins `leehack/llamadart-native@b9587` Apple XCFramework |
+| Apple SPM llama.cpp / GGUF | `llamadart_llama_cpp_flutter` pins `leehack/llamadart-native@b9694` Apple XCFramework |
 | Apple SPM LiteRT-LM / `.litertlm` | `llamadart_litert_lm_flutter` pins `leehack/litert-lm-native@v0.13.1-native.1` Apple XCFrameworks |
-| Web llama.cpp / GGUF | `leehack/llama-web-bridge-assets@v0.1.16` |
+| Web llama.cpp / GGUF | `leehack/llama-web-bridge-assets@v0.1.17` |
 | Web LiteRT-LM / `.litertlm` | App-provided `@litert-lm/core` module URL; the chat app defaults to jsDelivr `@litert-lm/core/+esm` |
 
 When bumping native runtime pins, publish the matching native repo release

--- a/doc/webgpu_bridge.md
+++ b/doc/webgpu_bridge.md
@@ -19,7 +19,7 @@ pipelines.
    `https://cdn.jsdelivr.net/gh/leehack/llama-web-bridge-assets@<tag>/llama_webgpu_bridge.js`
 2. Local fallback: `./webgpu_bridge/llama_webgpu_bridge.js`
 
-Default pinned tag in the example is `v0.1.16`.
+Default pinned tag in the example is `v0.1.17`.
 
 For broader browser coverage in this repository, fetched/local assets are patched
 to a universal Safari-compatible gate by default (`MIN_SAFARI_VERSION=170400`).
@@ -32,7 +32,7 @@ model bytes.
 To vendor pinned assets into local app web files:
 
 ```bash
-WEBGPU_BRIDGE_ASSETS_TAG=v0.1.16 ./scripts/fetch_webgpu_bridge_assets.sh
+WEBGPU_BRIDGE_ASSETS_TAG=v0.1.17 ./scripts/fetch_webgpu_bridge_assets.sh
 ```
 
 Optional compatibility env vars:
@@ -113,7 +113,7 @@ You can override CDN source/version before the bridge loader runs:
 ```html
 <script>
   window.__llamadartBridgeAssetsRepo = 'leehack/llama-web-bridge-assets';
-  window.__llamadartBridgeAssetsTag = 'v0.1.16';
+  window.__llamadartBridgeAssetsTag = 'v0.1.17';
 </script>
 ```
 

--- a/example/chat_app/web/index.html
+++ b/example/chat_app/web/index.html
@@ -215,13 +215,13 @@
     const bridgeAssetsTag =
       typeof configuredTag === 'string' && configuredTag.length > 0
         ? configuredTag
-        : 'v0.1.16';
+        : 'v0.1.17';
     window.__llamadartLiteRtLmModuleUrl =
       typeof window.__llamadartLiteRtLmModuleUrl === 'string' &&
       window.__llamadartLiteRtLmModuleUrl.length > 0
         ? window.__llamadartLiteRtLmModuleUrl
         : 'https://cdn.jsdelivr.net/npm/@litert-lm/core/+esm';
-    const localBridgeVersion = 'v0.1.16-local-b9165';
+    const localBridgeVersion = 'v0.1.17-local-b9699';
     window.__llamadartBridgeLocalVersion = localBridgeVersion;
 
     const localBridgeUrl = `./webgpu_bridge/llama_webgpu_bridge.js?v=${localBridgeVersion}`;

--- a/hook/build.dart
+++ b/hook/build.dart
@@ -11,7 +11,7 @@ import 'package:path/path.dart' as path;
 
 import 'package:llamadart/src/hook/native_bundle_config.dart';
 
-const _llamaCppTag = 'b9587';
+const _llamaCppTag = 'b9694';
 const _nativeRepoSlug = 'leehack/llamadart-native';
 
 const _packageName = 'llamadart';

--- a/lib/src/backends/llama_cpp/bindings.dart
+++ b/lib/src/backends/llama_cpp/bindings.dart
@@ -5848,6 +5848,7 @@ external ffi.Pointer<ggml_tensor> ggml_solve_tri(
     ffi.Pointer<ggml_tensor>,
     ffi.Pointer<ggml_tensor>,
     ffi.Pointer<ggml_tensor>,
+    ffi.Int64,
   )
 >()
 external ffi.Pointer<ggml_tensor> ggml_gated_delta_net(
@@ -5858,6 +5859,7 @@ external ffi.Pointer<ggml_tensor> ggml_gated_delta_net(
   ffi.Pointer<ggml_tensor> g,
   ffi.Pointer<ggml_tensor> beta,
   ffi.Pointer<ggml_tensor> state,
+  int K,
 );
 
 @ffi.Native<
@@ -7490,6 +7492,34 @@ external ffi.Pointer<ffi.Float> mtmd_get_output_embd(
   ffi.Pointer<mtmd_context> ctx,
 );
 
+@ffi.Native<ffi.Pointer<mtmd_batch> Function(ffi.Pointer<mtmd_context>)>()
+external ffi.Pointer<mtmd_batch> mtmd_batch_init(ffi.Pointer<mtmd_context> ctx);
+
+@ffi.Native<ffi.Void Function(ffi.Pointer<mtmd_batch>)>()
+external void mtmd_batch_free(ffi.Pointer<mtmd_batch> batch);
+
+@ffi.Native<
+  ffi.Int32 Function(ffi.Pointer<mtmd_batch>, ffi.Pointer<mtmd_input_chunk>)
+>()
+external int mtmd_batch_add_chunk(
+  ffi.Pointer<mtmd_batch> batch,
+  ffi.Pointer<mtmd_input_chunk> chunk,
+);
+
+@ffi.Native<ffi.Int32 Function(ffi.Pointer<mtmd_batch>)>()
+external int mtmd_batch_encode(ffi.Pointer<mtmd_batch> batch);
+
+@ffi.Native<
+  ffi.Pointer<ffi.Float> Function(
+    ffi.Pointer<mtmd_batch>,
+    ffi.Pointer<mtmd_input_chunk>,
+  )
+>()
+external ffi.Pointer<ffi.Float> mtmd_batch_get_output_embd(
+  ffi.Pointer<mtmd_batch> batch,
+  ffi.Pointer<mtmd_input_chunk> chunk,
+);
+
 @ffi.Native<ffi.Void Function(ggml_log_callback, ffi.Pointer<ffi.Void>)>()
 external void mtmd_log_set(
   ggml_log_callback log_callback,
@@ -7615,6 +7645,8 @@ external int mtmd_helper_eval_chunk_single(
     llama_seq_id,
     ffi.Int32,
     ffi.Pointer<llama_pos>,
+    mtmd_helper_post_decode_callback,
+    ffi.Pointer<ffi.Void>,
   )
 >()
 external int mtmd_helper_decode_image_chunk(
@@ -7626,6 +7658,8 @@ external int mtmd_helper_decode_image_chunk(
   int seq_id,
   int n_batch,
   ffi.Pointer<llama_pos> new_n_past,
+  mtmd_helper_post_decode_callback callback,
+  ffi.Pointer<ffi.Void> user_data,
 );
 
 @ffi.Native<mtmd_helper_video_init_params Function()>()
@@ -9037,91 +9071,89 @@ typedef llama_model_set_tensor_data_t =
 
 final class gguf_context extends ffi.Opaque {}
 
-final class _IO_marker extends ffi.Opaque {}
-
-typedef __off_t = ffi.Long;
-typedef Dart__off_t = int;
-typedef _IO_lock_t = ffi.Void;
-typedef Dart_IO_lock_t = void;
-typedef __off64_t = ffi.Long;
-typedef Dart__off64_t = int;
-
-final class _IO_codecvt extends ffi.Opaque {}
-
-final class _IO_wide_data extends ffi.Opaque {}
-
-final class _IO_FILE extends ffi.Struct {
-  @ffi.Int()
-  external int _flags;
-
-  external ffi.Pointer<ffi.Char> _IO_read_ptr;
-
-  external ffi.Pointer<ffi.Char> _IO_read_end;
-
-  external ffi.Pointer<ffi.Char> _IO_read_base;
-
-  external ffi.Pointer<ffi.Char> _IO_write_base;
-
-  external ffi.Pointer<ffi.Char> _IO_write_ptr;
-
-  external ffi.Pointer<ffi.Char> _IO_write_end;
-
-  external ffi.Pointer<ffi.Char> _IO_buf_base;
-
-  external ffi.Pointer<ffi.Char> _IO_buf_end;
-
-  external ffi.Pointer<ffi.Char> _IO_save_base;
-
-  external ffi.Pointer<ffi.Char> _IO_backup_base;
-
-  external ffi.Pointer<ffi.Char> _IO_save_end;
-
-  external ffi.Pointer<_IO_marker> _markers;
-
-  external ffi.Pointer<_IO_FILE> _chain;
+final class __sbuf extends ffi.Struct {
+  external ffi.Pointer<ffi.UnsignedChar> _base;
 
   @ffi.Int()
-  external int _fileno;
-
-  @ffi.Int()
-  external int _flags2;
-
-  @__off_t()
-  external int _old_offset;
-
-  @ffi.UnsignedShort()
-  external int _cur_column;
-
-  @ffi.SignedChar()
-  external int _vtable_offset;
-
-  @ffi.Array.multi([1])
-  external ffi.Array<ffi.Char> _shortbuf;
-
-  external ffi.Pointer<_IO_lock_t> _lock;
-
-  @__off64_t()
-  external int _offset;
-
-  external ffi.Pointer<_IO_codecvt> _codecvt;
-
-  external ffi.Pointer<_IO_wide_data> _wide_data;
-
-  external ffi.Pointer<_IO_FILE> _freeres_list;
-
-  external ffi.Pointer<ffi.Void> _freeres_buf;
-
-  @ffi.Size()
-  external int __pad5;
-
-  @ffi.Int()
-  external int _mode;
-
-  @ffi.Array.multi([20])
-  external ffi.Array<ffi.Char> _unused2;
+  external int _size;
 }
 
-typedef FILE = _IO_FILE;
+typedef __int64_t = ffi.LongLong;
+typedef Dart__int64_t = int;
+typedef __darwin_off_t = __int64_t;
+typedef fpos_t = __darwin_off_t;
+
+final class __sFILEX extends ffi.Opaque {}
+
+final class __sFILE extends ffi.Struct {
+  external ffi.Pointer<ffi.UnsignedChar> _p;
+
+  @ffi.Int()
+  external int _r;
+
+  @ffi.Int()
+  external int _w;
+
+  @ffi.Short()
+  external int _flags;
+
+  @ffi.Short()
+  external int _file;
+
+  external __sbuf _bf;
+
+  @ffi.Int()
+  external int _lbfsize;
+
+  external ffi.Pointer<ffi.Void> _cookie;
+
+  external ffi.Pointer<
+    ffi.NativeFunction<ffi.Int Function(ffi.Pointer<ffi.Void>)>
+  >
+  _close;
+
+  external ffi.Pointer<
+    ffi.NativeFunction<
+      ffi.Int Function(ffi.Pointer<ffi.Void>, ffi.Pointer<ffi.Char>, ffi.Int)
+    >
+  >
+  _read;
+
+  external ffi.Pointer<
+    ffi.NativeFunction<fpos_t Function(ffi.Pointer<ffi.Void>, fpos_t, ffi.Int)>
+  >
+  _seek;
+
+  external ffi.Pointer<
+    ffi.NativeFunction<
+      ffi.Int Function(ffi.Pointer<ffi.Void>, ffi.Pointer<ffi.Char>, ffi.Int)
+    >
+  >
+  _write;
+
+  external __sbuf _ub;
+
+  external ffi.Pointer<__sFILEX> _extra;
+
+  @ffi.Int()
+  external int _ur;
+
+  @ffi.Array.multi([3])
+  external ffi.Array<ffi.UnsignedChar> _ubuf;
+
+  @ffi.Array.multi([1])
+  external ffi.Array<ffi.UnsignedChar> _nbuf;
+
+  external __sbuf _lb;
+
+  @ffi.Int()
+  external int _blksize;
+
+  @fpos_t()
+  external int _offset;
+}
+
+typedef FILE = __sFILE;
 typedef llama_state_seq_flags = ffi.Uint32;
 typedef Dartllama_state_seq_flags = int;
 
@@ -10086,6 +10118,8 @@ final class mtmd_input_chunk extends ffi.Opaque {}
 
 final class mtmd_input_chunks extends ffi.Opaque {}
 
+final class mtmd_batch extends ffi.Opaque {}
+
 final class mtmd_input_text extends ffi.Struct {
   external ffi.Pointer<ffi.Char> text;
 
@@ -10128,6 +10162,9 @@ final class mtmd_context_params extends ffi.Struct {
   external ggml_backend_sched_eval_callback cb_eval;
 
   external ffi.Pointer<ffi.Void> cb_eval_user_data;
+
+  @ffi.Int32()
+  external int batch_max_tokens;
 }
 
 typedef mtmd_bitmap_lazy_callbackFunction =
@@ -10176,6 +10213,13 @@ final class mtmd_helper_bitmap_wrapper extends ffi.Struct {
 
   external ffi.Pointer<mtmd_helper_video> video_ctx;
 }
+
+typedef mtmd_helper_post_decode_callbackFunction =
+    ffi.Int32 Function(llama_batch batch, ffi.Pointer<ffi.Void> user_data);
+typedef Dartmtmd_helper_post_decode_callbackFunction =
+    int Function(llama_batch batch, ffi.Pointer<ffi.Void> user_data);
+typedef mtmd_helper_post_decode_callback =
+    ffi.Pointer<ffi.NativeFunction<mtmd_helper_post_decode_callbackFunction>>;
 
 final class mtmd_helper_video_info extends ffi.Struct {
   @ffi.Uint32()

--- a/lib/src/backends/webgpu/webgpu_backend.dart
+++ b/lib/src/backends/webgpu/webgpu_backend.dart
@@ -633,6 +633,9 @@ class WebGpuLlamaBackend
         normalizedUrl.contains('qwen3.5-0.8b') ||
         normalizedUrl.contains('qwen_qwen3.5-0.8b');
     final isGemma4 = normalizedUrl.contains('gemma-4');
+    final isLargeWebModel =
+        isGemma4 ||
+        (params.modelBytesHint ?? 0) >= _wasm32SafeModelCeilingBytes;
     final hasExplicitBatchSizes =
         params.batchSize > 0 || params.microBatchSize > 0;
     final shouldUseWebGpuDefaults =
@@ -640,14 +643,14 @@ class WebGpuLlamaBackend
         params.preferredBackend != GpuBackend.cpu &&
         gpuLayers != 0;
     final shouldUseQwen35SmallTuning = shouldUseWebGpuDefaults && isQwen35Small;
-    final shouldUseBridgeBatchDefaults = shouldUseWebGpuDefaults && isGemma4;
 
     if (shouldUseQwen35SmallTuning) {
       return (nBatch: 32, nUbatch: 8);
     }
 
-    if (shouldUseBridgeBatchDefaults) {
-      return (nBatch: null, nUbatch: null);
+    if (!hasExplicitBatchSizes && isLargeWebModel) {
+      final cappedBatch = math.min(contextSize, 512);
+      return (nBatch: cappedBatch, nUbatch: cappedBatch);
     }
 
     final resolved = resolveModelContextBatchSizes(params, contextSize);

--- a/lib/src/backends/webgpu/webgpu_backend.dart
+++ b/lib/src/backends/webgpu/webgpu_backend.dart
@@ -636,8 +636,10 @@ class WebGpuLlamaBackend
     final isLargeWebModel =
         isGemma4 ||
         (params.modelBytesHint ?? 0) >= _wasm32SafeModelCeilingBytes;
+    final hasExplicitBatchSize = params.batchSize > 0;
+    final hasExplicitMicroBatchSize = params.microBatchSize > 0;
     final hasExplicitBatchSizes =
-        params.batchSize > 0 || params.microBatchSize > 0;
+        hasExplicitBatchSize || hasExplicitMicroBatchSize;
     final shouldUseWebGpuDefaults =
         !hasExplicitBatchSizes &&
         params.preferredBackend != GpuBackend.cpu &&
@@ -648,9 +650,12 @@ class WebGpuLlamaBackend
       return (nBatch: 32, nUbatch: 8);
     }
 
-    if (!hasExplicitBatchSizes && isLargeWebModel) {
+    if (!hasExplicitBatchSize && isLargeWebModel) {
       final cappedBatch = math.min(contextSize, 512);
-      return (nBatch: cappedBatch, nUbatch: cappedBatch);
+      final cappedMicroBatch = hasExplicitMicroBatchSize
+          ? math.min(params.microBatchSize, cappedBatch)
+          : cappedBatch;
+      return (nBatch: cappedBatch, nUbatch: cappedMicroBatch);
     }
 
     final resolved = resolveModelContextBatchSizes(params, contextSize);

--- a/packages/llamadart_llama_cpp_flutter/CHANGELOG.md
+++ b/packages/llamadart_llama_cpp_flutter/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.0.3
+
+* Updated Apple SwiftPM native pin to `leehack/llamadart-native@b9694`.
+
 ## 0.0.2
 
 * Updated Apple SwiftPM native pin to `leehack/llamadart-native@b9587`.

--- a/packages/llamadart_llama_cpp_flutter/README.md
+++ b/packages/llamadart_llama_cpp_flutter/README.md
@@ -10,13 +10,13 @@ core package's native-assets fallback.
 ```yaml
 dependencies:
   llamadart: ^0.8.1
-  llamadart_llama_cpp_flutter: ^0.0.2
+  llamadart_llama_cpp_flutter: ^0.0.3
 ```
 
 This package has no runtime Dart API of its own. Import `package:llamadart`
 normally from the core package and use `LlamaBackend()` / `LlamaEngine` there.
 
-The Apple SwiftPM manifest pins `leehack/llamadart-native@b9587`.
+The Apple SwiftPM manifest pins `leehack/llamadart-native@b9694`.
 
 Source for this package lives in
 `packages/llamadart_llama_cpp_flutter` in the

--- a/packages/llamadart_llama_cpp_flutter/darwin/llamadart_llama_cpp_flutter/Package.swift
+++ b/packages/llamadart_llama_cpp_flutter/darwin/llamadart_llama_cpp_flutter/Package.swift
@@ -4,7 +4,7 @@ import PackageDescription
 
 let packageRoot = URL(fileURLWithPath: #filePath).deletingLastPathComponent()
 let artifactsRoot = packageRoot.appendingPathComponent("Artifacts")
-let llamaCppTag = "b9587"
+let llamaCppTag = "b9694"
 
 func localArtifactPath(_ name: String) -> String? {
     let path = artifactsRoot.appendingPathComponent(name).path
@@ -47,7 +47,7 @@ let package = Package(
             repository: "leehack/llamadart-native",
             artifactName: "llamadart-native-apple-xcframework-\(llamaCppTag).zip",
             tag: llamaCppTag,
-            checksum: "21b5cbec4c84fe46087fc5d2714ecf5d21764ab36a6d5b8f7dd0dd85b0cd3750"
+            checksum: "c7bbcab61a8d71f4ba717ccf0392564cfa184887ffb7ef106c8ac2b13cd7ee0e"
         ),
         .target(
             name: "llamadart_llama_cpp_flutter",

--- a/packages/llamadart_llama_cpp_flutter/pubspec.yaml
+++ b/packages/llamadart_llama_cpp_flutter/pubspec.yaml
@@ -1,6 +1,6 @@
 name: llamadart_llama_cpp_flutter
 description: Flutter Apple SwiftPM runtime companion package for llamadart llama.cpp and GGUF support.
-version: 0.0.2
+version: 0.0.3
 repository: https://github.com/leehack/llamadart/tree/main/packages/llamadart_llama_cpp_flutter
 homepage: https://github.com/leehack/llamadart
 issue_tracker: https://github.com/leehack/llamadart/issues

--- a/scripts/fetch_webgpu_bridge_assets.sh
+++ b/scripts/fetch_webgpu_bridge_assets.sh
@@ -4,7 +4,7 @@ set -euo pipefail
 ROOT_DIR="$(git rev-parse --show-toplevel)"
 OUT_DIR="${WEBGPU_BRIDGE_OUT_DIR:-$ROOT_DIR/example/chat_app/web/webgpu_bridge}"
 ASSETS_REPO="${WEBGPU_BRIDGE_ASSETS_REPO:-leehack/llama-web-bridge-assets}"
-ASSETS_TAG="${WEBGPU_BRIDGE_ASSETS_TAG:-v0.1.16}"
+ASSETS_TAG="${WEBGPU_BRIDGE_ASSETS_TAG:-v0.1.17}"
 CDN_BASE="${WEBGPU_BRIDGE_CDN_BASE:-https://cdn.jsdelivr.net/gh/${ASSETS_REPO}@${ASSETS_TAG}}"
 PATCH_SAFARI_COMPAT="${WEBGPU_BRIDGE_PATCH_SAFARI_COMPAT:-1}"
 MIN_SAFARI_VERSION="${WEBGPU_BRIDGE_MIN_SAFARI_VERSION:-170400}"
@@ -14,7 +14,7 @@ if [[ "${1:-}" == "--help" || "${1:-}" == "-h" ]]; then
 Downloads prebuilt WebGPU bridge assets into the chat_app web directory.
 
 Default source:
-  https://cdn.jsdelivr.net/gh/leehack/llama-web-bridge-assets@v0.1.16
+  https://cdn.jsdelivr.net/gh/leehack/llama-web-bridge-assets@v0.1.17
 
 Environment variables:
   WEBGPU_BRIDGE_ASSETS_REPO   Asset repo in owner/repo format
@@ -28,7 +28,7 @@ Usage:
   ./scripts/fetch_webgpu_bridge_assets.sh
 
 Examples:
-  WEBGPU_BRIDGE_ASSETS_TAG=v0.1.16 ./scripts/fetch_webgpu_bridge_assets.sh
+  WEBGPU_BRIDGE_ASSETS_TAG=v0.1.17 ./scripts/fetch_webgpu_bridge_assets.sh
   WEBGPU_BRIDGE_ASSETS_REPO=acme/llama-web-bridge-assets WEBGPU_BRIDGE_ASSETS_TAG=v2 ./scripts/fetch_webgpu_bridge_assets.sh
 USAGE
   exit 0
@@ -238,4 +238,3 @@ echo "[webgpu-assets] done"
 echo "  repo: $ASSETS_REPO"
 echo "  tag : $ASSETS_TAG"
 echo "  out : $OUT_DIR"
-

--- a/test/integration/backends/webgpu/webgpu_engine_multimodal_browser_integration_test.dart
+++ b/test/integration/backends/webgpu/webgpu_engine_multimodal_browser_integration_test.dart
@@ -269,14 +269,14 @@ void main() {
       await engine.dispose();
     });
 
-    test('WebGPU load leaves Gemma 4 batches to bridge defaults', () async {
+    test('WebGPU load bounds Gemma 4 batches for browser memory', () async {
       await engine.loadModelFromUrl(
         'https://example.com/gemma-4-E2B-it-Q4_K_S.gguf',
         modelParams: const ModelParams(contextSize: 4096, gpuLayers: 99),
       );
 
-      expect(lastLoadNBatch, isNull);
-      expect(lastLoadNUbatch, isNull);
+      expect(lastLoadNBatch, 512);
+      expect(lastLoadNUbatch, 512);
       expect(lastLoadUseCache, isTrue);
     });
 

--- a/test/unit/backends/webgpu/webgpu_backend_test.dart
+++ b/test/unit/backends/webgpu/webgpu_backend_test.dart
@@ -684,6 +684,19 @@ void main() {
       expect(lastRequestedMicroBatchSize, 512);
     });
 
+    test(
+      'bounds large model batch while preserving explicit micro batch',
+      () async {
+        await backend.modelLoadFromUrl(
+          'https://example.com/gemma-4-E2B-it-Q4_K_S.gguf',
+          const ModelParams(contextSize: 4096, microBatchSize: 128),
+        );
+
+        expect(lastRequestedBatchSize, 512);
+        expect(lastRequestedMicroBatchSize, 128);
+      },
+    );
+
     test('cascades unset WebGPU encoder batches before embedBatch', () async {
       await backend.modelLoadFromUrl(
         'https://example.com/multilingual-e5-small-Q8_0.gguf',

--- a/test/unit/backends/webgpu/webgpu_backend_test.dart
+++ b/test/unit/backends/webgpu/webgpu_backend_test.dart
@@ -669,6 +669,21 @@ void main() {
       expect(lastRequestedMicroBatchSize, 4096);
     });
 
+    test('bounds size-hinted large model batches when unset', () async {
+      await backend.modelLoadFromUrl(
+        'https://example.com/local-large-model.gguf',
+        const ModelParams(
+          contextSize: 2048,
+          gpuLayers: 0,
+          modelBytesHint: 3 * 1024 * 1024 * 1024,
+        ),
+      );
+
+      expect(lastRequestedGpuLayers, 0);
+      expect(lastRequestedBatchSize, 512);
+      expect(lastRequestedMicroBatchSize, 512);
+    });
+
     test('cascades unset WebGPU encoder batches before embedBatch', () async {
       await backend.modelLoadFromUrl(
         'https://example.com/multilingual-e5-small-Q8_0.gguf',
@@ -736,7 +751,7 @@ void main() {
       },
     );
 
-    test('Gemma 4 CPU fallback uses cascaded batch sizes', () async {
+    test('Gemma 4 CPU fallback uses capped web batch sizes', () async {
       var loadCallCount = 0;
       bridge.setProperty(
         'loadModelFromUrl'.toJS,
@@ -762,8 +777,8 @@ void main() {
       );
 
       expect(requestedContextSizes, <int>[4096, 4096]);
-      expect(requestedBatchSizes, <int>[4096]);
-      expect(requestedMicroBatchSizes, <int>[4096]);
+      expect(requestedBatchSizes, <int>[512, 512]);
+      expect(requestedMicroBatchSizes, <int>[512, 512]);
       expect(lastRequestedGpuLayers, 0);
     });
 

--- a/website/docs/changelog/recent-releases.md
+++ b/website/docs/changelog/recent-releases.md
@@ -9,6 +9,13 @@ For canonical full release notes, use:
 
 ## Unreleased
 
+- Updated the default llama.cpp native runtime pin to
+  `leehack/llamadart-native@b9694`, regenerated matching Dart FFI bindings,
+  refreshed the `llamadart_llama_cpp_flutter` Apple SwiftPM checksum, and
+  updated the default WebGPU bridge asset pin to
+  `leehack/llama-web-bridge-assets@v0.1.17` (llama.cpp `b9699`). The WebGPU
+  backend now caps unset large-model browser batches so Gemma 4 mem64 loads do
+  not fall back to context-sized compute buffers.
 - Added Cohere2 MoE / North Code chat-template detection and parsing so
   `<|START_TEXT|>` responses and `<|START_ACTION|>` tool-call arrays are
   handled separately from older Command-R templates.

--- a/website/docs/getting-started/installation.md
+++ b/website/docs/getting-started/installation.md
@@ -36,7 +36,7 @@ Package Manager, also add the runtime companion packages you need:
 ```yaml
 dependencies:
   llamadart: ^0.8.1
-  llamadart_llama_cpp_flutter: ^0.0.2 # GGUF / llama.cpp
+  llamadart_llama_cpp_flutter: ^0.0.3 # GGUF / llama.cpp
   llamadart_litert_lm_flutter: ^0.0.2 # .litertlm / LiteRT-LM
 ```
 
@@ -74,7 +74,7 @@ hooks:
     llamadart:
       # Optional. Defaults to llamadart's tested native runtime pin.
       # Use a leehack/llamadart-native release tag when testing another build.
-      llamadart_native_tag: b9587
+      llamadart_native_tag: b9694
 
       # Optional. GitHub repository slug or github.com URL.
       llamadart_native_repository: leehack/llamadart-native
@@ -100,7 +100,7 @@ per-target module list.
 
 Native source overrides are for compatibility testing. They do not regenerate
 Dart FFI bindings or symbol lookups, so the selected binary still must be ABI-
-and symbol-compatible with the default `leehack/llamadart-native@b9587` runtime.
+and symbol-compatible with the default `leehack/llamadart-native@b9694` runtime.
 
 Available native tags are published on the
 [`leehack/llamadart-native` releases page](https://github.com/leehack/llamadart-native/releases).
@@ -112,7 +112,7 @@ gh release list --repo leehack/llamadart-native --limit 20
 
 Before overriding, confirm the release includes the asset for your target. The
 hook downloads files named `llamadart-native-<bundle>-<tag>.tar.gz`, for example
-`llamadart-native-windows-x64-b9587.tar.gz`.
+`llamadart-native-windows-x64-b9694.tar.gz`.
 For local testing, `llamadart_native_path` may point directly at a bundle
 archive, at an extracted bundle directory, or at a directory containing
 `<tag>/<bundle>/`, `<bundle>/`, or the expected archive file.

--- a/website/docs/platforms/support-matrix.md
+++ b/website/docs/platforms/support-matrix.md
@@ -7,7 +7,7 @@ This page combines platform support, runtime-family selection, and
 backend-module configuration for
 `llamadart`.
 
-The native-assets hook currently pins `llamadart-native` tag `b9587` and
+The native-assets hook currently pins `llamadart-native` tag `b9694` and
 `litert-lm-native` release `v0.13.1-native.1` (`hook/build.dart`). Apps can
 override the llama.cpp native GitHub source with
 `hooks.user_defines.llamadart.llamadart_native_tag` and
@@ -172,7 +172,7 @@ not expose equivalent runtime controls.
   a web load failure as a package bug. The [WebGPU Bridge](./webgpu-bridge)
   page has the browser-console probe and Flutter Web smoke-test path.
 
-## Current llama.cpp module availability by bundle (`b9587`)
+## Current llama.cpp module availability by bundle (`b9694`)
 
 | Bundle key | Available backend modules in bundle |
 | --- | --- |
@@ -220,7 +220,7 @@ hooks:
   user_defines:
     llamadart:
       # Optional. Defaults to llamadart's tested native runtime pin.
-      llamadart_native_tag: b9587
+      llamadart_native_tag: b9694
 
       # Optional. GitHub repository slug or github.com URL.
       llamadart_native_repository: leehack/llamadart-native

--- a/website/docs/platforms/webgpu-bridge.md
+++ b/website/docs/platforms/webgpu-bridge.md
@@ -146,13 +146,13 @@ development validation, and CDN-first loading for normal hosted deployments:
 1. On localhost: local asset first, then CDN fallback.
 2. On hosted deployments: CDN asset first, then local fallback.
 
-The example currently pins bridge assets to `v0.1.16`, with local vendored assets
-identified as `v0.1.16-local-b9165`.
+The example currently pins bridge assets to `v0.1.17`, with local vendored assets
+identified as `v0.1.17-local-b9699`.
 
 Fetch pinned local assets with:
 
 ```bash
-WEBGPU_BRIDGE_ASSETS_TAG=v0.1.16 ./scripts/fetch_webgpu_bridge_assets.sh
+WEBGPU_BRIDGE_ASSETS_TAG=v0.1.17 ./scripts/fetch_webgpu_bridge_assets.sh
 ```
 
 To verify the loaded runtime in a browser console, inspect:
@@ -300,7 +300,7 @@ You can override bridge asset source/version before loader startup:
 ```html
 <script>
   window.__llamadartBridgeAssetsRepo = 'leehack/llama-web-bridge-assets';
-  window.__llamadartBridgeAssetsTag = 'v0.1.16';
+  window.__llamadartBridgeAssetsTag = 'v0.1.17';
   // Prefer local runtime even off localhost:
   // window.__llamadartPreferLocalBridgeRuntime = true;
   // Enable verbose bridge bootstrap console logs:

--- a/website/versioned_docs/version-0.8.1/getting-started/installation.md
+++ b/website/versioned_docs/version-0.8.1/getting-started/installation.md
@@ -36,7 +36,7 @@ Package Manager, also add the runtime companion packages you need:
 ```yaml
 dependencies:
   llamadart: ^0.8.1
-  llamadart_llama_cpp_flutter: ^0.0.2 # GGUF / llama.cpp
+  llamadart_llama_cpp_flutter: ^0.0.3 # GGUF / llama.cpp
   llamadart_litert_lm_flutter: ^0.0.2 # .litertlm / LiteRT-LM
 ```
 
@@ -74,7 +74,7 @@ hooks:
     llamadart:
       # Optional. Defaults to llamadart's tested native runtime pin.
       # Use a leehack/llamadart-native release tag when testing another build.
-      llamadart_native_tag: b9587
+      llamadart_native_tag: b9694
 
       # Optional. GitHub repository slug or github.com URL.
       llamadart_native_repository: leehack/llamadart-native
@@ -100,7 +100,7 @@ per-target module list.
 
 Native source overrides are for compatibility testing. They do not regenerate
 Dart FFI bindings or symbol lookups, so the selected binary still must be ABI-
-and symbol-compatible with the default `leehack/llamadart-native@b9587` runtime.
+and symbol-compatible with the default `leehack/llamadart-native@b9694` runtime.
 
 Available native tags are published on the
 [`leehack/llamadart-native` releases page](https://github.com/leehack/llamadart-native/releases).
@@ -112,7 +112,7 @@ gh release list --repo leehack/llamadart-native --limit 20
 
 Before overriding, confirm the release includes the asset for your target. The
 hook downloads files named `llamadart-native-<bundle>-<tag>.tar.gz`, for example
-`llamadart-native-windows-x64-b9587.tar.gz`.
+`llamadart-native-windows-x64-b9694.tar.gz`.
 For local testing, `llamadart_native_path` may point directly at a bundle
 archive, at an extracted bundle directory, or at a directory containing
 `<tag>/<bundle>/`, `<bundle>/`, or the expected archive file.

--- a/website/versioned_docs/version-0.8.1/platforms/support-matrix.md
+++ b/website/versioned_docs/version-0.8.1/platforms/support-matrix.md
@@ -7,7 +7,7 @@ This page combines platform support, runtime-family selection, and
 backend-module configuration for
 `llamadart`.
 
-The native-assets hook currently pins `llamadart-native` tag `b9587` and
+The native-assets hook currently pins `llamadart-native` tag `b9694` and
 `litert-lm-native` release `v0.13.1-native.1` (`hook/build.dart`). Apps can
 override the llama.cpp native GitHub source with
 `hooks.user_defines.llamadart.llamadart_native_tag` and
@@ -172,7 +172,7 @@ not expose equivalent runtime controls.
   a web load failure as a package bug. The [WebGPU Bridge](./webgpu-bridge)
   page has the browser-console probe and Flutter Web smoke-test path.
 
-## Current llama.cpp module availability by bundle (`b9587`)
+## Current llama.cpp module availability by bundle (`b9694`)
 
 | Bundle key | Available backend modules in bundle |
 | --- | --- |
@@ -220,7 +220,7 @@ hooks:
   user_defines:
     llamadart:
       # Optional. Defaults to llamadart's tested native runtime pin.
-      llamadart_native_tag: b9587
+      llamadart_native_tag: b9694
 
       # Optional. GitHub repository slug or github.com URL.
       llamadart_native_repository: leehack/llamadart-native

--- a/website/versioned_docs/version-0.8.1/platforms/webgpu-bridge.md
+++ b/website/versioned_docs/version-0.8.1/platforms/webgpu-bridge.md
@@ -146,13 +146,13 @@ development validation, and CDN-first loading for normal hosted deployments:
 1. On localhost: local asset first, then CDN fallback.
 2. On hosted deployments: CDN asset first, then local fallback.
 
-The example currently pins bridge assets to `v0.1.16`, with local vendored assets
-identified as `v0.1.16-local-b9165`.
+The example currently pins bridge assets to `v0.1.17`, with local vendored assets
+identified as `v0.1.17-local-b9699`.
 
 Fetch pinned local assets with:
 
 ```bash
-WEBGPU_BRIDGE_ASSETS_TAG=v0.1.16 ./scripts/fetch_webgpu_bridge_assets.sh
+WEBGPU_BRIDGE_ASSETS_TAG=v0.1.17 ./scripts/fetch_webgpu_bridge_assets.sh
 ```
 
 To verify the loaded runtime in a browser console, inspect:
@@ -300,7 +300,7 @@ You can override bridge asset source/version before loader startup:
 ```html
 <script>
   window.__llamadartBridgeAssetsRepo = 'leehack/llama-web-bridge-assets';
-  window.__llamadartBridgeAssetsTag = 'v0.1.16';
+  window.__llamadartBridgeAssetsTag = 'v0.1.17';
   // Prefer local runtime even off localhost:
   // window.__llamadartPreferLocalBridgeRuntime = true;
   // Enable verbose bridge bootstrap console logs:


### PR DESCRIPTION
## Summary

- Update the default native llama.cpp runtime to `leehack/llamadart-native@b9694`, regenerate Dart FFI bindings, and refresh the Apple SwiftPM checksum/version.
- Update the default WebGPU bridge assets to `leehack/llama-web-bridge-assets@v0.1.17`, built from llama.cpp `b9699`, and align README/docs/example pins.
- Cap unset large-model WebGPU logical batch sizes in the browser so Gemma 4 mem64 loads do not fall back to context-sized compute buffers; explicit `batchSize` still wins, explicit `microBatchSize` is preserved under the cap, and the Qwen3.5 0.8B tuning is unchanged.

## Validation

- `dart analyze` - PASS
- `dart analyze lib/src/backends/webgpu/webgpu_backend.dart test/unit/backends/webgpu/webgpu_backend_test.dart test/integration/backends/webgpu/webgpu_engine_multimodal_browser_integration_test.dart` - PASS
- `dart format --output=none --set-exit-if-changed .` - PASS, 0 files changed
- `dart test -p vm -j 1 --exclude-tags local-only` - PASS, 1172 passed, 1 skipped
- `dart test -p chrome --exclude-tags local-only` - PASS, 616 passed, 1 skipped
- `dart test -p chrome test/unit/backends/webgpu/webgpu_backend_test.dart test/integration/backends/webgpu/webgpu_engine_multimodal_browser_integration_test.dart` - PASS, 64 passed
- `./tool/docs/validate_links.sh` - PASS
- `flutter test` in `example/chat_app` - PASS, 122 passed
- `bridge-smoke` local E2E - PASS, loaded `v0.1.17-local-b9699`
- `chat-app-web-mock-smoke` local E2E - PASS
- `chat-app-web-real-model-smoke` with Qwen3.5 0.8B - PASS, generated `2+2 equals 4.`
- `chat-app-web-gemma4-webgpu-smoke --model-url http://127.0.0.1:7358/models/gemma-4-E2B-it-Q4_K_S.gguf` - PASS, Gemma 4 mem64 loaded with `n_batch=512` / `n_ubatch=512` and returned `4`