### PR TITLE
Prepare 0.8.2 release

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -340,6 +340,16 @@ WEBGPU_BRIDGE_ASSETS_TAG=<tag> ./scripts/fetch_webgpu_bridge_assets.sh
   the new version section.
 - Do not leave an empty `Unreleased` section in committed release prep. Add
   `Unreleased` back only when the next unreleased change is documented.
+- Before tagging the core `vX.Y.Z` release, verify any companion package
+  versions referenced by current install docs are already live on pub.dev. If a
+  changed companion package version is missing, publish it first with its
+  package-specific tag, for example
+  `llamadart_llama_cpp_flutter-v0.0.3`, wait for the companion publish workflow
+  to pass, and only then tag the core release.
+- Treat Apple SPM release readiness as two separate checks: the native GitHub
+  release must contain the XCFramework zip/checksum pinned in `Package.swift`,
+  and the Flutter companion pub package carrying that `Package.swift` must be
+  published before users can resolve the documented dependency.
 
 ### Adding New Features
 1. Create public API in appropriate `lib/src/` subdirectory

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-## Unreleased
+## 0.8.2
 
 * Updated the default llama.cpp native runtime pin to
   `leehack/llamadart-native@b9694`, regenerated matching Dart FFI bindings,

--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ JavaScript runtime.
 
 ```yaml
 dependencies:
-  llamadart: ^0.8.1
+  llamadart: ^0.8.2
 ```
 
 Flutter iOS/macOS apps that want Swift Package Manager-linked Apple
@@ -61,7 +61,7 @@ they ship:
 
 ```yaml
 dependencies:
-  llamadart: ^0.8.1
+  llamadart: ^0.8.2
   llamadart_llama_cpp_flutter: ^0.0.3 # GGUF / llama.cpp
   llamadart_litert_lm_flutter: ^0.0.2 # .litertlm / LiteRT-LM
 ```

--- a/doc/testing_matrix.md
+++ b/doc/testing_matrix.md
@@ -115,6 +115,21 @@ Rows that say `hook-only` must not be used as full runtime proof. They only show
 that package/bundle selection is covered; PR evidence still needs a hardware or
 emulator run when the runtime behavior itself is at risk.
 
+## Release Rows
+
+Release candidates should include the release tier:
+
+```bash
+dart run tool/testing/test_matrix.dart --tier release
+```
+
+For releases that change or newly document Flutter Apple SwiftPM companion
+package versions, include `release-companion-pub-gate` in the release evidence.
+That row requires verifying each referenced companion version on pub.dev before
+tagging the core `vX.Y.Z` release. If a companion version is missing, publish it
+with its package-specific tag, wait for `publish_companion_pubdev.yml`, verify
+the pub.dev version URL, and only then push the core release tag.
+
 ## Local Model Scenarios
 
 Real model checks are intentionally local-only. They can use the unified runner:

--- a/packages/llamadart_litert_lm_flutter/README.md
+++ b/packages/llamadart_litert_lm_flutter/README.md
@@ -10,7 +10,7 @@ core package's native-assets fallback.
 
 ```yaml
 dependencies:
-  llamadart: ^0.8.1
+  llamadart: ^0.8.2
   llamadart_litert_lm_flutter: ^0.0.2
 ```
 

--- a/packages/llamadart_llama_cpp_flutter/README.md
+++ b/packages/llamadart_llama_cpp_flutter/README.md
@@ -9,7 +9,7 @@ core package's native-assets fallback.
 
 ```yaml
 dependencies:
-  llamadart: ^0.8.1
+  llamadart: ^0.8.2
   llamadart_llama_cpp_flutter: ^0.0.3
 ```
 

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: llamadart
 description: Dart and Flutter local LLM inference with llama.cpp GGUF and LiteRT-LM across native platforms and web.
-version: 0.8.1
+version: 0.8.2
 homepage: https://github.com/leehack/llamadart
 repository: https://github.com/leehack/llamadart
 issue_tracker: https://github.com/leehack/llamadart/issues

--- a/test/unit/tooling/test_matrix_test.dart
+++ b/test/unit/tooling/test_matrix_test.dart
@@ -50,6 +50,14 @@ void main() {
       expect(ids, contains('web-chrome-runtime-smoke'));
     });
 
+    test('includes release gate for companion pub packages', () {
+      final releaseTable = formatTestMatrix(tier: 'release');
+
+      expect(releaseTable, contains('release-companion-pub-gate'));
+      expect(releaseTable, contains('publish_companion_pubdev.yml'));
+      expect(releaseTable, contains('pub.dev/api/packages'));
+    });
+
     test('formats PR evidence template with matrix ids', () {
       final template = formatPrEvidenceTemplate(tier: 'essential');
 

--- a/tool/testing/test_matrix.dart
+++ b/tool/testing/test_matrix.dart
@@ -383,6 +383,22 @@ const List<TestMatrixRow> testMatrixRows = <TestMatrixRow>[
         'native bundle changes affecting Android.',
   ),
   TestMatrixRow(
+    id: 'release-companion-pub-gate',
+    tier: 'release',
+    mode: 'manual/release',
+    covers:
+        'Flutter Apple SPM companion package pub.dev availability before the core tag',
+    command:
+        'Before tagging vX.Y.Z, verify each referenced companion version with '
+        'https://pub.dev/api/packages/<package>/versions/<version>. If a '
+        'changed version is missing, push the package tag first, for example '
+        'llamadart_llama_cpp_flutter-v0.0.3, wait for '
+        'publish_companion_pubdev.yml, then tag the core release.',
+    useWhen:
+        'Any release that changes companion packages or documents companion '
+        'package versions.',
+  ),
+  TestMatrixRow(
     id: 'release-representative-smokes',
     tier: 'release',
     mode: 'manual/local',

--- a/website/docs/changelog/recent-releases.md
+++ b/website/docs/changelog/recent-releases.md
@@ -7,7 +7,7 @@ For canonical full release notes, use:
 
 - [`CHANGELOG.md`](https://github.com/leehack/llamadart/blob/main/CHANGELOG.md)
 
-## Unreleased
+## 0.8.2
 
 - Updated the default llama.cpp native runtime pin to
   `leehack/llamadart-native@b9694`, regenerated matching Dart FFI bindings,
@@ -16,6 +16,9 @@ For canonical full release notes, use:
   `leehack/llama-web-bridge-assets@v0.1.17` (llama.cpp `b9699`). The WebGPU
   backend now caps unset large-model browser batches so Gemma 4 mem64 loads do
   not fall back to context-sized compute buffers.
+- Added `BackendGpuEnumeration.listGpuDevices({probeBackends})` and
+  `LlamaEngine.listGpuDevices` so apps can enumerate GPU-class devices and
+  select llama.cpp offload targets by backend-specific `mainGpu` index.
 - Added Cohere2 MoE / North Code chat-template detection and parsing so
   `<|START_TEXT|>` responses and `<|START_ACTION|>` tool-call arrays are
   handled separately from older Command-R templates.

--- a/website/docs/getting-started/installation.md
+++ b/website/docs/getting-started/installation.md
@@ -27,7 +27,7 @@ In Xcode, set `IPHONEOS_DEPLOYMENT_TARGET = 16.4` or
 
 ```yaml
 dependencies:
-  llamadart: ^0.8.1
+  llamadart: ^0.8.2
 ```
 
 For Flutter iOS/macOS apps that should link Apple XCFrameworks through Swift
@@ -35,7 +35,7 @@ Package Manager, also add the runtime companion packages you need:
 
 ```yaml
 dependencies:
-  llamadart: ^0.8.1
+  llamadart: ^0.8.2
   llamadart_llama_cpp_flutter: ^0.0.3 # GGUF / llama.cpp
   llamadart_litert_lm_flutter: ^0.0.2 # .litertlm / LiteRT-LM
 ```

--- a/website/docs/maintainers/native-and-web-sync.md
+++ b/website/docs/maintainers/native-and-web-sync.md
@@ -71,6 +71,28 @@ Use this checklist in native sync PRs:
   `llamadart-native` header bundle changed.
 - Update public docs that mention the pinned native versions or source table.
 
+## Companion package release handoff
+
+Native sync PRs can leave the repository in a state where the companion package
+source under `packages/` is ready, but the corresponding pub.dev package version
+does not exist yet. That is expected before merge, but it must be resolved before
+tagging the next core `llamadart` release.
+
+For every companion package whose `pubspec.yaml` version changed, or whose
+version is newly referenced by current install docs:
+
+1. Confirm the `Package.swift` binary targets point at published native GitHub
+   release assets and that the pinned checksums match those assets.
+2. After the sync/release-prep PR is merged, tag the companion package version
+   first, using the package-specific tag pattern:
+   `llamadart_llama_cpp_flutter-v{{version}}` or
+   `llamadart_litert_lm_flutter-v{{version}}`.
+3. Wait for `publish_companion_pubdev.yml` to pass.
+4. Verify the version URL on pub.dev, for example
+   `https://pub.dev/api/packages/llamadart_llama_cpp_flutter/versions/{{version}}`.
+5. Only then tag the core `vX.Y.Z` release that documents or depends on that
+   companion version.
+
 ## Web bridge asset sync flow
 
 When web bridge runtime behavior changes:

--- a/website/docs/maintainers/release-workflow.md
+++ b/website/docs/maintainers/release-workflow.md
@@ -57,7 +57,34 @@ version alignment:
 
 ## 3. Publish flow
 
-Tag with `vX.Y.Z` and push tag.
+Do not tag the core `vX.Y.Z` release until every companion package version named
+in the current install docs is already published on pub.dev. The release
+sequence is:
+
+1. Confirm the native GitHub releases referenced by `Package.swift` are live and
+   include the pinned XCFramework zip/checksum assets.
+2. For each companion package named in current install docs, check whether its
+   `pubspec.yaml` version exists on pub.dev:
+
+   ```bash
+   package_path=packages/llamadart_llama_cpp_flutter
+   package_name="$(awk '/^name:[[:space:]]*/ {print $2; exit}' "$package_path/pubspec.yaml")"
+   package_version="$(awk '/^version:[[:space:]]*/ {print $2; exit}' "$package_path/pubspec.yaml")"
+   curl -fsSL "https://pub.dev/api/packages/$package_name/versions/$package_version"
+   ```
+
+3. If a changed companion version is missing, tag and publish that companion
+   package first, for example:
+
+   ```bash
+   git tag llamadart_llama_cpp_flutter-v0.0.3
+   git push origin llamadart_llama_cpp_flutter-v0.0.3
+   ```
+
+   Wait for `publish_companion_pubdev.yml` to pass, then re-check the pub.dev
+   version URL.
+4. Tag `vX.Y.Z` and push the core release tag only after the companion packages
+   referenced by the release docs are resolvable from pub.dev.
 
 Current workflows involved:
 


### PR DESCRIPTION
## Summary

- Bump the core `llamadart` package to `0.8.2`.
- Promote the accumulated `Unreleased` notes into `0.8.2` in `CHANGELOG.md` and the current website changelog.
- Update current install snippets to `llamadart: ^0.8.2` while leaving independently versioned companion packages unchanged.
- Add the missing GPU enumeration entry to the website recent-release notes.

## Validation

- PASS `dart format --output=none --set-exit-if-changed .`
- PASS `dart analyze`
- PASS `dart run tool/testing/test_matrix.dart --tier release`
  - Listed release rows: `android-release-device-pool`, `release-companion-pub-gate`, `release-representative-smokes`
- PASS `dart test test/unit/tooling/test_matrix_test.dart`
- PASS `dart test -p vm -j 1 --exclude-tags local-only`
  - Result: `+1186 ~1`, all tests passed
- PASS `dart test -p chrome --exclude-tags local-only`
  - Result: `+628 ~1`, all tests passed
- PASS `./tool/docs/build_site.sh`
- PASS `./tool/docs/validate_links.sh`
- PASS `git diff --check`
- PASS `dart pub publish --dry-run`
  - `llamadart 0.8.2`: 0 warnings
- PASS `flutter pub publish --dry-run`
  - `packages/llamadart_llama_cpp_flutter`: 0 warnings, 1 pub hint because pub.dev reports previous visible version `0.0.1` while the package is locally `0.0.3`
- PASS `flutter pub publish --dry-run`
  - `packages/llamadart_litert_lm_flutter`: 0 warnings

## Release Notes

- Release order after merge:
  1. Tag/publish `llamadart_llama_cpp_flutter-v0.0.3` first so the Apple SPM companion package referenced by the docs exists on pub.dev.
  2. Verify `llamadart_llama_cpp_flutter 0.0.3` on pub.dev.
  3. Tag `v0.8.2` for the core package and docs version cut.
- Native Apple XCFramework assets are already published by `leehack/llamadart-native@b9694`; `Package.swift` pins the released `llamadart-native-apple-xcframework-b9694.zip` checksum.
- Versioned docs are intentionally not snapshot here; the existing tag-driven docs workflow should cut the `0.8.2` docs version after the release tag.
- Companion package versions remain independent of the core `llamadart` package version.
