### PR TITLE
Expose llama.cpp model file type metadata

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 ## Unreleased
 
+* Added `LlamaEngine.getModelFileType()` for llama.cpp/GGUF models, exposing
+  native model file type / quantization metadata from `llama_model_ftype` and
+  `llama_ftype_name` when available.
+
 * Updated the default llama.cpp native runtime pin to
   `leehack/llamadart-native@b9860`, regenerated matching Dart FFI bindings, refreshed
   the `llamadart_llama_cpp_flutter` Apple SwiftPM checksum, and

--- a/lib/llamadart.dart
+++ b/lib/llamadart.dart
@@ -46,6 +46,7 @@ export 'src/backends/backend.dart'
         BackendGpuEnumeration,
         BackendNativeChatGeneration,
         BackendRuntimeDiagnostics,
+        BackendModelFileTypeDiagnostics,
         BackendPerfContextData,
         BackendPerformanceDiagnostics,
         BackendEmbeddings,
@@ -87,6 +88,7 @@ export 'src/core/models/config/gpu_device_info.dart';
 export 'src/core/models/config/flash_attention.dart';
 export 'src/core/models/config/kv_cache_type.dart';
 export 'src/core/models/config/lora_config.dart';
+export 'src/core/models/diagnostics/model_file_type.dart';
 
 // Utils
 export 'src/core/exceptions.dart';

--- a/lib/src/backends/backend.dart
+++ b/lib/src/backends/backend.dart
@@ -6,6 +6,7 @@ import '../core/models/chat/content_part.dart';
 import '../core/models/config/gpu_backend.dart';
 import '../core/models/config/gpu_device_info.dart';
 import '../core/models/config/log_level.dart';
+import '../core/models/diagnostics/model_file_type.dart';
 import '../core/models/tools/tool_definition.dart';
 
 import 'web/web_backend.dart' if (dart.library.io) 'native/native_backend.dart';
@@ -172,6 +173,16 @@ abstract class BackendRuntimeDiagnostics {
   /// This value reflects the final layer count passed to native model load
   /// after backend policy/fallback decisions.
   Future<int?> getResolvedGpuLayers();
+}
+
+/// Optional backend capability for exposing loaded model file type metadata.
+///
+/// Backends that can identify the loaded model's native file type or
+/// quantization format return a [ModelFileType]. Backends that do not expose
+/// this data should omit this capability so high-level APIs return null.
+abstract class BackendModelFileTypeDiagnostics {
+  /// Returns file type metadata for [modelHandle], or null when unavailable.
+  Future<ModelFileType?> getModelFileType(int modelHandle);
 }
 
 /// Optional backend capability for enumerating GPU-class devices for offload

--- a/lib/src/backends/llama_cpp/llama_cpp_backend.dart
+++ b/lib/src/backends/llama_cpp/llama_cpp_backend.dart
@@ -7,6 +7,7 @@ import '../../core/models/chat/content_part.dart';
 import '../../core/models/config/gpu_backend.dart';
 import '../../core/models/config/gpu_device_info.dart';
 import '../../core/models/config/log_level.dart';
+import '../../core/models/diagnostics/model_file_type.dart';
 import '../../core/models/inference/model_params.dart';
 import '../../core/models/inference/generation_params.dart';
 import 'worker.dart';
@@ -20,6 +21,7 @@ class NativeLlamaBackend
         LlamaBackend,
         BackendAvailability,
         BackendRuntimeDiagnostics,
+        BackendModelFileTypeDiagnostics,
         BackendGpuEnumeration,
         BackendPerformanceDiagnostics,
         BackendEmbeddings,
@@ -347,6 +349,17 @@ class NativeLlamaBackend
     rp.close();
     if (res is MetadataResponse) return res.metadata;
     return {};
+  }
+
+  @override
+  Future<ModelFileType?> getModelFileType(int modelHandle) async {
+    final rp = ReceivePort();
+    _sendPort!.send(ModelFileTypeRequest(modelHandle, rp.sendPort));
+    final res = await rp.first;
+    rp.close();
+    if (res is ModelFileTypeResponse) return res.modelFileType;
+    if (res is ErrorResponse) throw Exception(res.message);
+    return null;
   }
 
   @override

--- a/lib/src/backends/llama_cpp/llama_cpp_raw_bindings.dart
+++ b/lib/src/backends/llama_cpp/llama_cpp_raw_bindings.dart
@@ -1,0 +1,20 @@
+// coverage:ignore-file
+// ignore_for_file: non_constant_identifier_names
+@ffi.DefaultAsset('package:llamadart/llamadart')
+library;
+
+import 'dart:ffi' as ffi;
+
+import 'bindings.dart';
+
+/// Raw `llama_model_ftype` binding used to preserve unknown future ftype IDs.
+@ffi.Native<ffi.UnsignedInt Function(ffi.Pointer<llama_model>)>(
+  symbol: 'llama_model_ftype',
+)
+external int llama_model_ftype_raw(ffi.Pointer<llama_model> model);
+
+/// Raw `llama_ftype_name` binding used with raw ftype IDs.
+@ffi.Native<ffi.Pointer<ffi.Char> Function(ffi.UnsignedInt)>(
+  symbol: 'llama_ftype_name',
+)
+external ffi.Pointer<ffi.Char> llama_ftype_name_raw(int ftype);

--- a/lib/src/backends/llama_cpp/llama_cpp_service.dart
+++ b/lib/src/backends/llama_cpp/llama_cpp_service.dart
@@ -12,10 +12,12 @@ import '../../core/models/chat/content_part.dart';
 import '../../core/models/config/gpu_backend.dart';
 import '../../core/models/config/gpu_device_info.dart';
 import '../../core/models/config/log_level.dart';
+import '../../core/models/diagnostics/model_file_type.dart';
 import '../../core/models/inference/generation_params.dart';
 import '../../core/models/inference/model_params.dart';
 import 'load_param_helpers.dart';
 import 'bindings.dart';
+import 'llama_cpp_raw_bindings.dart' as raw_bindings;
 
 const _llamadartWrapperAssetId = 'package:llamadart/llamadart_wrapper';
 
@@ -5200,6 +5202,19 @@ class LlamaCppService {
     malloc.free(keyBuf);
     malloc.free(valBuf);
     return metadata;
+  }
+
+  /// Returns model file type or quantization metadata for [modelHandle].
+  ModelFileType? getModelFileType(int modelHandle) {
+    final model = _models[modelHandle];
+    if (model == null) return null;
+
+    final ftype = raw_bindings.llama_model_ftype_raw(model.pointer);
+    final namePtr = raw_bindings.llama_ftype_name_raw(ftype);
+    if (namePtr == nullptr) return null;
+
+    final name = namePtr.cast<Utf8>().toDartString();
+    return ModelFileType(id: ftype, name: name);
   }
 
   /// Handles LoRA adapter operations.

--- a/lib/src/backends/llama_cpp/worker.dart
+++ b/lib/src/backends/llama_cpp/worker.dart
@@ -160,6 +160,10 @@ void llamaWorkerEntry(SendPort initialSendPort) {
             final metadata = service.getMetadata(message.modelHandle);
             message.sendPort.send(MetadataResponse(metadata));
 
+          case ModelFileTypeRequest():
+            final modelFileType = service.getModelFileType(message.modelHandle);
+            message.sendPort.send(ModelFileTypeResponse(modelFileType));
+
           case LoraRequest():
             service.handleLora(
               message.contextHandle,

--- a/lib/src/backends/llama_cpp/worker_messages.dart
+++ b/lib/src/backends/llama_cpp/worker_messages.dart
@@ -5,6 +5,7 @@ import '../../core/models/chat/content_part.dart';
 import '../../core/models/config/gpu_backend.dart';
 import '../../core/models/config/gpu_device_info.dart';
 import '../../core/models/config/log_level.dart';
+import '../../core/models/diagnostics/model_file_type.dart';
 
 /// Base class for all worker requests.
 abstract class WorkerRequest {
@@ -162,6 +163,15 @@ class MetadataRequest extends WorkerRequest {
 
   /// Creates a new [MetadataRequest].
   MetadataRequest(this.modelHandle, super.sendPort);
+}
+
+/// Request to get model file type metadata.
+class ModelFileTypeRequest extends WorkerRequest {
+  /// The handle of the model.
+  final int modelHandle;
+
+  /// Creates a new [ModelFileTypeRequest].
+  ModelFileTypeRequest(this.modelHandle, super.sendPort);
 }
 
 /// Request for LoRA operations.
@@ -433,6 +443,15 @@ class MetadataResponse {
 
   /// Creates a new [MetadataResponse].
   MetadataResponse(this.metadata);
+}
+
+/// Response containing model file type metadata.
+class ModelFileTypeResponse {
+  /// The model file type metadata, or null when unavailable.
+  final ModelFileType? modelFileType;
+
+  /// Creates a new [ModelFileTypeResponse].
+  ModelFileTypeResponse(this.modelFileType);
 }
 
 /// Response containing the context size.

--- a/lib/src/backends/native/native_backend.dart
+++ b/lib/src/backends/native/native_backend.dart
@@ -3,6 +3,7 @@ import '../../core/models/chat/content_part.dart';
 import '../../core/models/config/gpu_backend.dart';
 import '../../core/models/config/gpu_device_info.dart';
 import '../../core/models/config/log_level.dart';
+import '../../core/models/diagnostics/model_file_type.dart';
 import '../../core/models/inference/generation_params.dart';
 import '../../core/models/inference/model_params.dart';
 import '../../core/models/inference/tool_choice.dart';
@@ -23,6 +24,7 @@ class NativeAutoBackend
         LlamaBackend,
         BackendAvailability,
         BackendRuntimeDiagnostics,
+        BackendModelFileTypeDiagnostics,
         BackendGpuEnumeration,
         BackendPerformanceDiagnostics,
         BackendEmbeddings,
@@ -236,6 +238,17 @@ class NativeAutoBackend
       return (delegate as BackendRuntimeDiagnostics).getResolvedGpuLayers();
     }
     return Future<int?>.value(null);
+  }
+
+  @override
+  Future<ModelFileType?> getModelFileType(int modelHandle) {
+    final delegate = _delegate;
+    if (delegate is BackendModelFileTypeDiagnostics) {
+      return (delegate as BackendModelFileTypeDiagnostics).getModelFileType(
+        modelHandle,
+      );
+    }
+    return Future<ModelFileType?>.value(null);
   }
 
   @override

--- a/lib/src/core/engine/engine.dart
+++ b/lib/src/core/engine/engine.dart
@@ -9,6 +9,7 @@ import '../exceptions.dart';
 import '../models/config/gpu_backend.dart';
 import '../models/config/gpu_device_info.dart';
 import '../models/config/log_level.dart';
+import '../models/diagnostics/model_file_type.dart';
 import '../models/chat/chat_message.dart';
 import '../models/chat/completion_chunk.dart';
 import '../models/chat/content_part.dart';
@@ -1016,6 +1017,26 @@ class LlamaEngine {
       return (candidate as BackendRuntimeDiagnostics).getResolvedGpuLayers();
     }
     return Future<int?>.value(null);
+  }
+
+  /// Returns model file type or quantization metadata when available.
+  ///
+  /// llama.cpp/GGUF backends expose this via the native `llama_model_ftype` and
+  /// `llama_ftype_name` APIs. Backends that do not expose equivalent metadata,
+  /// such as LiteRT-LM or older web bridge assets, return null.
+  Future<ModelFileType?> getModelFileType() {
+    final modelHandle = _modelHandle;
+    if (!_isReady || modelHandle == null) {
+      return Future<ModelFileType?>.value(null);
+    }
+
+    final candidate = backend;
+    if (candidate is BackendModelFileTypeDiagnostics) {
+      return (candidate as BackendModelFileTypeDiagnostics).getModelFileType(
+        modelHandle,
+      );
+    }
+    return Future<ModelFileType?>.value(null);
   }
 
   /// Returns native llama.cpp perf timings for the active context when available.

--- a/lib/src/core/models/diagnostics/model_file_type.dart
+++ b/lib/src/core/models/diagnostics/model_file_type.dart
@@ -1,0 +1,26 @@
+/// Model file type and quantization metadata for a loaded model.
+///
+/// For llama.cpp/GGUF models, [id] is the native `llama_ftype` enum value and
+/// [name] is the human-readable value returned by `llama_ftype_name`, such as
+/// `Q8_0` or `Q4_K - Medium`.
+class ModelFileType {
+  /// Native model file type identifier.
+  final int id;
+
+  /// Human-readable model file type name.
+  final String name;
+
+  /// Creates a new [ModelFileType].
+  const ModelFileType({required this.id, required this.name});
+
+  @override
+  bool operator ==(Object other) =>
+      identical(this, other) ||
+      other is ModelFileType && other.id == id && other.name == name;
+
+  @override
+  int get hashCode => Object.hash(id, name);
+
+  @override
+  String toString() => 'ModelFileType(id: $id, name: $name)';
+}

--- a/test/integration/engine_integration_test.dart
+++ b/test/integration/engine_integration_test.dart
@@ -60,6 +60,12 @@ void main() async {
       expect(metadata, isNotEmpty);
       expect(metadata['general.architecture'], 'llama');
 
+      final modelFileType = await engine.getModelFileType();
+      expect(modelFileType, isNotNull);
+      final fileType = modelFileType!;
+      expect(fileType.id, greaterThanOrEqualTo(0));
+      expect(fileType.name, isNotEmpty);
+
       // 6. Backend Info
       expect(await engine.getBackendName(), isNotEmpty);
       expect(await engine.isGpuSupported(), isA<bool>());

--- a/test/unit/backends/llama_cpp/llama_cpp_raw_bindings_test.dart
+++ b/test/unit/backends/llama_cpp/llama_cpp_raw_bindings_test.dart
@@ -1,0 +1,22 @@
+@TestOn('vm')
+library;
+
+import 'dart:ffi' as ffi;
+
+import 'package:llamadart/src/backends/llama_cpp/bindings.dart';
+import 'package:llamadart/src/backends/llama_cpp/llama_cpp_raw_bindings.dart'
+    as raw;
+import 'package:test/test.dart';
+
+void main() {
+  test('raw ftype binding helpers are available for forward compatibility', () {
+    expect(
+      raw.llama_model_ftype_raw,
+      isA<int Function(ffi.Pointer<llama_model>)>(),
+    );
+    expect(
+      raw.llama_ftype_name_raw,
+      isA<ffi.Pointer<ffi.Char> Function(int)>(),
+    );
+  });
+}

--- a/test/unit/core/engine/model_file_type_test.dart
+++ b/test/unit/core/engine/model_file_type_test.dart
@@ -1,0 +1,201 @@
+import 'dart:async';
+
+import 'package:llamadart/llamadart.dart';
+import 'package:test/test.dart';
+
+void main() {
+  group('LlamaEngine.getModelFileType', () {
+    test(
+      'returns model file type from capable backends after model load',
+      () async {
+        final backend = _ModelFileTypeBackend(
+          const ModelFileType(id: 15, name: 'Q4_K - Medium'),
+        );
+        final engine = LlamaEngine(backend);
+
+        await engine.loadModel('model.gguf');
+
+        expect(await engine.getModelFileType(), backend.modelFileType);
+        expect(backend.modelFileTypeLookups, 1);
+      },
+    );
+
+    test('returns null when no model is loaded', () async {
+      final backend = _ModelFileTypeBackend(
+        const ModelFileType(id: 7, name: 'Q8_0'),
+      );
+      final engine = LlamaEngine(backend);
+
+      expect(await engine.getModelFileType(), isNull);
+      expect(backend.modelFileTypeLookups, 0);
+    });
+
+    test('returns null for backends without file type diagnostics', () async {
+      final backend = _BasicBackend();
+      final engine = LlamaEngine(backend);
+
+      await engine.loadModel('model.litertlm');
+
+      expect(await engine.getModelFileType(), isNull);
+    });
+
+    test(
+      'returns null when a capable backend has no file type for a model',
+      () async {
+        final backend = _NullableModelFileTypeBackend();
+        final engine = LlamaEngine(backend);
+
+        await engine.loadModel('model.gguf');
+
+        expect(await engine.getModelFileType(), isNull);
+        expect(backend.modelFileTypeLookups, 1);
+      },
+    );
+  });
+}
+
+class _ModelFileTypeBackend extends _BasicBackend
+    implements BackendModelFileTypeDiagnostics {
+  _ModelFileTypeBackend(this.modelFileType);
+
+  final ModelFileType modelFileType;
+  int modelFileTypeLookups = 0;
+
+  @override
+  Future<ModelFileType?> getModelFileType(int modelHandle) async {
+    modelFileTypeLookups++;
+    expect(modelHandle, 1);
+    return modelFileType;
+  }
+}
+
+class _NullableModelFileTypeBackend extends _BasicBackend
+    implements BackendModelFileTypeDiagnostics {
+  int modelFileTypeLookups = 0;
+
+  @override
+  Future<ModelFileType?> getModelFileType(int modelHandle) async {
+    modelFileTypeLookups++;
+    expect(modelHandle, 1);
+    return null;
+  }
+}
+
+class _BasicBackend implements LlamaBackend {
+  bool _isReady = false;
+
+  @override
+  bool get isReady => _isReady;
+
+  @override
+  Future<int> modelLoad(String path, ModelParams params) async {
+    _isReady = true;
+    return 1;
+  }
+
+  @override
+  Future<int> modelLoadFromUrl(
+    String url,
+    ModelParams params, {
+    Function(double progress)? onProgress,
+  }) {
+    throw UnsupportedError('URL loading is not supported by the test backend.');
+  }
+
+  @override
+  Future<void> modelFree(int modelHandle) async {
+    _isReady = false;
+  }
+
+  @override
+  Future<int> contextCreate(int modelHandle, ModelParams params) async => 1;
+
+  @override
+  Future<void> contextFree(int contextHandle) async {}
+
+  @override
+  Future<int> getContextSize(int contextHandle) async => 2048;
+
+  @override
+  Stream<List<int>> generate(
+    int contextHandle,
+    String prompt,
+    GenerationParams params, {
+    List<LlamaContentPart>? parts,
+  }) => const Stream<List<int>>.empty();
+
+  @override
+  void cancelGeneration() {}
+
+  @override
+  Future<List<int>> tokenize(
+    int modelHandle,
+    String text, {
+    bool addSpecial = true,
+  }) async => const <int>[];
+
+  @override
+  Future<String> detokenize(
+    int modelHandle,
+    List<int> tokens, {
+    bool special = false,
+  }) async => '';
+
+  @override
+  Future<Map<String, String>> modelMetadata(int modelHandle) async =>
+      const <String, String>{};
+
+  @override
+  Future<void> setLoraAdapter(
+    int contextHandle,
+    String path,
+    double scale,
+  ) async {}
+
+  @override
+  Future<void> removeLoraAdapter(int contextHandle, String path) async {}
+
+  @override
+  Future<void> clearLoraAdapters(int contextHandle) async {}
+
+  @override
+  Future<String> getBackendName() async => 'Test backend';
+
+  @override
+  bool get supportsUrlLoading => false;
+
+  @override
+  Future<bool> isGpuSupported() async => false;
+
+  @override
+  Future<void> setLogLevel(LlamaLogLevel level) async {}
+
+  @override
+  Future<void> dispose() async {}
+
+  @override
+  Future<int?> multimodalContextCreate(
+    int modelHandle,
+    String mmProjPath,
+  ) async => null;
+
+  @override
+  Future<void> multimodalContextFree(int mmContextHandle) async {}
+
+  @override
+  Future<bool> supportsVision(int mmContextHandle) async => false;
+
+  @override
+  Future<bool> supportsAudio(int mmContextHandle) async => false;
+
+  @override
+  Future<({int free, int total})> getVramInfo() async => (total: 0, free: 0);
+
+  @override
+  Future<String> applyChatTemplate(
+    int modelHandle,
+    List<Map<String, dynamic>> messages, {
+    String? customTemplate,
+    bool addAssistant = true,
+  }) async => '';
+}

--- a/test/unit/core/models/diagnostics/model_file_type_test.dart
+++ b/test/unit/core/models/diagnostics/model_file_type_test.dart
@@ -1,0 +1,24 @@
+import 'package:llamadart/llamadart.dart';
+import 'package:test/test.dart';
+
+void main() {
+  group('ModelFileType', () {
+    test('uses value equality', () {
+      expect(
+        const ModelFileType(id: 15, name: 'Q4_K - Medium'),
+        const ModelFileType(id: 15, name: 'Q4_K - Medium'),
+      );
+      expect(
+        const ModelFileType(id: 15, name: 'Q4_K - Medium'),
+        isNot(const ModelFileType(id: 7, name: 'Q8_0')),
+      );
+    });
+
+    test('formats useful diagnostics', () {
+      expect(
+        const ModelFileType(id: 7, name: 'Q8_0').toString(),
+        'ModelFileType(id: 7, name: Q8_0)',
+      );
+    });
+  });
+}


### PR DESCRIPTION
## Summary

Closes #255.

Adds a public model file type / quantization metadata surface for loaded llama.cpp/GGUF models:

- `ModelFileType` value object with native file-type id and display name
- `LlamaEngine.getModelFileType()` high-level helper
- optional `BackendModelFileTypeDiagnostics` backend capability
- native llama.cpp worker/service plumbing over `llama_model_ftype` and `llama_ftype_name`

Backends without equivalent metadata support return `null` rather than pretending the value is available.

## Production-readiness scope

This PR is intended to be merge-ready for the declared feature scope:

- Users can query model file type / quantization metadata after loading a llama.cpp/GGUF model.
- Supported path: native llama.cpp backend with the b9860 bindings from #254.
- Unsupported paths, including LiteRT-LM/web assets without equivalent metadata, return `null` explicitly.
- No public breaking API changes are intended; existing backend and engine callers are unchanged.
- Generated `bindings.dart` remains generated-only. A tiny prefixed raw-binding shim is used only so this public diagnostic API can expose raw future ftype IDs instead of throwing on generated enum skew.

## Test Plan

- [x] `dart format --output=none --set-exit-if-changed` on changed Dart files
- [x] `dart analyze` on changed Dart files
- [x] CI-style pub get setup for root + examples, then `dart analyze` from repo root
- [x] `dart test -p vm test/unit/backends/llama_cpp/llama_cpp_raw_bindings_test.dart test/unit/core/engine/model_file_type_test.dart test/unit/core/models/diagnostics/model_file_type_test.dart test/integration/engine_integration_test.dart`
- [x] `dart test -p vm -j 1 --exclude-tags local-only`
- [x] Latest PR CI/check matrix is green on head `e596819e8308b19209144259ddbf6d8fa96a3888`.

## Review Notes

- Static scan: no hardcoded secrets or dangerous exec. One raw-url-log regex hit is a false positive in a test-only `UnsupportedError('URL loading is not supported by the test backend.')` message.
- Review comments were addressed and there are no unresolved review threads.
- The repo-wide analyzer still reports three pre-existing infos after CI-style dependency setup (`use_null_aware_elements` in LiteRT-LM service and two `prefer_is_empty` hints in WebGPU tests); exit status is 0.
