### PR TITLE
Prepare 0.8.4 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-## Unreleased
+## 0.8.4
 
 * Updated the default llama.cpp native runtime pin to
   `leehack/llamadart-native@b9744`, regenerated matching Dart FFI bindings,

--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ JavaScript runtime.
 
 ```yaml
 dependencies:
-  llamadart: ^0.8.3
+  llamadart: ^0.8.4
 ```
 
 Flutter iOS/macOS apps that want Swift Package Manager-linked Apple
@@ -61,8 +61,8 @@ they ship:
 
 ```yaml
 dependencies:
-  llamadart: ^0.8.3
-  llamadart_llama_cpp_flutter: ^0.0.3 # GGUF / llama.cpp
+  llamadart: ^0.8.4
+  llamadart_llama_cpp_flutter: ^0.0.4 # GGUF / llama.cpp
   llamadart_litert_lm_flutter: ^0.0.2 # .litertlm / LiteRT-LM
 ```
 

--- a/packages/llamadart_litert_lm_flutter/README.md
+++ b/packages/llamadart_litert_lm_flutter/README.md
@@ -10,7 +10,7 @@ core package's native-assets fallback.
 
 ```yaml
 dependencies:
-  llamadart: ^0.8.3
+  llamadart: ^0.8.4
   llamadart_litert_lm_flutter: ^0.0.2
 ```
 

--- a/packages/llamadart_llama_cpp_flutter/README.md
+++ b/packages/llamadart_llama_cpp_flutter/README.md
@@ -9,7 +9,7 @@ core package's native-assets fallback.
 
 ```yaml
 dependencies:
-  llamadart: ^0.8.3
+  llamadart: ^0.8.4
   llamadart_llama_cpp_flutter: ^0.0.4
 ```
 

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: llamadart
 description: Dart and Flutter local LLM inference with llama.cpp GGUF and LiteRT-LM across native platforms and web.
-version: 0.8.3
+version: 0.8.4
 homepage: https://github.com/leehack/llamadart
 repository: https://github.com/leehack/llamadart
 issue_tracker: https://github.com/leehack/llamadart/issues

--- a/website/docs/changelog/recent-releases.md
+++ b/website/docs/changelog/recent-releases.md
@@ -7,6 +7,22 @@ For canonical full release notes, use:
 
 - [`CHANGELOG.md`](https://github.com/leehack/llamadart/blob/main/CHANGELOG.md)
 
+## 0.8.4
+
+- Updated the default llama.cpp native runtime pin to
+  `leehack/llamadart-native@b9744`, regenerated matching Dart FFI bindings,
+  refreshed the `llamadart_llama_cpp_flutter` Apple SwiftPM checksum, and
+  aligned current README/website native override docs.
+- Expanded llama.cpp chat-template parity coverage for current upstream
+  fixtures, including Cohere2 MoE, LFM2.5 tool-call, and Granite 4.1 templates.
+  LFM2.5 prompts that use plain `List of tools: [...]` now route through the
+  LFM2 handler, and `ToolChoice.required` uses grammar-constrained LFM2
+  tool-call generation.
+- Fixed streaming tool-call parsing so partial North/Cohere bare action arrays
+  are not emitted as content before the complete tool call is parsed, and
+  expanded the local GGUF feature smoke coverage for thinking, tool-call, and
+  optional multimodal turns.
+
 ## 0.8.3
 
 - Fixed Windows CUDA backend discovery when the native asset bundle directory is

--- a/website/docs/getting-started/installation.md
+++ b/website/docs/getting-started/installation.md
@@ -27,7 +27,7 @@ In Xcode, set `IPHONEOS_DEPLOYMENT_TARGET = 16.4` or
 
 ```yaml
 dependencies:
-  llamadart: ^0.8.3
+  llamadart: ^0.8.4
 ```
 
 For Flutter iOS/macOS apps that should link Apple XCFrameworks through Swift
@@ -35,8 +35,8 @@ Package Manager, also add the runtime companion packages you need:
 
 ```yaml
 dependencies:
-  llamadart: ^0.8.3
-  llamadart_llama_cpp_flutter: ^0.0.3 # GGUF / llama.cpp
+  llamadart: ^0.8.4
+  llamadart_llama_cpp_flutter: ^0.0.4 # GGUF / llama.cpp
   llamadart_litert_lm_flutter: ^0.0.2 # .litertlm / LiteRT-LM
 ```
 


### PR DESCRIPTION
## Summary
- Bump core package version to 0.8.4.
- Move accumulated changelog entries into the 0.8.4 release section.
- Update current install docs and companion README examples to llamadart 0.8.4 and llamadart_llama_cpp_flutter 0.0.4.
- Add 0.8.4 to website recent releases.

## Validation
- PASS: dart run tool/testing/test_matrix.dart --tier release listed release rows.
- PASS: dart format --output=none --set-exit-if-changed .
- PASS: git diff --check
- PASS: dart analyze
- PASS: dart test
- PASS: ./tool/docs/build_site.sh
- PASS: ./tool/docs/validate_links.sh
- PASS: dart pub publish --dry-run with 0 warnings after commit.
- PASS: flutter pub publish --dry-run in packages/llamadart_llama_cpp_flutter with 0 warnings.
- PASS: flutter pub publish --dry-run in packages/llamadart_litert_lm_flutter with 0 warnings.

## Release Gate
- llamadart_litert_lm_flutter 0.0.2 exists on pub.dev.
- llamadart_llama_cpp_flutter 0.0.4 is not on pub.dev yet. After this PR merges, tag and publish llamadart_llama_cpp_flutter-v0.0.4, then verify pub.dev before tagging core v0.8.4.