### PR TITLE
Document compatible DFlash GGUF metadata

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@
   generic fallback instead of silently falling back to a hard-coded Gemma
   prompt.
 
+* Documented compatible DFlash GGUF metadata, a known-good public target/draft
+  model pair, and troubleshooting guidance for incompatible `dflash-draft` or
+  missing `dflash.target_layers` artifacts.
+
 * Hardened generic llama.cpp external draft-model speculative decoding so
   draft-context processing does not request unused logits, avoiding a
   `draft-simple` native abort while preserving target verification logits.

--- a/README.md
+++ b/README.md
@@ -353,6 +353,19 @@ params: const GenerationParams(
 ),
 ```
 
+DFlash draft GGUFs are metadata-sensitive. The draft model must be an
+upstream-compatible DFlash artifact with `general.architecture=dflash` and
+the DFlash metadata block, including `dflash.target_layers`. A validated public
+pair is target `unsloth/Qwen3.5-4B-GGUF` (`Qwen3.5-4B-Q4_K_M.gguf`) with draft
+`EntityDeletr/Qwen3.5-4B-DFlash-GGUF` (`Qwen3.5-4B-DFlash.gguf`). Artifacts
+with `general.architecture=dflash-draft`, such as
+`Anbeeld/Qwen3.5-4B-DFlash-GGUF`, are not registered by the current upstream
+llama.cpp runtime and fail with errors like
+`unknown model architecture: 'dflash-draft'`. Artifacts missing
+`dflash.target_layers`, such as early `lym00/Qwen3-4B-DFlash-GGUF-Test`
+conversions, need to be reconverted or regenerated upstream; there is no
+Dart-side metadata workaround.
+
 Android Vulkan MTP is opt-in through the same runtime parameters: request
 `GpuBackend.vulkan` in `ModelParams` and pass
 `SpeculativeDecodingConfig.mtp(...)` in `GenerationParams`. Benchmark this

--- a/website/docs/changelog/recent-releases.md
+++ b/website/docs/changelog/recent-releases.md
@@ -19,6 +19,10 @@ For canonical full release notes, use:
   configured or loaded GGUF chat templates before the generic fallback instead
   of silently falling back to a hard-coded Gemma prompt.
 
+- Documented compatible DFlash GGUF metadata, a known-good public target/draft
+  model pair, and troubleshooting guidance for incompatible `dflash-draft` or
+  missing `dflash.target_layers` artifacts.
+
 - Updated the default llama.cpp native runtime pin to
   `leehack/llamadart-native@b9873`, refreshed the
   `llamadart_llama_cpp_flutter` Apple SwiftPM checksum, and aligned current

--- a/website/docs/guides/performance-tuning.md
+++ b/website/docs/guides/performance-tuning.md
@@ -120,6 +120,14 @@ Guidelines:
   draft-model strategy. Draft-model strategies can load a separate GGUF through
   `draftModelPath`; draftless n-gram strategies are workload-dependent and can
   be slower than baseline on prompts with little repetition.
+- DFlash draft models must use upstream-compatible GGUF metadata:
+  `general.architecture=dflash` plus the `dflash.*` metadata block, including
+  `dflash.target_layers`. A known-good public pair is target
+  `unsloth/Qwen3.5-4B-GGUF` (`Qwen3.5-4B-Q4_K_M.gguf`) with draft
+  `EntityDeletr/Qwen3.5-4B-DFlash-GGUF` (`Qwen3.5-4B-DFlash.gguf`). If a draft
+  artifact reports `general.architecture=dflash-draft` or lacks
+  `dflash.target_layers`, reconvert or replace the GGUF instead of trying to
+  compensate in Dart code.
 - `reusePromptPrefix` is enabled by default for native generation; keep it on
   for multi-turn chats and repeated prompts, and validate parity for your
   target model/workload.

--- a/website/docs/troubleshooting/common-issues.md
+++ b/website/docs/troubleshooting/common-issues.md
@@ -35,6 +35,27 @@ Checks:
 2. Tune `contextSize` and generation length (`maxTokens`).
 3. Use appropriate backend and GPU offload (`gpuLayers`).
 
+## DFlash draft model load failures
+
+Symptoms:
+
+- DFlash speculative decoding fails while loading the draft GGUF.
+- Native logs mention `unknown model architecture: 'dflash-draft'`.
+- Native logs mention missing DFlash target-layer metadata.
+
+Checks:
+
+1. Inspect the draft GGUF metadata. Compatible DFlash artifacts use
+   `general.architecture=dflash`, not `dflash-draft`.
+2. Confirm the draft contains the DFlash metadata block, especially
+   `dflash.target_layers`.
+3. Use an upstream-compatible target/draft pair. One validated public pair is
+   target `unsloth/Qwen3.5-4B-GGUF` (`Qwen3.5-4B-Q4_K_M.gguf`) with draft
+   `EntityDeletr/Qwen3.5-4B-DFlash-GGUF` (`Qwen3.5-4B-DFlash.gguf`).
+4. If the artifact uses `dflash-draft` or lacks `dflash.target_layers`, replace
+   or reconvert the draft GGUF. llamadart does not patch draft metadata at
+   runtime.
+
 ## Tool calling seems unstable
 
 Checks:


### PR DESCRIPTION
## Summary

- document DFlash GGUF metadata requirements for llama.cpp speculative decoding
- call out the validated Qwen3.5 4B target/draft public pair
- add troubleshooting for `dflash-draft` architecture artifacts and missing `dflash.target_layers`

Closes #273

## Validation

| Matrix row | Scope covered | Platform / model / backend | Result | Evidence / notes |
| --- | --- | --- | --- | --- |
| `docs-site` | README and website docs/changelog links/build | macOS arm64 local | PASS | `./tool/docs/validate_links.sh` |
| `static-format-analyze` | whitespace | macOS arm64 local | PASS | `git diff --check` |

## Notes

- Verified the cached known-good DFlash GGUF exposes `general.architecture=dflash` and `dflash.target_layers` metadata before documenting those keys.
- Runtime behavior is unchanged; this is docs-only.
