### PR TITLE
Fix n-gram speculative rollback parity

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -62,6 +62,12 @@ dart run tool/testing/run_local_e2e.dart --scenario gguf-chat-features-smoke --m
 dart run tool/testing/run_local_e2e.dart --scenario litert-lm-chat-features-smoke --model-path /path/to/gemma-4-E2B-it.litertlm --backend auto
 ```
 
+For llama.cpp n-gram speculative output-hash mismatches, compare the same
+prompt and sampling settings against upstream `llama-server` before classifying
+the mismatch as Dart-only. Upstream `ngram-map-k` can diverge from baseline
+when repeat penalties and accepted drafts are involved; use the benchmark
+runner's `--include-output` flag to capture exact generated text in JSON.
+
 ### Local Chat App Web E2E
 Use the scenario runner for chat app web validation after bridge/runtime or UI
 updates. This catches issues that direct bridge probes miss while keeping build,

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 ## Unreleased
 
+* Aligned llama.cpp n-gram speculative rejected-tail rollback with upstream
+  server behavior by trimming rejected target tokens before falling back to
+  checkpoint replay, avoiding early token-count/EOG drift in accepted-draft
+  `ngram-map-k` runs. The speculative benchmark can now emit full generated
+  text with `--include-output` for parity investigations.
+
 * Fixed llama.cpp n-gram speculative configuration mapping so
   `draftTokenMax` no longer implicitly overrides upstream `ngramSizeM`, and
   documented upstream comparison commands plus measured n-gram benchmark

--- a/README.md
+++ b/README.md
@@ -291,10 +291,11 @@ await for (final chunk in engine.create(
 
 Higher `draftTokenMax` values can be faster on some models/devices, but they
 should be benchmarked with the target model because excess draft depth can add
-verification overhead. For llama.cpp n-gram strategies, `draftTokenMax` caps
-the per-step draft length; use `ngramSizeM` when intentionally changing
-upstream's n-gram draft window. Measured parity results and upstream comparison
-commands are recorded in the
+verification overhead. For llama.cpp `ngram-simple`, `ngram-map-k`, and
+`ngram-map-k4v`, `ngramSizeM` is the effective draft length and mirrors
+upstream's n-gram window; `draftTokenMax` does not cap those pure n-gram map
+strategies. Measured parity results and upstream comparison commands are
+recorded in the
 [Backend Benchmarks](https://llamadart.leehack.com/docs/guides/backend-benchmarks)
 guide.
 
@@ -305,20 +306,23 @@ speculative decoding uses recent token history as the drafter:
 params: const GenerationParams(
   maxTokens: 128,
   speculativeDecodingConfig: SpeculativeDecodingConfig.ngramSimple(
-    draftTokenMax: 48,
     ngramSize: 12,
+    ngramSizeM: 48,
   ),
 ),
 ```
 
 Reserve `ModelParams.speculativeRollbackTokenMax` at least as large as
-`draftTokenMax` before using speculative decoding. N-gram speculation is
-workload-dependent and can be slower than baseline decoding on prompts with
-little repetition, so validate it with your model and prompt shape. Upstream
-`--spec-default` maps to `ngram-mod`; in llamadart, legacy
-`GenerationParams(speculativeDecoding: true)` uses that llama.cpp default. For
-local measurements, run the discoverable local E2E benchmark scenario with
-explicit cases:
+the largest effective draft length before using speculative decoding. For
+draft-model and `ngram-cache` strategies that is `draftTokenMax`; for
+`ngram-mod` it is `ngramTokenMax` when set, otherwise `draftTokenMax` or the
+llama.cpp default; for `ngram-simple`, `ngram-map-k`, and `ngram-map-k4v` it is
+`ngramSizeM`. N-gram speculation is workload-dependent and can be slower than
+baseline decoding on prompts with little repetition, so validate it with your
+model and prompt shape. Upstream `--spec-default` maps to `ngram-mod`; in
+llamadart, legacy `GenerationParams(speculativeDecoding: true)` uses that
+llama.cpp default. For local measurements, run the discoverable local E2E
+benchmark scenario with explicit cases:
 
 ```bash
 dart run tool/testing/run_local_e2e.dart \
@@ -330,6 +334,7 @@ dart run tool/testing/run_local_e2e.dart \
   --benchmark-max-tokens 128 \
   --benchmark-runs 3 \
   --draft-token-max 1,2 \
+  --ngram-size-m 8,16 \
   --benchmark-warmups 1 \
   --ngram-cache-build-static-path /tmp/llamadart-ngram-cache.bin
 ```
@@ -771,7 +776,13 @@ Notes:
 - `ModelParams.splitMode` passes through to llama.cpp `split_mode`; it defaults to upstream `layer` behavior.
 - `ModelParams.mainGpu` passes through to llama.cpp `main_gpu`. To select one GPU for the full model, use `splitMode: ModelSplitMode.none` with the desired `mainGpu` index.
 - `ModelParams.batchSize` (`n_batch`) and `ModelParams.microBatchSize` (`n_ubatch`) can be set independently for memory/performance tuning; defaults keep legacy behavior (`n_batch = n_ctx`, `n_ubatch = n_batch`).
-- `ModelParams.speculativeRollbackTokenMax` passes through to llama.cpp `n_rs_seq`. Keep the default `0` for normal generation; set it to at least the MTP draft token max when a llama.cpp MTP model needs bounded rollback snapshots, such as Qwen3.5 MTP.
+- `ModelParams.speculativeRollbackTokenMax` passes through to llama.cpp
+  `n_rs_seq`. Keep the default `0` for normal generation; set it to at least
+  the effective speculative draft length when a llama.cpp strategy needs
+  bounded rollback snapshots. For draft-model and `ngram-cache` strategies that
+  is `draftTokenMax`; for `ngram-mod` it is `ngramTokenMax` when set, otherwise
+  `draftTokenMax` or the llama.cpp default; for `ngram-simple`, `ngram-map-k`,
+  and `ngram-map-k4v` it is `ngramSizeM`.
 - Android Vulkan MTP is not enabled by default; it runs only when callers request both `GpuBackend.vulkan` and `SpeculativeDecodingConfig.mtp(...)`. Benchmark on target devices because MTP can increase memory use and may be slower than baseline decoding.
 - `ModelParams.preferMemory64` and `ModelParams.modelBytesHint` are web/WebGPU only (ignored on native). They select the 64-bit (wasm64/mem64) bridge core so models larger than the ~4 GiB wasm32 address space (for example Gemma 4 E2B) can load; `null` auto-decides from the size hint (size-driven, no hardcoded model names). See the [WebGPU bridge docs](https://leehack.github.io/llamadart/docs/platforms/webgpu-bridge).
 - Apple targets use consolidated llama.cpp native libraries, so

--- a/doc/testing_matrix.md
+++ b/doc/testing_matrix.md
@@ -169,6 +169,7 @@ dart run tool/testing/run_local_e2e.dart \
   --benchmark-max-tokens 128 \
   --benchmark-runs 3 \
   --draft-token-max 1,2 \
+  --ngram-size-m 8,16 \
   --benchmark-warmups 1 \
   --ngram-cache-build-static-path /tmp/llamadart-ngram-cache.bin
 ```
@@ -176,8 +177,19 @@ dart run tool/testing/run_local_e2e.dart \
 In the local E2E scenario, draft-model strategies require
 `--draft-model-path`; the n-gram cache strategy can use existing cache paths or
 build a static cache with `--ngram-cache-build-static-path`.
+For `ngram-simple`, `ngram-map-k`, and `ngram-map-k4v`, `--ngram-size-m`
+sweeps the effective n-gram draft length; `--draft-token-max` is still useful
+for draft-model, ngram-cache, and mixed draft-model cases. Use
+`--ngram-token-max` to cap ngram-mod when it should differ from
+`--draft-token-max`.
 Speculative benchmark prompts use the loaded model's chat template by default;
 use raw-prompt options only for intentional raw-vs-template comparisons.
+When investigating output-hash mismatches for n-gram speculation, compare the
+same prompt and sampling settings against upstream `llama-server` before
+classifying the mismatch as a Dart-only regression; upstream `ngram-map-k` can
+diverge from baseline once repeat penalties and accepted drafts are involved.
+Use `--include-output` when the exact divergence text is needed in the JSON
+report.
 When a speculative performance issue is being closed, include the matching
 upstream `llama-cli` or `llama-server` command where a comparable tool binary is
 available. If the exact packaged native tag does not publish standalone tools,

--- a/lib/src/backends/llama_cpp/llama_cpp_service.dart
+++ b/lib/src/backends/llama_cpp/llama_cpp_service.dart
@@ -3982,11 +3982,6 @@ class LlamaCppService {
     List<SpeculativeDecodingStrategy> strategies,
     SpeculativeDecodingConfig config,
   ) {
-    final explicit = config.draftTokenMax;
-    if (explicit != null) {
-      return explicit;
-    }
-
     var max = 0;
     for (final strategy in strategies) {
       switch (strategy) {
@@ -3994,7 +3989,7 @@ class LlamaCppService {
         case SpeculativeDecodingStrategy.draftEagle3:
         case SpeculativeDecodingStrategy.mtp:
         case SpeculativeDecodingStrategy.draftDflash:
-          max = math.max(max, 3);
+          max = math.max(max, config.draftTokenMax ?? 3);
           break;
         case SpeculativeDecodingStrategy.ngramSimple:
         case SpeculativeDecodingStrategy.ngramMapK:
@@ -4002,13 +3997,16 @@ class LlamaCppService {
           max = math.max(max, config.ngramSizeM ?? 48);
           break;
         case SpeculativeDecodingStrategy.ngramMod:
-          max = math.max(max, config.ngramTokenMax ?? 64);
+          max = math.max(
+            max,
+            config.ngramTokenMax ?? config.draftTokenMax ?? 64,
+          );
           break;
         case SpeculativeDecodingStrategy.ngramCache:
-          max = math.max(max, 8);
+          max = math.max(max, config.draftTokenMax ?? 8);
           break;
         case SpeculativeDecodingStrategy.backendDefault:
-          max = math.max(max, 64);
+          max = math.max(max, config.draftTokenMax ?? 64);
           break;
       }
     }
@@ -4103,8 +4101,12 @@ class LlamaCppService {
             'is not available for this model/context. $draftHint, use a '
             'native libllamadart build that includes llama-common generic '
             'speculative wrapper symbols, and set '
-            'ModelParams.speculativeRollbackTokenMax >= draftTokenMax when '
-            'the target architecture needs bounded rollback snapshots.',
+            'ModelParams.speculativeRollbackTokenMax >= the effective '
+            'speculative draft length (draftTokenMax for draft-model or '
+            'ngram-cache strategies; ngramTokenMax when set for ngram-mod, '
+            'otherwise draftTokenMax/default; ngramSizeM for ngram-simple, '
+            'ngram-map-k, or ngram-map-k4v) when the target architecture '
+            'needs bounded rollback snapshots.',
           );
         }
         if (speculativeApi.needEmbd(speculativeSession)) {
@@ -5575,82 +5577,93 @@ class LlamaCppService {
 
           final acceptedDraftCount = acceptedCount - 1;
           final rejectedTailCount = batchTokens - acceptedCount;
+          final keepUntil = currentPos + 1 + acceptedDraftCount;
+          var targetTailReconciled = false;
           if (!hasDraftContext && rejectedTailCount > 0) {
-            if (seqCheckpoint == nullptr) {
-              throw UnsupportedError(
-                'llama.cpp speculative checkpoint rollback is unavailable '
-                'for this context.',
-              );
-            }
-
-            final restored = llama_state_seq_set_data_ext(
-              ctx.pointer,
-              seqCheckpoint,
-              seqCheckpointSize,
-              0,
-              LLAMA_STATE_SEQ_FLAGS_PARTIAL_ONLY,
-            );
-            if (restored != seqCheckpointSize) {
-              throw Exception(
-                'speculative checkpoint restore failed '
-                '(expected $seqCheckpointSize bytes, got $restored)',
-              );
-            }
-
             final targetMemory = llama_get_memory(ctx.pointer);
-            if (targetMemory == nullptr ||
-                !llama_memory_seq_rm(targetMemory, 0, currentPos, -1)) {
-              throw UnsupportedError(
-                'llama.cpp speculative checkpoint rollback failed for this '
-                'context.',
+            final trimmedRejectedTail =
+                targetMemory != nullptr &&
+                llama_memory_seq_rm(targetMemory, 0, keepUntil, -1);
+            if (trimmedRejectedTail) {
+              targetTailReconciled = true;
+            } else {
+              if (seqCheckpoint == nullptr) {
+                throw UnsupportedError(
+                  'llama.cpp speculative checkpoint rollback is unavailable '
+                  'for this context.',
+                );
+              }
+
+              final restored = llama_state_seq_set_data_ext(
+                ctx.pointer,
+                seqCheckpoint,
+                seqCheckpointSize,
+                0,
+                LLAMA_STATE_SEQ_FLAGS_PARTIAL_ONLY,
               );
-            }
+              if (restored != seqCheckpointSize) {
+                throw Exception(
+                  'speculative checkpoint restore failed '
+                  '(expected $seqCheckpointSize bytes, got $restored)',
+                );
+              }
 
-            final replayTokens = 1 + acceptedDraftCount;
-            batch.n_tokens = replayTokens;
-            batch.token[0] = selectedToken;
-            batch.pos[0] = currentPos;
-            batch.n_seq_id[0] = 1;
-            batch.seq_id[0][0] = 0;
-            batch.logits[0] = 0;
-            for (int i = 0; i < acceptedDraftCount; i++) {
-              final batchIndex = i + 1;
-              batch.token[batchIndex] = acceptedPtr[i];
-              batch.pos[batchIndex] = currentPos + batchIndex;
-              batch.n_seq_id[batchIndex] = 1;
-              batch.seq_id[batchIndex][0] = 0;
-              batch.logits[batchIndex] = 0;
-            }
+              final targetMemory = llama_get_memory(ctx.pointer);
+              if (targetMemory == nullptr ||
+                  !llama_memory_seq_rm(targetMemory, 0, currentPos, -1)) {
+                throw UnsupportedError(
+                  'llama.cpp speculative checkpoint rollback failed for this '
+                  'context.',
+                );
+              }
 
-            final replayTick = Stopwatch()..start();
-            final replayStatus = llama_decode(ctx.pointer, batch);
-            if (replayStatus == 0 &&
-                !_processSpeculativeBatch(
-                  speculativeApi,
-                  speculativeSession,
-                  batch,
-                  speculativeConfig,
-                )) {
-              throw Exception("Speculative replay processing failed");
-            }
-            if (replayStatus == 0) {
-              llama_synchronize(ctx.pointer);
-            }
-            replayTick.stop();
-            evalMicros += replayTick.elapsedMicroseconds;
-            if (replayStatus != 0) {
-              throw Exception("Speculative replay decode failed");
+              final replayTokens = 1 + acceptedDraftCount;
+              batch.n_tokens = replayTokens;
+              batch.token[0] = selectedToken;
+              batch.pos[0] = currentPos;
+              batch.n_seq_id[0] = 1;
+              batch.seq_id[0][0] = 0;
+              batch.logits[0] = 0;
+              for (int i = 0; i < acceptedDraftCount; i++) {
+                final batchIndex = i + 1;
+                batch.token[batchIndex] = acceptedPtr[i];
+                batch.pos[batchIndex] = currentPos + batchIndex;
+                batch.n_seq_id[batchIndex] = 1;
+                batch.seq_id[batchIndex][0] = 0;
+                batch.logits[batchIndex] = 0;
+              }
+
+              final replayTick = Stopwatch()..start();
+              final replayStatus = llama_decode(ctx.pointer, batch);
+              if (replayStatus == 0 &&
+                  !_processSpeculativeBatch(
+                    speculativeApi,
+                    speculativeSession,
+                    batch,
+                    speculativeConfig,
+                  )) {
+                throw Exception("Speculative replay processing failed");
+              }
+              if (replayStatus == 0) {
+                llama_synchronize(ctx.pointer);
+              }
+              replayTick.stop();
+              evalMicros += replayTick.elapsedMicroseconds;
+              if (replayStatus != 0) {
+                throw Exception("Speculative replay decode failed");
+              }
+              targetTailReconciled = true;
             }
           }
 
           speculativeAcceptedDraftTokens += acceptedDraftCount;
           speculativeApi.accept(speculativeSession, 0, acceptedDraftCount);
 
-          final keepUntil = currentPos + 1 + acceptedDraftCount;
           final targetMemory = llama_get_memory(ctx.pointer);
           final targetRollbackOk =
+              targetTailReconciled ||
               targetMemory != nullptr &&
-              llama_memory_seq_rm(targetMemory, 0, keepUntil, -1);
+                  llama_memory_seq_rm(targetMemory, 0, keepUntil, -1);
           final draftRollbackOk =
               !hasDraftContext ||
               (draftMemory != nullptr &&
@@ -5658,8 +5671,12 @@ class LlamaCppService {
           if (!targetRollbackOk || !draftRollbackOk) {
             throw UnsupportedError(
               'llama.cpp speculative target rollback failed for this context. '
-              'Set ModelParams.speculativeRollbackTokenMax >= draftTokenMax if '
-              'this model/backend uses bounded rollback snapshots.',
+              'Set ModelParams.speculativeRollbackTokenMax >= the effective '
+              'speculative draft length (draftTokenMax for draft-model or '
+              'ngram-cache strategies; ngramTokenMax when set for ngram-mod, '
+              'otherwise draftTokenMax/default; ngramSizeM for ngram-simple, '
+              'ngram-map-k, or ngram-map-k4v) if this model/backend uses '
+              'bounded rollback snapshots.',
             );
           }
 
@@ -6251,78 +6268,89 @@ class LlamaCppService {
 
           final acceptedDraftCount = acceptedCount - 1;
           final rejectedTailCount = batchTokens - acceptedCount;
+          final keepUntil = currentPos + 1 + acceptedDraftCount;
+          var targetTailReconciled = false;
           if (rejectedTailCount > 0) {
-            if (seqCheckpoint == nullptr) {
-              throw UnsupportedError(
-                'llama.cpp ngram-simple checkpoint rollback is unavailable '
-                'for this context.',
-              );
-            }
-
-            final restored = llama_state_seq_set_data_ext(
-              ctx.pointer,
-              seqCheckpoint,
-              seqCheckpointSize,
-              0,
-              LLAMA_STATE_SEQ_FLAGS_PARTIAL_ONLY,
-            );
-            if (restored != seqCheckpointSize) {
-              throw Exception(
-                'ngram-simple checkpoint restore failed '
-                '(expected $seqCheckpointSize bytes, got $restored)',
-              );
-            }
-
             final targetMemory = llama_get_memory(ctx.pointer);
-            if (targetMemory == nullptr ||
-                !llama_memory_seq_rm(targetMemory, 0, currentPos, -1)) {
-              throw UnsupportedError(
-                'llama.cpp ngram-simple checkpoint rollback failed for this '
-                'context.',
+            final trimmedRejectedTail =
+                targetMemory != nullptr &&
+                llama_memory_seq_rm(targetMemory, 0, keepUntil, -1);
+            if (trimmedRejectedTail) {
+              targetTailReconciled = true;
+            } else {
+              if (seqCheckpoint == nullptr) {
+                throw UnsupportedError(
+                  'llama.cpp ngram-simple checkpoint rollback is unavailable '
+                  'for this context.',
+                );
+              }
+
+              final restored = llama_state_seq_set_data_ext(
+                ctx.pointer,
+                seqCheckpoint,
+                seqCheckpointSize,
+                0,
+                LLAMA_STATE_SEQ_FLAGS_PARTIAL_ONLY,
               );
-            }
+              if (restored != seqCheckpointSize) {
+                throw Exception(
+                  'ngram-simple checkpoint restore failed '
+                  '(expected $seqCheckpointSize bytes, got $restored)',
+                );
+              }
 
-            final replayTokens = 1 + acceptedDraftCount;
-            batch.n_tokens = replayTokens;
-            batch.token[0] = selectedToken;
-            batch.pos[0] = currentPos;
-            batch.n_seq_id[0] = 1;
-            batch.seq_id[0][0] = 0;
-            batch.logits[0] = 0;
-            for (int i = 0; i < acceptedDraftCount; i++) {
-              final batchIndex = i + 1;
-              batch.token[batchIndex] = acceptedPtr[i];
-              batch.pos[batchIndex] = currentPos + batchIndex;
-              batch.n_seq_id[batchIndex] = 1;
-              batch.seq_id[batchIndex][0] = 0;
-              batch.logits[batchIndex] = 0;
-            }
+              final targetMemory = llama_get_memory(ctx.pointer);
+              if (targetMemory == nullptr ||
+                  !llama_memory_seq_rm(targetMemory, 0, currentPos, -1)) {
+                throw UnsupportedError(
+                  'llama.cpp ngram-simple checkpoint rollback failed for this '
+                  'context.',
+                );
+              }
 
-            final replayTick = Stopwatch()..start();
-            final replayStatus = llama_decode(ctx.pointer, batch);
-            if (replayStatus == 0 &&
-                !ngramApi.processBatch(ngramSession, batch)) {
-              throw Exception("ngram-simple replay processing failed");
-            }
-            if (replayStatus == 0) {
-              llama_synchronize(ctx.pointer);
-            }
-            replayTick.stop();
-            evalMicros += replayTick.elapsedMicroseconds;
-            if (replayStatus != 0) {
-              throw Exception("ngram-simple replay decode failed");
+              final replayTokens = 1 + acceptedDraftCount;
+              batch.n_tokens = replayTokens;
+              batch.token[0] = selectedToken;
+              batch.pos[0] = currentPos;
+              batch.n_seq_id[0] = 1;
+              batch.seq_id[0][0] = 0;
+              batch.logits[0] = 0;
+              for (int i = 0; i < acceptedDraftCount; i++) {
+                final batchIndex = i + 1;
+                batch.token[batchIndex] = acceptedPtr[i];
+                batch.pos[batchIndex] = currentPos + batchIndex;
+                batch.n_seq_id[batchIndex] = 1;
+                batch.seq_id[batchIndex][0] = 0;
+                batch.logits[batchIndex] = 0;
+              }
+
+              final replayTick = Stopwatch()..start();
+              final replayStatus = llama_decode(ctx.pointer, batch);
+              if (replayStatus == 0 &&
+                  !ngramApi.processBatch(ngramSession, batch)) {
+                throw Exception("ngram-simple replay processing failed");
+              }
+              if (replayStatus == 0) {
+                llama_synchronize(ctx.pointer);
+              }
+              replayTick.stop();
+              evalMicros += replayTick.elapsedMicroseconds;
+              if (replayStatus != 0) {
+                throw Exception("ngram-simple replay decode failed");
+              }
+              targetTailReconciled = true;
             }
           }
           speculativeAcceptedDraftTokens += acceptedDraftCount;
           ngramApi.accept(ngramSession, 0, acceptedDraftCount);
 
-          final keepUntil = currentPos + 1 + acceptedDraftCount;
           final targetMemory = llama_get_memory(ctx.pointer);
-          if (targetMemory == nullptr ||
-              !llama_memory_seq_rm(targetMemory, 0, keepUntil, -1)) {
+          if (!targetTailReconciled &&
+              (targetMemory == nullptr ||
+                  !llama_memory_seq_rm(targetMemory, 0, keepUntil, -1))) {
             throw UnsupportedError(
               'llama.cpp ngram-simple target rollback failed for this context. '
-              'Set ModelParams.speculativeRollbackTokenMax >= draftTokenMax if '
+              'Set ModelParams.speculativeRollbackTokenMax >= ngramSizeM if '
               'this model/backend uses bounded rollback snapshots.',
             );
           }

--- a/lib/src/core/models/inference/generation_params.dart
+++ b/lib/src/core/models/inference/generation_params.dart
@@ -92,6 +92,11 @@ class SpeculativeDecodingConfig {
 
   /// Maximum number of draft tokens to propose per speculative step.
   ///
+  /// llama.cpp draft-model strategies map this to upstream
+  /// `--spec-draft-n-max`. Draftless `ngram-simple`, `ngram-map-k`, and
+  /// `ngram-map-k4v` use [ngramSizeM] as their effective draft length instead,
+  /// matching upstream n-gram map semantics.
+  ///
   /// `null` lets the backend choose its default.
   final int? draftTokenMax;
 
@@ -127,6 +132,9 @@ class SpeculativeDecodingConfig {
   final int? ngramSizeN;
 
   /// Draft m-gram size M for ngram-simple/map strategies.
+  ///
+  /// For llama.cpp `ngram-simple`, `ngram-map-k`, and `ngram-map-k4v`, this is
+  /// also the effective draft length passed to the n-gram strategy.
   final int? ngramSizeM;
 
   /// Minimum number of matching hits for ngram-simple/map strategies.

--- a/test/unit/backends/llama_cpp/llama_cpp_service_test.dart
+++ b/test/unit/backends/llama_cpp/llama_cpp_service_test.dart
@@ -169,30 +169,53 @@ void main() {
       expect(typeNames, 'ngram-mod,draft-mtp');
     });
 
-    test('keeps ngram size M separate from draft token cap', () {
-      final defaults = service.debugResolveSpeculativeNativeParamsForTesting(
-        const GenerationParams(
-          speculativeDecodingConfig: SpeculativeDecodingConfig.ngramMapK(
-            draftTokenMax: 8,
-          ),
+    test('uses ngram size M as native draft cap for map strategies', () {
+      final configs = <String, SpeculativeDecodingConfig>{
+        'ngram-simple': const SpeculativeDecodingConfig.ngramSimple(
+          draftTokenMax: 8,
         ),
-      );
-
-      expect(defaults['typeNames'], 'ngram-map-k');
-      expect(defaults['draftTokenMax'], 8);
-      expect(defaults['ngramSizeM'], isNull);
-
-      final explicit = service.debugResolveSpeculativeNativeParamsForTesting(
-        const GenerationParams(
-          speculativeDecodingConfig: SpeculativeDecodingConfig.ngramMapK(
-            draftTokenMax: 8,
-            ngramSizeM: 16,
-          ),
+        'ngram-map-k': const SpeculativeDecodingConfig.ngramMapK(
+          draftTokenMax: 8,
         ),
-      );
+        'ngram-map-k4v': const SpeculativeDecodingConfig.ngramMapK4v(
+          draftTokenMax: 8,
+        ),
+      };
 
-      expect(explicit['draftTokenMax'], 8);
-      expect(explicit['ngramSizeM'], 16);
+      for (final entry in configs.entries) {
+        final defaults = service.debugResolveSpeculativeNativeParamsForTesting(
+          GenerationParams(speculativeDecodingConfig: entry.value),
+        );
+
+        expect(defaults['typeNames'], entry.key);
+        expect(defaults['draftTokenMax'], 48);
+        expect(defaults['ngramSizeM'], isNull);
+      }
+
+      final explicitConfigs = <String, SpeculativeDecodingConfig>{
+        'ngram-simple': const SpeculativeDecodingConfig.ngramSimple(
+          draftTokenMax: 8,
+          ngramSizeM: 16,
+        ),
+        'ngram-map-k': const SpeculativeDecodingConfig.ngramMapK(
+          draftTokenMax: 8,
+          ngramSizeM: 16,
+        ),
+        'ngram-map-k4v': const SpeculativeDecodingConfig.ngramMapK4v(
+          draftTokenMax: 8,
+          ngramSizeM: 16,
+        ),
+      };
+
+      for (final entry in explicitConfigs.entries) {
+        final explicit = service.debugResolveSpeculativeNativeParamsForTesting(
+          GenerationParams(speculativeDecodingConfig: entry.value),
+        );
+
+        expect(explicit['typeNames'], entry.key);
+        expect(explicit['draftTokenMax'], 16);
+        expect(explicit['ngramSizeM'], 16);
+      }
     });
 
     test('uses upstream ngram size M default when draft cap is omitted', () {

--- a/test/unit/tooling/llama_cpp_speculative_benchmark_test.dart
+++ b/test/unit/tooling/llama_cpp_speculative_benchmark_test.dart
@@ -26,6 +26,7 @@ void main() {
       expect(result.stdout, contains('--ngram-cache-build-text <text>'));
       expect(result.stdout, contains('--raw-prompt'));
       expect(result.stdout, contains('intentional raw-prompt comparisons'));
+      expect(result.stdout, contains('--include-output'));
     });
 
     test('builds llama.cpp static ngram cache bytes', () {
@@ -85,6 +86,78 @@ void main() {
 
       expect(result.exitCode, isNot(0));
       expect(result.stderr, contains('all, draftless, ngram'));
+    });
+
+    test('expands pure ngram cases by ngram size M', () {
+      final names = speculative_benchmark
+          .debugBuildBenchmarkCaseNamesForTesting(const [
+            '--model',
+            'missing.gguf',
+            '--cases',
+            'baseline,ngram-map-k',
+            '--draft-token-max',
+            '4,8',
+            '--ngram-size-m',
+            '8,16',
+          ]);
+
+      expect(names, ['baseline', 'ngram-map-k_m_8', 'ngram-map-k_m_16']);
+    });
+
+    test('expands mixed ngram cases by draft depth and ngram size M', () {
+      final names = speculative_benchmark
+          .debugBuildBenchmarkCaseNamesForTesting(const [
+            '--model',
+            'missing.gguf',
+            '--cases',
+            'mixed-ngram',
+            '--draft-token-max',
+            '1,2',
+            '--ngram-size-m',
+            '8,16',
+          ]);
+
+      expect(names, [
+        'mixed-ngram_draft_1_m_8',
+        'mixed-ngram_draft_1_m_16',
+        'mixed-ngram_draft_2_m_8',
+        'mixed-ngram_draft_2_m_16',
+      ]);
+    });
+
+    test('reserves rollback capacity for explicit ngram token max', () {
+      final capacity = speculative_benchmark
+          .debugResolveSpeculativeRollbackCapacityForTesting(const [
+            '--model',
+            'missing.gguf',
+            '--cases',
+            'mixed-ngram',
+            '--draft-token-max',
+            '2',
+            '--ngram-size-m',
+            '8',
+            '--ngram-token-max',
+            '64',
+          ]);
+
+      expect(capacity, 64);
+    });
+
+    test('rejects non-positive ngram token max', () async {
+      final result = await Process.run(Platform.resolvedExecutable, [
+        '--disable-dart-dev',
+        'tool/testing/llama_cpp_speculative_benchmark.dart',
+        '--model',
+        'missing.gguf',
+        '--ngram-token-max',
+        '0',
+      ]);
+
+      expect(result.exitCode, isNot(0));
+      expect(
+        result.stderr,
+        contains('--ngram-token-max must be greater than zero.'),
+      );
     });
 
     test('rejects invalid flash-attention values', () async {

--- a/test/unit/tooling/run_local_e2e_test.dart
+++ b/test/unit/tooling/run_local_e2e_test.dart
@@ -14,6 +14,7 @@ void main() {
 
       expect(result.exitCode, 0);
       expect(result.stdout, contains('--ngram-cache-build-text <txt>'));
+      expect(result.stdout, contains('--ngram-token-max <n>'));
       expect(
         result.stdout,
         contains('defaults to the resolved benchmark prompt'),
@@ -247,6 +248,10 @@ void main() {
           '3',
           '--draft-token-max',
           '1,2',
+          '--ngram-size-m',
+          '8,16',
+          '--ngram-token-max',
+          '64',
           '--benchmark-warmups',
           '1',
           '--dry-run',
@@ -262,7 +267,8 @@ void main() {
             '--model models/Qwen3.5-0.8B-Q4_K_M.gguf '
             '--cases baseline,ngram-simple,ngram-map-k,ngram-map-k4v,'
             'ngram-mod,mixed-ngram --backend cpu --gpu-layers 0 '
-            '--max-tokens 128 --runs 3 --draft-token-max 1,2 --warmups 1',
+            '--max-tokens 128 --runs 3 --draft-token-max 1,2 --warmups 1 '
+            '--ngram-size-m 8,16 --ngram-token-max 64',
           ),
         );
       },

--- a/test/unit/tooling/test_matrix_test.dart
+++ b/test/unit/tooling/test_matrix_test.dart
@@ -87,7 +87,12 @@ void main() {
           'ngram-mod,ngram-cache,mixed-ngram',
         ),
       );
-      expect(table, contains('--draft-token-max 1,2 --benchmark-warmups 1'));
+      expect(
+        table,
+        contains(
+          '--draft-token-max 1,2 --ngram-size-m 8,16 --benchmark-warmups 1',
+        ),
+      );
       expect(
         table,
         contains(

--- a/tool/testing/llama_cpp_speculative_benchmark.dart
+++ b/tool/testing/llama_cpp_speculative_benchmark.dart
@@ -24,7 +24,7 @@ Future<void> main(List<String> arguments) async {
     flashAttention: options.flashAttention,
   );
   final speculativeModelParams = baselineModelParams.copyWith(
-    speculativeRollbackTokenMax: options.maxDraftTokenMax,
+    speculativeRollbackTokenMax: options.maxSpeculativeDraftCapacity,
   );
 
   final backend = LlamaBackend();
@@ -293,6 +293,7 @@ Future<_RunResult> _runCase({
       outputChars: text.length,
       outputHash: _fnv1a32(text),
       outputPreview: text.length <= 180 ? text : text.substring(0, 180),
+      outputText: options.includeOutput ? text : null,
       perf: perf,
     );
   } finally {
@@ -309,6 +310,40 @@ List<_BenchmarkCase> _buildBenchmarkCases(_BenchmarkOptions options) {
       continue;
     }
 
+    if (_usesNgramSizeMSweep(requestedCase)) {
+      for (final ngramSizeM in options.ngramSizeMValues) {
+        _addCase(
+          cases,
+          seen,
+          _BenchmarkCase.fromRequestedCase(
+            requestedCase,
+            options: options,
+            draftTokenMax: options.maxDraftTokenMax,
+            ngramSizeM: ngramSizeM,
+          ),
+        );
+      }
+      continue;
+    }
+
+    if (requestedCase == 'mixed-ngram') {
+      for (final draftTokenMax in options.draftTokenMaxValues) {
+        for (final ngramSizeM in options.ngramSizeMValues) {
+          _addCase(
+            cases,
+            seen,
+            _BenchmarkCase.fromRequestedCase(
+              requestedCase,
+              options: options,
+              draftTokenMax: draftTokenMax,
+              ngramSizeM: ngramSizeM,
+            ),
+          );
+        }
+      }
+      continue;
+    }
+
     for (final draftTokenMax in options.draftTokenMaxValues) {
       _addCase(
         cases,
@@ -322,6 +357,30 @@ List<_BenchmarkCase> _buildBenchmarkCases(_BenchmarkOptions options) {
     }
   }
   return cases;
+}
+
+bool _usesNgramSizeMSweep(String requestedCase) {
+  return requestedCase == 'ngram-simple' ||
+      requestedCase == 'ngram-map-k' ||
+      requestedCase == 'ngram-map-k4v';
+}
+
+/// Builds benchmark case names without loading a model.
+///
+/// Intended for unit tests of case expansion and option semantics.
+List<String> debugBuildBenchmarkCaseNamesForTesting(List<String> arguments) {
+  final options = _BenchmarkOptions.parse(arguments);
+  return [
+    for (final benchmarkCase in _buildBenchmarkCases(options))
+      benchmarkCase.name,
+  ];
+}
+
+/// Resolves the benchmark rollback reservation without loading a model.
+///
+/// Intended for unit tests of option semantics.
+int debugResolveSpeculativeRollbackCapacityForTesting(List<String> arguments) {
+  return _BenchmarkOptions.parse(arguments).maxSpeculativeDraftCapacity;
 }
 
 void _addCase(
@@ -487,7 +546,9 @@ class _BenchmarkCase {
     String requestedCase, {
     required _BenchmarkOptions options,
     required int draftTokenMax,
+    int? ngramSizeM,
   }) {
+    final effectiveNgramSizeM = ngramSizeM ?? options.ngramSizeMValues.first;
     switch (requestedCase) {
       case 'backend-default':
         return _BenchmarkCase._(
@@ -552,37 +613,34 @@ class _BenchmarkCase {
         );
       case 'ngram-simple':
         return _BenchmarkCase._(
-          name: 'ngram-simple_draft_$draftTokenMax',
+          name: 'ngram-simple_m_$effectiveNgramSizeM',
           caseType: requestedCase,
           strategies: const <String>['ngram-simple'],
           speculativeDecodingConfig: SpeculativeDecodingConfig.ngramSimple(
-            draftTokenMax: draftTokenMax,
             ngramSizeN: options.ngramSizeN,
-            ngramSizeM: options.ngramSizeM,
+            ngramSizeM: effectiveNgramSizeM,
             ngramMinHits: options.ngramMinHits,
           ),
         );
       case 'ngram-map-k':
         return _BenchmarkCase._(
-          name: 'ngram-map-k_draft_$draftTokenMax',
+          name: 'ngram-map-k_m_$effectiveNgramSizeM',
           caseType: requestedCase,
           strategies: const <String>['ngram-map-k'],
           speculativeDecodingConfig: SpeculativeDecodingConfig.ngramMapK(
-            draftTokenMax: draftTokenMax,
             ngramSizeN: options.ngramSizeN,
-            ngramSizeM: options.ngramSizeM,
+            ngramSizeM: effectiveNgramSizeM,
             ngramMinHits: options.ngramMinHits,
           ),
         );
       case 'ngram-map-k4v':
         return _BenchmarkCase._(
-          name: 'ngram-map-k4v_draft_$draftTokenMax',
+          name: 'ngram-map-k4v_m_$effectiveNgramSizeM',
           caseType: requestedCase,
           strategies: const <String>['ngram-map-k4v'],
           speculativeDecodingConfig: SpeculativeDecodingConfig.ngramMapK4v(
-            draftTokenMax: draftTokenMax,
             ngramSizeN: options.ngramSizeN,
-            ngramSizeM: options.ngramSizeM,
+            ngramSizeM: effectiveNgramSizeM,
             ngramMinHits: options.ngramMinHits,
           ),
         );
@@ -611,7 +669,7 @@ class _BenchmarkCase {
         );
       case 'mixed-ngram':
         return _BenchmarkCase._(
-          name: 'mixed-ngram_draft_$draftTokenMax',
+          name: 'mixed-ngram_draft_${draftTokenMax}_m_$effectiveNgramSizeM',
           caseType: requestedCase,
           strategies: const <String>['ngram-mod', 'ngram-map-k'],
           speculativeDecodingConfig: SpeculativeDecodingConfig.mixed(
@@ -621,7 +679,7 @@ class _BenchmarkCase {
             ],
             draftTokenMax: draftTokenMax,
             ngramSizeN: options.ngramSizeN,
-            ngramSizeM: options.ngramSizeM,
+            ngramSizeM: effectiveNgramSizeM,
             ngramMinHits: options.ngramMinHits,
             ngramMatch: options.ngramMatch,
             ngramTokenMin: options.ngramTokenMin,
@@ -698,6 +756,7 @@ class _RunResult {
     required this.outputChars,
     required this.outputHash,
     required this.outputPreview,
+    required this.outputText,
     required this.perf,
   });
 
@@ -713,6 +772,7 @@ class _RunResult {
   final int outputChars;
   final String outputHash;
   final String outputPreview;
+  final String? outputText;
   final BackendPerfContextData? perf;
 
   double? get evalTokensPerSecond {
@@ -747,6 +807,7 @@ class _RunResult {
       'outputChars': outputChars,
       'outputHash': outputHash,
       'outputPreview': outputPreview,
+      if (outputText != null) 'outputText': outputText,
       'perf': perf == null
           ? null
           : {
@@ -800,7 +861,7 @@ class _BenchmarkOptions {
     required this.minProbability,
     required this.draftSplitProbability,
     required this.ngramSizeN,
-    required this.ngramSizeM,
+    required this.ngramSizeMValues,
     required this.ngramMinHits,
     required this.ngramMatch,
     required this.ngramTokenMin,
@@ -811,6 +872,7 @@ class _BenchmarkOptions {
     required this.ngramCacheBuildText,
     required this.rawPrompt,
     required this.prompt,
+    required this.includeOutput,
     required this.streamBatchTokenThreshold,
     required this.streamBatchByteThreshold,
   });
@@ -834,6 +896,20 @@ class _BenchmarkOptions {
     );
     if (draftTokenMaxValues.any((value) => value <= 0)) {
       stderr.writeln('--draft-token-max values must be greater than zero.');
+      exit(64);
+    }
+    final ngramSizeMValues = _parseIntList(
+      map['ngram-size-m'],
+      fallback: const <int>[48],
+      name: 'ngram-size-m',
+    );
+    if (ngramSizeMValues.any((value) => value <= 0)) {
+      stderr.writeln('--ngram-size-m values must be greater than zero.');
+      exit(64);
+    }
+    final ngramTokenMax = _parseOptionalInt(map['ngram-token-max']);
+    if (ngramTokenMax != null && ngramTokenMax <= 0) {
+      stderr.writeln('--ngram-token-max must be greater than zero.');
       exit(64);
     }
     final ngramCacheStaticPath = _emptyToNull(map['ngram-cache-static-path']);
@@ -904,11 +980,11 @@ class _BenchmarkOptions {
         map['draft-split-probability'],
       ),
       ngramSizeN: _parseOptionalInt(map['ngram-size-n'] ?? map['ngram-size']),
-      ngramSizeM: _parseOptionalInt(map['ngram-size-m']),
+      ngramSizeMValues: ngramSizeMValues,
       ngramMinHits: _parseOptionalInt(map['ngram-min-hits']),
       ngramMatch: _parseOptionalInt(map['ngram-match']),
       ngramTokenMin: _parseOptionalInt(map['ngram-token-min']),
-      ngramTokenMax: _parseOptionalInt(map['ngram-token-max']),
+      ngramTokenMax: ngramTokenMax,
       ngramCacheStaticPath: ngramCacheStaticPath ?? ngramCacheBuildStaticPath,
       ngramCacheDynamicPath: _emptyToNull(map['ngram-cache-dynamic-path']),
       ngramCacheBuildStaticPath: ngramCacheBuildStaticPath,
@@ -919,6 +995,11 @@ class _BenchmarkOptions {
         name: 'raw-prompt',
       ),
       prompt: map['prompt'] ?? _defaultBenchmarkInstruction,
+      includeOutput: _parseBool(
+        map['include-output'],
+        fallback: false,
+        name: 'include-output',
+      ),
       streamBatchTokenThreshold: _parseInt(
         map['stream-batch-tokens'],
         fallback: GenerationParams.defaultStreamBatchTokenThreshold,
@@ -960,7 +1041,7 @@ class _BenchmarkOptions {
   final double? minProbability;
   final double? draftSplitProbability;
   final int? ngramSizeN;
-  final int? ngramSizeM;
+  final List<int> ngramSizeMValues;
   final int? ngramMinHits;
   final int? ngramMatch;
   final int? ngramTokenMin;
@@ -971,6 +1052,7 @@ class _BenchmarkOptions {
   final String? ngramCacheBuildText;
   final bool rawPrompt;
   final String prompt;
+  final bool includeOutput;
   final int streamBatchTokenThreshold;
   final int streamBatchByteThreshold;
 
@@ -978,6 +1060,19 @@ class _BenchmarkOptions {
     1,
     (max, value) => value > max ? value : max,
   );
+
+  int get maxNgramSizeM =>
+      ngramSizeMValues.fold<int>(1, (max, value) => value > max ? value : max);
+
+  int get maxSpeculativeDraftCapacity {
+    final draftMax = maxDraftTokenMax;
+    final ngramMax = maxNgramSizeM;
+    final ngramTokenMax = this.ngramTokenMax;
+    final ngramEffectiveMax = ngramTokenMax != null && ngramTokenMax > ngramMax
+        ? ngramTokenMax
+        : ngramMax;
+    return draftMax > ngramEffectiveMax ? draftMax : ngramEffectiveMax;
+  }
 
   String requiredDraftModelPath(String requestedCase) {
     final path = draftModelPath;
@@ -1013,7 +1108,10 @@ class _BenchmarkOptions {
       'minProbability': minProbability,
       'draftSplitProbability': draftSplitProbability,
       'ngramSizeN': ngramSizeN,
-      'ngramSizeM': ngramSizeM,
+      'ngramSizeM': ngramSizeMValues.length == 1
+          ? ngramSizeMValues.single
+          : null,
+      'ngramSizeMValues': ngramSizeMValues,
       'ngramMinHits': ngramMinHits,
       'ngramMatch': ngramMatch,
       'ngramTokenMin': ngramTokenMin,
@@ -1027,6 +1125,7 @@ class _BenchmarkOptions {
           ? ngramCacheBuildText
           : ngramCacheBuildText!.substring(0, 120),
       'rawPrompt': rawPrompt,
+      'includeOutput': includeOutput,
       'promptPreview': prompt.length <= 120 ? prompt : prompt.substring(0, 120),
       'streamBatchTokenThreshold': streamBatchTokenThreshold,
       'streamBatchByteThreshold': streamBatchByteThreshold,
@@ -1402,8 +1501,9 @@ Case selection:
                                        require --draft-model.
   --draft-model <draft.gguf>           Draft model for draft-simple, eagle3,
                                        dflash, and mixed draft-simple cases.
-  --draft-token-max <list>             Comma-separated draft-token depths.
-                                       Default: 1,2.
+  --draft-token-max <list>             Comma-separated draft-token depths for
+                                       draft-model, ngram-mod, and ngram-cache
+                                       cases. Default: 1,2.
 
 Supported cases:
   ${_allRequestedCases.join(', ')}
@@ -1425,6 +1525,7 @@ Generation:
   --prompt <text>                      Override benchmark prompt.
   --raw-prompt                         Skip model chat-template wrapping for
                                        intentional raw-prompt comparisons.
+  --include-output                     Include full generated output in JSON.
   --seed <n>                           Default: 7.
   --temp <n>                           Default: 0.0.
   --repeat-penalty <n>                 Default: 1.1.
@@ -1434,7 +1535,9 @@ Speculative knobs:
   --min-probability <n>
   --draft-split-probability <n>
   --ngram-size-n <n>                   Also accepts --ngram-size.
-  --ngram-size-m <n>
+  --ngram-size-m <list>                Comma-separated effective draft lengths
+                                       for ngram-simple/map-k/map-k4v.
+                                       Default: 48.
   --ngram-min-hits <n>
   --ngram-match <n>
   --ngram-token-min <n>
@@ -1451,7 +1554,7 @@ Examples:
     --model models/Qwen3.5-0.8B-Q4_K_M.gguf \\
     --cases baseline,ngram-simple,ngram-map-k,ngram-map-k4v,ngram-mod,mixed-ngram \\
     --backend cpu --gpu-layers 0 --max-tokens 128 --runs 3 \\
-    --draft-token-max 1,2 --warmups 1
+    --draft-token-max 1,2 --ngram-size-m 8,16 --warmups 1
 
   dart run tool/testing/llama_cpp_speculative_benchmark.dart \\
     --model models/gemma-4-E2B-it-Q4_K_S.gguf \\

--- a/tool/testing/run_local_e2e.dart
+++ b/tool/testing/run_local_e2e.dart
@@ -83,6 +83,8 @@ class LocalE2eRunContext {
     required this.benchmarkWarmups,
     required this.draftTokenMaxList,
     required this.ngramSize,
+    required this.ngramSizeM,
+    required this.ngramTokenMax,
     required this.ngramCacheStaticPath,
     required this.ngramCacheDynamicPath,
     required this.ngramCacheBuildStaticPath,
@@ -108,6 +110,8 @@ class LocalE2eRunContext {
   final String benchmarkWarmups;
   final String draftTokenMaxList;
   final String? ngramSize;
+  final String? ngramSizeM;
+  final String? ngramTokenMax;
   final String? ngramCacheStaticPath;
   final String? ngramCacheDynamicPath;
   final String? ngramCacheBuildStaticPath;
@@ -252,6 +256,14 @@ List<LocalE2eScenario> buildLocalE2eScenarios({String? projectRoot}) {
         final ngramSize = context.ngramSize;
         if (ngramSize != null) {
           arguments.addAll(['--ngram-size', ngramSize]);
+        }
+        final ngramSizeM = context.ngramSizeM;
+        if (ngramSizeM != null) {
+          arguments.addAll(['--ngram-size-m', ngramSizeM]);
+        }
+        final ngramTokenMax = context.ngramTokenMax;
+        if (ngramTokenMax != null) {
+          arguments.addAll(['--ngram-token-max', ngramTokenMax]);
         }
         final ngramCacheStaticPath = context.ngramCacheStaticPath;
         if (ngramCacheStaticPath != null) {
@@ -734,6 +746,8 @@ Future<LocalE2eResult> runLocalE2e(
     benchmarkWarmups: parsed.benchmarkWarmups,
     draftTokenMaxList: parsed.draftTokenMaxList,
     ngramSize: parsed.ngramSize,
+    ngramSizeM: parsed.ngramSizeM,
+    ngramTokenMax: parsed.ngramTokenMax,
     ngramCacheStaticPath: parsed.ngramCacheStaticPath,
     ngramCacheDynamicPath: parsed.ngramCacheDynamicPath,
     ngramCacheBuildStaticPath: parsed.ngramCacheBuildStaticPath,
@@ -941,6 +955,8 @@ Options:
   --benchmark-warmups <n>        Warmup runs for benchmark scenarios (default: 1).
   --draft-token-max <list>       Draft-token sweep for speculative benchmark (default: 1,2).
   --ngram-size <n>               Optional n-gram size for speculative benchmark.
+  --ngram-size-m <list>          Effective draft length sweep for ngram-simple/map benchmark cases.
+  --ngram-token-max <n>          Optional ngram-mod token cap for speculative benchmark.
   --ngram-cache-static-path <p>  Optional ngram-cache static path for speculative benchmark.
   --ngram-cache-dynamic-path <p> Optional ngram-cache dynamic path for speculative benchmark.
   --ngram-cache-build-static-path <p>
@@ -989,6 +1005,8 @@ class _ParsedArgs {
     this.imagePath,
     this.modelUrl,
     this.ngramSize,
+    this.ngramSizeM,
+    this.ngramTokenMax,
     this.ngramCacheStaticPath,
     this.ngramCacheDynamicPath,
     this.ngramCacheBuildStaticPath,
@@ -1016,6 +1034,8 @@ class _ParsedArgs {
   final String benchmarkWarmups;
   final String draftTokenMaxList;
   final String? ngramSize;
+  final String? ngramSizeM;
+  final String? ngramTokenMax;
   final String? ngramCacheStaticPath;
   final String? ngramCacheDynamicPath;
   final String? ngramCacheBuildStaticPath;
@@ -1048,6 +1068,8 @@ class _ParsedArgs {
     String? imagePath;
     String? modelUrl;
     String? ngramSize;
+    String? ngramSizeM;
+    String? ngramTokenMax;
     String? ngramCacheStaticPath;
     String? ngramCacheDynamicPath;
     String? ngramCacheBuildStaticPath;
@@ -1099,6 +1121,10 @@ class _ParsedArgs {
           draftTokenMaxList = _readValue(args, ++index, arg);
         case '--ngram-size':
           ngramSize = _readValue(args, ++index, arg);
+        case '--ngram-size-m':
+          ngramSizeM = _readValue(args, ++index, arg);
+        case '--ngram-token-max':
+          ngramTokenMax = _readValue(args, ++index, arg);
         case '--ngram-cache-static-path':
           ngramCacheStaticPath = _readValue(args, ++index, arg);
         case '--ngram-cache-dynamic-path':
@@ -1136,6 +1162,8 @@ class _ParsedArgs {
       benchmarkWarmups: benchmarkWarmups,
       draftTokenMaxList: draftTokenMaxList,
       ngramSize: ngramSize,
+      ngramSizeM: ngramSizeM,
+      ngramTokenMax: ngramTokenMax,
       ngramCacheStaticPath: ngramCacheStaticPath,
       ngramCacheDynamicPath: ngramCacheDynamicPath,
       ngramCacheBuildStaticPath: ngramCacheBuildStaticPath,

--- a/tool/testing/test_matrix.dart
+++ b/tool/testing/test_matrix.dart
@@ -150,7 +150,8 @@ const List<TestMatrixRow> testMatrixRows = <TestMatrixRow>[
         'ngram-map-k,ngram-map-k4v,ngram-mod,ngram-cache,mixed-ngram '
         '--benchmark-gpu-layers 0 --benchmark-max-tokens 128 '
         '--benchmark-runs 3 --draft-token-max 1,2 '
-        '--benchmark-warmups 1 --ngram-cache-build-static-path '
+        '--ngram-size-m 8,16 --benchmark-warmups 1 '
+        '--ngram-cache-build-static-path '
         '/tmp/llamadart-ngram-cache.bin',
     useWhen:
         'llama.cpp speculative decoding strategy, wrapper, rollback, or '

--- a/website/docs/guides/backend-benchmarks.md
+++ b/website/docs/guides/backend-benchmarks.md
@@ -85,8 +85,8 @@ CLI rows as behavior references, not exact artifact parity for b9873.
 
 | Runtime | Prompt / config | Backend | Baseline | Speculative | Relative | Notes |
 | --- | --- | --- | ---: | ---: | ---: | --- |
-| llamadart runner | Raw repeated sequence, `ngram-map-k`, `draftTokenMax=8`, `ngramSizeN=4`, `ngramSizeM=8` | CPU | 135.71 wall tok/s | 222.24 wall tok/s | 1.64x | 112/112 drafts accepted, output hash matched |
-| llamadart runner | Same, `ngram-map-k4v`, `draftTokenMax=8`, `ngramSizeN=4`, `ngramSizeM=8` | CPU | 135.71 wall tok/s | 212.21 wall tok/s | 1.56x | 112/112 drafts accepted, output hash matched |
+| llamadart runner | Raw repeated sequence, `ngram-map-k`, `ngramSizeN=4`, `ngramSizeM=8` | CPU | 135.71 wall tok/s | 222.24 wall tok/s | 1.64x | 112/112 drafts accepted, output hash matched |
+| llamadart runner | Same, `ngram-map-k4v`, `ngramSizeN=4`, `ngramSizeM=8` | CPU | 135.71 wall tok/s | 212.21 wall tok/s | 1.56x | 112/112 drafts accepted, output hash matched |
 | llamadart runner | Qwen chat-template code prompt, default `ngram-map-k` sizing | CPU | 103.11 wall tok/s | 67.82 wall tok/s | 0.66x | auxiliary observation from the investigation; zero drafts produced |
 | llamadart runner | Raw code prompt, default n-gram sizing | Metal | 250.63 wall tok/s | 125.61 wall tok/s | 0.50x | auxiliary observation from the investigation; zero drafts produced |
 | upstream `llama-cli` | Same repeated text through `llama-cli` single-turn chat/conversation path, same n-gram knobs as first row | CPU, `--device none` | 138.7 generation tok/s | 164.1 generation tok/s | 1.18x | local b9571 CLI; metric excludes prompt handling |
@@ -95,9 +95,11 @@ Conclusion: draftless n-gram speculation can be faster in llamadart when the
 prompt has reusable repeated context and the n-gram knobs match the workload.
 For natural short prompts or code prompts without a matching recent history,
 the draftless n-gram strategies can produce no drafts, so the extra speculative
-loop work is slower than baseline. Keep `draftTokenMax` as the per-step draft
-cap; set `ngramSizeM` explicitly only when intentionally changing upstream's
-n-gram draft window from its default.
+loop work is slower than baseline. For draft-model and `ngram-cache`
+strategies, use `draftTokenMax` as the per-step draft cap. For `ngram-mod`, use
+`ngramTokenMax` when set, otherwise `draftTokenMax` or the llama.cpp default.
+For `ngram-simple`, `ngram-map-k`, and `ngram-map-k4v`, tune the effective
+draft length with `ngramSizeM` to match upstream's n-gram draft window.
 
 Remaining actionable work was split out instead of being folded into this
 benchmark documentation: [llamadart#278](https://github.com/leehack/llamadart/issues/278)
@@ -207,7 +209,7 @@ dart run tool/testing/llama_cpp_speculative_benchmark.dart \
   --warmups 1 \
   --draft-token-max 8 \
   --ngram-size-n 4 \
-  --ngram-size-m 8 \
+  --ngram-size-m 8,16 \
   --ngram-min-hits 1 \
   --temp 0 \
   --repeat-penalty 1.0 \

--- a/website/docs/guides/performance-tuning.md
+++ b/website/docs/guides/performance-tuning.md
@@ -120,10 +120,11 @@ Guidelines:
   draft-model strategy. Draft-model strategies can load a separate GGUF through
   `draftModelPath`; draftless n-gram strategies are workload-dependent and can
   be slower than baseline on prompts with little repetition. For ngram-simple
-  and ngram-map strategies, `draftTokenMax` caps each speculative step while
-  `ngramSizeM` controls upstream's draft m-gram window; set `ngramSizeM`
-  explicitly only when intentionally changing the upstream n-gram lookup
-  behavior.
+  and ngram-map strategies, `ngramSizeM` is the effective draft length and
+  mirrors upstream's draft m-gram window; `draftTokenMax` does not cap those
+  pure n-gram map strategies. For ngram-mod, `ngramTokenMax` is the effective
+  draft cap when set; otherwise it falls back to `draftTokenMax` or the
+  llama.cpp default.
 - DFlash draft models must use upstream-compatible GGUF metadata:
   `general.architecture=dflash` plus the `dflash.*` metadata block, including
   `dflash.target_layers`. A known-good public pair is target
@@ -247,6 +248,7 @@ dart run tool/testing/llama_cpp_speculative_benchmark.dart \
   --max-tokens 128 \
   --runs 3 \
   --draft-token-max 1,2 \
+  --ngram-size-m 8,16 \
   --warmups 1
 
 # Benchmark embeddings (sequential vs batch)


### PR DESCRIPTION
## Summary
- Fix llama.cpp n-gram speculative rollback to trim rejected target-tail tokens before checkpoint replay fallback.
- Align pure `ngram-simple`, `ngram-map-k`, and `ngram-map-k4v` native draft length resolution with upstream by using `ngramSizeM` instead of `draftTokenMax`.
- Update the speculative benchmark, local E2E runner, docs, tests, and testing matrix so pure n-gram cases sweep/report `--ngram-size-m` instead of mislabeled `draft_*` cases.

## Production-readiness scope
- **User-facing scope:** Users can configure and benchmark llama.cpp pure n-gram speculative strategies with upstream-compatible `ngramSizeM` semantics; issue #280 no longer reproduces the early token-count/EOG drift from the Dart rollback/config mismatch.
- **Supported platforms/paths:** llama.cpp native speculative decoding, local benchmark tooling, local E2E dry-runs, README/website/testing-matrix docs.
- **Unsupported or intentionally unavailable paths:** Exact output hash parity between baseline and upstream `ngram-map-k` under repeat penalties is not guaranteed by this PR; upstream/runtime behavior is tracked in #281.
- **Out of scope / follow-ups:** #281 tracks whether upstream llama.cpp should guarantee exact baseline output parity for `ngram-map-k` with repeat penalties and accepted drafts.

Fixes #280.

## Completeness checklist
- [x] Declared scope is fully implemented, or explicitly reduced above.
- [x] Unsupported platform/option combinations fail loudly with actionable diagnostics or are clearly documented as unavailable.
- [x] Public API docs, README/website docs, examples, support matrices, and changelog entries are updated where relevant.
- [x] Regression coverage covers the original issue plus key negative/version-skew paths where relevant.
- [x] Security/privacy review completed: no secrets, bearer tokens, signed URLs, or raw secret-bearing paths leak through logs, cache keys, metadata, errors, or snapshots.
- [x] Follow-up work that is useful but not required for this PR is tracked in GitHub Issues, or explicitly marked "None" above.

## PR type guidance
- **Bugfix PR:** Root cause was a Dart wrapper mismatch with upstream speculative behavior: rejected-tail rollback replayed more than necessary, and explicit `draftTokenMax` capped pure n-gram map/simple strategies even though upstream uses the map M setting. Regression coverage now asserts resolver behavior across the three pure n-gram map/simple variants and benchmark case expansion.

## Test Plan
- [x] `dart format --output=none --set-exit-if-changed .`  
  Passed; emitted existing nested `example/chat_app` `flutter_lints` package-resolution warnings, but made no changes.
- [x] `dart analyze`  
  Targeted changed-file analyzer passed:
  `dart analyze lib/src/backends/llama_cpp/llama_cpp_service.dart lib/src/core/models/inference/generation_params.dart tool/testing/llama_cpp_speculative_benchmark.dart tool/testing/run_local_e2e.dart tool/testing/test_matrix.dart test/unit/backends/llama_cpp/llama_cpp_service_test.dart test/unit/tooling/llama_cpp_speculative_benchmark_test.dart test/unit/tooling/run_local_e2e_test.dart test/unit/tooling/test_matrix_test.dart`
  Full local `dart analyze` is noisy in this temp worktree due unrelated nested example package resolution errors.
- [x] `dart test -p vm -j 1 --exclude-tags local-only`
- [ ] `dart test -p chrome --exclude-tags local-only`  
  N/A locally for this native llama.cpp speculative path; no browser/runtime code changed.
- [x] Other targeted/local-only validation:
  `dart test test/unit/backends/llama_cpp/llama_cpp_service_test.dart test/unit/tooling/llama_cpp_speculative_benchmark_test.dart test/unit/tooling/run_local_e2e_test.dart test/unit/tooling/test_matrix_test.dart`
  Follow-up review fixes:
  `dart analyze lib/src/backends/llama_cpp/llama_cpp_service.dart tool/testing/llama_cpp_speculative_benchmark.dart tool/testing/run_local_e2e.dart test/unit/tooling/llama_cpp_speculative_benchmark_test.dart test/unit/tooling/run_local_e2e_test.dart`
  `dart test test/unit/tooling/llama_cpp_speculative_benchmark_test.dart test/unit/tooling/run_local_e2e_test.dart`
  `dart test test/unit/backends/llama_cpp/llama_cpp_service_test.dart`
  `dart run tool/testing/run_local_e2e.dart --scenario llama-cpp-speculative-benchmark --model-path models/Qwen3.5-0.8B-Q4_K_M.gguf --speculative-cases ngram-mod --ngram-token-max 64 --dry-run`
  Real-model benchmark:
  `LLAMADART_NATIVE_LIB_DIR=/private/tmp/llamadart-native-issue-25/bin/macos/arm64 dart run tool/testing/llama_cpp_speculative_benchmark.dart --model /Users/jhin.lee/Library/Caches/llamadart/models/Qwen3.5-0.8B-Q4_K_M.gguf --cases baseline,ngram-map-k --backend cpu --gpu-layers 0 --context-size 4096 --max-tokens 128 --runs 1 --warmups 0 --draft-token-max 4,8 --ngram-size-n 4 --ngram-size-m 8 --ngram-min-hits 1 --temp 0 --repeat-penalty 1.1 --raw-prompt --prompt <issue #280 repeated sequence>`

## Matrix Evidence
| Matrix row | Scope covered | Platform / model / backend | Result | Evidence / notes |
| --- | --- | --- | --- | --- |
| static-format-analyze | formatting and changed Dart-file analysis | macOS local worktree | PASS / partial | Format passed. Targeted analyzer passed. Full local analyze is blocked by unrelated nested example package resolution errors. |
| root-vm | native-safe unit/integration coverage | macOS local VM | PASS | `dart test -p vm -j 1 --exclude-tags local-only` passed. |
| llama-cpp-speculative-benchmark | real GGUF speculative rollback/config behavior | Qwen3.5-0.8B-Q4_K_M.gguf, CPU, `ngram-map-k`, `ngramSizeN=4`, `ngramSizeM=8`, repeat penalty 1.1 | PASS with tracked caveat | Baseline: 128 tokens, hash `8e3bf549`, 134.68 wall tok/s. `ngram-map-k_m_8`: 128 tokens, hash `a493305b`, 134.73 wall tok/s, 37 drafts / 32 accepted, acceptance 0.8648648648648649. Exact hash parity remains #281. |
| docs-site | README/website docs wording | Markdown docs only | Not run | Docs changed for benchmark semantics; no site build run locally. |

## Review Notes
- Independent review status: subagent reviews completed. Initial findings about stale docs/tests, mislabeled n-gram benchmark sweeps, `--ngram-token-max` rollback reservation, runner pass-through, ngram-mod docs/diagnostics, and non-positive `--ngram-token-max` validation were addressed.
- CI status / head SHA: checks restarted after the final review-comment fix; head `1daffa96c`.
