### PR TITLE
Update native runtime pin to b9873-llamadart.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 ## Unreleased
 
+* Updated the default llama.cpp native runtime pin to
+  `leehack/llamadart-native@b9873-llamadart.2`, keeping the `b9873`
+  llama.cpp ABI/bindings while picking up wrapper fixes for native release
+  provenance and backend-selected speculative sampler acceptance. Refreshed
+  the `llamadart_llama_cpp_flutter` Apple SwiftPM checksum and aligned current
+  README/website native override docs.
+
 * Aligned llama.cpp n-gram speculative rejected-tail rollback with upstream
   server behavior by trimming rejected target tokens before falling back to
   checkpoint replay, avoiding early token-count/EOG drift in accepted-draft
@@ -27,10 +34,6 @@
   draft-context processing does not request unused logits, avoiding a
   `draft-simple` native abort while preserving target verification logits.
 
-* Updated the default llama.cpp native runtime pin to
-  `leehack/llamadart-native@b9873`, regenerated matching Dart FFI bindings,
-  refreshed the `llamadart_llama_cpp_flutter` Apple SwiftPM checksum, and
-  aligned current README/website native override docs.
 
 * Hardened LiteRT-LM generation validation so llama.cpp-only speculative
   decoding knobs fail loudly instead of silently degrading to LiteRT-LM's

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,8 @@
 ## Unreleased
 
 * Updated the default llama.cpp native runtime pin to
-  `leehack/llamadart-native@b9873-llamadart.2`, keeping the `b9873`
-  llama.cpp ABI/bindings while picking up wrapper fixes for native release
+  `leehack/llamadart-native@b9873-llamadart.2`, keeping the `b9873` llama.cpp
+  ABI/bindings while picking up wrapper fixes for native release
   provenance and backend-selected speculative sampler acceptance. Refreshed
   the `llamadart_llama_cpp_flutter` Apple SwiftPM checksum and aligned current
   README/website native override docs.

--- a/README.md
+++ b/README.md
@@ -131,7 +131,7 @@ hooks:
     llamadart:
       # Optional. Defaults to llamadart's tested native runtime pin.
       # Use a leehack/llamadart-native release tag when testing another build.
-      llamadart_native_tag: b9873
+      llamadart_native_tag: b9873-llamadart.2
 
       # Optional. GitHub repository slug or github.com URL.
       llamadart_native_repository: leehack/llamadart-native
@@ -159,7 +159,7 @@ the native-assets hook fails while downloading that asset.
 
 Native source overrides are for compatibility testing. They do not regenerate
 Dart FFI bindings or symbol lookups, so the selected binary still must be ABI-
-and symbol-compatible with the default `leehack/llamadart-native@b9873` runtime.
+and symbol-compatible with the default `leehack/llamadart-native@b9873-llamadart.2` runtime.
 
 Available native tags are published on the
 [`leehack/llamadart-native` releases page](https://github.com/leehack/llamadart-native/releases).
@@ -171,7 +171,7 @@ gh release list --repo leehack/llamadart-native --limit 20
 
 Before overriding, confirm the release includes the asset for your target. The
 hook downloads files named `llamadart-native-<bundle>-<tag>.tar.gz`, for example
-`llamadart-native-windows-x64-b9873.tar.gz`.
+`llamadart-native-windows-x64-b9873-llamadart.2.tar.gz`.
 For local testing, `llamadart_native_path` may point directly at a bundle
 archive, at an extracted bundle directory, or at a directory containing
 `<tag>/<bundle>/`, `<bundle>/`, or the expected archive file.
@@ -656,7 +656,7 @@ the current strict structured-output boundary.
 <details>
 <summary>Full module matrix (available modules by target)</summary>
 
-Available llama.cpp module matrix from the default native tag `b9873`:
+Available llama.cpp module matrix from the default native tag `b9873-llamadart.2`:
 
 | Target | Available backend modules in bundle |
 |--------|-------------------------------------|
@@ -977,9 +977,9 @@ Current pinned runtime artifacts:
 
 | Runtime path | Published artifact |
 |--------------|--------------------|
-| Native llama.cpp / GGUF | `leehack/llamadart-native@b9873` |
+| Native llama.cpp / GGUF | `leehack/llamadart-native@b9873-llamadart.2` |
 | Native LiteRT-LM / `.litertlm` | `leehack/litert-lm-native@v0.14.0-native.1` |
-| Apple SPM llama.cpp / GGUF | `llamadart_llama_cpp_flutter` pins `leehack/llamadart-native@b9873` Apple XCFramework |
+| Apple SPM llama.cpp / GGUF | `llamadart_llama_cpp_flutter` pins `leehack/llamadart-native@b9873-llamadart.2` Apple XCFramework |
 | Apple SPM LiteRT-LM / `.litertlm` | `llamadart_litert_lm_flutter` pins `leehack/litert-lm-native@v0.14.0-native.1` Apple XCFrameworks |
 | Web llama.cpp / GGUF | `leehack/llama-web-bridge-assets@v0.1.17` |
 | Web LiteRT-LM / `.litertlm` | App-provided `@litert-lm/core` module URL; the chat app defaults to jsDelivr `@litert-lm/core/+esm` |

--- a/hook/build.dart
+++ b/hook/build.dart
@@ -11,7 +11,7 @@ import 'package:path/path.dart' as path;
 
 import 'package:llamadart/src/hook/native_bundle_config.dart';
 
-const _llamaCppTag = 'b9873';
+const _llamaCppTag = 'b9873-llamadart.2';
 const _nativeRepoSlug = 'leehack/llamadart-native';
 
 const _packageName = 'llamadart';

--- a/packages/llamadart_llama_cpp_flutter/CHANGELOG.md
+++ b/packages/llamadart_llama_cpp_flutter/CHANGELOG.md
@@ -1,6 +1,6 @@
 ## Unreleased
 
-* Updated Apple SwiftPM native pin to `leehack/llamadart-native@b9873`.
+* Updated Apple SwiftPM native pin to `leehack/llamadart-native@b9873-llamadart.2`.
 
 ## 0.0.8
 

--- a/packages/llamadart_llama_cpp_flutter/README.md
+++ b/packages/llamadart_llama_cpp_flutter/README.md
@@ -16,7 +16,7 @@ dependencies:
 This package has no runtime Dart API of its own. Import `package:llamadart`
 normally from the core package and use `LlamaBackend()` / `LlamaEngine` there.
 
-The Apple SwiftPM manifest pins `leehack/llamadart-native@b9873`.
+The Apple SwiftPM manifest pins `leehack/llamadart-native@b9873-llamadart.2`.
 
 Source for this package lives in
 `packages/llamadart_llama_cpp_flutter` in the

--- a/packages/llamadart_llama_cpp_flutter/darwin/llamadart_llama_cpp_flutter/Package.swift
+++ b/packages/llamadart_llama_cpp_flutter/darwin/llamadart_llama_cpp_flutter/Package.swift
@@ -4,7 +4,7 @@ import PackageDescription
 
 let packageRoot = URL(fileURLWithPath: #filePath).deletingLastPathComponent()
 let artifactsRoot = packageRoot.appendingPathComponent("Artifacts")
-let llamaCppTag = "b9873"
+let llamaCppTag = "b9873-llamadart.2"
 
 func localArtifactPath(_ name: String) -> String? {
     let path = artifactsRoot.appendingPathComponent(name).path
@@ -47,7 +47,7 @@ let package = Package(
             repository: "leehack/llamadart-native",
             artifactName: "llamadart-native-apple-xcframework-\(llamaCppTag).zip",
             tag: llamaCppTag,
-            checksum: "8500587c905928c9fc622b7138df83a7c8836e4d47bb538aea93bd57dc251da9"
+            checksum: "edf8be9f134fec095f061ec2558754eb9ddb20292b6a3b9ae9212df2554c86da"
         ),
         .target(
             name: "llamadart_llama_cpp_flutter",

--- a/test/unit/tooling/sync_native_release_pins_script_test.dart
+++ b/test/unit/tooling/sync_native_release_pins_script_test.dart
@@ -462,21 +462,21 @@ The Apple SwiftPM manifest pins `$repo@old`.
 
 Future<void> _writeProjectDocs(Directory root) async {
   await File(path.join(root.path, 'README.md')).writeAsString('''
-llamadart_native_tag: b0001
+llamadart_native_tag: b0001-llamadart.1
 
-ABI-compatible with the default `leehack/llamadart-native@b0001` runtime.
+ABI-compatible with the default `leehack/llamadart-native@b0001-llamadart.1` runtime.
 
 dependencies:
   llamadart: ^0.1.0
   llamadart_llama_cpp_flutter: ^0.0.1
   llamadart_litert_lm_flutter: ^0.0.1
 
-`llamadart-native-windows-x64-b0001.tar.gz`
+`llamadart-native-windows-x64-b0001-llamadart.1.tar.gz`
 
-Available llama.cpp module matrix from the default native tag `b0001`:
+Available llama.cpp module matrix from the default native tag `b0001-llamadart.1`:
 
-| Native llama.cpp / GGUF | `leehack/llamadart-native@b0001` |
-| Apple SPM llama.cpp / GGUF | `llamadart_llama_cpp_flutter` pins `leehack/llamadart-native@b0001` Apple XCFramework |
+| Native llama.cpp / GGUF | `leehack/llamadart-native@b0001-llamadart.1` |
+| Apple SPM llama.cpp / GGUF | `llamadart_llama_cpp_flutter` pins `leehack/llamadart-native@b0001-llamadart.1` Apple XCFramework |
 ''');
 
   final installDoc = File(
@@ -484,16 +484,16 @@ Available llama.cpp module matrix from the default native tag `b0001`:
   );
   await installDoc.parent.create(recursive: true);
   await installDoc.writeAsString('''
-llamadart_native_tag: b0001
+llamadart_native_tag: b0001-llamadart.1
 
-ABI-compatible with the default `leehack/llamadart-native@b0001` runtime.
+ABI-compatible with the default `leehack/llamadart-native@b0001-llamadart.1` runtime.
 
 dependencies:
   llamadart: ^0.1.0
   llamadart_llama_cpp_flutter: ^0.0.1
   llamadart_litert_lm_flutter: ^0.0.1
 
-`llamadart-native-windows-x64-b0001.tar.gz`
+`llamadart-native-windows-x64-b0001-llamadart.1.tar.gz`
 ''');
 
   final supportMatrix = File(
@@ -501,12 +501,12 @@ dependencies:
   );
   await supportMatrix.parent.create(recursive: true);
   await supportMatrix.writeAsString('''
-The native-assets hook currently pins `llamadart-native` tag `b0001` and
+The native-assets hook currently pins `llamadart-native` tag `b0001-llamadart.1` and
 `litert-lm-native` release `v0.13.1-native.1`.
 
-## Current llama.cpp module availability by bundle (`b0001`)
+## Current llama.cpp module availability by bundle (`b0001-llamadart.1`)
 
-llamadart_native_tag: b0001
+llamadart_native_tag: b0001-llamadart.1
 ''');
 
   await File(path.join(root.path, 'CHANGELOG.md')).writeAsString('''

--- a/tool/native/sync_native_release_pins.py
+++ b/tool/native/sync_native_release_pins.py
@@ -598,10 +598,12 @@ def update_llama_cpp_project_docs(
             tag,
         )
         if updated_doc_text == doc_text:
-            raise ReleaseError(
-                f"Could not update llama.cpp native pin references in {doc_path}"
-            )
-        pending_writes[doc_path] = updated_doc_text
+            if tag not in doc_text:
+                raise ReleaseError(
+                    f"Could not update llama.cpp native pin references in {doc_path}"
+                )
+        else:
+            pending_writes[doc_path] = updated_doc_text
 
     if not changelog_path.exists():
         raise ReleaseError(f"Missing project CHANGELOG {changelog_path}")
@@ -618,26 +620,28 @@ def replace_llama_cpp_native_doc_references(
     repo: str,
     tag: str,
 ) -> str:
+    native_tag_pattern = r"b[0-9]+(?:-[A-Za-z0-9._-]+)?"
     replacements = (
-        (r"(llamadart_native_tag:\s*)b[0-9]+", rf"\g<1>{tag}"),
+        (rf"(llamadart_native_tag:\s*){native_tag_pattern}", rf"\g<1>{tag}"),
         (
-            rf"({re.escape(repo)}@)b[0-9]+",
+            rf"({re.escape(repo)}@){native_tag_pattern}",
             rf"\g<1>{tag}",
         ),
         (
-            r"(llamadart-native-[a-z0-9_-]+-)b[0-9]+(?=\.tar\.gz`)",
+            rf"(llamadart-native-[a-z0-9_-]+-)"
+            rf"{native_tag_pattern}(?=\.tar\.gz`)",
             rf"\g<1>{tag}",
         ),
         (
-            r"(default native tag `)b[0-9]+(`)",
+            rf"(default native tag `){native_tag_pattern}(`)",
             rf"\g<1>{tag}\2",
         ),
         (
-            r"(llamadart-native` tag `)b[0-9]+(`)",
+            rf"(llamadart-native` tag `){native_tag_pattern}(`)",
             rf"\g<1>{tag}\2",
         ),
         (
-            r"(module availability by bundle \(`)b[0-9]+(`\))",
+            rf"(module availability by bundle \(`){native_tag_pattern}(`\))",
             rf"\g<1>{tag}\2",
         ),
     )
@@ -686,12 +690,22 @@ def update_core_changelog_native_pin(
     repo: str,
     tag: str,
 ) -> str:
-    entry = (
-        "* Updated the default llama.cpp native runtime pin to\n"
-        f"  `{repo}@{tag}`, regenerated matching Dart FFI bindings, refreshed\n"
-        "  the `llamadart_llama_cpp_flutter` Apple SwiftPM checksum, and\n"
-        "  aligned current README/website native override docs."
-    )
+    if re.fullmatch(r"b[0-9]+-llamadart\.[0-9]+", tag):
+        base_tag = tag.split("-", maxsplit=1)[0]
+        entry = (
+            "* Updated the default llama.cpp native runtime pin to\n"
+            f"  `{repo}@{tag}`, keeping the `{base_tag}` llama.cpp\n"
+            "  ABI/bindings while picking up wrapper-only native fixes. Refreshed the\n"
+            "  `llamadart_llama_cpp_flutter` Apple SwiftPM checksum and aligned\n"
+            "  current README/website native override docs."
+        )
+    else:
+        entry = (
+            "* Updated the default llama.cpp native runtime pin to\n"
+            f"  `{repo}@{tag}`, regenerated matching Dart FFI bindings, refreshed\n"
+            "  the `llamadart_llama_cpp_flutter` Apple SwiftPM checksum, and\n"
+            "  aligned current README/website native override docs."
+        )
     heading_match = re.search(r"(?m)^## Unreleased\s*\n+", changelog_text)
     if not heading_match:
         return f"## Unreleased\n\n{entry}\n\n{changelog_text.lstrip()}"

--- a/tool/native/sync_native_release_pins.py
+++ b/tool/native/sync_native_release_pins.py
@@ -695,9 +695,10 @@ def update_core_changelog_native_pin(
         entry = (
             "* Updated the default llama.cpp native runtime pin to\n"
             f"  `{repo}@{tag}`, keeping the `{base_tag}` llama.cpp\n"
-            "  ABI/bindings while picking up wrapper-only native fixes. Refreshed the\n"
-            "  `llamadart_llama_cpp_flutter` Apple SwiftPM checksum and aligned\n"
-            "  current README/website native override docs."
+            "  ABI/bindings while picking up wrapper fixes for native release\n"
+            "  provenance and backend-selected speculative sampler acceptance. Refreshed\n"
+            "  the `llamadart_llama_cpp_flutter` Apple SwiftPM checksum and aligned current\n"
+            "  README/website native override docs."
         )
     else:
         entry = (

--- a/website/docs/changelog/recent-releases.md
+++ b/website/docs/changelog/recent-releases.md
@@ -29,8 +29,10 @@ For canonical full release notes, use:
   missing `dflash.target_layers` artifacts.
 
 - Updated the default llama.cpp native runtime pin to
-  `leehack/llamadart-native@b9873`, refreshed the
-  `llamadart_llama_cpp_flutter` Apple SwiftPM checksum, and aligned current
+  `leehack/llamadart-native@b9873-llamadart.2`, keeping the `b9873`
+  llama.cpp ABI/bindings while picking up wrapper fixes for native release
+  provenance and backend-selected speculative sampler acceptance. Refreshed
+  the `llamadart_llama_cpp_flutter` Apple SwiftPM checksum and aligned current
   README/website native override docs.
 
 - Hardened LiteRT-LM generation validation so llama.cpp-only speculative

--- a/website/docs/getting-started/installation.md
+++ b/website/docs/getting-started/installation.md
@@ -74,7 +74,7 @@ hooks:
     llamadart:
       # Optional. Defaults to llamadart's tested native runtime pin.
       # Use a leehack/llamadart-native release tag when testing another build.
-      llamadart_native_tag: b9873
+      llamadart_native_tag: b9873-llamadart.2
 
       # Optional. GitHub repository slug or github.com URL.
       llamadart_native_repository: leehack/llamadart-native
@@ -100,7 +100,7 @@ per-target module list.
 
 Native source overrides are for compatibility testing. They do not regenerate
 Dart FFI bindings or symbol lookups, so the selected binary still must be ABI-
-and symbol-compatible with the default `leehack/llamadart-native@b9873` runtime.
+and symbol-compatible with the default `leehack/llamadart-native@b9873-llamadart.2` runtime.
 
 Available native tags are published on the
 [`leehack/llamadart-native` releases page](https://github.com/leehack/llamadart-native/releases).
@@ -112,7 +112,7 @@ gh release list --repo leehack/llamadart-native --limit 20
 
 Before overriding, confirm the release includes the asset for your target. The
 hook downloads files named `llamadart-native-<bundle>-<tag>.tar.gz`, for example
-`llamadart-native-windows-x64-b9873.tar.gz`.
+`llamadart-native-windows-x64-b9873-llamadart.2.tar.gz`.
 For local testing, `llamadart_native_path` may point directly at a bundle
 archive, at an extracted bundle directory, or at a directory containing
 `<tag>/<bundle>/`, `<bundle>/`, or the expected archive file.

--- a/website/docs/guides/backend-benchmarks.md
+++ b/website/docs/guides/backend-benchmarks.md
@@ -77,11 +77,12 @@ universally faster. It is workload- and knob-sensitive. The clear local speedup
 came from an explicit repeated-context workload with smaller n-gram lookup
 settings.
 
-The current package runtime pin was `leehack/llamadart-native@b9873`. That
-release does not publish standalone `llama-cli` / `llama-server` tool binaries,
-so upstream CLI comparison used the closest local llama.cpp tool build available
-from `llamadart-native` (`build b1-e3471b3e7`, from the b9571 line). Treat the
-CLI rows as behavior references, not exact artifact parity for b9873.
+At the time of this investigation, the package runtime pin was
+`leehack/llamadart-native@b9873`. That release did not publish standalone
+`llama-cli` / `llama-server` tool binaries, so upstream CLI comparison used the
+closest local llama.cpp tool build available from `llamadart-native`
+(`build b1-e3471b3e7`, from the b9571 line). Treat the CLI rows as historical
+behavior references, not exact artifact parity for the current runtime pin.
 
 | Runtime | Prompt / config | Backend | Baseline | Speculative | Relative | Notes |
 | --- | --- | --- | ---: | ---: | ---: | --- |

--- a/website/docs/platforms/support-matrix.md
+++ b/website/docs/platforms/support-matrix.md
@@ -7,7 +7,7 @@ This page combines platform support, runtime-family selection, and
 backend-module configuration for
 `llamadart`.
 
-The native-assets hook currently pins `llamadart-native` tag `b9873` and
+The native-assets hook currently pins `llamadart-native` tag `b9873-llamadart.2` and
 `litert-lm-native` release `v0.14.0-native.1` (`hook/build.dart`). Apps can
 override the llama.cpp native GitHub source with
 `hooks.user_defines.llamadart.llamadart_native_tag` and
@@ -191,7 +191,7 @@ device/model bundle, use `cpu` or `gpu` for that artifact.
   a web load failure as a package bug. The [WebGPU Bridge](./webgpu-bridge)
   page has the browser-console probe and Flutter Web smoke-test path.
 
-## Current llama.cpp module availability by bundle (`b9873`)
+## Current llama.cpp module availability by bundle (`b9873-llamadart.2`)
 
 | Bundle key | Available backend modules in bundle |
 | --- | --- |
@@ -239,7 +239,7 @@ hooks:
   user_defines:
     llamadart:
       # Optional. Defaults to llamadart's tested native runtime pin.
-      llamadart_native_tag: b9873
+      llamadart_native_tag: b9873-llamadart.2
 
       # Optional. GitHub repository slug or github.com URL.
       llamadart_native_repository: leehack/llamadart-native


### PR DESCRIPTION
## Summary

- Update the default llama.cpp native runtime pin to `leehack/llamadart-native@b9873-llamadart.2`.
- Refresh README, website docs, changelog entries, and the `llamadart_llama_cpp_flutter` SwiftPM checksum.
- Make `tool/native/sync_native_release_pins.py` handle suffixed native tags such as `b9873-llamadart.2` idempotently.
- Clarify that the standalone llama.cpp CLI parity rows are historical because native release artifacts still do not publish standalone tools.

Closes leehack/llamadart-native#25.

## Validation

- PASS: `python3 tool/native/sync_native_release_pins.py --llama-cpp-tag b9873-llamadart.2 --litert-lm-tag keep`
  - Re-run on clean head `e2ac63fe3`; worktree stayed clean.
- PASS: `dart format --output=none --set-exit-if-changed hook/build.dart test/unit/tooling/sync_native_release_pins_script_test.dart`
- PASS: `dart analyze`
  - Existing info-level suggestions only:
    - `test/integration/backends/webgpu/webgpu_engine_multimodal_browser_integration_test.dart:77`
    - `test/unit/backends/webgpu/webgpu_backend_test.dart:296`
- PASS: `dart run tool/testing/verify_release_docs_versions.dart`
- PASS: `dart test test/unit/tooling/sync_native_release_pins_script_test.dart`
- PASS: `dart test test/unit/hook/build_hook_integration_test.dart test/unit/hook/build_hook_android_integration_test.dart test/unit/hook/build_hook_linux_integration_test.dart test/unit/hook/build_hook_litert_lm_integration_test.dart`
- PASS: `dart test -p vm -j 1 --exclude-tags local-only`
  - Result: `1234` passed, `66` skipped.
- PASS: published-artifact Gemma 4 MTP smoke using default `b9873-llamadart.2` pin:
  - Command:
    ```bash
    LLAMADART_MTP_BENCHMARK_BACKEND=metal dart run tool/testing/llama_cpp_mtp_benchmark.dart \
      /Users/jhin.lee/Library/Caches/llamadart/models/gemma-4-E2B-it-Q4_K_S.gguf \
      /Users/jhin.lee/Library/Caches/llamadart/models/mtp-gemma-4-E2B-it.gguf \
      32 1 1 0
    ```
  - Baseline hash: `3d269fbd`
  - MTP hash: `3d269fbd`
  - Accepted draft tokens: `14/16`
  - Acceptance rate: `0.875`
  - Baseline wall throughput: `107.29 tok/s`
  - MTP wall throughput: `62.68 tok/s`
  - Note: this validates output/state parity and draft acceptance through the published native artifact; this specific short Gemma run is still slower than baseline.
