### PR TITLE
Validate generated ngram-cache benchmark files

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,8 @@
 
 * Added a durable flag-based llama.cpp speculative benchmark runner and wired
   it into the local E2E scenario list, testing matrix, README, and website
-  performance guide.
+  performance guide. The runner can now generate a llama.cpp-compatible
+  static n-gram cache file for `ngram-cache` E2E validation.
 
 * Hardened generic llama.cpp external draft-model speculative decoding so
   draft-context processing does not request unused logits, avoiding a

--- a/README.md
+++ b/README.md
@@ -319,17 +319,19 @@ explicit cases:
 dart run tool/testing/run_local_e2e.dart \
   --scenario llama-cpp-speculative-benchmark \
   --model-path path/to/model.gguf \
-  --speculative-cases baseline,ngram-simple,ngram-map-k,ngram-map-k4v,ngram-mod,mixed-ngram \
+  --speculative-cases baseline,ngram-simple,ngram-map-k,ngram-map-k4v,ngram-mod,ngram-cache,mixed-ngram \
   --backend cpu \
   --benchmark-gpu-layers 0 \
   --benchmark-max-tokens 128 \
   --benchmark-runs 3 \
   --draft-token-max 1,2 \
-  --benchmark-warmups 1
+  --benchmark-warmups 1 \
+  --ngram-cache-build-static-path /tmp/llamadart-ngram-cache.bin
 ```
 
 In the local E2E scenario, draft-model strategies require
-`--draft-model-path`; the n-gram cache strategy requires cache paths. Use
+`--draft-model-path`; the n-gram cache strategy can use existing cache paths or
+build a static cache with `--ngram-cache-build-static-path`. Use
 `tool/testing/llama_cpp_speculative_benchmark.dart` directly for advanced
 strategy-specific benchmark knobs; the raw runner's draft-model flag is
 `--draft-model`.

--- a/doc/testing_matrix.md
+++ b/doc/testing_matrix.md
@@ -163,17 +163,19 @@ dart run tool/testing/native_inference_benchmark.dart \
 dart run tool/testing/run_local_e2e.dart \
   --scenario llama-cpp-speculative-benchmark \
   --model-path models/Qwen3.5-0.8B-Q4_K_M.gguf \
-  --speculative-cases baseline,ngram-simple,ngram-map-k,ngram-map-k4v,ngram-mod,mixed-ngram \
+  --speculative-cases baseline,ngram-simple,ngram-map-k,ngram-map-k4v,ngram-mod,ngram-cache,mixed-ngram \
   --backend cpu \
   --benchmark-gpu-layers 0 \
   --benchmark-max-tokens 128 \
   --benchmark-runs 3 \
   --draft-token-max 1,2 \
-  --benchmark-warmups 1
+  --benchmark-warmups 1 \
+  --ngram-cache-build-static-path /tmp/llamadart-ngram-cache.bin
 ```
 
 In the local E2E scenario, draft-model strategies require
-`--draft-model-path`; the n-gram cache strategy requires cache paths.
+`--draft-model-path`; the n-gram cache strategy can use existing cache paths or
+build a static cache with `--ngram-cache-build-static-path`.
 
 Use `--dry-run` first when a scenario starts servers, builds Flutter web, or
 requires local model URLs.

--- a/test/unit/tooling/llama_cpp_speculative_benchmark_test.dart
+++ b/test/unit/tooling/llama_cpp_speculative_benchmark_test.dart
@@ -4,6 +4,7 @@ library;
 import 'dart:io';
 import 'dart:typed_data';
 
+import 'package:path/path.dart' as path;
 import 'package:test/test.dart';
 
 import '../../../tool/testing/llama_cpp_speculative_benchmark.dart'
@@ -125,7 +126,7 @@ void main() {
       'allows generated static cache path with equivalent absolute path',
       () async {
         final relativePath = 'relative-ngram-cache.bin';
-        final absolutePath = '${Directory.current.path}/$relativePath';
+        final absolutePath = path.absolute(relativePath);
         addTearDown(() async {
           final file = File(relativePath);
           if (await file.exists()) {

--- a/test/unit/tooling/llama_cpp_speculative_benchmark_test.dart
+++ b/test/unit/tooling/llama_cpp_speculative_benchmark_test.dart
@@ -120,5 +120,42 @@ void main() {
         ),
       );
     });
+
+    test(
+      'allows generated static cache path with equivalent absolute path',
+      () async {
+        final relativePath = 'relative-ngram-cache.bin';
+        final absolutePath = '${Directory.current.path}/$relativePath';
+        addTearDown(() async {
+          final file = File(relativePath);
+          if (await file.exists()) {
+            await file.delete();
+          }
+        });
+
+        final result = await Process.run(Platform.resolvedExecutable, [
+          '--disable-dart-dev',
+          'tool/testing/llama_cpp_speculative_benchmark.dart',
+          '--model',
+          'missing.gguf',
+          '--cases',
+          'ngram-cache',
+          '--ngram-cache-static-path',
+          relativePath,
+          '--ngram-cache-build-static-path',
+          absolutePath,
+        ]);
+
+        expect(result.exitCode, isNot(0));
+        expect(
+          result.stderr,
+          isNot(contains('N-gram cache path does not exist')),
+        );
+        expect(
+          result.stderr,
+          isNot(contains('omit --ngram-cache-static-path')),
+        );
+      },
+    );
   });
 }

--- a/test/unit/tooling/llama_cpp_speculative_benchmark_test.dart
+++ b/test/unit/tooling/llama_cpp_speculative_benchmark_test.dart
@@ -2,8 +2,12 @@
 library;
 
 import 'dart:io';
+import 'dart:typed_data';
 
 import 'package:test/test.dart';
+
+import '../../../tool/testing/llama_cpp_speculative_benchmark.dart'
+    as speculative_benchmark;
 
 void main() {
   group('llama_cpp_speculative_benchmark', () {
@@ -17,6 +21,53 @@ void main() {
       expect(result.exitCode, 0);
       expect(result.stdout, contains('--flash-attention <mode>'));
       expect(result.stdout, contains('auto, enabled, disabled'));
+      expect(result.stdout, contains('--ngram-cache-build-static-path <p>'));
+      expect(result.stdout, contains('--ngram-cache-build-text <text>'));
+    });
+
+    test('builds llama.cpp static ngram cache bytes', () {
+      final bytes = speculative_benchmark.buildLlamaCppStaticNgramCacheBytes(
+        const [10, 20, 30, 40, 30, 40, 50],
+      );
+      final data = ByteData.sublistView(Uint8List.fromList(bytes));
+      final words = [
+        for (var offset = 0; offset < bytes.length; offset += 4)
+          data.getInt32(offset, Endian.host),
+      ];
+
+      expect(bytes.length, 120);
+      expect(words, [
+        10,
+        20,
+        -1,
+        -1,
+        1,
+        30,
+        1,
+        20,
+        30,
+        -1,
+        -1,
+        1,
+        40,
+        1,
+        30,
+        40,
+        -1,
+        -1,
+        2,
+        30,
+        1,
+        50,
+        1,
+        40,
+        30,
+        -1,
+        -1,
+        1,
+        40,
+        1,
+      ]);
     });
 
     test('lists all case aliases in invalid cases errors', () async {
@@ -46,6 +97,28 @@ void main() {
       expect(result.exitCode, isNot(0));
       expect(result.stderr, contains('Invalid --flash-attention'));
       expect(result.stderr, contains('auto, enabled, disabled'));
+    });
+
+    test('rejects ngram cache build text without output path', () async {
+      final result = await Process.run(Platform.resolvedExecutable, [
+        '--disable-dart-dev',
+        'tool/testing/llama_cpp_speculative_benchmark.dart',
+        '--model',
+        'missing.gguf',
+        '--cases',
+        'ngram-cache',
+        '--ngram-cache-build-text',
+        'alpha beta gamma',
+      ]);
+
+      expect(result.exitCode, isNot(0));
+      expect(
+        result.stderr,
+        contains(
+          '--ngram-cache-build-text requires '
+          '--ngram-cache-build-static-path',
+        ),
+      );
     });
   });
 }

--- a/test/unit/tooling/run_local_e2e_test.dart
+++ b/test/unit/tooling/run_local_e2e_test.dart
@@ -9,6 +9,17 @@ import '../../../tool/testing/run_local_e2e.dart';
 
 void main() {
   group('run_local_e2e', () {
+    test('documents generated ngram cache text default', () async {
+      final result = await runLocalE2e(const ['--help'], projectRoot: '/repo');
+
+      expect(result.exitCode, 0);
+      expect(result.stdout, contains('--ngram-cache-build-text <txt>'));
+      expect(
+        result.stdout,
+        contains('defaults to the resolved benchmark prompt'),
+      );
+    });
+
     test('lists local-only Dart, Flutter, and Web smoke scenarios', () async {
       final result = await runLocalE2e(const ['--list'], projectRoot: '/repo');
 

--- a/test/unit/tooling/run_local_e2e_test.dart
+++ b/test/unit/tooling/run_local_e2e_test.dart
@@ -292,6 +292,37 @@ void main() {
       );
     });
 
+    test(
+      'dry-runs llama.cpp speculative benchmark with generated ngram cache',
+      () async {
+        final result = await runLocalE2e(const [
+          '--scenario',
+          'llama-cpp-speculative-benchmark',
+          '--model-path',
+          'models/Qwen3.5-0.8B-Q4_K_M.gguf',
+          '--speculative-cases',
+          'baseline,ngram-cache',
+          '--ngram-cache-build-static-path',
+          '/tmp/llamadart-ngram-cache.bin',
+          '--ngram-cache-build-text',
+          'alpha beta gamma alpha beta delta',
+          '--dry-run',
+        ], projectRoot: '/repo');
+
+        expect(result.exitCode, 0);
+        expect(
+          result.stdout,
+          contains(
+            '--cases baseline,ngram-cache --backend auto --gpu-layers 0 '
+            '--max-tokens 128 --runs 3 --draft-token-max 1,2 --warmups 1 '
+            '--ngram-cache-build-static-path '
+            '/tmp/llamadart-ngram-cache.bin --ngram-cache-build-text '
+            "'alpha beta gamma alpha beta delta'",
+          ),
+        );
+      },
+    );
+
     test('requires model path for llama.cpp speculative benchmark', () async {
       final result = await runLocalE2e(const [
         '--scenario',

--- a/test/unit/tooling/test_matrix_test.dart
+++ b/test/unit/tooling/test_matrix_test.dart
@@ -83,14 +83,21 @@ void main() {
         table,
         contains(
           '--speculative-cases baseline,ngram-simple,ngram-map-k,ngram-map-k4v,'
-          'ngram-mod,mixed-ngram',
+          'ngram-mod,ngram-cache,mixed-ngram',
         ),
       );
       expect(table, contains('--draft-token-max 1,2 --benchmark-warmups 1'));
       expect(
         table,
+        contains(
+          '--ngram-cache-build-static-path /tmp/llamadart-ngram-cache.bin',
+        ),
+      );
+      expect(
+        table,
         contains('Draft-model strategies require --draft-model-path'),
       );
+      expect(table, contains('ngram-cache can use'));
       expect(table, isNot(contains('LLAMADART_MTP_BENCHMARK')));
       expect(table, isNot(contains('llama_cpp_mtp_benchmark.dart')));
       expect(table, contains('run_local_e2e.dart'));

--- a/tool/testing/llama_cpp_speculative_benchmark.dart
+++ b/tool/testing/llama_cpp_speculative_benchmark.dart
@@ -836,8 +836,7 @@ class _BenchmarkOptions {
     );
     if (ngramCacheStaticPath != null &&
         ngramCacheBuildStaticPath != null &&
-        File(ngramCacheStaticPath).absolute.path !=
-            File(ngramCacheBuildStaticPath).absolute.path) {
+        !_sameAbsolutePath(ngramCacheStaticPath, ngramCacheBuildStaticPath)) {
       stderr.writeln(
         '--ngram-cache-build-static-path also provides the static cache used '
         'by ngram-cache; omit --ngram-cache-static-path or point both flags '
@@ -1235,7 +1234,8 @@ void _validate(_BenchmarkOptions options) {
     options.ngramCacheDynamicPath,
   ];
   for (final path in ngramCachePaths.whereType<String>()) {
-    if (path == options.ngramCacheBuildStaticPath) {
+    final buildPath = options.ngramCacheBuildStaticPath;
+    if (buildPath != null && _sameAbsolutePath(path, buildPath)) {
       continue;
     }
     if (!File(path).existsSync()) {
@@ -1244,6 +1244,9 @@ void _validate(_BenchmarkOptions options) {
     }
   }
 }
+
+bool _sameAbsolutePath(String first, String second) =>
+    File(first).absolute.path == File(second).absolute.path;
 
 GpuBackend _parsePreferredBackend(String? value) {
   final normalized = value?.trim().toLowerCase();

--- a/tool/testing/llama_cpp_speculative_benchmark.dart
+++ b/tool/testing/llama_cpp_speculative_benchmark.dart
@@ -3,6 +3,7 @@ import 'dart:io';
 import 'dart:typed_data';
 
 import 'package:llamadart/llamadart.dart';
+import 'package:path/path.dart' as path;
 
 Future<void> main(List<String> arguments) async {
   final options = _BenchmarkOptions.parse(arguments);
@@ -1246,7 +1247,7 @@ void _validate(_BenchmarkOptions options) {
 }
 
 bool _sameAbsolutePath(String first, String second) =>
-    File(first).absolute.path == File(second).absolute.path;
+    path.equals(path.absolute(first), path.absolute(second));
 
 GpuBackend _parsePreferredBackend(String? value) {
   final normalized = value?.trim().toLowerCase();

--- a/tool/testing/llama_cpp_speculative_benchmark.dart
+++ b/tool/testing/llama_cpp_speculative_benchmark.dart
@@ -1,5 +1,6 @@
 import 'dart:convert';
 import 'dart:io';
+import 'dart:typed_data';
 
 import 'package:llamadart/llamadart.dart';
 
@@ -38,6 +39,12 @@ Future<void> main(List<String> arguments) async {
       modelHandle,
       options.prompt,
       rawPrompt: options.rawPrompt,
+    );
+    await _prepareGeneratedNgramCache(
+      backend: backend,
+      modelHandle: modelHandle,
+      options: options,
+      prompt: prompt,
     );
 
     for (var i = 0; i < options.warmupRuns; i++) {
@@ -102,6 +109,91 @@ Future<void> main(List<String> arguments) async {
     }
     await backend.dispose();
   }
+}
+
+Future<void> _prepareGeneratedNgramCache({
+  required LlamaBackend backend,
+  required int modelHandle,
+  required _BenchmarkOptions options,
+  required String prompt,
+}) async {
+  final staticBuildPath = options.ngramCacheBuildStaticPath;
+  if (staticBuildPath == null) {
+    return;
+  }
+
+  final sourceText = options.ngramCacheBuildText ?? prompt;
+  final tokens = await backend.tokenize(modelHandle, sourceText);
+  final cacheBytes = buildLlamaCppStaticNgramCacheBytes(tokens);
+  if (cacheBytes.isEmpty) {
+    throw StateError(
+      'N-gram cache source produced ${tokens.length} token(s); at least '
+      'three tokens are required to build a static llama.cpp n-gram cache.',
+    );
+  }
+
+  final file = File(staticBuildPath);
+  await file.parent.create(recursive: true);
+  await file.writeAsBytes(cacheBytes, flush: true);
+  stderr.writeln(
+    'Wrote llama.cpp static n-gram cache to $staticBuildPath '
+    '(${tokens.length} tokens, ${cacheBytes.length} bytes).',
+  );
+}
+
+/// Builds bytes compatible with upstream llama.cpp `common_ngram_cache_save`.
+///
+/// The current upstream static lookup cache uses bigram keys
+/// (`LLAMA_NGRAM_STATIC == 2`) padded to `LLAMA_NGRAM_MAX == 4` with
+/// `LLAMA_TOKEN_NULL == -1`.
+List<int> buildLlamaCppStaticNgramCacheBytes(List<int> tokens) {
+  const ngramStatic = 2;
+  const ngramMax = 4;
+  const tokenNull = -1;
+  final cache = <(int, int), Map<int, int>>{};
+
+  for (var index = ngramStatic; index < tokens.length; index++) {
+    final ngram = (tokens[index - 2], tokens[index - 1]);
+    final tokenCounts = cache.putIfAbsent(ngram, () => <int, int>{});
+    final token = tokens[index];
+    tokenCounts[token] = (tokenCounts[token] ?? 0) + 1;
+  }
+
+  final bytes = BytesBuilder(copy: false);
+  final ngrams = cache.entries.toList()
+    ..sort((a, b) {
+      final first = a.key.$1.compareTo(b.key.$1);
+      if (first != 0) {
+        return first;
+      }
+      return a.key.$2.compareTo(b.key.$2);
+    });
+
+  for (final entry in ngrams) {
+    final paddedNgram = <int>[
+      entry.key.$1,
+      entry.key.$2,
+      for (var i = ngramStatic; i < ngramMax; i++) tokenNull,
+    ];
+    for (final token in paddedNgram) {
+      _addNativeInt32(bytes, token);
+    }
+
+    final tokenCounts = entry.value.entries.toList()
+      ..sort((a, b) => a.key.compareTo(b.key));
+    _addNativeInt32(bytes, tokenCounts.length);
+    for (final tokenCount in tokenCounts) {
+      _addNativeInt32(bytes, tokenCount.key);
+      _addNativeInt32(bytes, tokenCount.value);
+    }
+  }
+
+  return bytes.takeBytes();
+}
+
+void _addNativeInt32(BytesBuilder bytes, int value) {
+  final data = ByteData(4)..setInt32(0, value, Endian.host);
+  bytes.add(data.buffer.asUint8List());
 }
 
 Future<String> _resolvePrompt(
@@ -709,6 +801,8 @@ class _BenchmarkOptions {
     required this.ngramTokenMax,
     required this.ngramCacheStaticPath,
     required this.ngramCacheDynamicPath,
+    required this.ngramCacheBuildStaticPath,
+    required this.ngramCacheBuildText,
     required this.rawPrompt,
     required this.prompt,
     required this.streamBatchTokenThreshold,
@@ -734,6 +828,21 @@ class _BenchmarkOptions {
     );
     if (draftTokenMaxValues.any((value) => value <= 0)) {
       stderr.writeln('--draft-token-max values must be greater than zero.');
+      exit(64);
+    }
+    final ngramCacheStaticPath = _emptyToNull(map['ngram-cache-static-path']);
+    final ngramCacheBuildStaticPath = _emptyToNull(
+      map['ngram-cache-build-static-path'],
+    );
+    if (ngramCacheStaticPath != null &&
+        ngramCacheBuildStaticPath != null &&
+        File(ngramCacheStaticPath).absolute.path !=
+            File(ngramCacheBuildStaticPath).absolute.path) {
+      stderr.writeln(
+        '--ngram-cache-build-static-path also provides the static cache used '
+        'by ngram-cache; omit --ngram-cache-static-path or point both flags '
+        'at the same file.',
+      );
       exit(64);
     }
 
@@ -795,8 +904,10 @@ class _BenchmarkOptions {
       ngramMatch: _parseOptionalInt(map['ngram-match']),
       ngramTokenMin: _parseOptionalInt(map['ngram-token-min']),
       ngramTokenMax: _parseOptionalInt(map['ngram-token-max']),
-      ngramCacheStaticPath: _emptyToNull(map['ngram-cache-static-path']),
+      ngramCacheStaticPath: ngramCacheStaticPath ?? ngramCacheBuildStaticPath,
       ngramCacheDynamicPath: _emptyToNull(map['ngram-cache-dynamic-path']),
+      ngramCacheBuildStaticPath: ngramCacheBuildStaticPath,
+      ngramCacheBuildText: _emptyToNull(map['ngram-cache-build-text']),
       rawPrompt: _parseBool(
         map['raw-prompt'],
         fallback: false,
@@ -851,6 +962,8 @@ class _BenchmarkOptions {
   final int? ngramTokenMax;
   final String? ngramCacheStaticPath;
   final String? ngramCacheDynamicPath;
+  final String? ngramCacheBuildStaticPath;
+  final String? ngramCacheBuildText;
   final bool rawPrompt;
   final String prompt;
   final int streamBatchTokenThreshold;
@@ -902,6 +1015,12 @@ class _BenchmarkOptions {
       'ngramTokenMax': ngramTokenMax,
       'ngramCacheStaticPath': ngramCacheStaticPath,
       'ngramCacheDynamicPath': ngramCacheDynamicPath,
+      'ngramCacheBuildStaticPath': ngramCacheBuildStaticPath,
+      'ngramCacheBuildTextPreview': ngramCacheBuildText == null
+          ? null
+          : ngramCacheBuildText!.length <= 120
+          ? ngramCacheBuildText
+          : ngramCacheBuildText!.substring(0, 120),
       'rawPrompt': rawPrompt,
       'promptPreview': prompt.length <= 120 ? prompt : prompt.substring(0, 120),
       'streamBatchTokenThreshold': streamBatchTokenThreshold,
@@ -1087,6 +1206,13 @@ void _validate(_BenchmarkOptions options) {
   if (options.showHelp) {
     return;
   }
+  if (options.ngramCacheBuildText != null &&
+      options.ngramCacheBuildStaticPath == null) {
+    stderr.writeln(
+      '--ngram-cache-build-text requires --ngram-cache-build-static-path.',
+    );
+    exit(64);
+  }
   for (final requestedCase in options.requestedCases) {
     if (_draftModelRequiredCases.contains(requestedCase) &&
         options.draftModelPath == null) {
@@ -1097,8 +1223,8 @@ void _validate(_BenchmarkOptions options) {
         options.ngramCacheStaticPath == null &&
         options.ngramCacheDynamicPath == null) {
       stderr.writeln(
-        'ngram-cache requires --ngram-cache-static-path or '
-        '--ngram-cache-dynamic-path.',
+        'ngram-cache requires --ngram-cache-static-path, '
+        '--ngram-cache-dynamic-path, or --ngram-cache-build-static-path.',
       );
       exit(64);
     }
@@ -1109,6 +1235,9 @@ void _validate(_BenchmarkOptions options) {
     options.ngramCacheDynamicPath,
   ];
   for (final path in ngramCachePaths.whereType<String>()) {
+    if (path == options.ngramCacheBuildStaticPath) {
+      continue;
+    }
     if (!File(path).existsSync()) {
       stderr.writeln('N-gram cache path does not exist: $path');
       exit(64);
@@ -1302,6 +1431,10 @@ Speculative knobs:
   --ngram-token-max <n>
   --ngram-cache-static-path <path>     Optional existing cache file.
   --ngram-cache-dynamic-path <path>    Optional existing cache file.
+  --ngram-cache-build-static-path <p>  Build a static cache file before the run
+                                       and use it as ngram-cache input.
+  --ngram-cache-build-text <text>      Source text for the generated static
+                                       cache. Defaults to the resolved prompt.
 
 Examples:
   dart run tool/testing/llama_cpp_speculative_benchmark.dart \\

--- a/tool/testing/run_local_e2e.dart
+++ b/tool/testing/run_local_e2e.dart
@@ -85,6 +85,8 @@ class LocalE2eRunContext {
     required this.ngramSize,
     required this.ngramCacheStaticPath,
     required this.ngramCacheDynamicPath,
+    required this.ngramCacheBuildStaticPath,
+    required this.ngramCacheBuildText,
     required this.expect,
     required this.skipBuild,
   });
@@ -108,6 +110,8 @@ class LocalE2eRunContext {
   final String? ngramSize;
   final String? ngramCacheStaticPath;
   final String? ngramCacheDynamicPath;
+  final String? ngramCacheBuildStaticPath;
+  final String? ngramCacheBuildText;
   final String expect;
   final bool skipBuild;
 
@@ -259,6 +263,17 @@ List<LocalE2eScenario> buildLocalE2eScenarios({String? projectRoot}) {
             '--ngram-cache-dynamic-path',
             ngramCacheDynamicPath,
           ]);
+        }
+        final ngramCacheBuildStaticPath = context.ngramCacheBuildStaticPath;
+        if (ngramCacheBuildStaticPath != null) {
+          arguments.addAll([
+            '--ngram-cache-build-static-path',
+            ngramCacheBuildStaticPath,
+          ]);
+        }
+        final ngramCacheBuildText = context.ngramCacheBuildText;
+        if (ngramCacheBuildText != null) {
+          arguments.addAll(['--ngram-cache-build-text', ngramCacheBuildText]);
         }
         return [
           LocalE2eCommandStep(
@@ -691,6 +706,8 @@ Future<LocalE2eResult> runLocalE2e(
     ngramSize: parsed.ngramSize,
     ngramCacheStaticPath: parsed.ngramCacheStaticPath,
     ngramCacheDynamicPath: parsed.ngramCacheDynamicPath,
+    ngramCacheBuildStaticPath: parsed.ngramCacheBuildStaticPath,
+    ngramCacheBuildText: parsed.ngramCacheBuildText,
     expect: parsed.expect,
     skipBuild: parsed.skipBuild,
   );
@@ -896,6 +913,9 @@ Options:
   --ngram-size <n>               Optional n-gram size for speculative benchmark.
   --ngram-cache-static-path <p>  Optional ngram-cache static path for speculative benchmark.
   --ngram-cache-dynamic-path <p> Optional ngram-cache dynamic path for speculative benchmark.
+  --ngram-cache-build-static-path <p>
+                                 Build a static ngram-cache file before speculative benchmark.
+  --ngram-cache-build-text <txt> Source text for generated ngram-cache static file.
   --expect <text>                Expected response text for real-model web smoke.
   --skip-build                   Reuse an existing Flutter web build where supported.
   -h, --help                     Show this help.
@@ -940,6 +960,8 @@ class _ParsedArgs {
     this.ngramSize,
     this.ngramCacheStaticPath,
     this.ngramCacheDynamicPath,
+    this.ngramCacheBuildStaticPath,
+    this.ngramCacheBuildText,
   });
 
   final bool list;
@@ -965,6 +987,8 @@ class _ParsedArgs {
   final String? ngramSize;
   final String? ngramCacheStaticPath;
   final String? ngramCacheDynamicPath;
+  final String? ngramCacheBuildStaticPath;
+  final String? ngramCacheBuildText;
   final String expect;
   final bool skipBuild;
 
@@ -995,6 +1019,8 @@ class _ParsedArgs {
     String? ngramSize;
     String? ngramCacheStaticPath;
     String? ngramCacheDynamicPath;
+    String? ngramCacheBuildStaticPath;
+    String? ngramCacheBuildText;
 
     for (var index = 0; index < args.length; index++) {
       final arg = args[index];
@@ -1046,6 +1072,10 @@ class _ParsedArgs {
           ngramCacheStaticPath = _readValue(args, ++index, arg);
         case '--ngram-cache-dynamic-path':
           ngramCacheDynamicPath = _readValue(args, ++index, arg);
+        case '--ngram-cache-build-static-path':
+          ngramCacheBuildStaticPath = _readValue(args, ++index, arg);
+        case '--ngram-cache-build-text':
+          ngramCacheBuildText = _readValue(args, ++index, arg);
         case '--expect':
           expect = _readValue(args, ++index, arg);
         default:
@@ -1077,6 +1107,8 @@ class _ParsedArgs {
       ngramSize: ngramSize,
       ngramCacheStaticPath: ngramCacheStaticPath,
       ngramCacheDynamicPath: ngramCacheDynamicPath,
+      ngramCacheBuildStaticPath: ngramCacheBuildStaticPath,
+      ngramCacheBuildText: ngramCacheBuildText,
       expect: expect,
       skipBuild: skipBuild,
     );

--- a/tool/testing/run_local_e2e.dart
+++ b/tool/testing/run_local_e2e.dart
@@ -915,7 +915,8 @@ Options:
   --ngram-cache-dynamic-path <p> Optional ngram-cache dynamic path for speculative benchmark.
   --ngram-cache-build-static-path <p>
                                  Build a static ngram-cache file before speculative benchmark.
-  --ngram-cache-build-text <txt> Source text for generated ngram-cache static file.
+  --ngram-cache-build-text <txt> Optional source text for generated ngram-cache static file
+                                 (defaults to the resolved benchmark prompt).
   --expect <text>                Expected response text for real-model web smoke.
   --skip-build                   Reuse an existing Flutter web build where supported.
   -h, --help                     Show this help.

--- a/tool/testing/test_matrix.dart
+++ b/tool/testing/test_matrix.dart
@@ -147,15 +147,16 @@ const List<TestMatrixRow> testMatrixRows = <TestMatrixRow>[
         'dart run tool/testing/run_local_e2e.dart --scenario '
         'llama-cpp-speculative-benchmark --model-path <model.gguf> '
         '--backend cpu --speculative-cases baseline,ngram-simple,'
-        'ngram-map-k,ngram-map-k4v,ngram-mod,mixed-ngram '
+        'ngram-map-k,ngram-map-k4v,ngram-mod,ngram-cache,mixed-ngram '
         '--benchmark-gpu-layers 0 --benchmark-max-tokens 128 '
         '--benchmark-runs 3 --draft-token-max 1,2 '
-        '--benchmark-warmups 1',
+        '--benchmark-warmups 1 --ngram-cache-build-static-path '
+        '/tmp/llamadart-ngram-cache.bin',
     useWhen:
         'llama.cpp speculative decoding strategy, wrapper, rollback, or '
         'performance changes. Draft-model strategies require '
-        '--draft-model-path in the local E2E scenario; ngram-cache requires '
-        'cache paths.',
+        '--draft-model-path in the local E2E scenario; ngram-cache can use '
+        'an existing cache path or --ngram-cache-build-static-path.',
   ),
   TestMatrixRow(
     id: 'gguf-chat-features-smoke',

--- a/website/docs/changelog/recent-releases.md
+++ b/website/docs/changelog/recent-releases.md
@@ -13,7 +13,9 @@ For canonical full release notes, use:
   `SpeculativeDecodingConfig` constructors for draft-simple, EAGLE3, MTP,
   DFlash, ngram-simple, ngram-map-k, ngram-map-k4v, ngram-mod, ngram-cache,
   and mixed n-gram plus one draft-model strategy, including generic native
-  wrapper bindings, docs, and local benchmark matrix coverage.
+  wrapper bindings, docs, and local benchmark matrix coverage. The benchmark
+  tooling can generate a llama.cpp-compatible static n-gram cache file for
+  `ngram-cache` E2E validation.
 
 - Updated the default llama.cpp native runtime pin to
   `leehack/llamadart-native@b9873`, refreshed the


### PR DESCRIPTION
## Summary
- Add `--ngram-cache-build-static-path` and `--ngram-cache-build-text` to the llama.cpp speculative benchmark so `ngram-cache` can build and consume a real static cache file during E2E validation.
- Forward those flags through `run_local_e2e.dart`, update the testing matrix/README/changelog, and add unit coverage for cache bytes, CLI validation, dry-run forwarding, and matrix text.

Closes #271

## Production-readiness scope
- **User-facing scope:** Contributors can run the local speculative benchmark for `ngram-cache` without separately building an upstream `llama-lookup-create` binary; the runner tokenizes source text with the target model and writes a llama.cpp-compatible static n-gram cache before context creation.
- **Supported platforms/paths:** Native llama.cpp local-only benchmark paths; verified on macOS arm64 CPU with `Qwen3.5-0.8B-Q4_K_M.gguf`.
- **Unsupported or intentionally unavailable paths:** Existing static/dynamic cache-path validation remains strict for caller-provided paths. Generated static cache files use the current upstream host-endian `common_ngram_cache_save` layout and are intended for same-machine validation.
- **Out of scope / follow-ups:** #272 covers chat-template parity in the benchmark; #273 covers DFlash artifact compatibility docs; #274 covers broader performance parity experiments.

## Completeness checklist
- [x] Declared scope is fully implemented, or explicitly reduced above.
- [x] Unsupported platform/option combinations fail loudly with actionable diagnostics or are clearly documented as unavailable.
- [x] Public API docs, README/website docs, examples, support matrices, and changelog entries are updated where relevant.
- [x] Regression coverage covers the original issue plus key negative/version-skew paths where relevant.
- [x] Security/privacy review completed: no secrets, bearer tokens, signed URLs, or raw secret-bearing paths leak through logs, cache keys, metadata, errors, or snapshots.
- [x] Follow-up work that is useful but not required for this PR is tracked in GitHub Issues, or explicitly marked "None" above.

## PR type guidance
- **Feature PR:** Adds validation-tooling flags, docs, matrix coverage, and focused unit tests for the new benchmark path.

## Test Plan
- [x] `dart format tool/testing/llama_cpp_speculative_benchmark.dart tool/testing/run_local_e2e.dart tool/testing/test_matrix.dart test/unit/tooling/llama_cpp_speculative_benchmark_test.dart test/unit/tooling/run_local_e2e_test.dart test/unit/tooling/test_matrix_test.dart`
- [ ] `dart analyze`
  - Full-repo `dart analyze` currently fails on unrelated example package resolution errors under `example/basic_app` and Flutter example override warnings.
  - Touched-file analyzer passed: `dart analyze tool/testing/llama_cpp_speculative_benchmark.dart tool/testing/run_local_e2e.dart tool/testing/test_matrix.dart test/unit/tooling/llama_cpp_speculative_benchmark_test.dart test/unit/tooling/run_local_e2e_test.dart test/unit/tooling/test_matrix_test.dart`
- [x] `dart test test/unit/tooling/llama_cpp_speculative_benchmark_test.dart test/unit/tooling/run_local_e2e_test.dart test/unit/tooling/test_matrix_test.dart`
- [ ] `dart test -p vm -j 1 --exclude-tags local-only` - not run; this PR only changes local tooling/docs, and the focused tooling tests plus real-model local E2E cover the touched surface.
- [ ] `dart test -p chrome --exclude-tags local-only` - N/A; no browser/runtime code touched.
- [x] Other targeted/local-only validation:
  - `dart run tool/testing/run_local_e2e.dart --scenario llama-cpp-speculative-benchmark --model-path /Users/jhin.lee/Library/Caches/llamadart/models/Qwen3.5-0.8B-Q4_K_M.gguf --speculative-cases baseline,ngram-cache --backend cpu --benchmark-gpu-layers 0 --benchmark-max-tokens 32 --benchmark-runs 2 --benchmark-warmups 1 --draft-token-max 1,2 --ngram-cache-build-static-path /private/tmp/llamadart-qwen35-ngram-cache.bin --ngram-cache-build-text "alpha beta gamma alpha beta delta alpha beta gamma alpha beta delta"`
  - `dart run tool/testing/llama_cpp_speculative_benchmark.dart --model /Users/jhin.lee/Library/Caches/llamadart/models/Qwen3.5-0.8B-Q4_K_M.gguf --cases baseline,ngram-cache --backend cpu --gpu-layers 0 --max-tokens 24 --runs 1 --warmups 0 --draft-token-max 1,2 --raw-prompt --prompt "Repeat the pattern exactly and continue it: alpha beta gamma alpha beta " --ngram-cache-build-static-path /private/tmp/llamadart-qwen35-ngram-cache-observed.bin --ngram-cache-build-text "Repeat the pattern exactly and continue it: alpha beta gamma alpha beta 123456789012345678901234123456789012345678901234"`

## Matrix Evidence
| Matrix row | Scope covered | Platform / model / backend | Result | Evidence / notes |
| --- | --- | --- | --- | --- |
| `llama-cpp-speculative-benchmark` | Generated static cache file, `ngram-cache` loading, deterministic output parity | macOS arm64, `Qwen3.5-0.8B-Q4_K_M.gguf`, CPU | PASS | Local E2E wrote `/private/tmp/llamadart-qwen35-ngram-cache.bin` (12 tokens, 176 bytes); baseline and `ngram-cache` depths 1/2 produced matching hash `9ceb275d`; depth 1 median 78.94 tok/s, depth 2 median 79.86 tok/s vs baseline 91.59 tok/s for this non-overlapping synthetic cache. |
| `llama-cpp-speculative-benchmark` | Acceptance stats with generated cache candidates | macOS arm64, `Qwen3.5-0.8B-Q4_K_M.gguf`, CPU | PASS | Direct raw-prompt benchmark wrote `/private/tmp/llamadart-qwen35-ngram-cache-observed.bin` (62 tokens, 688 bytes); output hash matched baseline `972bcdb5`; depth 1 accepted 11/11 draft tokens at 1.08x baseline wall tok/s; depth 2 accepted 14/14 draft tokens at 1.09x baseline wall tok/s. |
| `static-format-analyze` | Touched-file analyzer only | macOS arm64, Dart SDK | PASS | `dart analyze` on the six touched Dart files reported `No issues found!`; full repo analyzer remains blocked by unrelated example package resolution errors. |

## Review Notes
- Independent review status: Two read-only review agents found no issues. One checked cache writer/file-format/runtime placement; one checked E2E forwarding, docs, matrix, and validation evidence.
- CI status / head SHA: Pending after review-fix push; head `64fa04fd0`.
