### PR TITLE
Automate release prep publishing

### DIFF
--- a/.github/workflows/publish_companion_pubdev.yml
+++ b/.github/workflows/publish_companion_pubdev.yml
@@ -47,9 +47,11 @@ jobs:
             exit 1
           fi
 
-          echo "name=$package_name" >> "$GITHUB_OUTPUT"
-          echo "path=$package_path" >> "$GITHUB_OUTPUT"
-          echo "version=$package_version" >> "$GITHUB_OUTPUT"
+          {
+            echo "name=$package_name"
+            echo "path=$package_path"
+            echo "version=$package_version"
+          } >> "$GITHUB_OUTPUT"
 
       - name: Decide whether to publish
         id: publish

--- a/.github/workflows/publish_pubdev.yml
+++ b/.github/workflows/publish_pubdev.yml
@@ -10,3 +10,50 @@ jobs:
     permissions:
       id-token: write # Required for authentication using OIDC
     uses: dart-lang/setup-dart/.github/workflows/publish.yml@v1
+
+  create-release:
+    name: Create GitHub Release
+    needs: publish
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          ref: ${{ github.ref }}
+          fetch-depth: 0
+
+      - name: Extract release notes
+        shell: bash
+        run: |
+          set -euo pipefail
+          version="${GITHUB_REF_NAME#v}"
+          awk -v version="$version" '
+            $0 == "## " version { found = 1; next }
+            found && /^## / { exit }
+            found { print }
+          ' CHANGELOG.md > release_notes.md
+
+          if ! grep -q '[^[:space:]]' release_notes.md; then
+            echo "CHANGELOG.md does not contain release notes for $version." >&2
+            exit 1
+          fi
+
+      - name: Create or update release
+        env:
+          GH_TOKEN: ${{ github.token }}
+        shell: bash
+        run: |
+          set -euo pipefail
+          if gh release view "$GITHUB_REF_NAME" >/dev/null 2>&1; then
+            gh release edit "$GITHUB_REF_NAME" \
+              --title "$GITHUB_REF_NAME" \
+              --notes-file release_notes.md \
+              --latest
+          else
+            gh release create "$GITHUB_REF_NAME" \
+              --title "$GITHUB_REF_NAME" \
+              --notes-file release_notes.md \
+              --verify-tag \
+              --latest
+          fi

--- a/.github/workflows/release_on_prep_merge.yml
+++ b/.github/workflows/release_on_prep_merge.yml
@@ -54,7 +54,7 @@ jobs:
       - uses: actions/checkout@v6
         if: steps.gate.outputs.should_release == 'true'
         with:
-          ref: main
+          ref: ${{ github.event.pull_request.merge_commit_sha }}
           fetch-depth: 0
           persist-credentials: false
 

--- a/.github/workflows/release_on_prep_merge.yml
+++ b/.github/workflows/release_on_prep_merge.yml
@@ -36,7 +36,8 @@ jobs:
           if printf '%s\n' "$labels" | grep -Fxq "release-prep"; then
             should_release=true
             reason="release-prep label"
-          elif [[ "$head_ref" == release/prep-* || "$head_ref" == release/*-prep ]]; then
+          elif [[ "$head_ref" =~ ^release/prep-[0-9]+\.[0-9]+\.[0-9]+([-+][A-Za-z0-9._-]+)?$ ||
+            "$head_ref" =~ ^release/[0-9]+\.[0-9]+\.[0-9]+([-+][A-Za-z0-9._-]+)?-prep$ ]]; then
             should_release=true
             reason="release-prep branch $head_ref"
           fi

--- a/.github/workflows/release_on_prep_merge.yml
+++ b/.github/workflows/release_on_prep_merge.yml
@@ -1,0 +1,196 @@
+name: Release on prep merge
+
+on:
+  pull_request:
+    branches:
+      - main
+    types:
+      - closed
+
+permissions:
+  contents: read
+  pull-requests: read
+
+concurrency:
+  group: release-on-prep-merge
+  cancel-in-progress: false
+
+jobs:
+  release:
+    name: Publish merged release prep
+    if: ${{ github.event.pull_request.merged == true }}
+    runs-on: ubuntu-latest
+    timeout-minutes: 45
+    steps:
+      - name: Check release-prep gate
+        id: gate
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          head_ref="$(jq -r '.pull_request.head.ref // ""' "$GITHUB_EVENT_PATH")"
+          labels="$(jq -r '.pull_request.labels[].name // empty' "$GITHUB_EVENT_PATH")"
+
+          should_release=false
+          reason="missing release-prep label or branch pattern"
+          if printf '%s\n' "$labels" | grep -Fxq "release-prep"; then
+            should_release=true
+            reason="release-prep label"
+          elif [[ "$head_ref" == release/prep-* || "$head_ref" == release/*-prep ]]; then
+            should_release=true
+            reason="release-prep branch $head_ref"
+          fi
+
+          {
+            echo "should_release=$should_release"
+            echo "reason=$reason"
+          } >> "$GITHUB_OUTPUT"
+
+      - name: Skip non-release PR
+        if: steps.gate.outputs.should_release != 'true'
+        run: |
+          echo "Skipping release automation: ${{ steps.gate.outputs.reason }}."
+
+      - uses: actions/checkout@v6
+        if: steps.gate.outputs.should_release == 'true'
+        with:
+          ref: main
+          fetch-depth: 0
+          persist-credentials: false
+
+      - uses: dart-lang/setup-dart@v1
+        if: steps.gate.outputs.should_release == 'true'
+
+      - name: Validate release state
+        if: steps.gate.outputs.should_release == 'true'
+        id: release
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          version="$(awk '/^version:[[:space:]]*/ {print $2; exit}' pubspec.yaml)"
+          if [[ -z "$version" ]]; then
+            echo "pubspec.yaml does not contain a top-level version." >&2
+            exit 1
+          fi
+          if [[ ! "$version" =~ ^[0-9]+\.[0-9]+\.[0-9]+([-+][A-Za-z0-9._-]+)?$ ]]; then
+            echo "Unsupported release version: $version" >&2
+            exit 1
+          fi
+
+          first_heading="$(awk '/^## / {print; exit}' CHANGELOG.md)"
+          if [[ "$first_heading" != "## $version" ]]; then
+            echo "CHANGELOG.md must start with ## $version before publishing." >&2
+            echo "Found: ${first_heading:-<none>}" >&2
+            exit 1
+          fi
+
+          dart run tool/testing/verify_release_docs_versions.dart
+
+          core_tag="v$version"
+          if git ls-remote --exit-code --tags origin "refs/tags/$core_tag" >/dev/null 2>&1; then
+            echo "Release tag $core_tag already exists. Refusing to publish again." >&2
+            exit 1
+          fi
+
+          release_sha="$(git rev-parse HEAD)"
+          {
+            echo "version=$version"
+            echo "core_tag=$core_tag"
+            echo "release_sha=$release_sha"
+          } >> "$GITHUB_OUTPUT"
+
+      - name: Publish companion packages and core tag
+        if: steps.gate.outputs.should_release == 'true'
+        env:
+          CORE_TAG: ${{ steps.release.outputs.core_tag }}
+          CORE_VERSION: ${{ steps.release.outputs.version }}
+          GH_TOKEN: ${{ github.token }}
+          RELEASE_SHA: ${{ steps.release.outputs.release_sha }}
+          RELEASE_TOKEN: ${{ secrets.RELEASE_AUTOMATION_TOKEN }}
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          if [[ -z "${RELEASE_TOKEN:-}" ]]; then
+            echo "Missing RELEASE_AUTOMATION_TOKEN." >&2
+            echo "Configure a fine-scoped PAT or GitHub App token that can create tags and trigger tag workflows." >&2
+            exit 1
+          fi
+
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+
+          push_tag() {
+            local tag="$1"
+            echo "Creating tag $tag at $RELEASE_SHA"
+            git tag "$tag" "$RELEASE_SHA"
+            git -c http.extraHeader="AUTHORIZATION: bearer $RELEASE_TOKEN" \
+              push origin "refs/tags/$tag"
+          }
+
+          wait_for_pub_version() {
+            local package_name="$1"
+            local package_version="$2"
+            local version_url="https://pub.dev/api/packages/$package_name/versions/$package_version"
+
+            for attempt in $(seq 1 90); do
+              if curl -fsSL "$version_url" >/dev/null; then
+                echo "$package_name $package_version is live on pub.dev."
+                return 0
+              fi
+              echo "Waiting for $package_name $package_version on pub.dev ($attempt/90)."
+              sleep 10
+            done
+
+            echo "$package_name $package_version did not appear on pub.dev." >&2
+            exit 1
+          }
+
+          wait_for_github_release() {
+            local tag="$1"
+            for attempt in $(seq 1 90); do
+              if gh release view "$tag" --repo "$GITHUB_REPOSITORY" >/dev/null 2>&1; then
+                echo "GitHub Release $tag exists."
+                return 0
+              fi
+              echo "Waiting for GitHub Release $tag ($attempt/90)."
+              sleep 10
+            done
+
+            echo "GitHub Release $tag was not created." >&2
+            exit 1
+          }
+
+          companion_paths=(
+            packages/llamadart_llama_cpp_flutter
+            packages/llamadart_litert_lm_flutter
+          )
+
+          for package_path in "${companion_paths[@]}"; do
+            package_name="$(awk '/^name:[[:space:]]*/ {print $2; exit}' "$package_path/pubspec.yaml")"
+            package_version="$(awk '/^version:[[:space:]]*/ {print $2; exit}' "$package_path/pubspec.yaml")"
+            if [[ -z "$package_name" || -z "$package_version" ]]; then
+              echo "$package_path/pubspec.yaml must contain name and version." >&2
+              exit 1
+            fi
+
+            if curl -fsSL "https://pub.dev/api/packages/$package_name/versions/$package_version" >/dev/null; then
+              echo "$package_name $package_version already exists on pub.dev."
+              continue
+            fi
+
+            companion_tag="$package_name-v$package_version"
+            if git ls-remote --exit-code --tags origin "refs/tags/$companion_tag" >/dev/null 2>&1; then
+              echo "$companion_tag already exists, but $package_name $package_version is missing on pub.dev." >&2
+              echo "Inspect publish_companion_pubdev.yml before retrying the core release." >&2
+              exit 1
+            fi
+
+            push_tag "$companion_tag"
+            wait_for_pub_version "$package_name" "$package_version"
+          done
+
+          push_tag "$CORE_TAG"
+          wait_for_pub_version "llamadart" "$CORE_VERSION"
+          wait_for_github_release "$CORE_TAG"

--- a/.github/workflows/release_on_prep_merge.yml
+++ b/.github/workflows/release_on_prep_merge.yml
@@ -20,7 +20,7 @@ jobs:
     name: Publish merged release prep
     if: ${{ github.event.pull_request.merged == true }}
     runs-on: ubuntu-latest
-    timeout-minutes: 45
+    timeout-minutes: 90
     steps:
       - name: Check release-prep gate
         id: gate

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -345,15 +345,21 @@ WEBGPU_BRIDGE_ASSETS_TAG=<tag> ./scripts/fetch_webgpu_bridge_assets.sh
   README/website snippets and companion package READMEs against package
   `pubspec.yaml` versions while intentionally ignoring historical versioned docs.
 - Release prep PRs must not publish anything by themselves. After the release
-  prep PR is merged, ask for explicit maintainer approval before pushing any
-  package-specific companion tag or the core `vX.Y.Z` tag.
-- Before tagging the core `vX.Y.Z` release, verify any companion package
-  versions referenced by current install docs are already live on pub.dev. If a
-  changed companion package version is missing, stop and request explicit
-  approval to push that companion's package-specific tag, for example
-  `llamadart_llama_cpp_flutter-v0.0.3`; wait for the companion publish workflow
-  to pass, verify pub.dev, then request explicit approval before pushing the
+  prep PR is merged, `release_on_prep_merge.yml` treats the merge as the
+  publishing approval boundary. Do not manually push package-specific companion
+  tags or the core `vX.Y.Z` tag unless that automation is disabled, blocked, or
+  being repaired.
+- Before merging the release-prep PR, verify any companion package versions
+  referenced by current install docs are either already live on pub.dev or ready
+  for the post-merge automation to publish. If a changed companion package
+  version is missing, keep the PR scoped to release prep; after merge,
+  `release_on_prep_merge.yml` pushes the companion tag, waits for
+  `publish_companion_pubdev.yml`, verifies pub.dev, and only then pushes the
   core release tag.
+- After release automation runs, verify `release_on_prep_merge.yml`,
+  `publish_pubdev.yml`, any relevant `publish_companion_pubdev.yml` run,
+  `docs_version_cut.yml`, `docs_pages.yml`, the pub.dev version URL, the GitHub
+  Release, and the docs version selector before calling the release complete.
 - Treat Apple SPM release readiness as two separate checks: the native GitHub
   release must contain the XCFramework zip/checksum pinned in `Package.swift`,
   and the Flutter companion pub package carrying that `Package.swift` must be

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -282,6 +282,20 @@ test -d ../llama-web-bridge-assets
 
 ## Development Workflow
 
+### AGENTS.md Maintenance
+- Treat `AGENTS.md` as a living source of repo guidance. When a task reveals a
+  durable workflow rule, command, ownership boundary, release gate, or validation
+  expectation that would help future agents, update this file in the same PR.
+- Remove or replace outdated guidance when the repo, workflows, or release
+  process change. Do not preserve historical instructions that now contradict
+  the current source of truth.
+- Keep entries actionable and concise. Avoid session logs, one-off incident
+  details, and duplicated advice; prefer stable commands, decision rules, and
+  pointers to discoverable tooling.
+- If this file becomes too long or noisy while adding guidance, compress nearby
+  sections by merging duplicates and trimming obsolete detail while preserving
+  critical safety constraints, validation commands, and release requirements.
+
 ### Before Committing
 1. Run `dart format .` to ensure code is properly formatted
 2. Run `dart analyze` to fix all warnings and lint errors

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 ## Unreleased
 
+* Added post-merge release automation so a merged release-prep PR can publish
+  missing companion package versions, push the core release tag, wait for
+  pub.dev, and confirm the GitHub Release without a separate manual tag step.
+
 * Added `LlamaEngine.getModelFileType()` for llama.cpp/GGUF models, exposing
   native model file type / quantization metadata from `llama_model_ftype` and
   `llama_ftype_name` when available.

--- a/doc/testing_matrix.md
+++ b/doc/testing_matrix.md
@@ -127,10 +127,10 @@ For releases that change or newly document Flutter Apple SwiftPM companion
 package versions, include `release-companion-pub-gate` in the release evidence.
 That row requires verifying each referenced companion version on pub.dev before
 tagging the core `vX.Y.Z` release. If a companion version is missing, merge the
-release-prep PR first, then get explicit maintainer approval before pushing that
-companion's package-specific tag. Wait for `publish_companion_pubdev.yml`, verify
-the pub.dev version URL, and get explicit maintainer approval again before
-pushing the core release tag.
+release-prep PR first. `release_on_prep_merge.yml` then publishes missing
+companion versions, waits for `publish_companion_pubdev.yml`, verifies the
+pub.dev version URL, and pushes the core release tag after the companion gate
+passes.
 
 ## Local Model Scenarios
 

--- a/tool/testing/verify_release_docs_versions.dart
+++ b/tool/testing/verify_release_docs_versions.dart
@@ -8,7 +8,8 @@ import 'dart:io';
 //
 // During release-prep PRs, current install docs are expected to track the
 // in-repository package versions being prepared. Publishing still happens only
-// after merge and explicit maintainer approval for each release tag.
+// after merge; the release-prep PR merge is the approval boundary for the
+// post-merge release automation.
 const Map<String, String> _packagePubspecs = <String, String>{
   'llamadart': 'pubspec.yaml',
   'llamadart_llama_cpp_flutter':

--- a/website/docs/changelog/recent-releases.md
+++ b/website/docs/changelog/recent-releases.md
@@ -7,6 +7,12 @@ For canonical full release notes, use:
 
 - [`CHANGELOG.md`](https://github.com/leehack/llamadart/blob/main/CHANGELOG.md)
 
+## Unreleased
+
+- Added post-merge release automation so a merged release-prep PR can publish
+  missing companion package versions, push the core release tag, wait for
+  pub.dev, and confirm the GitHub Release without a separate manual tag step.
+
 ## 0.8.11
 
 - Updated the default llama.cpp native runtime pin to

--- a/website/docs/maintainers/native-and-web-sync.md
+++ b/website/docs/maintainers/native-and-web-sync.md
@@ -85,16 +85,16 @@ version is newly referenced by current install docs:
    release assets and that the pinned checksums match those assets.
 2. Merge the sync/release-prep PR first. The PR itself must not publish the
    companion or core package.
-3. After merge, get explicit maintainer approval before pushing each
-   package-specific companion tag:
+3. After merge, `release_on_prep_merge.yml` uses the release-prep PR merge as
+   the publishing approval boundary and pushes each missing package-specific
+   companion tag:
    `llamadart_llama_cpp_flutter-v{{version}}` or
    `llamadart_litert_lm_flutter-v{{version}}`.
 4. Wait for `publish_companion_pubdev.yml` to pass.
 5. Verify the version URL on pub.dev, for example
    `https://pub.dev/api/packages/llamadart_llama_cpp_flutter/versions/{{version}}`.
-6. Only after the companion version is live, get explicit maintainer approval
-   before pushing the core `vX.Y.Z` release tag that documents or depends on
-   that companion version.
+6. Only after the companion version is live, the automation pushes the core
+   `vX.Y.Z` release tag that documents or depends on that companion version.
 
 ## Web bridge asset sync flow
 

--- a/website/docs/maintainers/release-workflow.md
+++ b/website/docs/maintainers/release-workflow.md
@@ -72,7 +72,7 @@ release-prep PR is the explicit approval boundary for publishing. After merge,
 `vX.Y.Z` tag, pub.dev publication, docs versioning, and GitHub Release creation.
 
 For automation to run, the merged PR must either carry the `release-prep` label
-or use a release-prep branch name such as `release/prep-0.8.12` or
+or use a versioned release-prep branch name such as `release/prep-0.8.12` or
 `release/0.8.12-prep`. The automation requires a `RELEASE_AUTOMATION_TOKEN`
 repository secret containing a fine-scoped PAT or GitHub App token that can push
 tags and trigger tag-based workflows. Do not use the default `GITHUB_TOKEN` for

--- a/website/docs/maintainers/release-workflow.md
+++ b/website/docs/maintainers/release-workflow.md
@@ -47,9 +47,10 @@ version alignment:
   publishable package contents changed, move their accumulated `Unreleased`
   notes into the new version section, and keep unchanged companion package
   versions as-is.
-- Companion packages publish only after the release-prep PR is merged and the
-  maintainer explicitly approves pushing the relevant package-specific tag; the
-  workflow skips a companion package version that already exists on pub.dev.
+- Companion packages publish only after the release-prep PR is merged. The
+  release-prep PR merge is the approval boundary; automation pushes the relevant
+  package-specific tags, and the publish workflow skips a companion package
+  version that already exists on pub.dev.
 - Keep current install snippets aligned with root and companion `pubspec.yaml`
   versions. Run `dart run tool/testing/verify_release_docs_versions.dart` before
   opening or merging the release-prep PR.
@@ -65,8 +66,17 @@ version alignment:
 ## 3. Publish flow
 
 A release-prep PR updates versions, changelogs, docs, and pins only; it must not
-publish companion packages or the core package. Merging release prep is a
-separate approval boundary from every tag push that triggers pub.dev publishing.
+publish companion packages or the core package before merge. Merging a
+release-prep PR is the explicit approval boundary for publishing. After merge,
+`release_on_prep_merge.yml` owns companion package tag ordering, the core
+`vX.Y.Z` tag, pub.dev publication, docs versioning, and GitHub Release creation.
+
+For automation to run, the merged PR must either carry the `release-prep` label
+or use a release-prep branch name such as `release/prep-0.8.12` or
+`release/0.8.12-prep`. The automation requires a `RELEASE_AUTOMATION_TOKEN`
+repository secret containing a fine-scoped PAT or GitHub App token that can push
+tags and trigger tag-based workflows. Do not use the default `GITHUB_TOKEN` for
+this step because GitHub suppresses most workflow runs caused by that token.
 
 Do not tag the core `vX.Y.Z` release until every companion package version named
 in the current install docs is already published on pub.dev. The release
@@ -85,24 +95,25 @@ sequence is:
    ```
 
 3. If a changed companion version is missing, first merge the release-prep PR.
-   Then request explicit maintainer approval to push that companion's
-   package-specific tag, for example:
+   The post-merge release workflow then pushes that companion's package-specific
+   tag, for example:
 
    ```bash
    git tag llamadart_llama_cpp_flutter-v0.0.3
    git push origin llamadart_llama_cpp_flutter-v0.0.3
    ```
 
-   Wait for `publish_companion_pubdev.yml` to pass, then re-check the pub.dev
-   version URL.
+   The workflow waits for `publish_companion_pubdev.yml` to publish the package
+   and re-checks the pub.dev version URL.
 4. Tag `vX.Y.Z` and push the core release tag only after the companion packages
-   referenced by the release docs are resolvable from pub.dev, and only after a
-   separate explicit maintainer approval for the core release tag.
+   referenced by the release docs are resolvable from pub.dev. Automation pushes
+   the core tag after that gate passes.
 
 Current workflows involved:
 
-- `publish_pubdev.yml`: publishes the core package on version tags, and
-  does not publish companion packages.
+- `publish_pubdev.yml`: publishes the core package on version tags, creates or
+  updates the GitHub Release after pub.dev publishing succeeds, and does not
+  publish companion packages.
 - `publish_companion_pubdev.yml`: publishes one companion package from a
   package-specific version tag after that package already exists on pub.dev:
   `llamadart_llama_cpp_flutter-v{{version}}` or
@@ -126,10 +137,18 @@ rsync -a --delete \
 - `docs_version_cut.yml`: creates versioned docs snapshot on `v*` tags.
 - `docs_pages.yml`: deploys docs to GitHub Pages after successful
   `docs_version_cut.yml` runs (and can be manually triggered).
+- `release_on_prep_merge.yml`: runs after a release-prep PR is merged into
+  `main`, validates the prepared version, publishes any missing companion
+  package versions first, pushes the core release tag, waits for pub.dev, and
+  confirms the GitHub Release exists.
 
 ## 4. Post-release verification
 
+- Verify `release_on_prep_merge.yml`, `publish_pubdev.yml`,
+  `publish_companion_pubdev.yml` when relevant, `docs_version_cut.yml`, and
+  `docs_pages.yml` all completed successfully.
 - Verify pub.dev package page and API docs for the new version.
+- Verify the GitHub Release exists and is marked latest.
 - Verify docs version selector includes the new release.
 - Re-run smoke checks for representative examples.
 


### PR DESCRIPTION
## Summary

- Add `release_on_prep_merge.yml` to publish merged release-prep PRs automatically after a guarded opt-in gate.
- Publish missing companion package versions before pushing the core `vX.Y.Z` tag, then wait for pub.dev and the GitHub Release.
- Extend `publish_pubdev.yml` so a successful core pub.dev publish creates or updates the GitHub Release from `CHANGELOG.md` notes.
- Update maintainer docs, `AGENTS.md`, testing matrix guidance, and release notes to make the release-prep PR merge the publishing approval boundary.
- Add `AGENTS.md` maintenance guidance so future agents update, prune, and compress durable repo instructions as workflows change.

## Operational note

`release_on_prep_merge.yml` requires a `RELEASE_AUTOMATION_TOKEN` repository secret containing a fine-scoped PAT or GitHub App token that can push tags and trigger tag-based workflows. The default `GITHUB_TOKEN` should not be used for tag creation because GitHub suppresses most workflow runs caused by that token.

## Validation

- `dart format --output=none --set-exit-if-changed tool/testing/verify_release_docs_versions.dart`
- `dart run tool/testing/verify_release_docs_versions.dart`
- `ruby -e 'require "yaml"; Dir[".github/workflows/*.{yml,yaml}"].sort.each { |path| YAML.load_file(path); puts "ok #{path}" }'`
- `actionlint`
- `git diff --check`
- `./tool/docs/build_site.sh`
- `./tool/docs/validate_links.sh`
