### PR TITLE
Prepare 0.8.8 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-## Unreleased
+## 0.8.8
 
 * Updated the default llama.cpp native runtime pin to
   `leehack/llamadart-native@b9803`, regenerated matching Dart FFI bindings, refreshed

--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ JavaScript runtime.
 
 ```yaml
 dependencies:
-  llamadart: ^0.8.7
+  llamadart: ^0.8.8
 ```
 
 Flutter iOS/macOS apps that want Swift Package Manager-linked Apple
@@ -61,7 +61,7 @@ they ship:
 
 ```yaml
 dependencies:
-  llamadart: ^0.8.7
+  llamadart: ^0.8.8
   llamadart_llama_cpp_flutter: ^0.0.5 # GGUF / llama.cpp
   llamadart_litert_lm_flutter: ^0.0.2 # .litertlm / LiteRT-LM
 ```

--- a/example/chat_app/pubspec.lock
+++ b/example/chat_app/pubspec.lock
@@ -349,7 +349,7 @@ packages:
       path: "../.."
       relative: true
     source: path
-    version: "0.8.1"
+    version: "0.8.8"
   logging:
     dependency: transitive
     description:

--- a/packages/llamadart_litert_lm_flutter/README.md
+++ b/packages/llamadart_litert_lm_flutter/README.md
@@ -10,7 +10,7 @@ core package's native-assets fallback.
 
 ```yaml
 dependencies:
-  llamadart: ^0.8.7
+  llamadart: ^0.8.8
   llamadart_litert_lm_flutter: ^0.0.2
 ```
 

--- a/packages/llamadart_llama_cpp_flutter/README.md
+++ b/packages/llamadart_llama_cpp_flutter/README.md
@@ -9,7 +9,7 @@ core package's native-assets fallback.
 
 ```yaml
 dependencies:
-  llamadart: ^0.8.7
+  llamadart: ^0.8.8
   llamadart_llama_cpp_flutter: ^0.0.6
 ```
 

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: llamadart
 description: Dart and Flutter local LLM inference with llama.cpp GGUF and LiteRT-LM across native platforms and web.
-version: 0.8.7
+version: 0.8.8
 homepage: https://github.com/leehack/llamadart
 repository: https://github.com/leehack/llamadart
 issue_tracker: https://github.com/leehack/llamadart/issues

--- a/website/docs/changelog/recent-releases.md
+++ b/website/docs/changelog/recent-releases.md
@@ -7,7 +7,7 @@ For canonical full release notes, use:
 
 - [`CHANGELOG.md`](https://github.com/leehack/llamadart/blob/main/CHANGELOG.md)
 
-## Unreleased
+## 0.8.8
 
 - Updated the default llama.cpp native runtime pin to
   `leehack/llamadart-native@b9803`, regenerated matching Dart FFI bindings,

--- a/website/docs/getting-started/installation.md
+++ b/website/docs/getting-started/installation.md
@@ -27,7 +27,7 @@ In Xcode, set `IPHONEOS_DEPLOYMENT_TARGET = 16.4` or
 
 ```yaml
 dependencies:
-  llamadart: ^0.8.7
+  llamadart: ^0.8.8
 ```
 
 For Flutter iOS/macOS apps that should link Apple XCFrameworks through Swift
@@ -35,7 +35,7 @@ Package Manager, also add the runtime companion packages you need:
 
 ```yaml
 dependencies:
-  llamadart: ^0.8.7
+  llamadart: ^0.8.8
   llamadart_llama_cpp_flutter: ^0.0.5 # GGUF / llama.cpp
   llamadart_litert_lm_flutter: ^0.0.2 # .litertlm / LiteRT-LM
 ```


### PR DESCRIPTION
## Summary

- Bump `llamadart` to `0.8.8`.
- Move the current `Unreleased` entries into the `0.8.8` release notes in `CHANGELOG.md` and website recent releases.
- Update install snippets to `llamadart: ^0.8.8` and refresh the tracked chat app lockfile local path version.

## Validation

- PASS: `dart format --output=none --set-exit-if-changed .`
- PASS: `dart analyze` (exit 0; existing info-level lints only)
- PASS: `dart run tool/testing/check_platform_boundaries.dart`
- PASS: `dart test -p vm -j 1 --exclude-tags local-only` (`1157` passed, `64` skipped)
- PASS: `./tool/docs/validate_links.sh`
- PASS: `flutter pub publish --dry-run` (0 warnings)
- PASS: `llamadart_llama_cpp_flutter 0.0.6` is live on pub.dev before the core release.
- PASS: post-merge LiteRT-LM smoke for native sync run `28231242139`.
