### PR TITLE
docs: use hf model sources in beginner examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -178,21 +178,41 @@ archive, at an extracted bundle directory, or at a directory containing
 
 ### 5. Minimal first model load
 
+Start with a model source instead of a machine-specific file path. On native
+Dart/Flutter targets, `loadModelSource(...)` downloads and caches the file on
+first run, then reuses the cached model on later runs.
+
 ```dart
+import 'dart:io';
+
 import 'package:llamadart/llamadart.dart';
 
 Future<void> main() async {
   final engine = LlamaEngine(LlamaBackend());
   try {
-    await engine.loadModel('path/to/model.gguf');
-    await for (final token in engine.generate('Hello')) {
-      print(token);
+    await engine.loadModelSource(
+      ModelSource.parse(
+        'hf://unsloth/SmolLM2-135M-Instruct-GGUF/'
+        'SmolLM2-135M-Instruct-Q2_K.gguf',
+      ),
+      modelParams: const ModelParams(contextSize: 1024, gpuLayers: 0),
+    );
+
+    await for (final token in engine.generate(
+      'Rewrite professionally: i need this done asap',
+      params: const GenerationParams(maxTokens: 64, temp: 0.2),
+    )) {
+      stdout.write(token);
     }
   } finally {
     await engine.dispose();
   }
 }
 ```
+
+The SmolLM2 GGUF above is a small copy/paste smoke-test model. For product demos,
+pre-cache the source before presenting so the code still shows the Hugging Face
+source while the live path uses the local cache rather than conference Wi-Fi.
 
 For LiteRT-LM bundles, use the same high-level API and pass a `.litertlm`
 path or URL. Native callers load local bundle paths; web callers load

--- a/README.md
+++ b/README.md
@@ -183,8 +183,6 @@ Dart/Flutter targets, `loadModelSource(...)` downloads and caches the file on
 first run, then reuses the cached model on later runs.
 
 ```dart
-import 'dart:io';
-
 import 'package:llamadart/llamadart.dart';
 
 Future<void> main() async {
@@ -198,12 +196,14 @@ Future<void> main() async {
       modelParams: const ModelParams(contextSize: 1024, gpuLayers: 0),
     );
 
+    final output = StringBuffer();
     await for (final token in engine.generate(
       'Rewrite professionally: i need this done asap',
       params: const GenerationParams(maxTokens: 64, temp: 0.2),
     )) {
-      stdout.write(token);
+      output.write(token);
     }
+    print(output.toString());
   } finally {
     await engine.dispose();
   }

--- a/README.md
+++ b/README.md
@@ -196,14 +196,16 @@ Future<void> main() async {
       modelParams: const ModelParams(contextSize: 1024, gpuLayers: 0),
     );
 
-    final output = StringBuffer();
-    await for (final token in engine.generate(
-      'Rewrite professionally: i need this done asap',
+    final output = await engine.create(
+      const [
+        LlamaChatMessage.fromText(
+          role: LlamaChatRole.user,
+          text: 'Rewrite professionally: i need this done asap',
+        ),
+      ],
       params: const GenerationParams(maxTokens: 64, temp: 0.2),
-    )) {
-      output.write(token);
-    }
-    print(output.toString());
+    ).map((chunk) => chunk.choices.first.delta.content ?? '').join();
+    print(output);
   } finally {
     await engine.dispose();
   }
@@ -257,8 +259,13 @@ await engine.loadModel(
   ),
 );
 
-await for (final token in engine.generate(
-  'Explain local inference in one paragraph.',
+await for (final chunk in engine.create(
+  const [
+    LlamaChatMessage.fromText(
+      role: LlamaChatRole.user,
+      text: 'Explain local inference in one paragraph.',
+    ),
+  ],
   params: const GenerationParams(
     maxTokens: 128,
     speculativeDecodingConfig: SpeculativeDecodingConfig.mtp(
@@ -266,7 +273,8 @@ await for (final token in engine.generate(
     ),
   ),
 )) {
-  stdout.write(token);
+  final text = chunk.choices.first.delta.content;
+  if (text != null) print(text);
 }
 ```
 
@@ -910,10 +918,16 @@ void main() async {
     // Initialize with a local GGUF model
     await engine.loadModel('path/to/model.gguf');
 
-    // Generate text (streaming)
-    await for (final token in engine.generate('The capital of France is')) {
-      print(token);
-    }
+    // Generate text with chat-template aware completion
+    final response = await engine.create(
+      const [
+        LlamaChatMessage.fromText(
+          role: LlamaChatRole.user,
+          text: 'What is the capital of France?',
+        ),
+      ],
+    ).map((chunk) => chunk.choices.first.delta.content ?? '').join();
+    print(response);
   } finally {
     // CRITICAL: Always dispose the engine to release native resources
     await engine.dispose();

--- a/README.md
+++ b/README.md
@@ -881,6 +881,18 @@ Core abstractions in this package:
 - Optional runtime diagnostics are exposed through `LlamaEngine` helpers such as `getBackendName()`, `getAvailableBackends()`, and `getResolvedGpuLayers()` when supported by the active backend.
 - `LlamaEngine.listGpuDevices()` enumerates GPU-class devices (backend, per-backend `mainGpu` index, name, description, device id, type, free/total memory) for offload selection. By default it inspects only already-registered backends; pass `probeBackends: [...]` to opt into loading specific backend modules first. Web/WebGPU return an empty list.
 
+Generation API selection:
+
+| API | Template-aware? | Keeps history? | Use when |
+| --- | --- | --- | --- |
+| `engine.generate(prompt)` | No | No | You already have a final raw prompt, or you are benchmarking, testing prefix-cache/state flows, or doing low-level runtime work. |
+| `engine.create(messages)` | Yes | No | You have the complete `List<LlamaChatMessage>` for each request, such as a one-shot completion or an OpenAI-compatible server. |
+| `ChatSession.create(parts)` | Yes | Yes | You are building a multi-turn chat UI/CLI and want the SDK to store user/assistant turns, apply the system prompt, and trim history as context grows. |
+
+Beginner examples use `engine.create(...)` so chat templates are applied without
+introducing hidden state. Use `ChatSession` for real multi-turn chat apps unless
+your app already owns the full transcript.
+
 ---
 ## ⚠️ Breaking Changes in 0.6.x
 

--- a/example/basic_app/README.md
+++ b/example/basic_app/README.md
@@ -6,7 +6,7 @@ A clean, organized CLI application demonstrating the capabilities of the `llamad
 
 - **Interactive Mode**: Have a back-and-forth conversation with an LLM in your terminal.
 - **Single Response Mode**: Pass a prompt as an argument for quick tasks.
-- **Automatic Model Management**: Automatically downloads models from Hugging Face if a URL is provided.
+- **Automatic Model Management**: Accepts local paths, HTTP(S) URLs, and `hf://` Hugging Face model sources, then resolves remote sources through the package-managed cache.
 - **Platform Cache Defaults**: Remote model URLs use `DefaultModelDownloadManager`, so desktop/server runs share the per-user `llamadart` model cache while explicit local paths are loaded directly.
 - **Backend Optimization**: Defaults to GPU acceleration (Metal/Vulkan) when available.
 - **LoRA Adapters**: Load one or more LoRA adapters with repeated `--lora` flags.
@@ -28,17 +28,25 @@ dart pub get
 
 ### 2. Run Interactive Mode (Default)
 
-This will download a small default model (Qwen 2.5 0.5B) if not already present and start a chat session.
+This uses a default Hugging Face source, downloads it on first run, and reuses
+the package-managed cache on later runs.
 
 ```bash
 dart run
 ```
 
+Default model source:
+
+```text
+hf://unsloth/Qwen3.5-0.8B-GGUF/Qwen3.5-0.8B-Q4_K_M.gguf
+```
+
 ### 3. Run with a Specific Model
 
-You can provide a local path or a Hugging Face GGUF URL.
+You can provide a local path, an HTTP(S) URL, or an `hf://` Hugging Face source.
 
 ```bash
+dart run -- -m "hf://unsloth/SmolLM2-135M-Instruct-GGUF/SmolLM2-135M-Instruct-Q2_K.gguf"
 dart run -- -m "path/to/model.gguf"
 ```
 
@@ -159,7 +167,7 @@ How to translate result values:
 
 ## Options
 
-- `-m, --model`: Path or URL to the GGUF model file.
+- `-m, --model`: Local path, HTTP(S) URL, or `hf://` Hugging Face source for a GGUF model.
 - `-l, --lora`: Path to LoRA adapter(s). Can be set multiple times.
 - `-p, --prompt`: Prompt for single response mode.
 - `-i, --interactive`: Start in interactive mode (default if no prompt provided).

--- a/example/basic_app/bin/llamadart_basic_example.dart
+++ b/example/basic_app/bin/llamadart_basic_example.dart
@@ -4,16 +4,17 @@ import 'package:llamadart/llamadart.dart';
 import 'package:llamadart_basic_example/services/model_service.dart';
 import 'package:llamadart_basic_example/services/llama_service.dart';
 
-const defaultModelUrl =
-    'https://huggingface.co/unsloth/Qwen3.5-0.8B-GGUF/resolve/main/Qwen3.5-0.8B-Q4_K_M.gguf?download=true';
+const defaultModelSource =
+    'hf://unsloth/Qwen3.5-0.8B-GGUF/Qwen3.5-0.8B-Q4_K_M.gguf';
 
 void main(List<String> arguments) async {
   final parser = ArgParser()
     ..addOption(
       'model',
       abbr: 'm',
-      help: 'Path or URL to the GGUF model file.',
-      defaultsTo: defaultModelUrl,
+      help:
+          'Local path, HTTP(S) URL, or hf:// Hugging Face source for a GGUF model.',
+      defaultsTo: defaultModelSource,
     )
     ..addMultiOption(
       'lora',

--- a/example/basic_app/lib/services/model_service.dart
+++ b/example/basic_app/lib/services/model_service.dart
@@ -16,8 +16,10 @@ class ModelService {
   String get cacheDir => _downloadManager.defaultCacheDirectory;
 
   /// Ensures the model at [urlOrPath] is available locally.
-  /// If it's a URL, it downloads it through the package-managed model cache.
-  /// If it's a path, it verifies existence.
+  ///
+  /// Supports local filesystem paths, HTTP(S) URLs, and `hf://` Hugging Face
+  /// sources. Remote sources are resolved through the package-managed model
+  /// cache and returned as local files for native loading.
   Future<File> ensureModel(String urlOrPath) async {
     final source = ModelSource.parse(urlOrPath);
     if (source.isLocal) {

--- a/website/docs/getting-started/first-chat-session.md
+++ b/website/docs/getting-started/first-chat-session.md
@@ -61,5 +61,12 @@ session.reset(keepSystemPrompt: false);
 
 ## When to use engine.create instead
 
-Use `engine.create(...)` directly if your application already owns full message
-history (for example an API server that receives complete request payloads).
+Use `engine.create(...)` directly if your application already owns the full
+message history. Common examples are OpenAI-compatible API servers, stateless
+HTTP handlers, or apps that persist/edit transcripts themselves.
+
+With `engine.create(...)`, you pass the complete `List<LlamaChatMessage>` for
+every request and you must append the assistant response yourself before the
+next turn. With `ChatSession`, each `session.create(...)` call takes only the new
+user content parts; the session appends user and assistant messages to its
+history for you.

--- a/website/docs/getting-started/first-chat-session.md
+++ b/website/docs/getting-started/first-chat-session.md
@@ -13,25 +13,37 @@ history management.
 
 ## Minimal chat session
 
+This example also starts from a Hugging Face source so new users can paste the
+code without first inventing a local model path. The first run downloads and
+caches the model; later runs reuse the cached GGUF.
+
 ```dart
 import 'package:llamadart/llamadart.dart';
 
 Future<void> main() async {
   final engine = LlamaEngine(LlamaBackend());
-  await engine.loadModel('path/to/model.gguf');
+  try {
+    await engine.loadModelSource(
+      ModelSource.parse(
+        'hf://unsloth/SmolLM2-135M-Instruct-GGUF/'
+        'SmolLM2-135M-Instruct-Q2_K.gguf',
+      ),
+      modelParams: const ModelParams(contextSize: 1024, gpuLayers: 0),
+    );
 
-  final session = ChatSession(engine, systemPrompt: 'You are concise.');
+    final session = ChatSession(engine, systemPrompt: 'You are concise.');
 
-  await for (final chunk in session.create([
-    const LlamaTextContent('What is quantization in one sentence?'),
-  ])) {
-    final text = chunk.choices.first.delta.content;
-    if (text != null) {
-      print(text);
+    await for (final chunk in session.create([
+      const LlamaTextContent('What is quantization in one sentence?'),
+    ])) {
+      final text = chunk.choices.first.delta.content;
+      if (text != null) {
+        print(text);
+      }
     }
+  } finally {
+    await engine.dispose();
   }
-
-  await engine.dispose();
 }
 ```
 

--- a/website/docs/getting-started/quickstart.md
+++ b/website/docs/getting-started/quickstart.md
@@ -33,14 +33,16 @@ Future<void> main() async {
       },
     );
 
-    final output = StringBuffer();
-    await for (final String token in engine.generate(
-      'Rewrite professionally: i need this done asap',
+    final output = await engine.create(
+      const [
+        LlamaChatMessage.fromText(
+          role: LlamaChatRole.user,
+          text: 'Rewrite professionally: i need this done asap',
+        ),
+      ],
       params: const GenerationParams(maxTokens: 64, temp: 0.2),
-    )) {
-      output.write(token);
-    }
-    print(output.toString());
+    ).map((chunk) => chunk.choices.first.delta.content ?? '').join();
+    print(output);
   } finally {
     await engine.dispose();
   }

--- a/website/docs/getting-started/quickstart.md
+++ b/website/docs/getting-started/quickstart.md
@@ -49,6 +49,12 @@ Future<void> main() async {
 }
 ```
 
+This example uses `engine.create(...)`, the stateless chat-completion API: the
+model's chat template is applied, but no conversation history is stored between
+calls. Use [First Chat Session](./first-chat-session) when you want automatic
+multi-turn history, or [Generation and Streaming](../guides/generation-and-streaming)
+when you need to choose between raw prompts, stateless chat, and stateful chat.
+
 The small SmolLM2 GGUF above is intended for copy/paste smoke tests. For a live
 conference demo, run it once beforehand so the Hugging Face source remains in
 the code while the actual presentation path uses the local cache instead of

--- a/website/docs/getting-started/quickstart.md
+++ b/website/docs/getting-started/quickstart.md
@@ -13,8 +13,6 @@ stores it in the package-managed model cache, and reuses the cached file on
 later runs.
 
 ```dart
-import 'dart:io';
-
 import 'package:llamadart/llamadart.dart';
 
 Future<void> main() async {
@@ -35,12 +33,14 @@ Future<void> main() async {
       },
     );
 
+    final output = StringBuffer();
     await for (final String token in engine.generate(
       'Rewrite professionally: i need this done asap',
       params: const GenerationParams(maxTokens: 64, temp: 0.2),
     )) {
-      stdout.write(token);
+      output.write(token);
     }
+    print(output.toString());
   } finally {
     await engine.dispose();
   }

--- a/website/docs/getting-started/quickstart.md
+++ b/website/docs/getting-started/quickstart.md
@@ -7,25 +7,50 @@ This quickstart uses the core `LlamaEngine` API.
 
 ## Minimal generation example
 
+Start with a model source instead of a machine-specific file path. On native
+Dart/Flutter targets, `loadModelSource(...)` downloads the file on first run,
+stores it in the package-managed model cache, and reuses the cached file on
+later runs.
+
 ```dart
+import 'dart:io';
+
 import 'package:llamadart/llamadart.dart';
 
 Future<void> main() async {
   final LlamaEngine engine = LlamaEngine(LlamaBackend());
 
   try {
-    await engine.loadModel('path/to/model.gguf');
+    await engine.loadModelSource(
+      ModelSource.parse(
+        'hf://unsloth/SmolLM2-135M-Instruct-GGUF/'
+        'SmolLM2-135M-Instruct-Q2_K.gguf',
+      ),
+      modelParams: const ModelParams(contextSize: 1024, gpuLayers: 0),
+      onProgress: (progress) {
+        final fraction = progress.fraction;
+        if (fraction != null) {
+          print('download ${(fraction * 100).toStringAsFixed(1)}%');
+        }
+      },
+    );
 
     await for (final String token in engine.generate(
-      'Write one short sentence about local inference.',
+      'Rewrite professionally: i need this done asap',
+      params: const GenerationParams(maxTokens: 64, temp: 0.2),
     )) {
-      print(token);
+      stdout.write(token);
     }
   } finally {
     await engine.dispose();
   }
 }
 ```
+
+The small SmolLM2 GGUF above is intended for copy/paste smoke tests. For a live
+conference demo, run it once beforehand so the Hugging Face source remains in
+the code while the actual presentation path uses the local cache instead of
+conference Wi-Fi.
 
 LiteRT-LM `.litertlm` bundles load through the same engine. Native targets load
 local bundle paths, including paths resolved by `loadModelSource(...)`; web

--- a/website/docs/guides/generation-and-streaming.md
+++ b/website/docs/guides/generation-and-streaming.md
@@ -2,10 +2,25 @@
 title: Generation and Streaming
 ---
 
-`llamadart` exposes two generation styles:
+`llamadart` exposes three generation entry points:
 
 - `engine.generate(prompt)` for raw prompt strings.
-- `engine.create(messages)` for chat-template aware completions.
+- `engine.create(messages)` for stateless, chat-template aware completions.
+- `ChatSession.create(parts)` for stateful, multi-turn chat with automatic
+  history management.
+
+## Choosing the right API
+
+| API | Template-aware? | Keeps history? | Use when |
+| --- | --- | --- | --- |
+| `engine.generate(prompt)` | No | No | You already rendered the final raw prompt, or you are benchmarking, testing prefix-cache/state flows, or doing other low-level runtime work. |
+| `engine.create(messages)` | Yes | No | You have the complete `List<LlamaChatMessage>` for each request, such as an OpenAI-compatible server, a one-shot completion, or an app that owns its transcript. |
+| `ChatSession.create(parts)` | Yes | Yes | You are building a multi-turn chat UI/CLI and want the SDK to append user/assistant turns, apply the system prompt, and trim history as the context grows. |
+
+For beginner or one-shot instruction examples, prefer `engine.create(...)` so the
+model's chat template is applied without introducing session state. For real
+chat applications, prefer `ChatSession` unless your app already stores and sends
+the full message list itself.
 
 ## Generation pipeline (visual)
 
@@ -18,7 +33,11 @@ sequenceDiagram
     participant Backend as Native/Web backend
     participant Parser as Stream parser
 
-    App->>Engine: generate(prompt) or create(messages)
+    App->>Engine: generate(prompt), create(messages), or ChatSession.create(parts)
+    alt ChatSession.create(parts)
+        App->>App: append turn to session history
+        App->>Engine: create(full session messages)
+    end
     alt create(messages)
         Engine->>Template: detect format + render template
         Template-->>Engine: prompt + stops + grammar
@@ -99,9 +118,18 @@ final count = await engine.getTokenCount('hello world');
 
 These helpers are useful for context budgeting and prompt diagnostics.
 
-## When to use which API
+## Stateless vs stateful chat
 
-- Use `generate(...)` when you already have a final raw prompt and do not need
-  chat-template tooling.
-- Use `create(...)` for OpenAI-style message arrays, template routing, and
-  tool-calling workflows.
+`engine.create(...)` is stateless: it uses exactly the messages you pass for that
+request and does not remember the assistant response. If you want a follow-up
+turn to see prior context, append both the user message and assistant response to
+your own `messages` list before calling `engine.create(...)` again.
+
+`ChatSession.create(...)` is stateful: it adds the new user content to session
+history, streams through `engine.create(...)`, then stores the assistant message
+for later turns. Use `session.addMessage(...)` when you need to restore history or
+insert tool results manually, and `session.reset(...)` when a conversation should
+start over.
+
+See [First Chat Session](../getting-started/first-chat-session) for a minimal
+multi-turn example.

--- a/website/docs/guides/lora-adapters.md
+++ b/website/docs/guides/lora-adapters.md
@@ -29,10 +29,18 @@ Future<void> main() async {
 
     await engine.setLora('/models/lora/domain.gguf', scale: 0.7);
 
-    await for (final chunk in engine.generate(
-      'Answer as a domain specialist in one paragraph.',
+    await for (final chunk in engine.create(
+      const [
+        LlamaChatMessage.fromText(
+          role: LlamaChatRole.user,
+          text: 'Answer as a domain specialist in one paragraph.',
+        ),
+      ],
     )) {
-      print(chunk);
+      final text = chunk.choices.first.delta.content;
+      if (text != null) {
+        print(text);
+      }
     }
   } finally {
     await engine.dispose();


### PR DESCRIPTION
## Summary
- switch beginner docs from machine-specific file paths to `ModelSource.parse('hf://...')` examples
- document first-run download/cache behavior and pre-cache demo strategy
- update the basic CLI default model source/help text to use `hf://` while preserving local path and HTTP(S) support

## Verification
- `dart format example/basic_app/bin/llamadart_basic_example.dart example/basic_app/lib/services/model_service.dart`
- `dart analyze` in `example/basic_app`
- `dart test` in `example/basic_app`
- `dart run bin/llamadart_basic_example.dart -m "hf://unsloth/SmolLM2-135M-Instruct-GGUF/SmolLM2-135M-Instruct-Q2_K.gguf" -p "Return OK" -G 'root ::= "OK"' --temp 0.2`\n- root `dart analyze` (passes with existing info-level lints in unrelated files)\n