### PR TITLE
chore: restore pub score compatibility

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,14 @@
+## 0.8.9
+
+* Broadened the `hooks` dependency constraint to support both the existing
+  build-hooks package family and the latest stable release, restoring the
+  pub.dev dependency freshness score without breaking downstream packages that
+  still resolve `hooks` 1.x.
+
+* Made web-safe backend stubs the default conditional import/export targets,
+  preserving native `dart:io` selection while avoiding false WASM compatibility
+  deductions in pub.dev analysis.
+
 ## 0.8.8
 
 * Added a CI release-doc version consistency check so current README/website

--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ JavaScript runtime.
 
 ```yaml
 dependencies:
-  llamadart: ^0.8.8
+  llamadart: ^0.8.9
 ```
 
 Flutter iOS/macOS apps that want Swift Package Manager-linked Apple
@@ -61,7 +61,7 @@ they ship:
 
 ```yaml
 dependencies:
-  llamadart: ^0.8.8
+  llamadart: ^0.8.9
   llamadart_llama_cpp_flutter: ^0.0.6 # GGUF / llama.cpp
   llamadart_litert_lm_flutter: ^0.0.2 # .litertlm / LiteRT-LM
 ```

--- a/example/chat_app/pubspec.lock
+++ b/example/chat_app/pubspec.lock
@@ -349,7 +349,7 @@ packages:
       path: "../.."
       relative: true
     source: path
-    version: "0.8.8"
+    version: "0.8.9"
   logging:
     dependency: transitive
     description:

--- a/lib/llamadart.dart
+++ b/lib/llamadart.dart
@@ -105,5 +105,5 @@ export 'src/experimental/litert_lm/litert_lm_benchmark_stub.dart'
     if (dart.library.io) 'src/experimental/litert_lm/litert_lm_benchmark.dart';
 
 // Bindings - conditional export for web/native
-export 'src/backends/llama_cpp/bindings.dart'
-    if (dart.library.js_interop) 'src/backends/llama_cpp/bindings_stub.dart';
+export 'src/backends/llama_cpp/bindings_stub.dart'
+    if (dart.library.io) 'src/backends/llama_cpp/bindings.dart';

--- a/lib/src/backends/backend.dart
+++ b/lib/src/backends/backend.dart
@@ -8,8 +8,7 @@ import '../core/models/config/gpu_device_info.dart';
 import '../core/models/config/log_level.dart';
 import '../core/models/tools/tool_definition.dart';
 
-import 'native/native_backend.dart'
-    if (dart.library.js_interop) 'web/web_backend.dart';
+import 'web/web_backend.dart' if (dart.library.io) 'native/native_backend.dart';
 
 /// Platform-agnostic interface for local model inference.
 abstract class LlamaBackend {

--- a/lib/src/backends/llama_cpp/bindings_stub.dart
+++ b/lib/src/backends/llama_cpp/bindings_stub.dart
@@ -1,3 +1,23 @@
 // coverage:ignore-file
-// Stub file for web platform where dart:ffi is not available.
-// This file intentionally exposes nothing or non-FFI members.
+// ignore_for_file: public_member_api_docs, non_constant_identifier_names
+// Stub file for web/WASM analysis where dart:ffi is not available.
+//
+// Keep these signatures free of dart:ffi types so pub.dev/pana can analyze the
+// default conditional-export branch without selecting native bindings. The VM
+// still selects bindings.dart through the dart.library.io conditional export.
+
+void llama_backend_init() => throw UnsupportedError(
+  'llama_backend_init is only available on native platforms.',
+);
+
+void llama_backend_free() => throw UnsupportedError(
+  'llama_backend_free is only available on native platforms.',
+);
+
+dynamic llama_print_system_info() => throw UnsupportedError(
+  'llama_print_system_info is only available on native platforms.',
+);
+
+void llama_dart_set_log_level(int level) => throw UnsupportedError(
+  'llama_dart_set_log_level is only available on native platforms.',
+);

--- a/packages/llamadart_litert_lm_flutter/README.md
+++ b/packages/llamadart_litert_lm_flutter/README.md
@@ -10,7 +10,7 @@ core package's native-assets fallback.
 
 ```yaml
 dependencies:
-  llamadart: ^0.8.8
+  llamadart: ^0.8.9
   llamadart_litert_lm_flutter: ^0.0.2
 ```
 

--- a/packages/llamadart_llama_cpp_flutter/README.md
+++ b/packages/llamadart_llama_cpp_flutter/README.md
@@ -9,7 +9,7 @@ core package's native-assets fallback.
 
 ```yaml
 dependencies:
-  llamadart: ^0.8.8
+  llamadart: ^0.8.9
   llamadart_llama_cpp_flutter: ^0.0.6
 ```
 

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: llamadart
 description: Dart and Flutter local LLM inference with llama.cpp GGUF and LiteRT-LM across native platforms and web.
-version: 0.8.8
+version: 0.8.9
 homepage: https://github.com/leehack/llamadart
 repository: https://github.com/leehack/llamadart
 issue_tracker: https://github.com/leehack/llamadart/issues
@@ -30,7 +30,7 @@ dependencies:
   crypto: ^3.0.0
   web: ^1.0.0
   code_assets: ^1.0.0
-  hooks: ^1.0.0
+  hooks: '>=1.0.0 <3.0.0'
   logging: ^1.3.0
   dinja: ^1.0.0
 

--- a/website/docs/changelog/recent-releases.md
+++ b/website/docs/changelog/recent-releases.md
@@ -7,6 +7,17 @@ For canonical full release notes, use:
 
 - [`CHANGELOG.md`](https://github.com/leehack/llamadart/blob/main/CHANGELOG.md)
 
+## 0.8.9
+
+- Broadened the `hooks` dependency constraint to support both the existing
+  build-hooks package family and the latest stable release, restoring the
+  pub.dev dependency freshness score without breaking downstream packages that
+  still resolve `hooks` 1.x.
+
+- Made web-safe backend stubs the default conditional import/export targets,
+  preserving native `dart:io` selection while avoiding false WASM compatibility
+  deductions in pub.dev analysis.
+
 ## 0.8.8
 
 - Added a CI release-doc version consistency check so current README/website

--- a/website/docs/getting-started/installation.md
+++ b/website/docs/getting-started/installation.md
@@ -27,7 +27,7 @@ In Xcode, set `IPHONEOS_DEPLOYMENT_TARGET = 16.4` or
 
 ```yaml
 dependencies:
-  llamadart: ^0.8.8
+  llamadart: ^0.8.9
 ```
 
 For Flutter iOS/macOS apps that should link Apple XCFrameworks through Swift
@@ -35,7 +35,7 @@ Package Manager, also add the runtime companion packages you need:
 
 ```yaml
 dependencies:
-  llamadart: ^0.8.8
+  llamadart: ^0.8.9
   llamadart_llama_cpp_flutter: ^0.0.6 # GGUF / llama.cpp
   llamadart_litert_lm_flutter: ^0.0.2 # .litertlm / LiteRT-LM
 ```


### PR DESCRIPTION
## Summary
- prepare `llamadart` `0.8.9` for release after merge
- broaden the `hooks` dependency constraint so the package supports both existing `hooks` 1.x consumers and the latest `hooks` 2.x release
- make web-safe backend/stub targets the default conditional import/export targets, while preserving native `dart:io` selection at runtime
- add non-FFI analyzer stubs for native binding helpers so full-repo analysis still sees the exported symbols without selecting `dart:ffi`
- promote the pub.dev score compatibility notes into the `0.8.9` changelog/recent-release docs and update current install snippets to `^0.8.9`

## Release readiness
- pub.dev latest is `0.8.8`; target `0.8.9` is not published yet
- remote/local `v0.8.9` tag is absent
- companion package install snippets remain aligned with published companion versions:
  - `llamadart_llama_cpp_flutter` `0.0.6`
  - `llamadart_litert_lm_flutter` `0.0.2`
- after merge, publishing still requires explicit approval for the `v0.8.9` tag/publish handoff

## Verification
- `flutter pub get`
- `(cd example/basic_app && flutter pub get)`
- `(cd example/chat_app && flutter pub get)`
- `(cd example/llamadart_cli && dart pub get)`
- `(cd example/llamadart_server && dart pub get)`
- `(cd example/tui_coding_agent && dart pub get)`
- `dart format --output=none --set-exit-if-changed .`
- `git diff --check`
- `dart analyze` (exit 0; existing info-level lints only)
- `dart test --reporter compact` (1799 passed, 69 skipped)
- `dart run tool/testing/verify_release_docs_versions.dart`
- `dart run tool/testing/test_matrix.dart --tier targeted | grep -F release-doc-version-consistency`
- `(cd website && npm ci)`
- `./tool/docs/build_site.sh`
- `./tool/docs/validate_links.sh`
- WASM smoke consumer: `dart compile wasm main.dart -o main.wasm`
- `pana 0.23.13`: 160/160
- `dart pub publish --dry-run`: 0 warnings

Notes: website `npm ci` reports existing npmrc deprecation warnings and audit findings, but docs build/link validation passes.