### PR TITLE
Prepare 0.8.6 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,8 @@
-## Unreleased
+## 0.8.6
 
 * Updated the default llama.cpp native runtime pin to
-  `leehack/llamadart-native@b9776`, regenerated matching Dart FFI bindings, refreshed
-  the `llamadart_llama_cpp_flutter` Apple SwiftPM checksum, and
+  `leehack/llamadart-native@b9776`, regenerated matching Dart FFI bindings,
+  refreshed the `llamadart_llama_cpp_flutter` Apple SwiftPM checksum, and
   aligned current README/website native override docs.
 
 ## 0.8.5

--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ JavaScript runtime.
 
 ```yaml
 dependencies:
-  llamadart: ^0.8.5
+  llamadart: ^0.8.6
 ```
 
 Flutter iOS/macOS apps that want Swift Package Manager-linked Apple
@@ -61,7 +61,7 @@ they ship:
 
 ```yaml
 dependencies:
-  llamadart: ^0.8.5
+  llamadart: ^0.8.6
   llamadart_llama_cpp_flutter: ^0.0.5 # GGUF / llama.cpp
   llamadart_litert_lm_flutter: ^0.0.2 # .litertlm / LiteRT-LM
 ```

--- a/packages/llamadart_litert_lm_flutter/README.md
+++ b/packages/llamadart_litert_lm_flutter/README.md
@@ -10,7 +10,7 @@ core package's native-assets fallback.
 
 ```yaml
 dependencies:
-  llamadart: ^0.8.5
+  llamadart: ^0.8.6
   llamadart_litert_lm_flutter: ^0.0.2
 ```
 

--- a/packages/llamadart_llama_cpp_flutter/README.md
+++ b/packages/llamadart_llama_cpp_flutter/README.md
@@ -9,7 +9,7 @@ core package's native-assets fallback.
 
 ```yaml
 dependencies:
-  llamadart: ^0.8.5
+  llamadart: ^0.8.6
   llamadart_llama_cpp_flutter: ^0.0.5
 ```
 

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: llamadart
 description: Dart and Flutter local LLM inference with llama.cpp GGUF and LiteRT-LM across native platforms and web.
-version: 0.8.5
+version: 0.8.6
 homepage: https://github.com/leehack/llamadart
 repository: https://github.com/leehack/llamadart
 issue_tracker: https://github.com/leehack/llamadart/issues

--- a/website/docs/changelog/recent-releases.md
+++ b/website/docs/changelog/recent-releases.md
@@ -7,6 +7,13 @@ For canonical full release notes, use:
 
 - [`CHANGELOG.md`](https://github.com/leehack/llamadart/blob/main/CHANGELOG.md)
 
+## 0.8.6
+
+- Updated the default llama.cpp native runtime pin to
+  `leehack/llamadart-native@b9776`, regenerated matching Dart FFI bindings,
+  refreshed the `llamadart_llama_cpp_flutter` Apple SwiftPM checksum, and
+  aligned README/website native override docs.
+
 ## 0.8.5
 
 - Fixed the split-library mtmd fallback ABI for image and byte-buffer

--- a/website/docs/getting-started/installation.md
+++ b/website/docs/getting-started/installation.md
@@ -27,7 +27,7 @@ In Xcode, set `IPHONEOS_DEPLOYMENT_TARGET = 16.4` or
 
 ```yaml
 dependencies:
-  llamadart: ^0.8.5
+  llamadart: ^0.8.6
 ```
 
 For Flutter iOS/macOS apps that should link Apple XCFrameworks through Swift
@@ -35,7 +35,7 @@ Package Manager, also add the runtime companion packages you need:
 
 ```yaml
 dependencies:
-  llamadart: ^0.8.5
+  llamadart: ^0.8.6
   llamadart_llama_cpp_flutter: ^0.0.5 # GGUF / llama.cpp
   llamadart_litert_lm_flutter: ^0.0.2 # .litertlm / LiteRT-LM
 ```


### PR DESCRIPTION
## Summary
- Prepare the core `llamadart` package for version `0.8.6`.
- Move the native sync changelog entry from `Unreleased` into the `0.8.6` release notes.
- Update README, website install docs, and companion package README snippets to use `llamadart: ^0.8.6`.

## Production-readiness scope
- **User-facing scope:** Users can install `llamadart: ^0.8.6`, which includes the default llama.cpp native runtime pin `leehack/llamadart-native@b9776` from #236.
- **Supported platforms/paths:** Release metadata/docs for the existing native, WebGPU, Flutter companion, and docs paths. Runtime behavior is unchanged from the merged native sync PR.
- **Unsupported or intentionally unavailable paths:** None introduced by this release-prep PR.
- **Out of scope / follow-ups:** None.

## Completeness checklist
- [x] Declared scope is fully implemented, or explicitly reduced above.
- [x] Unsupported platform/option combinations fail loudly with actionable diagnostics or are clearly documented as unavailable.
- [x] Public API docs, README/website docs, examples, support matrices, and changelog entries are updated where relevant.
- [x] Regression coverage covers the original issue plus key negative/version-skew paths where relevant.
- [x] Security/privacy review completed: no secrets, bearer tokens, signed URLs, or raw secret-bearing paths leak through logs, cache keys, metadata, errors, or snapshots.
- [x] Follow-up work that is useful but not required for this PR is tracked in GitHub Issues, or explicitly marked "None" above.

## PR type guidance
- **Docs/release-prep PR:** Runtime behavior is unchanged from #236. This PR only cuts the release metadata/docs for `0.8.6`.

## Test Plan
- [x] `dart format --output=none --set-exit-if-changed .`
- [x] `dart analyze` (exits 0; existing info-level lints remain outside this release-prep diff)
- [x] `dart test -p vm -j 1 --exclude-tags local-only`
- [ ] `dart test -p chrome --exclude-tags local-only` - N/A: release metadata/docs-only prep; no browser implementation changed.
- [x] Other targeted/local-only validation:
  - `./tool/docs/validate_links.sh`
  - `dart pub publish --dry-run`
  - Verified `llamadart_llama_cpp_flutter 0.0.5` is live on pub.dev.
  - Verified `llamadart_litert_lm_flutter 0.0.2` is live on pub.dev.
  - Verified `leehack/llamadart-native@b9776` GitHub release includes platform archives, headers, `assets.json`, `SHA256SUMS`, and the Apple XCFramework zip.

## Matrix Evidence
| Matrix row | Scope covered | Platform / model / backend | Result | Evidence / notes |
| --- | --- | --- | --- | --- |
| `static-format-analyze` | format, analyzer, web/native import boundaries | repo | PASS | `dart format --output=none --set-exit-if-changed .`; `dart analyze` exited 0 with three pre-existing info-level lints outside this diff. |
| `root-vm` | native-safe unit/integration coverage on the Dart VM | local macOS / default native bundle | PASS | `dart test -p vm -j 1 --exclude-tags local-only` passed. |
| `docs-site` | website build, docs metadata, generated docs routes | website | PASS | `./tool/docs/validate_links.sh` built Docusaurus and passed link validation. |
| `release-companion-pub-gate` | Flutter Apple SPM companion package pub.dev availability before the core tag | pub.dev / Apple SPM companions | PASS | `llamadart_llama_cpp_flutter 0.0.5` and `llamadart_litert_lm_flutter 0.0.2` are live on pub.dev. |
| `release-representative-smokes` | representative checks before publishing a package release | package publish validation | PASS | `dart pub publish --dry-run` completed with 0 warnings. |
| `root-chrome` | browser-compatible unit/integration coverage | browser | N/A | No browser runtime code changed in this release-prep PR. |
| `coverage-lib` | >=70% line coverage for maintainable lib/ code | repo | N/A | No maintainable `lib/` source changed in this release-prep PR. |

## Review Notes
- Independent review status: self-reviewed release-prep diff against #236 and release checklist.
- CI status / head SHA: all checks passing for `ea856033f`.
