### PR TITLE
chore: prepare 0.8.10 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-## Unreleased
+## 0.8.10
 
 * **Potentially breaking behavior change:** native model cache defaults changed
   without breaking Dart source compatibility. `DefaultModelDownloadManager()` now

--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ JavaScript runtime.
 
 ```yaml
 dependencies:
-  llamadart: ^0.8.9
+  llamadart: ^0.8.10
 ```
 
 Flutter iOS/macOS apps that want Swift Package Manager-linked Apple
@@ -61,7 +61,7 @@ they ship:
 
 ```yaml
 dependencies:
-  llamadart: ^0.8.9
+  llamadart: ^0.8.10
   llamadart_llama_cpp_flutter: ^0.0.6 # GGUF / llama.cpp
   llamadart_litert_lm_flutter: ^0.0.2 # .litertlm / LiteRT-LM
 ```

--- a/example/chat_app/pubspec.lock
+++ b/example/chat_app/pubspec.lock
@@ -349,7 +349,7 @@ packages:
       path: "../.."
       relative: true
     source: path
-    version: "0.8.9"
+    version: "0.8.10"
   logging:
     dependency: transitive
     description:

--- a/packages/llamadart_litert_lm_flutter/README.md
+++ b/packages/llamadart_litert_lm_flutter/README.md
@@ -10,7 +10,7 @@ core package's native-assets fallback.
 
 ```yaml
 dependencies:
-  llamadart: ^0.8.9
+  llamadart: ^0.8.10
   llamadart_litert_lm_flutter: ^0.0.2
 ```
 

--- a/packages/llamadart_llama_cpp_flutter/README.md
+++ b/packages/llamadart_llama_cpp_flutter/README.md
@@ -9,7 +9,7 @@ core package's native-assets fallback.
 
 ```yaml
 dependencies:
-  llamadart: ^0.8.9
+  llamadart: ^0.8.10
   llamadart_llama_cpp_flutter: ^0.0.6
 ```
 

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: llamadart
 description: Dart and Flutter local LLM inference with llama.cpp GGUF and LiteRT-LM across native platforms and web.
-version: 0.8.9
+version: 0.8.10
 homepage: https://github.com/leehack/llamadart
 repository: https://github.com/leehack/llamadart
 issue_tracker: https://github.com/leehack/llamadart/issues

--- a/website/docs/changelog/recent-releases.md
+++ b/website/docs/changelog/recent-releases.md
@@ -7,7 +7,7 @@ For canonical full release notes, use:
 
 - [`CHANGELOG.md`](https://github.com/leehack/llamadart/blob/main/CHANGELOG.md)
 
-## Unreleased
+## 0.8.10
 
 - **Potentially breaking behavior change:** native model cache defaults changed
   without breaking Dart source compatibility. `DefaultModelDownloadManager()` now

--- a/website/docs/getting-started/installation.md
+++ b/website/docs/getting-started/installation.md
@@ -27,7 +27,7 @@ In Xcode, set `IPHONEOS_DEPLOYMENT_TARGET = 16.4` or
 
 ```yaml
 dependencies:
-  llamadart: ^0.8.9
+  llamadart: ^0.8.10
 ```
 
 For Flutter iOS/macOS apps that should link Apple XCFrameworks through Swift
@@ -35,7 +35,7 @@ Package Manager, also add the runtime companion packages you need:
 
 ```yaml
 dependencies:
-  llamadart: ^0.8.9
+  llamadart: ^0.8.10
   llamadart_llama_cpp_flutter: ^0.0.6 # GGUF / llama.cpp
   llamadart_litert_lm_flutter: ^0.0.2 # .litertlm / LiteRT-LM
 ```


### PR DESCRIPTION
## Summary
- Prepare the core `llamadart` package for `0.8.10`.
- Promote the current cache-default release notes from `Unreleased` to `0.8.10` in `CHANGELOG.md` and the current docs recent releases page.
- Align current README, website installation docs, companion READMEs, and the chat app path lockfile with the in-repo `0.8.10` prep version.

## Release scope
- Core package version: `llamadart` `0.8.10`.
- Companion package versions remain unchanged: `llamadart_llama_cpp_flutter` `0.0.6`, `llamadart_litert_lm_flutter` `0.0.2`.
- No publish/tag action is included in this PR; companion/core publishing remains a separate post-merge approval boundary.
- Preflight checked pub.dev latest versions before prep: `llamadart` `0.8.9`, `llamadart_llama_cpp_flutter` `0.0.6`, `llamadart_litert_lm_flutter` `0.0.2`.

## Test Plan
- [x] `dart pub get`
- [x] `(cd example/chat_app && flutter pub get)`; kept only the root path package lockfile version change
- [x] `dart format --output=none --set-exit-if-changed .`
- [x] `dart run tool/testing/verify_release_docs_versions.dart`
- [x] `dart run tool/testing/test_matrix.dart --tier targeted | grep -F release-doc-version-consistency`
- [x] `dart analyze` (exit 0; reports existing info-level lints only)
- [x] `dart test -p vm -j 1 --exclude-tags local-only`
- [x] `dart test -p chrome --exclude-tags local-only`
- [x] `./tool/docs/build_site.sh`
- [x] `./tool/docs/validate_links.sh`
- [x] `dart pub publish --dry-run`
- [x] `git diff --check origin/main...HEAD`
