### PR TITLE
fix: preserve VLM thinking stream state

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+## Unreleased
+
+* Fixed multimodal chat-template rendering so templates that force-open
+  reasoning (for example Qwen3.5 VLM prompts ending with `<think>`) preserve
+  `enable_thinking` and stream generated reasoning through `delta.thinking`
+  instead of `delta.content`.
+
 ## 0.8.6
 
 * Updated the default llama.cpp native runtime pin to

--- a/lib/src/core/template/chat_template_handler.dart
+++ b/lib/src/core/template/chat_template_handler.dart
@@ -8,6 +8,7 @@ import 'chat_format.dart';
 import 'chat_parse_result.dart';
 import 'template_internal_metadata.dart';
 import 'template_render_context.dart';
+import 'thinking_utils.dart';
 import 'tool_call_parsing_utils.dart';
 
 export 'template_render_context.dart' show TemplateToolCallSerialization;
@@ -166,10 +167,20 @@ abstract class ChatTemplateHandler {
         'messages': templateMessages(messages, multimodal: true),
         'add_generation_prompt': addAssistant,
         'tools': tools?.map((t) => t.toJson()).toList(),
+        'enable_thinking': enableThinking,
         'bos_token': metadata['tokenizer.ggml.bos_token'] ?? '',
         'eos_token': metadata['tokenizer.ggml.eos_token'] ?? '',
       },
     );
+
+    var thinkingForcedOpen = false;
+    if (isThinkingForcedOpen(prompt, startTag: thinkingStartTag.trimRight())) {
+      if (!enableThinking) {
+        prompt = '${prompt.trimRight()}$thinkingEndTag\n';
+      } else {
+        thinkingForcedOpen = true;
+      }
+    }
 
     // Post-process: replace model-specific image placeholders with
     // the mtmd marker so the native tokenizer can match bitmaps to markers.
@@ -199,6 +210,7 @@ abstract class ChatTemplateHandler {
         hasTools: hasTools,
         enableThinking: enableThinking,
       ),
+      thinkingForcedOpen: thinkingForcedOpen,
     );
   }
 

--- a/test/unit/core/template/chat_template_engine_test.dart
+++ b/test/unit/core/template/chat_template_engine_test.dart
@@ -1,4 +1,5 @@
 import 'dart:convert';
+import 'dart:typed_data';
 
 import 'package:llamadart/src/core/exceptions.dart';
 import 'package:llamadart/src/core/models/chat/chat_message.dart';
@@ -61,6 +62,138 @@ void main() {
         expect(result.prompt, isNot(contains('weather')));
       },
     );
+
+    test(
+      'multimodal templates propagate enableThinking and force-open state',
+      () {
+        const template = '''
+{%- macro render_content(content) -%}
+  {%- if content is string -%}
+    {{- content -}}
+  {%- elif content is iterable and content is not mapping -%}
+    {%- for item in content -%}
+      {%- if 'image' in item or item.type == 'image' -%}
+        {{- '<|vision_start|><|image_pad|><|vision_end|>' -}}
+      {%- elif 'text' in item -%}
+        {{- item.text -}}
+      {%- endif -%}
+    {%- endfor -%}
+  {%- endif -%}
+{%- endmacro -%}
+{%- for message in messages -%}
+  {{- '<|im_start|>' + message.role + '\n' + render_content(message.content) + '<|im_end|>\n' -}}
+{%- endfor -%}
+{%- if add_generation_prompt -%}
+  {{- '<|im_start|>assistant\n' -}}
+  {%- if enable_thinking is defined and enable_thinking is true -%}
+    {{- '<think>\n' -}}
+  {%- else -%}
+    {{- '<think>\n\n</think>\n\n' -}}
+  {%- endif -%}
+{%- endif -%}
+''';
+        final multimodalMessages = [
+          LlamaChatMessage.withContent(
+            role: LlamaChatRole.user,
+            content: [
+              const LlamaTextContent('look'),
+              LlamaImageContent(
+                bytes: Uint8List.fromList([0]),
+                width: 1,
+                height: 1,
+              ),
+            ],
+          ),
+        ];
+
+        final enabled = ChatTemplateEngine.render(
+          templateSource: template,
+          messages: multimodalMessages,
+          metadata: const {},
+          enableThinking: true,
+        );
+
+        expect(
+          enabled.prompt,
+          contains('look<|vision_start|><|image_pad|><|vision_end|>'),
+        );
+        expect(enabled.prompt, endsWith('<|im_start|>assistant\n<think>\n'));
+        expect(enabled.thinkingForcedOpen, isTrue);
+
+        final disabled = ChatTemplateEngine.render(
+          templateSource: template,
+          messages: multimodalMessages,
+          metadata: const {},
+          enableThinking: false,
+        );
+
+        expect(disabled.prompt, contains('<think>\n\n</think>\n\n'));
+        expect(disabled.thinkingForcedOpen, isFalse);
+      },
+    );
+
+    test('multimodal thinking uses handler-specific reasoning tags', () {
+      const template = '''
+{%- macro render_content(content) -%}
+  {%- if content is string -%}
+    {{- content -}}
+  {%- elif content is iterable and content is not mapping -%}
+    {%- for item in content -%}
+      {%- if item.type == 'image' -%}
+        {{- '<|image|>' -}}
+      {%- elif item.type == 'text' -%}
+        {{- item.text -}}
+      {%- endif -%}
+    {%- endfor -%}
+  {%- endif -%}
+{%- endmacro -%}
+{%- for message in messages -%}
+  {{- '[INST]' + render_content(message.content) + '[/INST]' -}}
+{%- endfor -%}
+{%- if add_generation_prompt -%}
+  {%- if enable_thinking is defined and enable_thinking is true -%}
+    {{- '[THINK]\n' -}}
+  {%- else -%}
+    {{- '[THINK]\n[/THINK]\n' -}}
+  {%- endif -%}
+{%- endif -%}
+''';
+      final multimodalMessages = [
+        LlamaChatMessage.withContent(
+          role: LlamaChatRole.user,
+          content: [
+            const LlamaTextContent('look'),
+            LlamaImageContent(
+              bytes: Uint8List.fromList([0]),
+              width: 1,
+              height: 1,
+            ),
+          ],
+        ),
+      ];
+
+      final enabled = ChatTemplateEngine.render(
+        templateSource: template,
+        messages: multimodalMessages,
+        metadata: const {},
+        enableThinking: true,
+      );
+
+      expect(enabled.format, ChatFormat.magistral.index);
+      expect(enabled.prompt, endsWith('[THINK]\n'));
+      expect(enabled.thinkingForcedOpen, isTrue);
+
+      final disabled = ChatTemplateEngine.render(
+        templateSource: template,
+        messages: multimodalMessages,
+        metadata: const {},
+        enableThinking: false,
+      );
+
+      expect(disabled.prompt, contains('[THINK]\n[/THINK]\n'));
+      expect(disabled.prompt, isNot(contains('</think>')));
+      expect(disabled.thinkingForcedOpen, isFalse);
+    });
 
     test('keeps old workaround format matrix in handler policies', () {
       final expectedPolicies = <ChatFormat, TemplateToolCallSerialization>{

--- a/website/docs/changelog/recent-releases.md
+++ b/website/docs/changelog/recent-releases.md
@@ -7,6 +7,13 @@ For canonical full release notes, use:
 
 - [`CHANGELOG.md`](https://github.com/leehack/llamadart/blob/main/CHANGELOG.md)
 
+## Unreleased
+
+- Fixed multimodal chat-template rendering so templates that force-open
+  reasoning, such as Qwen3.5 VLM prompts ending with `<think>`, preserve
+  `enable_thinking` and stream generated reasoning through `delta.thinking`
+  instead of `delta.content`.
+
 ## 0.8.6
 
 - Updated the default llama.cpp native runtime pin to


### PR DESCRIPTION
## Summary
- Pass `enable_thinking` into multimodal Jinja chat-template rendering.
- Preserve `thinkingForcedOpen` for multimodal prompts that end with an open thinking block so generated reasoning streams through `delta.thinking`.
- Use each handler's configured thinking start/end tags for multimodal forced-open detection/closure, add regression coverage for default and non-default tags, and document the fix in `CHANGELOG.md`.

Fixes #238.

## Root cause
The text-only template path already propagated both the `enable_thinking` render variable and the forced-open thinking state. The multimodal `renderWithMultimodalContent` path used for typed image/audio content did not, so Qwen3.5 VLM prompts could render a thinking-prefill shape while the stream parser treated subsequent reasoning as normal content.

## Test Plan
- [x] `git diff --check origin/main...HEAD`
- [x] `dart format --output=none --set-exit-if-changed lib/src/core/template/chat_template_handler.dart test/unit/core/template/chat_template_engine_test.dart`
- [x] `dart analyze lib/src/core/template/chat_template_handler.dart test/unit/core/template/chat_template_engine_test.dart`
- [x] `dart test test/unit/core/template/chat_template_engine_test.dart test/unit/core/engine/chat_completion_stream_parser_test.dart`
- [x] Local CPU probe with available Qwen3.5 0.8B GGUF + mmproj after the fix: multimodal generation emitted `thinkingLength=122` and `contentLength=0` for the short reasoning probe.
- [x] GitHub Actions CI for latest head `97e69919f575eb18c720b1f025c86ab89c870166`: all PR checks passed, including Analyze & Lint, VM/Web/Native tests, companion packages, docs build, Native Prompt Reuse Parity, Codecov summary, and chat app PR preview deploy.

## Testing matrix
- Template/unit routing: PASS via targeted template and stream parser tests above.
- Real-model local smoke: PASS via local Qwen3.5 0.8B + mmproj CPU probe.
- Full package CI: PASS on GitHub Actions for latest head `97e69919f575eb18c720b1f025c86ab89c870166`.

## Review notes
- Copilot initial review raised one actionable comment about hard-coded `<think>` tags in the multimodal forced-open path.
- Fixed by using handler-specific `thinkingStartTag` / `thinkingEndTag` and adding non-default `[THINK]` regression coverage.
- No unresolved review threads remain after the fix.
