### PR TITLE
Validate expanded llama.cpp speculative strategies

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 ## Unreleased
 
+* Added a durable flag-based llama.cpp speculative benchmark runner and wired
+  it into the local E2E scenario list, testing matrix, README, and website
+  performance guide.
+
+* Hardened generic llama.cpp external draft-model speculative decoding so
+  draft-context processing does not request unused logits, avoiding a
+  `draft-simple` native abort while preserving target verification logits.
+
 * Updated the default llama.cpp native runtime pin to
   `leehack/llamadart-native@b9873`, regenerated matching Dart FFI bindings,
   refreshed the `llamadart_llama_cpp_flutter` Apple SwiftPM checksum, and

--- a/README.md
+++ b/README.md
@@ -312,10 +312,27 @@ workload-dependent and can be slower than baseline decoding on prompts with
 little repetition, so validate it with your model and prompt shape. Upstream
 `--spec-default` maps to `ngram-mod`; in llamadart, legacy
 `GenerationParams(speculativeDecoding: true)` uses that llama.cpp default. For
-local measurements, set
-`LLAMADART_MTP_BENCHMARK_NGRAM=true` and
-`LLAMADART_MTP_BENCHMARK_NGRAM_ONLY=true` when running
-`tool/testing/llama_cpp_mtp_benchmark.dart`.
+local measurements, run the discoverable local E2E benchmark scenario with
+explicit cases:
+
+```bash
+dart run tool/testing/run_local_e2e.dart \
+  --scenario llama-cpp-speculative-benchmark \
+  --model-path path/to/model.gguf \
+  --speculative-cases baseline,ngram-simple,ngram-map-k,ngram-map-k4v,ngram-mod,mixed-ngram \
+  --backend cpu \
+  --benchmark-gpu-layers 0 \
+  --benchmark-max-tokens 128 \
+  --benchmark-runs 3 \
+  --draft-token-max 1,2 \
+  --benchmark-warmups 1
+```
+
+In the local E2E scenario, draft-model strategies require
+`--draft-model-path`; the n-gram cache strategy requires cache paths. Use
+`tool/testing/llama_cpp_speculative_benchmark.dart` directly for advanced
+strategy-specific benchmark knobs; the raw runner's draft-model flag is
+`--draft-model`.
 
 For target/draft model pairs, pass the separate drafter GGUF with
 `draftModelPath`. Use `draftSimple`, `draftEagle3`, `mtp`, or `draftDflash`

--- a/doc/testing_matrix.md
+++ b/doc/testing_matrix.md
@@ -160,12 +160,20 @@ dart run tool/testing/native_inference_benchmark.dart \
   --runs 3 \
   --max-tokens 128
 
-LLAMADART_MTP_BENCHMARK_NGRAM=true \
-LLAMADART_MTP_BENCHMARK_NGRAM_ONLY=true \
-LLAMADART_MTP_BENCHMARK_NGRAM_SIZE=1 \
-  dart run tool/testing/llama_cpp_mtp_benchmark.dart \
-  models/Qwen3.5-0.8B-Q4_K_M.gguf - 128 3 1,2,4 1
+dart run tool/testing/run_local_e2e.dart \
+  --scenario llama-cpp-speculative-benchmark \
+  --model-path models/Qwen3.5-0.8B-Q4_K_M.gguf \
+  --speculative-cases baseline,ngram-simple,ngram-map-k,ngram-map-k4v,ngram-mod,mixed-ngram \
+  --backend cpu \
+  --benchmark-gpu-layers 0 \
+  --benchmark-max-tokens 128 \
+  --benchmark-runs 3 \
+  --draft-token-max 1,2 \
+  --benchmark-warmups 1
 ```
+
+In the local E2E scenario, draft-model strategies require
+`--draft-model-path`; the n-gram cache strategy requires cache paths.
 
 Use `--dry-run` first when a scenario starts servers, builds Flutter web, or
 requires local model URLs.

--- a/lib/src/backends/llama_cpp/llama_cpp_service.dart
+++ b/lib/src/backends/llama_cpp/llama_cpp_service.dart
@@ -5154,20 +5154,13 @@ class LlamaCppService {
       return action();
     }
 
-    final previousLogits = List<int>.generate(
-      tokenCount,
-      (index) => logits[index],
-      growable: false,
-    );
+    final logitView = logits.asTypedList(tokenCount);
+    final previousLogits = List<int>.of(logitView, growable: false);
     try {
-      for (var i = 0; i < tokenCount; i++) {
-        logits[i] = 0;
-      }
+      logitView.fillRange(0, tokenCount, 0);
       return action();
     } finally {
-      for (var i = 0; i < previousLogits.length; i++) {
-        logits[i] = previousLogits[i];
-      }
+      logitView.setAll(0, previousLogits);
     }
   }
 

--- a/lib/src/backends/llama_cpp/llama_cpp_service.dart
+++ b/lib/src/backends/llama_cpp/llama_cpp_service.dart
@@ -686,6 +686,13 @@ class _LlamaCppSpeculativeConfig {
         strategy == SpeculativeDecodingStrategy.draftEagle3 ||
         strategy == SpeculativeDecodingStrategy.draftDflash,
   );
+
+  bool get suppressDraftProcessLogits => strategies.any(
+    (strategy) =>
+        strategy == SpeculativeDecodingStrategy.draftSimple ||
+        strategy == SpeculativeDecodingStrategy.draftEagle3 ||
+        strategy == SpeculativeDecodingStrategy.draftDflash,
+  );
 }
 
 class _LlamaCppMtpConfig {
@@ -3931,6 +3938,28 @@ class LlamaCppService {
     )?.typeNames;
   }
 
+  /// Resolves whether llama.cpp speculative prompt processing suppresses logits.
+  bool debugSuppressesDraftProcessLogitsForTesting(
+    GenerationParams params, {
+    bool hasMediaParts = false,
+  }) {
+    return _resolveLlamaCppSpeculativeConfig(
+          params,
+          hasMediaParts: hasMediaParts,
+        )?.suppressDraftProcessLogits ??
+        false;
+  }
+
+  /// Runs [action] while native batch logits are temporarily zeroed.
+  static T debugWithSuppressedBatchLogitsForTesting<T>(
+    Pointer<Int8> logits,
+    int tokenCount,
+    bool suppress,
+    T Function() action,
+  ) {
+    return _withSuppressedBatchLogits(logits, tokenCount, suppress, action);
+  }
+
   int _resolveLlamaCppSpeculativeDraftTokenMax(
     List<SpeculativeDecodingStrategy> strategies,
     SpeculativeDecodingConfig config,
@@ -4113,6 +4142,7 @@ class LlamaCppService {
             params.reusePromptPrefix,
         speculativeSession: speculativeSession,
         speculativeApi: speculativeApi,
+        speculativeConfig: speculativeConfig,
       );
       promptEvalStopwatch.stop();
       ctx.lastPerfPromptEvalMs =
@@ -4602,6 +4632,7 @@ class LlamaCppService {
     required bool allowTextPromptReuse,
     required Pointer<llama_dart_speculative> speculativeSession,
     required _SpeculativeApi? speculativeApi,
+    required _LlamaCppSpeculativeConfig? speculativeConfig,
   }) {
     final mediaParts =
         parts
@@ -4632,6 +4663,7 @@ class LlamaCppService {
         allowPromptReuse: allowTextPromptReuse,
         speculativeSession: speculativeSession,
         speculativeApi: speculativeApi,
+        speculativeConfig: speculativeConfig,
       );
     }
   }
@@ -4872,6 +4904,7 @@ class LlamaCppService {
     required bool allowPromptReuse,
     required Pointer<llama_dart_speculative> speculativeSession,
     required _SpeculativeApi? speculativeApi,
+    required _LlamaCppSpeculativeConfig? speculativeConfig,
   }) {
     final promptPtr = prompt.toNativeUtf8();
     final shouldAddSpecial = !_promptStartsWithBosToken(vocab, prompt);
@@ -4900,6 +4933,7 @@ class LlamaCppService {
         outputAllLogits: speculativeSession != nullptr,
         speculativeSession: speculativeSession,
         speculativeApi: speculativeApi,
+        speculativeConfig: speculativeConfig,
       );
     }
 
@@ -4914,6 +4948,7 @@ class LlamaCppService {
         outputAllLogits: speculativeSession != nullptr,
         speculativeSession: speculativeSession,
         speculativeApi: speculativeApi,
+        speculativeConfig: speculativeConfig,
       );
     }
 
@@ -4941,6 +4976,7 @@ class LlamaCppService {
         outputAllLogits: speculativeSession != nullptr,
         speculativeSession: speculativeSession,
         speculativeApi: speculativeApi,
+        speculativeConfig: speculativeConfig,
       );
     }
 
@@ -4955,6 +4991,7 @@ class LlamaCppService {
         outputAllLogits: speculativeSession != nullptr,
         speculativeSession: speculativeSession,
         speculativeApi: speculativeApi,
+        speculativeConfig: speculativeConfig,
       );
     }
 
@@ -4973,6 +5010,7 @@ class LlamaCppService {
         outputAllLogits: speculativeSession != nullptr,
         speculativeSession: speculativeSession,
         speculativeApi: speculativeApi,
+        speculativeConfig: speculativeConfig,
       );
     }
 
@@ -4987,6 +5025,7 @@ class LlamaCppService {
       outputAllLogits: speculativeSession != nullptr,
       speculativeSession: speculativeSession,
       speculativeApi: speculativeApi,
+      speculativeConfig: speculativeConfig,
     );
 
     ctx.cachedPromptTokens = exactStateLoadMatch
@@ -5007,6 +5046,7 @@ class LlamaCppService {
     bool outputAllLogits = false,
     Pointer<llama_dart_speculative>? speculativeSession,
     _SpeculativeApi? speculativeApi,
+    _LlamaCppSpeculativeConfig? speculativeConfig,
   }) {
     _clearContextMemory(ctx.pointer);
     _decodePromptSegment(
@@ -5019,6 +5059,7 @@ class LlamaCppService {
       outputAllLogits: outputAllLogits,
       speculativeSession: speculativeSession,
       speculativeApi: speculativeApi,
+      speculativeConfig: speculativeConfig,
     );
     ctx.cachedPromptTokens =
         existingCachedTokens ?? _copyPromptTokens(tokensPtr, nTokens);
@@ -5043,6 +5084,7 @@ class LlamaCppService {
     bool outputAllLogits = false,
     Pointer<llama_dart_speculative>? speculativeSession,
     _SpeculativeApi? speculativeApi,
+    _LlamaCppSpeculativeConfig? speculativeConfig,
   }) {
     if (tokenCount <= 0) {
       return;
@@ -5075,11 +5117,57 @@ class LlamaCppService {
       }
       if (speculativeSession != null &&
           speculativeSession != nullptr &&
-          !speculativeApi!.processBatch(speculativeSession, batch)) {
+          !_processSpeculativeBatch(
+            speculativeApi!,
+            speculativeSession,
+            batch,
+            speculativeConfig,
+          )) {
         throw Exception("Speculative prompt decode processing failed");
       }
 
       decoded += chunkTokenCount;
+    }
+  }
+
+  bool _processSpeculativeBatch(
+    _SpeculativeApi speculativeApi,
+    Pointer<llama_dart_speculative> speculativeSession,
+    llama_batch batch,
+    _LlamaCppSpeculativeConfig? speculativeConfig,
+  ) {
+    return _withSuppressedBatchLogits(
+      batch.logits,
+      batch.n_tokens,
+      speculativeConfig?.suppressDraftProcessLogits == true,
+      () => speculativeApi.processBatch(speculativeSession, batch),
+    );
+  }
+
+  static T _withSuppressedBatchLogits<T>(
+    Pointer<Int8> logits,
+    int tokenCount,
+    bool suppress,
+    T Function() action,
+  ) {
+    if (!suppress || logits == nullptr || tokenCount <= 0) {
+      return action();
+    }
+
+    final previousLogits = List<int>.generate(
+      tokenCount,
+      (index) => logits[index],
+      growable: false,
+    );
+    try {
+      for (var i = 0; i < tokenCount; i++) {
+        logits[i] = 0;
+      }
+      return action();
+    } finally {
+      for (var i = 0; i < previousLogits.length; i++) {
+        logits[i] = previousLogits[i];
+      }
     }
   }
 
@@ -5383,7 +5471,12 @@ class LlamaCppService {
           final evalTick = Stopwatch()..start();
           final decodeStatus = llama_decode(ctx.pointer, batch);
           if (decodeStatus == 0 &&
-              !speculativeApi.processBatch(speculativeSession, batch)) {
+              !_processSpeculativeBatch(
+                speculativeApi,
+                speculativeSession,
+                batch,
+                speculativeConfig,
+              )) {
             throw Exception("Speculative decode processing failed");
           }
           evalTick.stop();
@@ -5453,7 +5546,12 @@ class LlamaCppService {
           final evalTick = Stopwatch()..start();
           final decodeStatus = llama_decode(ctx.pointer, batch);
           if (decodeStatus == 0 &&
-              !speculativeApi.processBatch(speculativeSession, batch)) {
+              !_processSpeculativeBatch(
+                speculativeApi,
+                speculativeSession,
+                batch,
+                speculativeConfig,
+              )) {
             throw Exception("Speculative decode processing failed");
           }
           if (decodeStatus == 0) {
@@ -5536,7 +5634,12 @@ class LlamaCppService {
             final replayTick = Stopwatch()..start();
             final replayStatus = llama_decode(ctx.pointer, batch);
             if (replayStatus == 0 &&
-                !speculativeApi.processBatch(speculativeSession, batch)) {
+                !_processSpeculativeBatch(
+                  speculativeApi,
+                  speculativeSession,
+                  batch,
+                  speculativeConfig,
+                )) {
               throw Exception("Speculative replay processing failed");
             }
             if (replayStatus == 0) {

--- a/test/unit/backends/llama_cpp/llama_cpp_service_test.dart
+++ b/test/unit/backends/llama_cpp/llama_cpp_service_test.dart
@@ -1,8 +1,10 @@
 @TestOn('vm')
 library;
 
+import 'dart:ffi';
 import 'dart:io';
 
+import 'package:ffi/ffi.dart';
 import 'package:llamadart/src/backends/llama_cpp/llama_cpp_service.dart';
 import 'package:llamadart/src/core/models/config/gpu_backend.dart';
 import 'package:llamadart/src/core/models/config/gpu_device_info.dart';
@@ -207,6 +209,89 @@ void main() {
           ),
         ),
       );
+    });
+
+    test('suppresses process logits only for external draft strategies', () {
+      expect(
+        service.debugSuppressesDraftProcessLogitsForTesting(
+          const GenerationParams(
+            speculativeDecodingConfig: SpeculativeDecodingConfig.draftSimple(
+              draftModelPath: 'draft.gguf',
+            ),
+          ),
+        ),
+        isTrue,
+      );
+      expect(
+        service.debugSuppressesDraftProcessLogitsForTesting(
+          const GenerationParams(
+            speculativeDecodingConfig: SpeculativeDecodingConfig.draftEagle3(
+              draftModelPath: 'draft.gguf',
+            ),
+          ),
+        ),
+        isTrue,
+      );
+      expect(
+        service.debugSuppressesDraftProcessLogitsForTesting(
+          const GenerationParams(
+            speculativeDecodingConfig: SpeculativeDecodingConfig.mtp(),
+          ),
+        ),
+        isFalse,
+      );
+      expect(
+        service.debugSuppressesDraftProcessLogitsForTesting(
+          const GenerationParams(
+            speculativeDecodingConfig: SpeculativeDecodingConfig.ngramSimple(),
+          ),
+        ),
+        isFalse,
+      );
+    });
+
+    test('temporarily zeros and restores suppressed batch logits', () {
+      final logits = malloc<Int8>(3);
+      addTearDown(() => malloc.free(logits));
+      logits[0] = 1;
+      logits[1] = 0;
+      logits[2] = 1;
+
+      final seenLogits = <int>[];
+      final result = LlamaCppService.debugWithSuppressedBatchLogitsForTesting(
+        logits,
+        3,
+        true,
+        () {
+          seenLogits.addAll([logits[0], logits[1], logits[2]]);
+          logits[1] = 7;
+          return 'processed';
+        },
+      );
+
+      expect(result, 'processed');
+      expect(seenLogits, [0, 0, 0]);
+      expect([logits[0], logits[1], logits[2]], [1, 0, 1]);
+    });
+
+    test('leaves batch logits untouched when suppression is disabled', () {
+      final logits = malloc<Int8>(2);
+      addTearDown(() => malloc.free(logits));
+      logits[0] = 1;
+      logits[1] = 0;
+
+      final seenLogits = <int>[];
+      LlamaCppService.debugWithSuppressedBatchLogitsForTesting(
+        logits,
+        2,
+        false,
+        () {
+          seenLogits.addAll([logits[0], logits[1]]);
+        },
+      );
+
+      expect(seenLogits, [1, 0]);
+      expect([logits[0], logits[1]], [1, 0]);
     });
 
     test('rejects invalid ngram-cache paths', () {

--- a/test/unit/tooling/llama_cpp_speculative_benchmark_test.dart
+++ b/test/unit/tooling/llama_cpp_speculative_benchmark_test.dart
@@ -7,6 +7,18 @@ import 'package:test/test.dart';
 
 void main() {
   group('llama_cpp_speculative_benchmark', () {
+    test('documents flash-attention runtime option', () async {
+      final result = await Process.run(Platform.resolvedExecutable, [
+        '--disable-dart-dev',
+        'tool/testing/llama_cpp_speculative_benchmark.dart',
+        '--help',
+      ]);
+
+      expect(result.exitCode, 0);
+      expect(result.stdout, contains('--flash-attention <mode>'));
+      expect(result.stdout, contains('auto, enabled, disabled'));
+    });
+
     test('lists all case aliases in invalid cases errors', () async {
       final result = await Process.run(Platform.resolvedExecutable, [
         '--disable-dart-dev',
@@ -19,6 +31,21 @@ void main() {
 
       expect(result.exitCode, isNot(0));
       expect(result.stderr, contains('all, draftless, ngram'));
+    });
+
+    test('rejects invalid flash-attention values', () async {
+      final result = await Process.run(Platform.resolvedExecutable, [
+        '--disable-dart-dev',
+        'tool/testing/llama_cpp_speculative_benchmark.dart',
+        '--model',
+        'missing.gguf',
+        '--flash-attention',
+        'sometimes',
+      ]);
+
+      expect(result.exitCode, isNot(0));
+      expect(result.stderr, contains('Invalid --flash-attention'));
+      expect(result.stderr, contains('auto, enabled, disabled'));
     });
   });
 }

--- a/test/unit/tooling/llama_cpp_speculative_benchmark_test.dart
+++ b/test/unit/tooling/llama_cpp_speculative_benchmark_test.dart
@@ -17,7 +17,7 @@ void main() {
         'not-a-case',
       ]);
 
-      expect(result.exitCode, 64);
+      expect(result.exitCode, isNot(0));
       expect(result.stderr, contains('all, draftless, ngram'));
     });
   });

--- a/test/unit/tooling/llama_cpp_speculative_benchmark_test.dart
+++ b/test/unit/tooling/llama_cpp_speculative_benchmark_test.dart
@@ -1,0 +1,24 @@
+@TestOn('vm')
+library;
+
+import 'dart:io';
+
+import 'package:test/test.dart';
+
+void main() {
+  group('llama_cpp_speculative_benchmark', () {
+    test('lists all case aliases in invalid cases errors', () async {
+      final result = await Process.run(Platform.resolvedExecutable, [
+        'run',
+        'tool/testing/llama_cpp_speculative_benchmark.dart',
+        '--model',
+        'missing.gguf',
+        '--cases',
+        'not-a-case',
+      ]);
+
+      expect(result.exitCode, 64);
+      expect(result.stderr, contains('all, draftless, ngram'));
+    });
+  });
+}

--- a/test/unit/tooling/llama_cpp_speculative_benchmark_test.dart
+++ b/test/unit/tooling/llama_cpp_speculative_benchmark_test.dart
@@ -9,7 +9,7 @@ void main() {
   group('llama_cpp_speculative_benchmark', () {
     test('lists all case aliases in invalid cases errors', () async {
       final result = await Process.run(Platform.resolvedExecutable, [
-        'run',
+        '--disable-dart-dev',
         'tool/testing/llama_cpp_speculative_benchmark.dart',
         '--model',
         'missing.gguf',

--- a/test/unit/tooling/run_local_e2e_test.dart
+++ b/test/unit/tooling/run_local_e2e_test.dart
@@ -16,6 +16,7 @@ void main() {
       expect(result.stdout, contains('root-template-e2e'));
       expect(result.stdout, contains('qwen35-multimodal-macos-repro'));
       expect(result.stdout, contains('gguf-chat-features-smoke'));
+      expect(result.stdout, contains('llama-cpp-speculative-benchmark'));
       expect(result.stdout, contains('litert-lm-chat-features-smoke'));
       expect(result.stdout, contains('webgpu-multimodal-regression'));
       expect(result.stdout, contains('chat-app-model-cache'));
@@ -214,6 +215,97 @@ void main() {
 
       expect(result.exitCode, 64);
       expect(result.stderr, contains('--image-path requires --mmproj-path'));
+    });
+
+    test(
+      'dry-runs llama.cpp speculative benchmark with matrix options',
+      () async {
+        final result = await runLocalE2e(const [
+          '--scenario',
+          'llama-cpp-speculative-benchmark',
+          '--model-path',
+          'models/Qwen3.5-0.8B-Q4_K_M.gguf',
+          '--backend',
+          'cpu',
+          '--speculative-cases',
+          'baseline,ngram-simple,ngram-map-k,ngram-map-k4v,ngram-mod,mixed-ngram',
+          '--benchmark-max-tokens',
+          '128',
+          '--benchmark-runs',
+          '3',
+          '--draft-token-max',
+          '1,2',
+          '--benchmark-warmups',
+          '1',
+          '--dry-run',
+        ], projectRoot: '/repo');
+
+        expect(result.exitCode, 0);
+        expect(result.stdout, contains('llama-cpp-speculative-benchmark'));
+        expect(
+          result.stdout,
+          contains(
+            'cd /repo && dart run '
+            'tool/testing/llama_cpp_speculative_benchmark.dart '
+            '--model models/Qwen3.5-0.8B-Q4_K_M.gguf '
+            '--cases baseline,ngram-simple,ngram-map-k,ngram-map-k4v,'
+            'ngram-mod,mixed-ngram --backend cpu --gpu-layers 0 '
+            '--max-tokens 128 --runs 3 --draft-token-max 1,2 --warmups 1',
+          ),
+        );
+      },
+    );
+
+    test('dry-runs llama.cpp speculative benchmark with draft model', () async {
+      final result = await runLocalE2e(const [
+        '--scenario',
+        'llama-cpp-speculative-benchmark',
+        '--model-path',
+        'models/qwen2.5-1.5b-instruct-q4_k_m.gguf',
+        '--draft-model-path',
+        'models/qwen2.5-0.5b-instruct-q4_k_m.gguf',
+        '--speculative-cases',
+        'baseline,draft-simple,mixed-ngram-draft-simple',
+        '--benchmark-max-tokens',
+        '16',
+        '--benchmark-runs',
+        '1',
+        '--draft-token-max',
+        '1',
+        '--benchmark-warmups',
+        '0',
+        '--dry-run',
+      ], projectRoot: '/repo');
+
+      expect(result.exitCode, 0);
+      expect(
+        result.stdout,
+        contains(
+          'cd /repo && dart run '
+          'tool/testing/llama_cpp_speculative_benchmark.dart '
+          '--model models/qwen2.5-1.5b-instruct-q4_k_m.gguf '
+          '--cases baseline,draft-simple,mixed-ngram-draft-simple '
+          '--backend auto --gpu-layers 0 --max-tokens 16 --runs 1 '
+          '--draft-token-max 1 --warmups 0 '
+          '--draft-model models/qwen2.5-0.5b-instruct-q4_k_m.gguf',
+        ),
+      );
+    });
+
+    test('requires model path for llama.cpp speculative benchmark', () async {
+      final result = await runLocalE2e(const [
+        '--scenario',
+        'llama-cpp-speculative-benchmark',
+        '--dry-run',
+      ], projectRoot: '/repo');
+
+      expect(result.exitCode, 64);
+      expect(
+        result.stderr,
+        contains(
+          '--model-path is required for llama-cpp-speculative-benchmark',
+        ),
+      );
     });
 
     test('dry-runs LiteRT-LM chat feature smoke with model path', () async {

--- a/test/unit/tooling/test_matrix_test.dart
+++ b/test/unit/tooling/test_matrix_test.dart
@@ -73,9 +73,26 @@ void main() {
 
       expect(table, contains('| ID | Tier | Mode |'));
       expect(table, contains('gguf-chat-features-smoke'));
-      expect(table, contains('LLAMADART_MTP_BENCHMARK_NGRAM_ONLY=true'));
-      expect(table, contains('llama_cpp_mtp_benchmark.dart <model.gguf>'));
-      expect(table, contains('1,2 1'));
+      expect(
+        table,
+        contains(
+          'run_local_e2e.dart --scenario llama-cpp-speculative-benchmark',
+        ),
+      );
+      expect(
+        table,
+        contains(
+          '--speculative-cases baseline,ngram-simple,ngram-map-k,ngram-map-k4v,'
+          'ngram-mod,mixed-ngram',
+        ),
+      );
+      expect(table, contains('--draft-token-max 1,2 --benchmark-warmups 1'));
+      expect(
+        table,
+        contains('Draft-model strategies require --draft-model-path'),
+      );
+      expect(table, isNot(contains('LLAMADART_MTP_BENCHMARK')));
+      expect(table, isNot(contains('llama_cpp_mtp_benchmark.dart')));
       expect(table, contains('run_local_e2e.dart'));
       expect(table, isNot(contains('static-format-analyze')));
     });

--- a/tool/testing/llama_cpp_speculative_benchmark.dart
+++ b/tool/testing/llama_cpp_speculative_benchmark.dart
@@ -19,6 +19,7 @@ Future<void> main(List<String> arguments) async {
     numberOfThreadsBatch: options.threadsBatch,
     batchSize: options.batchSize,
     microBatchSize: options.microBatchSize,
+    flashAttention: options.flashAttention,
   );
   final speculativeModelParams = baselineModelParams.copyWith(
     speculativeRollbackTokenMax: options.maxDraftTokenMax,
@@ -686,6 +687,7 @@ class _BenchmarkOptions {
     required this.contextSize,
     required this.preferredBackend,
     required this.gpuLayers,
+    required this.flashAttention,
     required this.threads,
     required this.threadsBatch,
     required this.batchSize,
@@ -759,6 +761,7 @@ class _BenchmarkOptions {
       ),
       preferredBackend: _parsePreferredBackend(map['backend']),
       gpuLayers: _parseInt(map['gpu-layers'], fallback: 0, name: 'gpu-layers'),
+      flashAttention: _parseFlashAttention(map['flash-attention']),
       threads: _parseInt(map['threads'], fallback: 4, name: 'threads'),
       threadsBatch: _parseInt(
         map['threads-batch'],
@@ -826,6 +829,7 @@ class _BenchmarkOptions {
   final int contextSize;
   final GpuBackend preferredBackend;
   final int gpuLayers;
+  final FlashAttention flashAttention;
   final int threads;
   final int threadsBatch;
   final int batchSize;
@@ -876,6 +880,7 @@ class _BenchmarkOptions {
       'contextSize': contextSize,
       'preferredBackend': preferredBackend.name,
       'gpuLayers': gpuLayers,
+      'flashAttention': flashAttention.name,
       'threads': threads,
       'threadsBatch': threadsBatch,
       'batchSize': batchSize,
@@ -1128,6 +1133,23 @@ GpuBackend _parsePreferredBackend(String? value) {
   exit(64);
 }
 
+FlashAttention _parseFlashAttention(String? value) {
+  final normalized = value?.trim().toLowerCase();
+  if (normalized == null || normalized.isEmpty) {
+    return FlashAttention.auto;
+  }
+  for (final mode in FlashAttention.values) {
+    if (mode.name == normalized) {
+      return mode;
+    }
+  }
+  stderr.writeln(
+    'Invalid --flash-attention: $value. Allowed values: '
+    '${FlashAttention.values.map((mode) => mode.name).join(', ')}.',
+  );
+  exit(64);
+}
+
 List<int> _parseIntList(
   String? value, {
   required List<int> fallback,
@@ -1251,6 +1273,7 @@ Supported cases:
 Runtime:
   --backend <name>                     ${GpuBackend.values.map((b) => b.name).join(', ')}. Default: cpu.
   --gpu-layers <n>                     Default: 0.
+  --flash-attention <mode>             ${FlashAttention.values.map((m) => m.name).join(', ')}. Default: auto.
   --context-size <n>                   Default: 2048.
   --threads <n>                        Default: 4.
   --threads-batch <n>                  Default: 4.

--- a/tool/testing/llama_cpp_speculative_benchmark.dart
+++ b/tool/testing/llama_cpp_speculative_benchmark.dart
@@ -1011,7 +1011,7 @@ List<String> _parseCases(String? value) {
     if (!_allRequestedCases.contains(canonical)) {
       stderr.writeln(
         'Invalid --cases entry: $raw. Allowed values: '
-        '${_allRequestedCases.join(', ')}, all, draftless.',
+        '${_allRequestedCases.join(', ')}, all, draftless, ngram.',
       );
       exit(64);
     }
@@ -1237,7 +1237,7 @@ Required:
 Case selection:
   --cases <list>                       Comma-separated cases. Defaults to:
                                        ${_defaultRequestedCases.join(', ')}
-  --cases draftless                    Baseline plus all draftless n-gram cases.
+  --cases draftless | ngram            Baseline plus all draftless n-gram cases.
   --cases all                          Every supported case; draft-model cases
                                        require --draft-model.
   --draft-model <draft.gguf>           Draft model for draft-simple, eagle3,

--- a/tool/testing/llama_cpp_speculative_benchmark.dart
+++ b/tool/testing/llama_cpp_speculative_benchmark.dart
@@ -1,0 +1,1297 @@
+import 'dart:convert';
+import 'dart:io';
+
+import 'package:llamadart/llamadart.dart';
+
+Future<void> main(List<String> arguments) async {
+  final options = _BenchmarkOptions.parse(arguments);
+  if (options.showHelp) {
+    _printUsage();
+    return;
+  }
+
+  final benchmarkCases = _buildBenchmarkCases(options);
+  final baselineModelParams = ModelParams(
+    contextSize: options.contextSize,
+    preferredBackend: options.preferredBackend,
+    gpuLayers: options.gpuLayers,
+    numberOfThreads: options.threads,
+    numberOfThreadsBatch: options.threadsBatch,
+    batchSize: options.batchSize,
+    microBatchSize: options.microBatchSize,
+  );
+  final speculativeModelParams = baselineModelParams.copyWith(
+    speculativeRollbackTokenMax: options.maxDraftTokenMax,
+  );
+
+  final backend = LlamaBackend();
+  int? modelHandle;
+  try {
+    await backend.setLogLevel(LlamaLogLevel.warn);
+    modelHandle = await backend.modelLoad(
+      options.modelPath,
+      baselineModelParams,
+    );
+    final prompt = await _resolvePrompt(
+      backend,
+      modelHandle,
+      options.prompt,
+      rawPrompt: options.rawPrompt,
+    );
+
+    for (var i = 0; i < options.warmupRuns; i++) {
+      for (final benchmarkCase in benchmarkCases) {
+        await _runCase(
+          backend: backend,
+          modelHandle: modelHandle,
+          modelParams: benchmarkCase.requiresSpeculativeRollback
+              ? speculativeModelParams
+              : baselineModelParams,
+          prompt: prompt,
+          options: options,
+          benchmarkCase: benchmarkCase,
+          runIndex: i,
+          warmup: true,
+        );
+      }
+    }
+
+    final results = <_RunResult>[];
+    for (var i = 0; i < options.measuredRuns; i++) {
+      for (final benchmarkCase in _rotated(benchmarkCases, i)) {
+        final result = await _runCase(
+          backend: backend,
+          modelHandle: modelHandle,
+          modelParams: benchmarkCase.requiresSpeculativeRollback
+              ? speculativeModelParams
+              : baselineModelParams,
+          prompt: prompt,
+          options: options,
+          benchmarkCase: benchmarkCase,
+          runIndex: i,
+          warmup: false,
+        );
+        results.add(result);
+        stderr.writeln(
+          '${result.caseName} run ${i + 1}/${options.measuredRuns}: '
+          '${result.wallTokensPerSecond?.toStringAsFixed(2) ?? 'n/a'} tok/s '
+          '(${result.elapsedMs} ms, ${result.generatedTokens ?? 0} tokens, '
+          'hash ${result.outputHash})',
+        );
+      }
+    }
+
+    final backendName = await backend.getBackendName();
+    stdout.writeln(
+      const JsonEncoder.withIndent('  ').convert({
+        'backend': backendName,
+        'model': options.modelPath,
+        'draftModel': options.draftModelPath,
+        'requestedCases': options.requestedCases,
+        'expandedCases': benchmarkCases.map((c) => c.toJson()).toList(),
+        'promptChars': prompt.length,
+        'options': options.toJson(),
+        'results': results.map((result) => result.toJson()).toList(),
+        'summary': _summarize(results),
+      }),
+    );
+  } finally {
+    if (modelHandle != null) {
+      await backend.modelFree(modelHandle);
+    }
+    await backend.dispose();
+  }
+}
+
+Future<String> _resolvePrompt(
+  LlamaBackend backend,
+  int modelHandle,
+  String benchmarkInstruction, {
+  required bool rawPrompt,
+}) async {
+  if (rawPrompt) {
+    return benchmarkInstruction;
+  }
+  try {
+    return await backend.applyChatTemplate(modelHandle, [
+      {'role': 'user', 'content': benchmarkInstruction},
+    ]);
+  } catch (error) {
+    stderr.writeln(
+      'Falling back to raw Gemma-style prompt because backend chat-template '
+      'rendering failed: $error',
+    );
+    return '<start_of_turn>user\n'
+        '$benchmarkInstruction'
+        '<end_of_turn>\n'
+        '<start_of_turn>model\n';
+  }
+}
+
+Future<_RunResult> _runCase({
+  required LlamaBackend backend,
+  required int modelHandle,
+  required ModelParams modelParams,
+  required String prompt,
+  required _BenchmarkOptions options,
+  required _BenchmarkCase benchmarkCase,
+  required int runIndex,
+  required bool warmup,
+}) async {
+  final contextWatch = Stopwatch()..start();
+  final contextHandle = await backend.contextCreate(modelHandle, modelParams);
+  contextWatch.stop();
+
+  final outputBytes = <int>[];
+  final generationWatch = Stopwatch()..start();
+  int? firstTokenLatencyMs;
+
+  try {
+    await for (final chunk in backend.generate(
+      contextHandle,
+      prompt,
+      GenerationParams(
+        maxTokens: options.maxTokens,
+        temp: options.temperature,
+        topK: options.topK,
+        topP: options.topP,
+        minP: options.minP,
+        penalty: options.repeatPenalty,
+        seed: options.seed,
+        reusePromptPrefix: false,
+        streamBatchTokenThreshold: options.streamBatchTokenThreshold,
+        streamBatchByteThreshold: options.streamBatchByteThreshold,
+        speculativeDecodingConfig: benchmarkCase.speculativeDecodingConfig,
+      ),
+    )) {
+      if (chunk.isNotEmpty && firstTokenLatencyMs == null) {
+        firstTokenLatencyMs = generationWatch.elapsedMilliseconds;
+      }
+      outputBytes.addAll(chunk);
+    }
+    generationWatch.stop();
+
+    final perf = backend is BackendPerformanceDiagnostics
+        ? await (backend as BackendPerformanceDiagnostics)
+              .getPerformanceContext(contextHandle)
+        : null;
+    final generatedTokens = perf?.evalTokens;
+    final elapsedSeconds = generationWatch.elapsedMicroseconds / 1000000.0;
+    final text = utf8.decode(outputBytes, allowMalformed: true);
+
+    return _RunResult(
+      caseName: benchmarkCase.name,
+      caseType: benchmarkCase.caseType,
+      runIndex: runIndex,
+      warmup: warmup,
+      contextCreateMs: contextWatch.elapsedMilliseconds,
+      elapsedMs: generationWatch.elapsedMilliseconds,
+      firstTokenLatencyMs: firstTokenLatencyMs,
+      generatedTokens: generatedTokens,
+      wallTokensPerSecond: generatedTokens == null || elapsedSeconds <= 0
+          ? null
+          : generatedTokens / elapsedSeconds,
+      outputChars: text.length,
+      outputHash: _fnv1a32(text),
+      outputPreview: text.length <= 180 ? text : text.substring(0, 180),
+      perf: perf,
+    );
+  } finally {
+    await backend.contextFree(contextHandle);
+  }
+}
+
+List<_BenchmarkCase> _buildBenchmarkCases(_BenchmarkOptions options) {
+  final cases = <_BenchmarkCase>[];
+  final seen = <String>{};
+  for (final requestedCase in options.requestedCases) {
+    if (requestedCase == 'baseline') {
+      _addCase(cases, seen, const _BenchmarkCase.baseline());
+      continue;
+    }
+
+    for (final draftTokenMax in options.draftTokenMaxValues) {
+      _addCase(
+        cases,
+        seen,
+        _BenchmarkCase.fromRequestedCase(
+          requestedCase,
+          options: options,
+          draftTokenMax: draftTokenMax,
+        ),
+      );
+    }
+  }
+  return cases;
+}
+
+void _addCase(
+  List<_BenchmarkCase> cases,
+  Set<String> seen,
+  _BenchmarkCase benchmarkCase,
+) {
+  if (seen.add(benchmarkCase.name)) {
+    cases.add(benchmarkCase);
+  }
+}
+
+List<_BenchmarkCase> _rotated(List<_BenchmarkCase> cases, int offset) {
+  if (cases.isEmpty) {
+    return cases;
+  }
+  final normalized = offset % cases.length;
+  return <_BenchmarkCase>[...cases.skip(normalized), ...cases.take(normalized)];
+}
+
+Map<String, Object?> _summarize(List<_RunResult> results) {
+  final byCase = <String, List<_RunResult>>{};
+  for (final result in results) {
+    byCase.putIfAbsent(result.caseName, () => <_RunResult>[]).add(result);
+  }
+
+  final baselineTokensPerSecond = _median(
+    byCase['baseline']
+            ?.map((result) => result.wallTokensPerSecond)
+            .whereType<double>()
+            .toList() ??
+        const <double>[],
+  );
+  final baselineOutputHashes =
+      byCase['baseline']?.map((r) => r.outputHash).toSet() ?? const <String>{};
+
+  return {
+    for (final entry in byCase.entries)
+      entry.key: _summarizeCase(
+        entry.value,
+        baselineTokensPerSecond: baselineTokensPerSecond,
+        baselineOutputHashes: baselineOutputHashes,
+      ),
+  };
+}
+
+Map<String, Object?> _summarizeCase(
+  List<_RunResult> results, {
+  required double? baselineTokensPerSecond,
+  required Set<String> baselineOutputHashes,
+}) {
+  final medianWallTokensPerSecond = _median(
+    results
+        .map((result) => result.wallTokensPerSecond)
+        .whereType<double>()
+        .toList(),
+  );
+  final uniqueOutputHashes = results.map((result) => result.outputHash).toSet();
+  return {
+    'runs': results.length,
+    'caseType': results.first.caseType,
+    'medianElapsedMs': _median(
+      results.map((result) => result.elapsedMs.toDouble()).toList(),
+    ),
+    'medianFirstTokenLatencyMs': _median(
+      results
+          .map((result) => result.firstTokenLatencyMs?.toDouble())
+          .whereType<double>()
+          .toList(),
+    ),
+    'medianGeneratedTokens': _median(
+      results
+          .map((result) => result.generatedTokens?.toDouble())
+          .whereType<double>()
+          .toList(),
+    ),
+    'medianWallTokensPerSecond': medianWallTokensPerSecond,
+    'relativeWallTokensPerSecondVsBaseline':
+        baselineTokensPerSecond == null ||
+            baselineTokensPerSecond <= 0 ||
+            medianWallTokensPerSecond == null
+        ? null
+        : medianWallTokensPerSecond / baselineTokensPerSecond,
+    'medianEvalTokensPerSecond': _median(
+      results
+          .map((result) => result.evalTokensPerSecond)
+          .whereType<double>()
+          .toList(),
+    ),
+    'medianDecodeTokensPerSecond': _median(
+      results
+          .map((result) => result.decodeTokensPerSecond)
+          .whereType<double>()
+          .toList(),
+    ),
+    'medianSpeculativeAcceptanceRate': _median(
+      results
+          .map((result) => result.perf?.speculativeAcceptanceRate)
+          .whereType<double>()
+          .toList(),
+    ),
+    'medianSpeculativeDraftTokens': _median(
+      results
+          .map((result) => result.perf?.speculativeDraftTokens?.toDouble())
+          .whereType<double>()
+          .toList(),
+    ),
+    'medianSpeculativeAcceptedDraftTokens': _median(
+      results
+          .map(
+            (result) => result.perf?.speculativeAcceptedDraftTokens?.toDouble(),
+          )
+          .whereType<double>()
+          .toList(),
+    ),
+    'uniqueOutputHashes': uniqueOutputHashes.toList()..sort(),
+    'outputHashMatchesBaselineRuns': baselineOutputHashes.isEmpty
+        ? null
+        : results
+              .where(
+                (result) => baselineOutputHashes.contains(result.outputHash),
+              )
+              .length,
+  };
+}
+
+double? _median(List<double> values) {
+  if (values.isEmpty) {
+    return null;
+  }
+  values.sort();
+  final middle = values.length ~/ 2;
+  if (values.length.isOdd) {
+    return values[middle];
+  }
+  return (values[middle - 1] + values[middle]) / 2.0;
+}
+
+String _fnv1a32(String text) {
+  var hash = 0x811c9dc5;
+  for (final codeUnit in text.codeUnits) {
+    hash ^= codeUnit;
+    hash = (hash * 0x01000193) & 0xffffffff;
+  }
+  return hash.toRadixString(16).padLeft(8, '0');
+}
+
+class _BenchmarkCase {
+  const _BenchmarkCase._({
+    required this.name,
+    required this.caseType,
+    required this.strategies,
+    required this.speculativeDecodingConfig,
+  });
+
+  const _BenchmarkCase.baseline()
+    : name = 'baseline',
+      caseType = 'baseline',
+      strategies = const <String>[],
+      speculativeDecodingConfig = null;
+
+  factory _BenchmarkCase.fromRequestedCase(
+    String requestedCase, {
+    required _BenchmarkOptions options,
+    required int draftTokenMax,
+  }) {
+    switch (requestedCase) {
+      case 'backend-default':
+        return _BenchmarkCase._(
+          name: 'backend-default_draft_$draftTokenMax',
+          caseType: requestedCase,
+          strategies: const <String>['backend-default'],
+          speculativeDecodingConfig: SpeculativeDecodingConfig(
+            draftTokenMax: draftTokenMax,
+          ),
+        );
+      case 'draft-simple':
+        return _BenchmarkCase._(
+          name: 'draft-simple_draft_$draftTokenMax',
+          caseType: requestedCase,
+          strategies: const <String>['draft-simple'],
+          speculativeDecodingConfig: SpeculativeDecodingConfig.draftSimple(
+            draftModelPath: options.requiredDraftModelPath(requestedCase),
+            draftTokenMax: draftTokenMax,
+            draftTokenMin: options.draftTokenMin,
+            minProbability: options.minProbability,
+            draftSplitProbability: options.draftSplitProbability,
+          ),
+        );
+      case 'draft-eagle3':
+        return _BenchmarkCase._(
+          name: 'draft-eagle3_draft_$draftTokenMax',
+          caseType: requestedCase,
+          strategies: const <String>['draft-eagle3'],
+          speculativeDecodingConfig: SpeculativeDecodingConfig.draftEagle3(
+            draftModelPath: options.requiredDraftModelPath(requestedCase),
+            draftTokenMax: draftTokenMax,
+            draftTokenMin: options.draftTokenMin,
+            minProbability: options.minProbability,
+            draftSplitProbability: options.draftSplitProbability,
+          ),
+        );
+      case 'draft-mtp':
+        return _BenchmarkCase._(
+          name: 'draft-mtp_draft_$draftTokenMax',
+          caseType: requestedCase,
+          strategies: const <String>['draft-mtp'],
+          speculativeDecodingConfig: SpeculativeDecodingConfig.mtp(
+            draftModelPath: options.draftModelPath,
+            draftTokenMax: draftTokenMax,
+            draftTokenMin: options.draftTokenMin,
+            minProbability: options.minProbability,
+            draftSplitProbability: options.draftSplitProbability,
+          ),
+        );
+      case 'draft-dflash':
+        return _BenchmarkCase._(
+          name: 'draft-dflash_draft_$draftTokenMax',
+          caseType: requestedCase,
+          strategies: const <String>['draft-dflash'],
+          speculativeDecodingConfig: SpeculativeDecodingConfig.draftDflash(
+            draftModelPath: options.requiredDraftModelPath(requestedCase),
+            draftTokenMax: draftTokenMax,
+            draftTokenMin: options.draftTokenMin,
+            minProbability: options.minProbability,
+            draftSplitProbability: options.draftSplitProbability,
+          ),
+        );
+      case 'ngram-simple':
+        return _BenchmarkCase._(
+          name: 'ngram-simple_draft_$draftTokenMax',
+          caseType: requestedCase,
+          strategies: const <String>['ngram-simple'],
+          speculativeDecodingConfig: SpeculativeDecodingConfig.ngramSimple(
+            draftTokenMax: draftTokenMax,
+            ngramSizeN: options.ngramSizeN,
+            ngramSizeM: options.ngramSizeM,
+            ngramMinHits: options.ngramMinHits,
+          ),
+        );
+      case 'ngram-map-k':
+        return _BenchmarkCase._(
+          name: 'ngram-map-k_draft_$draftTokenMax',
+          caseType: requestedCase,
+          strategies: const <String>['ngram-map-k'],
+          speculativeDecodingConfig: SpeculativeDecodingConfig.ngramMapK(
+            draftTokenMax: draftTokenMax,
+            ngramSizeN: options.ngramSizeN,
+            ngramSizeM: options.ngramSizeM,
+            ngramMinHits: options.ngramMinHits,
+          ),
+        );
+      case 'ngram-map-k4v':
+        return _BenchmarkCase._(
+          name: 'ngram-map-k4v_draft_$draftTokenMax',
+          caseType: requestedCase,
+          strategies: const <String>['ngram-map-k4v'],
+          speculativeDecodingConfig: SpeculativeDecodingConfig.ngramMapK4v(
+            draftTokenMax: draftTokenMax,
+            ngramSizeN: options.ngramSizeN,
+            ngramSizeM: options.ngramSizeM,
+            ngramMinHits: options.ngramMinHits,
+          ),
+        );
+      case 'ngram-mod':
+        return _BenchmarkCase._(
+          name: 'ngram-mod_draft_$draftTokenMax',
+          caseType: requestedCase,
+          strategies: const <String>['ngram-mod'],
+          speculativeDecodingConfig: SpeculativeDecodingConfig.ngramMod(
+            draftTokenMax: draftTokenMax,
+            ngramMatch: options.ngramMatch,
+            ngramTokenMin: options.ngramTokenMin,
+            ngramTokenMax: options.ngramTokenMax,
+          ),
+        );
+      case 'ngram-cache':
+        return _BenchmarkCase._(
+          name: 'ngram-cache_draft_$draftTokenMax',
+          caseType: requestedCase,
+          strategies: const <String>['ngram-cache'],
+          speculativeDecodingConfig: SpeculativeDecodingConfig.ngramCache(
+            draftTokenMax: draftTokenMax,
+            ngramCacheStaticPath: options.ngramCacheStaticPath,
+            ngramCacheDynamicPath: options.ngramCacheDynamicPath,
+          ),
+        );
+      case 'mixed-ngram':
+        return _BenchmarkCase._(
+          name: 'mixed-ngram_draft_$draftTokenMax',
+          caseType: requestedCase,
+          strategies: const <String>['ngram-mod', 'ngram-map-k'],
+          speculativeDecodingConfig: SpeculativeDecodingConfig.mixed(
+            strategies: const <SpeculativeDecodingStrategy>[
+              SpeculativeDecodingStrategy.ngramMod,
+              SpeculativeDecodingStrategy.ngramMapK,
+            ],
+            draftTokenMax: draftTokenMax,
+            ngramSizeN: options.ngramSizeN,
+            ngramSizeM: options.ngramSizeM,
+            ngramMinHits: options.ngramMinHits,
+            ngramMatch: options.ngramMatch,
+            ngramTokenMin: options.ngramTokenMin,
+            ngramTokenMax: options.ngramTokenMax,
+          ),
+        );
+      case 'mixed-ngram-mtp':
+        return _BenchmarkCase._(
+          name: 'mixed-ngram-mtp_draft_$draftTokenMax',
+          caseType: requestedCase,
+          strategies: const <String>['ngram-mod', 'draft-mtp'],
+          speculativeDecodingConfig: SpeculativeDecodingConfig.mixed(
+            strategies: const <SpeculativeDecodingStrategy>[
+              SpeculativeDecodingStrategy.ngramMod,
+              SpeculativeDecodingStrategy.mtp,
+            ],
+            draftModelPath: options.draftModelPath,
+            draftTokenMax: draftTokenMax,
+            draftTokenMin: options.draftTokenMin,
+            minProbability: options.minProbability,
+            draftSplitProbability: options.draftSplitProbability,
+            ngramMatch: options.ngramMatch,
+            ngramTokenMin: options.ngramTokenMin,
+            ngramTokenMax: options.ngramTokenMax,
+          ),
+        );
+      case 'mixed-ngram-draft-simple':
+        return _BenchmarkCase._(
+          name: 'mixed-ngram-draft-simple_draft_$draftTokenMax',
+          caseType: requestedCase,
+          strategies: const <String>['ngram-mod', 'draft-simple'],
+          speculativeDecodingConfig: SpeculativeDecodingConfig.mixed(
+            strategies: const <SpeculativeDecodingStrategy>[
+              SpeculativeDecodingStrategy.ngramMod,
+              SpeculativeDecodingStrategy.draftSimple,
+            ],
+            draftModelPath: options.requiredDraftModelPath(requestedCase),
+            draftTokenMax: draftTokenMax,
+            draftTokenMin: options.draftTokenMin,
+            minProbability: options.minProbability,
+            draftSplitProbability: options.draftSplitProbability,
+            ngramMatch: options.ngramMatch,
+            ngramTokenMin: options.ngramTokenMin,
+            ngramTokenMax: options.ngramTokenMax,
+          ),
+        );
+    }
+    throw StateError('Unsupported benchmark case: $requestedCase');
+  }
+
+  final String name;
+  final String caseType;
+  final List<String> strategies;
+  final SpeculativeDecodingConfig? speculativeDecodingConfig;
+
+  bool get requiresSpeculativeRollback => speculativeDecodingConfig != null;
+
+  Map<String, Object?> toJson() {
+    return {'name': name, 'caseType': caseType, 'strategies': strategies};
+  }
+}
+
+class _RunResult {
+  const _RunResult({
+    required this.caseName,
+    required this.caseType,
+    required this.runIndex,
+    required this.warmup,
+    required this.contextCreateMs,
+    required this.elapsedMs,
+    required this.firstTokenLatencyMs,
+    required this.generatedTokens,
+    required this.wallTokensPerSecond,
+    required this.outputChars,
+    required this.outputHash,
+    required this.outputPreview,
+    required this.perf,
+  });
+
+  final String caseName;
+  final String caseType;
+  final int runIndex;
+  final bool warmup;
+  final int contextCreateMs;
+  final int elapsedMs;
+  final int? firstTokenLatencyMs;
+  final int? generatedTokens;
+  final double? wallTokensPerSecond;
+  final int outputChars;
+  final String outputHash;
+  final String outputPreview;
+  final BackendPerfContextData? perf;
+
+  double? get evalTokensPerSecond {
+    final perf = this.perf;
+    if (perf == null || perf.evalMs <= 0) {
+      return null;
+    }
+    return perf.evalTokens / (perf.evalMs / 1000.0);
+  }
+
+  double? get decodeTokensPerSecond {
+    final perf = this.perf;
+    final decodeMs = perf?.decodeMs;
+    if (perf == null || decodeMs == null || decodeMs <= 0) {
+      return null;
+    }
+    return perf.evalTokens / (decodeMs / 1000.0);
+  }
+
+  Map<String, Object?> toJson() {
+    final perf = this.perf;
+    return {
+      'case': caseName,
+      'caseType': caseType,
+      'runIndex': runIndex,
+      'warmup': warmup,
+      'contextCreateMs': contextCreateMs,
+      'elapsedMs': elapsedMs,
+      'firstTokenLatencyMs': firstTokenLatencyMs,
+      'generatedTokens': generatedTokens,
+      'wallTokensPerSecond': wallTokensPerSecond,
+      'outputChars': outputChars,
+      'outputHash': outputHash,
+      'outputPreview': outputPreview,
+      'perf': perf == null
+          ? null
+          : {
+              'loadMs': perf.loadMs,
+              'promptEvalMs': perf.promptEvalMs,
+              'evalMs': perf.evalMs,
+              'sampleMs': perf.sampleMs,
+              'decodeMs': perf.decodeMs,
+              'promptEvalTokens': perf.promptEvalTokens,
+              'evalTokens': perf.evalTokens,
+              'sampleCount': perf.sampleCount,
+              'evalTokensPerSecond': evalTokensPerSecond,
+              'decodeTokensPerSecond': decodeTokensPerSecond,
+              'reusedGraphs': perf.reusedGraphs,
+              'speculativeDraftTokens': perf.speculativeDraftTokens,
+              'speculativeAcceptedDraftTokens':
+                  perf.speculativeAcceptedDraftTokens,
+              'speculativeAcceptanceRate': perf.speculativeAcceptanceRate,
+              'speculativeDraftMs': perf.speculativeDraftMs,
+              'speculativeVerifyMs': perf.speculativeVerifyMs,
+            },
+    };
+  }
+}
+
+class _BenchmarkOptions {
+  const _BenchmarkOptions({
+    required this.showHelp,
+    required this.modelPath,
+    required this.draftModelPath,
+    required this.requestedCases,
+    required this.draftTokenMaxValues,
+    required this.measuredRuns,
+    required this.warmupRuns,
+    required this.maxTokens,
+    required this.contextSize,
+    required this.preferredBackend,
+    required this.gpuLayers,
+    required this.threads,
+    required this.threadsBatch,
+    required this.batchSize,
+    required this.microBatchSize,
+    required this.seed,
+    required this.temperature,
+    required this.topK,
+    required this.topP,
+    required this.minP,
+    required this.repeatPenalty,
+    required this.draftTokenMin,
+    required this.minProbability,
+    required this.draftSplitProbability,
+    required this.ngramSizeN,
+    required this.ngramSizeM,
+    required this.ngramMinHits,
+    required this.ngramMatch,
+    required this.ngramTokenMin,
+    required this.ngramTokenMax,
+    required this.ngramCacheStaticPath,
+    required this.ngramCacheDynamicPath,
+    required this.rawPrompt,
+    required this.prompt,
+    required this.streamBatchTokenThreshold,
+    required this.streamBatchByteThreshold,
+  });
+
+  static _BenchmarkOptions parse(List<String> args) {
+    final map = _parseFlags(args);
+    final showHelp = map['help'] == 'true' || map['h'] == 'true';
+    final modelPath = map['model'] ?? '';
+    if (!showHelp && modelPath.isEmpty) {
+      stderr.writeln('Missing required --model option.');
+      _printUsage();
+      exit(64);
+    }
+
+    final requestedCases = _parseCases(map['cases']);
+    final draftModelPath = _emptyToNull(map['draft-model']);
+    final draftTokenMaxValues = _parseIntList(
+      map['draft-token-max'],
+      fallback: const <int>[1, 2],
+      name: 'draft-token-max',
+    );
+    if (draftTokenMaxValues.any((value) => value <= 0)) {
+      stderr.writeln('--draft-token-max values must be greater than zero.');
+      exit(64);
+    }
+
+    final options = _BenchmarkOptions(
+      showHelp: showHelp,
+      modelPath: modelPath,
+      draftModelPath: draftModelPath,
+      requestedCases: requestedCases,
+      draftTokenMaxValues: draftTokenMaxValues,
+      measuredRuns: _parseInt(map['runs'], fallback: 3, name: 'runs'),
+      warmupRuns: _parseInt(
+        map['warmups'] ?? map['warmup'],
+        fallback: 1,
+        name: 'warmups',
+      ),
+      maxTokens: _parseInt(
+        map['max-tokens'],
+        fallback: 128,
+        name: 'max-tokens',
+      ),
+      contextSize: _parseInt(
+        map['context-size'] ?? map['ctx-size'],
+        fallback: 2048,
+        name: 'context-size',
+      ),
+      preferredBackend: _parsePreferredBackend(map['backend']),
+      gpuLayers: _parseInt(map['gpu-layers'], fallback: 0, name: 'gpu-layers'),
+      threads: _parseInt(map['threads'], fallback: 4, name: 'threads'),
+      threadsBatch: _parseInt(
+        map['threads-batch'],
+        fallback: 4,
+        name: 'threads-batch',
+      ),
+      batchSize: _parseInt(map['batch-size'], fallback: 0, name: 'batch-size'),
+      microBatchSize: _parseInt(
+        map['micro-batch-size'] ?? map['ubatch-size'],
+        fallback: 0,
+        name: 'micro-batch-size',
+      ),
+      seed: _parseInt(map['seed'], fallback: 7, name: 'seed'),
+      temperature: _parseDouble(map['temp'], fallback: 0.0, name: 'temp'),
+      topK: _parseInt(map['top-k'], fallback: 40, name: 'top-k'),
+      topP: _parseDouble(map['top-p'], fallback: 0.95, name: 'top-p'),
+      minP: _parseDouble(map['min-p'], fallback: 0.05, name: 'min-p'),
+      repeatPenalty: _parseDouble(
+        map['repeat-penalty'],
+        fallback: 1.1,
+        name: 'repeat-penalty',
+      ),
+      draftTokenMin: _parseOptionalInt(map['draft-token-min']),
+      minProbability: _parseOptionalDouble(map['min-probability']),
+      draftSplitProbability: _parseOptionalDouble(
+        map['draft-split-probability'],
+      ),
+      ngramSizeN: _parseOptionalInt(map['ngram-size-n'] ?? map['ngram-size']),
+      ngramSizeM: _parseOptionalInt(map['ngram-size-m']),
+      ngramMinHits: _parseOptionalInt(map['ngram-min-hits']),
+      ngramMatch: _parseOptionalInt(map['ngram-match']),
+      ngramTokenMin: _parseOptionalInt(map['ngram-token-min']),
+      ngramTokenMax: _parseOptionalInt(map['ngram-token-max']),
+      ngramCacheStaticPath: _emptyToNull(map['ngram-cache-static-path']),
+      ngramCacheDynamicPath: _emptyToNull(map['ngram-cache-dynamic-path']),
+      rawPrompt: _parseBool(
+        map['raw-prompt'],
+        fallback: false,
+        name: 'raw-prompt',
+      ),
+      prompt: map['prompt'] ?? _defaultBenchmarkInstruction,
+      streamBatchTokenThreshold: _parseInt(
+        map['stream-batch-tokens'],
+        fallback: GenerationParams.defaultStreamBatchTokenThreshold,
+        name: 'stream-batch-tokens',
+      ),
+      streamBatchByteThreshold: _parseInt(
+        map['stream-batch-bytes'],
+        fallback: GenerationParams.defaultStreamBatchByteThreshold,
+        name: 'stream-batch-bytes',
+      ),
+    );
+    _validate(options);
+    return options;
+  }
+
+  final bool showHelp;
+  final String modelPath;
+  final String? draftModelPath;
+  final List<String> requestedCases;
+  final List<int> draftTokenMaxValues;
+  final int measuredRuns;
+  final int warmupRuns;
+  final int maxTokens;
+  final int contextSize;
+  final GpuBackend preferredBackend;
+  final int gpuLayers;
+  final int threads;
+  final int threadsBatch;
+  final int batchSize;
+  final int microBatchSize;
+  final int seed;
+  final double temperature;
+  final int topK;
+  final double topP;
+  final double minP;
+  final double repeatPenalty;
+  final int? draftTokenMin;
+  final double? minProbability;
+  final double? draftSplitProbability;
+  final int? ngramSizeN;
+  final int? ngramSizeM;
+  final int? ngramMinHits;
+  final int? ngramMatch;
+  final int? ngramTokenMin;
+  final int? ngramTokenMax;
+  final String? ngramCacheStaticPath;
+  final String? ngramCacheDynamicPath;
+  final bool rawPrompt;
+  final String prompt;
+  final int streamBatchTokenThreshold;
+  final int streamBatchByteThreshold;
+
+  int get maxDraftTokenMax => draftTokenMaxValues.fold<int>(
+    1,
+    (max, value) => value > max ? value : max,
+  );
+
+  String requiredDraftModelPath(String requestedCase) {
+    final path = draftModelPath;
+    if (path == null) {
+      throw ArgumentError(
+        '$requestedCase requires --draft-model <draft.gguf>.',
+      );
+    }
+    return path;
+  }
+
+  Map<String, Object?> toJson() {
+    return {
+      'draftTokenMaxValues': draftTokenMaxValues,
+      'maxTokens': maxTokens,
+      'measuredRuns': measuredRuns,
+      'warmupRuns': warmupRuns,
+      'contextSize': contextSize,
+      'preferredBackend': preferredBackend.name,
+      'gpuLayers': gpuLayers,
+      'threads': threads,
+      'threadsBatch': threadsBatch,
+      'batchSize': batchSize,
+      'microBatchSize': microBatchSize,
+      'seed': seed,
+      'temperature': temperature,
+      'topK': topK,
+      'topP': topP,
+      'minP': minP,
+      'repeatPenalty': repeatPenalty,
+      'draftTokenMin': draftTokenMin,
+      'minProbability': minProbability,
+      'draftSplitProbability': draftSplitProbability,
+      'ngramSizeN': ngramSizeN,
+      'ngramSizeM': ngramSizeM,
+      'ngramMinHits': ngramMinHits,
+      'ngramMatch': ngramMatch,
+      'ngramTokenMin': ngramTokenMin,
+      'ngramTokenMax': ngramTokenMax,
+      'ngramCacheStaticPath': ngramCacheStaticPath,
+      'ngramCacheDynamicPath': ngramCacheDynamicPath,
+      'rawPrompt': rawPrompt,
+      'promptPreview': prompt.length <= 120 ? prompt : prompt.substring(0, 120),
+      'streamBatchTokenThreshold': streamBatchTokenThreshold,
+      'streamBatchByteThreshold': streamBatchByteThreshold,
+    };
+  }
+}
+
+const _defaultBenchmarkInstruction =
+    'Write a continuous technical essay of at least 400 words about why fast '
+    'local inference matters for private, offline, user-facing AI '
+    'applications. Do not use bullets, headings, or lists. Keep writing until '
+    'you reach the requested length.';
+
+const _defaultRequestedCases = <String>[
+  'baseline',
+  'ngram-simple',
+  'ngram-map-k',
+  'ngram-map-k4v',
+  'ngram-mod',
+  'mixed-ngram',
+];
+
+const _allRequestedCases = <String>[
+  'baseline',
+  'backend-default',
+  'draft-simple',
+  'draft-eagle3',
+  'draft-mtp',
+  'draft-dflash',
+  'ngram-simple',
+  'ngram-map-k',
+  'ngram-map-k4v',
+  'ngram-mod',
+  'ngram-cache',
+  'mixed-ngram',
+  'mixed-ngram-mtp',
+  'mixed-ngram-draft-simple',
+];
+
+const _draftlessRequestedCases = <String>[
+  'baseline',
+  'backend-default',
+  'ngram-simple',
+  'ngram-map-k',
+  'ngram-map-k4v',
+  'ngram-mod',
+  'ngram-cache',
+  'mixed-ngram',
+];
+
+const _draftModelRequiredCases = <String>{
+  'draft-simple',
+  'draft-eagle3',
+  'draft-dflash',
+  'mixed-ngram-draft-simple',
+};
+
+Map<String, String> _parseFlags(List<String> args) {
+  final map = <String, String>{};
+  for (var i = 0; i < args.length; i++) {
+    final arg = args[i];
+    if (arg == '-h') {
+      map['h'] = 'true';
+      continue;
+    }
+    if (!arg.startsWith('--')) {
+      stderr.writeln('Unexpected positional argument: $arg');
+      _printUsage();
+      exit(64);
+    }
+
+    final eq = arg.indexOf('=');
+    if (eq > 0) {
+      map[arg.substring(2, eq)] = arg.substring(eq + 1);
+      continue;
+    }
+
+    final key = arg.substring(2);
+    final nextIsValue = i + 1 < args.length && !args[i + 1].startsWith('--');
+    if (nextIsValue) {
+      map[key] = args[i + 1];
+      i++;
+    } else {
+      map[key] = 'true';
+    }
+  }
+  return map;
+}
+
+List<String> _parseCases(String? value) {
+  if (value == null || value.trim().isEmpty) {
+    return _defaultRequestedCases;
+  }
+
+  final cases = <String>[];
+  for (final raw in value.split(',')) {
+    final normalized = raw.trim().toLowerCase();
+    if (normalized.isEmpty) {
+      continue;
+    }
+    if (normalized == 'all') {
+      cases.addAll(_allRequestedCases);
+      continue;
+    }
+    if (normalized == 'draftless' || normalized == 'ngram') {
+      cases.addAll(_draftlessRequestedCases);
+      continue;
+    }
+
+    final canonical = _canonicalCase(normalized);
+    if (!_allRequestedCases.contains(canonical)) {
+      stderr.writeln(
+        'Invalid --cases entry: $raw. Allowed values: '
+        '${_allRequestedCases.join(', ')}, all, draftless.',
+      );
+      exit(64);
+    }
+    cases.add(canonical);
+  }
+  if (cases.isEmpty) {
+    stderr.writeln('--cases must include at least one benchmark case.');
+    exit(64);
+  }
+
+  final seen = <String>{};
+  return [
+    for (final benchmarkCase in cases)
+      if (seen.add(benchmarkCase)) benchmarkCase,
+  ];
+}
+
+String _canonicalCase(String value) {
+  switch (value) {
+    case 'default':
+    case 'spec-default':
+    case 'backend-default':
+      return 'backend-default';
+    case 'mtp':
+    case 'draft-mtp':
+      return 'draft-mtp';
+    case 'ngram-simple':
+    case 'ngram_simple':
+      return 'ngram-simple';
+    case 'ngram-map-k':
+    case 'ngram_map_k':
+      return 'ngram-map-k';
+    case 'ngram-map-k4v':
+    case 'ngram_map_k4v':
+      return 'ngram-map-k4v';
+    case 'ngram-mod':
+    case 'ngram_mod':
+      return 'ngram-mod';
+    case 'ngram-cache':
+    case 'ngram_cache':
+      return 'ngram-cache';
+    case 'draft-simple':
+    case 'draft_simple':
+      return 'draft-simple';
+    case 'draft-eagle3':
+    case 'eagle3':
+    case 'draft_eagle3':
+      return 'draft-eagle3';
+    case 'draft-dflash':
+    case 'dflash':
+    case 'draft_dflash':
+      return 'draft-dflash';
+    case 'mixed-ngram':
+    case 'mixed_ngram':
+      return 'mixed-ngram';
+    case 'mixed-ngram-mtp':
+    case 'mixed_ngram_mtp':
+      return 'mixed-ngram-mtp';
+    case 'mixed-ngram-draft-simple':
+    case 'mixed_ngram_draft_simple':
+      return 'mixed-ngram-draft-simple';
+    default:
+      return value;
+  }
+}
+
+void _validate(_BenchmarkOptions options) {
+  if (options.showHelp) {
+    return;
+  }
+  for (final requestedCase in options.requestedCases) {
+    if (_draftModelRequiredCases.contains(requestedCase) &&
+        options.draftModelPath == null) {
+      stderr.writeln('$requestedCase requires --draft-model <draft.gguf>.');
+      exit(64);
+    }
+    if (requestedCase == 'ngram-cache' &&
+        options.ngramCacheStaticPath == null &&
+        options.ngramCacheDynamicPath == null) {
+      stderr.writeln(
+        'ngram-cache requires --ngram-cache-static-path or '
+        '--ngram-cache-dynamic-path.',
+      );
+      exit(64);
+    }
+  }
+
+  final ngramCachePaths = <String?>[
+    options.ngramCacheStaticPath,
+    options.ngramCacheDynamicPath,
+  ];
+  for (final path in ngramCachePaths.whereType<String>()) {
+    if (!File(path).existsSync()) {
+      stderr.writeln('N-gram cache path does not exist: $path');
+      exit(64);
+    }
+  }
+}
+
+GpuBackend _parsePreferredBackend(String? value) {
+  final normalized = value?.trim().toLowerCase();
+  if (normalized == null || normalized.isEmpty) {
+    return GpuBackend.cpu;
+  }
+  for (final backend in GpuBackend.values) {
+    if (backend.name == normalized) {
+      return backend;
+    }
+  }
+  stderr.writeln(
+    'Invalid --backend: $value. Allowed values: '
+    '${GpuBackend.values.map((b) => b.name).join(', ')}.',
+  );
+  exit(64);
+}
+
+List<int> _parseIntList(
+  String? value, {
+  required List<int> fallback,
+  required String name,
+}) {
+  if (value == null || value.trim().isEmpty) {
+    return fallback;
+  }
+  final parsed = <int>[];
+  for (final item in value.split(',')) {
+    final intValue = int.tryParse(item.trim());
+    if (intValue == null) {
+      stderr.writeln('Invalid integer in --$name: $item');
+      exit(64);
+    }
+    parsed.add(intValue);
+  }
+  if (parsed.isEmpty) {
+    stderr.writeln('--$name must contain at least one integer.');
+    exit(64);
+  }
+  return parsed;
+}
+
+int _parseInt(String? value, {required int fallback, required String name}) {
+  if (value == null || value.isEmpty) {
+    return fallback;
+  }
+  final parsed = int.tryParse(value);
+  if (parsed == null) {
+    stderr.writeln('Invalid integer for --$name: $value');
+    exit(64);
+  }
+  return parsed;
+}
+
+int? _parseOptionalInt(String? value) {
+  if (value == null || value.isEmpty) {
+    return null;
+  }
+  final parsed = int.tryParse(value);
+  if (parsed == null) {
+    stderr.writeln('Invalid integer: $value');
+    exit(64);
+  }
+  return parsed;
+}
+
+double _parseDouble(
+  String? value, {
+  required double fallback,
+  required String name,
+}) {
+  if (value == null || value.isEmpty) {
+    return fallback;
+  }
+  final parsed = double.tryParse(value);
+  if (parsed == null) {
+    stderr.writeln('Invalid number for --$name: $value');
+    exit(64);
+  }
+  return parsed;
+}
+
+double? _parseOptionalDouble(String? value) {
+  if (value == null || value.isEmpty) {
+    return null;
+  }
+  final parsed = double.tryParse(value);
+  if (parsed == null) {
+    stderr.writeln('Invalid number: $value');
+    exit(64);
+  }
+  return parsed;
+}
+
+bool _parseBool(String? value, {required bool fallback, required String name}) {
+  if (value == null || value.isEmpty) {
+    return fallback;
+  }
+  final normalized = value.trim().toLowerCase();
+  if (normalized == 'true' || normalized == '1' || normalized == 'yes') {
+    return true;
+  }
+  if (normalized == 'false' || normalized == '0' || normalized == 'no') {
+    return false;
+  }
+  stderr.writeln('Invalid boolean for --$name: $value');
+  exit(64);
+}
+
+String? _emptyToNull(String? value) {
+  if (value == null || value.trim().isEmpty || value == '-') {
+    return null;
+  }
+  return value;
+}
+
+void _printUsage() {
+  stdout.writeln('''
+Usage:
+  dart run tool/testing/llama_cpp_speculative_benchmark.dart --model <model.gguf> [options]
+
+Required:
+  --model <model.gguf>                 Target GGUF model.
+
+Case selection:
+  --cases <list>                       Comma-separated cases. Defaults to:
+                                       ${_defaultRequestedCases.join(', ')}
+  --cases draftless                    Baseline plus all draftless n-gram cases.
+  --cases all                          Every supported case; draft-model cases
+                                       require --draft-model.
+  --draft-model <draft.gguf>           Draft model for draft-simple, eagle3,
+                                       dflash, and mixed draft-simple cases.
+  --draft-token-max <list>             Comma-separated draft-token depths.
+                                       Default: 1,2.
+
+Supported cases:
+  ${_allRequestedCases.join(', ')}
+
+Runtime:
+  --backend <name>                     ${GpuBackend.values.map((b) => b.name).join(', ')}. Default: cpu.
+  --gpu-layers <n>                     Default: 0.
+  --context-size <n>                   Default: 2048.
+  --threads <n>                        Default: 4.
+  --threads-batch <n>                  Default: 4.
+  --batch-size <n>                     Default: backend model default.
+  --micro-batch-size <n>               Default: backend model default.
+
+Generation:
+  --max-tokens <n>                     Default: 128.
+  --runs <n>                           Measured runs per case. Default: 3.
+  --warmups <n>                        Warmup runs per case. Default: 1.
+  --prompt <text>                      Override benchmark prompt.
+  --raw-prompt                         Skip chat-template wrapping.
+  --seed <n>                           Default: 7.
+  --temp <n>                           Default: 0.0.
+  --repeat-penalty <n>                 Default: 1.1.
+
+Speculative knobs:
+  --draft-token-min <n>
+  --min-probability <n>
+  --draft-split-probability <n>
+  --ngram-size-n <n>                   Also accepts --ngram-size.
+  --ngram-size-m <n>
+  --ngram-min-hits <n>
+  --ngram-match <n>
+  --ngram-token-min <n>
+  --ngram-token-max <n>
+  --ngram-cache-static-path <path>     Optional existing cache file.
+  --ngram-cache-dynamic-path <path>    Optional existing cache file.
+
+Examples:
+  dart run tool/testing/llama_cpp_speculative_benchmark.dart \\
+    --model models/Qwen3.5-0.8B-Q4_K_M.gguf \\
+    --cases baseline,ngram-simple,ngram-map-k,ngram-map-k4v,ngram-mod,mixed-ngram \\
+    --backend cpu --gpu-layers 0 --max-tokens 128 --runs 3 \\
+    --draft-token-max 1,2 --warmups 1
+
+  dart run tool/testing/llama_cpp_speculative_benchmark.dart \\
+    --model models/gemma-4-E2B-it-Q4_K_S.gguf \\
+    --draft-model models/mtp-gemma-4-E2B-it.gguf \\
+    --cases baseline,draft-mtp,mixed-ngram-mtp \\
+    --backend cpu --gpu-layers 0 --max-tokens 64 --runs 3 \\
+    --draft-token-max 1,2
+''');
+}

--- a/tool/testing/run_local_e2e.dart
+++ b/tool/testing/run_local_e2e.dart
@@ -71,10 +71,20 @@ class LocalE2eRunContext {
     required this.port,
     required this.python,
     required this.modelPath,
+    required this.draftModelPath,
     required this.mmprojPath,
     required this.imagePath,
     required this.modelUrl,
     required this.backend,
+    required this.speculativeCases,
+    required this.benchmarkGpuLayers,
+    required this.benchmarkMaxTokens,
+    required this.benchmarkRuns,
+    required this.benchmarkWarmups,
+    required this.draftTokenMaxList,
+    required this.ngramSize,
+    required this.ngramCacheStaticPath,
+    required this.ngramCacheDynamicPath,
     required this.expect,
     required this.skipBuild,
   });
@@ -84,10 +94,20 @@ class LocalE2eRunContext {
   final int port;
   final String python;
   final String? modelPath;
+  final String? draftModelPath;
   final String? mmprojPath;
   final String? imagePath;
   final String? modelUrl;
   final String backend;
+  final String speculativeCases;
+  final String benchmarkGpuLayers;
+  final String benchmarkMaxTokens;
+  final String benchmarkRuns;
+  final String benchmarkWarmups;
+  final String draftTokenMaxList;
+  final String? ngramSize;
+  final String? ngramCacheStaticPath;
+  final String? ngramCacheDynamicPath;
   final String expect;
   final bool skipBuild;
 
@@ -190,6 +210,62 @@ List<LocalE2eScenario> buildLocalE2eScenarios({String? projectRoot}) {
             executable: 'dart',
             arguments: arguments,
             description: 'GGUF chat feature smoke',
+          ),
+        ];
+      },
+    ),
+    LocalE2eScenario(
+      name: 'llama-cpp-speculative-benchmark',
+      group: LocalE2eScenarioGroup.dartLocalOnly,
+      description:
+          'Benchmark real GGUF llama.cpp speculative decoding strategies.',
+      requiresDevice: false,
+      stepsBuilder: (context) {
+        final arguments = <String>[
+          'run',
+          'tool/testing/llama_cpp_speculative_benchmark.dart',
+          '--model',
+          context.modelPath!,
+          '--cases',
+          context.speculativeCases,
+          '--backend',
+          context.backend,
+          '--gpu-layers',
+          context.benchmarkGpuLayers,
+          '--max-tokens',
+          context.benchmarkMaxTokens,
+          '--runs',
+          context.benchmarkRuns,
+          '--draft-token-max',
+          context.draftTokenMaxList,
+          '--warmups',
+          context.benchmarkWarmups,
+        ];
+        final draftModelPath = context.draftModelPath;
+        if (draftModelPath != null) {
+          arguments.addAll(['--draft-model', draftModelPath]);
+        }
+        final ngramSize = context.ngramSize;
+        if (ngramSize != null) {
+          arguments.addAll(['--ngram-size', ngramSize]);
+        }
+        final ngramCacheStaticPath = context.ngramCacheStaticPath;
+        if (ngramCacheStaticPath != null) {
+          arguments.addAll(['--ngram-cache-static-path', ngramCacheStaticPath]);
+        }
+        final ngramCacheDynamicPath = context.ngramCacheDynamicPath;
+        if (ngramCacheDynamicPath != null) {
+          arguments.addAll([
+            '--ngram-cache-dynamic-path',
+            ngramCacheDynamicPath,
+          ]);
+        }
+        return [
+          LocalE2eCommandStep(
+            workingDirectory: context.projectRoot,
+            executable: 'dart',
+            arguments: arguments,
+            description: 'llama.cpp speculative benchmark',
           ),
         ];
       },
@@ -587,6 +663,13 @@ Future<LocalE2eResult> runLocalE2e(
   if (parsed.imagePath != null && parsed.mmprojPath == null) {
     return LocalE2eResult(64, stderr: '--image-path requires --mmproj-path.\n');
   }
+  if (scenario.name == 'llama-cpp-speculative-benchmark' &&
+      parsed.modelPath == null) {
+    return LocalE2eResult(
+      64,
+      stderr: '--model-path is required for llama-cpp-speculative-benchmark.\n',
+    );
+  }
 
   final context = LocalE2eRunContext(
     projectRoot: root,
@@ -594,10 +677,20 @@ Future<LocalE2eResult> runLocalE2e(
     port: parsed.port,
     python: parsed.pythonProvided ? parsed.python : _defaultPython(root),
     modelPath: parsed.modelPath,
+    draftModelPath: parsed.draftModelPath,
     mmprojPath: parsed.mmprojPath,
     imagePath: parsed.imagePath,
     modelUrl: parsed.modelUrl,
     backend: parsed.backend,
+    speculativeCases: parsed.speculativeCases,
+    benchmarkGpuLayers: parsed.benchmarkGpuLayers,
+    benchmarkMaxTokens: parsed.benchmarkMaxTokens,
+    benchmarkRuns: parsed.benchmarkRuns,
+    benchmarkWarmups: parsed.benchmarkWarmups,
+    draftTokenMaxList: parsed.draftTokenMaxList,
+    ngramSize: parsed.ngramSize,
+    ngramCacheStaticPath: parsed.ngramCacheStaticPath,
+    ngramCacheDynamicPath: parsed.ngramCacheDynamicPath,
     expect: parsed.expect,
     skipBuild: parsed.skipBuild,
   );
@@ -789,10 +882,20 @@ Options:
   --port <port>                  Local web server port (default: 7358).
   --python <path>                Python executable for helper scripts (default: repo Playwright venv, then python3).
   --model-path <path>            Local model path for Dart local-only model scenarios.
+  --draft-model-path <path>      Optional draft GGUF model path for llama.cpp speculative benchmark.
   --mmproj-path <path>           Optional multimodal projector path for GGUF chat smoke.
   --image-path <path>            Optional image path for GGUF chat smoke multimodal variant.
   --model-url <url>              Model URL for real-model web smoke.
   --backend <name>               Backend for local model scenarios (default: auto).
+  --speculative-cases <list>     Benchmark cases for llama.cpp speculative benchmark.
+  --benchmark-gpu-layers <n>     GPU layers for benchmark scenarios (default: 0).
+  --benchmark-max-tokens <n>     Max tokens for benchmark scenarios (default: 128).
+  --benchmark-runs <n>           Measured runs for benchmark scenarios (default: 3).
+  --benchmark-warmups <n>        Warmup runs for benchmark scenarios (default: 1).
+  --draft-token-max <list>       Draft-token sweep for speculative benchmark (default: 1,2).
+  --ngram-size <n>               Optional n-gram size for speculative benchmark.
+  --ngram-cache-static-path <p>  Optional ngram-cache static path for speculative benchmark.
+  --ngram-cache-dynamic-path <p> Optional ngram-cache dynamic path for speculative benchmark.
   --expect <text>                Expected response text for real-model web smoke.
   --skip-build                   Reuse an existing Flutter web build where supported.
   -h, --help                     Show this help.
@@ -820,13 +923,23 @@ class _ParsedArgs {
     required this.python,
     required this.pythonProvided,
     required this.backend,
+    required this.speculativeCases,
+    required this.benchmarkGpuLayers,
+    required this.benchmarkMaxTokens,
+    required this.benchmarkRuns,
+    required this.benchmarkWarmups,
+    required this.draftTokenMaxList,
     required this.expect,
     required this.skipBuild,
     this.scenario,
     this.modelPath,
+    this.draftModelPath,
     this.mmprojPath,
     this.imagePath,
     this.modelUrl,
+    this.ngramSize,
+    this.ngramCacheStaticPath,
+    this.ngramCacheDynamicPath,
   });
 
   final bool list;
@@ -838,10 +951,20 @@ class _ParsedArgs {
   final String python;
   final bool pythonProvided;
   final String? modelPath;
+  final String? draftModelPath;
   final String? mmprojPath;
   final String? imagePath;
   final String? modelUrl;
   final String backend;
+  final String speculativeCases;
+  final String benchmarkGpuLayers;
+  final String benchmarkMaxTokens;
+  final String benchmarkRuns;
+  final String benchmarkWarmups;
+  final String draftTokenMaxList;
+  final String? ngramSize;
+  final String? ngramCacheStaticPath;
+  final String? ngramCacheDynamicPath;
   final String expect;
   final bool skipBuild;
 
@@ -854,13 +977,24 @@ class _ParsedArgs {
     var python = 'python3';
     var pythonProvided = false;
     var backend = 'auto';
+    var speculativeCases =
+        'baseline,ngram-simple,ngram-map-k,ngram-map-k4v,ngram-mod,mixed-ngram';
+    var benchmarkGpuLayers = '0';
+    var benchmarkMaxTokens = '128';
+    var benchmarkRuns = '3';
+    var benchmarkWarmups = '1';
+    var draftTokenMaxList = '1,2';
     var expect = '4';
     var skipBuild = false;
     String? scenario;
     String? modelPath;
+    String? draftModelPath;
     String? mmprojPath;
     String? imagePath;
     String? modelUrl;
+    String? ngramSize;
+    String? ngramCacheStaticPath;
+    String? ngramCacheDynamicPath;
 
     for (var index = 0; index < args.length; index++) {
       final arg = args[index];
@@ -884,6 +1018,8 @@ class _ParsedArgs {
           pythonProvided = true;
         case '--model-path':
           modelPath = _readValue(args, ++index, arg);
+        case '--draft-model-path':
+          draftModelPath = _readValue(args, ++index, arg);
         case '--mmproj-path':
           mmprojPath = _readValue(args, ++index, arg);
         case '--image-path':
@@ -892,6 +1028,24 @@ class _ParsedArgs {
           modelUrl = _readValue(args, ++index, arg);
         case '--backend':
           backend = _readValue(args, ++index, arg);
+        case '--speculative-cases':
+          speculativeCases = _readValue(args, ++index, arg);
+        case '--benchmark-gpu-layers':
+          benchmarkGpuLayers = _readValue(args, ++index, arg);
+        case '--benchmark-max-tokens':
+          benchmarkMaxTokens = _readValue(args, ++index, arg);
+        case '--benchmark-runs':
+          benchmarkRuns = _readValue(args, ++index, arg);
+        case '--benchmark-warmups':
+          benchmarkWarmups = _readValue(args, ++index, arg);
+        case '--draft-token-max':
+          draftTokenMaxList = _readValue(args, ++index, arg);
+        case '--ngram-size':
+          ngramSize = _readValue(args, ++index, arg);
+        case '--ngram-cache-static-path':
+          ngramCacheStaticPath = _readValue(args, ++index, arg);
+        case '--ngram-cache-dynamic-path':
+          ngramCacheDynamicPath = _readValue(args, ++index, arg);
         case '--expect':
           expect = _readValue(args, ++index, arg);
         default:
@@ -909,10 +1063,20 @@ class _ParsedArgs {
       python: python,
       pythonProvided: pythonProvided,
       modelPath: modelPath,
+      draftModelPath: draftModelPath,
       mmprojPath: mmprojPath,
       imagePath: imagePath,
       modelUrl: modelUrl,
       backend: backend,
+      speculativeCases: speculativeCases,
+      benchmarkGpuLayers: benchmarkGpuLayers,
+      benchmarkMaxTokens: benchmarkMaxTokens,
+      benchmarkRuns: benchmarkRuns,
+      benchmarkWarmups: benchmarkWarmups,
+      draftTokenMaxList: draftTokenMaxList,
+      ngramSize: ngramSize,
+      ngramCacheStaticPath: ngramCacheStaticPath,
+      ngramCacheDynamicPath: ngramCacheDynamicPath,
       expect: expect,
       skipBuild: skipBuild,
     );

--- a/tool/testing/test_matrix.dart
+++ b/tool/testing/test_matrix.dart
@@ -141,17 +141,21 @@ const List<TestMatrixRow> testMatrixRows = <TestMatrixRow>[
     tier: 'targeted',
     mode: 'local-only',
     covers:
-        'real GGUF llama.cpp speculative decoding baseline, draft-model, and '
-        'n-gram throughput/acceptance metrics',
+        'real GGUF llama.cpp speculative decoding baseline, n-gram, '
+        'draft-model, and cache throughput/acceptance metrics',
     command:
-        'LLAMADART_MTP_BENCHMARK_NGRAM=true '
-        'LLAMADART_MTP_BENCHMARK_NGRAM_ONLY=true '
-        'LLAMADART_MTP_BENCHMARK_NGRAM_SIZE=1 dart run '
-        'tool/testing/llama_cpp_mtp_benchmark.dart <model.gguf> - 128 3 '
-        '1,2 1',
+        'dart run tool/testing/run_local_e2e.dart --scenario '
+        'llama-cpp-speculative-benchmark --model-path <model.gguf> '
+        '--backend cpu --speculative-cases baseline,ngram-simple,'
+        'ngram-map-k,ngram-map-k4v,ngram-mod,mixed-ngram '
+        '--benchmark-gpu-layers 0 --benchmark-max-tokens 128 '
+        '--benchmark-runs 3 --draft-token-max 1,2 '
+        '--benchmark-warmups 1',
     useWhen:
         'llama.cpp speculative decoding strategy, wrapper, rollback, or '
-        'performance changes.',
+        'performance changes. Draft-model strategies require '
+        '--draft-model-path in the local E2E scenario; ngram-cache requires '
+        'cache paths.',
   ),
   TestMatrixRow(
     id: 'gguf-chat-features-smoke',

--- a/website/docs/guides/performance-tuning.md
+++ b/website/docs/guides/performance-tuning.md
@@ -226,6 +226,17 @@ dart run tool/testing/native_inference_benchmark.dart \
   --runs 3 \
   --max-tokens 128
 
+# Benchmark llama.cpp speculative decoding strategies
+dart run tool/testing/llama_cpp_speculative_benchmark.dart \
+  --model path/to/model.gguf \
+  --cases baseline,ngram-simple,ngram-map-k,ngram-map-k4v,ngram-mod,mixed-ngram \
+  --backend cpu \
+  --gpu-layers 0 \
+  --max-tokens 128 \
+  --runs 3 \
+  --draft-token-max 1,2 \
+  --warmups 1
+
 # Benchmark embeddings (sequential vs batch)
 dart run tool/testing/native_embedding_benchmark.dart \
   --model path/to/model.gguf \
@@ -241,6 +252,9 @@ dart run tool/testing/native_embedding_sweep.dart \
   --max-seq-values 1,2,4,8 \
   --csv-out embedding_speedup.csv
 ```
+
+For the speculative benchmark runner, draft-model strategies require
+`--draft-model`; the n-gram cache strategy requires cache paths.
 
 Compare llama.cpp/GGUF and LiteRT-LM with the bundled fair benchmark scripts:
 


### PR DESCRIPTION
## Summary

- Add a repeatable llama.cpp speculative benchmark runner and wire it into `run_local_e2e`, `test_matrix`, README, website docs, and the changelog.
- Harden external draft-model speculative processing by suppressing unused batch logits while calling the generic native speculative process hook.
- Add unit coverage for speculative validation, logits suppression/restore behavior, and default plus draft-model benchmark dry-runs.
- Add a benchmark `--flash-attention auto|enabled|disabled` option so local DFlash runs can match upstream `-fa on` examples.

## Validation

- `dart format lib/src/backends/llama_cpp/llama_cpp_service.dart test/unit/backends/llama_cpp/llama_cpp_service_test.dart test/unit/tooling/run_local_e2e_test.dart tool/testing/llama_cpp_speculative_benchmark.dart tool/testing/run_local_e2e.dart tool/testing/test_matrix.dart test/unit/tooling/test_matrix_test.dart`
- `dart analyze lib/src/backends/llama_cpp/llama_cpp_service.dart tool/testing/llama_cpp_speculative_benchmark.dart tool/testing/run_local_e2e.dart tool/testing/test_matrix.dart test/unit/tooling/run_local_e2e_test.dart test/unit/tooling/test_matrix_test.dart test/unit/backends/llama_cpp/llama_cpp_service_test.dart`
- `/Users/jhin.lee/development/flutter/bin/cache/dart-sdk/bin/dart --disable-dart-dev analyze tool/testing/llama_cpp_speculative_benchmark.dart test/unit/tooling/llama_cpp_speculative_benchmark_test.dart`
- `dart test -p vm test/unit/tooling/run_local_e2e_test.dart test/unit/tooling/test_matrix_test.dart test/unit/backends/llama_cpp/llama_cpp_service_test.dart --reporter compact`
- `/Users/jhin.lee/development/flutter/bin/cache/dart-sdk/bin/dart --disable-dart-dev test test/unit/tooling/llama_cpp_speculative_benchmark_test.dart`
- `git diff --check`
- `dart run tool/testing/run_local_e2e.dart --scenario llama-cpp-speculative-benchmark --model-path models/Qwen3.5-0.8B-Q4_K_M.gguf --backend cpu --dry-run`
- `dart run tool/testing/run_local_e2e.dart --scenario llama-cpp-speculative-benchmark --model-path models/qwen2.5-1.5b-instruct-q4_k_m.gguf --draft-model-path models/qwen2.5-0.5b-instruct-q4_k_m.gguf --speculative-cases baseline,draft-simple,mixed-ngram-draft-simple --benchmark-max-tokens 16 --benchmark-runs 1 --draft-token-max 1 --benchmark-warmups 0 --dry-run`
- `dart run tool/testing/test_matrix.dart --tier targeted`

Full-repo `dart analyze` was also attempted on this worktree and is currently blocked by unrelated example dependency/import failures under `example/basic_app` plus existing example warnings.

Real-model benchmark evidence:

- Models are now reusable from the default macOS llamadart cache root: `/Users/jhin.lee/Library/Caches/llamadart/models`. Existing repo-local `models/*.gguf` files were moved there and symlinked back locally.
- Qwen3.5 0.8B Q4_K_M, CPU, default draftless n-gram matrix: baseline 115.17 tok/s; `ngram-simple` 87.81 tok/s; `ngram-map-k` 94.90 tok/s; `ngram-map-k4v` 94.91 tok/s; `ngram-mod` 112.21 tok/s; `mixed-ngram` 94.63 tok/s. All output hashes matched baseline (`8dfd1182`).
- Qwen2.5 1.5B target + Qwen2.5 0.5B draft, CPU, `draft-simple`: baseline 92.04 tok/s; `draft-simple` 23.84 tok/s; `mixed-ngram-draft-simple` 59.10 tok/s. All output hashes matched baseline (`15d06886`); draft paths accepted 7/8 draft tokens.
- Gemma 4 E2B Q4_K_S target + Gemma 4 MTP draft, CPU, `draft-mtp`: baseline 32.19 tok/s; `draft-mtp` 18.78 tok/s; `mixed-ngram-mtp` 30.26 tok/s. All output hashes matched baseline (`ae4e5ac8`); draft paths accepted 7/8 draft tokens.
- Gemma 4 E2B Q4_K_S target + Gemma 4 MTP draft, Metal, `draft-mtp`: baseline 142.68 tok/s; `draft-mtp` depth 1 150.70 tok/s; `mixed-ngram-mtp` depth 1 151.19 tok/s; depth 2+ was slower. Depth 1 hashes matched baseline, showing a small local Metal speedup for MTP.
- Qwen2.5 3B target + Qwen2.5 0.5B draft, Metal, `draft-simple`: baseline 148.29 tok/s; best draft-simple depth 1 112.97 tok/s. Hashes matched but no speedup.
- Qwen3 8B Q4_K_M target + Qwen3 8B EAGLE3 F16 speculator, Metal, raw code prompt: baseline 78.80 tok/s; `draft-eagle3` depth 1 73.91 tok/s; depth 2 73.56 tok/s; depth 4 61.32 tok/s; depth 8 62.63 tok/s. All output hashes matched baseline (`8fedc67f`); median acceptance was 0.955, 0.902, 0.873, and 0.749 respectively.
- Qwen3 8B EAGLE3 templated attempt could not exercise the real Qwen chat template because this backend path reported `Chat template not implemented in service yet`; it fell back to the tool's Gemma-style prompt. Hashes still matched baseline (`52a26cbd`), but throughput stayed below baseline.
- Qwen3.5 4B Q4_K_M target + compatible Qwen3.5 4B DFlash GGUF (`general.architecture=dflash`), Metal, raw code prompt: baseline 93.36 tok/s; `draft-dflash` depth 1 73.91 tok/s; depth 2 75.81 tok/s; depth 4 72.68 tok/s; depth 8 79.98 tok/s; depth 15 89.08 tok/s. All output hashes matched baseline (`f4a1ccda`).
- Same Qwen3.5 DFlash pair with `--flash-attention enabled` to match upstream `-fa on`: baseline 93.06 tok/s; depth 8 80.38 tok/s; depth 15 91.75 tok/s (`0.986x` baseline). All output hashes matched baseline (`f4a1ccda`).
- Incompatible DFlash artifacts were identified and kept out of passing evidence: `Anbeeld/Qwen3.5-4B-DFlash-GGUF` uses `general.architecture=dflash-draft`, which current upstream/native does not register; `lym00/Qwen3-4B-DFlash-GGUF-Test` uses `dflash` but lacks the required `target_layers` metadata.
- Upstream `llama-cli` b9870 completed the same Qwen2.5 `draft-simple` CPU smoke with `--device none`, confirming upstream behavior does not hit the b9873 Dart-wrapper abort path.

## Follow-ups

- Refs #269. This PR materially improves parity and validates compatible `draft-eagle3`, `draft-dflash`, `draft-mtp`, `draft-simple`, and n-gram paths, but it does not close the full issue because `ngram-cache` and broader platform/device sweeps still need coverage.
- Split native wrapper provenance/hardening follow-up to leehack/llamadart-native#24.
- Incompatible community DFlash GGUFs should be regenerated with upstream llama.cpp metadata (`general.architecture=dflash` plus required `dflash.*` keys), or compatibility aliases should be handled upstream first and then consumed through a future `llamadart-native` release.
