### PR TITLE
Prepare 0.8.13 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-## Unreleased
+## 0.8.13
 
 * Fixed load lifecycle guards so repeated model loads preserve the active
   model state, URL load unsupported-runtime diagnostics stay typed, and unload

--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ For Dart or Flutter apps:
 
 ```yaml
 dependencies:
-  llamadart: ^0.8.12
+  llamadart: ^0.8.13
 ```
 
 Flutter iOS/macOS apps that should link Apple XCFrameworks through Swift
@@ -57,9 +57,9 @@ Package Manager should also add the runtime companion packages they need:
 
 ```yaml
 dependencies:
-  llamadart: ^0.8.12
+  llamadart: ^0.8.13
   llamadart_llama_cpp_flutter: ^0.0.8 # GGUF / llama.cpp
-  llamadart_litert_lm_flutter: ^0.0.3 # iOS .litertlm / LiteRT-LM
+  llamadart_litert_lm_flutter: ^0.0.4 # iOS .litertlm / LiteRT-LM
 ```
 
 At the current LiteRT-LM native pin, Flutter macOS `.litertlm` builds keep

--- a/packages/llamadart_litert_lm_flutter/CHANGELOG.md
+++ b/packages/llamadart_litert_lm_flutter/CHANGELOG.md
@@ -1,4 +1,4 @@
-## Unreleased
+## 0.0.4
 
 * Added the `GemmaModelConstraintProvider` SwiftPM binary target required by
   the pinned LiteRT-LM iOS Apple frameworks.

--- a/packages/llamadart_litert_lm_flutter/README.md
+++ b/packages/llamadart_litert_lm_flutter/README.md
@@ -12,8 +12,8 @@ for the selected architecture.
 
 ```yaml
 dependencies:
-  llamadart: ^0.8.12
-  llamadart_litert_lm_flutter: ^0.0.3
+  llamadart: ^0.8.13
+  llamadart_litert_lm_flutter: ^0.0.4
 ```
 
 This package has no runtime Dart API of its own. Import `package:llamadart`

--- a/packages/llamadart_litert_lm_flutter/pubspec.yaml
+++ b/packages/llamadart_litert_lm_flutter/pubspec.yaml
@@ -1,6 +1,6 @@
 name: llamadart_litert_lm_flutter
 description: Flutter Apple SwiftPM runtime companion package for llamadart LiteRT-LM support.
-version: 0.0.3
+version: 0.0.4
 repository: https://github.com/leehack/llamadart/tree/main/packages/llamadart_litert_lm_flutter
 homepage: https://github.com/leehack/llamadart
 issue_tracker: https://github.com/leehack/llamadart/issues

--- a/packages/llamadart_llama_cpp_flutter/README.md
+++ b/packages/llamadart_llama_cpp_flutter/README.md
@@ -9,7 +9,7 @@ core package's native-assets fallback.
 
 ```yaml
 dependencies:
-  llamadart: ^0.8.12
+  llamadart: ^0.8.13
   llamadart_llama_cpp_flutter: ^0.0.8
 ```
 

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: llamadart
 description: Dart and Flutter local LLM inference with llama.cpp GGUF and LiteRT-LM across native platforms and web.
-version: 0.8.12
+version: 0.8.13
 homepage: https://github.com/leehack/llamadart
 repository: https://github.com/leehack/llamadart
 issue_tracker: https://github.com/leehack/llamadart/issues

--- a/website/docs/changelog/recent-releases.md
+++ b/website/docs/changelog/recent-releases.md
@@ -7,7 +7,17 @@ For canonical full release notes, use:
 
 - [`CHANGELOG.md`](https://github.com/leehack/llamadart/blob/main/CHANGELOG.md)
 
-## Unreleased
+## 0.8.13
+
+- Fixed load lifecycle guards so repeated model loads preserve the active
+  model state, URL load unsupported-runtime diagnostics stay typed, and unload
+  cancels active generation before freeing llama.cpp handles.
+
+- Tightened LiteRT-LM runtime validation and local smoke coverage by requiring
+  complete macOS arm64 runtime caches, adding the missing iOS-compatible
+  SwiftPM Gemma provider target, and keeping Flutter macOS LiteRT-LM
+  companion-package builds on hook-managed native assets while the current
+  SwiftPM artifact set is incomplete.
 
 - Reworked the README into a shorter entry point, fixed stale docs/examples
   found during the documentation review, and aligned release, Android smoke,

--- a/website/docs/getting-started/installation.md
+++ b/website/docs/getting-started/installation.md
@@ -27,7 +27,7 @@ In Xcode, set `IPHONEOS_DEPLOYMENT_TARGET = 16.4` or
 
 ```yaml
 dependencies:
-  llamadart: ^0.8.12
+  llamadart: ^0.8.13
 ```
 
 For Flutter iOS/macOS apps that should link Apple XCFrameworks through Swift
@@ -35,9 +35,9 @@ Package Manager, also add the runtime companion packages you need:
 
 ```yaml
 dependencies:
-  llamadart: ^0.8.12
+  llamadart: ^0.8.13
   llamadart_llama_cpp_flutter: ^0.0.8 # GGUF / llama.cpp
-  llamadart_litert_lm_flutter: ^0.0.3 # iOS .litertlm / LiteRT-LM
+  llamadart_litert_lm_flutter: ^0.0.4 # iOS .litertlm / LiteRT-LM
 ```
 
 The companion packages are published independently from the `packages/`


### PR DESCRIPTION
## Summary

- Bump `llamadart` to `0.8.13`.
- Bump `llamadart_litert_lm_flutter` to `0.0.4` so the LiteRT-LM companion package version matches the fixed release surface.
- Promote the current changelog/recent-release entries and align install snippets across the README, website docs, and companion READMEs.

## Release notes

This release includes the merged LiteRT-LM packaging/runtime guard fixes from #287 and the prior 0.8.13 changelog entries. The new versions are not published on pub.dev yet (`llamadart 0.8.13` and `llamadart_litert_lm_flutter 0.0.4` both returned HTTP 404 during prep), so the release-on-prep-merge workflow should publish the missing companion version first and then create the core `v0.8.13` tag.

## Validation

- `git diff --check`
- `dart format --output=none --set-exit-if-changed .`
- `dart run tool/testing/verify_release_docs_versions.dart`
- `./tool/docs/validate_links.sh`
- `dart pub publish --dry-run` (`llamadart 0.8.13`, 0 warnings)
- `flutter pub publish --dry-run` from `packages/llamadart_litert_lm_flutter` (`0.0.4`, 0 warnings)
