### PR TITLE
docs: bump llama.cpp Flutter companion snippet

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -42,6 +42,9 @@ jobs:
       - name: Check platform boundaries
         run: dart run tool/testing/check_platform_boundaries.dart
 
+      - name: Verify release docs versions
+        run: dart run tool/testing/verify_release_docs_versions.dart
+
       - name: Pub Publish Dry Run
         run: flutter pub publish --dry-run
 

--- a/.github/workflows/sync_native_bindings.yml
+++ b/.github/workflows/sync_native_bindings.yml
@@ -83,6 +83,7 @@ jobs:
             - [ ] If LiteRT-LM sync was requested (`litert_lm_tag` is not `keep`), confirm `leehack/litert-lm-native` release `${{ steps.sync_pins.outputs.resolved_litert_lm_tag }}` includes the required runtime archives.
             - [ ] Confirm matching Apple SPM pins changed under `packages/` when Apple XCFramework releases changed.
             - [ ] Confirm current README/website native pin docs and `CHANGELOG.md` describe the new default pin.
+            - [ ] Do not tag or publish companion/core packages from this PR. After merge, request explicit maintainer approval before pushing any package-specific companion tag or core `vX.Y.Z` tag.
           branch: "automation/native-sync-${{ steps.sync_headers.outputs.resolved_tag }}"
           labels: automation/native-sync
           add-paths: |

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -340,12 +340,20 @@ WEBGPU_BRIDGE_ASSETS_TAG=<tag> ./scripts/fetch_webgpu_bridge_assets.sh
   the new version section.
 - Do not leave an empty `Unreleased` section in committed release prep. Add
   `Unreleased` back only when the next unreleased change is documented.
+- Run `dart run tool/testing/verify_release_docs_versions.dart` before release
+  prep PRs and any PR that edits current install snippets; it verifies current
+  README/website snippets and companion package READMEs against package
+  `pubspec.yaml` versions while intentionally ignoring historical versioned docs.
+- Release prep PRs must not publish anything by themselves. After the release
+  prep PR is merged, ask for explicit maintainer approval before pushing any
+  package-specific companion tag or the core `vX.Y.Z` tag.
 - Before tagging the core `vX.Y.Z` release, verify any companion package
   versions referenced by current install docs are already live on pub.dev. If a
-  changed companion package version is missing, publish it first with its
-  package-specific tag, for example
-  `llamadart_llama_cpp_flutter-v0.0.3`, wait for the companion publish workflow
-  to pass, and only then tag the core release.
+  changed companion package version is missing, stop and request explicit
+  approval to push that companion's package-specific tag, for example
+  `llamadart_llama_cpp_flutter-v0.0.3`; wait for the companion publish workflow
+  to pass, verify pub.dev, then request explicit approval before pushing the
+  core release tag.
 - Treat Apple SPM release readiness as two separate checks: the native GitHub
   release must contain the XCFramework zip/checksum pinned in `Package.swift`,
   and the Flutter companion pub package carrying that `Package.swift` must be

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,11 @@
+## Unreleased
+
+* Added a CI release-doc version consistency check so current README/website
+  install snippets and companion package READMEs stay aligned with package
+  `pubspec.yaml` versions, and documented that companion/core package publishing
+  happens only after release-prep merge with explicit maintainer approval for
+  each tag.
+
 ## 0.8.8
 
 * Updated the default llama.cpp native runtime pin to

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,12 +1,10 @@
-## Unreleased
+## 0.8.8
 
 * Added a CI release-doc version consistency check so current README/website
   install snippets and companion package READMEs stay aligned with package
   `pubspec.yaml` versions, and documented that companion/core package publishing
   happens only after release-prep merge with explicit maintainer approval for
   each tag.
-
-## 0.8.8
 
 * Updated the default llama.cpp native runtime pin to
   `leehack/llamadart-native@b9803`, regenerated matching Dart FFI bindings, refreshed

--- a/README.md
+++ b/README.md
@@ -62,7 +62,7 @@ they ship:
 ```yaml
 dependencies:
   llamadart: ^0.8.8
-  llamadart_llama_cpp_flutter: ^0.0.5 # GGUF / llama.cpp
+  llamadart_llama_cpp_flutter: ^0.0.6 # GGUF / llama.cpp
   llamadart_litert_lm_flutter: ^0.0.2 # .litertlm / LiteRT-LM
 ```
 

--- a/doc/testing_matrix.md
+++ b/doc/testing_matrix.md
@@ -126,9 +126,11 @@ dart run tool/testing/test_matrix.dart --tier release
 For releases that change or newly document Flutter Apple SwiftPM companion
 package versions, include `release-companion-pub-gate` in the release evidence.
 That row requires verifying each referenced companion version on pub.dev before
-tagging the core `vX.Y.Z` release. If a companion version is missing, publish it
-with its package-specific tag, wait for `publish_companion_pubdev.yml`, verify
-the pub.dev version URL, and only then push the core release tag.
+tagging the core `vX.Y.Z` release. If a companion version is missing, merge the
+release-prep PR first, then get explicit maintainer approval before pushing that
+companion's package-specific tag. Wait for `publish_companion_pubdev.yml`, verify
+the pub.dev version URL, and get explicit maintainer approval again before
+pushing the core release tag.
 
 ## Local Model Scenarios
 

--- a/tool/testing/test_matrix.dart
+++ b/tool/testing/test_matrix.dart
@@ -82,6 +82,16 @@ const List<TestMatrixRow> testMatrixRows = <TestMatrixRow>[
     useWhen: 'Docs, README, website, migration, or changelog changes.',
   ),
   TestMatrixRow(
+    id: 'release-doc-version-consistency',
+    tier: 'targeted',
+    mode: 'CI + local',
+    covers:
+        'current README/website install snippets and companion README versions',
+    command: 'dart run tool/testing/verify_release_docs_versions.dart',
+    useWhen:
+        'Release prep, companion package version bumps, or current install docs.',
+  ),
+  TestMatrixRow(
     id: 'examples-tests',
     tier: 'targeted',
     mode: 'local',
@@ -393,9 +403,11 @@ const List<TestMatrixRow> testMatrixRows = <TestMatrixRow>[
     command:
         'Before tagging vX.Y.Z, verify each referenced companion version with '
         'https://pub.dev/api/packages/<package>/versions/<version>. If a '
-        'changed version is missing, push the package tag first, for example '
-        'llamadart_llama_cpp_flutter-v0.0.3, wait for '
-        'publish_companion_pubdev.yml, then tag the core release.',
+        'changed version is missing, merge the release-prep PR first, then get '
+        'explicit approval before pushing the companion package tag, for '
+        'example llamadart_llama_cpp_flutter-v0.0.3. Wait for '
+        'publish_companion_pubdev.yml, verify pub.dev, then get explicit '
+        'approval before pushing the core release tag.',
     useWhen:
         'Any release that changes companion packages or documents companion '
         'package versions.',

--- a/tool/testing/verify_release_docs_versions.dart
+++ b/tool/testing/verify_release_docs_versions.dart
@@ -5,6 +5,10 @@ import 'dart:io';
 // Keep these maps in sync when adding companion packages or moving the current
 // installation docs. Historical website/versioned_docs pages are intentionally
 // excluded so archived release docs can keep their original package versions.
+//
+// During release-prep PRs, current install docs are expected to track the
+// in-repository package versions being prepared. Publishing still happens only
+// after merge and explicit maintainer approval for each release tag.
 const Map<String, String> _packagePubspecs = <String, String>{
   'llamadart': 'pubspec.yaml',
   'llamadart_llama_cpp_flutter':

--- a/tool/testing/verify_release_docs_versions.dart
+++ b/tool/testing/verify_release_docs_versions.dart
@@ -1,0 +1,123 @@
+#!/usr/bin/env dart
+
+import 'dart:io';
+
+const Map<String, String> _packagePubspecs = <String, String>{
+  'llamadart': 'pubspec.yaml',
+  'llamadart_llama_cpp_flutter':
+      'packages/llamadart_llama_cpp_flutter/pubspec.yaml',
+  'llamadart_litert_lm_flutter':
+      'packages/llamadart_litert_lm_flutter/pubspec.yaml',
+};
+
+const Map<String, List<String>> _currentDocDependencies =
+    <String, List<String>>{
+      'README.md': <String>[
+        'llamadart',
+        'llamadart_llama_cpp_flutter',
+        'llamadart_litert_lm_flutter',
+      ],
+      'website/docs/getting-started/installation.md': <String>[
+        'llamadart',
+        'llamadart_llama_cpp_flutter',
+        'llamadart_litert_lm_flutter',
+      ],
+      'packages/llamadart_llama_cpp_flutter/README.md': <String>[
+        'llamadart',
+        'llamadart_llama_cpp_flutter',
+      ],
+      'packages/llamadart_litert_lm_flutter/README.md': <String>[
+        'llamadart',
+        'llamadart_litert_lm_flutter',
+      ],
+    };
+
+final RegExp _dependencyLine = RegExp(
+  r'^\s+(llamadart(?:_[a-z0-9_]+)?):\s+\^([0-9]+\.[0-9]+\.[0-9]+(?:[-+][^\s#]+)?)',
+);
+
+void main() {
+  final versions = <String, String>{
+    for (final entry in _packagePubspecs.entries)
+      entry.key: _readPubspecVersion(entry.value),
+  };
+
+  final errors = <String>[];
+  for (final entry in _currentDocDependencies.entries) {
+    _checkCurrentDoc(
+      path: entry.key,
+      expectedPackages: entry.value,
+      versions: versions,
+      errors: errors,
+    );
+  }
+
+  if (errors.isNotEmpty) {
+    stderr.writeln('Release docs version verification failed:');
+    for (final error in errors) {
+      stderr.writeln('- $error');
+    }
+    exitCode = 1;
+    return;
+  }
+
+  stdout.writeln(
+    'Release docs versions verified: '
+    '${versions.entries.map((entry) => '${entry.key} ${entry.value}').join(', ')}.',
+  );
+}
+
+String _readPubspecVersion(String path) {
+  final lines = File(path).readAsLinesSync();
+  for (final line in lines) {
+    final match = RegExp(r'^version:\s*(\S+)\s*$').firstMatch(line);
+    if (match != null) {
+      return match.group(1)!;
+    }
+  }
+  throw StateError('$path does not contain a top-level version field.');
+}
+
+void _checkCurrentDoc({
+  required String path,
+  required List<String> expectedPackages,
+  required Map<String, String> versions,
+  required List<String> errors,
+}) {
+  final expectedPackageSet = expectedPackages.toSet();
+  final seen = <String>{};
+  final lines = File(path).readAsLinesSync();
+
+  for (var index = 0; index < lines.length; index += 1) {
+    final match = _dependencyLine.firstMatch(lines[index]);
+    if (match == null) {
+      continue;
+    }
+
+    final package = match.group(1)!;
+    if (!expectedPackageSet.contains(package)) {
+      continue;
+    }
+
+    seen.add(package);
+    final documentedVersion = match.group(2)!;
+    final expectedVersion = versions[package]!;
+    if (documentedVersion != expectedVersion) {
+      errors.add(
+        '$path:${index + 1} documents $package ^$documentedVersion, '
+        'but ${packagePubspecPath(package)} is $expectedVersion.',
+      );
+    }
+  }
+
+  for (final package in expectedPackages) {
+    if (!seen.contains(package)) {
+      errors.add(
+        '$path is missing a current dependency snippet for '
+        '$package ^${versions[package]}.',
+      );
+    }
+  }
+}
+
+String packagePubspecPath(String package) => _packagePubspecs[package]!;

--- a/tool/testing/verify_release_docs_versions.dart
+++ b/tool/testing/verify_release_docs_versions.dart
@@ -2,6 +2,9 @@
 
 import 'dart:io';
 
+// Keep these maps in sync when adding companion packages or moving the current
+// installation docs. Historical website/versioned_docs pages are intentionally
+// excluded so archived release docs can keep their original package versions.
 const Map<String, String> _packagePubspecs = <String, String>{
   'llamadart': 'pubspec.yaml',
   'llamadart_llama_cpp_flutter':
@@ -35,21 +38,28 @@ const Map<String, List<String>> _currentDocDependencies =
 final RegExp _dependencyLine = RegExp(
   r'^\s+(llamadart(?:_[a-z0-9_]+)?):\s+\^([0-9]+\.[0-9]+\.[0-9]+(?:[-+][^\s#]+)?)',
 );
+final RegExp _fenceLine = RegExp(r'^\s*```\s*([^\s`]*)?\s*$');
+final RegExp _versionLine = RegExp(r'^version:\s*(\S+)\s*$');
 
 void main() {
-  final versions = <String, String>{
-    for (final entry in _packagePubspecs.entries)
-      entry.key: _readPubspecVersion(entry.value),
-  };
-
   final errors = <String>[];
-  for (final entry in _currentDocDependencies.entries) {
-    _checkCurrentDoc(
-      path: entry.key,
-      expectedPackages: entry.value,
-      versions: versions,
-      errors: errors,
-    );
+  final versions = <String, String>{};
+  for (final entry in _packagePubspecs.entries) {
+    final version = _readPubspecVersion(entry.value, errors);
+    if (version != null) {
+      versions[entry.key] = version;
+    }
+  }
+
+  if (errors.isEmpty) {
+    for (final entry in _currentDocDependencies.entries) {
+      _checkCurrentDoc(
+        path: entry.key,
+        expectedPackages: entry.value,
+        versions: versions,
+        errors: errors,
+      );
+    }
   }
 
   if (errors.isNotEmpty) {
@@ -67,15 +77,21 @@ void main() {
   );
 }
 
-String _readPubspecVersion(String path) {
-  final lines = File(path).readAsLinesSync();
+String? _readPubspecVersion(String path, List<String> errors) {
+  final lines = _readLines(path, errors);
+  if (lines == null) {
+    return null;
+  }
+
   for (final line in lines) {
-    final match = RegExp(r'^version:\s*(\S+)\s*$').firstMatch(line);
+    final match = _versionLine.firstMatch(line);
     if (match != null) {
       return match.group(1)!;
     }
   }
-  throw StateError('$path does not contain a top-level version field.');
+
+  errors.add('$path does not contain a top-level version field.');
+  return null;
 }
 
 void _checkCurrentDoc({
@@ -86,10 +102,33 @@ void _checkCurrentDoc({
 }) {
   final expectedPackageSet = expectedPackages.toSet();
   final seen = <String>{};
-  final lines = File(path).readAsLinesSync();
+  final lines = _readLines(path, errors);
+  if (lines == null) {
+    return;
+  }
 
+  var inFence = false;
+  var inYamlFence = false;
   for (var index = 0; index < lines.length; index += 1) {
-    final match = _dependencyLine.firstMatch(lines[index]);
+    final line = lines[index];
+    final fenceMatch = _fenceLine.firstMatch(line);
+    if (fenceMatch != null) {
+      if (inFence) {
+        inFence = false;
+        inYamlFence = false;
+      } else {
+        final language = fenceMatch.group(1)?.toLowerCase();
+        inFence = true;
+        inYamlFence = language == 'yaml' || language == 'yml';
+      }
+      continue;
+    }
+
+    if (!inYamlFence) {
+      continue;
+    }
+
+    final match = _dependencyLine.firstMatch(line);
     if (match == null) {
       continue;
     }
@@ -113,10 +152,25 @@ void _checkCurrentDoc({
   for (final package in expectedPackages) {
     if (!seen.contains(package)) {
       errors.add(
-        '$path is missing a current dependency snippet for '
+        '$path is missing a current YAML dependency snippet for '
         '$package ^${versions[package]}.',
       );
     }
+  }
+}
+
+List<String>? _readLines(String path, List<String> errors) {
+  final file = File(path);
+  if (!file.existsSync()) {
+    errors.add('$path does not exist.');
+    return null;
+  }
+
+  try {
+    return file.readAsLinesSync();
+  } on FileSystemException catch (error) {
+    errors.add('Could not read $path: ${error.message}.');
+    return null;
   }
 }
 

--- a/website/docs/changelog/recent-releases.md
+++ b/website/docs/changelog/recent-releases.md
@@ -7,6 +7,14 @@ For canonical full release notes, use:
 
 - [`CHANGELOG.md`](https://github.com/leehack/llamadart/blob/main/CHANGELOG.md)
 
+## Unreleased
+
+- Added a CI release-doc version consistency check so current README/website
+  install snippets and companion package READMEs stay aligned with package
+  `pubspec.yaml` versions, and documented that companion/core package publishing
+  happens only after release-prep merge with explicit maintainer approval for
+  each tag.
+
 ## 0.8.8
 
 - Updated the default llama.cpp native runtime pin to

--- a/website/docs/changelog/recent-releases.md
+++ b/website/docs/changelog/recent-releases.md
@@ -7,15 +7,13 @@ For canonical full release notes, use:
 
 - [`CHANGELOG.md`](https://github.com/leehack/llamadart/blob/main/CHANGELOG.md)
 
-## Unreleased
+## 0.8.8
 
 - Added a CI release-doc version consistency check so current README/website
   install snippets and companion package READMEs stay aligned with package
   `pubspec.yaml` versions, and documented that companion/core package publishing
   happens only after release-prep merge with explicit maintainer approval for
   each tag.
-
-## 0.8.8
 
 - Updated the default llama.cpp native runtime pin to
   `leehack/llamadart-native@b9803`, regenerated matching Dart FFI bindings,

--- a/website/docs/getting-started/installation.md
+++ b/website/docs/getting-started/installation.md
@@ -36,7 +36,7 @@ Package Manager, also add the runtime companion packages you need:
 ```yaml
 dependencies:
   llamadart: ^0.8.8
-  llamadart_llama_cpp_flutter: ^0.0.5 # GGUF / llama.cpp
+  llamadart_llama_cpp_flutter: ^0.0.6 # GGUF / llama.cpp
   llamadart_litert_lm_flutter: ^0.0.2 # .litertlm / LiteRT-LM
 ```
 

--- a/website/docs/maintainers/native-and-web-sync.md
+++ b/website/docs/maintainers/native-and-web-sync.md
@@ -83,15 +83,18 @@ version is newly referenced by current install docs:
 
 1. Confirm the `Package.swift` binary targets point at published native GitHub
    release assets and that the pinned checksums match those assets.
-2. After the sync/release-prep PR is merged, tag the companion package version
-   first, using the package-specific tag pattern:
+2. Merge the sync/release-prep PR first. The PR itself must not publish the
+   companion or core package.
+3. After merge, get explicit maintainer approval before pushing each
+   package-specific companion tag:
    `llamadart_llama_cpp_flutter-v{{version}}` or
    `llamadart_litert_lm_flutter-v{{version}}`.
-3. Wait for `publish_companion_pubdev.yml` to pass.
-4. Verify the version URL on pub.dev, for example
+4. Wait for `publish_companion_pubdev.yml` to pass.
+5. Verify the version URL on pub.dev, for example
    `https://pub.dev/api/packages/llamadart_llama_cpp_flutter/versions/{{version}}`.
-5. Only then tag the core `vX.Y.Z` release that documents or depends on that
-   companion version.
+6. Only after the companion version is live, get explicit maintainer approval
+   before pushing the core `vX.Y.Z` release tag that documents or depends on
+   that companion version.
 
 ## Web bridge asset sync flow
 

--- a/website/docs/maintainers/release-workflow.md
+++ b/website/docs/maintainers/release-workflow.md
@@ -14,6 +14,7 @@ dart run tool/testing/test_matrix.dart --tier release
 dart format --output=none --set-exit-if-changed .
 dart analyze
 dart test
+dart run tool/testing/verify_release_docs_versions.dart
 ./tool/docs/build_site.sh
 ./tool/docs/validate_links.sh
 ```
@@ -44,8 +45,12 @@ version alignment:
   version, updates its `pubspec.yaml`, and writes a versioned changelog entry
   that includes the native repo tag.
 - Leave unchanged companion package versions as-is. Companion packages publish
-  from package-specific tags after their first manual pub.dev publish; the
-  workflow skips a companion package version that already exists on pub.dev.
+  only after the release-prep PR is merged and the maintainer explicitly
+  approves pushing the relevant package-specific tag; the workflow skips a
+  companion package version that already exists on pub.dev.
+- Keep current install snippets aligned with root and companion `pubspec.yaml`
+  versions. Run `dart run tool/testing/verify_release_docs_versions.dart` before
+  opening or merging the release-prep PR.
 - Move accumulated `Unreleased` entries into the new version section; remove
   the `Unreleased` heading when it would otherwise be empty. Add it back only
   when the next unreleased change is documented.
@@ -56,6 +61,10 @@ version alignment:
   `llamadart` package.
 
 ## 3. Publish flow
+
+A release-prep PR updates versions, changelogs, docs, and pins only; it must not
+publish companion packages or the core package. Merging release prep is a
+separate approval boundary from every tag push that triggers pub.dev publishing.
 
 Do not tag the core `vX.Y.Z` release until every companion package version named
 in the current install docs is already published on pub.dev. The release
@@ -73,8 +82,9 @@ sequence is:
    curl -fsSL "https://pub.dev/api/packages/$package_name/versions/$package_version"
    ```
 
-3. If a changed companion version is missing, tag and publish that companion
-   package first, for example:
+3. If a changed companion version is missing, first merge the release-prep PR.
+   Then request explicit maintainer approval to push that companion's
+   package-specific tag, for example:
 
    ```bash
    git tag llamadart_llama_cpp_flutter-v0.0.3
@@ -84,7 +94,8 @@ sequence is:
    Wait for `publish_companion_pubdev.yml` to pass, then re-check the pub.dev
    version URL.
 4. Tag `vX.Y.Z` and push the core release tag only after the companion packages
-   referenced by the release docs are resolvable from pub.dev.
+   referenced by the release docs are resolvable from pub.dev, and only after a
+   separate explicit maintainer approval for the core release tag.
 
 Current workflows involved:
 


### PR DESCRIPTION
## Summary
- Updates the current README and website install snippets to the release-prep versions for `llamadart` 0.8.8 and `llamadart_llama_cpp_flutter` 0.0.6.
- Adds `tool/testing/verify_release_docs_versions.dart` and wires it into CI so release-prep current install snippets plus companion package READMEs must match the in-repository package `pubspec.yaml` versions being prepared.
- Documents the release boundary: release-prep PRs do not publish; after merge, companion package tags and the core `vX.Y.Z` tag each require explicit maintainer approval.
- Leaves historical versioned docs unchanged.

## Context
This follows up on the Copilot review comments from #245 that found stale companion package snippets after the 0.8.8 / companion 0.0.6 release prep. The guard intentionally validates release-prep docs against the repository versions, not pub.dev latest; publishing still happens only after this PR is merged and explicitly approved.

## Test Plan
- [x] `dart format tool/testing/verify_release_docs_versions.dart tool/testing/test_matrix.dart`
- [x] `dart run tool/testing/verify_release_docs_versions.dart`
- [x] `dart analyze tool/testing/verify_release_docs_versions.dart tool/testing/test_matrix.dart`
- [x] `dart run tool/testing/test_matrix.dart --tier targeted | grep -F 'release-doc-version-consistency'`
- [x] `git diff --check`
- [x] `go run github.com/rhysd/actionlint/cmd/actionlint@latest -color=false .github/workflows/ci.yml .github/workflows/sync_native_bindings.yml`
- [x] `npm run build` (from `website/`)
