### PR TITLE
Prepare 0.8.7 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-## Unreleased
+## 0.8.7
 
 * Fixed multimodal chat-template rendering so templates that force-open
   reasoning (for example Qwen3.5 VLM prompts ending with `<think>`) preserve

--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ JavaScript runtime.
 
 ```yaml
 dependencies:
-  llamadart: ^0.8.6
+  llamadart: ^0.8.7
 ```
 
 Flutter iOS/macOS apps that want Swift Package Manager-linked Apple
@@ -61,7 +61,7 @@ they ship:
 
 ```yaml
 dependencies:
-  llamadart: ^0.8.6
+  llamadart: ^0.8.7
   llamadart_llama_cpp_flutter: ^0.0.5 # GGUF / llama.cpp
   llamadart_litert_lm_flutter: ^0.0.2 # .litertlm / LiteRT-LM
 ```

--- a/packages/llamadart_litert_lm_flutter/README.md
+++ b/packages/llamadart_litert_lm_flutter/README.md
@@ -10,7 +10,7 @@ core package's native-assets fallback.
 
 ```yaml
 dependencies:
-  llamadart: ^0.8.6
+  llamadart: ^0.8.7
   llamadart_litert_lm_flutter: ^0.0.2
 ```
 

--- a/packages/llamadart_llama_cpp_flutter/README.md
+++ b/packages/llamadart_llama_cpp_flutter/README.md
@@ -9,7 +9,7 @@ core package's native-assets fallback.
 
 ```yaml
 dependencies:
-  llamadart: ^0.8.6
+  llamadart: ^0.8.7
   llamadart_llama_cpp_flutter: ^0.0.5
 ```
 

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: llamadart
 description: Dart and Flutter local LLM inference with llama.cpp GGUF and LiteRT-LM across native platforms and web.
-version: 0.8.6
+version: 0.8.7
 homepage: https://github.com/leehack/llamadart
 repository: https://github.com/leehack/llamadart
 issue_tracker: https://github.com/leehack/llamadart/issues

--- a/test/unit/tooling/release_install_snippets_test.dart
+++ b/test/unit/tooling/release_install_snippets_test.dart
@@ -1,0 +1,94 @@
+@TestOn('vm')
+library;
+
+import 'dart:io';
+
+import 'package:test/test.dart';
+
+void main() {
+  group('release install snippets', () {
+    test('current install docs use the core pubspec version', () {
+      final coreVersion = _readCorePackageVersion();
+      final staleConstraints = <String>[];
+
+      for (final target in _installSnippetTargets) {
+        final text = File(target.path).readAsStringSync();
+        final matches = _coreDependencyPattern.allMatches(text).toList();
+
+        expect(
+          matches,
+          hasLength(target.expectedCoreDependencySnippets),
+          reason:
+              '${target.path} should contain exactly '
+              '${target.expectedCoreDependencySnippets} current core install '
+              'snippet(s).',
+        );
+
+        for (final match in matches) {
+          final snippetVersion = match.namedGroup('version')!;
+          if (snippetVersion != coreVersion) {
+            staleConstraints.add(
+              '${target.path}: found llamadart: ^$snippetVersion, '
+              'expected ^$coreVersion',
+            );
+          }
+        }
+      }
+
+      expect(
+        staleConstraints,
+        isEmpty,
+        reason:
+            'Release prep must keep user-facing install snippets aligned with '
+            'the core pubspec version:\n${staleConstraints.join('\n')}',
+      );
+    });
+  });
+}
+
+final _coreVersionPattern = RegExp(
+  r'^version:\s*(?<version>[0-9]+\.[0-9]+\.[0-9]+(?:[-+][0-9A-Za-z.-]+)?)\s*$',
+  multiLine: true,
+);
+
+final _coreDependencyPattern = RegExp(
+  r'^\s*llamadart:\s*\^(?<version>[0-9]+\.[0-9]+\.[0-9]+(?:[-+][0-9A-Za-z.-]+)?)\s*$',
+  multiLine: true,
+);
+
+final _installSnippetTargets = <_InstallSnippetTarget>[
+  _InstallSnippetTarget('README.md', expectedCoreDependencySnippets: 2),
+  _InstallSnippetTarget(
+    'website/docs/getting-started/installation.md',
+    expectedCoreDependencySnippets: 2,
+  ),
+  _InstallSnippetTarget(
+    'packages/llamadart_llama_cpp_flutter/README.md',
+    expectedCoreDependencySnippets: 1,
+  ),
+  _InstallSnippetTarget(
+    'packages/llamadart_litert_lm_flutter/README.md',
+    expectedCoreDependencySnippets: 1,
+  ),
+];
+
+String _readCorePackageVersion() {
+  final pubspec = File('pubspec.yaml').readAsStringSync();
+  final match = _coreVersionPattern.firstMatch(pubspec);
+
+  if (match == null) {
+    throw StateError('Could not read core package version from pubspec.yaml');
+  }
+
+  return match.namedGroup('version')!;
+}
+
+class _InstallSnippetTarget {
+  const _InstallSnippetTarget(
+    this.path, {
+    required this.expectedCoreDependencySnippets,
+  });
+
+  final String path;
+  final int expectedCoreDependencySnippets;
+}

--- a/website/docs/changelog/recent-releases.md
+++ b/website/docs/changelog/recent-releases.md
@@ -7,7 +7,7 @@ For canonical full release notes, use:
 
 - [`CHANGELOG.md`](https://github.com/leehack/llamadart/blob/main/CHANGELOG.md)
 
-## Unreleased
+## 0.8.7
 
 - Fixed multimodal chat-template rendering so templates that force-open
   reasoning, such as Qwen3.5 VLM prompts ending with `<think>`, preserve

--- a/website/docs/getting-started/installation.md
+++ b/website/docs/getting-started/installation.md
@@ -27,7 +27,7 @@ In Xcode, set `IPHONEOS_DEPLOYMENT_TARGET = 16.4` or
 
 ```yaml
 dependencies:
-  llamadart: ^0.8.6
+  llamadart: ^0.8.7
 ```
 
 For Flutter iOS/macOS apps that should link Apple XCFrameworks through Swift
@@ -35,7 +35,7 @@ Package Manager, also add the runtime companion packages you need:
 
 ```yaml
 dependencies:
-  llamadart: ^0.8.6
+  llamadart: ^0.8.7
   llamadart_llama_cpp_flutter: ^0.0.5 # GGUF / llama.cpp
   llamadart_litert_lm_flutter: ^0.0.2 # .litertlm / LiteRT-LM
 ```


### PR DESCRIPTION
## Summary

- Bump the core `llamadart` package version to `0.8.7`.
- Move the VLM thinking-stream fix from `Unreleased` into the `0.8.7` release notes.
- Keep companion package versions unchanged.

## Validation

- `dart run tool/testing/test_matrix.dart --tier release`
- `dart format --output=none --set-exit-if-changed .`
- `dart analyze`
  - Exits 0; reports existing info-level style lints outside this release metadata change.
- `dart test`
  - PASS: 1844 tests, 6 skipped.
- `./tool/docs/build_site.sh`
- `./tool/docs/validate_links.sh`
- `dart pub publish --dry-run`
  - PASS: 0 warnings after the release-prep commit.
- `dart run tool/testing/run_local_e2e.dart --scenario qwen35-multimodal-macos-repro`
  - PASS: Qwen3.5 0.8B GGUF + mmproj on CPU and Metal.
- `dart run tool/testing/run_local_e2e.dart --scenario gguf-chat-features-smoke --model-path models/gemma-4-E2B-it-Q4_K_S.gguf --backend auto`
  - PASS: Gemma 4 GGUF on Metal, including tool-call-with-thinking.

## Release Checklist

- `llamadart` latest on pub.dev is `0.8.6`; this prepares `0.8.7`.
- `v0.8.7` does not exist locally.
- Referenced companion packages are already available on pub.dev:
  - `llamadart_llama_cpp_flutter` `0.0.5`
  - `llamadart_litert_lm_flutter` `0.0.2`
- No native runtime pins changed.

## Publish After Merge

- Tag the merged commit as `v0.8.7`.
- Push the tag to trigger `publish_pubdev.yml` and `docs_version_cut.yml`.
- Verify pub.dev, docs version cut, and GitHub Release state after automation completes.
