### PR TITLE
Prepare 0.8.3 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,9 +1,10 @@
-## Unreleased
+## 0.8.3
 
-* Preload Windows backend modules with `LOAD_WITH_ALTERED_SEARCH_PATH` from
-  the resolved native backend bundle directory before handing them to
-  llama.cpp, so CUDA backend discovery can resolve colocated CUDA
-  redistributables without app `PATH` changes.
+* Fixed Windows CUDA backend discovery when the native asset bundle directory is
+  not on the app `PATH`. llama.cpp backend modules are now loaded from their
+  resolved bundle path in a way that lets colocated CUDA redistributables such
+  as `cudart64_12.dll`, `cublas64_12.dll`, and `cublasLt64_12.dll` resolve
+  correctly.
 
 ## 0.8.2
 

--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ JavaScript runtime.
 
 ```yaml
 dependencies:
-  llamadart: ^0.8.2
+  llamadart: ^0.8.3
 ```
 
 Flutter iOS/macOS apps that want Swift Package Manager-linked Apple
@@ -61,7 +61,7 @@ they ship:
 
 ```yaml
 dependencies:
-  llamadart: ^0.8.2
+  llamadart: ^0.8.3
   llamadart_llama_cpp_flutter: ^0.0.3 # GGUF / llama.cpp
   llamadart_litert_lm_flutter: ^0.0.2 # .litertlm / LiteRT-LM
 ```

--- a/packages/llamadart_litert_lm_flutter/README.md
+++ b/packages/llamadart_litert_lm_flutter/README.md
@@ -10,7 +10,7 @@ core package's native-assets fallback.
 
 ```yaml
 dependencies:
-  llamadart: ^0.8.2
+  llamadart: ^0.8.3
   llamadart_litert_lm_flutter: ^0.0.2
 ```
 

--- a/packages/llamadart_llama_cpp_flutter/README.md
+++ b/packages/llamadart_llama_cpp_flutter/README.md
@@ -9,7 +9,7 @@ core package's native-assets fallback.
 
 ```yaml
 dependencies:
-  llamadart: ^0.8.2
+  llamadart: ^0.8.3
   llamadart_llama_cpp_flutter: ^0.0.3
 ```
 

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: llamadart
 description: Dart and Flutter local LLM inference with llama.cpp GGUF and LiteRT-LM across native platforms and web.
-version: 0.8.2
+version: 0.8.3
 homepage: https://github.com/leehack/llamadart
 repository: https://github.com/leehack/llamadart
 issue_tracker: https://github.com/leehack/llamadart/issues

--- a/website/docs/changelog/recent-releases.md
+++ b/website/docs/changelog/recent-releases.md
@@ -7,6 +7,13 @@ For canonical full release notes, use:
 
 - [`CHANGELOG.md`](https://github.com/leehack/llamadart/blob/main/CHANGELOG.md)
 
+## 0.8.3
+
+- Fixed Windows CUDA backend discovery when the native asset bundle directory is
+  not on the app `PATH`. Apps using the CUDA llama.cpp backend can now resolve
+  bundled CUDA redistributables beside `ggml-cuda.dll` without manually adding
+  `.dart_tool/lib` or the native bundle path to `PATH`.
+
 ## 0.8.2
 
 - Updated the default llama.cpp native runtime pin to

--- a/website/docs/getting-started/installation.md
+++ b/website/docs/getting-started/installation.md
@@ -27,7 +27,7 @@ In Xcode, set `IPHONEOS_DEPLOYMENT_TARGET = 16.4` or
 
 ```yaml
 dependencies:
-  llamadart: ^0.8.2
+  llamadart: ^0.8.3
 ```
 
 For Flutter iOS/macOS apps that should link Apple XCFrameworks through Swift
@@ -35,7 +35,7 @@ Package Manager, also add the runtime companion packages you need:
 
 ```yaml
 dependencies:
-  llamadart: ^0.8.2
+  llamadart: ^0.8.3
   llamadart_llama_cpp_flutter: ^0.0.3 # GGUF / llama.cpp
   llamadart_litert_lm_flutter: ^0.0.2 # .litertlm / LiteRT-LM
 ```


### PR DESCRIPTION
## Summary
- Bump the core `llamadart` package version to `0.8.3`.
- Move the Windows CUDA backend discovery fix from `Unreleased` into the `0.8.3` changelog section.
- Update current install snippets and recent-release docs to use `^0.8.3`.

## Release Scope
- Patch release for the Windows CUDA native-asset backend loading fix from #227.
- No native runtime pin changes.
- No companion package version changes.

## Release Gate Evidence
- Latest pub.dev core version check: `llamadart` latest is `0.8.2`, so `0.8.3` is the next patch release.
- `release-companion-pub-gate`: verified `llamadart_llama_cpp_flutter` `0.0.3` and `llamadart_litert_lm_flutter` `0.0.2` exist on pub.dev before the core tag.
- `release-representative-smokes`: runtime behavior covered by #227 validation; the RTX 5050 Windows CUDA smoke loaded `ggml-cuda.dll` from `.dart_tool/lib` with the native bundle directory not on `PATH` and enumerated the GPU successfully.

## Validation
- [x] `dart run tool/testing/test_matrix.dart --tier release`
- [x] `dart format --output=none --set-exit-if-changed .`
- [x] `dart analyze`
- [x] `dart test` - 1817 passed, 6 skipped
- [x] `./tool/docs/build_site.sh`
- [x] `./tool/docs/validate_links.sh`
- [x] `dart pub publish --dry-run` - 0 warnings
