### PR TITLE
Fix release automation tag creation

### DIFF
--- a/.github/workflows/release_on_prep_merge.yml
+++ b/.github/workflows/release_on_prep_merge.yml
@@ -120,7 +120,7 @@ jobs:
 
           if [[ -z "${RELEASE_TOKEN:-}" ]]; then
             echo "Missing RELEASE_AUTOMATION_TOKEN." >&2
-            echo "Configure a fine-scoped PAT or GitHub App token that can create tags and trigger tag workflows." >&2
+            echo "Configure a fine-scoped PAT or GitHub App token that can create tag refs and trigger tag workflows." >&2
             exit 1
           fi
 
@@ -138,15 +138,15 @@ jobs:
           require_positive_integer "GITHUB_RELEASE_WAIT_ATTEMPTS" "$GITHUB_RELEASE_WAIT_ATTEMPTS"
           require_positive_integer "GITHUB_RELEASE_WAIT_INTERVAL_SECONDS" "$GITHUB_RELEASE_WAIT_INTERVAL_SECONDS"
 
-          git config user.name "github-actions[bot]"
-          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
-
           push_tag() {
             local tag="$1"
             echo "Creating tag $tag at $RELEASE_SHA"
-            git tag "$tag" "$RELEASE_SHA"
-            git -c http.extraHeader="AUTHORIZATION: bearer $RELEASE_TOKEN" \
-              push origin "refs/tags/$tag"
+            GH_TOKEN="$RELEASE_TOKEN" gh api \
+              --method POST \
+              "repos/$GITHUB_REPOSITORY/git/refs" \
+              -f "ref=refs/tags/$tag" \
+              -f "sha=$RELEASE_SHA" \
+              >/dev/null
           }
 
           wait_for_pub_version() {

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -369,9 +369,9 @@ WEBGPU_BRIDGE_ASSETS_TAG=<tag> ./scripts/fetch_webgpu_bridge_assets.sh
   metadata. CODEOWNERS only enforces review when GitHub branch protection or a
   ruleset requires code-owner review.
 - `RELEASE_AUTOMATION_TOKEN` must stay a fine-scoped PAT or GitHub App token
-  that can push tags and trigger tag workflows. Prefer a GitHub App token where
-  practical, rotate the credential regularly, and never log it or derived
-  credential-bearing remotes.
+  that can create tag refs through the GitHub API and trigger tag workflows.
+  Prefer a GitHub App token where practical, rotate the credential regularly,
+  and never log it or derived credential-bearing remotes.
 - `release_on_prep_merge.yml` defaults to 180 attempts at 10 seconds for both
   pub.dev and GitHub Release propagation checks. Tune
   `RELEASE_AUTOMATION_PUBDEV_WAIT_ATTEMPTS`,


### PR DESCRIPTION
## Summary
- Switch `release_on_prep_merge.yml` tag creation from Git HTTPS push to GitHub API ref creation using `RELEASE_AUTOMATION_TOKEN`.
- Update maintainer release notes to describe the API tag-ref requirement.

## Why
The 0.8.12 release-prep merge started correctly, but the publish step failed before creating any remote tags:

```text
fatal: could not read Username for 'https://github.com': No such device or address
```

The same tag-ref creation done manually through `gh api` successfully triggered the companion/core publish workflows for 0.8.12.

## Validation
- `actionlint .github/workflows/release_on_prep_merge.yml`
- `git diff --check`
- Manual release recovery evidence for 0.8.12:
  - `llamadart_llama_cpp_flutter-v0.0.8` tag triggered publish and pub.dev reports 200.
  - `llamadart_litert_lm_flutter-v0.0.3` tag triggered publish and pub.dev reports 200.
  - `v0.8.12` tag triggered core publish, GitHub Release creation, docs version cut, and docs pages deploy.
