### PR TITLE
docs: restore model cache release note history

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,12 +8,11 @@
   of throwing. Apps or tests that asserted the old temp path or mobile exception
   should pass an explicit cache directory or follow `MIGRATION.md`.
 
-* Added `DefaultModelDownloadManager.auto(...)` plus explicit model cache root
-  constructors for shared desktop caches, app-private mobile caches,
-  user-selected model libraries, and App Group containers. `auto(...)` now uses
-  platform-specific or generic app-private directories on Android/iOS when
-  supplied, and otherwise falls back to a best-effort temporary/cache directory
-  instead of requiring application `if` branches for simple cross-platform code.
+* Added optional `androidAppPrivateCacheDirectory` and
+  `iosAppPrivateCacheDirectory` arguments to
+  `DefaultModelDownloadManager.auto(...)` so apps can provide platform-specific
+  mobile cache roots without constructor-level `Platform.isAndroid` /
+  `Platform.isIOS` branching.
 * Updated the default native `DefaultModelDownloadManager()` constructor to use
   the per-user shared model cache on desktop/server platforms and the mobile
   app-private cache fallback, so plain `LlamaEngine(...)` remote source loads use
@@ -43,6 +42,12 @@
   `leehack/llamadart-native@b9803`, regenerated matching Dart FFI bindings, refreshed
   the `llamadart_llama_cpp_flutter` Apple SwiftPM checksum, and
   aligned current README/website native override docs.
+
+* Added `DefaultModelDownloadManager.auto(...)` plus explicit model cache root
+  constructors for shared desktop caches, app-private mobile caches,
+  user-selected model libraries, and App Group containers. Implicit shared cache
+  resolution now fails loudly on mobile and web where the OS cannot provide a
+  hidden cross-developer model folder.
 
 ## 0.8.7
 

--- a/website/docs/changelog/recent-releases.md
+++ b/website/docs/changelog/recent-releases.md
@@ -17,12 +17,11 @@ For canonical full release notes, use:
   of throwing. Apps or tests that asserted the old temp path or mobile exception
   should pass an explicit cache directory or follow `MIGRATION.md`.
 
-- Added `DefaultModelDownloadManager.auto(...)` plus explicit model cache root
-  constructors for shared desktop caches, app-private mobile caches,
-  user-selected model libraries, and App Group containers. `auto(...)` now uses
-  platform-specific or generic app-private directories on Android/iOS when
-  supplied, and otherwise falls back to a best-effort temporary/cache directory
-  instead of requiring application `if` branches for simple cross-platform code.
+- Added optional `androidAppPrivateCacheDirectory` and
+  `iosAppPrivateCacheDirectory` arguments to
+  `DefaultModelDownloadManager.auto(...)` so apps can provide platform-specific
+  mobile cache roots without constructor-level `Platform.isAndroid` /
+  `Platform.isIOS` branching.
 - Updated the default native `DefaultModelDownloadManager()` constructor to use
   the per-user shared model cache on desktop/server platforms and the mobile
   app-private cache fallback, so plain `LlamaEngine(...)` remote source loads use
@@ -52,6 +51,12 @@ For canonical full release notes, use:
   `leehack/llamadart-native@b9803`, regenerated matching Dart FFI bindings,
   refreshed the `llamadart_llama_cpp_flutter` Apple SwiftPM checksum, and
   aligned current README/website native override docs.
+
+- Added `DefaultModelDownloadManager.auto(...)` plus explicit model cache root
+  constructors for shared desktop caches, app-private mobile caches,
+  user-selected model libraries, and App Group containers. Implicit shared cache
+  resolution now fails loudly on mobile and web where the OS cannot provide a
+  hidden cross-developer model folder.
 
 ## 0.8.7
 


### PR DESCRIPTION
## Summary
- Restore the historical `DefaultModelDownloadManager.auto(...)` / explicit cache-root constructor release note to the `0.8.8` section.
- Keep the PR #248 `Unreleased` notes focused on the actual new changes: platform default-path behavior and the Android/iOS-specific optional `auto(...)` arguments.
- Mirror the same correction in the website recent releases page.

## Why
A late independent review of PR #248 correctly noticed that the existing 0.8.8 API-addition note had been moved into `Unreleased`. The merged PR already fixed runtime/docs behavior, but the release-note history should remain accurate.

## Test Plan
- [x] `git diff --check`
- [x] `npm ci && npm run build` in `website/`