### PR TITLE
Prepare 0.8.5 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,11 @@
-## Unreleased
+## 0.8.5
 
-* Fixed the Windows split-library mtmd fallback ABI for image and byte-buffer
-  multimodal inputs so `mtmd.dll` uses the same bitmap helper signature as the
-  generated native binding path.
+* Fixed the split-library mtmd fallback ABI for image and byte-buffer
+  multimodal inputs so Windows `mtmd.dll` and other split mtmd native bundles
+  use the same bitmap helper signature as the generated native binding path.
+  This avoids corrupting the first mtmd bitmap-helper call for Gemma 4/MMProj
+  style multimodal loads and adds native symbol regression coverage for the
+  fallback ABI.
 
 ## 0.8.4
 

--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ JavaScript runtime.
 
 ```yaml
 dependencies:
-  llamadart: ^0.8.4
+  llamadart: ^0.8.5
 ```
 
 Flutter iOS/macOS apps that want Swift Package Manager-linked Apple
@@ -61,7 +61,7 @@ they ship:
 
 ```yaml
 dependencies:
-  llamadart: ^0.8.4
+  llamadart: ^0.8.5
   llamadart_llama_cpp_flutter: ^0.0.4 # GGUF / llama.cpp
   llamadart_litert_lm_flutter: ^0.0.2 # .litertlm / LiteRT-LM
 ```

--- a/packages/llamadart_litert_lm_flutter/README.md
+++ b/packages/llamadart_litert_lm_flutter/README.md
@@ -10,7 +10,7 @@ core package's native-assets fallback.
 
 ```yaml
 dependencies:
-  llamadart: ^0.8.4
+  llamadart: ^0.8.5
   llamadart_litert_lm_flutter: ^0.0.2
 ```
 

--- a/packages/llamadart_llama_cpp_flutter/README.md
+++ b/packages/llamadart_llama_cpp_flutter/README.md
@@ -9,7 +9,7 @@ core package's native-assets fallback.
 
 ```yaml
 dependencies:
-  llamadart: ^0.8.4
+  llamadart: ^0.8.5
   llamadart_llama_cpp_flutter: ^0.0.4
 ```
 

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: llamadart
 description: Dart and Flutter local LLM inference with llama.cpp GGUF and LiteRT-LM across native platforms and web.
-version: 0.8.4
+version: 0.8.5
 homepage: https://github.com/leehack/llamadart
 repository: https://github.com/leehack/llamadart
 issue_tracker: https://github.com/leehack/llamadart/issues

--- a/website/docs/changelog/recent-releases.md
+++ b/website/docs/changelog/recent-releases.md
@@ -7,6 +7,15 @@ For canonical full release notes, use:
 
 - [`CHANGELOG.md`](https://github.com/leehack/llamadart/blob/main/CHANGELOG.md)
 
+## 0.8.5
+
+- Fixed the split-library mtmd fallback ABI for image and byte-buffer
+  multimodal inputs so Windows `mtmd.dll` and other split mtmd native bundles
+  use the same bitmap helper signature as the generated native binding path.
+  This avoids corrupting the first mtmd bitmap-helper call for Gemma 4/MMProj
+  style multimodal loads and adds native symbol regression coverage for the
+  fallback ABI.
+
 ## 0.8.4
 
 - Updated the default llama.cpp native runtime pin to

--- a/website/docs/getting-started/installation.md
+++ b/website/docs/getting-started/installation.md
@@ -27,7 +27,7 @@ In Xcode, set `IPHONEOS_DEPLOYMENT_TARGET = 16.4` or
 
 ```yaml
 dependencies:
-  llamadart: ^0.8.4
+  llamadart: ^0.8.5
 ```
 
 For Flutter iOS/macOS apps that should link Apple XCFrameworks through Swift
@@ -35,7 +35,7 @@ Package Manager, also add the runtime companion packages you need:
 
 ```yaml
 dependencies:
-  llamadart: ^0.8.4
+  llamadart: ^0.8.5
   llamadart_llama_cpp_flutter: ^0.0.4 # GGUF / llama.cpp
   llamadart_litert_lm_flutter: ^0.0.2 # .litertlm / LiteRT-LM
 ```


### PR DESCRIPTION
## Summary

- Bump `llamadart` to `0.8.5`.
- Move the mtmd split-library fallback ABI fix from `Unreleased` into the `0.8.5` changelog.
- Add the matching `0.8.5` entry to the website recent releases page.
- Update README, website installation docs, and companion package README dependency snippets to `^0.8.5`.

## Release scope

Patch release for the mtmd bitmap-helper fallback ABI fix merged in #234. This is intended to make the latest Gemma 4/MMProj multimodal fix available through the published package.

## Test plan

- [x] `git diff --check`
- [x] `dart analyze` (exits 0; reports existing info-level lints outside this release change)
- [x] `./tool/docs/validate_links.sh`
- [x] `dart pub publish --dry-run` (`Package has 0 warnings`)
- [x] GitHub Actions CI run `27993456899` on head `405528ad6`
- [x] GitHub Actions LiteRT-LM Smoke run `27993456908` on head `405528ad6`
- [x] GitHub Actions preview run `27993456948` on head `405528ad6`
