### PR TITLE
Fix ngram speculative parity docs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 ## Unreleased
 
+* Fixed llama.cpp n-gram speculative configuration mapping so
+  `draftTokenMax` no longer implicitly overrides upstream `ngramSizeM`, and
+  documented upstream comparison commands plus measured n-gram benchmark
+  results.
+
 * Added a durable flag-based llama.cpp speculative benchmark runner and wired
   it into the local E2E scenario list, testing matrix, README, and website
   performance guide. The runner can now generate a llama.cpp-compatible

--- a/README.md
+++ b/README.md
@@ -291,7 +291,12 @@ await for (final chunk in engine.create(
 
 Higher `draftTokenMax` values can be faster on some models/devices, but they
 should be benchmarked with the target model because excess draft depth can add
-verification overhead.
+verification overhead. For llama.cpp n-gram strategies, `draftTokenMax` caps
+the per-step draft length; use `ngramSizeM` when intentionally changing
+upstream's n-gram draft window. Measured parity results and upstream comparison
+commands are recorded in the
+[Backend Benchmarks](https://llamadart.leehack.com/docs/guides/backend-benchmarks)
+guide.
 
 For GGUF models without an MTP or separate draft model, llama.cpp n-gram
 speculative decoding uses recent token history as the drafter:

--- a/doc/testing_matrix.md
+++ b/doc/testing_matrix.md
@@ -178,6 +178,11 @@ In the local E2E scenario, draft-model strategies require
 build a static cache with `--ngram-cache-build-static-path`.
 Speculative benchmark prompts use the loaded model's chat template by default;
 use raw-prompt options only for intentional raw-vs-template comparisons.
+When a speculative performance issue is being closed, include the matching
+upstream `llama-cli` or `llama-server` command where a comparable tool binary is
+available. If the exact packaged native tag does not publish standalone tools,
+state the closest upstream build used and keep any remaining artifact-parity gap
+linked as a follow-up.
 
 ```bash
 dart run tool/testing/run_local_e2e.dart \

--- a/lib/src/backends/llama_cpp/llama_cpp_service.dart
+++ b/lib/src/backends/llama_cpp/llama_cpp_service.dart
@@ -3913,10 +3913,7 @@ class LlamaCppService {
       draftSplitProbability: speculativeConfig.draftSplitProbability,
       draftModelPath: draftModelPath,
       ngramSizeN: speculativeConfig.ngramSizeN ?? speculativeConfig.ngramSize,
-      ngramSizeM: _resolveLlamaCppNgramSizeM(
-        uniqueStrategies,
-        speculativeConfig,
-      ),
+      ngramSizeM: speculativeConfig.ngramSizeM,
       ngramMinHits: speculativeConfig.ngramMinHits,
       ngramMatch: speculativeConfig.ngramMatch,
       ngramTokenMin: ngramTokenMin,
@@ -3951,6 +3948,24 @@ class LlamaCppService {
           hasMediaParts: hasMediaParts,
         )?.suppressDraftProcessLogits ??
         false;
+  }
+
+  /// Resolves llama.cpp speculative native params for unit tests.
+  Map<String, Object?> debugResolveSpeculativeNativeParamsForTesting(
+    GenerationParams params, {
+    bool hasMediaParts = false,
+  }) {
+    final config = _resolveLlamaCppSpeculativeConfig(
+      params,
+      hasMediaParts: hasMediaParts,
+    );
+    return <String, Object?>{
+      'typeNames': config?.typeNames,
+      'draftTokenMax': config?.draftTokenMax,
+      'ngramSizeN': config?.ngramSizeN,
+      'ngramSizeM': config?.ngramSizeM,
+      'ngramTokenMax': config?.ngramTokenMax,
+    };
   }
 
   /// Runs [action] while native batch logits are temporarily zeroed.
@@ -3998,26 +4013,6 @@ class LlamaCppService {
       }
     }
     return max == 0 ? 64 : max;
-  }
-
-  int? _resolveLlamaCppNgramSizeM(
-    List<SpeculativeDecodingStrategy> strategies,
-    SpeculativeDecodingConfig config,
-  ) {
-    final explicit = config.ngramSizeM;
-    if (explicit != null) {
-      return explicit;
-    }
-    if (config.draftTokenMax == null) {
-      return null;
-    }
-    final hasMapStrategy = strategies.any(
-      (strategy) =>
-          strategy == SpeculativeDecodingStrategy.ngramSimple ||
-          strategy == SpeculativeDecodingStrategy.ngramMapK ||
-          strategy == SpeculativeDecodingStrategy.ngramMapK4v,
-    );
-    return hasMapStrategy ? config.draftTokenMax : null;
   }
 
   /// Generates text based on the given [prompt] and [params].

--- a/test/unit/backends/llama_cpp/llama_cpp_service_test.dart
+++ b/test/unit/backends/llama_cpp/llama_cpp_service_test.dart
@@ -169,6 +169,43 @@ void main() {
       expect(typeNames, 'ngram-mod,draft-mtp');
     });
 
+    test('keeps ngram size M separate from draft token cap', () {
+      final defaults = service.debugResolveSpeculativeNativeParamsForTesting(
+        const GenerationParams(
+          speculativeDecodingConfig: SpeculativeDecodingConfig.ngramMapK(
+            draftTokenMax: 8,
+          ),
+        ),
+      );
+
+      expect(defaults['typeNames'], 'ngram-map-k');
+      expect(defaults['draftTokenMax'], 8);
+      expect(defaults['ngramSizeM'], isNull);
+
+      final explicit = service.debugResolveSpeculativeNativeParamsForTesting(
+        const GenerationParams(
+          speculativeDecodingConfig: SpeculativeDecodingConfig.ngramMapK(
+            draftTokenMax: 8,
+            ngramSizeM: 16,
+          ),
+        ),
+      );
+
+      expect(explicit['draftTokenMax'], 8);
+      expect(explicit['ngramSizeM'], 16);
+    });
+
+    test('uses upstream ngram size M default when draft cap is omitted', () {
+      final resolved = service.debugResolveSpeculativeNativeParamsForTesting(
+        const GenerationParams(
+          speculativeDecodingConfig: SpeculativeDecodingConfig.ngramMapK(),
+        ),
+      );
+
+      expect(resolved['draftTokenMax'], 48);
+      expect(resolved['ngramSizeM'], isNull);
+    });
+
     test('rejects mixed configs with more than one draft strategy', () {
       expect(
         () => service.debugResolveSpeculativeTypeNamesForTesting(

--- a/website/docs/changelog/recent-releases.md
+++ b/website/docs/changelog/recent-releases.md
@@ -9,6 +9,11 @@ For canonical full release notes, use:
 
 ## Unreleased
 
+- Fixed llama.cpp n-gram speculative configuration mapping so
+  `draftTokenMax` no longer implicitly overrides upstream `ngramSizeM`, and
+  documented upstream comparison commands plus measured n-gram benchmark
+  results.
+
 - Added llama.cpp upstream speculative decoding parity through
   `SpeculativeDecodingConfig` constructors for draft-simple, EAGLE3, MTP,
   DFlash, ngram-simple, ngram-map-k, ngram-map-k4v, ngram-mod, ngram-cache,

--- a/website/docs/guides/backend-benchmarks.md
+++ b/website/docs/guides/backend-benchmarks.md
@@ -69,6 +69,44 @@ and reported that the Android NPU delegate may not support the device, OS,
 model, or bundle. Use GPU or CPU for this artifact unless a newer LiteRT-LM
 bundle/runtime combination validates NPU support.
 
+### llama.cpp upstream speculative parity check
+
+The llama.cpp speculative investigation on 2026-07-05 found no package-level
+model-cache issue and no evidence that upstream speculative decoding is
+universally faster. It is workload- and knob-sensitive. The clear local speedup
+came from an explicit repeated-context workload with smaller n-gram lookup
+settings.
+
+The current package runtime pin was `leehack/llamadart-native@b9873`. That
+release does not publish standalone `llama-cli` / `llama-server` tool binaries,
+so upstream CLI comparison used the closest local llama.cpp tool build available
+from `llamadart-native` (`build b1-e3471b3e7`, from the b9571 line). Treat the
+CLI rows as behavior references, not exact artifact parity for b9873.
+
+| Runtime | Prompt / config | Backend | Baseline | Speculative | Relative | Notes |
+| --- | --- | --- | ---: | ---: | ---: | --- |
+| llamadart runner | Raw repeated sequence, `ngram-map-k`, `draftTokenMax=8`, `ngramSizeN=4`, `ngramSizeM=8` | CPU | 135.71 wall tok/s | 222.24 wall tok/s | 1.64x | 112/112 drafts accepted, output hash matched |
+| llamadart runner | Same, `ngram-map-k4v`, `draftTokenMax=8`, `ngramSizeN=4`, `ngramSizeM=8` | CPU | 135.71 wall tok/s | 212.21 wall tok/s | 1.56x | 112/112 drafts accepted, output hash matched |
+| llamadart runner | Qwen chat-template code prompt, default `ngram-map-k` sizing | CPU | 103.11 wall tok/s | 67.82 wall tok/s | 0.66x | auxiliary observation from the investigation; zero drafts produced |
+| llamadart runner | Raw code prompt, default n-gram sizing | Metal | 250.63 wall tok/s | 125.61 wall tok/s | 0.50x | auxiliary observation from the investigation; zero drafts produced |
+| upstream `llama-cli` | Same repeated text through `llama-cli` single-turn chat/conversation path, same n-gram knobs as first row | CPU, `--device none` | 138.7 generation tok/s | 164.1 generation tok/s | 1.18x | local b9571 CLI; metric excludes prompt handling |
+
+Conclusion: draftless n-gram speculation can be faster in llamadart when the
+prompt has reusable repeated context and the n-gram knobs match the workload.
+For natural short prompts or code prompts without a matching recent history,
+the draftless n-gram strategies can produce no drafts, so the extra speculative
+loop work is slower than baseline. Keep `draftTokenMax` as the per-step draft
+cap; set `ngramSizeM` explicitly only when intentionally changing upstream's
+n-gram draft window from its default.
+
+Remaining actionable work was split out instead of being folded into this
+benchmark documentation: [llamadart#278](https://github.com/leehack/llamadart/issues/278)
+tracks generic n-gram rollback/metrics optimization,
+[llamadart-native#25](https://github.com/leehack/llamadart-native/issues/25)
+tracks the native sampler accept bug, and
+[llamadart-native#26](https://github.com/leehack/llamadart-native/issues/26)
+tracks exact native tool artifacts for future same-tag upstream comparisons.
+
 ## Interpretation
 
 On Pixel 9 Pro, LiteRT-LM GPU was about 9x faster than llama.cpp Vulkan for this
@@ -139,3 +177,79 @@ single-threaded file servers can make large browser model loads fail before the
 runtime sees real GGUF bytes. `python -m http.server` is not a good substitute
 for this benchmark because it does not provide the same browser isolation and
 large-file behavior.
+
+Speculative n-gram parity:
+
+Set `MODEL_PATH` to the cached GGUF location on your machine. Set `LLAMA_CLI`
+to the upstream `llama-cli` build you are comparing; the table above used a
+local b9571-line tool because the b9873 native release did not publish
+standalone CLI artifacts.
+
+```bash
+MODEL_PATH="${MODEL_PATH:-$HOME/Library/Caches/llamadart/models/Qwen3.5-0.8B-Q4_K_M.gguf}"
+LLAMA_CLI="${LLAMA_CLI:-/path/to/llama-cli}"
+
+PROMPT_REPEAT='Repeat and continue this sequence exactly:
+alpha beta gamma delta epsilon zeta eta theta
+alpha beta gamma delta epsilon zeta eta theta
+alpha beta gamma delta epsilon zeta eta theta
+alpha beta gamma delta epsilon zeta eta theta
+alpha beta gamma delta epsilon zeta eta theta'
+
+dart run tool/testing/llama_cpp_speculative_benchmark.dart \
+  --model "$MODEL_PATH" \
+  --cases baseline,ngram-map-k,ngram-map-k4v \
+  --backend cpu \
+  --gpu-layers 0 \
+  --context-size 4096 \
+  --max-tokens 128 \
+  --runs 2 \
+  --warmups 1 \
+  --draft-token-max 8 \
+  --ngram-size-n 4 \
+  --ngram-size-m 8 \
+  --ngram-min-hits 1 \
+  --temp 0 \
+  --repeat-penalty 1.0 \
+  --raw-prompt \
+  --prompt "$PROMPT_REPEAT"
+
+"$LLAMA_CLI" \
+  -m "$MODEL_PATH" \
+  --device none \
+  -ngl 0 \
+  -c 4096 \
+  -n 128 \
+  --temp 0 \
+  --repeat-penalty 1.0 \
+  --top-k 40 \
+  --top-p 0.95 \
+  --min-p 0.05 \
+  --seed 7 \
+  --single-turn \
+  --no-display-prompt \
+  --simple-io \
+  -p "$PROMPT_REPEAT"
+
+"$LLAMA_CLI" \
+  -m "$MODEL_PATH" \
+  --device none \
+  -ngl 0 \
+  -c 4096 \
+  -n 128 \
+  --temp 0 \
+  --repeat-penalty 1.0 \
+  --top-k 40 \
+  --top-p 0.95 \
+  --min-p 0.05 \
+  --seed 7 \
+  --single-turn \
+  --no-display-prompt \
+  --simple-io \
+  --spec-type ngram-map-k \
+  --spec-draft-n-max 8 \
+  --spec-ngram-map-k-size-n 4 \
+  --spec-ngram-map-k-size-m 8 \
+  --spec-ngram-map-k-min-hits 1 \
+  -p "$PROMPT_REPEAT"
+```

--- a/website/docs/guides/performance-tuning.md
+++ b/website/docs/guides/performance-tuning.md
@@ -119,7 +119,11 @@ Guidelines:
   `ngramCache(...)`, and `mixed(...)` for draftless n-gram strategies plus one
   draft-model strategy. Draft-model strategies can load a separate GGUF through
   `draftModelPath`; draftless n-gram strategies are workload-dependent and can
-  be slower than baseline on prompts with little repetition.
+  be slower than baseline on prompts with little repetition. For ngram-simple
+  and ngram-map strategies, `draftTokenMax` caps each speculative step while
+  `ngramSizeM` controls upstream's draft m-gram window; set `ngramSizeM`
+  explicitly only when intentionally changing the upstream n-gram lookup
+  behavior.
 - DFlash draft models must use upstream-compatible GGUF metadata:
   `general.architecture=dflash` plus the `dflash.*` metadata block, including
   `dflash.target_layers`. A known-good public pair is target
@@ -262,7 +266,9 @@ dart run tool/testing/native_embedding_sweep.dart \
 ```
 
 For the speculative benchmark runner, draft-model strategies require
-`--draft-model`; the n-gram cache strategy requires cache paths.
+`--draft-model`; the n-gram cache strategy requires cache paths. Current
+measured llama.cpp n-gram parity results, including exact upstream comparison
+commands, are recorded in [Backend Benchmarks](./backend-benchmarks).
 
 Compare llama.cpp/GGUF and LiteRT-LM with the bundled fair benchmark scripts:
 


### PR DESCRIPTION
## Summary

- Fix llama.cpp n-gram speculative config mapping so `draftTokenMax` no longer implicitly overrides upstream `ngramSizeM`.
- Document the issue #274 benchmark results, upstream `llama-cli` behavior reference commands, and the limits of exact b9873 artifact parity.
- Split remaining actionable work into follow-ups:
  - https://github.com/leehack/llamadart/issues/278
  - https://github.com/leehack/llamadart-native/issues/25
  - https://github.com/leehack/llamadart-native/issues/26

Closes #274.

## Matrix Evidence

| Matrix row | Scope covered | Platform / model / backend | Result | Evidence / notes |
| --- | --- | --- | --- | --- |
| `llama-cpp-speculative-benchmark` | repeated-context n-gram speculation vs baseline | macOS arm64, `Qwen3.5-0.8B-Q4_K_M.gguf`, llama.cpp CPU | PASS | `dart run tool/testing/llama_cpp_speculative_benchmark.dart --model /Users/jhin.lee/Library/Caches/llamadart/models/Qwen3.5-0.8B-Q4_K_M.gguf --cases baseline,ngram-map-k,ngram-map-k4v --backend cpu --gpu-layers 0 --context-size 4096 --max-tokens 128 --runs 2 --warmups 1 --draft-token-max 8 --ngram-size-n 4 --ngram-size-m 8 --ngram-min-hits 1 --temp 0 --repeat-penalty 1.0 --raw-prompt --prompt "$PROMPT_REPEAT"`; `ngram-map-k` 222.24 wall tok/s, 1.64x baseline, 112/112 accepted drafts; `ngram-map-k4v` 212.21 wall tok/s, 1.56x baseline, output hashes matched. |
| upstream behavior reference | same repeated prompt via closest available upstream CLI | macOS arm64, local `llama-cli` b9571-line build, CPU `--device none` | PASS | Baseline `138.7` generation tok/s; `--spec-type ngram-map-k --spec-draft-n-max 8 --spec-ngram-map-k-size-n 4 --spec-ngram-map-k-size-m 8` produced `164.1` generation tok/s. Current b9873 native release does not publish standalone CLI tools, so exact artifact parity is tracked in `llamadart-native#26`. |
| `docs-site` | README/website/doc links and benchmark docs | Docusaurus site | PASS | `./tool/docs/validate_links.sh` |
| targeted unit | speculative config resolver regression | VM | PASS | `dart test test/unit/backends/llama_cpp/llama_cpp_service_test.dart` |
| targeted analyzer | touched Dart files | VM analyzer | PASS | `dart analyze lib/src/backends/llama_cpp/llama_cpp_service.dart test/unit/backends/llama_cpp/llama_cpp_service_test.dart` |

## Additional Validation

- `dart format lib/src/backends/llama_cpp/llama_cpp_service.dart test/unit/backends/llama_cpp/llama_cpp_service_test.dart`
- `git diff --check`

`dart analyze` for the whole repository was attempted, but it is currently blocked by unrelated existing example package analyzer failures, mostly missing `example/basic_app` imports/dependencies and override warnings outside this change.
