### PR TITLE
fix: align mtmd fallback bitmap ABI

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## Unreleased
+
+* Fixed the Windows split-library mtmd fallback ABI for image and byte-buffer
+  multimodal inputs so `mtmd.dll` uses the same bitmap helper signature as the
+  generated native binding path.
+
 ## 0.8.4
 
 * Updated the default llama.cpp native runtime pin to

--- a/lib/src/backends/llama_cpp/llama_cpp_service.dart
+++ b/lib/src/backends/llama_cpp/llama_cpp_service.dart
@@ -101,20 +101,30 @@ typedef _MtmdInputChunksInitDart = Pointer<mtmd_input_chunks> Function();
 typedef _MtmdInputChunksFreeNative = Void Function(Pointer<mtmd_input_chunks>);
 typedef _MtmdInputChunksFreeDart = void Function(Pointer<mtmd_input_chunks>);
 typedef _MtmdHelperBitmapInitFromFileNative =
-    Pointer<mtmd_bitmap> Function(Pointer<mtmd_context>, Pointer<Char>);
+    mtmd_helper_bitmap_wrapper Function(
+      Pointer<mtmd_context>,
+      Pointer<Char>,
+      Bool,
+    );
 typedef _MtmdHelperBitmapInitFromFileDart =
-    Pointer<mtmd_bitmap> Function(Pointer<mtmd_context>, Pointer<Char>);
+    mtmd_helper_bitmap_wrapper Function(
+      Pointer<mtmd_context>,
+      Pointer<Char>,
+      bool,
+    );
 typedef _MtmdHelperBitmapInitFromBufNative =
-    Pointer<mtmd_bitmap> Function(
+    mtmd_helper_bitmap_wrapper Function(
       Pointer<mtmd_context>,
       Pointer<UnsignedChar>,
       Size,
+      Bool,
     );
 typedef _MtmdHelperBitmapInitFromBufDart =
-    Pointer<mtmd_bitmap> Function(
+    mtmd_helper_bitmap_wrapper Function(
       Pointer<mtmd_context>,
       Pointer<UnsignedChar>,
       int,
+      bool,
     );
 typedef _MtmdBitmapInitFromAudioNative =
     Pointer<mtmd_bitmap> Function(Size, Pointer<Float>);
@@ -5620,7 +5630,7 @@ class LlamaCppService {
         _mtmdUnavailableMessage('mtmd_helper_bitmap_init_from_file'),
       );
     }
-    return fallback.helperBitmapInitFromFile(ctx, pathPtr);
+    return fallback.helperBitmapInitFromFile(ctx, pathPtr, false).bitmap;
   }
 
   Pointer<mtmd_bitmap> _mtmdHelperBitmapInitFromBuf(
@@ -5641,7 +5651,7 @@ class LlamaCppService {
         _mtmdUnavailableMessage('mtmd_helper_bitmap_init_from_buf'),
       );
     }
-    return fallback.helperBitmapInitFromBuf(ctx, data, size);
+    return fallback.helperBitmapInitFromBuf(ctx, data, size, false).bitmap;
   }
 
   Pointer<mtmd_bitmap> _mtmdBitmapInitFromAudio(int n, Pointer<Float> samples) {

--- a/test/integration/backends/llama_cpp/native_symbol_integration_test.dart
+++ b/test/integration/backends/llama_cpp/native_symbol_integration_test.dart
@@ -5,8 +5,9 @@ import 'dart:convert';
 import 'dart:ffi' as ffi;
 import 'dart:io';
 
-import 'package:test/test.dart';
+import 'package:ffi/ffi.dart';
 import 'package:llamadart/src/backends/llama_cpp/bindings.dart';
+import 'package:test/test.dart';
 
 const _llamadartWrapperAssetId = 'package:llamadart/llamadart_wrapper';
 
@@ -21,6 +22,93 @@ const _mtpSymbols = [
   'llama_dart_mtp_accept',
   'llama_dart_sampler_sample_and_accept_n',
 ];
+
+const _transparentPngBytes = <int>[
+  0x89,
+  0x50,
+  0x4E,
+  0x47,
+  0x0D,
+  0x0A,
+  0x1A,
+  0x0A,
+  0x00,
+  0x00,
+  0x00,
+  0x0D,
+  0x49,
+  0x48,
+  0x44,
+  0x52,
+  0x00,
+  0x00,
+  0x00,
+  0x01,
+  0x00,
+  0x00,
+  0x00,
+  0x01,
+  0x08,
+  0x06,
+  0x00,
+  0x00,
+  0x00,
+  0x1F,
+  0x15,
+  0xC4,
+  0x89,
+  0x00,
+  0x00,
+  0x00,
+  0x0A,
+  0x49,
+  0x44,
+  0x41,
+  0x54,
+  0x78,
+  0x9C,
+  0x63,
+  0x00,
+  0x01,
+  0x00,
+  0x00,
+  0x05,
+  0x00,
+  0x01,
+  0x0D,
+  0x0A,
+  0x2D,
+  0xB4,
+  0x00,
+  0x00,
+  0x00,
+  0x00,
+  0x49,
+  0x45,
+  0x4E,
+  0x44,
+  0xAE,
+  0x42,
+  0x60,
+  0x82,
+];
+
+typedef _MtmdHelperBitmapInitFromBufNative =
+    mtmd_helper_bitmap_wrapper Function(
+      ffi.Pointer<mtmd_context>,
+      ffi.Pointer<ffi.UnsignedChar>,
+      ffi.Size,
+      ffi.Bool,
+    );
+typedef _MtmdHelperBitmapInitFromBufDart =
+    mtmd_helper_bitmap_wrapper Function(
+      ffi.Pointer<mtmd_context>,
+      ffi.Pointer<ffi.UnsignedChar>,
+      int,
+      bool,
+    );
+typedef _MtmdBitmapFreeNative = ffi.Void Function(ffi.Pointer<mtmd_bitmap>);
+typedef _MtmdBitmapFreeDart = void Function(ffi.Pointer<mtmd_bitmap>);
 
 @ffi.Native<ffi.Void Function(ffi.Pointer<llama_dart_mtp>)>(
   assetId: _llamadartWrapperAssetId,
@@ -63,6 +151,54 @@ File _windowsMtpWrapperLibraryFile() {
     'Unable to find Windows llama.cpp MTP wrapper library. '
     'Tried: ${tried.join(', ')}.',
   );
+}
+
+File? _mtmdFallbackLibraryFile() {
+  final fileNamePattern = _mtmdFallbackLibraryPattern();
+  if (fileNamePattern == null) {
+    return null;
+  }
+
+  final dartToolLibPath = [
+    Directory.current.path,
+    '.dart_tool',
+    'lib',
+  ].join(Platform.pathSeparator);
+  final directories = <Directory>[];
+  final nativeAssetPath = _nativeAssetFilePath(_llamadartWrapperAssetId);
+  if (nativeAssetPath != null) {
+    directories.add(File(nativeAssetPath).parent);
+  }
+  directories.add(Directory(dartToolLibPath));
+  directories.add(Directory.current);
+
+  final tried = <String>{};
+  for (final directory in directories) {
+    final directoryPath = directory.path;
+    if (!tried.add(directoryPath)) {
+      continue;
+    }
+
+    final matches = _matchingLibraryPaths(directory, fileNamePattern);
+    if (matches.isNotEmpty) {
+      return File(matches.first);
+    }
+  }
+
+  return null;
+}
+
+RegExp? _mtmdFallbackLibraryPattern() {
+  if (Platform.isWindows) {
+    return RegExp(r'^mtmd(?:[-_][^.\\/]+)*\.dll$');
+  }
+  if (Platform.isLinux || Platform.isAndroid) {
+    return RegExp(r'^libmtmd(?:[-_][^.\\/]+)*\.so$');
+  }
+  if (Platform.isMacOS || Platform.isIOS) {
+    return RegExp(r'^libmtmd(?:[-_][^.\\/]+)*\.dylib$');
+  }
+  return null;
 }
 
 bool _fileContainsAscii(File file, String text) {
@@ -129,6 +265,10 @@ String? _nativeAssetFilePath(String assetId) {
 }
 
 List<String> _matchingWindowsLibraryPaths(Directory directory, RegExp regex) {
+  return _matchingLibraryPaths(directory, regex);
+}
+
+List<String> _matchingLibraryPaths(Directory directory, RegExp regex) {
   try {
     return directory
         .listSync()
@@ -144,6 +284,44 @@ List<String> _matchingWindowsLibraryPaths(Directory directory, RegExp regex) {
         .toList(growable: false);
   } catch (_) {
     return const <String>[];
+  }
+}
+
+String _sourceSection(String source, String startMarker, String endMarker) {
+  final start = source.indexOf(startMarker);
+  expect(start, isNot(-1), reason: startMarker);
+  final end = source.indexOf(endMarker, start + startMarker.length);
+  expect(end, isNot(-1), reason: endMarker);
+  return source.substring(start, end);
+}
+
+void _expectBitmapHelperDecodesTransparentPng(
+  _MtmdHelperBitmapInitFromBufDart helper,
+  _MtmdBitmapFreeDart bitmapFree,
+) {
+  final data = malloc<ffi.UnsignedChar>(_transparentPngBytes.length);
+  ffi.Pointer<mtmd_bitmap> bitmap = ffi.nullptr;
+
+  try {
+    data
+        .cast<ffi.Uint8>()
+        .asTypedList(_transparentPngBytes.length)
+        .setAll(0, _transparentPngBytes);
+    final result = helper(
+      ffi.nullptr.cast<mtmd_context>(),
+      data,
+      _transparentPngBytes.length,
+      false,
+    );
+    bitmap = result.bitmap;
+
+    expect(bitmap.address, isNot(0));
+    expect(result.video_ctx.address, 0);
+  } finally {
+    if (bitmap.address != 0) {
+      bitmapFree(bitmap);
+    }
+    malloc.free(data);
   }
 }
 
@@ -261,6 +439,97 @@ void main() {
       }
 
       expect(() => mtmd_context_params_default(), returnsNormally);
+    });
+
+    test('Verify mtmd fallback bitmap helper ABI mirrors bindings', () {
+      final serviceSource = File(
+        'lib/src/backends/llama_cpp/llama_cpp_service.dart',
+      ).readAsStringSync();
+
+      final fileNative = _sourceSection(
+        serviceSource,
+        'typedef _MtmdHelperBitmapInitFromFileNative =',
+        'typedef _MtmdHelperBitmapInitFromFileDart =',
+      );
+      expect(fileNative, contains('mtmd_helper_bitmap_wrapper Function('));
+      expect(fileNative, contains('Pointer<mtmd_context>,'));
+      expect(fileNative, contains('Pointer<Char>,'));
+      expect(fileNative, contains('Bool,'));
+      expect(fileNative, isNot(contains('Pointer<mtmd_bitmap> Function(')));
+
+      final fileDart = _sourceSection(
+        serviceSource,
+        'typedef _MtmdHelperBitmapInitFromFileDart =',
+        'typedef _MtmdHelperBitmapInitFromBufNative =',
+      );
+      expect(fileDart, contains('mtmd_helper_bitmap_wrapper Function('));
+      expect(fileDart, contains('Pointer<mtmd_context>,'));
+      expect(fileDart, contains('Pointer<Char>,'));
+      expect(fileDart, contains('bool,'));
+
+      final bufNative = _sourceSection(
+        serviceSource,
+        'typedef _MtmdHelperBitmapInitFromBufNative =',
+        'typedef _MtmdHelperBitmapInitFromBufDart =',
+      );
+      expect(bufNative, contains('mtmd_helper_bitmap_wrapper Function('));
+      expect(bufNative, contains('Pointer<mtmd_context>,'));
+      expect(bufNative, contains('Pointer<UnsignedChar>,'));
+      expect(bufNative, contains('Size,'));
+      expect(bufNative, contains('Bool,'));
+      expect(bufNative, isNot(contains('Pointer<mtmd_bitmap> Function(')));
+
+      final bufDart = _sourceSection(
+        serviceSource,
+        'typedef _MtmdHelperBitmapInitFromBufDart =',
+        'typedef _MtmdBitmapInitFromAudioNative =',
+      );
+      expect(bufDart, contains('mtmd_helper_bitmap_wrapper Function('));
+      expect(bufDart, contains('Pointer<mtmd_context>,'));
+      expect(bufDart, contains('Pointer<UnsignedChar>,'));
+      expect(bufDart, contains('int,'));
+      expect(bufDart, contains('bool,'));
+
+      expect(
+        serviceSource,
+        contains(
+          'mtmd_helper_bitmap_init_from_file(ctx, pathPtr, false).bitmap',
+        ),
+      );
+      expect(
+        serviceSource,
+        contains(
+          'mtmd_helper_bitmap_init_from_buf(ctx, data, size, false)'
+          '.bitmap',
+        ),
+      );
+    });
+
+    test('Verify mtmd bitmap helper ABI is callable', () {
+      final libraryFile = _mtmdFallbackLibraryFile();
+      if (libraryFile == null) {
+        if (Platform.isLinux || Platform.isAndroid || Platform.isWindows) {
+          fail('Expected a split mtmd fallback library for this platform.');
+        }
+        _expectBitmapHelperDecodesTransparentPng(
+          (ctx, data, len, placeholder) =>
+              mtmd_helper_bitmap_init_from_buf(ctx, data, len, placeholder),
+          (bitmap) => mtmd_bitmap_free(bitmap),
+        );
+        return;
+      }
+
+      final library = ffi.DynamicLibrary.open(libraryFile.path);
+      final helper = library
+          .lookupFunction<
+            _MtmdHelperBitmapInitFromBufNative,
+            _MtmdHelperBitmapInitFromBufDart
+          >('mtmd_helper_bitmap_init_from_buf');
+      final bitmapFree = library
+          .lookupFunction<_MtmdBitmapFreeNative, _MtmdBitmapFreeDart>(
+            'mtmd_bitmap_free',
+          );
+      _expectBitmapHelperDecodesTransparentPng(helper, bitmapFree);
     });
 
     test('Verify core llama symbols are resolvable', () {


### PR DESCRIPTION
## Summary

- Align the Windows split-library mtmd fallback typedef for `mtmd_helper_bitmap_init_from_file` with the current generated native ABI.
- Return/use `mtmd_helper_bitmap_wrapper` from the fallback path instead of the old raw `mtmd_bitmap*` signature.
- Pass `placeholder: false` in the fallback call so the split `mtmd.dll` path matches the generated binding path.
- Add native symbol regression coverage for the mtmd bitmap-helper ABI, including a split-library fallback smoke when the bundle ships mtmd separately.
- Add an `Unreleased` changelog entry for the mtmd fallback ABI fix.

## Issue

Refs #230.

The reporter confirmed the Gemma 4 multimodal crash still reproduces on `llamadart 0.8.4` / native `b9744`, including with `gpuLayers: 0`. That points away from CUDA and toward the first bitmap-helper call in the split-library mtmd path. This PR fixes a stale fallback ABI that could corrupt that call when the primary lookup falls back to `mtmd.dll` or another split mtmd shared library.

## Test plan

- [x] `git diff --check`
- [x] `dart format --output=none --set-exit-if-changed lib/src/backends/llama_cpp/llama_cpp_service.dart`
- [x] `dart format test/integration/backends/llama_cpp/native_symbol_integration_test.dart`
- [x] `dart analyze lib/src/backends/llama_cpp/llama_cpp_service.dart`
- [x] `dart analyze` (exits 0; reports existing info-level lints outside this PR)
- [x] `dart test -p vm test/unit/backends/llama_cpp/load_param_helpers_test.dart`
- [x] `dart test -p vm test/integration/backends/llama_cpp/native_symbol_integration_test.dart`
- [x] GitHub Actions CI run `27946670625` on head `2b097eea8`
- [x] GitHub Actions preview run `27946670687` on head `2b097eea8`

## Validation note

The new integration coverage would have caught the stale fallback typedef by checking the fallback ABI against the generated bindings. On consolidated bundles, it also calls the primary mtmd bitmap helper with the current struct-return ABI; on split-library bundles, it opens the split mtmd library and calls the fallback symbol directly. I still could not reproduce the reporter's exact Windows/Gemma 4 multimodal crash from this macOS environment, so final confirmation for #230 remains a reporter retry or equivalent Windows/Gemma 4 multimodal runtime validation after merge/release.
