### PR TITLE
Add cross-platform model cache strategies

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,11 @@
+## Unreleased
+
+* Added `DefaultModelDownloadManager.auto(...)` plus explicit model cache root
+  constructors for shared desktop caches, app-private mobile caches,
+  user-selected model libraries, and App Group containers. Implicit shared cache
+  resolution now fails loudly on mobile and web where the OS cannot provide a
+  hidden cross-developer model folder.
+
 ## 0.8.7
 
 * Fixed multimodal chat-template rendering so templates that force-open

--- a/README.md
+++ b/README.md
@@ -279,13 +279,22 @@ slower than baseline decoding for some draft/target model pairs.
 import 'package:llamadart/llamadart.dart';
 
 Future<void> main() async {
-  final engine = LlamaEngine(LlamaBackend());
+  final String? appPrivateModelsDirectory =
+      await resolveMobileAppPrivateModelsDirectory();
+
+  // Desktop/server apps use a per-user shared cache. Android/iOS apps use the
+  // supplied app-private directory instead, so one code path works everywhere.
+  final engine = LlamaEngine(
+    LlamaBackend(),
+    modelDownloadManager: DefaultModelDownloadManager.auto(
+      appPrivateCacheDirectory: appPrivateModelsDirectory,
+    ),
+  );
   try {
     await engine.loadModelSource(
       ModelSource.parse('hf://owner/repo/model-Q4_K_M.gguf'),
       options: ModelLoadOptions(
         cachePolicy: ModelCachePolicy.preferCached,
-        cacheDirectory: '/path/to/app/model-cache',
       ),
       onProgress: (progress) {
         final fraction = progress.fraction;
@@ -300,6 +309,11 @@ Future<void> main() async {
 }
 ```
 
+`resolveMobileAppPrivateModelsDirectory()` represents your app storage layer, for
+example a Flutter `path_provider` application-support path on Android/iOS. On
+desktop/server, `auto(...)` ignores `appPrivateCacheDirectory` and uses the
+per-user shared model cache.
+
 Native/file-backed backends stream remote models into the package-managed cache,
 resume partial `.part` downloads when the server supports HTTP Range and the
 partial has a safe validator (ETag/Last-Modified) or caller-provided SHA-256,
@@ -309,6 +323,19 @@ appended. Local `ModelSource.path(...)` values are already files: only
 cancellation and optional `sha256` verification apply, while remote/download-only
 options such as cache policies, `cacheDirectory`, authenticated headers, resume,
 and retries are rejected for local paths.
+
+`DefaultModelDownloadManager.auto(...)` is the recommended cross-platform
+entrypoint: desktop/server platforms use a per-user shared cache, while
+Android/iOS use the app-private directory supplied by the app storage layer.
+`DefaultModelDownloadManager.sharedCache()` is the explicit desktop/server shared
+cache entrypoint, so multiple `llamadart` apps that use the same stable
+`ModelSource` can reuse one downloaded file. Mobile platforms do not have a safe
+implicit cross-developer model folder: use
+`DefaultModelDownloadManager.appPrivate(cacheDirectory: ...)` for normal
+Android/iOS app storage, `userSelected(cacheDirectory: ...)` after an Android
+Storage Access Framework-style user grant, or `appGroup(cacheDirectory: ...)`
+for explicitly configured iOS/macOS App Group containers. Web backends use
+origin-scoped browser/runtime caches instead of a file-backed shared directory.
 
 `hf://` references point at one Hugging Face file, such as a `.gguf` model or
 `.litertlm` LiteRT-LM bundle:

--- a/README.md
+++ b/README.md
@@ -337,6 +337,18 @@ Storage Access Framework-style user grant, or `appGroup(cacheDirectory: ...)`
 for explicitly configured iOS/macOS App Group containers. Web backends use
 origin-scoped browser/runtime caches instead of a file-backed shared directory.
 
+Desktop shared-cache roots use the default `llamadart` namespace:
+
+| Platform | Default path |
+| --- | --- |
+| Linux | `$XDG_CACHE_HOME/llamadart/models`, or `$HOME/.cache/llamadart/models` when `XDG_CACHE_HOME` is unset |
+| macOS | `$HOME/Library/Caches/llamadart/models` |
+| Windows | `%LOCALAPPDATA%\llamadart\models`, then `%APPDATA%\llamadart\models`, then `%USERPROFILE%\AppData\Local\llamadart\models` |
+
+Pass `namespace: 'your.namespace'` to `auto(...)` or `sharedCache(...)` to
+replace the `llamadart` path segment, or pass `cacheDirectory` to force an
+explicit root.
+
 `hf://` references point at one Hugging Face file, such as a `.gguf` model or
 `.litertlm` LiteRT-LM bundle:
 `hf://owner/repo/path/to/model.gguf` uses `main`,

--- a/example/llamadart_server/lib/src/features/model_management/infrastructure/model_service.dart
+++ b/example/llamadart_server/lib/src/features/model_management/infrastructure/model_service.dart
@@ -1,7 +1,6 @@
 import 'dart:io';
 
 import 'package:llamadart/llamadart.dart';
-import 'package:path/path.dart' as path;
 
 /// Resolves a model path or downloads a model URL into local cache.
 class ModelService {
@@ -10,12 +9,12 @@ class ModelService {
 
   ModelService._(String resolvedCacheDir)
     : cacheDir = resolvedCacheDir,
-      _downloadManager = DefaultModelDownloadManager(
-        defaultCacheDirectory: resolvedCacheDir,
+      _downloadManager = DefaultModelDownloadManager.auto(
+        cacheDirectory: resolvedCacheDir,
       );
 
   static String _defaultCacheDir() =>
-      path.join(Directory.current.path, 'models');
+      DefaultModelDownloadManager.auto().defaultCacheDirectory;
 
   /// Directory where downloaded model files are cached.
   final String cacheDir;

--- a/example/tui_coding_agent/README.md
+++ b/example/tui_coding_agent/README.md
@@ -116,7 +116,8 @@ In the exit confirmation dialog:
 ## Notes
 
 - The first run may take time due to model download and initialization.
-- Downloaded models are cached under `models/` by default.
+- Downloaded models use the per-user shared `llamadart` model cache by default;
+  pass `--cache-dir` to use a workspace-local or app-specific cache instead.
 - `run_command` uses a safety filter and executes from the workspace root
   (or a workspace-relative subdirectory).
 - `run_command` accepts `command` and also tolerates alias keys (`cmd`,

--- a/example/tui_coding_agent/bin/tui_coding_agent.dart
+++ b/example/tui_coding_agent/bin/tui_coding_agent.dart
@@ -22,8 +22,8 @@ Future<void> main(List<String> arguments) async {
     )
     ..addOption(
       'cache-dir',
-      help: 'Directory used to cache downloaded models.',
-      defaultsTo: 'models',
+      help:
+          'Directory used to cache downloaded models. Defaults to the per-user shared llamadart model cache.',
     )
     ..addOption(
       'ctx-size',
@@ -84,8 +84,10 @@ Future<void> main(List<String> arguments) async {
     return;
   }
 
-  final cacheDirRaw = results['cache-dir'] as String;
-  final cacheDirectory = p.isAbsolute(cacheDirRaw)
+  final cacheDirRaw = (results['cache-dir'] as String?)?.trim();
+  final cacheDirectory = cacheDirRaw == null || cacheDirRaw.isEmpty
+      ? DefaultModelDownloadManager.auto().defaultCacheDirectory
+      : p.isAbsolute(cacheDirRaw)
       ? p.normalize(cacheDirRaw)
       : p.normalize(p.join(workspaceRoot, cacheDirRaw));
 

--- a/lib/src/core/models/download/model_download_manager_base.dart
+++ b/lib/src/core/models/download/model_download_manager_base.dart
@@ -6,6 +6,70 @@ import '../model_source.dart';
 typedef ModelDownloadProgressCallback =
     void Function(ModelDownloadProgress progress);
 
+/// Operating-system families relevant to model cache directory selection.
+enum ModelCachePlatform {
+  /// Android apps use app-specific storage by default and require explicit user
+  /// or app-managed grants for cross-app model libraries.
+  android,
+
+  /// Fuchsia has no implicit package-defined shared model cache.
+  fuchsia,
+
+  /// iOS apps use sandboxed storage by default and require App Groups or
+  /// user-picked files for sharing.
+  ios,
+
+  /// Linux desktop/server processes can use a per-user shared cache.
+  linux,
+
+  /// macOS desktop/server processes can use a per-user shared cache.
+  macos,
+
+  /// Windows desktop/server processes can use a per-user shared cache.
+  windows,
+
+  /// Browser runtimes use origin-scoped browser/runtime cache storage.
+  web,
+
+  /// Unknown platforms must not claim an implicit shared model cache.
+  unknown;
+
+  /// Parses a Dart `Platform.operatingSystem` style value.
+  static ModelCachePlatform parse(String operatingSystem) {
+    switch (operatingSystem.toLowerCase()) {
+      case 'android':
+        return ModelCachePlatform.android;
+      case 'fuchsia':
+        return ModelCachePlatform.fuchsia;
+      case 'ios':
+        return ModelCachePlatform.ios;
+      case 'linux':
+        return ModelCachePlatform.linux;
+      case 'macos':
+        return ModelCachePlatform.macos;
+      case 'windows':
+        return ModelCachePlatform.windows;
+      case 'web':
+        return ModelCachePlatform.web;
+      default:
+        return ModelCachePlatform.unknown;
+    }
+  }
+
+  /// Whether this platform is a phone/tablet OS with app sandboxing by default.
+  bool get isMobile {
+    return this == ModelCachePlatform.android || this == ModelCachePlatform.ios;
+  }
+
+  /// Whether `llamadart` can choose a per-user shared cache root without app or
+  /// user-specific storage grants.
+  bool get supportsImplicitSharedModelCache {
+    return this == ModelCachePlatform.linux ||
+        this == ModelCachePlatform.macos ||
+        this == ModelCachePlatform.windows;
+  }
+}
+
 /// Progress information for a package-managed model download.
 class ModelDownloadProgress {
   /// Creates download progress information.

--- a/lib/src/core/models/download/model_download_manager_stub.dart
+++ b/lib/src/core/models/download/model_download_manager_stub.dart
@@ -6,6 +6,55 @@ class DefaultModelDownloadManager extends ThrowingModelDownloadManager {
   /// Creates a non-IO placeholder download manager.
   const DefaultModelDownloadManager({String? defaultCacheDirectory});
 
+  /// Creates a non-IO placeholder for an automatic model cache manager.
+  const DefaultModelDownloadManager.auto({
+    String namespace = 'llamadart',
+    String? cacheDirectory,
+    String? appPrivateCacheDirectory,
+    ModelCachePlatform? platform,
+    Map<String, String>? environment,
+    String? homeDirectory,
+  });
+
+  /// Creates a non-IO placeholder for a shared model cache manager.
+  const DefaultModelDownloadManager.sharedCache({
+    String namespace = 'llamadart',
+    String? cacheDirectory,
+    ModelCachePlatform? platform,
+    Map<String, String>? environment,
+    String? homeDirectory,
+  });
+
+  /// Creates a non-IO placeholder for an app-private model cache manager.
+  const DefaultModelDownloadManager.appPrivate({
+    required String cacheDirectory,
+  });
+
+  /// Creates a non-IO placeholder for a user-selected model library manager.
+  const DefaultModelDownloadManager.userSelected({
+    required String cacheDirectory,
+  });
+
+  /// Creates a non-IO placeholder for an app-group model cache manager.
+  const DefaultModelDownloadManager.appGroup({required String cacheDirectory});
+
+  /// Non-IO platforms do not expose a file-backed shared cache directory.
+  static String defaultSharedCacheDirectory({
+    String namespace = 'llamadart',
+    ModelCachePlatform? platform,
+    Map<String, String>? environment,
+    String? homeDirectory,
+  }) {
+    throw LlamaUnsupportedException(
+      'File-backed shared model cache directories are not supported on this platform.',
+    );
+  }
+
+  /// Default cache root used when a per-call cache directory is absent.
+  String get defaultCacheDirectory => throw LlamaUnsupportedException(
+    'File-backed model cache directories are not supported on this platform.',
+  );
+
   @override
   Object unsupported(String operation) => LlamaUnsupportedException(
     'Model download manager $operation is not supported on this platform.',

--- a/lib/src/platform/io/model_download_manager_io.dart
+++ b/lib/src/platform/io/model_download_manager_io.dart
@@ -21,10 +21,161 @@ class DefaultModelDownloadManager implements ModelDownloadManager {
           defaultCacheDirectory ??
           path.join(Directory.systemTemp.path, 'llamadart', 'models');
 
+  /// Creates a manager using the recommended cache root for the current platform.
+  ///
+  /// Desktop/server platforms use the per-user shared `llamadart/models` cache.
+  /// Android and iOS use [appPrivateCacheDirectory] because `llamadart` cannot
+  /// discover an app's durable sandbox directory without app/platform storage
+  /// APIs. Pass [cacheDirectory] to force a specific root on every platform,
+  /// including an OS-granted mobile model library directory.
+  factory DefaultModelDownloadManager.auto({
+    String namespace = 'llamadart',
+    String? cacheDirectory,
+    String? appPrivateCacheDirectory,
+    ModelCachePlatform? platform,
+    Map<String, String>? environment,
+    String? homeDirectory,
+  }) {
+    final explicitCacheDirectory = _nonEmpty(cacheDirectory);
+    if (explicitCacheDirectory != null) {
+      return DefaultModelDownloadManager(
+        defaultCacheDirectory: explicitCacheDirectory,
+      );
+    }
+
+    final effectivePlatform =
+        platform ?? ModelCachePlatform.parse(Platform.operatingSystem);
+    if (effectivePlatform.supportsImplicitSharedModelCache) {
+      return DefaultModelDownloadManager.sharedCache(
+        namespace: namespace,
+        platform: effectivePlatform,
+        environment: environment,
+        homeDirectory: homeDirectory,
+      );
+    }
+
+    if (effectivePlatform.isMobile) {
+      final appPrivateDirectory = _nonEmpty(appPrivateCacheDirectory);
+      if (appPrivateDirectory != null) {
+        return DefaultModelDownloadManager.appPrivate(
+          cacheDirectory: appPrivateDirectory,
+        );
+      }
+      throw LlamaUnsupportedException(
+        'DefaultModelDownloadManager.auto cannot choose a durable model cache '
+        'directory for ${effectivePlatform.name}. Pass appPrivateCacheDirectory '
+        'from your app storage layer, or pass cacheDirectory for an explicit '
+        'OS-granted model library.',
+      );
+    }
+
+    if (effectivePlatform == ModelCachePlatform.web) {
+      throw LlamaUnsupportedException(
+        'DefaultModelDownloadManager.auto cannot create a file-backed shared '
+        'cache on web. Web model caches are origin-scoped browser/runtime '
+        'caches.',
+      );
+    }
+
+    throw LlamaUnsupportedException(
+      'DefaultModelDownloadManager.auto cannot choose a model cache directory '
+      'for ${effectivePlatform.name}. Pass cacheDirectory explicitly.',
+    );
+  }
+
+  /// Creates a manager rooted at a per-user shared model cache.
+  ///
+  /// On desktop/server platforms this resolves to a conventional per-user cache
+  /// directory. On Android and iOS no implicit cross-app shared folder is
+  /// available: pass [cacheDirectory] after your app obtains an OS-supported
+  /// shared/user-selected directory, or use [DefaultModelDownloadManager.appPrivate]
+  /// for app-private mobile storage.
+  factory DefaultModelDownloadManager.sharedCache({
+    String namespace = 'llamadart',
+    String? cacheDirectory,
+    ModelCachePlatform? platform,
+    Map<String, String>? environment,
+    String? homeDirectory,
+  }) {
+    return DefaultModelDownloadManager(
+      defaultCacheDirectory:
+          cacheDirectory ??
+          defaultSharedCacheDirectory(
+            namespace: namespace,
+            platform: platform,
+            environment: environment,
+            homeDirectory: homeDirectory,
+          ),
+    );
+  }
+
+  /// Creates a manager rooted at an app-private durable cache directory.
+  ///
+  /// Flutter apps typically pass an application-support or documents directory
+  /// resolved with platform storage APIs. This avoids cross-app storage claims on
+  /// mobile while still deduping model downloads within the app.
+  factory DefaultModelDownloadManager.appPrivate({
+    required String cacheDirectory,
+  }) {
+    return DefaultModelDownloadManager(defaultCacheDirectory: cacheDirectory);
+  }
+
+  /// Creates a manager rooted at a user-selected model library directory.
+  ///
+  /// This is the intended Android cross-developer sharing shape: the user grants
+  /// each app access to the same model library using platform APIs such as the
+  /// Storage Access Framework. The returned manager is file-backed; apps that
+  /// receive only content URIs must first bridge them to a local file path or a
+  /// future file-descriptor-backed loader.
+  factory DefaultModelDownloadManager.userSelected({
+    required String cacheDirectory,
+  }) {
+    return DefaultModelDownloadManager(defaultCacheDirectory: cacheDirectory);
+  }
+
+  /// Creates a manager rooted at an app-group shared container directory.
+  ///
+  /// This supports iOS/macOS apps that are explicitly configured into the same
+  /// App Group. It is not a cross-developer global model cache.
+  factory DefaultModelDownloadManager.appGroup({
+    required String cacheDirectory,
+  }) {
+    return DefaultModelDownloadManager(defaultCacheDirectory: cacheDirectory);
+  }
+
   /// Default cache root used when [ModelLoadOptions.cacheDirectory] is absent.
   final String defaultCacheDirectory;
 
   static final Map<String, Future<void>> _cacheLocks = <String, Future<void>>{};
+
+  /// Returns the default per-user shared model cache directory for desktop/CLI.
+  ///
+  /// Android, iOS, web, and unknown platforms throw because `llamadart` cannot
+  /// safely choose a cross-app shared folder without explicit platform grants.
+  /// [environment], [homeDirectory], and [platform] are optional overrides for
+  /// deterministic tests and custom embedders; omitted values use the current
+  /// process platform and environment.
+  static String defaultSharedCacheDirectory({
+    String namespace = 'llamadart',
+    ModelCachePlatform? platform,
+    Map<String, String>? environment,
+    String? homeDirectory,
+  }) {
+    final cacheNamespace = _validateCacheNamespace(namespace);
+    final effectivePlatform =
+        platform ?? ModelCachePlatform.parse(Platform.operatingSystem);
+    final effectiveEnvironment = environment ?? Platform.environment;
+    final effectiveHomeDirectory =
+        homeDirectory ??
+        _homeDirectoryFor(effectivePlatform, effectiveEnvironment);
+
+    return _defaultSharedCacheDirectoryFor(
+      platform: effectivePlatform,
+      namespace: cacheNamespace,
+      environment: effectiveEnvironment,
+      homeDirectory: effectiveHomeDirectory,
+    );
+  }
 
   @override
   Future<ModelCacheEntry> ensureModel(
@@ -1180,4 +1331,118 @@ Future<void> _deleteIfExists(File file) async {
   } on FileSystemException {
     // Best effort cleanup; later file operations surface actionable errors.
   }
+}
+
+String _defaultSharedCacheDirectoryFor({
+  required ModelCachePlatform platform,
+  required String namespace,
+  required Map<String, String> environment,
+  required String? homeDirectory,
+}) {
+  final context = _pathContextFor(platform);
+  switch (platform) {
+    case ModelCachePlatform.linux:
+      final xdgCacheHome = _nonEmpty(environment['XDG_CACHE_HOME']);
+      if (xdgCacheHome != null) {
+        return context.join(xdgCacheHome, namespace, 'models');
+      }
+      final home = _requiredHomeDirectory(platform, homeDirectory);
+      return context.join(home, '.cache', namespace, 'models');
+    case ModelCachePlatform.macos:
+      final home = _requiredHomeDirectory(platform, homeDirectory);
+      return context.join(home, 'Library', 'Caches', namespace, 'models');
+    case ModelCachePlatform.windows:
+      final localAppData =
+          _nonEmpty(environment['LOCALAPPDATA']) ??
+          _nonEmpty(environment['APPDATA']);
+      if (localAppData != null) {
+        return context.join(localAppData, namespace, 'models');
+      }
+      final home = _requiredHomeDirectory(platform, homeDirectory);
+      return context.join(home, 'AppData', 'Local', namespace, 'models');
+    case ModelCachePlatform.android:
+      throw LlamaUnsupportedException(
+        'Android has no implicit cross-app shared model cache directory. '
+        'Use app-private storage with DefaultModelDownloadManager.appPrivate, '
+        'or pass a user-granted model library directory to '
+        'DefaultModelDownloadManager.userSelected.',
+      );
+    case ModelCachePlatform.ios:
+      throw LlamaUnsupportedException(
+        'iOS has no implicit cross-app shared model cache directory. '
+        'Use app-private storage with DefaultModelDownloadManager.appPrivate, '
+        'or pass an App Group container path to '
+        'DefaultModelDownloadManager.appGroup for same-group apps.',
+      );
+    case ModelCachePlatform.web:
+      throw LlamaUnsupportedException(
+        'Web model caches are origin-scoped browser/runtime caches; there is no '
+        'file-backed shared cache directory.',
+      );
+    case ModelCachePlatform.fuchsia:
+    case ModelCachePlatform.unknown:
+      throw LlamaUnsupportedException(
+        'No implicit shared model cache directory is known for '
+        '${platform.name}. Pass an explicit cacheDirectory.',
+      );
+  }
+}
+
+path.Context _pathContextFor(ModelCachePlatform platform) {
+  if (platform == ModelCachePlatform.windows) {
+    return path.Context(style: path.Style.windows);
+  }
+  return path.Context(style: path.Style.posix);
+}
+
+String? _homeDirectoryFor(
+  ModelCachePlatform platform,
+  Map<String, String> environment,
+) {
+  if (platform == ModelCachePlatform.windows) {
+    final userProfile = _nonEmpty(environment['USERPROFILE']);
+    if (userProfile != null) {
+      return userProfile;
+    }
+    final homeDrive = _nonEmpty(environment['HOMEDRIVE']);
+    final homePath = _nonEmpty(environment['HOMEPATH']);
+    if (homeDrive != null && homePath != null) {
+      return path.Context(style: path.Style.windows).join(homeDrive, homePath);
+    }
+  }
+  return _nonEmpty(environment['HOME']);
+}
+
+String _requiredHomeDirectory(
+  ModelCachePlatform platform,
+  String? homeDirectory,
+) {
+  final home = _nonEmpty(homeDirectory);
+  if (home != null) {
+    return home;
+  }
+  throw LlamaUnsupportedException(
+    'Cannot resolve a shared model cache directory for ${platform.name}: '
+    'no home directory was available. Pass cacheDirectory explicitly.',
+  );
+}
+
+String? _nonEmpty(String? value) {
+  if (value == null || value.trim().isEmpty) {
+    return null;
+  }
+  return value;
+}
+
+String _validateCacheNamespace(String namespace) {
+  final trimmed = namespace.trim();
+  if (!RegExp(r'^[A-Za-z0-9][A-Za-z0-9._-]*$').hasMatch(trimmed)) {
+    throw ArgumentError.value(
+      namespace,
+      'namespace',
+      'Cache namespace must contain only letters, numbers, dot, underscore, '
+          'or dash, and must not include path separators.',
+    );
+  }
+  return trimmed;
 }

--- a/lib/src/platform/io/model_download_manager_io.dart
+++ b/lib/src/platform/io/model_download_manager_io.dart
@@ -23,11 +23,17 @@ class DefaultModelDownloadManager implements ModelDownloadManager {
 
   /// Creates a manager using the recommended cache root for the current platform.
   ///
-  /// Desktop/server platforms use the per-user shared `llamadart/models` cache.
-  /// Android and iOS use [appPrivateCacheDirectory] because `llamadart` cannot
-  /// discover an app's durable sandbox directory without app/platform storage
-  /// APIs. Pass [cacheDirectory] to force a specific root on every platform,
-  /// including an OS-granted mobile model library directory.
+  /// Pass [cacheDirectory] to force a specific root on every platform,
+  /// including an OS-granted mobile model library directory. Otherwise,
+  /// desktop/server platforms use [defaultSharedCacheDirectory] with
+  /// [namespace], [environment], and [homeDirectory]. Android and iOS use
+  /// [appPrivateCacheDirectory] because `llamadart` cannot discover an app's
+  /// durable sandbox directory without app/platform storage APIs.
+  ///
+  /// Throws [LlamaUnsupportedException] on Android or iOS when neither
+  /// [cacheDirectory] nor [appPrivateCacheDirectory] is supplied, on web because
+  /// browser caches are origin-scoped instead of file-backed, and on unknown
+  /// platforms where no implicit shared cache root is known.
   factory DefaultModelDownloadManager.auto({
     String namespace = 'llamadart',
     String? cacheDirectory,
@@ -90,6 +96,11 @@ class DefaultModelDownloadManager implements ModelDownloadManager {
   /// available: pass [cacheDirectory] after your app obtains an OS-supported
   /// shared/user-selected directory, or use [DefaultModelDownloadManager.appPrivate]
   /// for app-private mobile storage.
+  ///
+  /// When [cacheDirectory] is omitted, this uses [defaultSharedCacheDirectory].
+  /// That means Linux resolves under `$XDG_CACHE_HOME` or `$HOME/.cache`, macOS
+  /// resolves under `$HOME/Library/Caches`, and Windows resolves under
+  /// `%LOCALAPPDATA%`, `%APPDATA%`, or `%USERPROFILE%\AppData\Local`.
   factory DefaultModelDownloadManager.sharedCache({
     String namespace = 'llamadart',
     String? cacheDirectory,
@@ -149,6 +160,15 @@ class DefaultModelDownloadManager implements ModelDownloadManager {
   static final Map<String, Future<void>> _cacheLocks = <String, Future<void>>{};
 
   /// Returns the default per-user shared model cache directory for desktop/CLI.
+  ///
+  /// The default [namespace] is `llamadart`, producing these roots:
+  ///
+  /// - Linux: `$XDG_CACHE_HOME/llamadart/models`, or
+  ///   `$HOME/.cache/llamadart/models` when `XDG_CACHE_HOME` is unset.
+  /// - macOS: `$HOME/Library/Caches/llamadart/models`.
+  /// - Windows: `%LOCALAPPDATA%\llamadart\models`, then
+  ///   `%APPDATA%\llamadart\models`, then
+  ///   `%USERPROFILE%\AppData\Local\llamadart\models`.
   ///
   /// Android, iOS, web, and unknown platforms throw because `llamadart` cannot
   /// safely choose a cross-app shared folder without explicit platform grants.

--- a/test/unit/core/models/download/model_download_manager_base_test.dart
+++ b/test/unit/core/models/download/model_download_manager_base_test.dart
@@ -3,6 +3,40 @@ import 'package:llamadart/src/core/models/model_source.dart';
 import 'package:test/test.dart';
 
 void main() {
+  group('ModelCachePlatform', () {
+    test('parses Platform.operatingSystem values', () {
+      expect(ModelCachePlatform.parse('android'), ModelCachePlatform.android);
+      expect(ModelCachePlatform.parse('fuchsia'), ModelCachePlatform.fuchsia);
+      expect(ModelCachePlatform.parse('ios'), ModelCachePlatform.ios);
+      expect(ModelCachePlatform.parse('linux'), ModelCachePlatform.linux);
+      expect(ModelCachePlatform.parse('macos'), ModelCachePlatform.macos);
+      expect(ModelCachePlatform.parse('windows'), ModelCachePlatform.windows);
+      expect(ModelCachePlatform.parse('web'), ModelCachePlatform.web);
+      expect(
+        ModelCachePlatform.parse('unsupported-os'),
+        ModelCachePlatform.unknown,
+      );
+    });
+
+    test('identifies mobile and implicit shared-cache platforms', () {
+      expect(ModelCachePlatform.android.isMobile, isTrue);
+      expect(ModelCachePlatform.ios.isMobile, isTrue);
+      expect(ModelCachePlatform.linux.isMobile, isFalse);
+
+      expect(ModelCachePlatform.linux.supportsImplicitSharedModelCache, isTrue);
+      expect(ModelCachePlatform.macos.supportsImplicitSharedModelCache, isTrue);
+      expect(
+        ModelCachePlatform.windows.supportsImplicitSharedModelCache,
+        isTrue,
+      );
+      expect(
+        ModelCachePlatform.android.supportsImplicitSharedModelCache,
+        isFalse,
+      );
+      expect(ModelCachePlatform.web.supportsImplicitSharedModelCache, isFalse);
+    });
+  });
+
   group('ThrowingModelDownloadManager', () {
     test('base placeholder throws for all operations', () async {
       const manager = _TestDownloadManager();

--- a/test/unit/core/models/download/model_download_manager_stub_test.dart
+++ b/test/unit/core/models/download/model_download_manager_stub_test.dart
@@ -16,5 +16,34 @@ void main() {
         throwsA(isA<LlamaUnsupportedException>()),
       );
     });
+
+    test('auto constructor compiles on non-IO platforms', () async {
+      const manager = DefaultModelDownloadManager.auto(
+        appPrivateCacheDirectory: '/app/models',
+      );
+
+      await expectLater(
+        manager.ensureModel(ModelSource.path('/models/model.gguf')),
+        throwsA(isA<LlamaUnsupportedException>()),
+      );
+    });
+
+    test('default cache directory getter throws unsupported exception', () {
+      const manager = DefaultModelDownloadManager.auto(
+        appPrivateCacheDirectory: '/app/models',
+      );
+
+      expect(
+        () => manager.defaultCacheDirectory,
+        throwsA(isA<LlamaUnsupportedException>()),
+      );
+    });
+
+    test('throws unsupported exception for file-backed shared cache root', () {
+      expect(
+        DefaultModelDownloadManager.defaultSharedCacheDirectory,
+        throwsA(isA<LlamaUnsupportedException>()),
+      );
+    });
   });
 }

--- a/test/unit/platform/io/model_download_manager_io_test.dart
+++ b/test/unit/platform/io/model_download_manager_io_test.dart
@@ -33,6 +33,185 @@ void main() {
       }
     });
 
+    test('resolves desktop shared model cache directories', () {
+      expect(
+        DefaultModelDownloadManager.defaultSharedCacheDirectory(
+          platform: ModelCachePlatform.linux,
+          environment: const <String, String>{
+            'XDG_CACHE_HOME': '/tmp/cache-home',
+          },
+        ),
+        '/tmp/cache-home/llamadart/models',
+      );
+      expect(
+        DefaultModelDownloadManager.defaultSharedCacheDirectory(
+          platform: ModelCachePlatform.linux,
+          environment: const <String, String>{},
+          homeDirectory: '/home/alice',
+        ),
+        '/home/alice/.cache/llamadart/models',
+      );
+      expect(
+        DefaultModelDownloadManager.defaultSharedCacheDirectory(
+          platform: ModelCachePlatform.macos,
+          environment: const <String, String>{},
+          homeDirectory: '/Users/alice',
+        ),
+        '/Users/alice/Library/Caches/llamadart/models',
+      );
+      expect(
+        DefaultModelDownloadManager.defaultSharedCacheDirectory(
+          platform: ModelCachePlatform.windows,
+          environment: const <String, String>{
+            'LOCALAPPDATA': r'C:\Users\Alice\AppData\Local',
+          },
+        ),
+        r'C:\Users\Alice\AppData\Local\llamadart\models',
+      );
+    });
+
+    test('auto uses desktop shared cache directories', () {
+      final linuxManager = DefaultModelDownloadManager.auto(
+        platform: ModelCachePlatform.linux,
+        environment: const <String, String>{
+          'XDG_CACHE_HOME': '/tmp/cache-home',
+        },
+        appPrivateCacheDirectory: path.join(tempDir.path, 'mobile-private'),
+      );
+      final macosManager = DefaultModelDownloadManager.auto(
+        platform: ModelCachePlatform.macos,
+        environment: const <String, String>{},
+        homeDirectory: '/Users/alice',
+      );
+
+      expect(
+        linuxManager.defaultCacheDirectory,
+        '/tmp/cache-home/llamadart/models',
+      );
+      expect(
+        macosManager.defaultCacheDirectory,
+        '/Users/alice/Library/Caches/llamadart/models',
+      );
+    });
+
+    test('auto uses explicit app-private directories on mobile', () {
+      final androidManager = DefaultModelDownloadManager.auto(
+        platform: ModelCachePlatform.android,
+        appPrivateCacheDirectory: path.join(tempDir.path, 'android-private'),
+      );
+      final iosManager = DefaultModelDownloadManager.auto(
+        platform: ModelCachePlatform.ios,
+        appPrivateCacheDirectory: path.join(tempDir.path, 'ios-private'),
+      );
+
+      expect(androidManager.defaultCacheDirectory, endsWith('android-private'));
+      expect(iosManager.defaultCacheDirectory, endsWith('ios-private'));
+    });
+
+    test('auto explicit cache directory overrides platform defaults', () {
+      final manager = DefaultModelDownloadManager.auto(
+        platform: ModelCachePlatform.android,
+        cacheDirectory: path.join(tempDir.path, 'user-library'),
+      );
+
+      expect(manager.defaultCacheDirectory, endsWith('user-library'));
+    });
+
+    test('auto rejects mobile without an explicit durable directory', () {
+      for (final platform in <ModelCachePlatform>[
+        ModelCachePlatform.android,
+        ModelCachePlatform.ios,
+      ]) {
+        expect(
+          () => DefaultModelDownloadManager.auto(platform: platform),
+          throwsA(
+            isA<LlamaUnsupportedException>().having(
+              (error) => error.toString(),
+              'message',
+              contains('appPrivateCacheDirectory'),
+            ),
+          ),
+          reason: platform.name,
+        );
+      }
+    });
+
+    test('auto rejects non-file-backed and unknown platforms', () {
+      for (final platform in <ModelCachePlatform>[
+        ModelCachePlatform.web,
+        ModelCachePlatform.fuchsia,
+        ModelCachePlatform.unknown,
+      ]) {
+        expect(
+          () => DefaultModelDownloadManager.auto(platform: platform),
+          throwsA(isA<LlamaUnsupportedException>()),
+          reason: platform.name,
+        );
+      }
+    });
+
+    test('rejects implicit shared cache directories on mobile and web', () {
+      for (final platform in <ModelCachePlatform>[
+        ModelCachePlatform.android,
+        ModelCachePlatform.ios,
+        ModelCachePlatform.web,
+        ModelCachePlatform.fuchsia,
+        ModelCachePlatform.unknown,
+      ]) {
+        expect(
+          () => DefaultModelDownloadManager.defaultSharedCacheDirectory(
+            platform: platform,
+            environment: const <String, String>{},
+            homeDirectory: '/home/alice',
+          ),
+          throwsA(isA<LlamaUnsupportedException>()),
+          reason: platform.name,
+        );
+      }
+    });
+
+    test('uses explicit directories for mobile sharing modes', () {
+      final appPrivate = DefaultModelDownloadManager.appPrivate(
+        cacheDirectory: path.join(tempDir.path, 'app-private'),
+      );
+      final userSelected = DefaultModelDownloadManager.userSelected(
+        cacheDirectory: path.join(tempDir.path, 'user-selected'),
+      );
+      final appGroup = DefaultModelDownloadManager.appGroup(
+        cacheDirectory: path.join(tempDir.path, 'app-group'),
+      );
+      final explicitShared = DefaultModelDownloadManager.sharedCache(
+        cacheDirectory: path.join(tempDir.path, 'explicit-shared'),
+        platform: ModelCachePlatform.android,
+      );
+
+      expect(appPrivate.defaultCacheDirectory, endsWith('app-private'));
+      expect(userSelected.defaultCacheDirectory, endsWith('user-selected'));
+      expect(appGroup.defaultCacheDirectory, endsWith('app-group'));
+      expect(explicitShared.defaultCacheDirectory, endsWith('explicit-shared'));
+    });
+
+    test('validates shared cache namespace', () {
+      expect(
+        () => DefaultModelDownloadManager.defaultSharedCacheDirectory(
+          namespace: '../llamadart',
+          platform: ModelCachePlatform.linux,
+          environment: const <String, String>{},
+          homeDirectory: '/home/alice',
+        ),
+        throwsArgumentError,
+      );
+      expect(
+        DefaultModelDownloadManager.defaultSharedCacheDirectory(
+          namespace: 'com.example.llamadart',
+          platform: ModelCachePlatform.linux,
+          environment: const <String, String>{},
+          homeDirectory: '/home/alice',
+        ),
+        '/home/alice/.cache/com.example.llamadart/models',
+      );
+    });
+
     test(
       'downloads remote source, writes metadata, reports progress, and reuses cache',
       () async {
@@ -88,6 +267,31 @@ void main() {
         );
       },
     );
+
+    test('sharedCache managers reuse one explicit model library', () async {
+      server.payload = utf8.encode('shared-cache-model');
+      server.responseDelay = const Duration(milliseconds: 100);
+      final firstManager = DefaultModelDownloadManager.sharedCache(
+        cacheDirectory: tempDir.path,
+      );
+      final secondManager = DefaultModelDownloadManager.sharedCache(
+        cacheDirectory: tempDir.path,
+      );
+      final source = ModelSource.url(server.modelUri, fileName: 'tiny.gguf');
+
+      final entries = await Future.wait(<Future<ModelCacheEntry>>[
+        firstManager.ensureModel(source),
+        secondManager.ensureModel(source),
+      ]);
+
+      expect(server.requestCount, 1);
+      expect(server.maxActiveRequests, 1);
+      expect(entries.map((entry) => entry.filePath).toSet(), hasLength(1));
+      expect(
+        File(entries.first.filePath).readAsStringSync(),
+        'shared-cache-model',
+      );
+    });
 
     test('downloads and caches LiteRT-LM bundle files', () async {
       server.payload = utf8.encode('litert-lm-bundle-bytes');

--- a/website/docs/changelog/recent-releases.md
+++ b/website/docs/changelog/recent-releases.md
@@ -7,6 +7,14 @@ For canonical full release notes, use:
 
 - [`CHANGELOG.md`](https://github.com/leehack/llamadart/blob/main/CHANGELOG.md)
 
+## Unreleased
+
+- Added `DefaultModelDownloadManager.auto(...)` plus explicit model cache root
+  constructors for shared desktop caches, app-private mobile caches,
+  user-selected model libraries, and App Group containers. Implicit shared cache
+  resolution now fails loudly on mobile and web where the OS cannot provide a
+  hidden cross-developer model folder.
+
 ## 0.8.7
 
 - Fixed multimodal chat-template rendering so templates that force-open

--- a/website/docs/guides/model-lifecycle.md
+++ b/website/docs/guides/model-lifecycle.md
@@ -168,12 +168,17 @@ verification, explicit cache policies, retries, or resume.
 
 ```dart
 final cancelToken = ModelDownloadCancelToken();
+// Desktop/server uses the shared cache. Android/iOS uses the supplied
+// app-private directory, so the call site can stay platform-neutral.
+final manager = DefaultModelDownloadManager.auto(
+  appPrivateCacheDirectory: appSupportModelsDirectory,
+);
+final engine = LlamaEngine(LlamaBackend(), modelDownloadManager: manager);
 
 await engine.loadModelSource(
   ModelSource.url(Uri.parse('https://example.com/model.gguf')),
   options: ModelLoadOptions(
     cachePolicy: ModelCachePolicy.preferCached,
-    cacheDirectory: '/app/cache/llamadart-models',
     sha256: '0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef',
     bearerToken: 'hf_xxx',
     cancelToken: cancelToken,
@@ -198,11 +203,49 @@ Cache policies:
   `remove(entry.cacheKey)`/`clear()` when the returned file is no longer needed, or
   use thresholded `prune(...)` for age/size-based cleanup.
 
+Recommended cache roots:
+
+```dart
+// Cross-platform default: desktop shared cache, mobile app-private cache.
+final crossPlatformManager = DefaultModelDownloadManager.auto(
+  appPrivateCacheDirectory: appSupportModelsDirectory,
+);
+
+// Desktop/server: per-user cache, shared across llamadart apps using the same source.
+final desktopManager = DefaultModelDownloadManager.sharedCache();
+
+// Mobile default: app-private durable storage resolved by your app/platform layer.
+final mobileManager = DefaultModelDownloadManager.appPrivate(
+  cacheDirectory: appSupportModelsDirectory,
+);
+
+// Android cross-developer sharing: only after the user grants this directory.
+final androidUserLibrary = DefaultModelDownloadManager.userSelected(
+  cacheDirectory: userGrantedModelLibraryDirectory,
+);
+
+// iOS/macOS same-team sharing: only for apps configured into the App Group.
+final appGroupLibrary = DefaultModelDownloadManager.appGroup(
+  cacheDirectory: appGroupModelsDirectory,
+);
+```
+
+`auto(...)` is the easiest way to keep one code path: desktop/server platforms
+use the shared cache, and Android/iOS use `appPrivateCacheDirectory`. If that
+mobile directory is missing, `auto(...)` throws an actionable
+`LlamaUnsupportedException` instead of falling back to a temporary or hidden
+cross-app location. `sharedCache()` intentionally refuses to invent a mobile
+shared folder when no `cacheDirectory` is supplied. Android requires an explicit
+user or app-managed grant for a shared model library, and iOS requires an App
+Group for same-group apps. For apps from unrelated developers, iOS can load
+user-picked files but does not provide a writable hidden shared model cache. Web
+model caches remain origin-scoped browser/runtime caches.
+
 The download manager can also inspect and clean the persisted cache:
 
 ```dart
-final manager = DefaultModelDownloadManager(
-  defaultCacheDirectory: '/app/cache/llamadart-models',
+final manager = DefaultModelDownloadManager.auto(
+  appPrivateCacheDirectory: appSupportModelsDirectory,
 );
 
 final cached = await manager.list();
@@ -223,8 +266,8 @@ that lifecycle without depending on Flutter:
 
 ```dart
 final controller = ModelDownloadController(
-  manager: DefaultModelDownloadManager(
-    defaultCacheDirectory: '/app/cache/llamadart-models',
+  manager: DefaultModelDownloadManager.auto(
+    appPrivateCacheDirectory: appSupportModelsDirectory,
   ),
 );
 
@@ -315,13 +358,16 @@ strings, fragments, and userinfo are redacted from display strings and metadata.
 
 ### Mobile large-download guidance
 
-For Flutter apps, pass an app-controlled `cacheDirectory` from your storage
-strategy (for example an application-support or documents directory selected by
-`path_provider`). Surface progress/cancel controls in the UI, keep downloads
-serialized for large GGUF files, and tell users to keep the app open for the
-foreground download. Do not cancel purely because the app receives a lifecycle
-pause: Android/iOS may allow short screen-lock or app-switch interruptions to
-continue, while an eager cancellation guarantees a pause on every lock.
+For Flutter apps on Android/iOS, pass an app-controlled `cacheDirectory` from
+your storage strategy (for example an application-support or documents directory
+selected by `path_provider`) to `DefaultModelDownloadManager.appPrivate(...)`,
+or pass it as `appPrivateCacheDirectory` to `DefaultModelDownloadManager.auto(...)`
+when you want one constructor across desktop and mobile.
+Surface progress/cancel controls in the UI, keep downloads serialized for large
+GGUF files, and tell users to keep the app open for the foreground download. Do
+not cancel purely because the app receives a lifecycle pause: Android/iOS may
+allow short screen-lock or app-switch interruptions to continue, while an eager
+cancellation guarantees a pause on every lock.
 
 Foreground Dart HTTP requests are still not a substitute for native background
 downloads. If the OS suspends or kills the app, the request can fail later. The
@@ -335,11 +381,14 @@ core package.
 
 For shared device-level GGUF storage, keep the same separation: core
 `llamadart` exposes source identities, cache metadata, progress, cancellation,
-retry, and verification hooks; a future opt-in platform model-store package can
-decide how apps share files, metadata, permissions, pruning, and native
-background download execution. On Android, prefer app-private storage unless the
-app intentionally exposes model files to the user; on iOS, avoid cache
-directories that the OS may purge while a model is still needed.
+retry, and verification hooks. On Android, use
+`DefaultModelDownloadManager.userSelected(...)` only after the user grants all
+participating apps access to the same model library directory; do not request
+All Files Access as a default. On iOS, use
+`DefaultModelDownloadManager.appGroup(...)` only for apps configured into the
+same App Group. For apps from unrelated developers, support user-picked model
+files through the Files/document picker and expect copy-to-app-cache fallback
+until the native loaders grow file-descriptor/content-URI backed loading.
 
 ## State persistence
 

--- a/website/docs/guides/model-lifecycle.md
+++ b/website/docs/guides/model-lifecycle.md
@@ -241,6 +241,18 @@ Group for same-group apps. For apps from unrelated developers, iOS can load
 user-picked files but does not provide a writable hidden shared model cache. Web
 model caches remain origin-scoped browser/runtime caches.
 
+Desktop shared-cache roots use the default `llamadart` namespace:
+
+| Platform | Default path |
+| --- | --- |
+| Linux | `$XDG_CACHE_HOME/llamadart/models`, or `$HOME/.cache/llamadart/models` when `XDG_CACHE_HOME` is unset |
+| macOS | `$HOME/Library/Caches/llamadart/models` |
+| Windows | `%LOCALAPPDATA%\llamadart\models`, then `%APPDATA%\llamadart\models`, then `%USERPROFILE%\AppData\Local\llamadart\models` |
+
+Pass `namespace: 'your.namespace'` to `auto(...)` or `sharedCache(...)` to
+replace the `llamadart` path segment, or pass `cacheDirectory` to force an
+explicit root.
+
 The download manager can also inspect and clean the persisted cache:
 
 ```dart


### PR DESCRIPTION
## Summary
- Add platform-aware model cache strategy APIs: `DefaultModelDownloadManager.auto(...)`, `sharedCache(...)`, `appPrivate(...)`, `userSelected(...)`, `appGroup(...)`, and `ModelCachePlatform`.
- Use a per-user shared `llamadart/models` cache on desktop/server platforms while keeping Android/iOS app-private by default through `auto(appPrivateCacheDirectory: ...)`.
- Document explicit mobile sharing flows: Android user-granted directories, iOS/macOS App Groups, and user-picked file fallback for unrelated iOS apps.
- Update README, website docs, examples, changelog, and model-download tests.

## Production-readiness scope
- **User-facing scope:** Apps can opt into a cross-platform model cache constructor. Desktop/server apps share a stable per-user cache by default; mobile apps keep one code path by passing their app-private durable directory.
- **Supported platforms/paths:** Native/file-backed IO platforms; desktop shared cache resolution for Linux/macOS/Windows; explicit app-private/user-selected/App Group file-backed cache roots for mobile integrations.
- **Unsupported or intentionally unavailable paths:** `sharedCache()` without `cacheDirectory` fails loudly on Android/iOS/web/unknown platforms. `auto()` fails loudly on Android/iOS when `appPrivateCacheDirectory` is missing. Web remains origin-scoped and does not expose a file-backed shared cache. No default `MANAGE_EXTERNAL_STORAGE` / All Files Access path.
- **Out of scope / follow-ups:** No-copy content-URI/file-descriptor-backed loading for mobile external libraries is tracked in #243; until then, apps may need copy-to-app-cache fallback.

## Completeness checklist
- [x] Declared scope is fully implemented, or explicitly reduced above.
- [x] Unsupported platform/option combinations fail loudly with actionable diagnostics or are clearly documented as unavailable.
- [x] Public API docs, README/website docs, examples, support matrices, and changelog entries are updated where relevant.
- [x] Regression coverage covers the original issue plus key negative/version-skew paths where relevant.
- [x] Security/privacy review completed: no secrets, bearer tokens, signed URLs, or raw secret-bearing paths leak through logs, cache keys, metadata, errors, or snapshots.
- [x] Follow-up work that is useful but not required for this PR is tracked in GitHub Issues, or explicitly marked "None" above.

## PR type guidance
- **Feature PR:** Adds API/docs/example updates, platform matrix, unsupported-path behavior, and tests for happy and negative paths.
- **Bugfix PR:** N/A.
- **Docs-only PR:** N/A; runtime API behavior changes.

## Test Plan
- [x] `dart format --output=none --set-exit-if-changed .`
- [x] `dart analyze` (passes with 3 pre-existing info-level lints outside this PR)
- [x] `dart test -p vm -j 1 --exclude-tags local-only`
- [x] `dart test -p chrome --exclude-tags local-only` - N/A for full Chrome suite; targeted browser stub coverage ran below.
- [x] Other targeted/local-only validation:
  - `dart test -p vm test/unit/core/models/download/model_download_manager_base_test.dart test/unit/platform/io/model_download_manager_io_test.dart`
  - `dart test -p chrome test/unit/core/models/download/model_download_manager_stub_test.dart`
  - `dart test -p vm test/unit/core/models test/unit/platform/io`
  - `./tool/docs/validate_links.sh`
  - `git diff --check`

## Matrix Evidence
| Matrix row | Scope covered | Platform / model / backend | Result | Evidence / notes |
| --- | --- | --- | --- | --- |
| `static-format-analyze` | format, analyzer, web/native import boundaries | Dart VM / repo static checks | PASS | `dart format --output=none --set-exit-if-changed .`; `dart analyze` exits 0 with 3 unrelated existing info lints |
| `root-vm` | native-safe unit/integration coverage on the Dart VM | macOS local / native IO | PASS | `dart test -p vm -j 1 --exclude-tags local-only` |
| `root-chrome` | browser-compatible unit/integration coverage | Chrome / non-IO stub API | PASS | CI `Test Web (Chrome)` passed; targeted stub test passed with `dart test -p chrome test/unit/core/models/download/model_download_manager_stub_test.dart` |
| `docs-site` | website build, docs metadata, generated docs routes | Docusaurus website | PASS | `./tool/docs/validate_links.sh`; CI `Docs Build Check` passed |
| `examples-tests` | example package unit tests and Flutter app regressions | CLI/server examples | N/A | Example changes only switch default cache constructor/path documentation; covered by analyzer and VM compile checks |
| `native-hook-bundles` | native-assets hook, bundle selection, runtime companions | Native assets | N/A | No hook/runtime bundle changes |
| `web-bridge-smoke` | WebGPU bridge bootstrap and fallback wiring | WebGPU bridge | N/A | No web bridge runtime changes |
| `chat-app-device-cache` | Flutter device model/mmproj download-cache-load flow | Android/iOS device | N/A | Device-level mobile model library flows are documented/constructor-level in this PR; no native content-URI loader change; no-copy loader follow-up tracked in #243 |

## Review Notes
- Independent review status: Local cleanup/readiness review completed after implementation. No blocking findings; added direct public `ModelCachePlatform` coverage during review.
- CI status / head SHA: All GitHub checks passed on head `373b502df`; `mergeStateStatus=CLEAN`, `mergeable=MERGEABLE`.

