### PR TITLE
Prepare 0.8.12 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,9 +1,18 @@
-## Unreleased
+## 0.8.12
 
 * Updated the default LiteRT-LM native runtime pin to
   `leehack/litert-lm-native@v0.14.0-native.1`, refreshed matching native-assets
   checksums, aligned the `llamadart_litert_lm_flutter` Apple SwiftPM checksums,
-  and documented the newly exposed native LiteRT-LM load/generation controls.
+  and documented the newly exposed native LiteRT-LM load/generation controls:
+  per-request max output tokens, native sampler params, thread count, one
+  default-scale initial text LoRA adapter, activation data type, prefill chunk
+  size, parallel file-section loading, and Android LiteRT dispatch library
+  directory.
+
+* Hardened LiteRT-LM runtime packaging and local runtime preparation for the
+  0.14 line, including Linux/Windows runtime dependency resolution, Android
+  Dawn companion libraries, Apple SwiftPM checksums, and macOS fallback app
+  runtime copying.
 
 * Hardened release automation by adding CODEOWNERS coverage for
   publication-sensitive files and making pub.dev/GitHub Release propagation

--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ JavaScript runtime.
 
 ```yaml
 dependencies:
-  llamadart: ^0.8.11
+  llamadart: ^0.8.12
 ```
 
 Flutter iOS/macOS apps that want Swift Package Manager-linked Apple
@@ -61,9 +61,9 @@ they ship:
 
 ```yaml
 dependencies:
-  llamadart: ^0.8.11
-  llamadart_llama_cpp_flutter: ^0.0.7 # GGUF / llama.cpp
-  llamadart_litert_lm_flutter: ^0.0.2 # .litertlm / LiteRT-LM
+  llamadart: ^0.8.12
+  llamadart_llama_cpp_flutter: ^0.0.8 # GGUF / llama.cpp
+  llamadart_litert_lm_flutter: ^0.0.3 # .litertlm / LiteRT-LM
 ```
 
 The companion packages are published independently from the `packages/`

--- a/packages/llamadart_litert_lm_flutter/CHANGELOG.md
+++ b/packages/llamadart_litert_lm_flutter/CHANGELOG.md
@@ -1,4 +1,4 @@
-## Unreleased
+## 0.0.3
 
 * Updated Apple SwiftPM native pin to `leehack/litert-lm-native@v0.14.0-native.1`.
 

--- a/packages/llamadart_litert_lm_flutter/README.md
+++ b/packages/llamadart_litert_lm_flutter/README.md
@@ -10,8 +10,8 @@ core package's native-assets fallback.
 
 ```yaml
 dependencies:
-  llamadart: ^0.8.11
-  llamadart_litert_lm_flutter: ^0.0.2
+  llamadart: ^0.8.12
+  llamadart_litert_lm_flutter: ^0.0.3
 ```
 
 This package has no runtime Dart API of its own. Import `package:llamadart`

--- a/packages/llamadart_litert_lm_flutter/pubspec.yaml
+++ b/packages/llamadart_litert_lm_flutter/pubspec.yaml
@@ -1,6 +1,6 @@
 name: llamadart_litert_lm_flutter
 description: Flutter Apple SwiftPM runtime companion package for llamadart LiteRT-LM support.
-version: 0.0.2
+version: 0.0.3
 repository: https://github.com/leehack/llamadart/tree/main/packages/llamadart_litert_lm_flutter
 homepage: https://github.com/leehack/llamadart
 issue_tracker: https://github.com/leehack/llamadart/issues

--- a/packages/llamadart_llama_cpp_flutter/CHANGELOG.md
+++ b/packages/llamadart_llama_cpp_flutter/CHANGELOG.md
@@ -1,4 +1,4 @@
-## Unreleased
+## 0.0.8
 
 * Updated Apple SwiftPM native pin to `leehack/llamadart-native@b9860`.
 

--- a/packages/llamadart_llama_cpp_flutter/README.md
+++ b/packages/llamadart_llama_cpp_flutter/README.md
@@ -9,8 +9,8 @@ core package's native-assets fallback.
 
 ```yaml
 dependencies:
-  llamadart: ^0.8.11
-  llamadart_llama_cpp_flutter: ^0.0.7
+  llamadart: ^0.8.12
+  llamadart_llama_cpp_flutter: ^0.0.8
 ```
 
 This package has no runtime Dart API of its own. Import `package:llamadart`

--- a/packages/llamadart_llama_cpp_flutter/pubspec.yaml
+++ b/packages/llamadart_llama_cpp_flutter/pubspec.yaml
@@ -1,6 +1,6 @@
 name: llamadart_llama_cpp_flutter
 description: Flutter Apple SwiftPM runtime companion package for llamadart llama.cpp and GGUF support.
-version: 0.0.7
+version: 0.0.8
 repository: https://github.com/leehack/llamadart/tree/main/packages/llamadart_llama_cpp_flutter
 homepage: https://github.com/leehack/llamadart
 issue_tracker: https://github.com/leehack/llamadart/issues

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: llamadart
 description: Dart and Flutter local LLM inference with llama.cpp GGUF and LiteRT-LM across native platforms and web.
-version: 0.8.11
+version: 0.8.12
 homepage: https://github.com/leehack/llamadart
 repository: https://github.com/leehack/llamadart
 issue_tracker: https://github.com/leehack/llamadart/issues

--- a/website/docs/changelog/recent-releases.md
+++ b/website/docs/changelog/recent-releases.md
@@ -7,7 +7,15 @@ For canonical full release notes, use:
 
 - [`CHANGELOG.md`](https://github.com/leehack/llamadart/blob/main/CHANGELOG.md)
 
-## Unreleased
+## 0.8.12
+
+- Updated the default LiteRT-LM native runtime pin to
+  `leehack/litert-lm-native@v0.14.0-native.1`, refreshed native-assets and
+  Apple SwiftPM checksums, and exposed the new native LiteRT-LM 0.14
+  load/generation controls.
+
+- Hardened LiteRT-LM 0.14 runtime packaging across Linux, Windows, Android,
+  Apple SwiftPM, and macOS local runtime-prep paths.
 
 - Hardened release automation by adding CODEOWNERS coverage for
   publication-sensitive files and making pub.dev/GitHub Release propagation
@@ -16,6 +24,11 @@ For canonical full release notes, use:
 - Added post-merge release automation so a merged release-prep PR can publish
   missing companion package versions, push the core release tag, wait for
   pub.dev, and confirm the GitHub Release without a separate manual tag step.
+
+- Added `LlamaEngine.getModelFileType()` for llama.cpp/GGUF models.
+
+- Refreshed llama.cpp `b9860` native runtime pins and template parity for
+  DeepSeek V4 and MiniCPM5, including MiniCPM5 XML tool-call handling.
 
 ## 0.8.11
 

--- a/website/docs/getting-started/installation.md
+++ b/website/docs/getting-started/installation.md
@@ -27,7 +27,7 @@ In Xcode, set `IPHONEOS_DEPLOYMENT_TARGET = 16.4` or
 
 ```yaml
 dependencies:
-  llamadart: ^0.8.11
+  llamadart: ^0.8.12
 ```
 
 For Flutter iOS/macOS apps that should link Apple XCFrameworks through Swift
@@ -35,9 +35,9 @@ Package Manager, also add the runtime companion packages you need:
 
 ```yaml
 dependencies:
-  llamadart: ^0.8.11
-  llamadart_llama_cpp_flutter: ^0.0.7 # GGUF / llama.cpp
-  llamadart_litert_lm_flutter: ^0.0.2 # .litertlm / LiteRT-LM
+  llamadart: ^0.8.12
+  llamadart_llama_cpp_flutter: ^0.0.8 # GGUF / llama.cpp
+  llamadart_litert_lm_flutter: ^0.0.3 # .litertlm / LiteRT-LM
 ```
 
 The companion packages are published independently from the `packages/`


### PR DESCRIPTION
## Summary
- Bump `llamadart` to `0.8.12`.
- Bump companion packages: `llamadart_llama_cpp_flutter` to `0.0.8` and `llamadart_litert_lm_flutter` to `0.0.3`.
- Move accumulated release notes from `Unreleased` into the `0.8.12`, `0.0.8`, and `0.0.3` sections.
- Update README and website install snippets to the release versions.

## Release Notes
- Includes the LiteRT-LM 0.14.0 runtime API/support work, the b9860 llama.cpp native pin, runtime packaging hardening, model file type support, and release automation updates already merged to `main`.
- New pub.dev versions are expected to be absent before merge. The post-merge release workflow should publish the companion packages before tagging/publishing the core release.
- Native artifacts verified before opening this PR: `leehack/llamadart-native@b9860` and `leehack/litert-lm-native@v0.14.0-native.1` both have the expected release assets.

## Validation
- `dart pub get`
- `dart run tool/testing/verify_release_docs_versions.dart`
- `dart format --output=none --set-exit-if-changed .`
- `dart analyze` (passes; reports two pre-existing info-level `prefer_is_empty` lints)
- `dart run tool/testing/check_platform_boundaries.dart`
- `dart test -p vm -j 1 --exclude-tags local-only`
- `flutter pub get`, `dart format --output=none --set-exit-if-changed .`, `flutter analyze`, `flutter test`, and `swift package --package-path ... dump-package` for both companion packages
- `./tool/docs/build_site.sh`
- `./tool/docs/validate_links.sh`
- `flutter pub publish --dry-run` for `llamadart`, `llamadart_llama_cpp_flutter`, and `llamadart_litert_lm_flutter` (all zero warnings)
