### PR TITLE
fix: load Windows backend modules with altered search path

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## Unreleased
+
+* Preloaded Windows CUDA redistributable DLLs from the resolved native backend
+  bundle directory before loading the CUDA backend module, so CUDA backend
+  discovery no longer depends on the app `PATH` or current working directory.
+
 ## 0.8.2
 
 * Updated the default llama.cpp native runtime pin to

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,9 @@
 ## Unreleased
 
-* Preloaded Windows CUDA redistributable DLLs from the resolved native backend
-  bundle directory before loading the CUDA backend module, so CUDA backend
-  discovery no longer depends on the app `PATH` or current working directory.
+* Preload Windows backend modules with `LOAD_WITH_ALTERED_SEARCH_PATH` from
+  the resolved native backend bundle directory before handing them to
+  llama.cpp, so CUDA backend discovery can resolve colocated CUDA
+  redistributables without app `PATH` changes.
 
 ## 0.8.2
 

--- a/lib/src/backends/llama_cpp/llama_cpp_service.dart
+++ b/lib/src/backends/llama_cpp/llama_cpp_service.dart
@@ -398,6 +398,8 @@ class LlamaCppService {
   final Set<String> _failedBackendModules = <String>{};
   final Map<String, DynamicLibrary> _loadedBackendLibraries =
       <String, DynamicLibrary>{};
+  final Map<String, List<DynamicLibrary>> _preloadedBackendDependencyLibraries =
+      <String, List<DynamicLibrary>>{};
   final List<DynamicLibrary> _preloadedCoreLibraries = <DynamicLibrary>[];
   bool _backendLoadAllSymbolUnavailable = false;
   bool _backendLoadAllFromPathSymbolUnavailable = false;
@@ -1835,6 +1837,8 @@ class LlamaCppService {
       candidates.addAll(fileNameCandidates);
     }
 
+    _preloadWindowsBackendDependencies(backend);
+
     for (final candidate in candidates) {
       if (path.isAbsolute(candidate) && !File(candidate).existsSync()) {
         continue;
@@ -1898,6 +1902,117 @@ class LlamaCppService {
     }
 
     return candidates.toList(growable: false);
+  }
+
+  void _preloadWindowsBackendDependencies(String backend) {
+    if (!Platform.isWindows) {
+      return;
+    }
+
+    final backendModuleDirectory = _backendModuleDirectory;
+    if (backendModuleDirectory == null) {
+      return;
+    }
+
+    final cacheKey =
+        '$backend|${path.normalize(backendModuleDirectory).toLowerCase()}';
+    if (_preloadedBackendDependencyLibraries.containsKey(cacheKey)) {
+      return;
+    }
+
+    final handles = <DynamicLibrary>[];
+    _preloadedBackendDependencyLibraries[cacheKey] = handles;
+
+    for (final dependencyPath in windowsBackendDependencyPaths(
+      backendModuleDirectory,
+      backend,
+    )) {
+      try {
+        handles.add(DynamicLibrary.open(dependencyPath));
+      } catch (error) {
+        _recordStartupDiagnostic(
+          'Failed to preload Windows backend dependency '
+          '`$dependencyPath` for `$backend`: $error',
+        );
+      }
+    }
+  }
+
+  /// Returns absolute paths for backend-owned Windows dependency DLLs that
+  /// should be loaded before asking llama.cpp to dynamically load [backend].
+  ///
+  /// `ggml_backend_load()` loads backend modules by absolute path, but Windows
+  /// resolves those modules' transitive imports through the process DLL search
+  /// path, not reliably through the module directory. Native-asset builds place
+  /// CUDA redistributables beside `ggml-cuda.dll`, so preloading those DLLs by
+  /// absolute path makes the subsequent backend load independent of PATH/current
+  /// directory state.
+  static List<String> windowsBackendDependencyPaths(
+    String directoryPath,
+    String backend, {
+    Iterable<String>? fileNames,
+  }) {
+    if (backend != 'cuda') {
+      return const <String>[];
+    }
+
+    final names =
+        fileNames?.toList(growable: false) ??
+        _listWindowsBackendDependencyFileNames(directoryPath);
+    final selected = <String>[];
+    for (final name in names) {
+      final lower = name.toLowerCase();
+      if (!lower.endsWith('.dll')) {
+        continue;
+      }
+      if (lower.startsWith('cudart64_') ||
+          lower.startsWith('cublas64_') ||
+          lower.startsWith('cublaslt64_')) {
+        selected.add(name);
+      }
+    }
+
+    selected.sort((a, b) {
+      final priorityCompare = _windowsCudaDependencyPriority(
+        a,
+      ).compareTo(_windowsCudaDependencyPriority(b));
+      if (priorityCompare != 0) {
+        return priorityCompare;
+      }
+      return a.toLowerCase().compareTo(b.toLowerCase());
+    });
+
+    return selected
+        .map((name) => path.join(directoryPath, name))
+        .toList(growable: false);
+  }
+
+  static List<String> _listWindowsBackendDependencyFileNames(
+    String directoryPath,
+  ) {
+    try {
+      return Directory(directoryPath)
+          .listSync()
+          .whereType<File>()
+          .map((file) => path.basename(file.path))
+          .toList(growable: false);
+    } catch (_) {
+      return const <String>[];
+    }
+  }
+
+  static int _windowsCudaDependencyPriority(String fileName) {
+    final lower = fileName.toLowerCase();
+    if (lower.startsWith('cudart64_')) {
+      return 0;
+    }
+    if (lower.startsWith('cublas64_')) {
+      return 1;
+    }
+    if (lower.startsWith('cublaslt64_')) {
+      return 2;
+    }
+    return 100;
   }
 
   bool _tryRegisterBackendModuleViaAsset(String backend) {

--- a/lib/src/backends/llama_cpp/llama_cpp_service.dart
+++ b/lib/src/backends/llama_cpp/llama_cpp_service.dart
@@ -46,6 +46,14 @@ typedef _GgmlBackendRegDevGetNative =
     ggml_backend_dev_t Function(ggml_backend_reg_t, Size);
 typedef _GgmlBackendRegDevGetDart =
     ggml_backend_dev_t Function(ggml_backend_reg_t, int);
+typedef _LoadLibraryExWNative =
+    Pointer<Void> Function(Pointer<Utf16>, Pointer<Void>, Uint32);
+typedef _LoadLibraryExWDart =
+    Pointer<Void> Function(Pointer<Utf16>, Pointer<Void>, int);
+typedef _FreeLibraryNative = Int32 Function(Pointer<Void>);
+typedef _FreeLibraryDart = int Function(Pointer<Void>);
+typedef _SetErrorModeNative = Uint32 Function(Uint32);
+typedef _SetErrorModeDart = int Function(int);
 typedef _GgmlBackendDevCountNative = Size Function();
 typedef _GgmlBackendDevCountDart = int Function();
 typedef _GgmlBackendDevGetNative = ggml_backend_dev_t Function(Size);
@@ -382,6 +390,8 @@ class LlamaCppService {
     defaultValue: false,
   );
   static const int _maxStartupDiagnostics = 32;
+  static const int _loadWithAlteredSearchPath = 0x00000008;
+  static const int _semFailCriticalErrors = 0x0001;
   static const Map<String, int> _androidCpuVariantPriority = <String, int>{
     'android_armv9.2_2': 0,
     'android_armv9.2_1': 1,
@@ -1844,6 +1854,10 @@ class LlamaCppService {
         continue;
       }
 
+      final alteredSearchPathHandle = _preloadWindowsBackendModule(
+        candidate,
+        backend,
+      );
       final libraryPathPtr = candidate.toNativeUtf8();
       try {
         ggml_backend_reg_t reg;
@@ -1873,6 +1887,13 @@ class LlamaCppService {
         _failedBackendModules.remove(backend);
         return true;
       } finally {
+        if (alteredSearchPathHandle != nullptr) {
+          _freeWindowsBackendModule(
+            alteredSearchPathHandle,
+            candidate,
+            backend,
+          );
+        }
         malloc.free(libraryPathPtr);
       }
     }
@@ -1902,6 +1923,78 @@ class LlamaCppService {
     }
 
     return candidates.toList(growable: false);
+  }
+
+  Pointer<Void> _preloadWindowsBackendModule(
+    String libraryPath,
+    String backend,
+  ) {
+    final flags = windowsBackendModuleLoadFlags(libraryPath);
+    if (!Platform.isWindows || flags == 0) {
+      return nullptr;
+    }
+
+    try {
+      final kernel32 = DynamicLibrary.open('kernel32.dll');
+      final setErrorMode = kernel32
+          .lookupFunction<_SetErrorModeNative, _SetErrorModeDart>(
+            'SetErrorMode',
+          );
+      final loadLibraryExW = kernel32
+          .lookupFunction<_LoadLibraryExWNative, _LoadLibraryExWDart>(
+            'LoadLibraryExW',
+          );
+      final oldMode = setErrorMode(_semFailCriticalErrors);
+      setErrorMode(oldMode | _semFailCriticalErrors);
+
+      final libraryPathPtr = libraryPath.toNativeUtf16();
+      try {
+        final handle = loadLibraryExW(libraryPathPtr, nullptr, flags);
+        if (handle == nullptr) {
+          _recordStartupDiagnostic(
+            'Failed to preload Windows backend module `$libraryPath` with '
+            'LOAD_WITH_ALTERED_SEARCH_PATH for `$backend`.',
+          );
+        }
+        return handle;
+      } finally {
+        malloc.free(libraryPathPtr);
+        setErrorMode(oldMode);
+      }
+    } catch (error) {
+      _recordStartupDiagnostic(
+        'Failed to preload Windows backend module `$libraryPath` with '
+        'LOAD_WITH_ALTERED_SEARCH_PATH for `$backend`: $error',
+      );
+      return nullptr;
+    }
+  }
+
+  void _freeWindowsBackendModule(
+    Pointer<Void> handle,
+    String libraryPath,
+    String backend,
+  ) {
+    if (!Platform.isWindows || handle == nullptr) {
+      return;
+    }
+
+    try {
+      final kernel32 = DynamicLibrary.open('kernel32.dll');
+      final freeLibrary = kernel32
+          .lookupFunction<_FreeLibraryNative, _FreeLibraryDart>('FreeLibrary');
+      if (freeLibrary(handle) == 0) {
+        _recordStartupDiagnostic(
+          'Failed to release temporary Windows backend module preload for '
+          '`$libraryPath` (`$backend`).',
+        );
+      }
+    } catch (error) {
+      _recordStartupDiagnostic(
+        'Failed to release temporary Windows backend module preload for '
+        '`$libraryPath` (`$backend`): $error',
+      );
+    }
   }
 
   void _preloadWindowsBackendDependencies(String backend) {
@@ -1938,15 +2031,26 @@ class LlamaCppService {
     }
   }
 
-  /// Returns absolute paths for backend-owned Windows dependency DLLs that
-  /// should be loaded before asking llama.cpp to dynamically load [backend].
+  /// Returns Windows `LoadLibraryExW` flags for preloading a backend module.
   ///
-  /// `ggml_backend_load()` loads backend modules by absolute path, but Windows
-  /// resolves those modules' transitive imports through the process DLL search
-  /// path, not reliably through the module directory. Native-asset builds place
-  /// CUDA redistributables beside `ggml-cuda.dll`, so preloading those DLLs by
-  /// absolute path makes the subsequent backend load independent of PATH/current
-  /// directory state.
+  /// llama.cpp currently opens dynamic backend modules with plain
+  /// `LoadLibraryW`. For absolute native-asset bundle paths, an earlier
+  /// `LOAD_WITH_ALTERED_SEARCH_PATH` load lets Windows resolve transitive DLL
+  /// imports from the backend module directory before llama.cpp registers it.
+  static int windowsBackendModuleLoadFlags(String libraryPath) {
+    if (!path.isAbsolute(libraryPath)) {
+      return 0;
+    }
+    return _loadWithAlteredSearchPath;
+  }
+
+  /// Returns absolute paths for backend-owned Windows dependency DLLs that
+  /// can be preloaded before asking llama.cpp to dynamically load [backend].
+  ///
+  /// This is only a best-effort compatibility path. The backend module itself
+  /// is also preloaded with `LOAD_WITH_ALTERED_SEARCH_PATH`, because Windows
+  /// may still fail to resolve module-owned transitive imports from the bundle
+  /// directory after individual dependency DLLs were loaded by absolute path.
   static List<String> windowsBackendDependencyPaths(
     String directoryPath,
     String backend, {

--- a/test/unit/backends/llama_cpp/llama_cpp_service_test.dart
+++ b/test/unit/backends/llama_cpp/llama_cpp_service_test.dart
@@ -726,6 +726,34 @@ void main() {
       expect(path.normalize(resolved!), path.normalize(overrideDir.path));
     });
 
+    test('orders CUDA redistributable DLLs for preloading', () {
+      final dependencyPaths = LlamaCppService.windowsBackendDependencyPaths(
+        tempRoot.path,
+        'cuda',
+        fileNames: const <String>[
+          'ggml-cuda.dll',
+          'cublasLt64_12.dll',
+          'notes.txt',
+          'cudart64_12.dll',
+          'cublas64_12.dll',
+        ],
+      );
+
+      expect(dependencyPaths, <String>[
+        path.join(tempRoot.path, 'cudart64_12.dll'),
+        path.join(tempRoot.path, 'cublas64_12.dll'),
+        path.join(tempRoot.path, 'cublasLt64_12.dll'),
+      ]);
+      expect(
+        LlamaCppService.windowsBackendDependencyPaths(
+          tempRoot.path,
+          'vulkan',
+          fileNames: const <String>['cudart64_12.dll'],
+        ),
+        isEmpty,
+      );
+    });
+
     test('falls back to hook cache extracted bundle directory', () {
       final extractedDir = Directory(
         path.join(

--- a/test/unit/backends/llama_cpp/llama_cpp_service_test.dart
+++ b/test/unit/backends/llama_cpp/llama_cpp_service_test.dart
@@ -726,7 +726,20 @@ void main() {
       expect(path.normalize(resolved!), path.normalize(overrideDir.path));
     });
 
-    test('orders CUDA redistributable DLLs for preloading', () {
+    test('uses altered search path for absolute Windows backend modules', () {
+      expect(
+        LlamaCppService.windowsBackendModuleLoadFlags(
+          path.join(tempRoot.path, 'ggml-cuda.dll'),
+        ),
+        0x00000008,
+      );
+      expect(
+        LlamaCppService.windowsBackendModuleLoadFlags('ggml-cuda.dll'),
+        isZero,
+      );
+    });
+
+    test('orders CUDA redistributable DLLs for best-effort preloading', () {
       final dependencyPaths = LlamaCppService.windowsBackendDependencyPaths(
         tempRoot.path,
         'cuda',


### PR DESCRIPTION
## Summary
- Temporarily preload the Windows CUDA backend module itself with `LoadLibraryExW(..., LOAD_WITH_ALTERED_SEARCH_PATH)` before handing the same path to llama.cpp's `ggml_backend_load()`.
- Keep bundled CUDA redistributable preloading as a best-effort compatibility path, but no longer rely on it as the primary loader fix.
- Add regression coverage for the altered-search-path backend preload, update the dependency-preload test wording, and document the fix in `CHANGELOG.md`.

## Context
Elana reported in `leehack/llamadart-native#22` that `llamadart-native` `b9694` bundles `cudart64_12.dll`, `cublas64_12.dll`, and `cublasLt64_12.dll` beside the CUDA backend, but `llamadart` still fails to load CUDA with an empty reason and enumerates 0 devices. Upstream llama.cpp b9700 CUDA works on the same RTX 5050, so this points at Windows dependency resolution in the package load path rather than the CUDA binary itself.

On Windows, preloading the CUDA redistributables by absolute path is not enough if llama.cpp later calls plain `LoadLibraryW` for `ggml-cuda.dll`; Windows can still fail to resolve module-owned transitive imports from the bundle directory. The package-side fix now preloads the backend module with `LOAD_WITH_ALTERED_SEARCH_PATH`, then releases the temporary preload reference after `ggml_backend_load()` takes ownership through the llama.cpp registry path.

## Existing issue check
- Related current report: `leehack/llamadart-native#22`.
- Checked `leehack/llamadart` issues/PRs for `CUDA DLL Windows`, `ggml-cuda`, `cudart64 cublas64`, `LoadLibraryEx`, and `backend dependencies`; no open duplicate package-side PR was found. Older related issues/PRs include #111, #114, and #115.

## Test Plan
- [x] `dart format lib/src/backends/llama_cpp/llama_cpp_service.dart test/unit/backends/llama_cpp/llama_cpp_service_test.dart`
- [x] `git diff --check origin/watcher/windows-cuda-dll-preload..HEAD`
- [x] `dart analyze lib/src/backends/llama_cpp/llama_cpp_service.dart test/unit/backends/llama_cpp/llama_cpp_service_test.dart`
- [x] `dart test test/unit/backends/llama_cpp/llama_cpp_service_test.dart` - 72 tests passed locally on macOS
- [x] Fixed Copilot review feedback by renaming the helper to `windowsBackendDependencyPaths` and clarifying that it returns absolute paths; resolved the now-outdated thread.
- [x] Latest-head CI for `e2f68f9c35fc15df25b04e319828e6506ebdd335` passed: `Analyze & Lint`, companion packages, `Native Prompt Reuse Parity`, docs build, Linux VM coverage, Chrome web tests, `Test Native (macos-latest)`, `Test Native (windows-latest)`, coverage aggregator, and chat app PR preview.
- [x] Real Windows CUDA smoke: Elana retested `e2f68f9` on the RTX 5050 with the native bundle directory not on `PATH`; `listGpuDevices(probeBackends: [GpuBackend.cuda])` loaded `ggml-cuda.dll` from `.dart_tool/lib` and enumerated the RTX 5050 successfully.

## Follow-up
- After merge, update/close the linked native issue with the confirmed package-side loader fix and the RTX 5050 no-`PATH` validation result.
