### PR TITLE
Use GGUF chat templates in speculative benchmarks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,10 @@
 * Added a durable flag-based llama.cpp speculative benchmark runner and wired
   it into the local E2E scenario list, testing matrix, README, and website
   performance guide. The runner can now generate a llama.cpp-compatible
-  static n-gram cache file for `ngram-cache` E2E validation.
+  static n-gram cache file for `ngram-cache` E2E validation, and renders
+  benchmark prompts with configured or loaded GGUF chat templates before the
+  generic fallback instead of silently falling back to a hard-coded Gemma
+  prompt.
 
 * Hardened generic llama.cpp external draft-model speculative decoding so
   draft-context processing does not request unused logits, avoiding a

--- a/README.md
+++ b/README.md
@@ -334,7 +334,10 @@ In the local E2E scenario, draft-model strategies require
 build a static cache with `--ngram-cache-build-static-path`. Use
 `tool/testing/llama_cpp_speculative_benchmark.dart` directly for advanced
 strategy-specific benchmark knobs; the raw runner's draft-model flag is
-`--draft-model`.
+`--draft-model`. Benchmark prompts use an explicit `ModelParams.chatTemplate`
+or the loaded GGUF model's chat template before the engine's generic fallback,
+so upstream `--jinja` comparisons are not mixed with a hard-coded Gemma
+fallback; pass `--raw-prompt` only for intentional raw-prompt comparisons.
 
 For target/draft model pairs, pass the separate drafter GGUF with
 `draftModelPath`. Use `draftSimple`, `draftEagle3`, `mtp`, or `draftDflash`

--- a/doc/testing_matrix.md
+++ b/doc/testing_matrix.md
@@ -65,7 +65,7 @@ Pick targeted rows based on the touched surface:
 | --- | --- |
 | Native-assets hook, runtime pin, bundle layout | `native-hook-bundles`, `litert-lm-engine-smoke`, and relevant `platform` rows such as `android-arm64-device-smoke` |
 | llama.cpp / GGUF generation, prompt reuse, context reuse | `native-prompt-reuse-parity`, `native-inference-benchmark`, `gguf-chat-features-smoke` |
-| Chat template, parser, tools, thinking extraction | `template-parity`, `gguf-chat-features-smoke`, `litert-lm-chat-features-smoke` |
+| Chat template, parser, tools, thinking extraction | `template-parity`, `llama-cpp-chat-template-smoke`, `gguf-chat-features-smoke`, `litert-lm-chat-features-smoke` |
 | LiteRT-LM native backend | `litert-lm-engine-smoke`, `litert-lm-chat-features-smoke` |
 | Web bridge bootstrap or interop | `web-bridge-smoke`, `web-mock-chat-smoke`, `web-real-model-smoke` |
 | WebGPU multimodal | `webgpu-multimodal-regression` |
@@ -176,6 +176,14 @@ dart run tool/testing/run_local_e2e.dart \
 In the local E2E scenario, draft-model strategies require
 `--draft-model-path`; the n-gram cache strategy can use existing cache paths or
 build a static cache with `--ngram-cache-build-static-path`.
+Speculative benchmark prompts use the loaded model's chat template by default;
+use raw-prompt options only for intentional raw-vs-template comparisons.
+
+```bash
+dart run tool/testing/run_local_e2e.dart \
+  --scenario llama-cpp-chat-template-smoke \
+  --model-path models/Qwen3.5-0.8B-Q4_K_M.gguf
+```
 
 Use `--dry-run` first when a scenario starts servers, builds Flutter web, or
 requires local model URLs.

--- a/lib/src/backends/llama_cpp/llama_cpp_service.dart
+++ b/lib/src/backends/llama_cpp/llama_cpp_service.dart
@@ -8,6 +8,8 @@ import 'package:ffi/ffi.dart';
 import 'package:path/path.dart' as path;
 
 import '../../core/llama_logger.dart';
+import '../../core/models/chat/chat_message.dart';
+import '../../core/models/chat/chat_role.dart';
 import '../../core/models/chat/content_part.dart';
 import '../../core/models/config/gpu_backend.dart';
 import '../../core/models/config/gpu_device_info.dart';
@@ -15,6 +17,7 @@ import '../../core/models/config/log_level.dart';
 import '../../core/models/diagnostics/model_file_type.dart';
 import '../../core/models/inference/generation_params.dart';
 import '../../core/models/inference/model_params.dart';
+import '../../core/template/chat_template_engine.dart';
 import 'load_param_helpers.dart';
 import 'bindings.dart';
 import 'llama_cpp_raw_bindings.dart' as raw_bindings;
@@ -6740,6 +6743,112 @@ class LlamaCppService {
 
     final name = namePtr.cast<Utf8>().toDartString();
     return ModelFileType(id: ftype, name: name);
+  }
+
+  /// Applies the configured or loaded model chat template to [messages].
+  String applyChatTemplate(
+    int modelHandle,
+    List<Map<String, dynamic>> messages, {
+    String? customTemplate,
+    bool addAssistant = true,
+  }) {
+    if (!_models.containsKey(modelHandle)) {
+      throw Exception('Invalid model handle');
+    }
+    final metadata = getMetadata(modelHandle);
+    final modelParamsTemplate = _modelLoadParams[modelHandle]?.chatTemplate;
+    final templateSource = customTemplate == null
+        ? modelParamsTemplate ?? _modelChatTemplate(modelHandle)
+        : null;
+    final result = ChatTemplateEngine.render(
+      templateSource: templateSource ?? metadata['tokenizer.chat_template'],
+      messages: messages.map(_messageFromTemplateMap).toList(growable: false),
+      metadata: metadata,
+      addAssistant: addAssistant,
+      customTemplate: customTemplate,
+    );
+    return result.prompt;
+  }
+
+  String? _modelChatTemplate(int modelHandle) {
+    final model = _models[modelHandle];
+    if (model == null) {
+      return null;
+    }
+    final templatePtr = llama_model_chat_template(model.pointer, nullptr);
+    if (templatePtr == nullptr) {
+      return null;
+    }
+    final template = templatePtr.cast<Utf8>().toDartString();
+    return template.isEmpty ? null : template;
+  }
+
+  LlamaChatMessage _messageFromTemplateMap(Map<String, dynamic> message) {
+    final roleName = message['role']?.toString() ?? LlamaChatRole.user.name;
+    final role = LlamaChatRole.values.byName(roleName);
+    return LlamaChatMessage.fromText(
+      role: role,
+      text: _contentTextFromTemplateMap(message['content']),
+    );
+  }
+
+  String _contentTextFromTemplateMap(Object? content) {
+    if (content == null) {
+      return '';
+    }
+    if (content is String) {
+      return content;
+    }
+    if (content is Map) {
+      if (_isUnsupportedTemplateContentPart(content)) {
+        throw UnsupportedError(
+          'LlamaCppBackend does not support multimodal chat-template content.',
+        );
+      }
+      if (content['type']?.toString() == 'text' && content['text'] != null) {
+        return content['text'].toString();
+      }
+      return content.toString();
+    }
+    if (content is Iterable) {
+      final buffer = StringBuffer();
+      for (final part in content) {
+        if (part is Map) {
+          if (_isUnsupportedTemplateContentPart(part)) {
+            throw UnsupportedError(
+              'LlamaCppBackend does not support multimodal chat-template '
+              'content.',
+            );
+          }
+          final type = part['type']?.toString();
+          if (type == 'text' && part['text'] != null) {
+            buffer.write(part['text']);
+            continue;
+          }
+        }
+        buffer.write(part);
+      }
+      return buffer.toString();
+    }
+    return content.toString();
+  }
+
+  bool _isUnsupportedTemplateContentPart(Map<dynamic, dynamic> part) {
+    final type = part['type']?.toString().toLowerCase();
+    if (type == 'image' ||
+        type == 'image_url' ||
+        type == 'input_image' ||
+        type == 'audio' ||
+        type == 'input_audio' ||
+        type == 'video' ||
+        type == 'input_video') {
+      return true;
+    }
+    return part.containsKey('image') ||
+        part.containsKey('image_url') ||
+        part.containsKey('input_audio') ||
+        part.containsKey('audio') ||
+        part.containsKey('video');
   }
 
   /// Handles LoRA adapter operations.

--- a/lib/src/backends/llama_cpp/llama_cpp_service.dart
+++ b/lib/src/backends/llama_cpp/llama_cpp_service.dart
@@ -6753,10 +6753,12 @@ class LlamaCppService {
     bool addAssistant = true,
   }) {
     if (!_models.containsKey(modelHandle)) {
-      throw Exception('Invalid model handle');
+      throw StateError('Invalid model handle for chat template: $modelHandle');
     }
     final metadata = getMetadata(modelHandle);
-    final modelParamsTemplate = _modelLoadParams[modelHandle]?.chatTemplate;
+    final modelParamsTemplate = _nonEmptyTemplate(
+      _modelLoadParams[modelHandle]?.chatTemplate,
+    );
     final templateSource = customTemplate == null
         ? modelParamsTemplate ?? _modelChatTemplate(modelHandle)
         : null;
@@ -6768,6 +6770,13 @@ class LlamaCppService {
       customTemplate: customTemplate,
     );
     return result.prompt;
+  }
+
+  String? _nonEmptyTemplate(String? template) {
+    if (template == null || template.isEmpty) {
+      return null;
+    }
+    return template;
   }
 
   String? _modelChatTemplate(int modelHandle) {

--- a/lib/src/backends/llama_cpp/worker.dart
+++ b/lib/src/backends/llama_cpp/worker.dart
@@ -245,7 +245,14 @@ void llamaWorkerEntry(SendPort initialSendPort) {
 
           case ChatTemplateRequest():
             message.sendPort.send(
-              ErrorResponse("Chat template not implemented in service yet"),
+              ChatTemplateResponse(
+                service.applyChatTemplate(
+                  message.modelHandle,
+                  message.messages,
+                  customTemplate: message.customTemplate,
+                  addAssistant: message.addAssistant,
+                ),
+              ),
             );
 
           case StateSaveFileRequest():

--- a/test/e2e/backends/llama_cpp_chat_template_backend_e2e_test.dart
+++ b/test/e2e/backends/llama_cpp_chat_template_backend_e2e_test.dart
@@ -1,0 +1,161 @@
+@TestOn('vm')
+@Tags(['local-only', 'e2e'])
+@Timeout(Duration(minutes: 5))
+library;
+
+import 'dart:io';
+
+import 'package:llamadart/llamadart.dart';
+import 'package:path/path.dart' as path;
+import 'package:test/test.dart';
+
+const String _modelPathEnv = 'LLAMADART_LLAMA_CPP_TEMPLATE_MODEL_PATH';
+const String _defaultModelFileName = 'Qwen3.5-0.8B-Q4_K_M.gguf';
+
+void main() {
+  group('llama.cpp direct chat-template backend', () {
+    late String modelPath;
+
+    setUpAll(() {
+      final resolved = _resolveModelPath();
+      if (resolved == null) {
+        markTestSkipped(
+          'Set $_modelPathEnv or place $_defaultModelFileName in the default '
+          'llamadart cache to run llama.cpp chat-template backend E2E.',
+        );
+      }
+      modelPath = resolved ?? '';
+    });
+
+    test(
+      'renders default, custom, and unsupported multimodal templates',
+      () async {
+        if (modelPath.isEmpty) {
+          return;
+        }
+
+        final backend = LlamaBackend();
+        int? modelHandle;
+        try {
+          await backend.setLogLevel(LlamaLogLevel.warn);
+          modelHandle = await backend.modelLoad(
+            modelPath,
+            const ModelParams(
+              contextSize: 512,
+              preferredBackend: GpuBackend.cpu,
+              gpuLayers: 0,
+              numberOfThreads: 2,
+              numberOfThreadsBatch: 2,
+            ),
+          );
+
+          final rendered = await backend.applyChatTemplate(modelHandle, const [
+            {'role': 'user', 'content': 'Say hello.'},
+          ]);
+          expect(rendered, contains('Say hello.'));
+          expect(rendered, isNot(equals('Say hello.')));
+
+          final custom = await backend.applyChatTemplate(
+            modelHandle,
+            const [
+              {'role': 'user', 'content': 'Say hello.'},
+            ],
+            customTemplate: '{{ "CUSTOM:" ~ messages[0]["content"] }}',
+          );
+          expect(custom, contains('CUSTOM:Say hello.'));
+
+          await backend.modelFree(modelHandle);
+          modelHandle = null;
+          modelHandle = await backend.modelLoad(
+            modelPath,
+            const ModelParams(
+              contextSize: 512,
+              preferredBackend: GpuBackend.cpu,
+              gpuLayers: 0,
+              numberOfThreads: 2,
+              numberOfThreadsBatch: 2,
+              chatTemplate: '{{ "MODELPARAM:" ~ messages[0]["content"] }}',
+            ),
+          );
+
+          final modelParamRendered = await backend.applyChatTemplate(
+            modelHandle,
+            const [
+              {'role': 'user', 'content': 'Use the configured template.'},
+            ],
+          );
+          expect(
+            modelParamRendered,
+            contains('MODELPARAM:Use the configured template.'),
+          );
+
+          final perCallCustom = await backend.applyChatTemplate(
+            modelHandle,
+            const [
+              {'role': 'user', 'content': 'Use the per-call template.'},
+            ],
+            customTemplate: '{{ "PERCALL:" ~ messages[0]["content"] }}',
+          );
+          expect(perCallCustom, contains('PERCALL:Use the per-call template.'));
+          expect(perCallCustom, isNot(contains('MODELPARAM:')));
+
+          await expectLater(
+            backend.applyChatTemplate(modelHandle, const [
+              {
+                'role': 'user',
+                'content': [
+                  {
+                    'type': 'image_url',
+                    'image_url': {'url': 'file:///tmp/image.png'},
+                  },
+                  {'type': 'text', 'text': 'Describe it.'},
+                ],
+              },
+            ]),
+            throwsA(
+              isA<Exception>().having(
+                (error) => error.toString(),
+                'message',
+                contains('multimodal chat-template content'),
+              ),
+            ),
+          );
+        } finally {
+          if (modelHandle != null) {
+            await backend.modelFree(modelHandle);
+          }
+          await backend.dispose();
+        }
+      },
+    );
+  });
+}
+
+String? _resolveModelPath() {
+  final explicit = Platform.environment[_modelPathEnv];
+  if (explicit != null && explicit.isNotEmpty) {
+    if (File(explicit).existsSync()) {
+      return explicit;
+    }
+    throw StateError('$_modelPathEnv does not exist: $explicit');
+  }
+
+  final candidates = <String>[
+    path.join(Directory.current.path, 'models', _defaultModelFileName),
+    if (Platform.environment['HOME'] case final home?)
+      path.join(
+        home,
+        'Library',
+        'Caches',
+        'llamadart',
+        'models',
+        _defaultModelFileName,
+      ),
+  ];
+  for (final candidate in candidates) {
+    if (File(candidate).existsSync()) {
+      return candidate;
+    }
+  }
+  return null;
+}

--- a/test/e2e/backends/llama_cpp_chat_template_backend_e2e_test.dart
+++ b/test/e2e/backends/llama_cpp_chat_template_backend_e2e_test.dart
@@ -99,6 +99,28 @@ void main() {
           expect(perCallCustom, contains('PERCALL:Use the per-call template.'));
           expect(perCallCustom, isNot(contains('MODELPARAM:')));
 
+          await backend.modelFree(modelHandle);
+          modelHandle = null;
+          modelHandle = await backend.modelLoad(
+            modelPath,
+            const ModelParams(
+              contextSize: 512,
+              preferredBackend: GpuBackend.cpu,
+              gpuLayers: 0,
+              numberOfThreads: 2,
+              numberOfThreadsBatch: 2,
+              chatTemplate: '',
+            ),
+          );
+
+          final emptyTemplateRendered = await backend.applyChatTemplate(
+            modelHandle,
+            const [
+              {'role': 'user', 'content': 'Say hello.'},
+            ],
+          );
+          expect(emptyTemplateRendered, rendered);
+
           await expectLater(
             backend.applyChatTemplate(modelHandle, const [
               {

--- a/test/unit/backends/llama_cpp/worker_test.dart
+++ b/test/unit/backends/llama_cpp/worker_test.dart
@@ -105,6 +105,11 @@ void main() {
           ),
         );
         expect(chatTemplate, isA<ErrorResponse>());
+        expect(
+          (chatTemplate as ErrorResponse).message,
+          contains('Invalid model handle'),
+        );
+        expect(chatTemplate.message, isNot(contains('not implemented')));
 
         final tokenize = await _sendRequest(
           worker.sendPort,

--- a/test/unit/backends/llama_cpp/worker_test.dart
+++ b/test/unit/backends/llama_cpp/worker_test.dart
@@ -109,6 +109,7 @@ void main() {
           (chatTemplate as ErrorResponse).message,
           contains('Invalid model handle'),
         );
+        expect(chatTemplate.message, contains('1'));
         expect(chatTemplate.message, isNot(contains('not implemented')));
 
         final tokenize = await _sendRequest(

--- a/test/unit/tooling/llama_cpp_speculative_benchmark_test.dart
+++ b/test/unit/tooling/llama_cpp_speculative_benchmark_test.dart
@@ -24,6 +24,8 @@ void main() {
       expect(result.stdout, contains('auto, enabled, disabled'));
       expect(result.stdout, contains('--ngram-cache-build-static-path <p>'));
       expect(result.stdout, contains('--ngram-cache-build-text <text>'));
+      expect(result.stdout, contains('--raw-prompt'));
+      expect(result.stdout, contains('intentional raw-prompt comparisons'));
     });
 
     test('builds llama.cpp static ngram cache bytes', () {

--- a/test/unit/tooling/run_local_e2e_test.dart
+++ b/test/unit/tooling/run_local_e2e_test.dart
@@ -28,6 +28,7 @@ void main() {
       expect(result.stdout, contains('qwen35-multimodal-macos-repro'));
       expect(result.stdout, contains('gguf-chat-features-smoke'));
       expect(result.stdout, contains('llama-cpp-speculative-benchmark'));
+      expect(result.stdout, contains('llama-cpp-chat-template-smoke'));
       expect(result.stdout, contains('litert-lm-chat-features-smoke'));
       expect(result.stdout, contains('webgpu-multimodal-regression'));
       expect(result.stdout, contains('chat-app-model-cache'));
@@ -347,6 +348,46 @@ void main() {
         contains(
           '--model-path is required for llama-cpp-speculative-benchmark',
         ),
+      );
+    });
+
+    test('dry-runs llama.cpp chat-template smoke with model path', () async {
+      final result = await runLocalE2e(const [
+        '--scenario',
+        'llama-cpp-chat-template-smoke',
+        '--model-path',
+        'models/Qwen3.5-0.8B-Q4_K_M.gguf',
+        '--dry-run',
+      ], projectRoot: '/repo');
+
+      expect(result.exitCode, 0);
+      expect(result.stdout, contains('llama-cpp-chat-template-smoke'));
+      expect(
+        result.stdout,
+        contains(
+          'LLAMADART_LLAMA_CPP_TEMPLATE_MODEL_PATH='
+          'models/Qwen3.5-0.8B-Q4_K_M.gguf',
+        ),
+      );
+      expect(
+        result.stdout,
+        contains(
+          'dart test --run-skipped -t local-only '
+          'test/e2e/backends/llama_cpp_chat_template_backend_e2e_test.dart',
+        ),
+      );
+    });
+
+    test('requires model path for llama.cpp chat-template smoke', () async {
+      final result = await runLocalE2e(const [
+        '--scenario',
+        'llama-cpp-chat-template-smoke',
+      ], projectRoot: '/repo');
+
+      expect(result.exitCode, 64);
+      expect(
+        result.stderr,
+        contains('--model-path is required for llama-cpp-chat-template-smoke'),
       );
     });
 

--- a/test/unit/tooling/test_matrix_test.dart
+++ b/test/unit/tooling/test_matrix_test.dart
@@ -73,6 +73,7 @@ void main() {
 
       expect(table, contains('| ID | Tier | Mode |'));
       expect(table, contains('gguf-chat-features-smoke'));
+      expect(table, contains('llama-cpp-chat-template-smoke'));
       expect(
         table,
         contains(

--- a/tool/testing/llama_cpp_mtp_benchmark.dart
+++ b/tool/testing/llama_cpp_mtp_benchmark.dart
@@ -75,12 +75,20 @@ Future<void> main(List<String> args) async {
   try {
     await backend.setLogLevel(LlamaLogLevel.warn);
     modelHandle = await backend.modelLoad(modelPath, baselineModelParams);
-    final prompt = await _resolvePrompt(
-      backend,
-      modelHandle,
-      benchmarkInstruction,
-      rawPrompt: rawPrompt,
-    );
+    final prompt =
+        await _resolvePrompt(
+          backend,
+          modelHandle,
+          benchmarkInstruction,
+          rawPrompt: rawPrompt,
+        ).onError<StateError>((error, stackTrace) {
+          stderr.writeln(error.message);
+          exitCode = 64;
+          return '';
+        });
+    if (exitCode == 64) {
+      return;
+    }
 
     final benchmarkCases = <_BenchmarkCase>[
       const _BenchmarkCase.baseline(),

--- a/tool/testing/llama_cpp_mtp_benchmark.dart
+++ b/tool/testing/llama_cpp_mtp_benchmark.dart
@@ -200,14 +200,11 @@ Future<String> _resolvePrompt(
       {'role': 'user', 'content': benchmarkInstruction},
     ]);
   } catch (error) {
-    stderr.writeln(
-      'Falling back to raw Gemma-style prompt because backend chat-template '
-      'rendering failed: $error',
+    throw StateError(
+      'Failed to apply the model chat template for the MTP benchmark: $error. '
+      'Set LLAMADART_MTP_BENCHMARK_RAW_PROMPT=true only when intentionally '
+      'comparing raw prompt behavior.',
     );
-    return '<start_of_turn>user\n'
-        '$benchmarkInstruction'
-        '<end_of_turn>\n'
-        '<start_of_turn>model\n';
   }
 }
 

--- a/tool/testing/llama_cpp_speculative_benchmark.dart
+++ b/tool/testing/llama_cpp_speculative_benchmark.dart
@@ -35,12 +35,20 @@ Future<void> main(List<String> arguments) async {
       options.modelPath,
       baselineModelParams,
     );
-    final prompt = await _resolvePrompt(
-      backend,
-      modelHandle,
-      options.prompt,
-      rawPrompt: options.rawPrompt,
-    );
+    final prompt =
+        await _resolvePrompt(
+          backend,
+          modelHandle,
+          options.prompt,
+          rawPrompt: options.rawPrompt,
+        ).onError<StateError>((error, stackTrace) {
+          stderr.writeln(error.message);
+          exitCode = 64;
+          return '';
+        });
+    if (exitCode == 64) {
+      return;
+    }
     await _prepareGeneratedNgramCache(
       backend: backend,
       modelHandle: modelHandle,

--- a/tool/testing/llama_cpp_speculative_benchmark.dart
+++ b/tool/testing/llama_cpp_speculative_benchmark.dart
@@ -211,14 +211,11 @@ Future<String> _resolvePrompt(
       {'role': 'user', 'content': benchmarkInstruction},
     ]);
   } catch (error) {
-    stderr.writeln(
-      'Falling back to raw Gemma-style prompt because backend chat-template '
-      'rendering failed: $error',
+    throw StateError(
+      'Failed to apply the model chat template for the speculative '
+      'benchmark: $error. Pass --raw-prompt only when intentionally '
+      'comparing raw prompt behavior.',
     );
-    return '<start_of_turn>user\n'
-        '$benchmarkInstruction'
-        '<end_of_turn>\n'
-        '<start_of_turn>model\n';
   }
 }
 
@@ -1418,7 +1415,8 @@ Generation:
   --runs <n>                           Measured runs per case. Default: 3.
   --warmups <n>                        Warmup runs per case. Default: 1.
   --prompt <text>                      Override benchmark prompt.
-  --raw-prompt                         Skip chat-template wrapping.
+  --raw-prompt                         Skip model chat-template wrapping for
+                                       intentional raw-prompt comparisons.
   --seed <n>                           Default: 7.
   --temp <n>                           Default: 0.0.
   --repeat-penalty <n>                 Default: 1.1.

--- a/tool/testing/run_local_e2e.dart
+++ b/tool/testing/run_local_e2e.dart
@@ -286,6 +286,35 @@ List<LocalE2eScenario> buildLocalE2eScenarios({String? projectRoot}) {
       },
     ),
     LocalE2eScenario(
+      name: 'llama-cpp-chat-template-smoke',
+      group: LocalE2eScenarioGroup.dartLocalOnly,
+      description:
+          'Run real GGUF llama.cpp direct backend chat-template smoke.',
+      requiresDevice: false,
+      stepsBuilder: (context) {
+        final environment = <String, String>{};
+        final modelPath = context.modelPath;
+        if (modelPath != null) {
+          environment['LLAMADART_LLAMA_CPP_TEMPLATE_MODEL_PATH'] = modelPath;
+        }
+        return [
+          LocalE2eCommandStep(
+            workingDirectory: context.projectRoot,
+            executable: 'dart',
+            arguments: const [
+              'test',
+              '--run-skipped',
+              '-t',
+              'local-only',
+              'test/e2e/backends/llama_cpp_chat_template_backend_e2e_test.dart',
+            ],
+            environment: environment,
+            description: 'llama.cpp chat-template backend smoke',
+          ),
+        ];
+      },
+    ),
+    LocalE2eScenario(
       name: 'litert-lm-chat-features-smoke',
       group: LocalE2eScenarioGroup.dartLocalOnly,
       description: 'Run real LiteRT-LM chat, thinking, and tool-call smoke.',
@@ -678,11 +707,12 @@ Future<LocalE2eResult> runLocalE2e(
   if (parsed.imagePath != null && parsed.mmprojPath == null) {
     return LocalE2eResult(64, stderr: '--image-path requires --mmproj-path.\n');
   }
-  if (scenario.name == 'llama-cpp-speculative-benchmark' &&
+  if ((scenario.name == 'llama-cpp-speculative-benchmark' ||
+          scenario.name == 'llama-cpp-chat-template-smoke') &&
       parsed.modelPath == null) {
     return LocalE2eResult(
       64,
-      stderr: '--model-path is required for llama-cpp-speculative-benchmark.\n',
+      stderr: '--model-path is required for ${scenario.name}.\n',
     );
   }
 

--- a/tool/testing/test_matrix.dart
+++ b/tool/testing/test_matrix.dart
@@ -173,6 +173,20 @@ const List<TestMatrixRow> testMatrixRows = <TestMatrixRow>[
         'Chat rendering, parser, tool calling, thinking, or GGUF feature work.',
   ),
   TestMatrixRow(
+    id: 'llama-cpp-chat-template-smoke',
+    tier: 'targeted',
+    mode: 'local-only',
+    covers:
+        'real GGUF llama.cpp direct backend chat-template rendering, custom '
+        'template override, and unsupported multimodal template diagnostics',
+    command:
+        'dart run tool/testing/run_local_e2e.dart --scenario '
+        'llama-cpp-chat-template-smoke --model-path <model.gguf>',
+    useWhen:
+        'llama.cpp backend applyChatTemplate, speculative benchmark prompt '
+        'wrapping, or raw-vs-template parity changes.',
+  ),
+  TestMatrixRow(
     id: 'template-parity',
     tier: 'targeted',
     mode: 'local-only',

--- a/website/docs/changelog/recent-releases.md
+++ b/website/docs/changelog/recent-releases.md
@@ -15,7 +15,9 @@ For canonical full release notes, use:
   and mixed n-gram plus one draft-model strategy, including generic native
   wrapper bindings, docs, and local benchmark matrix coverage. The benchmark
   tooling can generate a llama.cpp-compatible static n-gram cache file for
-  `ngram-cache` E2E validation.
+  `ngram-cache` E2E validation. Speculative benchmark prompts now render with
+  configured or loaded GGUF chat templates before the generic fallback instead
+  of silently falling back to a hard-coded Gemma prompt.
 
 - Updated the default llama.cpp native runtime pin to
   `leehack/llamadart-native@b9873`, refreshed the


### PR DESCRIPTION
## Summary

- route llama.cpp `ChatTemplateRequest` through the native service so direct backend calls can render chat templates
- make speculative and MTP benchmark prompts use per-call, configured, or loaded GGUF chat templates before the generic fallback instead of a hard-coded Gemma fallback
- add a local-only real GGUF chat-template smoke and matrix/docs coverage for default, configured, per-call, and unsupported multimodal template paths

Closes #272

## Validation

| Matrix row | Scope covered | Platform / model / backend | Result | Evidence / notes |
| --- | --- | --- | --- | --- |
| `static-format-analyze` | touched implementation, tooling, and tests | macOS arm64 local | PASS | `dart analyze lib/src/backends/llama_cpp/llama_cpp_service.dart lib/src/backends/llama_cpp/worker.dart tool/testing/llama_cpp_mtp_benchmark.dart tool/testing/llama_cpp_speculative_benchmark.dart tool/testing/run_local_e2e.dart tool/testing/test_matrix.dart test/e2e/backends/llama_cpp_chat_template_backend_e2e_test.dart test/unit/backends/llama_cpp/worker_test.dart test/unit/tooling/llama_cpp_speculative_benchmark_test.dart test/unit/tooling/run_local_e2e_test.dart test/unit/tooling/test_matrix_test.dart` |
| `root-vm` targeted subset | worker routing and benchmark/tooling regressions | macOS arm64 local | PASS | `dart test test/unit/backends/llama_cpp/worker_test.dart test/unit/tooling/llama_cpp_speculative_benchmark_test.dart test/unit/tooling/run_local_e2e_test.dart test/unit/tooling/test_matrix_test.dart` |
| `static-format-analyze` | whitespace | macOS arm64 local | PASS | `git diff --check` |
| `llama-cpp-chat-template-smoke` | real GGUF direct backend template rendering, configured template precedence, per-call override precedence, unsupported multimodal diagnostics | macOS arm64 local, `/Users/jhin.lee/Library/Caches/llamadart/models/Qwen3.5-0.8B-Q4_K_M.gguf`, llama.cpp CPU | PASS | `dart run tool/testing/run_local_e2e.dart --scenario llama-cpp-chat-template-smoke --model-path /Users/jhin.lee/Library/Caches/llamadart/models/Qwen3.5-0.8B-Q4_K_M.gguf` |

## Real-model benchmark evidence

All benchmark rows used `llama-cpp-speculative-benchmark` on macOS arm64 with Metal and cached models. These are short current-branch smoke runs (`--runs 1 --warmups 0 --max-tokens 32`) intended to validate raw-vs-template behavior and output parity, not final performance tuning.

### EAGLE3 templated

Command:

```bash
dart run tool/testing/llama_cpp_speculative_benchmark.dart \
  --model /Users/jhin.lee/Library/Caches/llamadart/models/qwen3-8b-q4_k_m.gguf \
  --draft-model /Users/jhin.lee/Library/Caches/llamadart/models/Qwen3-8B-speculator.eagle3-F16.gguf \
  --cases baseline,draft-eagle3 \
  --backend metal \
  --gpu-layers 99 \
  --max-tokens 32 \
  --runs 1 \
  --warmups 0 \
  --draft-token-max 1
```

Result: baseline 64.05 tok/s, draft 23.19 tok/s, relative 0.362x, accepted 15/16, acceptance 0.9375, prompt chars 287, raw prompt false, output hash `bc842b2c` matched baseline.

### EAGLE3 raw prompt

Command:

```bash
dart run tool/testing/llama_cpp_speculative_benchmark.dart \
  --model /Users/jhin.lee/Library/Caches/llamadart/models/qwen3-8b-q4_k_m.gguf \
  --draft-model /Users/jhin.lee/Library/Caches/llamadart/models/Qwen3-8B-speculator.eagle3-F16.gguf \
  --cases baseline,draft-eagle3 \
  --backend metal \
  --gpu-layers 99 \
  --max-tokens 32 \
  --runs 1 \
  --warmups 0 \
  --draft-token-max 1 \
  --raw-prompt
```

Result: baseline 64.19 tok/s, draft 29.67 tok/s, relative 0.462x, accepted 9/21, acceptance 0.4286, prompt chars 237, raw prompt true, output hash `15bf3396` matched baseline.

### DFlash templated

Command:

```bash
dart run tool/testing/llama_cpp_speculative_benchmark.dart \
  --model /Users/jhin.lee/Library/Caches/llamadart/models/Qwen3.5-4B-Q4_K_M.gguf \
  --draft-model /Users/jhin.lee/Library/Caches/llamadart/models/Qwen3.5-4B-DFlash.gguf \
  --cases baseline,draft-dflash \
  --backend metal \
  --gpu-layers 99 \
  --flash-attention enabled \
  --max-tokens 32 \
  --runs 1 \
  --warmups 0 \
  --draft-token-max 15
```

Result: baseline 72.41 tok/s, draft 36.07 tok/s, relative 0.498x, accepted 28/33, acceptance 0.8485, prompt chars 295, raw prompt false, output hash `4edcb947` matched baseline.

### DFlash raw prompt

Command:

```bash
dart run tool/testing/llama_cpp_speculative_benchmark.dart \
  --model /Users/jhin.lee/Library/Caches/llamadart/models/Qwen3.5-4B-Q4_K_M.gguf \
  --draft-model /Users/jhin.lee/Library/Caches/llamadart/models/Qwen3.5-4B-DFlash.gguf \
  --cases baseline,draft-dflash \
  --backend metal \
  --gpu-layers 99 \
  --flash-attention enabled \
  --max-tokens 32 \
  --runs 1 \
  --warmups 0 \
  --draft-token-max 15 \
  --raw-prompt
```

Result: baseline 76.60 tok/s, draft 39.27 tok/s, relative 0.513x, accepted 26/69, acceptance 0.3768, prompt chars 237, raw prompt true, output hash `1c5a1665` matched baseline.
