### PR TITLE
chore(release): prepare 0.8.11

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,9 +1,9 @@
-## Unreleased
+## 0.8.11
 
 * Updated the default llama.cpp native runtime pin to
-  `leehack/llamadart-native@b9829`, regenerated matching Dart FFI bindings, refreshed
-  the `llamadart_llama_cpp_flutter` Apple SwiftPM checksum, and
-  aligned current README/website native override docs.
+  `leehack/llamadart-native@b9829`, refreshed the
+  `llamadart_llama_cpp_flutter` Apple SwiftPM checksum, and aligned current
+  README/website native override docs for the release.
 
 ## 0.8.10
 

--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ JavaScript runtime.
 
 ```yaml
 dependencies:
-  llamadart: ^0.8.10
+  llamadart: ^0.8.11
 ```
 
 Flutter iOS/macOS apps that want Swift Package Manager-linked Apple
@@ -61,8 +61,8 @@ they ship:
 
 ```yaml
 dependencies:
-  llamadart: ^0.8.10
-  llamadart_llama_cpp_flutter: ^0.0.6 # GGUF / llama.cpp
+  llamadart: ^0.8.11
+  llamadart_llama_cpp_flutter: ^0.0.7 # GGUF / llama.cpp
   llamadart_litert_lm_flutter: ^0.0.2 # .litertlm / LiteRT-LM
 ```
 

--- a/packages/llamadart_litert_lm_flutter/README.md
+++ b/packages/llamadart_litert_lm_flutter/README.md
@@ -10,7 +10,7 @@ core package's native-assets fallback.
 
 ```yaml
 dependencies:
-  llamadart: ^0.8.10
+  llamadart: ^0.8.11
   llamadart_litert_lm_flutter: ^0.0.2
 ```
 

--- a/packages/llamadart_llama_cpp_flutter/CHANGELOG.md
+++ b/packages/llamadart_llama_cpp_flutter/CHANGELOG.md
@@ -1,4 +1,4 @@
-## Unreleased
+## 0.0.7
 
 * Updated Apple SwiftPM native pin to `leehack/llamadart-native@b9829`.
 

--- a/packages/llamadart_llama_cpp_flutter/README.md
+++ b/packages/llamadart_llama_cpp_flutter/README.md
@@ -9,8 +9,8 @@ core package's native-assets fallback.
 
 ```yaml
 dependencies:
-  llamadart: ^0.8.10
-  llamadart_llama_cpp_flutter: ^0.0.6
+  llamadart: ^0.8.11
+  llamadart_llama_cpp_flutter: ^0.0.7
 ```
 
 This package has no runtime Dart API of its own. Import `package:llamadart`

--- a/packages/llamadart_llama_cpp_flutter/pubspec.yaml
+++ b/packages/llamadart_llama_cpp_flutter/pubspec.yaml
@@ -1,6 +1,6 @@
 name: llamadart_llama_cpp_flutter
 description: Flutter Apple SwiftPM runtime companion package for llamadart llama.cpp and GGUF support.
-version: 0.0.6
+version: 0.0.7
 repository: https://github.com/leehack/llamadart/tree/main/packages/llamadart_llama_cpp_flutter
 homepage: https://github.com/leehack/llamadart
 issue_tracker: https://github.com/leehack/llamadart/issues

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: llamadart
 description: Dart and Flutter local LLM inference with llama.cpp GGUF and LiteRT-LM across native platforms and web.
-version: 0.8.10
+version: 0.8.11
 homepage: https://github.com/leehack/llamadart
 repository: https://github.com/leehack/llamadart
 issue_tracker: https://github.com/leehack/llamadart/issues

--- a/website/docs/changelog/recent-releases.md
+++ b/website/docs/changelog/recent-releases.md
@@ -7,6 +7,13 @@ For canonical full release notes, use:
 
 - [`CHANGELOG.md`](https://github.com/leehack/llamadart/blob/main/CHANGELOG.md)
 
+## 0.8.11
+
+- Updated the default llama.cpp native runtime pin to
+  `leehack/llamadart-native@b9829`, refreshed the
+  `llamadart_llama_cpp_flutter` Apple SwiftPM checksum, and aligned current
+  README/website native override docs for the release.
+
 ## 0.8.10
 
 - **Potentially breaking behavior change:** native model cache defaults changed

--- a/website/docs/getting-started/installation.md
+++ b/website/docs/getting-started/installation.md
@@ -27,7 +27,7 @@ In Xcode, set `IPHONEOS_DEPLOYMENT_TARGET = 16.4` or
 
 ```yaml
 dependencies:
-  llamadart: ^0.8.10
+  llamadart: ^0.8.11
 ```
 
 For Flutter iOS/macOS apps that should link Apple XCFrameworks through Swift
@@ -35,8 +35,8 @@ Package Manager, also add the runtime companion packages you need:
 
 ```yaml
 dependencies:
-  llamadart: ^0.8.10
-  llamadart_llama_cpp_flutter: ^0.0.6 # GGUF / llama.cpp
+  llamadart: ^0.8.11
+  llamadart_llama_cpp_flutter: ^0.0.7 # GGUF / llama.cpp
   llamadart_litert_lm_flutter: ^0.0.2 # .litertlm / LiteRT-LM
 ```
 

--- a/website/docs/maintainers/release-workflow.md
+++ b/website/docs/maintainers/release-workflow.md
@@ -41,13 +41,15 @@ version alignment:
 - Update `pubspec.yaml` version.
 - Update `CHANGELOG.md`.
 - Companion packages start at `0.0.1` and move independently from the core
-  package. Native pin sync bumps only the changed companion package patch
-  version, updates its `pubspec.yaml`, and writes a versioned changelog entry
-  that includes the native repo tag.
-- Leave unchanged companion package versions as-is. Companion packages publish
-  only after the release-prep PR is merged and the maintainer explicitly
-  approves pushing the relevant package-specific tag; the workflow skips a
-  companion package version that already exists on pub.dev.
+  package. Native pin sync records changed companion native pins under
+  `Unreleased` but does not bump companion package versions by default.
+- In the release-prep PR, bump only companion packages whose native pins or
+  publishable package contents changed, move their accumulated `Unreleased`
+  notes into the new version section, and keep unchanged companion package
+  versions as-is.
+- Companion packages publish only after the release-prep PR is merged and the
+  maintainer explicitly approves pushing the relevant package-specific tag; the
+  workflow skips a companion package version that already exists on pub.dev.
 - Keep current install snippets aligned with root and companion `pubspec.yaml`
   versions. Run `dart run tool/testing/verify_release_docs_versions.dart` before
   opening or merging the release-prep PR.


### PR DESCRIPTION
## Summary
- prepare llamadart 0.8.11 from the merged native b9829 sync
- bump llamadart_llama_cpp_flutter to 0.0.7 and move its native pin note out of Unreleased
- keep llamadart_litert_lm_flutter at 0.0.2 while updating current docs snippets to the core release version
- update current README/website install snippets and recent release notes
- document that native sync records companion native pin changes under Unreleased, while release-prep performs explicit companion version bumps

## Local validation
- dart pub get
- dart format --output=none --set-exit-if-changed .
- dart run tool/testing/verify_release_docs_versions.dart
- dart test test/unit/tooling/release_install_snippets_test.dart
- dart test test/unit/tooling/sync_native_release_pins_script_test.dart
- git diff --check
- dart analyze lib test tool (passes with 3 existing info-level lints)
- dart pub publish --dry-run (0 warnings)
- flutter pub publish --dry-run in packages/llamadart_llama_cpp_flutter (0 warnings)
- flutter pub publish --dry-run in packages/llamadart_litert_lm_flutter (0 warnings)
- ./tool/docs/build_site.sh

## Release notes
- Do not publish/tag from this PR directly. After merge, publish the changed companion package tag first (llamadart_llama_cpp_flutter-v0.0.7), verify pub.dev, then tag the core v0.8.11 release with separate maintainer approval.