### PR TITLE
Harden release automation

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,18 @@
+# Release automation and publication-sensitive files require maintainer review.
+.github/CODEOWNERS @leehack
+.github/dependabot.yml @leehack
+.github/pull_request_template.md @leehack
+.github/workflows/ @leehack
+
+# Version, release, and native-runtime publication surfaces.
+pubspec.yaml @leehack
+CHANGELOG.md @leehack
+doc/testing_matrix.md @leehack
+hook/build.dart @leehack
+tool/testing/verify_release_docs_versions.dart @leehack
+website/docs/changelog/recent-releases.md @leehack
+website/docs/maintainers/native-and-web-sync.md @leehack
+website/docs/maintainers/release-workflow.md @leehack
+packages/*/CHANGELOG.md @leehack
+packages/*/Package.swift @leehack
+packages/*/pubspec.yaml @leehack

--- a/.github/workflows/release_on_prep_merge.yml
+++ b/.github/workflows/release_on_prep_merge.yml
@@ -20,7 +20,12 @@ jobs:
     name: Publish merged release prep
     if: ${{ github.event.pull_request.merged == true }}
     runs-on: ubuntu-latest
-    timeout-minutes: 90
+    timeout-minutes: 150
+    env:
+      GITHUB_RELEASE_WAIT_ATTEMPTS: ${{ vars.RELEASE_AUTOMATION_GITHUB_RELEASE_WAIT_ATTEMPTS || '180' }}
+      GITHUB_RELEASE_WAIT_INTERVAL_SECONDS: ${{ vars.RELEASE_AUTOMATION_GITHUB_RELEASE_WAIT_INTERVAL_SECONDS || '10' }}
+      PUBDEV_WAIT_ATTEMPTS: ${{ vars.RELEASE_AUTOMATION_PUBDEV_WAIT_ATTEMPTS || '180' }}
+      PUBDEV_WAIT_INTERVAL_SECONDS: ${{ vars.RELEASE_AUTOMATION_PUBDEV_WAIT_INTERVAL_SECONDS || '10' }}
     steps:
       - name: Check release-prep gate
         id: gate
@@ -119,6 +124,20 @@ jobs:
             exit 1
           fi
 
+          require_positive_integer() {
+            local name="$1"
+            local value="$2"
+            if [[ ! "$value" =~ ^[1-9][0-9]*$ ]]; then
+              echo "$name must be a positive integer; got '$value'." >&2
+              exit 1
+            fi
+          }
+
+          require_positive_integer "PUBDEV_WAIT_ATTEMPTS" "$PUBDEV_WAIT_ATTEMPTS"
+          require_positive_integer "PUBDEV_WAIT_INTERVAL_SECONDS" "$PUBDEV_WAIT_INTERVAL_SECONDS"
+          require_positive_integer "GITHUB_RELEASE_WAIT_ATTEMPTS" "$GITHUB_RELEASE_WAIT_ATTEMPTS"
+          require_positive_integer "GITHUB_RELEASE_WAIT_INTERVAL_SECONDS" "$GITHUB_RELEASE_WAIT_INTERVAL_SECONDS"
+
           git config user.name "github-actions[bot]"
           git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
 
@@ -134,14 +153,16 @@ jobs:
             local package_name="$1"
             local package_version="$2"
             local version_url="https://pub.dev/api/packages/$package_name/versions/$package_version"
+            local attempts="$PUBDEV_WAIT_ATTEMPTS"
+            local interval_seconds="$PUBDEV_WAIT_INTERVAL_SECONDS"
 
-            for attempt in $(seq 1 90); do
+            for attempt in $(seq 1 "$attempts"); do
               if curl -fsSL "$version_url" >/dev/null; then
                 echo "$package_name $package_version is live on pub.dev."
                 return 0
               fi
-              echo "Waiting for $package_name $package_version on pub.dev ($attempt/90)."
-              sleep 10
+              echo "Waiting for $package_name $package_version on pub.dev ($attempt/$attempts)."
+              sleep "$interval_seconds"
             done
 
             echo "$package_name $package_version did not appear on pub.dev." >&2
@@ -150,13 +171,16 @@ jobs:
 
           wait_for_github_release() {
             local tag="$1"
-            for attempt in $(seq 1 90); do
+            local attempts="$GITHUB_RELEASE_WAIT_ATTEMPTS"
+            local interval_seconds="$GITHUB_RELEASE_WAIT_INTERVAL_SECONDS"
+
+            for attempt in $(seq 1 "$attempts"); do
               if gh release view "$tag" --repo "$GITHUB_REPOSITORY" >/dev/null 2>&1; then
                 echo "GitHub Release $tag exists."
                 return 0
               fi
-              echo "Waiting for GitHub Release $tag ($attempt/90)."
-              sleep 10
+              echo "Waiting for GitHub Release $tag ($attempt/$attempts)."
+              sleep "$interval_seconds"
             done
 
             echo "GitHub Release $tag was not created." >&2

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -363,6 +363,22 @@ WEBGPU_BRIDGE_ASSETS_TAG=<tag> ./scripts/fetch_webgpu_bridge_assets.sh
   publishing approval boundary. Do not manually push package-specific companion
   tags or the core `vX.Y.Z` tag unless that automation is disabled, blocked, or
   being repaired.
+- Keep release-sensitive paths covered by `.github/CODEOWNERS`, especially
+  `.github/workflows/`, `.github/CODEOWNERS`, `pubspec.yaml`, changelogs,
+  maintainer release docs, `hook/build.dart`, and companion package publish
+  metadata. CODEOWNERS only enforces review when GitHub branch protection or a
+  ruleset requires code-owner review.
+- `RELEASE_AUTOMATION_TOKEN` must stay a fine-scoped PAT or GitHub App token
+  that can push tags and trigger tag workflows. Prefer a GitHub App token where
+  practical, rotate the credential regularly, and never log it or derived
+  credential-bearing remotes.
+- `release_on_prep_merge.yml` defaults to 180 attempts at 10 seconds for both
+  pub.dev and GitHub Release propagation checks. Tune
+  `RELEASE_AUTOMATION_PUBDEV_WAIT_ATTEMPTS`,
+  `RELEASE_AUTOMATION_PUBDEV_WAIT_INTERVAL_SECONDS`,
+  `RELEASE_AUTOMATION_GITHUB_RELEASE_WAIT_ATTEMPTS`, and
+  `RELEASE_AUTOMATION_GITHUB_RELEASE_WAIT_INTERVAL_SECONDS` as repository
+  variables rather than editing the workflow for routine propagation variance.
 - Before merging the release-prep PR, verify any companion package versions
   referenced by current install docs are either already live on pub.dev or ready
   for the post-merge automation to publish. If a changed companion package

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 ## Unreleased
 
+* Hardened release automation by adding CODEOWNERS coverage for
+  publication-sensitive files and making pub.dev/GitHub Release propagation
+  waits configurable with longer defaults.
+
 * Added post-merge release automation so a merged release-prep PR can publish
   missing companion package versions, push the core release tag, wait for
   pub.dev, and confirm the GitHub Release without a separate manual tag step.

--- a/website/docs/changelog/recent-releases.md
+++ b/website/docs/changelog/recent-releases.md
@@ -9,6 +9,10 @@ For canonical full release notes, use:
 
 ## Unreleased
 
+- Hardened release automation by adding CODEOWNERS coverage for
+  publication-sensitive files and making pub.dev/GitHub Release propagation
+  waits configurable with longer defaults.
+
 - Added post-merge release automation so a merged release-prep PR can publish
   missing companion package versions, push the core release tag, wait for
   pub.dev, and confirm the GitHub Release without a separate manual tag step.

--- a/website/docs/maintainers/release-workflow.md
+++ b/website/docs/maintainers/release-workflow.md
@@ -77,6 +77,26 @@ or use a versioned release-prep branch name such as `release/prep-0.8.12` or
 repository secret containing a fine-scoped PAT or GitHub App token that can push
 tags and trigger tag-based workflows. Do not use the default `GITHUB_TOKEN` for
 this step because GitHub suppresses most workflow runs caused by that token.
+Prefer a GitHub App token or fine-scoped PAT with only the repository permissions
+needed to create tags, and rotate it on a regular maintainer cadence. Never echo
+the token or derived credential-bearing URLs in workflow logs.
+
+Release automation and publication-sensitive files are covered by
+`.github/CODEOWNERS`. CODEOWNERS is only advisory until the repository's branch
+protection or ruleset requires code-owner review, so keep that setting enabled
+before relying on the post-merge workflow as the publication approval boundary.
+When adding new workflow, release, version, or native-runtime publication
+surfaces, update `.github/CODEOWNERS` in the same PR.
+
+The post-merge workflow waits for pub.dev and GitHub Release propagation using
+repository-variable defaults that can be tuned without editing the workflow:
+
+| Variable | Default | Meaning |
+| --- | --- | --- |
+| `RELEASE_AUTOMATION_PUBDEV_WAIT_ATTEMPTS` | `180` | Number of pub.dev version URL checks. |
+| `RELEASE_AUTOMATION_PUBDEV_WAIT_INTERVAL_SECONDS` | `10` | Delay between pub.dev checks. |
+| `RELEASE_AUTOMATION_GITHUB_RELEASE_WAIT_ATTEMPTS` | `180` | Number of GitHub Release existence checks. |
+| `RELEASE_AUTOMATION_GITHUB_RELEASE_WAIT_INTERVAL_SECONDS` | `10` | Delay between GitHub Release checks. |
 
 Do not tag the core `vX.Y.Z` release until every companion package version named
 in the current install docs is already published on pub.dev. The release


### PR DESCRIPTION
## Summary
- add CODEOWNERS coverage for workflow and publication-sensitive release files
- make release automation wait caps configurable via repository variables with longer defaults
- document the token, code-owner review, and wait-variable expectations for maintainers and agents

## Production-readiness scope
- **User-facing scope:** Maintainers get safer release automation defaults and explicit ownership guidance for release-sensitive paths.
- **Supported platforms/paths:** GitHub Actions release automation and maintainer docs.
- **Unsupported or intentionally unavailable paths:** Runtime package behavior is unchanged.
- **Out of scope / follow-ups:** Repo settings still need code-owner review enforcement enabled through branch protection or a ruleset; CODEOWNERS alone is advisory until that setting is active.

## Completeness checklist
- [x] Declared scope is fully implemented, or explicitly reduced above.
- [x] Unsupported platform/option combinations fail loudly with actionable diagnostics or are clearly documented as unavailable.
- [x] Public API docs, README/website docs, examples, support matrices, and changelog entries are updated where relevant.
- [x] Regression coverage covers the original issue plus key negative/version-skew paths where relevant.
- [x] Security/privacy review completed: no secrets, bearer tokens, signed URLs, or raw secret-bearing paths leak through logs, cache keys, metadata, errors, or snapshots.
- [x] Follow-up work that is useful but not required for this PR is tracked in GitHub Issues, or explicitly marked "None" above.

## PR type guidance
- **Docs/workflow PR:** runtime behavior is unchanged. This addresses the unresolved post-merge Copilot review comments from #260 around wait caps and release-token governance.

## Test Plan
- [x] `git diff --check`
- [x] `actionlint .github/workflows/release_on_prep_merge.yml`
- [x] `dart run tool/testing/verify_release_docs_versions.dart`
- [x] `./tool/docs/build_site.sh` after `cd website && npm ci`
- [x] `./tool/docs/validate_links.sh`
- [x] `dart analyze` - N/A, docs/workflow-only change with no Dart source changes.
- [x] `dart test -p vm -j 1 --exclude-tags local-only` - N/A, no runtime/test code changed.
- [x] `dart test -p chrome --exclude-tags local-only` - N/A, no runtime/web code changed.

## Matrix Evidence
| Matrix row | Scope covered | Platform / model / backend | Result | Evidence / notes |
| --- | --- | --- | --- | --- |
| `docs-site` | Maintainer release docs and changelog pages | Local Docusaurus build | PASS | `./tool/docs/build_site.sh`; `./tool/docs/validate_links.sh` |
| release automation workflow lint | GitHub Actions expression/shell wiring | Local `actionlint` | PASS | `actionlint .github/workflows/release_on_prep_merge.yml` |
| release docs version gate | Current release install-doc consistency | Local Dart verifier | PASS | `dart run tool/testing/verify_release_docs_versions.dart` |

## Review Notes
- Independent review status: Follow-up to Copilot comments on #260.
- CI status / head SHA: Green for `46ef0b015`; CI run `28677193772` passed.