### PR TITLE
Improve chat app web cache and model UX

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 ## Unreleased
 
+* Improved the runnable chat app's model-cache UX by reusing cached GGUF and
+  LiteRT-LM web bundles for benign catalog URLs such as `?download=true`,
+  preserving browser model caches during app cache cleanup, adding a text-only
+  projector skip path, and polishing download/load progress states.
+
 * Updated the default llama.cpp native runtime pin to
   `leehack/llamadart-native@b9935`, regenerated matching Dart FFI bindings, refreshed
   the `llamadart_llama_cpp_flutter` Apple SwiftPM checksum, and

--- a/example/chat_app/lib/providers/chat_provider.dart
+++ b/example/chat_app/lib/providers/chat_provider.dart
@@ -365,20 +365,8 @@ class ChatProvider extends ChangeNotifier {
     if (targetModelPath == null || targetModelPath.isEmpty) {
       _session = null;
       _isLoaded = false;
-      _supportsVision = false;
-      _supportsAudio = false;
-      _mmprojLoaded = false;
-      _templateSupportsTools = true;
-      _thinkingControlsSupported = true;
-      _runtimeGpuLayers = null;
-      _runtimeThreads = null;
-      _runtimeThreadPoolSize = null;
-      _runtimeExecution = null;
-      _runtimeCoreVariant = null;
-      _runtimeWorkerFallbackReason = null;
-      _runtimeNotes = null;
-      _runtimeModelSource = null;
-      _runtimeModelCacheState = null;
+      _resetRuntimeCapabilities();
+      _clearRuntimeDiagnostics();
       notifyListeners();
       return;
     }
@@ -547,6 +535,51 @@ class ChatProvider extends ChangeNotifier {
     _activeModelPrefetchCancelToken = null;
   }
 
+  void _resetRuntimeCapabilities() {
+    _supportsVision = false;
+    _supportsAudio = false;
+    _mmprojLoaded = false;
+    _templateSupportsTools = true;
+    _thinkingControlsSupported = true;
+  }
+
+  void _clearRuntimeDiagnostics() {
+    _runtimeGpuLayers = null;
+    _runtimeThreads = null;
+    _runtimeThreadPoolSize = null;
+    _runtimeExecution = null;
+    _runtimeCoreVariant = null;
+    _runtimeWorkerFallbackReason = null;
+    _runtimeNotes = null;
+    _runtimeModelSource = null;
+    _runtimeModelCacheState = null;
+  }
+
+  void _clearGenerationMetrics() {
+    _lastTokensPerSecond = null;
+    _lastDecodeTokensPerSecond = null;
+    _lastNativePromptEvalMs = null;
+    _lastNativeEvalMs = null;
+    _lastNativeSampleMs = null;
+    _lastNativePromptEvalTokens = null;
+    _lastNativeEvalTokens = null;
+    _lastNativeReusedGraphs = null;
+  }
+
+  void _clearLoadedRuntimeState({String? activeBackend, int? contextLimit}) {
+    _isLoaded = false;
+    if (activeBackend != null) {
+      _activeBackend = activeBackend;
+    }
+    if (contextLimit != null) {
+      _contextLimit = contextLimit;
+    }
+    _loadedModelPath = null;
+    _loadedMmprojPath = null;
+    _resetRuntimeCapabilities();
+    _clearRuntimeDiagnostics();
+  }
+
   Future<bool> _prefetchWebRemoteModelIfNeeded(
     void Function(double value, {String? backendLabel, bool forceNotify})
     updateLoadingUi,
@@ -683,20 +716,8 @@ class ChatProvider extends ChangeNotifier {
     _error = null;
     _loadingProgress = 0.0;
     _activeBackend = 'Loading model...';
-    _supportsVision = false;
-    _supportsAudio = false;
-    _mmprojLoaded = false;
-    _templateSupportsTools = true;
-    _thinkingControlsSupported = true;
-    _runtimeGpuLayers = null;
-    _runtimeThreads = null;
-    _runtimeThreadPoolSize = null;
-    _runtimeExecution = null;
-    _runtimeCoreVariant = null;
-    _runtimeWorkerFallbackReason = null;
-    _runtimeNotes = null;
-    _runtimeModelSource = null;
-    _runtimeModelCacheState = null;
+    _resetRuntimeCapabilities();
+    _clearRuntimeDiagnostics();
     notifyListeners();
 
     DateTime lastProgressNotifyAt = DateTime.now();
@@ -925,11 +946,7 @@ class ChatProvider extends ChangeNotifier {
       _error = displayError;
       _loadedModelPath = null;
       _loadedMmprojPath = null;
-      _supportsVision = false;
-      _supportsAudio = false;
-      _mmprojLoaded = false;
-      _templateSupportsTools = true;
-      _thinkingControlsSupported = true;
+      _resetRuntimeCapabilities();
     } finally {
       _isInitializing = false;
       if (!_isDisposed) {
@@ -995,14 +1012,7 @@ class ChatProvider extends ChangeNotifier {
     _isPruning = false;
     _isGenerating = false;
     _stagedParts.clear();
-    _lastTokensPerSecond = null;
-    _lastDecodeTokensPerSecond = null;
-    _lastNativePromptEvalMs = null;
-    _lastNativeEvalMs = null;
-    _lastNativeSampleMs = null;
-    _lastNativePromptEvalTokens = null;
-    _lastNativeEvalTokens = null;
-    _lastNativeReusedGraphs = null;
+    _clearGenerationMetrics();
     _messages.add(
       ChatMessage(
         text: 'Conversation cleared. Ready for a new topic!',
@@ -1960,26 +1970,8 @@ class ChatProvider extends ChangeNotifier {
 
     _isInitializing = false;
     _loadingProgress = 0.0;
-    _isLoaded = false;
     _error = null;
-    _activeBackend = 'Unloaded';
-    _contextLimit = 0;
-    _loadedModelPath = null;
-    _loadedMmprojPath = null;
-    _supportsVision = false;
-    _supportsAudio = false;
-    _mmprojLoaded = false;
-    _templateSupportsTools = true;
-    _thinkingControlsSupported = true;
-    _runtimeGpuLayers = null;
-    _runtimeThreads = null;
-    _runtimeThreadPoolSize = null;
-    _runtimeExecution = null;
-    _runtimeCoreVariant = null;
-    _runtimeWorkerFallbackReason = null;
-    _runtimeNotes = null;
-    _runtimeModelSource = null;
-    _runtimeModelCacheState = null;
+    _clearLoadedRuntimeState(activeBackend: 'Unloaded', contextLimit: 0);
     _syncActiveConversationSnapshot(touchUpdatedAt: false);
     notifyListeners();
   }

--- a/example/chat_app/lib/providers/chat_provider.dart
+++ b/example/chat_app/lib/providers/chat_provider.dart
@@ -439,13 +439,13 @@ class ChatProvider extends ChangeNotifier {
     try {
       availableBackendInfo = await _chatService.engine.getAvailableBackends();
     } catch (e) {
-      debugPrint("Error fetching available backends: $e");
+      _logDart(LlamaLogLevel.warn, "Error fetching available backends: $e");
     }
 
     try {
       activeBackendInfo = await _chatService.engine.getBackendName();
     } catch (e) {
-      debugPrint("Error fetching active backend: $e");
+      _logDart(LlamaLogLevel.warn, "Error fetching active backend: $e");
     }
 
     if (availableBackendInfo != null) {
@@ -470,6 +470,14 @@ class ChatProvider extends ChangeNotifier {
     notifyListeners();
   }
 
+  void _logDart(LlamaLogLevel level, String message) {
+    final configured = _settings.logLevel;
+    if (configured == LlamaLogLevel.none || level.index < configured.index) {
+      return;
+    }
+    debugPrint(message);
+  }
+
   bool _isRemoteUrl(String? value) {
     if (value == null || value.isEmpty) {
       return false;
@@ -491,9 +499,29 @@ class ChatProvider extends ChangeNotifier {
       return false;
     }
     final uri = Uri.parse(value!);
-    return uri.userInfo.isNotEmpty ||
-        uri.query.isNotEmpty ||
-        uri.fragment.isNotEmpty;
+    if (uri.userInfo.isNotEmpty || uri.fragment.isNotEmpty) {
+      return true;
+    }
+    // Match the browser-cache service/backend policy: normal catalog flags
+    // such as Hugging Face's `?download=true` may be persisted as cache keys,
+    // while token/signature-like query keys are loaded directly from network.
+    const benignQueryKeys = {'download'};
+    return uri.queryParameters.keys.any((key) {
+      final lower = key.toLowerCase();
+      if (benignQueryKeys.contains(lower)) {
+        return false;
+      }
+      return lower.contains('token') ||
+          lower.contains('sig') ||
+          lower.contains('signature') ||
+          lower.contains('expires') ||
+          lower.contains('credential') ||
+          lower.contains('key') ||
+          lower.contains('secret') ||
+          lower.contains('auth') ||
+          lower.contains('session') ||
+          lower.startsWith('x-amz');
+    });
   }
 
   bool _webCachePrefetchWouldPersistSensitiveUrl() {
@@ -585,14 +613,6 @@ class ChatProvider extends ChangeNotifier {
     updateLoadingUi,
   ) async {
     if (!_enableWebModelPrefetch || !_isRemoteUrl(_settings.modelPath)) {
-      return false;
-    }
-    // The WebGPU bridge prefetch stores into a CacheStorage bucket that only
-    // the llama.cpp/GGUF bridge reads back. The @litert-lm/core engine fetches
-    // the .litertlm URL itself and has no access to that cache, so prefetching
-    // here just downloads the whole model an extra time before the engine
-    // re-downloads it. Skip it and let the engine fetch once.
-    if (_isLiteRtLmModelPath(_settings.modelPath)) {
       return false;
     }
     if (_webCachePrefetchWouldPersistSensitiveUrl()) {
@@ -696,7 +716,9 @@ class ChatProvider extends ChangeNotifier {
 
     updateLoadingUi(
       0.72,
-      backendLabel: 'Preparing WebGPU runtime...',
+      backendLabel: _isLiteRtLmModelPath(_settings.modelPath)
+          ? 'Preparing LiteRT-LM runtime...'
+          : 'Preparing WebGPU runtime...',
       forceNotify: true,
     );
     return true;
@@ -774,7 +796,7 @@ class ChatProvider extends ChangeNotifier {
       try {
         await estimateDynamicSettings();
       } catch (e) {
-        debugPrint("Dynamic estimation failed: $e");
+        _logDart(LlamaLogLevel.warn, "Dynamic estimation failed: $e");
       }
     }
 
@@ -791,11 +813,6 @@ class ChatProvider extends ChangeNotifier {
       }
       updateLoadingUi(0.14);
 
-      final prefetchedWebModel = await _prefetchWebRemoteModelIfNeeded(
-        updateLoadingUi,
-      );
-      final modelLoadStart = prefetchedWebModel ? 0.72 : 0.14;
-      final modelLoadSpan = prefetchedWebModel ? 0.12 : 0.7;
       // On web the LiteRT-LM backend downloads + initializes the model through
       // @litert-lm/core and only reports 0%/100%, so a percentage would sit at
       // "0%" for the whole download and look frozen. Show an honest
@@ -803,12 +820,21 @@ class ChatProvider extends ChangeNotifier {
       // file path (no download), so they keep the generic progress label.
       final isLiteRtLmLoad =
           kIsWeb && _isLiteRtLmModelPath(_settings.modelPath);
+      final prefetchedWebModel = await _prefetchWebRemoteModelIfNeeded(
+        updateLoadingUi,
+      );
+      final modelLoadStart = prefetchedWebModel ? 0.72 : 0.14;
+      final modelLoadSpan = prefetchedWebModel ? 0.12 : 0.7;
       const liteRtLmLoadingLabel =
           'Downloading and initializing model (first load may take a while)...';
+      const liteRtLmCachedLoadingLabel =
+          'Initializing cached LiteRT-LM model...';
       if (prefetchedWebModel) {
         updateLoadingUi(
           modelLoadStart,
-          backendLabel: 'Loading model into memory...',
+          backendLabel: isLiteRtLmLoad
+              ? liteRtLmCachedLoadingLabel
+              : 'Loading model into memory...',
           forceNotify: true,
         );
       } else if (isLiteRtLmLoad) {
@@ -819,14 +845,21 @@ class ChatProvider extends ChangeNotifier {
         );
       }
 
+      if (isLiteRtLmLoad) {
+        await Future<void>.delayed(Duration.zero);
+      }
+
       await _chatService.init(
         _settings,
         eagerLoadMultimodalProjector: eagerLoadMmproj,
+        eagerWarmUpLiteRtLmRuntime: !isLiteRtLmLoad,
         onProgress: (progress) {
           final normalized = progress.clamp(0.0, 1.0);
           final staged = modelLoadStart + (normalized * modelLoadSpan);
           final String backendLabel;
-          if (prefetchedWebModel) {
+          if (prefetchedWebModel && isLiteRtLmLoad) {
+            backendLabel = liteRtLmCachedLoadingLabel;
+          } else if (prefetchedWebModel) {
             backendLabel =
                 'Loading model into memory ${(normalized * 100).toStringAsFixed(0)}%';
           } else if (isLiteRtLmLoad) {
@@ -941,8 +974,8 @@ class ChatProvider extends ChangeNotifier {
         return;
       }
       final displayError = _formatDisplayError(e);
-      debugPrint('Error loading model: $displayError');
-      debugPrint(stackTrace.toString());
+      _logDart(LlamaLogLevel.error, 'Error loading model: $displayError');
+      _logDart(LlamaLogLevel.debug, stackTrace.toString());
       _error = displayError;
       _loadedModelPath = null;
       _loadedMmprojPath = null;
@@ -1761,7 +1794,7 @@ class ChatProvider extends ChangeNotifier {
       _addInfoMessage(fileReadError);
       notifyListeners();
     } catch (error) {
-      debugPrint('Error picking $debugLabel: $error');
+      _logDart(LlamaLogLevel.warn, 'Error picking $debugLabel: $error');
     }
   }
 
@@ -1770,7 +1803,10 @@ class ChatProvider extends ChangeNotifier {
       final bytes = await File(path).readAsBytes();
       return _prepareImagePartFromBytes(bytes);
     } catch (error) {
-      debugPrint('Error preparing image bytes from path: $error');
+      _logDart(
+        LlamaLogLevel.warn,
+        'Error preparing image bytes from path: $error',
+      );
       return null;
     }
   }
@@ -2190,7 +2226,7 @@ class ChatProvider extends ChangeNotifier {
       try {
         await _chatService.unloadMultimodalProjector();
       } catch (error) {
-        debugPrint('Failed to unload active mmproj: $error');
+        _logDart(LlamaLogLevel.warn, 'Failed to unload active mmproj: $error');
         _addInfoMessage(
           'Failed to unload the active mmproj cleanly. Reload the model if text output still looks wrong.',
         );
@@ -2290,7 +2326,7 @@ class ChatProvider extends ChangeNotifier {
         ),
       );
     } catch (e) {
-      debugPrint("Error estimating dynamic settings: $e");
+      _logDart(LlamaLogLevel.warn, "Error estimating dynamic settings: $e");
     }
   }
 }

--- a/example/chat_app/lib/providers/chat_provider.dart
+++ b/example/chat_app/lib/providers/chat_provider.dart
@@ -494,38 +494,8 @@ class ChatProvider extends ChangeNotifier {
     return withoutQuery.toLowerCase().endsWith('.litertlm');
   }
 
-  bool _hasPersistentCacheSensitiveUrlParts(String? value) {
-    if (!_isRemoteUrl(value)) {
-      return false;
-    }
-    final uri = Uri.parse(value!);
-    if (uri.userInfo.isNotEmpty || uri.fragment.isNotEmpty) {
-      return true;
-    }
-    // Match the browser-cache service/backend policy: normal catalog flags
-    // such as Hugging Face's `?download=true` may be persisted as cache keys,
-    // while token/signature-like query keys are loaded directly from network.
-    const benignQueryKeys = {'download'};
-    return uri.queryParameters.keys.any((key) {
-      final lower = key.toLowerCase();
-      if (benignQueryKeys.contains(lower)) {
-        return false;
-      }
-      return lower.contains('token') ||
-          lower.contains('sig') ||
-          lower.contains('signature') ||
-          lower.contains('expires') ||
-          lower.contains('credential') ||
-          lower.contains('key') ||
-          lower.contains('secret') ||
-          lower.contains('auth') ||
-          lower.contains('session') ||
-          lower.startsWith('x-amz');
-    });
-  }
-
   bool _webCachePrefetchWouldPersistSensitiveUrl() {
-    return _hasPersistentCacheSensitiveUrlParts(_settings.modelPath);
+    return hasPersistentCacheSensitiveUrlParts(_settings.modelPath ?? '');
   }
 
   String _filenameFromPathOrUrl(

--- a/example/chat_app/lib/screens/app_shell_screen.dart
+++ b/example/chat_app/lib/screens/app_shell_screen.dart
@@ -124,7 +124,8 @@ class _AppShellScreenState extends State<AppShellScreen> {
                               child: ChatScreen(
                                 onOpenModelSelection: showSlidingSettings
                                     ? _openSettingsPanel
-                                    : () {},
+                                    : null,
+                                showModelSelectionAction: showSlidingSettings,
                               ),
                             ),
                           ),
@@ -207,25 +208,33 @@ class _ShellTopBar extends StatelessWidget {
       child: Row(
         children: [
           if (showMenuButton)
-            IconButton(
-              onPressed: onMenuPressed,
-              icon: const Icon(Icons.menu_rounded),
-              tooltip: 'Menu',
+            Semantics(
+              button: true,
+              label: 'Open navigation menu',
+              child: IconButton(
+                onPressed: onMenuPressed,
+                icon: const Icon(Icons.menu_rounded),
+                tooltip: 'Open navigation menu',
+              ),
             ),
           const SizedBox(width: 6),
           Text(
             'llamadart chat',
             style: Theme.of(context).textTheme.headlineSmall?.copyWith(
               fontWeight: FontWeight.w800,
-              letterSpacing: -0.4,
+              letterSpacing: 0,
             ),
           ),
           const Spacer(),
           if (showSettingsButton)
-            IconButton(
-              onPressed: onOpenSettings,
-              tooltip: 'Inference settings',
-              icon: const Icon(Icons.tune_rounded),
+            Semantics(
+              button: true,
+              label: 'Open model and inference settings',
+              child: IconButton(
+                onPressed: onOpenSettings,
+                tooltip: 'Open model and inference settings',
+                icon: const Icon(Icons.tune_rounded),
+              ),
             ),
         ],
       ),
@@ -421,14 +430,18 @@ class _ConversationTileState extends State<_ConversationTile> {
                 AnimatedOpacity(
                   opacity: (_hovered || widget.selected) ? 1.0 : 0.0,
                   duration: const Duration(milliseconds: 120),
-                  child: IconButton(
-                    onPressed: widget.onDelete,
-                    visualDensity: VisualDensity.compact,
-                    iconSize: 17,
-                    tooltip: 'Delete conversation',
-                    icon: Icon(
-                      Icons.delete_outline_rounded,
-                      color: colorScheme.error,
+                  child: Semantics(
+                    button: true,
+                    label: 'Delete conversation',
+                    child: IconButton(
+                      onPressed: widget.onDelete,
+                      visualDensity: VisualDensity.compact,
+                      iconSize: 17,
+                      tooltip: 'Delete conversation',
+                      icon: Icon(
+                        Icons.delete_outline_rounded,
+                        color: colorScheme.error,
+                      ),
                     ),
                   ),
                 ),

--- a/example/chat_app/lib/screens/chat_screen.dart
+++ b/example/chat_app/lib/screens/chat_screen.dart
@@ -11,8 +11,13 @@ import 'manage_models_screen.dart';
 
 class ChatScreen extends StatefulWidget {
   final VoidCallback? onOpenModelSelection;
+  final bool showModelSelectionAction;
 
-  const ChatScreen({super.key, this.onOpenModelSelection});
+  const ChatScreen({
+    super.key,
+    this.onOpenModelSelection,
+    this.showModelSelectionAction = true,
+  });
 
   @override
   State<ChatScreen> createState() => _ChatScreenState();
@@ -181,34 +186,6 @@ class _ChatScreenState extends State<ChatScreen> {
       ),
       child: Stack(
         children: [
-          Positioned(
-            top: -100,
-            right: -64,
-            child: IgnorePointer(
-              child: Container(
-                width: 250,
-                height: 250,
-                decoration: BoxDecoration(
-                  shape: BoxShape.circle,
-                  color: colorScheme.primary.withValues(alpha: 0.07),
-                ),
-              ),
-            ),
-          ),
-          Positioned(
-            bottom: -130,
-            left: -90,
-            child: IgnorePointer(
-              child: Container(
-                width: 300,
-                height: 300,
-                decoration: BoxDecoration(
-                  shape: BoxShape.circle,
-                  color: colorScheme.tertiary.withValues(alpha: 0.06),
-                ),
-              ),
-            ),
-          ),
           Column(
             children: [
               const PruningIndicator(),
@@ -223,7 +200,9 @@ class _ChatScreenState extends State<ChatScreen> {
                         isLoaded: provider.isLoaded,
                         loadingProgress: provider.loadingProgress,
                         onRetry: () => provider.loadModel(),
-                        onSelectModel: _openModelSelection,
+                        onSelectModel: widget.showModelSelectionAction
+                            ? _openModelSelection
+                            : null,
                       );
                     }
 

--- a/example/chat_app/lib/screens/manage_models_screen.dart
+++ b/example/chat_app/lib/screens/manage_models_screen.dart
@@ -13,6 +13,7 @@ import '../models/downloadable_model.dart';
 import '../providers/chat_provider.dart';
 import '../services/hugging_face_model_discovery_service.dart';
 import '../services/model_download_controller_adapter.dart';
+import '../services/model_download_ui_controller.dart';
 import '../services/model_service_base.dart';
 import '../utils/backend_utils.dart';
 import '../widgets/model_card.dart';
@@ -52,15 +53,9 @@ class _ManageModelsScreenState extends State<ManageModelsScreen>
   final List<DownloadableModel> _models = <DownloadableModel>[];
   final List<DownloadableModel> _customModels = <DownloadableModel>[];
 
-  final Map<String, ValueNotifier<_ModelDownloadUiState>>
-  _downloadUiStateByFile = {};
   final Map<String, ModelProfileCacheState> _cacheStateByFile = {};
-  final Map<String, int> _lastDownloadedBytes = {};
-  final Map<String, DateTime> _lastDownloadSampleAt = {};
-  final Map<String, double> _smoothedDownloadRateBytesPerSec = {};
-  final Map<String, ModelDownloadController> _downloadControllers = {};
-  final Map<String, StreamSubscription<ModelDownloadTaskSnapshot>>
-  _downloadSubscriptions = {};
+  final Map<String, bool> _includeProjectorByFile = {};
+  final ModelDownloadUiController _downloadUi = ModelDownloadUiController();
 
   Set<String> _downloadedFiles = {};
   String? _modelsDir;
@@ -97,17 +92,33 @@ class _ManageModelsScreenState extends State<ManageModelsScreen>
   Future<void> _initModelService() async {
     await _loadCustomModels();
     _modelsDir = await _modelService.getModelsDirectory();
-    _downloadedFiles = await _modelService.getDownloadedModels(_models);
-    await _refreshCacheStates(_models);
+    await _refreshDownloadedModelState();
     if (mounted) {
       setState(() {});
     }
   }
 
+  Future<void> _refreshDownloadedModelState({
+    Iterable<DownloadableModel>? cacheModels,
+    bool clearCacheStates = false,
+  }) async {
+    final downloadedFiles = await _modelService.getDownloadedModels(_models);
+    if (clearCacheStates) {
+      _cacheStateByFile.clear();
+    }
+    await _refreshCacheStates(cacheModels ?? _models);
+    _downloadedFiles = downloadedFiles;
+  }
+
   Future<void> _refreshCacheStates(Iterable<DownloadableModel> models) async {
-    for (final model in models) {
-      _cacheStateByFile[model.filename] = await _modelService
-          .getModelCacheState(model);
+    final entries = await Future.wait(
+      models.map((model) async {
+        final state = await _modelService.getModelCacheState(model);
+        return MapEntry(model.filename, state);
+      }),
+    );
+    for (final entry in entries) {
+      _cacheStateByFile[entry.key] = entry.value;
     }
   }
 
@@ -241,8 +252,7 @@ class _ManageModelsScreenState extends State<ManageModelsScreen>
       _showModelLibrary = true;
     });
 
-    _downloadedFiles = await _modelService.getDownloadedModels(_models);
-    await _refreshCacheStates(<DownloadableModel>[model]);
+    await _refreshDownloadedModelState(cacheModels: <DownloadableModel>[model]);
     if (mounted) {
       setState(() {});
     }
@@ -563,38 +573,6 @@ class _ManageModelsScreenState extends State<ManageModelsScreen>
     return value.toString();
   }
 
-  String _downloadStageLabel(ModelDownloadProgress detail) {
-    final actionText = detail.resumed
-        ? (kIsWeb ? 'Resuming cache' : 'Resuming')
-        : (kIsWeb ? 'Caching' : 'Downloading');
-    final stageText = switch (detail.stage) {
-      ModelDownloadStage.model => '$actionText model',
-      ModelDownloadStage.multimodalProjector => '$actionText mmproj',
-    };
-
-    if (detail.stageCount > 1) {
-      return '$stageText (${detail.stageIndex}/${detail.stageCount})';
-    }
-    return stageText;
-  }
-
-  String? _downloadTaskLabel(ModelDownloadTaskSnapshot? task) {
-    if (task == null) {
-      return null;
-    }
-    return switch (task.stage) {
-      ModelDownloadTaskStage.idle => null,
-      ModelDownloadTaskStage.resolving => 'Resolving model',
-      ModelDownloadTaskStage.checkingCache => 'Checking cache',
-      ModelDownloadTaskStage.downloading =>
-        kIsWeb ? 'Caching model' : 'Downloading model',
-      ModelDownloadTaskStage.verifying => 'Verifying model',
-      ModelDownloadTaskStage.ready => 'Ready',
-      ModelDownloadTaskStage.failed => task.errorMessage ?? 'Download failed',
-      ModelDownloadTaskStage.cancelled => 'Paused',
-    };
-  }
-
   String _downloadFailureMessage(dynamic error) {
     if (error is DioException) {
       final normalized = '${error.message ?? ''} ${error.error ?? ''}'
@@ -626,88 +604,14 @@ class _ManageModelsScreenState extends State<ManageModelsScreen>
     return 'Download failed. Please retry.';
   }
 
-  void _updateDownloadRate(String filename, ModelDownloadProgress detail) {
-    final now = DateTime.now();
-    final previousBytes = _lastDownloadedBytes[filename];
-    final previousSampleAt = _lastDownloadSampleAt[filename];
-
-    if (previousBytes != null && previousSampleAt != null) {
-      final elapsedMs = now.difference(previousSampleAt).inMilliseconds;
-      final deltaBytes = detail.downloadedBytes - previousBytes;
-      if (elapsedMs > 0 && deltaBytes > 0) {
-        final instantRate = (deltaBytes * 1000.0) / elapsedMs;
-        final previousRate = _smoothedDownloadRateBytesPerSec[filename];
-        _smoothedDownloadRateBytesPerSec[filename] = previousRate == null
-            ? instantRate
-            : ((previousRate * 0.72) + (instantRate * 0.28));
-      }
-    }
-
-    _lastDownloadedBytes[filename] = detail.downloadedBytes;
-    _lastDownloadSampleAt[filename] = now;
+  bool _includeProjectorFor(DownloadableModel model) {
+    return _includeProjectorByFile[model.filename] ?? true;
   }
 
-  String? _downloadTransferLabel(
-    String filename,
-    ModelDownloadProgress detail,
-  ) {
-    final bytesPerSecond = _smoothedDownloadRateBytesPerSec[filename];
-    if (bytesPerSecond == null || bytesPerSecond <= 0) {
-      return null;
-    }
-
-    final speedLabel = _formatByteRate(bytesPerSecond);
-    final totalBytes = detail.totalBytes;
-    if (totalBytes == null || totalBytes <= 0) {
-      return speedLabel;
-    }
-
-    final remainingBytes = totalBytes - detail.downloadedBytes;
-    if (remainingBytes <= 0) {
-      return speedLabel;
-    }
-
-    final etaSeconds = (remainingBytes / bytesPerSecond).ceil();
-    final etaLabel = _formatEta(Duration(seconds: etaSeconds));
-    return '$speedLabel | $etaLabel left';
-  }
-
-  String _formatByteRate(double bytesPerSecond) {
-    if (bytesPerSecond >= 1024 * 1024 * 1024) {
-      return '${(bytesPerSecond / (1024 * 1024 * 1024)).toStringAsFixed(2)} GB/s';
-    }
-    if (bytesPerSecond >= 1024 * 1024) {
-      return '${(bytesPerSecond / (1024 * 1024)).toStringAsFixed(2)} MB/s';
-    }
-    if (bytesPerSecond >= 1024) {
-      return '${(bytesPerSecond / 1024).toStringAsFixed(1)} KB/s';
-    }
-    return '${bytesPerSecond.toStringAsFixed(0)} B/s';
-  }
-
-  String _formatEta(Duration duration) {
-    if (duration.inHours > 0) {
-      final minutes = duration.inMinutes
-          .remainder(60)
-          .toString()
-          .padLeft(2, '0');
-      return '${duration.inHours}h ${minutes}m';
-    }
-    if (duration.inMinutes > 0) {
-      final seconds = duration.inSeconds
-          .remainder(60)
-          .toString()
-          .padLeft(2, '0');
-      return '${duration.inMinutes}m ${seconds}s';
-    }
-    return '${duration.inSeconds}s';
-  }
-
-  ValueNotifier<_ModelDownloadUiState> _downloadUiStateFor(String filename) {
-    return _downloadUiStateByFile.putIfAbsent(
-      filename,
-      () => ValueNotifier<_ModelDownloadUiState>(const _ModelDownloadUiState()),
-    );
+  void _setIncludeProjector(DownloadableModel model, bool value) {
+    setState(() {
+      _includeProjectorByFile[model.filename] = value;
+    });
   }
 
   void _updateDownloadUiState(
@@ -720,9 +624,8 @@ class _ManageModelsScreenState extends State<ManageModelsScreen>
     bool clearTask = false,
     bool clearProgress = false,
   }) {
-    final notifier = _downloadUiStateFor(filename);
-    final current = notifier.value;
-    notifier.value = current.copyWith(
+    _downloadUi.updateState(
+      filename,
       isDownloading: isDownloading,
       progress: clearProgress ? 0.0 : progress,
       detail: detail,
@@ -733,17 +636,11 @@ class _ManageModelsScreenState extends State<ManageModelsScreen>
   }
 
   void _clearDownloadTracking(String filename) {
-    _lastDownloadedBytes.remove(filename);
-    _lastDownloadSampleAt.remove(filename);
-    _smoothedDownloadRateBytesPerSec.remove(filename);
+    _downloadUi.clearTracking(filename);
   }
 
   void _pauseActiveDownloads() {
-    for (final controller in _downloadControllers.values) {
-      if (controller.snapshot.isRunning) {
-        controller.cancel();
-      }
-    }
+    _downloadUi.pauseActiveDownloads();
   }
 
   Future<void> _disposeDownloadController(
@@ -751,19 +648,11 @@ class _ManageModelsScreenState extends State<ManageModelsScreen>
     ModelDownloadController? controller,
     StreamSubscription<ModelDownloadTaskSnapshot>? subscription,
   }) async {
-    final currentSubscription = _downloadSubscriptions[filename];
-    if (subscription == null || identical(currentSubscription, subscription)) {
-      await _downloadSubscriptions.remove(filename)?.cancel();
-    } else {
-      await subscription.cancel();
-    }
-
-    final currentController = _downloadControllers[filename];
-    if (controller == null || identical(currentController, controller)) {
-      await _downloadControllers.remove(filename)?.dispose();
-    } else {
-      await controller.dispose();
-    }
+    await _downloadUi.disposeDownload(
+      filename,
+      controller: controller,
+      subscription: subscription,
+    );
   }
 
   void _handleDownloadSnapshot(
@@ -781,11 +670,14 @@ class _ManageModelsScreenState extends State<ManageModelsScreen>
     );
   }
 
-  Future<void> _downloadModel(DownloadableModel model) async {
+  Future<void> _downloadModel(
+    DownloadableModel model, {
+    bool? includeProjector,
+  }) async {
     if (!kIsWeb && _modelsDir == null) {
       return;
     }
-    if (_downloadControllers[model.filename]?.snapshot.isRunning ?? false) {
+    if (_downloadUi.isRunning(model.filename)) {
       return;
     }
 
@@ -804,16 +696,19 @@ class _ManageModelsScreenState extends State<ManageModelsScreen>
     _clearDownloadTracking(model.filename);
 
     try {
+      final shouldIncludeProjector =
+          includeProjector ?? _includeProjectorFor(model);
       final manager = ChatAppModelDownloadManager(
         modelService: _modelService,
         model: model,
         modelsDir: _modelsDir ?? '',
         useWebSources: kIsWeb,
+        includeProjector: shouldIncludeProjector,
         onProgressDetail: (detail) {
           if (!mounted) {
             return;
           }
-          _updateDownloadRate(model.filename, detail);
+          _downloadUi.updateDownloadRate(model.filename, detail);
           _updateDownloadUiState(
             model.filename,
             progress: detail.overallProgress,
@@ -822,11 +717,14 @@ class _ManageModelsScreenState extends State<ManageModelsScreen>
         },
       );
       controller = ModelDownloadController(manager: manager);
-      _downloadControllers[model.filename] = controller;
       subscription = controller.snapshots.listen(
         (snapshot) => _handleDownloadSnapshot(model, snapshot),
       );
-      _downloadSubscriptions[model.filename] = subscription;
+      _downloadUi.registerDownload(
+        filename: model.filename,
+        controller: controller,
+        subscription: subscription,
+      );
 
       await controller.start(manager.source);
       if (!mounted) {
@@ -840,17 +738,17 @@ class _ManageModelsScreenState extends State<ManageModelsScreen>
         clearTask: true,
       );
       _clearDownloadTracking(model.filename);
-      final downloadedFiles = await _modelService.getDownloadedModels(_models);
-      await _refreshCacheStates(_models);
+      await _refreshDownloadedModelState();
       if (!mounted) {
         return;
       }
-      setState(() {
-        _downloadedFiles = downloadedFiles;
-      });
-      ScaffoldMessenger.of(context).showSnackBar(
-        SnackBar(content: Text('${model.name} downloaded successfully.')),
-      );
+      setState(() {});
+      final successAction = shouldIncludeProjector
+          ? 'downloaded successfully'
+          : 'downloaded for text-only chat';
+      ScaffoldMessenger.of(
+        context,
+      ).showSnackBar(SnackBar(content: Text('${model.name} $successAction.')));
     } catch (error) {
       if (!mounted) {
         return;
@@ -870,14 +768,11 @@ class _ManageModelsScreenState extends State<ManageModelsScreen>
         _clearDownloadTracking(model.filename);
       }
 
-      final downloadedFiles = await _modelService.getDownloadedModels(_models);
-      await _refreshCacheStates(_models);
+      await _refreshDownloadedModelState();
       if (!mounted) {
         return;
       }
-      setState(() {
-        _downloadedFiles = downloadedFiles;
-      });
+      setState(() {});
 
       ScaffoldMessenger.of(context).showSnackBar(
         SnackBar(
@@ -900,7 +795,7 @@ class _ManageModelsScreenState extends State<ManageModelsScreen>
   }
 
   void _cancelDownload(DownloadableModel model) {
-    _downloadControllers[model.filename]?.cancel();
+    _downloadUi.cancel(model.filename);
   }
 
   Future<void> _selectModel(DownloadableModel model) async {
@@ -925,7 +820,14 @@ class _ManageModelsScreenState extends State<ManageModelsScreen>
 
     if (model.isMultimodal) {
       final mmprojPath = _resolveMmprojPathForModel(model);
-      provider.updateMmprojPath(mmprojPath ?? '');
+      final mmprojSource = model.multimodalProjectorSourceFor(web: kIsWeb);
+      final projectorIsAvailable =
+          mmprojSource == null ||
+          (_cacheStateByFile[model.filename]
+                  ?.multimodalProjector
+                  ?.isAvailable ??
+              false);
+      provider.updateMmprojPath(projectorIsAvailable ? (mmprojPath ?? '') : '');
     } else {
       provider.updateMmprojPath('');
     }
@@ -967,7 +869,7 @@ class _ManageModelsScreenState extends State<ManageModelsScreen>
   Future<void> _deleteModel(DownloadableModel model) async {
     if (_modelsDir == null) return;
 
-    if (_downloadUiStateFor(model.filename).value.isDownloading) {
+    if (_downloadUi.listenableFor(model.filename).value.isDownloading) {
       _cancelDownload(model);
     }
 
@@ -982,13 +884,10 @@ class _ManageModelsScreenState extends State<ManageModelsScreen>
     );
     _clearDownloadTracking(model.filename);
     await _disposeDownloadController(model.filename);
-    final downloadedFiles = await _modelService.getDownloadedModels(_models);
-    await _refreshCacheStates(_models);
+    await _refreshDownloadedModelState();
     if (!mounted) return;
 
-    setState(() {
-      _downloadedFiles = downloadedFiles;
-    });
+    setState(() {});
   }
 
   Future<void> _removeAllModels() async {
@@ -1039,24 +938,11 @@ class _ManageModelsScreenState extends State<ManageModelsScreen>
       ..clear()
       ..addAll(_initialModelCatalog());
     _customModels.clear();
-    for (final notifier in _downloadUiStateByFile.values) {
-      notifier.dispose();
-    }
-    _downloadUiStateByFile.clear();
-    _lastDownloadedBytes.clear();
-    _lastDownloadSampleAt.clear();
-    _smoothedDownloadRateBytesPerSec.clear();
-    for (final subscription in _downloadSubscriptions.values) {
-      await subscription.cancel();
-    }
-    _downloadSubscriptions.clear();
-    for (final controller in _downloadControllers.values) {
-      await controller.dispose();
-    }
-    _downloadControllers.clear();
-    _downloadedFiles = await _modelService.getDownloadedModels(_models);
-    _cacheStateByFile.clear();
-    await _refreshCacheStates(_models);
+    _downloadUi.clearUiState();
+    _downloadUi.clearRateTracking();
+    _includeProjectorByFile.clear();
+    await _downloadUi.disposeDownloads();
+    await _refreshDownloadedModelState(clearCacheStates: true);
 
     await _saveCustomModels();
 
@@ -1465,16 +1351,16 @@ class _ManageModelsScreenState extends State<ManageModelsScreen>
                       ..._models.map((model) {
                         final selectedPath = _resolveModelLoadReference(model);
                         final isActivating = _activatingModel == model.filename;
-                        final downloadStateListenable = _downloadUiStateFor(
-                          model.filename,
-                        );
+                        final downloadStateListenable = _downloadUi
+                            .listenableFor(model.filename);
 
-                        return ValueListenableBuilder<_ModelDownloadUiState>(
+                        return ValueListenableBuilder<ModelDownloadUiState>(
                           valueListenable: downloadStateListenable,
                           builder: (context, downloadState, _) {
                             final detail = downloadState.detail;
-                            final taskLabel = _downloadTaskLabel(
+                            final taskLabel = downloadTaskLabel(
                               downloadState.task,
+                              isWeb: kIsWeb,
                             );
 
                             final card = ModelCard(
@@ -1487,10 +1373,10 @@ class _ManageModelsScreenState extends State<ManageModelsScreen>
                               progress: downloadState.progress,
                               downloadStatusLabel: detail == null
                                   ? taskLabel
-                                  : _downloadStageLabel(detail),
+                                  : downloadStageLabel(detail, isWeb: kIsWeb),
                               downloadTransferLabel: detail == null
                                   ? null
-                                  : _downloadTransferLabel(
+                                  : _downloadUi.transferLabel(
                                       model.filename,
                                       detail,
                                     ),
@@ -1501,12 +1387,15 @@ class _ManageModelsScreenState extends State<ManageModelsScreen>
                               onGpuLayersChanged: provider.updateGpuLayers,
                               onContextSizeChanged: provider.updateContextSize,
                               onSelect: isActivating
-                                  ? () {}
+                                  ? null
                                   : () => unawaited(_selectModel(model)),
                               onDownload: () =>
                                   unawaited(_downloadModel(model)),
                               onDelete: () => unawaited(_deleteModel(model)),
                               onCancel: () => _cancelDownload(model),
+                              includeProjector: _includeProjectorFor(model),
+                              onIncludeProjectorChanged: (value) =>
+                                  _setIncludeProjector(model, value),
                             );
 
                             return Padding(
@@ -2090,53 +1979,8 @@ class _ManageModelsScreenState extends State<ManageModelsScreen>
   @override
   void dispose() {
     WidgetsBinding.instance.removeObserver(this);
-    _pauseActiveDownloads();
-    for (final subscription in _downloadSubscriptions.values) {
-      unawaited(subscription.cancel());
-    }
-    _downloadSubscriptions.clear();
-    for (final controller in _downloadControllers.values) {
-      unawaited(controller.dispose());
-    }
-    _downloadControllers.clear();
-    for (final notifier in _downloadUiStateByFile.values) {
-      notifier.dispose();
-    }
-    _downloadUiStateByFile.clear();
+    _downloadUi.dispose();
     super.dispose();
-  }
-}
-
-class _ModelDownloadUiState {
-  final bool isDownloading;
-  final double progress;
-  final ModelDownloadProgress? detail;
-  final ModelDownloadTaskSnapshot? task;
-
-  const _ModelDownloadUiState({
-    this.isDownloading = false,
-    this.progress = 0.0,
-    this.detail,
-    this.task,
-  });
-
-  _ModelDownloadUiState copyWith({
-    bool? isDownloading,
-    double? progress,
-    ModelDownloadProgress? detail,
-    ModelDownloadTaskSnapshot? task,
-    bool clearDetail = false,
-    bool clearTask = false,
-  }) {
-    final normalizedProgress =
-        ((progress ?? this.progress).clamp(0.0, 1.0) as num).toDouble();
-
-    return _ModelDownloadUiState(
-      isDownloading: isDownloading ?? this.isDownloading,
-      progress: normalizedProgress,
-      detail: clearDetail ? null : (detail ?? this.detail),
-      task: clearTask ? null : (task ?? this.task),
-    );
   }
 }
 

--- a/example/chat_app/lib/screens/manage_models_screen.dart
+++ b/example/chat_app/lib/screens/manage_models_screen.dart
@@ -289,31 +289,7 @@ class _ManageModelsScreenState extends State<ManageModelsScreen>
   }
 
   bool _hasCredentialLikePersistentUrlParts(String value) {
-    final uri = Uri.tryParse(value.trim());
-    if (uri == null) {
-      return false;
-    }
-    if (uri.userInfo.isNotEmpty || uri.fragment.isNotEmpty) {
-      return true;
-    }
-
-    const benignQueryKeys = {'download'};
-    return uri.queryParameters.keys.any((key) {
-      final lower = key.toLowerCase();
-      if (benignQueryKeys.contains(lower)) {
-        return false;
-      }
-      return lower.contains('token') ||
-          lower.contains('sig') ||
-          lower.contains('signature') ||
-          lower.contains('expires') ||
-          lower.contains('credential') ||
-          lower.contains('key') ||
-          lower.contains('secret') ||
-          lower.contains('auth') ||
-          lower.contains('session') ||
-          lower.startsWith('x-amz');
-    });
+    return hasPersistentCacheSensitiveUrlParts(value.trim());
   }
 
   Future<bool> _confirmSavingCredentialLikeCustomUrls(

--- a/example/chat_app/lib/services/chat_service.dart
+++ b/example/chat_app/lib/services/chat_service.dart
@@ -24,6 +24,7 @@ class ChatService {
     ChatSettings settings, {
     Function(double progress)? onProgress,
     bool eagerLoadMultimodalProjector = true,
+    bool eagerWarmUpLiteRtLmRuntime = true,
   }) async {
     if (settings.modelPath == null) throw Exception("Model path is null");
 
@@ -85,7 +86,7 @@ class ChatService {
         await _engine.loadModel(settings.modelPath!, modelParams: modelParams);
       }
 
-      if (_isLiteRtLmModel(settings.modelPath)) {
+      if (eagerWarmUpLiteRtLmRuntime && _isLiteRtLmModel(settings.modelPath)) {
         emitProgress(0.92);
         await _warmUpLiteRtLmRuntime(settings);
       }

--- a/example/chat_app/lib/services/model_download_controller_adapter.dart
+++ b/example/chat_app/lib/services/model_download_controller_adapter.dart
@@ -19,6 +19,7 @@ class ChatAppModelDownloadManager implements llama.ModelDownloadManager {
     required this.model,
     required this.modelsDir,
     this.useWebSources = false,
+    this.includeProjector = true,
     this.onProgressDetail,
   }) : source = sourceFor(model, useWebSources: useWebSources);
 
@@ -26,6 +27,7 @@ class ChatAppModelDownloadManager implements llama.ModelDownloadManager {
   final DownloadableModel model;
   final String modelsDir;
   final bool useWebSources;
+  final bool includeProjector;
   final void Function(ModelDownloadProgress progress)? onProgressDetail;
   final llama.ModelSource source;
 
@@ -71,8 +73,11 @@ class ChatAppModelDownloadManager implements llama.ModelDownloadManager {
     );
 
     try {
+      final downloadModel = includeProjector
+          ? model
+          : _modelWithoutProjector(model);
       await modelService.downloadModel(
-        model: model,
+        model: downloadModel,
         modelsDir: modelsDir,
         cancelToken: cancelToken,
         onProgress: (progress) {
@@ -210,6 +215,25 @@ class ChatAppModelDownloadManager implements llama.ModelDownloadManager {
       updatedAt: now,
     );
   }
+}
+
+DownloadableModel _modelWithoutProjector(DownloadableModel model) {
+  return DownloadableModel.fromSources(
+    id: model.id,
+    name: model.name,
+    description: model.description,
+    modelSource: model.modelSource,
+    webModelSource: model.webModelSource,
+    sizeBytes: model.sizeBytes,
+    webSizeBytes: model.webSizeBytes,
+    supportsVision: false,
+    supportsAudio: false,
+    supportsVideo: false,
+    supportsToolCalling: model.supportsToolCalling,
+    supportsThinking: model.supportsThinking,
+    minRamGb: model.minRamGb,
+    preset: model.preset,
+  );
 }
 
 llama.ModelSource _sourceForAsset(ModelAssetSource source) {

--- a/example/chat_app/lib/services/model_download_ui_controller.dart
+++ b/example/chat_app/lib/services/model_download_ui_controller.dart
@@ -1,0 +1,274 @@
+import 'dart:async';
+
+import 'package:flutter/foundation.dart';
+import 'package:llamadart/llamadart.dart' hide ModelDownloadProgress;
+
+import 'model_service_base.dart';
+
+class ModelDownloadUiController {
+  final Map<String, ValueNotifier<ModelDownloadUiState>> _uiStateByFile = {};
+  final Map<String, int> _lastDownloadedBytes = {};
+  final Map<String, DateTime> _lastDownloadSampleAt = {};
+  final Map<String, double> _smoothedDownloadRateBytesPerSec = {};
+  final Map<String, ModelDownloadController> _downloadControllers = {};
+  final Map<String, StreamSubscription<ModelDownloadTaskSnapshot>>
+  _downloadSubscriptions = {};
+
+  ValueNotifier<ModelDownloadUiState> listenableFor(String filename) {
+    return _uiStateByFile.putIfAbsent(
+      filename,
+      () => ValueNotifier<ModelDownloadUiState>(const ModelDownloadUiState()),
+    );
+  }
+
+  ModelDownloadTaskSnapshot? snapshotFor(String filename) {
+    return _downloadControllers[filename]?.snapshot;
+  }
+
+  bool isRunning(String filename) {
+    return _downloadControllers[filename]?.snapshot.isRunning ?? false;
+  }
+
+  void registerDownload({
+    required String filename,
+    required ModelDownloadController controller,
+    required StreamSubscription<ModelDownloadTaskSnapshot> subscription,
+  }) {
+    _downloadControllers[filename] = controller;
+    _downloadSubscriptions[filename] = subscription;
+  }
+
+  void updateState(
+    String filename, {
+    bool? isDownloading,
+    double? progress,
+    ModelDownloadProgress? detail,
+    ModelDownloadTaskSnapshot? task,
+    bool clearDetail = false,
+    bool clearTask = false,
+    bool clearProgress = false,
+  }) {
+    final notifier = listenableFor(filename);
+    final current = notifier.value;
+    notifier.value = current.copyWith(
+      isDownloading: isDownloading,
+      progress: clearProgress ? 0.0 : progress,
+      detail: detail,
+      task: task,
+      clearDetail: clearDetail,
+      clearTask: clearTask,
+    );
+  }
+
+  void updateDownloadRate(String filename, ModelDownloadProgress detail) {
+    final now = DateTime.now();
+    final previousBytes = _lastDownloadedBytes[filename];
+    final previousSampleAt = _lastDownloadSampleAt[filename];
+
+    if (previousBytes != null && previousSampleAt != null) {
+      final elapsedMs = now.difference(previousSampleAt).inMilliseconds;
+      final deltaBytes = detail.downloadedBytes - previousBytes;
+      if (elapsedMs > 0 && deltaBytes > 0) {
+        final instantRate = (deltaBytes * 1000.0) / elapsedMs;
+        final previousRate = _smoothedDownloadRateBytesPerSec[filename];
+        _smoothedDownloadRateBytesPerSec[filename] = previousRate == null
+            ? instantRate
+            : ((previousRate * 0.72) + (instantRate * 0.28));
+      }
+    }
+
+    _lastDownloadedBytes[filename] = detail.downloadedBytes;
+    _lastDownloadSampleAt[filename] = now;
+  }
+
+  String? transferLabel(String filename, ModelDownloadProgress detail) {
+    final bytesPerSecond = _smoothedDownloadRateBytesPerSec[filename];
+    if (bytesPerSecond == null || bytesPerSecond <= 0) {
+      return null;
+    }
+
+    final speedLabel = _formatByteRate(bytesPerSecond);
+    final totalBytes = detail.totalBytes;
+    if (totalBytes == null || totalBytes <= 0) {
+      return speedLabel;
+    }
+
+    final remainingBytes = totalBytes - detail.downloadedBytes;
+    if (remainingBytes <= 0) {
+      return speedLabel;
+    }
+
+    final etaSeconds = (remainingBytes / bytesPerSecond).ceil();
+    final etaLabel = _formatEta(Duration(seconds: etaSeconds));
+    return '$speedLabel | $etaLabel left';
+  }
+
+  void clearTracking(String filename) {
+    _lastDownloadedBytes.remove(filename);
+    _lastDownloadSampleAt.remove(filename);
+    _smoothedDownloadRateBytesPerSec.remove(filename);
+  }
+
+  void clearRateTracking() {
+    _lastDownloadedBytes.clear();
+    _lastDownloadSampleAt.clear();
+    _smoothedDownloadRateBytesPerSec.clear();
+  }
+
+  void cancel(String filename) {
+    _downloadControllers[filename]?.cancel();
+  }
+
+  void pauseActiveDownloads() {
+    for (final controller in _downloadControllers.values) {
+      if (controller.snapshot.isRunning) {
+        controller.cancel();
+      }
+    }
+  }
+
+  Future<void> disposeDownload(
+    String filename, {
+    ModelDownloadController? controller,
+    StreamSubscription<ModelDownloadTaskSnapshot>? subscription,
+  }) async {
+    final currentSubscription = _downloadSubscriptions[filename];
+    if (subscription == null || identical(currentSubscription, subscription)) {
+      await _downloadSubscriptions.remove(filename)?.cancel();
+    } else {
+      await subscription.cancel();
+    }
+
+    final currentController = _downloadControllers[filename];
+    if (controller == null || identical(currentController, controller)) {
+      await _downloadControllers.remove(filename)?.dispose();
+    } else {
+      await controller.dispose();
+    }
+  }
+
+  Future<void> disposeDownloads() async {
+    for (final subscription in _downloadSubscriptions.values) {
+      await subscription.cancel();
+    }
+    _downloadSubscriptions.clear();
+    for (final controller in _downloadControllers.values) {
+      await controller.dispose();
+    }
+    _downloadControllers.clear();
+  }
+
+  void clearUiState() {
+    for (final notifier in _uiStateByFile.values) {
+      notifier.dispose();
+    }
+    _uiStateByFile.clear();
+  }
+
+  void dispose() {
+    pauseActiveDownloads();
+    for (final subscription in _downloadSubscriptions.values) {
+      unawaited(subscription.cancel());
+    }
+    _downloadSubscriptions.clear();
+    for (final controller in _downloadControllers.values) {
+      unawaited(controller.dispose());
+    }
+    _downloadControllers.clear();
+    clearUiState();
+    clearRateTracking();
+  }
+}
+
+class ModelDownloadUiState {
+  final bool isDownloading;
+  final double progress;
+  final ModelDownloadProgress? detail;
+  final ModelDownloadTaskSnapshot? task;
+
+  const ModelDownloadUiState({
+    this.isDownloading = false,
+    this.progress = 0.0,
+    this.detail,
+    this.task,
+  });
+
+  ModelDownloadUiState copyWith({
+    bool? isDownloading,
+    double? progress,
+    ModelDownloadProgress? detail,
+    ModelDownloadTaskSnapshot? task,
+    bool clearDetail = false,
+    bool clearTask = false,
+  }) {
+    final normalizedProgress =
+        ((progress ?? this.progress).clamp(0.0, 1.0) as num).toDouble();
+
+    return ModelDownloadUiState(
+      isDownloading: isDownloading ?? this.isDownloading,
+      progress: normalizedProgress,
+      detail: clearDetail ? null : (detail ?? this.detail),
+      task: clearTask ? null : (task ?? this.task),
+    );
+  }
+}
+
+String downloadStageLabel(ModelDownloadProgress detail, {required bool isWeb}) {
+  final actionText = detail.resumed
+      ? (isWeb ? 'Resuming cache' : 'Resuming')
+      : (isWeb ? 'Caching' : 'Downloading');
+  final stageText = switch (detail.stage) {
+    ModelDownloadStage.model => '$actionText model',
+    ModelDownloadStage.multimodalProjector => '$actionText mmproj',
+  };
+
+  if (detail.stageCount > 1) {
+    return '$stageText (${detail.stageIndex}/${detail.stageCount})';
+  }
+  return stageText;
+}
+
+String? downloadTaskLabel(
+  ModelDownloadTaskSnapshot? task, {
+  required bool isWeb,
+}) {
+  if (task == null) {
+    return null;
+  }
+  return switch (task.stage) {
+    ModelDownloadTaskStage.idle => null,
+    ModelDownloadTaskStage.resolving => 'Resolving model',
+    ModelDownloadTaskStage.checkingCache => 'Checking cache',
+    ModelDownloadTaskStage.downloading =>
+      isWeb ? 'Caching model' : 'Downloading model',
+    ModelDownloadTaskStage.verifying => 'Verifying model',
+    ModelDownloadTaskStage.ready => 'Ready',
+    ModelDownloadTaskStage.failed => task.errorMessage ?? 'Download failed',
+    ModelDownloadTaskStage.cancelled => 'Paused',
+  };
+}
+
+String _formatByteRate(double bytesPerSecond) {
+  if (bytesPerSecond >= 1024 * 1024 * 1024) {
+    return '${(bytesPerSecond / (1024 * 1024 * 1024)).toStringAsFixed(2)} GB/s';
+  }
+  if (bytesPerSecond >= 1024 * 1024) {
+    return '${(bytesPerSecond / (1024 * 1024)).toStringAsFixed(2)} MB/s';
+  }
+  if (bytesPerSecond >= 1024) {
+    return '${(bytesPerSecond / 1024).toStringAsFixed(1)} KB/s';
+  }
+  return '${bytesPerSecond.toStringAsFixed(0)} B/s';
+}
+
+String _formatEta(Duration duration) {
+  if (duration.inHours > 0) {
+    final minutes = duration.inMinutes.remainder(60).toString().padLeft(2, '0');
+    return '${duration.inHours}h ${minutes}m';
+  }
+  if (duration.inMinutes > 0) {
+    final seconds = duration.inSeconds.remainder(60).toString().padLeft(2, '0');
+    return '${duration.inMinutes}m ${seconds}s';
+  }
+  return '${duration.inSeconds}s';
+}

--- a/example/chat_app/lib/services/model_download_ui_controller.dart
+++ b/example/chat_app/lib/services/model_download_ui_controller.dart
@@ -160,9 +160,8 @@ class ModelDownloadUiController {
 
   void clearUiState() {
     for (final notifier in _uiStateByFile.values) {
-      notifier.dispose();
+      notifier.value = const ModelDownloadUiState();
     }
-    _uiStateByFile.clear();
   }
 
   void dispose() {
@@ -175,7 +174,10 @@ class ModelDownloadUiController {
       unawaited(controller.dispose());
     }
     _downloadControllers.clear();
-    clearUiState();
+    for (final notifier in _uiStateByFile.values) {
+      notifier.dispose();
+    }
+    _uiStateByFile.clear();
     clearRateTracking();
   }
 }

--- a/example/chat_app/lib/services/model_service_io.dart
+++ b/example/chat_app/lib/services/model_service_io.dart
@@ -1,6 +1,7 @@
 import 'dart:io';
 
 import 'package:dio/dio.dart';
+import 'package:llamadart/llamadart.dart' as llama;
 import 'package:path/path.dart' as p;
 import 'package:path_provider/path_provider.dart';
 
@@ -32,12 +33,25 @@ class ModelServiceIO implements ModelService {
 
   @override
   Future<String> getModelsDirectory() async {
-    final dir = await getApplicationCacheDirectory();
-    final modelsDir = Directory(p.join(dir.path, 'models'));
+    final modelsDir = Directory(await _defaultModelsDirectory());
     if (!await modelsDir.exists()) {
       await modelsDir.create(recursive: true);
     }
     return modelsDir.path;
+  }
+
+  Future<String> _defaultModelsDirectory() async {
+    if (Platform.isAndroid || Platform.isIOS) {
+      final dir = await getApplicationCacheDirectory();
+      return p.join(dir.path, 'models');
+    }
+
+    try {
+      return llama.DefaultModelDownloadManager.auto().defaultCacheDirectory;
+    } catch (_) {
+      final dir = await getApplicationCacheDirectory();
+      return p.join(dir.path, 'models');
+    }
   }
 
   @override

--- a/example/chat_app/lib/services/model_service_web.dart
+++ b/example/chat_app/lib/services/model_service_web.dart
@@ -3,6 +3,7 @@ import 'dart:js_interop';
 import 'dart:js_interop_unsafe';
 
 import 'package:dio/dio.dart';
+import 'package:llamadart/llamadart.dart' as llama;
 import 'package:shared_preferences/shared_preferences.dart';
 
 import '../models/downloadable_model.dart';
@@ -159,7 +160,7 @@ class ModelServiceWeb implements ModelService, WebCachePrefetchModelService {
       return;
     }
     if (pendingAssets.any(
-      (asset) => _hasPersistentCacheSensitiveUrlParts(asset.source.url),
+      (asset) => llama.hasPersistentCacheSensitiveUrlParts(asset.source.url),
     )) {
       onError(
         UnsupportedError(
@@ -366,35 +367,6 @@ class ModelServiceWeb implements ModelService, WebCachePrefetchModelService {
       return pendingAssets.single.source.sizeBytes;
     }
     return null;
-  }
-
-  bool _hasPersistentCacheSensitiveUrlParts(String value) {
-    final uri = Uri.tryParse(value);
-    if (uri == null) {
-      return false;
-    }
-    if (uri.userInfo.isNotEmpty || uri.fragment.isNotEmpty) {
-      return true;
-    }
-    // Only block queries that look like signed credentials. Benign flags such
-    // as Hugging Face's `?download=true` are safe to persist in the cache key.
-    const benignQueryKeys = {'download'};
-    return uri.queryParameters.keys.any((key) {
-      final lower = key.toLowerCase();
-      if (benignQueryKeys.contains(lower)) {
-        return false;
-      }
-      return lower.contains('token') ||
-          lower.contains('sig') ||
-          lower.contains('signature') ||
-          lower.contains('expires') ||
-          lower.contains('credential') ||
-          lower.contains('key') ||
-          lower.contains('secret') ||
-          lower.contains('auth') ||
-          lower.contains('session') ||
-          lower.startsWith('x-amz');
-    });
   }
 
   /// Awaits the bridge-readiness signal published by `web/index.html`.

--- a/example/chat_app/lib/services/model_service_web.dart
+++ b/example/chat_app/lib/services/model_service_web.dart
@@ -23,21 +23,40 @@ class ModelServiceWeb implements ModelService, WebCachePrefetchModelService {
     final downloaded = prefs.getStringList(_downloadedModelsKey) ?? const [];
     final markers = ModelAssetCacheMarkers(downloaded);
     final cachedModels = <String>{};
-    var migratedLegacyMarkers = false;
+    final cache = await _openModelCache();
+    var markersChanged = false;
 
     for (final model in models) {
+      markersChanged =
+          await _syncMarkersWithCache(
+            markers,
+            _remoteSourcesFor(model),
+            cache: cache,
+          ) ||
+          markersChanged;
+
       if (markers.isProfileCached(model, web: true)) {
         cachedModels.add(model.filename);
         continue;
       }
 
       if (markers.migrateLegacyProfileMarker(model, web: true)) {
+        markersChanged = true;
+        markersChanged =
+            await _syncMarkersWithCache(
+              markers,
+              _remoteSourcesFor(model),
+              cache: cache,
+            ) ||
+            markersChanged;
+      }
+
+      if (markers.isProfileCached(model, web: true)) {
         cachedModels.add(model.filename);
-        migratedLegacyMarkers = true;
       }
     }
 
-    if (migratedLegacyMarkers) {
+    if (markersChanged) {
       await prefs.setStringList(_downloadedModelsKey, markers.toSet().toList());
     }
 
@@ -50,7 +69,17 @@ class ModelServiceWeb implements ModelService, WebCachePrefetchModelService {
   ) async {
     final prefs = await SharedPreferences.getInstance();
     final downloaded = prefs.getStringList(_downloadedModelsKey) ?? const [];
-    return ModelAssetCacheMarkers(downloaded).modelCacheState(model, web: true);
+    final markers = ModelAssetCacheMarkers(downloaded);
+    final cache = await _openModelCache();
+    final changed = await _syncMarkersWithCache(
+      markers,
+      _remoteSourcesFor(model),
+      cache: cache,
+    );
+    if (changed) {
+      await prefs.setStringList(_downloadedModelsKey, markers.toSet().toList());
+    }
+    return markers.modelCacheState(model, web: true);
   }
 
   List<ModelAssetSource> _assetSourcesFor(DownloadableModel model) {
@@ -90,7 +119,16 @@ class ModelServiceWeb implements ModelService, WebCachePrefetchModelService {
     final downloaded =
         prefs.getStringList(_downloadedModelsKey)?.toSet() ?? <String>{};
     final markers = ModelAssetCacheMarkers(downloaded);
-    if (markers.migrateLegacyProfileMarker(model, web: true)) {
+    final cache = await _openModelCache();
+    var markersChanged = markers.migrateLegacyProfileMarker(model, web: true);
+    markersChanged =
+        await _syncMarkersWithCache(
+          markers,
+          _remoteSourcesFor(model),
+          cache: cache,
+        ) ||
+        markersChanged;
+    if (markersChanged) {
       await prefs.setStringList(_downloadedModelsKey, markers.toSet().toList());
     }
     final pendingAssets = <_PendingWebCacheAsset>[
@@ -185,6 +223,12 @@ class ModelServiceWeb implements ModelService, WebCachePrefetchModelService {
           onProgress: onProgress,
           onProgressDetail: onProgressDetail,
         );
+        if (!await _isRemoteAssetInCache(asset.source, cache: cache)) {
+          throw StateError(
+            'Browser cache prefetch completed, but ${asset.source.filename} '
+            'was not found in Cache Storage. Reload the page and try again.',
+          );
+        }
         markers.markAssetCached(asset.source);
         await prefs.setStringList(
           _downloadedModelsKey,
@@ -252,6 +296,60 @@ class ModelServiceWeb implements ModelService, WebCachePrefetchModelService {
       }
       final openMember = (caches as JSObject).getProperty<JSAny?>('open'.toJS);
       return openMember != null && openMember.isA<JSFunction>();
+    } catch (_) {
+      return false;
+    }
+  }
+
+  Future<bool> _syncMarkersWithCache(
+    ModelAssetCacheMarkers markers,
+    Iterable<RemoteModelAssetSource> sources, {
+    _BrowserCache? cache,
+  }) async {
+    var changed = false;
+    for (final source in sources) {
+      final marked = markers.containsAsset(source);
+      final cached = await _isRemoteAssetInCache(source, cache: cache);
+      if (cached && !marked) {
+        markers.markAssetCached(source);
+        changed = true;
+      } else if (!cached && marked) {
+        markers.removeAssets(<RemoteModelAssetSource>[source]);
+        changed = true;
+      }
+    }
+    return changed;
+  }
+
+  Future<_BrowserCache?> _openModelCache() async {
+    if (!_hasCacheStorageApi()) {
+      return null;
+    }
+
+    try {
+      final caches = globalContext.getProperty<JSAny?>('caches'.toJS);
+      if (caches == null || !caches.isA<JSObject>()) {
+        return null;
+      }
+      final cacheStorage = caches as _BrowserCacheStorage;
+      return await cacheStorage.open(_modelCacheName).toDart;
+    } catch (_) {
+      return null;
+    }
+  }
+
+  Future<bool> _isRemoteAssetInCache(
+    RemoteModelAssetSource source, {
+    _BrowserCache? cache,
+  }) async {
+    final modelCache = cache ?? await _openModelCache();
+    if (modelCache == null) {
+      return false;
+    }
+
+    try {
+      final response = await modelCache.match(source.url).toDart;
+      return response != null;
     } catch (_) {
       return false;
     }
@@ -597,6 +695,14 @@ extension type _WebModelCacheOptions._(JSObject _) implements JSObject {
     JSString? cacheName,
     JSFunction? progressCallback,
   });
+}
+
+extension type _BrowserCacheStorage._(JSObject _) implements JSObject {
+  external JSPromise<_BrowserCache> open(String cacheName);
+}
+
+extension type _BrowserCache._(JSObject _) implements JSObject {
+  external JSPromise<JSAny?> match(String request);
 }
 
 ModelService createModelService() => ModelServiceWeb();

--- a/example/chat_app/lib/services/runtime_profile_service.dart
+++ b/example/chat_app/lib/services/runtime_profile_service.dart
@@ -45,16 +45,22 @@ class RuntimeProfileService {
       runtimeModelSource: _metadataValue(
         metadata,
         'llamadart.webgpu.model_source',
+        fallbackKey: 'llamadart.litert_lm_web.model_source',
       ),
       runtimeModelCacheState: _metadataValue(
         metadata,
         'llamadart.webgpu.model_cache_state',
+        fallbackKey: 'llamadart.litert_lm_web.model_cache_state',
       ),
     );
   }
 
-  String? _metadataValue(Map<String, String> metadata, String key) {
-    final value = metadata[key]?.trim();
+  String? _metadataValue(
+    Map<String, String> metadata,
+    String key, {
+    String? fallbackKey,
+  }) {
+    final value = (metadata[key] ?? metadata[fallbackKey])?.trim();
     if (value == null || value.isEmpty) {
       return null;
     }

--- a/example/chat_app/lib/widgets/model_card.dart
+++ b/example/chat_app/lib/widgets/model_card.dart
@@ -18,10 +18,12 @@ class ModelCard extends StatelessWidget {
   final int contextSize;
   final ValueChanged<int> onGpuLayersChanged;
   final ValueChanged<int> onContextSizeChanged;
-  final VoidCallback onSelect;
+  final VoidCallback? onSelect;
   final VoidCallback onDownload;
   final VoidCallback onDelete;
   final VoidCallback? onCancel;
+  final bool includeProjector;
+  final ValueChanged<bool>? onIncludeProjectorChanged;
 
   const ModelCard({
     super.key,
@@ -42,6 +44,8 @@ class ModelCard extends StatelessWidget {
     required this.onDownload,
     required this.onDelete,
     this.onCancel,
+    this.includeProjector = true,
+    this.onIncludeProjectorChanged,
   });
 
   @override
@@ -49,7 +53,14 @@ class ModelCard extends StatelessWidget {
     final colorScheme = Theme.of(context).colorScheme;
     const webLargeModelWarningThresholdBytes = 1900 * 1024 * 1024;
     final isWebLiteRtLmModel = isWeb && _isLiteRtLmModel(model);
-    final canLoadModel = isDownloaded || isWebLiteRtLmModel;
+    final isModelCached =
+        isDownloaded || (cacheState?.model.isAvailable ?? false);
+    final projectorSource = model.multimodalProjectorSourceFor(web: isWeb);
+    final hasProjector = projectorSource != null;
+    final isProjectorCached =
+        cacheState?.multimodalProjector?.isAvailable ?? false;
+    final isProjectorMissing = hasProjector && !isProjectorCached;
+    final canLoadModel = isModelCached || isWebLiteRtLmModel;
     final effectiveModelSizeBytes = model.sizeBytesFor(web: isWeb);
     final showWebLargeModelWarning =
         isWeb && effectiveModelSizeBytes >= webLargeModelWarningThresholdBytes;
@@ -62,16 +73,25 @@ class ModelCard extends StatelessWidget {
         !isWeb &&
         (defaultTargetPlatform == TargetPlatform.android ||
             defaultTargetPlatform == TargetPlatform.iOS);
+    final shouldShowProjectorOption =
+        isProjectorMissing &&
+        !isDownloading &&
+        onIncludeProjectorChanged != null &&
+        !isWebLiteRtLmModel;
+    final shouldShowProjectorDownloadAction =
+        canLoadModel && isProjectorMissing && includeProjector;
+    final willLoadTextOnly = canLoadModel && isProjectorMissing;
+    final clampedProgress = progress.clamp(0.0, 1.0).toDouble();
 
     return Container(
       decoration: BoxDecoration(
         color: colorScheme.surfaceContainer,
-        borderRadius: BorderRadius.circular(20),
+        borderRadius: BorderRadius.circular(8),
         border: Border.all(
-          color: colorScheme.outlineVariant.withValues(alpha: 0.1),
+          color: colorScheme.outlineVariant.withValues(alpha: 0.24),
         ),
       ),
-      padding: const EdgeInsets.all(20),
+      padding: const EdgeInsets.all(16),
       child: Column(
         crossAxisAlignment: CrossAxisAlignment.start,
         children: [
@@ -262,6 +282,50 @@ class ModelCard extends StatelessWidget {
             ),
           ],
           const SizedBox(height: 12),
+          if (shouldShowProjectorOption) ...[
+            Divider(
+              height: 1,
+              color: colorScheme.outlineVariant.withValues(alpha: 0.35),
+            ),
+            const SizedBox(height: 10),
+            Row(
+              children: [
+                Icon(
+                  Icons.visibility_outlined,
+                  size: 18,
+                  color: colorScheme.onSurfaceVariant,
+                ),
+                const SizedBox(width: 10),
+                Expanded(
+                  child: Text(
+                    isWeb ? 'Cache projector for media' : 'Download projector',
+                    maxLines: 1,
+                    overflow: TextOverflow.ellipsis,
+                    style: TextStyle(
+                      fontSize: 13,
+                      color: colorScheme.onSurface,
+                      fontWeight: FontWeight.w600,
+                    ),
+                  ),
+                ),
+                Switch(
+                  value: includeProjector,
+                  onChanged: onIncludeProjectorChanged,
+                ),
+              ],
+            ),
+            Text(
+              'Off keeps this model text-only and skips the mmproj file.',
+              maxLines: 2,
+              overflow: TextOverflow.ellipsis,
+              style: TextStyle(
+                fontSize: 11,
+                height: 1.25,
+                color: colorScheme.onSurfaceVariant,
+              ),
+            ),
+            const SizedBox(height: 12),
+          ],
           Wrap(
             spacing: 8,
             runSpacing: 8,
@@ -285,30 +349,40 @@ class ModelCard extends StatelessWidget {
           const SizedBox(height: 16),
           if (isDownloading || (progress > 0 && !isDownloaded)) ...[
             ClipRRect(
-              borderRadius: BorderRadius.circular(8),
+              borderRadius: BorderRadius.circular(4),
               child: LinearProgressIndicator(
-                value: progress,
+                value: clampedProgress,
                 backgroundColor: colorScheme.surfaceContainerHighest,
+                minHeight: 7,
               ),
             ),
             const SizedBox(height: 8),
             Row(
-              mainAxisAlignment: MainAxisAlignment.spaceBetween,
               children: [
-                Text(
-                  isDownloading
-                      ? (downloadStatusLabel ??
-                            (isWeb ? 'Caching model...' : 'Downloading...'))
-                      : 'Paused',
-                  style: TextStyle(
-                    fontSize: 12,
-                    color: isDownloading ? colorScheme.primary : Colors.orange,
+                Expanded(
+                  child: Text(
+                    isDownloading
+                        ? (downloadStatusLabel ??
+                              (isWeb ? 'Caching model...' : 'Downloading...'))
+                        : 'Paused',
+                    maxLines: 2,
+                    overflow: TextOverflow.ellipsis,
+                    style: TextStyle(
+                      fontSize: 12,
+                      height: 1.2,
+                      color: isDownloading
+                          ? colorScheme.primary
+                          : Colors.orange,
+                      fontWeight: FontWeight.w600,
+                    ),
                   ),
                 ),
+                const SizedBox(width: 12),
                 Row(
+                  mainAxisSize: MainAxisSize.min,
                   children: [
                     Text(
-                      '${(progress * 100).toStringAsFixed(0)}%',
+                      '${(clampedProgress * 100).toStringAsFixed(0)}%',
                       style: TextStyle(
                         fontSize: 12,
                         color: isDownloading
@@ -345,6 +419,8 @@ class ModelCard extends StatelessWidget {
               const SizedBox(height: 6),
               Text(
                 downloadTransferLabel!,
+                maxLines: 2,
+                overflow: TextOverflow.ellipsis,
                 style: TextStyle(
                   fontSize: 11,
                   color: colorScheme.onSurfaceVariant,
@@ -488,15 +564,19 @@ class ModelCard extends StatelessWidget {
                             : isWeb
                             ? (isSelected
                                   ? 'Reload Cached Model'
+                                  : willLoadTextOnly
+                                  ? 'Use Text Only'
                                   : 'Use Cached Model')
                             : (isSelected
                                   ? 'Reload Selected Model'
+                                  : willLoadTextOnly
+                                  ? 'Use Text Only'
                                   : 'Use this model'),
                       ),
                       style: FilledButton.styleFrom(
                         padding: const EdgeInsets.symmetric(vertical: 16),
                         shape: RoundedRectangleBorder(
-                          borderRadius: BorderRadius.circular(12),
+                          borderRadius: BorderRadius.circular(8),
                         ),
                       ),
                     )
@@ -514,21 +594,46 @@ class ModelCard extends StatelessWidget {
                                   ? 'Resume Cache'
                                   : hasPartialCache
                                   ? 'Cache Missing Assets'
+                                  : isProjectorMissing && !includeProjector
+                                  ? 'Cache Model Only'
+                                  : isProjectorMissing
+                                  ? 'Cache Model + Projector'
                                   : 'Cache Model')
                             : (progress > 0
                                   ? 'Resume Download'
                                   : hasPartialCache
                                   ? 'Download Missing Assets'
+                                  : isProjectorMissing && !includeProjector
+                                  ? 'Download Model Only'
+                                  : isProjectorMissing
+                                  ? 'Download Model + Projector'
                                   : 'Download'),
                       ),
                       style: OutlinedButton.styleFrom(
                         padding: const EdgeInsets.symmetric(vertical: 16),
                         shape: RoundedRectangleBorder(
-                          borderRadius: BorderRadius.circular(12),
+                          borderRadius: BorderRadius.circular(8),
                         ),
                       ),
                     ),
             ),
+            if (shouldShowProjectorDownloadAction) ...[
+              const SizedBox(height: 8),
+              SizedBox(
+                width: double.infinity,
+                child: OutlinedButton.icon(
+                  onPressed: onDownload,
+                  icon: const Icon(Icons.visibility_outlined, size: 18),
+                  label: Text(isWeb ? 'Cache Projector' : 'Download Projector'),
+                  style: OutlinedButton.styleFrom(
+                    padding: const EdgeInsets.symmetric(vertical: 14),
+                    shape: RoundedRectangleBorder(
+                      borderRadius: BorderRadius.circular(8),
+                    ),
+                  ),
+                ),
+              ),
+            ],
           ],
         ],
       ),
@@ -587,7 +692,7 @@ class ModelCard extends StatelessWidget {
       padding: const EdgeInsets.symmetric(horizontal: 8, vertical: 4),
       decoration: BoxDecoration(
         color: background,
-        borderRadius: BorderRadius.circular(8),
+        borderRadius: BorderRadius.circular(6),
       ),
       child: Row(
         mainAxisSize: MainAxisSize.min,
@@ -625,7 +730,7 @@ class ModelCard extends StatelessWidget {
       padding: const EdgeInsets.symmetric(horizontal: 8, vertical: 4),
       decoration: BoxDecoration(
         color: background,
-        borderRadius: BorderRadius.circular(8),
+        borderRadius: BorderRadius.circular(6),
         border: supported
             ? null
             : Border.all(
@@ -662,7 +767,7 @@ class ModelCard extends StatelessWidget {
       padding: const EdgeInsets.symmetric(horizontal: 8, vertical: 4),
       decoration: BoxDecoration(
         color: colorScheme.tertiaryContainer.withValues(alpha: 0.45),
-        borderRadius: BorderRadius.circular(8),
+        borderRadius: BorderRadius.circular(6),
       ),
       child: Text(
         label,

--- a/example/chat_app/lib/widgets/model_card.dart
+++ b/example/chat_app/lib/widgets/model_card.dart
@@ -559,8 +559,12 @@ class ModelCard extends StatelessWidget {
                       label: Text(
                         isWebLiteRtLmModel
                             ? (isSelected
-                                  ? 'Reload Web Model'
-                                  : 'Load Web Model')
+                                  ? isModelCached
+                                        ? 'Reload Cached Model'
+                                        : 'Reload Web Model'
+                                  : isModelCached
+                                  ? 'Use Cached Model'
+                                  : 'Load & Cache Model')
                             : isWeb
                             ? (isSelected
                                   ? 'Reload Cached Model'

--- a/example/chat_app/lib/widgets/welcome_view.dart
+++ b/example/chat_app/lib/widgets/welcome_view.dart
@@ -8,7 +8,7 @@ class WelcomeView extends StatelessWidget {
   final bool isLoaded;
   final double loadingProgress;
   final VoidCallback onRetry;
-  final VoidCallback onSelectModel;
+  final VoidCallback? onSelectModel;
 
   const WelcomeView({
     super.key,
@@ -25,135 +25,203 @@ class WelcomeView extends StatelessWidget {
   Widget build(BuildContext context) {
     if (isInitializing) {
       return Center(
-        child: Column(
-          mainAxisAlignment: MainAxisAlignment.center,
-          children: [
-            if (loadingProgress > 0)
-              SizedBox(
-                width: 200,
-                child: LinearProgressIndicator(value: loadingProgress),
-              )
-            else
-              const CircularProgressIndicator(),
-            const SizedBox(height: 24),
-            Text(
-              loadingProgress > 0
-                  ? 'Loading Model: ${(loadingProgress * 100).toStringAsFixed(0)}%'
-                  : 'Loading Model...',
-              style: GoogleFonts.outfit(
-                fontSize: 18,
-                color: Theme.of(context).colorScheme.secondary,
-              ),
+        child: ConstrainedBox(
+          constraints: const BoxConstraints(maxWidth: 420),
+          child: Padding(
+            padding: const EdgeInsets.all(24),
+            child: Column(
+              mainAxisSize: MainAxisSize.min,
+              children: [
+                if (loadingProgress > 0)
+                  ClipRRect(
+                    borderRadius: BorderRadius.circular(999),
+                    child: LinearProgressIndicator(
+                      value: loadingProgress,
+                      minHeight: 8,
+                    ),
+                  )
+                else
+                  const CircularProgressIndicator(),
+                const SizedBox(height: 18),
+                Text(
+                  loadingProgress > 0
+                      ? 'Loading model ${(loadingProgress * 100).toStringAsFixed(0)}%'
+                      : 'Loading model...',
+                  style: GoogleFonts.outfit(
+                    fontSize: 16,
+                    fontWeight: FontWeight.w600,
+                    color: Theme.of(context).colorScheme.secondary,
+                  ),
+                ),
+              ],
             ),
-          ],
+          ),
         ),
       );
     }
+
+    final colorScheme = Theme.of(context).colorScheme;
+    final selectedModelName = modelPath?.split('/').last;
 
     if (error != null) {
       return Center(
-        child: Container(
-          margin: const EdgeInsets.all(32),
-          padding: const EdgeInsets.all(24),
-          decoration: BoxDecoration(
-            color: Theme.of(
-              context,
-            ).colorScheme.errorContainer.withValues(alpha: 0.5),
-            borderRadius: BorderRadius.circular(24),
-            border: Border.all(
-              color: Theme.of(context).colorScheme.error.withValues(alpha: 0.2),
+        child: ConstrainedBox(
+          constraints: const BoxConstraints(maxWidth: 520),
+          child: Container(
+            margin: const EdgeInsets.all(24),
+            padding: const EdgeInsets.all(20),
+            decoration: BoxDecoration(
+              color: colorScheme.errorContainer.withValues(alpha: 0.5),
+              borderRadius: BorderRadius.circular(16),
+              border: Border.all(
+                color: colorScheme.error.withValues(alpha: 0.2),
+              ),
             ),
-          ),
-          child: Column(
-            mainAxisSize: MainAxisSize.min,
-            children: [
-              Icon(
-                Icons.error_rounded,
-                size: 48,
-                color: Theme.of(context).colorScheme.error,
-              ),
-              const SizedBox(height: 16),
-              Text(
-                'Something went wrong',
-                style: GoogleFonts.outfit(
-                  fontSize: 18,
-                  fontWeight: FontWeight.bold,
-                  color: Theme.of(context).colorScheme.error,
+            child: Column(
+              mainAxisSize: MainAxisSize.min,
+              children: [
+                Icon(Icons.error_rounded, size: 40, color: colorScheme.error),
+                const SizedBox(height: 14),
+                Text(
+                  'Model failed to load',
+                  style: GoogleFonts.outfit(
+                    fontSize: 18,
+                    fontWeight: FontWeight.bold,
+                    color: colorScheme.error,
+                  ),
                 ),
-              ),
-              const SizedBox(height: 8),
-              Text(
-                error!,
-                textAlign: TextAlign.center,
-                style: TextStyle(
-                  color: Theme.of(context).colorScheme.onErrorContainer,
+                const SizedBox(height: 8),
+                Text(
+                  error!,
+                  textAlign: TextAlign.center,
+                  style: TextStyle(color: colorScheme.onErrorContainer),
                 ),
-              ),
-              const SizedBox(height: 24),
-              FilledButton.icon(
-                onPressed: onRetry,
-                icon: const Icon(Icons.refresh_rounded),
-                label: const Text('Retry'),
-              ),
-            ],
+                const SizedBox(height: 18),
+                Wrap(
+                  spacing: 10,
+                  runSpacing: 10,
+                  alignment: WrapAlignment.center,
+                  children: [
+                    FilledButton.icon(
+                      onPressed: onRetry,
+                      icon: const Icon(Icons.refresh_rounded),
+                      label: const Text('Retry'),
+                    ),
+                    if (onSelectModel != null)
+                      OutlinedButton.icon(
+                        onPressed: onSelectModel,
+                        icon: const Icon(Icons.tune_rounded),
+                        label: const Text('Change model'),
+                      ),
+                  ],
+                ),
+              ],
+            ),
           ),
         ),
       );
     }
 
+    final canSelectModel = onSelectModel != null;
+
     return Center(
-      child: Column(
-        mainAxisAlignment: MainAxisAlignment.center,
-        children: [
-          Container(
-            padding: const EdgeInsets.all(32),
-            decoration: BoxDecoration(
-              color: Theme.of(
-                context,
-              ).colorScheme.primaryContainer.withValues(alpha: 0.3),
-              shape: BoxShape.circle,
-            ),
-            child: Icon(
-              Icons.chat_bubble_outline_rounded,
-              size: 64,
-              color: Theme.of(context).colorScheme.primary,
-            ),
-          ),
-          const SizedBox(height: 32),
-          Text(
-            'Start a conversation',
-            style: GoogleFonts.outfit(
-              fontSize: 24,
-              fontWeight: FontWeight.bold,
-            ),
-          ),
-          const SizedBox(height: 12),
-          Text(
-            modelPath != null
-                ? (isLoaded
-                      ? 'Model Loaded: ${modelPath!.split('/').last}'
-                      : 'Model Selected: ${modelPath!.split('/').last}')
-                : 'No model selected',
-            style: TextStyle(color: Theme.of(context).colorScheme.secondary),
-          ),
-          const SizedBox(height: 32),
-          if (!isLoaded)
-            FilledButton.icon(
-              onPressed: modelPath == null ? onSelectModel : onRetry,
-              style: FilledButton.styleFrom(
-                padding: const EdgeInsets.symmetric(
-                  horizontal: 32,
-                  vertical: 16,
+      child: ConstrainedBox(
+        constraints: const BoxConstraints(maxWidth: 520),
+        child: Padding(
+          padding: const EdgeInsets.all(24),
+          child: Column(
+            mainAxisSize: MainAxisSize.min,
+            children: [
+              Container(
+                padding: const EdgeInsets.all(18),
+                decoration: BoxDecoration(
+                  color: colorScheme.primaryContainer.withValues(alpha: 0.25),
+                  borderRadius: BorderRadius.circular(18),
+                  border: Border.all(
+                    color: colorScheme.outlineVariant.withValues(alpha: 0.35),
+                  ),
+                ),
+                child: Icon(
+                  Icons.chat_bubble_outline_rounded,
+                  size: 42,
+                  color: colorScheme.primary,
                 ),
               ),
-              icon: Icon(
-                modelPath == null
-                    ? Icons.file_open_rounded
-                    : Icons.power_settings_new_rounded,
+              const SizedBox(height: 22),
+              Text(
+                isLoaded ? 'Ready to chat' : 'Load a model to begin',
+                textAlign: TextAlign.center,
+                style: GoogleFonts.outfit(
+                  fontSize: 24,
+                  fontWeight: FontWeight.bold,
+                ),
               ),
-              label: Text(modelPath == null ? 'Select Model' : 'Load Model'),
-            ),
-        ],
+              const SizedBox(height: 12),
+              Container(
+                width: double.infinity,
+                padding: const EdgeInsets.symmetric(
+                  horizontal: 14,
+                  vertical: 12,
+                ),
+                decoration: BoxDecoration(
+                  color: colorScheme.surfaceContainerHighest.withValues(
+                    alpha: 0.36,
+                  ),
+                  borderRadius: BorderRadius.circular(12),
+                  border: Border.all(
+                    color: colorScheme.outlineVariant.withValues(alpha: 0.35),
+                  ),
+                ),
+                child: Row(
+                  children: [
+                    Icon(
+                      selectedModelName == null
+                          ? Icons.folder_open_rounded
+                          : Icons.sd_storage_outlined,
+                      size: 18,
+                      color: colorScheme.secondary,
+                    ),
+                    const SizedBox(width: 10),
+                    Expanded(
+                      child: Text(
+                        selectedModelName ?? 'No model selected',
+                        maxLines: 1,
+                        overflow: TextOverflow.ellipsis,
+                        style: TextStyle(color: colorScheme.onSurfaceVariant),
+                      ),
+                    ),
+                  ],
+                ),
+              ),
+              const SizedBox(height: 20),
+              if (!isLoaded && (canSelectModel || modelPath != null))
+                Wrap(
+                  spacing: 10,
+                  runSpacing: 10,
+                  alignment: WrapAlignment.center,
+                  children: [
+                    FilledButton.icon(
+                      onPressed: modelPath == null ? onSelectModel : onRetry,
+                      icon: Icon(
+                        modelPath == null
+                            ? Icons.file_open_rounded
+                            : Icons.power_settings_new_rounded,
+                      ),
+                      label: Text(
+                        modelPath == null ? 'Select model' : 'Load model',
+                      ),
+                    ),
+                    if (modelPath != null && canSelectModel)
+                      OutlinedButton.icon(
+                        onPressed: onSelectModel,
+                        icon: const Icon(Icons.tune_rounded),
+                        label: const Text('Change model'),
+                      ),
+                  ],
+                ),
+            ],
+          ),
+        ),
       ),
     );
   }

--- a/example/chat_app/pubspec.lock
+++ b/example/chat_app/pubspec.lock
@@ -349,7 +349,7 @@ packages:
       path: "../.."
       relative: true
     source: path
-    version: "0.8.10"
+    version: "0.8.13"
   logging:
     dependency: transitive
     description:
@@ -386,10 +386,10 @@ packages:
     dependency: transitive
     description:
       name: meta
-      sha256: "23f08335362185a5ea2ad3a4e597f1375e78bce8a040df5c600c8d3552ef2394"
+      sha256: "1741988757a65eb6b36abe716829688cf01910bbf91c34354ff7ec1c3de2b349"
       url: "https://pub.dev"
     source: hosted
-    version: "1.17.0"
+    version: "1.18.0"
   mime:
     dependency: transitive
     description:
@@ -719,26 +719,26 @@ packages:
     dependency: "direct dev"
     description:
       name: test
-      sha256: "280d6d890011ca966ad08df7e8a4ddfab0fb3aa49f96ed6de56e3521347a9ae7"
+      sha256: "8d9ceddbab833f180fbefed08afa76d7c03513dfdba87ffcec2718b02bbcbf20"
       url: "https://pub.dev"
     source: hosted
-    version: "1.30.0"
+    version: "1.31.0"
   test_api:
     dependency: transitive
     description:
       name: test_api
-      sha256: "8161c84903fd860b26bfdefb7963b3f0b68fee7adea0f59ef805ecca346f0c7a"
+      sha256: "949a932224383300f01be9221c39180316445ecb8e7547f70a41a35bf421fb9e"
       url: "https://pub.dev"
     source: hosted
-    version: "0.7.10"
+    version: "0.7.11"
   test_core:
     dependency: transitive
     description:
       name: test_core
-      sha256: "0381bd1585d1a924763c308100f2138205252fb90c9d4eeaf28489ee65ccde51"
+      sha256: "1991d4cfe85d5043241acac92962c3977c8d2f2add1ee73130c7b286417d1d34"
       url: "https://pub.dev"
     source: hosted
-    version: "0.6.16"
+    version: "0.6.17"
   typed_data:
     dependency: transitive
     description:

--- a/example/chat_app/test/app_shell_screen_test.dart
+++ b/example/chat_app/test/app_shell_screen_test.dart
@@ -51,6 +51,41 @@ void main() {
       expect(find.text('New conversation'), findsWidgets);
 
       expect(find.text('Inference parameters'), findsOneWidget);
+      expect(find.text('Change model'), findsNothing);
+    });
+
+    testWidgets('shows change model action when settings panel is hidden', (
+      tester,
+    ) async {
+      final oldSize = tester.view.physicalSize;
+      final oldRatio = tester.view.devicePixelRatio;
+
+      tester.view
+        ..physicalSize = const Size(1024, 820)
+        ..devicePixelRatio = 1.0;
+
+      addTearDown(() {
+        tester.view
+          ..physicalSize = oldSize
+          ..devicePixelRatio = oldRatio;
+      });
+
+      final provider = ChatProvider(
+        chatService: MockChatService(),
+        settingsService: MockSettingsService(),
+        initialSettings: const ChatSettings(modelPath: 'test_model.gguf'),
+      );
+
+      await tester.pumpWidget(
+        ChangeNotifierProvider<ChatProvider>.value(
+          value: provider,
+          child: const MaterialApp(home: AppShellScreen()),
+        ),
+      );
+
+      await tester.pumpAndSettle();
+
+      expect(find.text('Change model'), findsOneWidget);
     });
   });
 }

--- a/example/chat_app/test/chat_service_test.dart
+++ b/example/chat_app/test/chat_service_test.dart
@@ -183,6 +183,26 @@ void main() {
       },
     );
 
+    test('can skip LiteRT-LM runtime warmup during model load', () async {
+      final engine = MockLlamaEngine();
+      final service = ChatService(engine: engine);
+
+      await service.init(
+        const ChatSettings(
+          modelPath: 'gemma-4-E2B-it.litertlm',
+          preferredBackend: GpuBackend.auto,
+          contextSize: 8192,
+          maxTokens: 32,
+          gpuLayers: 0,
+        ),
+        eagerLoadMultimodalProjector: false,
+        eagerWarmUpLiteRtLmRuntime: false,
+      );
+
+      expect(engine.lastModelParams, isNotNull);
+      expect(engine.createCalls, 0);
+    });
+
     test('keeps explicit CPU loads on LiteRT-LM models', () async {
       debugDefaultTargetPlatformOverride = TargetPlatform.android;
       final engine = MockLlamaEngine();

--- a/example/chat_app/test/mocks.dart
+++ b/example/chat_app/test/mocks.dart
@@ -256,6 +256,7 @@ class MockChatService extends ChatService {
     ChatSettings settings, {
     Function(double progress)? onProgress,
     bool eagerLoadMultimodalProjector = true,
+    bool eagerWarmUpLiteRtLmRuntime = true,
   }) async {
     if (settings.modelPath == null || settings.modelPath!.isEmpty) {
       throw Exception("Invalid model path");

--- a/example/chat_app/test/model_card_test.dart
+++ b/example/chat_app/test/model_card_test.dart
@@ -70,11 +70,12 @@ void main() {
     expect(find.textContaining('very large LiteRT-LM'), findsNothing);
   });
 
-  testWidgets('partial multimodal cache shows missing mmproj state', (
+  testWidgets('partial multimodal cache allows text-only load', (
     tester,
   ) async {
     var downloadCalls = 0;
     var deleteCalls = 0;
+    var includeProjector = true;
 
     await _pumpCard(
       tester,
@@ -96,6 +97,8 @@ void main() {
       onSelect: () {},
       onDownload: () => downloadCalls += 1,
       onDelete: () => deleteCalls += 1,
+      includeProjector: includeProjector,
+      onIncludeProjectorChanged: (value) => includeProjector = value,
     );
 
     expect(find.text('Model cached'), findsOneWidget);
@@ -106,10 +109,12 @@ void main() {
       ),
       findsOneWidget,
     );
-    expect(find.text('Download Missing Assets'), findsOneWidget);
+    expect(find.text('Download projector'), findsOneWidget);
+    expect(find.text('Use Text Only'), findsOneWidget);
+    expect(find.text('Download Projector'), findsOneWidget);
     expect(find.byTooltip('Delete cached assets'), findsOneWidget);
 
-    await tester.tap(find.text('Download Missing Assets'));
+    await tester.tap(find.text('Download Projector'));
     await tester.pump();
 
     expect(downloadCalls, 1);
@@ -119,6 +124,32 @@ void main() {
 
     expect(deleteCalls, 1);
   });
+
+  testWidgets('download progress row does not overflow narrow cards', (
+    tester,
+  ) async {
+    tester.view.physicalSize = const Size(320, 900);
+    tester.view.devicePixelRatio = 1.0;
+    addTearDown(tester.view.resetPhysicalSize);
+    addTearDown(tester.view.resetDevicePixelRatio);
+
+    await _pumpCard(
+      tester,
+      model: _vlmModel(),
+      isWeb: true,
+      isDownloaded: false,
+      isDownloading: true,
+      progress: 0.67,
+      downloadStatusLabel:
+          'Caching multimodal projector with an unusually long status label (2/2)',
+      downloadTransferLabel: '123.45 MB/s | 12m 34s left',
+      onSelect: () {},
+      onDownload: () {},
+    );
+
+    expect(tester.takeException(), isNull);
+    expect(find.byTooltip('Pause Download'), findsOneWidget);
+  });
 }
 
 Future<void> _pumpCard(
@@ -127,9 +158,15 @@ Future<void> _pumpCard(
   required bool isWeb,
   required bool isDownloaded,
   ModelProfileCacheState? cacheState,
+  bool isDownloading = false,
+  double progress = 0,
+  String? downloadStatusLabel,
+  String? downloadTransferLabel,
   required VoidCallback onSelect,
   required VoidCallback onDownload,
   VoidCallback? onDelete,
+  bool includeProjector = true,
+  ValueChanged<bool>? onIncludeProjectorChanged,
 }) async {
   await tester.pumpWidget(
     MaterialApp(
@@ -139,8 +176,10 @@ Future<void> _pumpCard(
             model: model,
             isDownloaded: isDownloaded,
             cacheState: cacheState,
-            isDownloading: false,
-            progress: 0,
+            isDownloading: isDownloading,
+            progress: progress,
+            downloadStatusLabel: downloadStatusLabel,
+            downloadTransferLabel: downloadTransferLabel,
             isWeb: isWeb,
             isSelected: false,
             gpuLayers: 0,
@@ -150,6 +189,8 @@ Future<void> _pumpCard(
             onSelect: onSelect,
             onDownload: onDownload,
             onDelete: onDelete ?? () {},
+            includeProjector: includeProjector,
+            onIncludeProjectorChanged: onIncludeProjectorChanged,
           ),
         ),
       ),

--- a/example/chat_app/test/model_card_test.dart
+++ b/example/chat_app/test/model_card_test.dart
@@ -5,7 +5,7 @@ import 'package:llamadart_chat_example/services/model_service_base.dart';
 import 'package:llamadart_chat_example/widgets/model_card.dart';
 
 void main() {
-  testWidgets('web LiteRT-LM presets load directly instead of showing cache', (
+  testWidgets('web LiteRT-LM presets load and cache on first use', (
     tester,
   ) async {
     var selectCalls = 0;
@@ -20,14 +20,36 @@ void main() {
       onDownload: () => downloadCalls += 1,
     );
 
-    expect(find.text('Load Web Model'), findsOneWidget);
+    expect(find.text('Load & Cache Model'), findsOneWidget);
     expect(find.text('Cache Model'), findsNothing);
 
-    await tester.tap(find.text('Load Web Model'));
+    await tester.tap(find.text('Load & Cache Model'));
     await tester.pump();
 
     expect(selectCalls, 1);
     expect(downloadCalls, 0);
+  });
+
+  testWidgets('web LiteRT-LM cached presets show cached load action', (
+    tester,
+  ) async {
+    var selectCalls = 0;
+
+    await _pumpCard(
+      tester,
+      model: _litertLmModel(),
+      isWeb: true,
+      isDownloaded: true,
+      onSelect: () => selectCalls += 1,
+      onDownload: () {},
+    );
+
+    expect(find.text('Use Cached Model'), findsOneWidget);
+
+    await tester.tap(find.text('Use Cached Model'));
+    await tester.pump();
+
+    expect(selectCalls, 1);
   });
 
   testWidgets('web GGUF presets still show the cache action before download', (
@@ -70,9 +92,7 @@ void main() {
     expect(find.textContaining('very large LiteRT-LM'), findsNothing);
   });
 
-  testWidgets('partial multimodal cache allows text-only load', (
-    tester,
-  ) async {
+  testWidgets('partial multimodal cache allows text-only load', (tester) async {
     var downloadCalls = 0;
     var deleteCalls = 0;
     var includeProjector = true;

--- a/example/chat_app/test/model_download_controller_adapter_test.dart
+++ b/example/chat_app/test/model_download_controller_adapter_test.dart
@@ -127,6 +127,28 @@ void main() {
       },
     );
 
+    test('can download only the base model without projector', () async {
+      final model = _remoteVlmModel();
+      final service = _FakeModelService();
+      final manager = ChatAppModelDownloadManager(
+        modelService: service,
+        model: model,
+        modelsDir: '/models',
+        includeProjector: false,
+      );
+
+      await manager.ensureModel(
+        manager.source,
+        options: llama.ModelLoadOptions(
+          cachePolicy: llama.ModelCachePolicy.refresh,
+        ),
+      );
+
+      expect(service.downloadCalls, 1);
+      expect(service.lastModel?.filename, model.filename);
+      expect(service.lastModel?.multimodalProjectorSource, isNull);
+    });
+
     test(
       'bridges controller cancellation into the chat app Dio cancel token',
       () async {
@@ -163,6 +185,19 @@ DownloadableModel _remoteModel() {
     url: 'https://example.com/tiny.gguf?token=secret',
     filename: 'tiny.gguf',
     sizeBytes: 10,
+  );
+}
+
+DownloadableModel _remoteVlmModel() {
+  return const DownloadableModel(
+    name: 'Tiny VLM Test Model',
+    description: 'Small fake VLM for adapter tests.',
+    url: 'https://example.com/tiny-vlm.gguf?download=true',
+    filename: 'tiny-vlm.gguf',
+    mmprojUrl: 'https://example.com/tiny-mmproj.gguf?download=true',
+    mmprojFilename: 'tiny-mmproj.gguf',
+    sizeBytes: 10,
+    supportsVision: true,
   );
 }
 

--- a/example/chat_app/test/model_download_ui_controller_test.dart
+++ b/example/chat_app/test/model_download_ui_controller_test.dart
@@ -1,0 +1,31 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:llamadart_chat_example/services/model_download_ui_controller.dart';
+
+void main() {
+  group('ModelDownloadUiController', () {
+    test('clearUiState resets active notifiers without disposing them', () {
+      final controller = ModelDownloadUiController();
+      addTearDown(controller.dispose);
+
+      final notifier = controller.listenableFor('model.gguf');
+      var notifications = 0;
+      void listener() {
+        notifications += 1;
+      }
+
+      notifier.addListener(listener);
+      controller.updateState('model.gguf', isDownloading: true, progress: 0.5);
+
+      controller.clearUiState();
+
+      expect(notifier.value.isDownloading, isFalse);
+      expect(notifier.value.progress, 0);
+      expect(notifications, greaterThanOrEqualTo(2));
+
+      notifier.removeListener(listener);
+      controller.updateState('model.gguf', progress: 0.25);
+
+      expect(notifier.value.progress, 0.25);
+    });
+  });
+}

--- a/example/chat_app/test/runtime_profile_service_test.dart
+++ b/example/chat_app/test/runtime_profile_service_test.dart
@@ -36,6 +36,21 @@ void main() {
       expect(diagnostics.runtimeModelCacheState, 'hit');
     });
 
+    test(
+      'uses LiteRT-LM web cache diagnostics when WebGPU keys are absent',
+      () {
+        final diagnostics = service.buildDiagnostics(
+          metadata: const <String, String>{
+            'llamadart.litert_lm_web.model_source': 'cache',
+            'llamadart.litert_lm_web.model_cache_state': 'hit',
+          },
+        );
+
+        expect(diagnostics.runtimeModelSource, 'cache');
+        expect(diagnostics.runtimeModelCacheState, 'hit');
+      },
+    );
+
     test('returns fallback estimate when VRAM unavailable', () {
       final estimate = service.estimateDynamicSettings(
         totalVramBytes: 0,

--- a/example/chat_app/test/unit_test.dart
+++ b/example/chat_app/test/unit_test.dart
@@ -369,31 +369,33 @@ void main() {
       expect(provider.currentTokens, 1);
     });
 
-    test('web remote load skips cache prefetch for .litertlm models', () async {
-      final webEngine = MockLlamaEngine();
-      final modelService = _RecordingModelService();
-      final webProvider = ChatProvider(
-        chatService: ChatService(engine: webEngine),
-        settingsService: mockSettingsService,
-        modelService: modelService,
-        enableWebModelPrefetch: true,
-        initialSettings: const ChatSettings(
-          modelPath: 'https://example.com/models/gemma-4-E2B-it-web.litertlm',
-        ),
-      );
-      addTearDown(webProvider.dispose);
+    test(
+      'web remote load prefetches .litertlm models before runtime load',
+      () async {
+        final webEngine = MockLlamaEngine();
+        final modelService = _RecordingModelService();
+        final webProvider = ChatProvider(
+          chatService: ChatService(engine: webEngine),
+          settingsService: mockSettingsService,
+          modelService: modelService,
+          enableWebModelPrefetch: true,
+          initialSettings: const ChatSettings(
+            modelPath:
+                'https://example.com/models/gemma-4-E2B-it-web.litertlm?download=true',
+          ),
+        );
+        addTearDown(webProvider.dispose);
 
-      await webProvider.loadModel();
+        await webProvider.loadModel();
 
-      // The @litert-lm/core engine fetches the URL itself and cannot read the
-      // WebGPU CacheStorage bucket the prefetch fills, so prefetching would
-      // download the whole model an extra time. It must be skipped for
-      // .litertlm (a .gguf URL still prefetches; see the test above).
-      expect(modelService.downloadCalls, 0);
-      expect(webEngine.lastLoadedModelUrl, webProvider.settings.modelPath);
-      expect(webProvider.isLoaded, isTrue);
-      expect(webProvider.error, isNull);
-    });
+        // LiteRT-LM web can consume cached browser bytes as a Blob, so the app
+        // should prefetch once and let the backend initialize from CacheStorage.
+        expect(modelService.downloadCalls, 1);
+        expect(webEngine.lastLoadedModelUrl, webProvider.settings.modelPath);
+        expect(webProvider.isLoaded, isTrue);
+        expect(webProvider.error, isNull);
+      },
+    );
 
     test(
       'sendMessage swallows unsupported getTokenCount without an error bubble',

--- a/example/chat_app/test/welcome_view_test.dart
+++ b/example/chat_app/test/welcome_view_test.dart
@@ -1,0 +1,59 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:llamadart_chat_example/widgets/welcome_view.dart';
+
+void main() {
+  Widget buildSubject({
+    required String? modelPath,
+    required VoidCallback? onSelectModel,
+    required VoidCallback onRetry,
+  }) {
+    return MaterialApp(
+      home: Scaffold(
+        body: WelcomeView(
+          isInitializing: false,
+          error: null,
+          modelPath: modelPath,
+          isLoaded: false,
+          onRetry: onRetry,
+          onSelectModel: onSelectModel,
+        ),
+      ),
+    );
+  }
+
+  testWidgets(
+    'shows load action for selected model without selector callback',
+    (tester) async {
+      var retried = false;
+
+      await tester.pumpWidget(
+        buildSubject(
+          modelPath: '/models/tiny.gguf',
+          onSelectModel: null,
+          onRetry: () {
+            retried = true;
+          },
+        ),
+      );
+
+      expect(find.widgetWithText(FilledButton, 'Load model'), findsOneWidget);
+      expect(find.widgetWithText(OutlinedButton, 'Change model'), findsNothing);
+
+      await tester.tap(find.widgetWithText(FilledButton, 'Load model'));
+      expect(retried, isTrue);
+    },
+  );
+
+  testWidgets('hides model actions when no model or selector is available', (
+    tester,
+  ) async {
+    await tester.pumpWidget(
+      buildSubject(modelPath: null, onSelectModel: null, onRetry: () {}),
+    );
+
+    expect(find.widgetWithText(FilledButton, 'Load model'), findsNothing);
+    expect(find.widgetWithText(FilledButton, 'Select model'), findsNothing);
+    expect(find.widgetWithText(OutlinedButton, 'Change model'), findsNothing);
+  });
+}

--- a/example/chat_app/web/index.html
+++ b/example/chat_app/web/index.html
@@ -71,8 +71,7 @@
           const flutterLikeKeys = keys.filter((key) =>
             key.startsWith('flutter-') ||
             key.startsWith('workbox-') ||
-            key.includes('flutter-app-cache') ||
-            key.includes('llamadart-webgpu')
+            key.includes('flutter-app-cache')
           );
           await Promise.allSettled(
             flutterLikeKeys.map((key) => caches.delete(key)),

--- a/lib/llamadart.dart
+++ b/lib/llamadart.dart
@@ -98,6 +98,7 @@ export 'src/core/models/diagnostics/model_file_type.dart';
 
 // Utils
 export 'src/core/exceptions.dart';
+export 'src/core/cache_policy.dart' show hasPersistentCacheSensitiveUrlParts;
 
 // LiteRT-LM native APIs
 export 'src/backends/litert_lm/litert_lm_backend_stub.dart'

--- a/lib/src/backends/litert_lm/litert_lm_backend_web.dart
+++ b/lib/src/backends/litert_lm/litert_lm_backend_web.dart
@@ -10,6 +10,7 @@ import 'dart:math' as math;
 import 'package:web/web.dart';
 
 import '../../core/models/chat/content_part.dart';
+import '../../core/cache_policy.dart';
 import '../../core/models/config/flash_attention.dart';
 import '../../core/models/config/gpu_backend.dart';
 import '../../core/models/config/kv_cache_type.dart';
@@ -865,7 +866,7 @@ class LiteRtLmBackend
         uri.host.isEmpty) {
       return null;
     }
-    if (_urlHasPersistentCacheSensitiveParts(sourceUrl)) {
+    if (hasPersistentCacheSensitiveUrlParts(sourceUrl)) {
       return null;
     }
 
@@ -885,36 +886,6 @@ class LiteRtLmBackend
     } catch (_) {
       return null;
     }
-  }
-
-  bool _urlHasPersistentCacheSensitiveParts(String value) {
-    final uri = Uri.tryParse(value);
-    if (uri == null ||
-        (uri.scheme != 'http' && uri.scheme != 'https') ||
-        uri.host.isEmpty) {
-      return false;
-    }
-    if (uri.userInfo.isNotEmpty || uri.fragment.isNotEmpty) {
-      return true;
-    }
-
-    const benignQueryKeys = {'download'};
-    return uri.queryParameters.keys.any((key) {
-      final lower = key.toLowerCase();
-      if (benignQueryKeys.contains(lower)) {
-        return false;
-      }
-      return lower.contains('token') ||
-          lower.contains('sig') ||
-          lower.contains('signature') ||
-          lower.contains('expires') ||
-          lower.contains('credential') ||
-          lower.contains('key') ||
-          lower.contains('secret') ||
-          lower.contains('auth') ||
-          lower.contains('session') ||
-          lower.startsWith('x-amz');
-    });
   }
 
   Stream<String> _withScopedConsoleGuardedStream(Stream<String> source) async* {

--- a/lib/src/backends/litert_lm/litert_lm_backend_web.dart
+++ b/lib/src/backends/litert_lm/litert_lm_backend_web.dart
@@ -35,6 +35,8 @@ class LiteRtLmBackend
         BackendStatePersistenceSupport {
   static const Duration _engineReadyTimeout = Duration(seconds: 12);
   static const Duration _enginePollInterval = Duration(milliseconds: 100);
+  static const String _defaultModelCacheName =
+      'llamadart-webgpu-model-cache-v1';
   // The current @litert-lm/core web API accepts one string prompt and applies
   // the model's chat wrapper internally. Until the JS API exposes structured
   // messages/tools, keep the Dart template intentionally single-turn.
@@ -52,6 +54,7 @@ class LiteRtLmBackend
 
   _LiteRtLmWebEngine? _engine;
   _LiteRtLmWebConversation? _activeConversation;
+  LlamaLogLevel _logLevel = LlamaLogLevel.warn;
   bool _isReady = false;
   bool _hasContext = false;
   bool _cancelRequested = false;
@@ -61,6 +64,8 @@ class LiteRtLmBackend
   int? _contextHandle;
   ModelParams? _modelParams;
   String? _modelUrl;
+  String? _modelSource;
+  String? _modelCacheState;
   String? _activeBackend;
   String? _chatTemplate;
 
@@ -109,19 +114,25 @@ class LiteRtLmBackend
 
     onProgress?.call(0);
     final constructor = await _ensureEngineConstructor();
+    final cachedModelBlob = await _cachedModelBlobFor(url);
+    final modelValue = cachedModelBlob ?? url.toJS;
     final settings = _createEngineSettings(
-      model: url,
+      model: modelValue,
       params: params,
       backend: backend,
     );
 
     await _disposeEngine();
     _modelUrl = url;
+    _modelSource = cachedModelBlob == null ? 'network' : 'cache';
+    _modelCacheState = cachedModelBlob == null ? 'miss' : 'hit';
     _modelParams = params;
     _chatTemplate = params.chatTemplate;
     _activeBackend = backend;
     _hasContext = false;
 
+    _setLiteRtLmConsoleLogLevel();
+    final consoleGuard = _installScopedConsoleGuard();
     try {
       _engine = await constructor.create(settings).toDart;
       _modelHandle = _nextModelHandle++;
@@ -133,10 +144,14 @@ class LiteRtLmBackend
       _modelHandle = null;
       _contextHandle = null;
       _modelUrl = null;
+      _modelSource = null;
+      _modelCacheState = null;
       _modelParams = null;
       _chatTemplate = null;
       _activeBackend = null;
       throw StateError('LiteRT-LM web engine creation failed: $error');
+    } finally {
+      consoleGuard?.restore();
     }
   }
 
@@ -205,7 +220,9 @@ class LiteRtLmBackend
         .where((sequence) => sequence.isNotEmpty)
         .toList(growable: false);
     try {
-      final stream = _streamConversation(conversation, prompt);
+      final stream = _withScopedConsoleGuardedStream(
+        _streamConversation(conversation, prompt),
+      );
       await for (final chunk in _applyStopSequences(
         stream,
         stopSequences,
@@ -281,6 +298,12 @@ class LiteRtLmBackend
     if (_modelParams case final params?) {
       metadata['llm.context_length'] = params.contextSize.toString();
     }
+    if (_modelSource case final source?) {
+      metadata['llamadart.litert_lm_web.model_source'] = source;
+    }
+    if (_modelCacheState case final state?) {
+      metadata['llamadart.litert_lm_web.model_cache_state'] = state;
+    }
     final activeBackend = _activeBackend;
     if (activeBackend != null) {
       metadata['litert_lm.backend'] = activeBackend;
@@ -331,7 +354,10 @@ class LiteRtLmBackend
   }
 
   @override
-  Future<void> setLogLevel(LlamaLogLevel level) async {}
+  Future<void> setLogLevel(LlamaLogLevel level) async {
+    _logLevel = level;
+    _setLiteRtLmConsoleLogLevel();
+  }
 
   @override
   Future<void> dispose() async {
@@ -522,12 +548,12 @@ class LiteRtLmBackend
   }
 
   JSObject _createEngineSettings({
-    required String model,
+    required JSAny model,
     required ModelParams params,
     required String backend,
   }) {
     final settings = JSObject();
-    settings.setProperty('model'.toJS, model.toJS);
+    settings.setProperty('model'.toJS, model);
     settings.setProperty('backend'.toJS, _backendValueFor(backend).toJS);
 
     final executorSettings = JSObject();
@@ -797,6 +823,8 @@ class LiteRtLmBackend
     _modelHandle = null;
     _contextHandle = null;
     _modelUrl = null;
+    _modelSource = null;
+    _modelCacheState = null;
     _modelParams = null;
     _chatTemplate = null;
     _activeBackend = null;
@@ -828,6 +856,181 @@ class LiteRtLmBackend
         'LiteRtLmBackend web expects a .litertlm model URL/path; got $source',
       );
     }
+  }
+
+  Future<Blob?> _cachedModelBlobFor(String sourceUrl) async {
+    final uri = Uri.tryParse(sourceUrl);
+    if (uri == null ||
+        (uri.scheme != 'http' && uri.scheme != 'https') ||
+        uri.host.isEmpty) {
+      return null;
+    }
+    if (_urlHasPersistentCacheSensitiveParts(sourceUrl)) {
+      return null;
+    }
+
+    try {
+      final caches = globalContext.getProperty<JSAny?>('caches'.toJS);
+      if (caches == null || !caches.isA<JSObject>()) {
+        return null;
+      }
+
+      final cache = await window.caches.open(_defaultModelCacheName).toDart;
+      final cachedResponse = await cache.match(sourceUrl.toJS).toDart;
+      if (cachedResponse == null) {
+        return null;
+      }
+
+      return await cachedResponse.blob().toDart;
+    } catch (_) {
+      return null;
+    }
+  }
+
+  bool _urlHasPersistentCacheSensitiveParts(String value) {
+    final uri = Uri.tryParse(value);
+    if (uri == null ||
+        (uri.scheme != 'http' && uri.scheme != 'https') ||
+        uri.host.isEmpty) {
+      return false;
+    }
+    if (uri.userInfo.isNotEmpty || uri.fragment.isNotEmpty) {
+      return true;
+    }
+
+    const benignQueryKeys = {'download'};
+    return uri.queryParameters.keys.any((key) {
+      final lower = key.toLowerCase();
+      if (benignQueryKeys.contains(lower)) {
+        return false;
+      }
+      return lower.contains('token') ||
+          lower.contains('sig') ||
+          lower.contains('signature') ||
+          lower.contains('expires') ||
+          lower.contains('credential') ||
+          lower.contains('key') ||
+          lower.contains('secret') ||
+          lower.contains('auth') ||
+          lower.contains('session') ||
+          lower.startsWith('x-amz');
+    });
+  }
+
+  Stream<String> _withScopedConsoleGuardedStream(Stream<String> source) async* {
+    _setLiteRtLmConsoleLogLevel();
+    final consoleGuard = _installScopedConsoleGuard();
+    try {
+      await for (final chunk in source) {
+        yield chunk;
+      }
+    } finally {
+      consoleGuard?.restore();
+    }
+  }
+
+  void _setLiteRtLmConsoleLogLevel() {
+    globalContext.setProperty(
+      '__llamadartLiteRtLmLogLevel'.toJS,
+      _logLevel.index.toJS,
+    );
+  }
+
+  _LiteRtLmConsoleGuard? _installScopedConsoleGuard() {
+    _ensureConsoleGuardInstaller();
+    final rawInstaller = globalContext.getProperty<JSAny?>(
+      '__llamadartInstallLiteRtLmConsoleGuard'.toJS,
+    );
+    if (rawInstaller == null || !rawInstaller.isA<JSFunction>()) {
+      return null;
+    }
+
+    try {
+      final rawGuard = (rawInstaller as JSFunction).callAsFunction(null);
+      if (rawGuard != null && rawGuard.isA<JSObject>()) {
+        return _LiteRtLmConsoleGuard._(rawGuard as JSObject);
+      }
+    } catch (_) {
+      return null;
+    }
+    return null;
+  }
+
+  void _ensureConsoleGuardInstaller() {
+    if (globalContext.has('__llamadartInstallLiteRtLmConsoleGuard')) {
+      return;
+    }
+
+    final script = HTMLScriptElement();
+    script.text = r'''
+(() => {
+  if (window.__llamadartInstallLiteRtLmConsoleGuard) {
+    return;
+  }
+
+  window.__llamadartLiteRtLmLogLevel =
+    Number.isFinite(Number(window.__llamadartLiteRtLmLogLevel))
+      ? Number(window.__llamadartLiteRtLmLogLevel)
+      : 0;
+
+  const methods = ['debug', 'log', 'info', 'warn', 'error'];
+  const methodLevels = { debug: 1, log: 2, info: 2, warn: 3, error: 4 };
+
+  window.__llamadartInstallLiteRtLmConsoleGuard = function () {
+    if (typeof console === 'undefined') {
+      return { restore() {} };
+    }
+
+    const originals = {};
+    const wrappers = {};
+    for (const method of methods) {
+      originals[method] = console[method];
+    }
+
+    function targetFor(method) {
+      const candidate =
+        originals[method] ||
+        (method === 'info' ? originals.log : undefined) ||
+        originals.log ||
+        originals.error ||
+        originals.warn ||
+        originals.debug;
+      return typeof candidate === 'function' ? candidate : null;
+    }
+
+    for (const method of methods) {
+      const original = originals[method];
+      if (typeof original !== 'function') {
+        continue;
+      }
+      wrappers[method] = function (...args) {
+        const configured = Number(window.__llamadartLiteRtLmLogLevel ?? 0);
+        const threshold = Number.isFinite(configured) ? configured : 0;
+        if (threshold === 0 || threshold > methodLevels[method]) {
+          return;
+        }
+        const target = targetFor(method);
+        if (target) {
+          target.apply(console, args);
+        }
+      };
+      console[method] = wrappers[method];
+    }
+
+    return {
+      restore() {
+        for (const method of methods) {
+          if (wrappers[method] && console[method] === wrappers[method]) {
+            console[method] = originals[method];
+          }
+        }
+      },
+    };
+  };
+})();
+''';
+    document.head?.append(script);
+    script.remove();
   }
 
   String _sourcePath(String source) {
@@ -1085,6 +1288,11 @@ class LiteRtLmBackend
       'LiteRtLmBackend backend must be cpu, gpu, or npu; got $backend',
     );
   }
+}
+
+@JS()
+extension type _LiteRtLmConsoleGuard._(JSObject _) implements JSObject {
+  external void restore();
 }
 
 @JS()

--- a/lib/src/backends/webgpu/webgpu_backend.dart
+++ b/lib/src/backends/webgpu/webgpu_backend.dart
@@ -36,6 +36,8 @@ class WebGpuLlamaBackend
   static const int _gpuMultimodalMaxImagePixels = 1048576;
   static const int _gpuMultimodalMaxImageEdge = 1280;
   static const Duration _webGpuMultimodalWarmupTimeout = Duration(seconds: 12);
+  static const String _defaultModelCacheName =
+      'llamadart-webgpu-model-cache-v1';
   static const String _runtimeLoraUnsupportedMessage =
       'WebGPU LoRA runtime updates are not supported by the current bridge. '
       'Use a native llama.cpp backend when runtime LoRA adapter changes are '
@@ -578,9 +580,27 @@ class WebGpuLlamaBackend
         uri.host.isEmpty) {
       return false;
     }
-    return uri.userInfo.isNotEmpty ||
-        uri.query.isNotEmpty ||
-        uri.fragment.isNotEmpty;
+    if (uri.userInfo.isNotEmpty || uri.fragment.isNotEmpty) {
+      return true;
+    }
+
+    const benignQueryKeys = {'download'};
+    return uri.queryParameters.keys.any((key) {
+      final lower = key.toLowerCase();
+      if (benignQueryKeys.contains(lower)) {
+        return false;
+      }
+      return lower.contains('token') ||
+          lower.contains('sig') ||
+          lower.contains('signature') ||
+          lower.contains('expires') ||
+          lower.contains('credential') ||
+          lower.contains('key') ||
+          lower.contains('secret') ||
+          lower.contains('auth') ||
+          lower.contains('session') ||
+          lower.startsWith('x-amz');
+    });
   }
 
   List<({int contextSize, int gpuLayers})> _buildLoadAttempts({
@@ -972,6 +992,7 @@ class WebGpuLlamaBackend
       requestedContextSize: params.contextSize,
       requestedGpuLayers: requestedGpuLayers,
     );
+    final cachedWebModel = await _isModelResponseCachedForUrl(url);
     Object? lastError;
     Map<String, String> lastRuntimeHints = const <String, String>{};
     var retriedWithWasm32 = false;
@@ -1012,6 +1033,8 @@ class WebGpuLlamaBackend
           forceRemoteFetchBackend = _forceRemoteFetchBackendOverride;
         } else if (_getGlobalBool('__llamadartBridgeForceRemoteFetchBackend')) {
           forceRemoteFetchBackend = true;
+        } else if (cachedWebModel) {
+          forceRemoteFetchBackend = false;
         }
 
         final loadPromise = bridge.loadModelFromUrl(
@@ -2244,23 +2267,85 @@ class WebGpuLlamaBackend
     String mmProjPath,
   ) async {
     final bridge = _requireBridge();
-    final result = await _toFuture(bridge.loadMultimodalProjector(mmProjPath));
-    _mmContextActive = true;
-    _resetWebGpuMultimodalWarmupState();
-    await _ensureWebGpuMultimodalWarmup(
-      bridge,
-      isCpuMultimodalRuntime: _isCpuRuntimeForMultimodal(bridge),
-    );
+    final cachedBlobUrl = await _cachedModelBlobUrlFor(mmProjPath);
+    final projectorPath = cachedBlobUrl ?? mmProjPath;
 
-    if (result == null) {
+    try {
+      final result = await _toFuture(
+        bridge.loadMultimodalProjector(projectorPath),
+      );
+      _mmContextActive = true;
+      _resetWebGpuMultimodalWarmupState();
+      await _ensureWebGpuMultimodalWarmup(
+        bridge,
+        isCpuMultimodalRuntime: _isCpuRuntimeForMultimodal(bridge),
+      );
+
+      if (result == null) {
+        return 1;
+      }
+
+      if (result.isA<JSNumber>()) {
+        return (result as JSNumber).toDartInt;
+      }
+
       return 1;
+    } finally {
+      if (cachedBlobUrl != null) {
+        URL.revokeObjectURL(cachedBlobUrl);
+      }
+    }
+  }
+
+  Future<String?> _cachedModelBlobUrlFor(String sourceUrl) async {
+    final uri = Uri.tryParse(sourceUrl);
+    if (uri == null || !(uri.isScheme('http') || uri.isScheme('https'))) {
+      return null;
+    }
+    if (_urlHasPersistentCacheSensitiveParts(sourceUrl)) {
+      return null;
     }
 
-    if (result.isA<JSNumber>()) {
-      return (result as JSNumber).toDartInt;
+    try {
+      final caches = globalContext.getProperty<JSAny?>('caches'.toJS);
+      if (caches == null || !caches.isA<JSObject>()) {
+        return null;
+      }
+
+      final cache = await window.caches.open(_defaultModelCacheName).toDart;
+      final cachedResponse = await cache.match(sourceUrl.toJS).toDart;
+      if (cachedResponse == null) {
+        return null;
+      }
+
+      final blob = await cachedResponse.blob().toDart;
+      return URL.createObjectURL(blob);
+    } catch (_) {
+      return null;
+    }
+  }
+
+  Future<bool> _isModelResponseCachedForUrl(String sourceUrl) async {
+    final uri = Uri.tryParse(sourceUrl);
+    if (uri == null || !(uri.isScheme('http') || uri.isScheme('https'))) {
+      return false;
+    }
+    if (_urlHasPersistentCacheSensitiveParts(sourceUrl)) {
+      return false;
     }
 
-    return 1;
+    try {
+      final caches = globalContext.getProperty<JSAny?>('caches'.toJS);
+      if (caches == null || !caches.isA<JSObject>()) {
+        return false;
+      }
+
+      final cache = await window.caches.open(_defaultModelCacheName).toDart;
+      final cachedResponse = await cache.match(sourceUrl.toJS).toDart;
+      return cachedResponse != null;
+    } catch (_) {
+      return false;
+    }
   }
 
   @override

--- a/lib/src/backends/webgpu/webgpu_backend.dart
+++ b/lib/src/backends/webgpu/webgpu_backend.dart
@@ -8,6 +8,7 @@ import 'dart:typed_data';
 import 'package:web/web.dart';
 
 import '../../core/models/chat/content_part.dart';
+import '../../core/cache_policy.dart';
 import '../../core/models/config/gpu_backend.dart';
 import '../../core/models/config/llama_cpp_param_values.dart';
 import '../../core/models/config/log_level.dart';
@@ -573,36 +574,6 @@ class WebGpuLlamaBackend
         lowered.contains('error 138');
   }
 
-  bool _urlHasPersistentCacheSensitiveParts(String value) {
-    final uri = Uri.tryParse(value);
-    if (uri == null ||
-        (uri.scheme != 'http' && uri.scheme != 'https') ||
-        uri.host.isEmpty) {
-      return false;
-    }
-    if (uri.userInfo.isNotEmpty || uri.fragment.isNotEmpty) {
-      return true;
-    }
-
-    const benignQueryKeys = {'download'};
-    return uri.queryParameters.keys.any((key) {
-      final lower = key.toLowerCase();
-      if (benignQueryKeys.contains(lower)) {
-        return false;
-      }
-      return lower.contains('token') ||
-          lower.contains('sig') ||
-          lower.contains('signature') ||
-          lower.contains('expires') ||
-          lower.contains('credential') ||
-          lower.contains('key') ||
-          lower.contains('secret') ||
-          lower.contains('auth') ||
-          lower.contains('session') ||
-          lower.startsWith('x-amz');
-    });
-  }
-
   List<({int contextSize, int gpuLayers})> _buildLoadAttempts({
     required int requestedContextSize,
     required int requestedGpuLayers,
@@ -1057,7 +1028,7 @@ class WebGpuLlamaBackend
             ropeFrequencyScale: params.ropeFrequencyScale,
             splitMode: params.splitMode.llamaCppValue,
             mainGpu: params.mainGpu,
-            useCache: !_urlHasPersistentCacheSensitiveParts(url),
+            useCache: !hasPersistentCacheSensitiveUrlParts(url),
             forceRemoteFetchBackend: forceRemoteFetchBackend,
             remoteFetchChunkBytes: remoteFetchChunkBytesOverride,
             modelBytesHint: params.modelBytesHint,
@@ -2302,7 +2273,7 @@ class WebGpuLlamaBackend
     if (uri == null || !(uri.isScheme('http') || uri.isScheme('https'))) {
       return null;
     }
-    if (_urlHasPersistentCacheSensitiveParts(sourceUrl)) {
+    if (hasPersistentCacheSensitiveUrlParts(sourceUrl)) {
       return null;
     }
 
@@ -2330,7 +2301,7 @@ class WebGpuLlamaBackend
     if (uri == null || !(uri.isScheme('http') || uri.isScheme('https'))) {
       return false;
     }
-    if (_urlHasPersistentCacheSensitiveParts(sourceUrl)) {
+    if (hasPersistentCacheSensitiveUrlParts(sourceUrl)) {
       return false;
     }
 

--- a/lib/src/core/cache_policy.dart
+++ b/lib/src/core/cache_policy.dart
@@ -1,0 +1,36 @@
+/// Returns whether [value] contains URL parts that should not be persisted as
+/// browser cache keys.
+///
+/// The browser model cache stores request URLs in CacheStorage. Plain catalog
+/// flags such as Hugging Face's `?download=true` are safe to persist, but
+/// user info, fragments, and credential-like query keys can leak signed or
+/// session-specific material into durable browser storage.
+bool hasPersistentCacheSensitiveUrlParts(String value) {
+  final uri = Uri.tryParse(value);
+  if (uri == null ||
+      (uri.scheme != 'http' && uri.scheme != 'https') ||
+      uri.host.isEmpty) {
+    return false;
+  }
+  if (uri.userInfo.isNotEmpty || uri.fragment.isNotEmpty) {
+    return true;
+  }
+
+  const benignQueryKeys = {'download'};
+  return uri.queryParameters.keys.any((key) {
+    final lower = key.toLowerCase();
+    if (benignQueryKeys.contains(lower)) {
+      return false;
+    }
+    return lower.contains('token') ||
+        lower.contains('sig') ||
+        lower.contains('signature') ||
+        lower.contains('expires') ||
+        lower.contains('credential') ||
+        lower.contains('key') ||
+        lower.contains('secret') ||
+        lower.contains('auth') ||
+        lower.contains('session') ||
+        lower.startsWith('x-amz');
+  });
+}

--- a/lib/src/core/cache_policy.dart
+++ b/lib/src/core/cache_policy.dart
@@ -16,21 +16,48 @@ bool hasPersistentCacheSensitiveUrlParts(String value) {
     return true;
   }
 
-  const benignQueryKeys = {'download'};
   return uri.queryParameters.keys.any((key) {
     final lower = key.toLowerCase();
-    if (benignQueryKeys.contains(lower)) {
+    if (_benignPersistentQueryKeys.contains(lower)) {
       return false;
     }
-    return lower.contains('token') ||
-        lower.contains('sig') ||
-        lower.contains('signature') ||
-        lower.contains('expires') ||
-        lower.contains('credential') ||
-        lower.contains('key') ||
-        lower.contains('secret') ||
-        lower.contains('auth') ||
-        lower.contains('session') ||
-        lower.startsWith('x-amz');
+    if (_sensitivePersistentQueryKeys.contains(lower) ||
+        _sensitivePersistentQueryPrefixes.any(lower.startsWith)) {
+      return true;
+    }
+    final segments = lower.split(RegExp(r'[._-]+'));
+    return segments.any(_sensitivePersistentQueryKeySegments.contains);
   });
 }
+
+const _benignPersistentQueryKeys = {'download'};
+
+const _sensitivePersistentQueryKeys = {
+  'apikey',
+  'authorization',
+  'awsaccesskeyid',
+  'credential',
+  'expires',
+  'key',
+  'key-pair-id',
+  'policy',
+  'secret',
+  'session',
+  'sessionid',
+  'sig',
+  'signature',
+  'token',
+};
+
+const _sensitivePersistentQueryKeySegments = {
+  'auth',
+  'credential',
+  'key',
+  'secret',
+  'session',
+  'sig',
+  'signature',
+  'token',
+};
+
+const _sensitivePersistentQueryPrefixes = {'x-amz', 'x-goog'};

--- a/test/unit/backends/litert_lm/litert_lm_backend_web_test.dart
+++ b/test/unit/backends/litert_lm/litert_lm_backend_web_test.dart
@@ -10,10 +10,12 @@ import 'package:llamadart/src/core/engine/engine.dart';
 import 'package:llamadart/src/core/models/chat/chat_message.dart';
 import 'package:llamadart/src/core/models/chat/chat_role.dart';
 import 'package:llamadart/src/core/models/config/gpu_backend.dart';
+import 'package:llamadart/src/core/models/config/log_level.dart';
 import 'package:llamadart/src/core/models/inference/generation_params.dart';
 import 'package:llamadart/src/core/models/inference/model_params.dart';
 import 'package:llamadart/src/core/template/chat_template_engine.dart';
 import 'package:test/test.dart';
+import 'package:web/web.dart';
 
 void main() {
   setUp(_clearGlobals);
@@ -102,6 +104,88 @@ void main() {
       0.2,
     );
     expect((sampler.getProperty('seed'.toJS) as JSNumber).toDartInt, 42);
+  });
+
+  test('loads cached .litertlm URL through CacheStorage Blob', () async {
+    const cacheName = 'llamadart-webgpu-model-cache-v1';
+    const modelUrl = 'https://example.com/gemma-web.litertlm?download=true';
+    final cache = await window.caches.open(cacheName).toDart;
+    await cache.put(modelUrl.toJS, Response('cached litert'.toJS)).toDart;
+    addTearDown(() async {
+      await window.caches.delete(cacheName).toDart;
+    });
+
+    JSAny? lastModelSetting;
+    _installFakeEngine(
+      onCreate: (settings) {
+        lastModelSetting = settings.getProperty('model'.toJS);
+      },
+      chunks: <JSAny?>[_messageChunk('ok')],
+    );
+
+    final backend = LiteRtLmBackend();
+    final modelHandle = await backend.modelLoadFromUrl(
+      modelUrl,
+      const ModelParams(),
+    );
+
+    expect(lastModelSetting, isNotNull);
+    expect(lastModelSetting!.isA<Blob>(), isTrue);
+    expect(
+      await backend.modelMetadata(modelHandle),
+      containsPair('llamadart.litert_lm_web.model_source', 'cache'),
+    );
+    expect(
+      await backend.modelMetadata(modelHandle),
+      containsPair('llamadart.litert_lm_web.model_cache_state', 'hit'),
+    );
+  });
+
+  test('does not use cached Blob for credential-like .litertlm URLs', () async {
+    const cacheName = 'llamadart-webgpu-model-cache-v1';
+    const modelUrl = 'https://example.com/gemma-web.litertlm?token=secret';
+    final cache = await window.caches.open(cacheName).toDart;
+    await cache.put(modelUrl.toJS, Response('cached litert'.toJS)).toDart;
+    addTearDown(() async {
+      await window.caches.delete(cacheName).toDart;
+    });
+
+    JSAny? lastModelSetting;
+    _installFakeEngine(
+      onCreate: (settings) {
+        lastModelSetting = settings.getProperty('model'.toJS);
+      },
+      chunks: <JSAny?>[_messageChunk('ok')],
+    );
+
+    final backend = LiteRtLmBackend();
+    final modelHandle = await backend.modelLoadFromUrl(
+      modelUrl,
+      const ModelParams(),
+    );
+
+    expect(lastModelSetting, isA<JSString>());
+    expect((lastModelSetting as JSString).toDart, modelUrl);
+    expect(
+      await backend.modelMetadata(modelHandle),
+      containsPair('llamadart.litert_lm_web.model_source', 'network'),
+    );
+    expect(
+      await backend.modelMetadata(modelHandle),
+      containsPair('llamadart.litert_lm_web.model_cache_state', 'miss'),
+    );
+  });
+
+  test('setLogLevel updates LiteRT-LM web console log level', () async {
+    final backend = LiteRtLmBackend();
+
+    await backend.setLogLevel(LlamaLogLevel.error);
+
+    final raw = globalContext.getProperty<JSAny?>(
+      '__llamadartLiteRtLmLogLevel'.toJS,
+    );
+    expect(raw, isA<JSNumber>());
+    expect((raw as JSNumber).toDartInt, LlamaLogLevel.error.index);
   });
 
   test(
@@ -797,4 +881,6 @@ void _clearGlobals() {
   globalContext.delete('__llamadartLiteRtLmModuleSettings'.toJS);
   globalContext.delete('__llamadartLiteRtLmModuleConversationConfig'.toJS);
   globalContext.delete('__llamadartLiteRtLmModulePrompt'.toJS);
+  globalContext.delete('__llamadartLiteRtLmLogLevel'.toJS);
+  globalContext.delete('__llamadartInstallLiteRtLmConsoleGuard'.toJS);
 }

--- a/test/unit/backends/webgpu/webgpu_backend_test.dart
+++ b/test/unit/backends/webgpu/webgpu_backend_test.dart
@@ -11,6 +11,7 @@ import 'package:llamadart/llamadart.dart';
 import 'package:llamadart/src/backends/webgpu/interop.dart';
 import 'package:llamadart/src/backends/webgpu/webgpu_backend.dart';
 import 'package:test/test.dart';
+import 'package:web/web.dart' show Response, window;
 
 @JS('Promise.reject')
 external JSPromise<JSAny?> _rejectPromise(JSAny? reason);
@@ -35,6 +36,8 @@ void main() {
     int? lastRequestedFlashAttention;
     int? lastRequestedCacheTypeK;
     int? lastRequestedCacheTypeV;
+    bool? lastRequestedUseCache;
+    bool? lastRequestedForceRemoteFetchBackend;
     bool? lastRequestedKvUnified;
     double? lastRequestedRopeFrequencyBase;
     double? lastRequestedRopeFrequencyScale;
@@ -48,6 +51,7 @@ void main() {
     String? lastTokenEventEncoding;
     int? lastTokenEventFlushMs;
     int? lastTokenEventFlushChars;
+    String? lastMmprojPath;
     String? lastPrompt;
     String? lastStateSavePath;
     List<int>? lastStateSaveTokens;
@@ -135,6 +139,19 @@ void main() {
         lastRequestedCacheTypeV = (cacheTypeV as JSNumber).toDartInt;
       }
 
+      final useCache = config.getProperty('useCache'.toJS);
+      if (useCache.isA<JSBoolean>()) {
+        lastRequestedUseCache = (useCache as JSBoolean).toDart;
+      }
+
+      final forceRemoteFetchBackend = config.getProperty(
+        'forceRemoteFetchBackend'.toJS,
+      );
+      if (forceRemoteFetchBackend.isA<JSBoolean>()) {
+        lastRequestedForceRemoteFetchBackend =
+            (forceRemoteFetchBackend as JSBoolean).toDart;
+      }
+
       final kvUnified = config.getProperty('kvUnified'.toJS);
       if (kvUnified.isA<JSBoolean>()) {
         lastRequestedKvUnified = (kvUnified as JSBoolean).toDart;
@@ -183,6 +200,8 @@ void main() {
       lastRequestedFlashAttention = null;
       lastRequestedCacheTypeK = null;
       lastRequestedCacheTypeV = null;
+      lastRequestedUseCache = null;
+      lastRequestedForceRemoteFetchBackend = null;
       lastRequestedKvUnified = null;
       lastRequestedRopeFrequencyBase = null;
       lastRequestedRopeFrequencyScale = null;
@@ -196,6 +215,7 @@ void main() {
       lastTokenEventEncoding = null;
       lastTokenEventFlushMs = null;
       lastTokenEventFlushChars = null;
+      lastMmprojPath = null;
       lastPrompt = null;
       lastStateSavePath = null;
       lastStateSaveTokens = null;
@@ -333,6 +353,7 @@ void main() {
         'loadMultimodalProjector'.toJS,
         ((String path) {
           mmLoaded = true;
+          lastMmprojPath = path;
           return Future<JSNumber>.value(1.toJS).toJS;
         }).toJS,
       );
@@ -570,6 +591,42 @@ void main() {
         const ModelParams(),
       );
       expect(capturedPreferMemory64(), isNull);
+    });
+
+    test('keeps cache enabled for benign download query URLs', () async {
+      await backend.modelLoadFromUrl(
+        'https://example.com/model.gguf?download=true',
+        const ModelParams(),
+      );
+
+      expect(lastRequestedUseCache, isTrue);
+    });
+
+    test('disables cache for signed query URLs', () async {
+      await backend.modelLoadFromUrl(
+        'https://example.com/model.gguf?token=secret',
+        const ModelParams(),
+      );
+
+      expect(lastRequestedUseCache, isFalse);
+    });
+
+    test('prefers cached model stream over remote fetch backend', () async {
+      const cacheName = 'llamadart-webgpu-model-cache-v1';
+      const modelUrl = 'https://example.com/model.gguf?download=true';
+      final cache = await window.caches.open(cacheName).toDart;
+      await cache.put(modelUrl.toJS, Response('cached model'.toJS)).toDart;
+      addTearDown(() async {
+        await window.caches.delete(cacheName).toDart;
+      });
+
+      await backend.modelLoadFromUrl(
+        modelUrl,
+        const ModelParams(modelBytesHint: 3 * 1024 * 1024 * 1024),
+      );
+
+      expect(lastRequestedUseCache, isTrue);
+      expect(lastRequestedForceRemoteFetchBackend, isFalse);
     });
 
     test('forwards batch threading and batching model params', () async {
@@ -1686,6 +1743,27 @@ void main() {
       await backend.multimodalContextFree(mmHandle);
       expect(mmLoaded, isFalse);
       expect(await backend.supportsVision(mmHandle), isFalse);
+    });
+
+    test('loads cached projector through blob URL', () async {
+      const cacheName = 'llamadart-webgpu-model-cache-v1';
+      const mmprojUrl = 'https://example.com/mmproj-cached.gguf?download=true';
+      final cache = await window.caches.open(cacheName).toDart;
+      await cache.put(mmprojUrl.toJS, Response('cached projector'.toJS)).toDart;
+      addTearDown(() async {
+        await window.caches.delete(cacheName).toDart;
+      });
+
+      await backend.modelLoadFromUrl(
+        'https://example.com/model.gguf',
+        const ModelParams(),
+      );
+
+      final mmHandle = await backend.multimodalContextCreate(1, mmprojUrl);
+
+      expect(mmHandle, 1);
+      expect(lastMmprojPath, startsWith('blob:'));
+      expect(lastMmprojPath, isNot(mmprojUrl));
     });
 
     test('runs WebGPU multimodal warmup once per projector load', () async {

--- a/test/unit/core/cache_policy_test.dart
+++ b/test/unit/core/cache_policy_test.dart
@@ -22,14 +22,29 @@ void main() {
       const sensitiveUrls = <String>[
         'https://user:pass@example.com/model.gguf',
         'https://example.com/model.gguf#signed-fragment',
+        'https://example.com/model.gguf?access_token=secret',
+        'https://example.com/model.gguf?apiKey=secret',
         'https://example.com/model.gguf?token=secret',
         'https://example.com/model.gguf?X-Amz-Signature=secret',
         'https://example.com/model.gguf?credential=secret',
+        'https://example.com/model.gguf?key-pair-id=secret',
         'https://example.com/model.gguf?session_id=secret',
       ];
 
       for (final url in sensitiveUrls) {
         expect(hasPersistentCacheSensitiveUrlParts(url), isTrue, reason: url);
+      }
+    });
+
+    test('allows benign query keys that contain sensitive substrings', () {
+      const benignUrls = <String>[
+        'https://example.com/model.gguf?design=compact',
+        'https://example.com/model.gguf?author=maintainer',
+        'https://example.com/model.gguf?monkey=banana',
+      ];
+
+      for (final url in benignUrls) {
+        expect(hasPersistentCacheSensitiveUrlParts(url), isFalse, reason: url);
       }
     });
 

--- a/test/unit/core/cache_policy_test.dart
+++ b/test/unit/core/cache_policy_test.dart
@@ -1,0 +1,41 @@
+import 'package:llamadart/llamadart.dart';
+import 'package:test/test.dart';
+
+void main() {
+  group('hasPersistentCacheSensitiveUrlParts', () {
+    test('allows regular model URLs and benign catalog query keys', () {
+      expect(
+        hasPersistentCacheSensitiveUrlParts(
+          'https://example.com/model.gguf?download=true',
+        ),
+        isFalse,
+      );
+      expect(
+        hasPersistentCacheSensitiveUrlParts(
+          'https://example.com/model.litertlm?DOWNLOAD=true',
+        ),
+        isFalse,
+      );
+    });
+
+    test('blocks user info, fragments, and credential-like query keys', () {
+      const sensitiveUrls = <String>[
+        'https://user:pass@example.com/model.gguf',
+        'https://example.com/model.gguf#signed-fragment',
+        'https://example.com/model.gguf?token=secret',
+        'https://example.com/model.gguf?X-Amz-Signature=secret',
+        'https://example.com/model.gguf?credential=secret',
+        'https://example.com/model.gguf?session_id=secret',
+      ];
+
+      for (final url in sensitiveUrls) {
+        expect(hasPersistentCacheSensitiveUrlParts(url), isTrue, reason: url);
+      }
+    });
+
+    test('ignores non-remote values', () {
+      expect(hasPersistentCacheSensitiveUrlParts('/local/model.gguf'), isFalse);
+      expect(hasPersistentCacheSensitiveUrlParts('not a url'), isFalse);
+    });
+  });
+}

--- a/tool/testing/playwright_chat_app_benchmark.py
+++ b/tool/testing/playwright_chat_app_benchmark.py
@@ -14,6 +14,7 @@ from playwright_chat_app_utils import (
     browser_args,
     emit,
     enable_flutter_semantics,
+    enter_chat_prompt,
     local_storage_init_script,
     safe_body_text,
 )
@@ -197,7 +198,6 @@ def run_chat_benchmark(
 
     runs: list[dict[str, Any]] = []
     total_runs = args.warmups + args.runs
-    textbox = page.get_by_role("textbox").last
     for index in range(total_runs):
         measured = index >= args.warmups
         page.evaluate(
@@ -209,7 +209,7 @@ def run_chat_benchmark(
               window.__llamadartRealLiteRtLmLastChunks = [];
             }"""
         )
-        textbox.fill(args.prompt)
+        enter_chat_prompt(page, args.prompt)
         generation_started = time.monotonic()
         page.get_by_role("button", name="Send message").click()
         try:

--- a/tool/testing/playwright_chat_app_mock_smoke.py
+++ b/tool/testing/playwright_chat_app_mock_smoke.py
@@ -1,12 +1,14 @@
 #!/usr/bin/env python3
 import argparse
 import json
+import re
 
 from playwright.sync_api import sync_playwright
 
 from playwright_chat_app_utils import (
     append_console_log,
     enable_flutter_semantics,
+    enter_chat_prompt,
     local_storage_init_script,
 )
 
@@ -54,11 +56,10 @@ def main() -> int:
 
         enable_flutter_semantics(page)
 
-        page.get_by_role("button", name="Load Model").click()
+        page.get_by_role("button", name=re.compile(r"Load Model", re.I)).click()
         page.get_by_text("Model loaded successfully! Ready to chat.").wait_for()
 
-        textbox = page.get_by_role("textbox")
-        textbox.fill("hi")
+        enter_chat_prompt(page, "hi")
         page.get_by_role("button", name="Send message").click()
 
         page.wait_for_function(

--- a/tool/testing/playwright_chat_app_real_model_smoke.py
+++ b/tool/testing/playwright_chat_app_real_model_smoke.py
@@ -13,6 +13,7 @@ from playwright_chat_app_utils import (
     browser_args,
     emit,
     enable_flutter_semantics,
+    enter_chat_prompt,
     local_storage_init_script,
     safe_body_text,
 )
@@ -128,6 +129,8 @@ def main() -> int:
     parser.add_argument("app_url")
     parser.add_argument("--model-url", required=True)
     parser.add_argument("--mmproj-url")
+    parser.add_argument("--prefetch-mmproj-cache", action="store_true")
+    parser.add_argument("--expect-mmproj-cache-hit", action="store_true")
     parser.add_argument("--prompt", default="What is 2+2? Answer in one short sentence.")
     parser.add_argument("--expect", default="4")
     parser.add_argument("--allow-any-response", action="store_true")
@@ -158,6 +161,7 @@ def main() -> int:
     console_logs: list[dict[str, str]] = []
     page_errors: list[str] = []
     request_failures: list[str] = []
+    mmproj_requests: list[str] = []
     started_at = time.monotonic()
 
     seeded_settings = {
@@ -453,6 +457,15 @@ def main() -> int:
 
         page.on("console", on_console)
         page.on("pageerror", lambda error: page_errors.append(str(error)))
+        if args.mmproj_url:
+            page.on(
+                "request",
+                lambda request: (
+                    mmproj_requests.append(request.url)
+                    if request.url == args.mmproj_url
+                    else None
+                ),
+            )
         page.on(
             "requestfailed",
             lambda request: request_failures.append(
@@ -465,7 +478,27 @@ def main() -> int:
 
         enable_flutter_semantics(page)
 
-        button = page.get_by_role("button", name=re.compile(r"Load Model"))
+        if args.prefetch_mmproj_cache:
+            if not args.mmproj_url:
+                raise ValueError("--prefetch-mmproj-cache requires --mmproj-url")
+            cached = page.evaluate(
+                """async (url) => {
+                  const cache = await caches.open('llamadart-webgpu-model-cache-v1');
+                  await cache.add(url);
+                  return Boolean(await cache.match(url));
+                }""",
+                args.mmproj_url,
+            )
+            emit(
+                "mmproj_cache_prefetch",
+                mmproj_url=args.mmproj_url,
+                cached=bool(cached),
+                request_count=len(mmproj_requests),
+            )
+            if not cached:
+                raise RuntimeError("mmproj prefetch did not populate CacheStorage")
+
+        button = page.get_by_role("button", name=re.compile(r"Load Model", re.I))
         button.wait_for(timeout=120000)
         emit("load_click", model_url=args.model_url, mmproj_url=args.mmproj_url)
         button.click()
@@ -482,8 +515,7 @@ def main() -> int:
             body_tail=body_after_load[-500:],
         )
 
-        textbox = page.get_by_role("textbox").last
-        textbox.fill(args.prompt)
+        enter_chat_prompt(page, args.prompt)
         page.get_by_role("button", name="Send message").click()
 
         try:
@@ -516,6 +548,11 @@ def main() -> int:
               liteRtLmPatched: window.LiteRtLmEngine?.__llamadartRealE2ePatched ?? null,
             })"""
         )
+        if args.expect_mmproj_cache_hit and len(mmproj_requests) != 1:
+            raise RuntimeError(
+                "Expected one mmproj network request from CacheStorage prefetch, "
+                f"but saw {len(mmproj_requests)} requests: {mmproj_requests}"
+            )
         emit(
             "result",
             ok=True,
@@ -524,6 +561,7 @@ def main() -> int:
             mmprojUrl=args.mmproj_url,
             expectedText=args.expect,
             bridgeResponse=bridge_response,
+            mmprojRequestCount=len(mmproj_requests),
             bridgeGlobals=bridge_globals,
             bodyTail=body_after_response[-1200:],
             consoleTail=console_logs[-30:],

--- a/tool/testing/playwright_chat_app_real_model_smoke.py
+++ b/tool/testing/playwright_chat_app_real_model_smoke.py
@@ -157,6 +157,8 @@ def main() -> int:
     )
     parser.add_argument("--headed", action="store_true")
     args = parser.parse_args()
+    if args.expect_mmproj_cache_hit and not args.prefetch_mmproj_cache:
+        parser.error("--expect-mmproj-cache-hit requires --prefetch-mmproj-cache")
 
     console_logs: list[dict[str, str]] = []
     page_errors: list[str] = []

--- a/tool/testing/playwright_chat_app_utils.py
+++ b/tool/testing/playwright_chat_app_utils.py
@@ -1,5 +1,6 @@
 import json
 import platform
+import time
 from typing import Any, Callable
 
 
@@ -89,3 +90,22 @@ def append_console_log(
     if echo_predicate is not None and echo_predicate(record):
         emit("console", **record)
     return record
+
+
+def enter_chat_prompt(page, prompt: str, *, timeout_ms: int = 30000) -> None:
+    textbox = page.get_by_role("textbox").last
+    textbox.click()
+    modifier = "Meta" if platform.system() == "Darwin" else "Control"
+    page.keyboard.press(f"{modifier}+A")
+    page.keyboard.press("Backspace")
+    page.keyboard.type(prompt)
+    wait_for_send_enabled(page, timeout_ms=timeout_ms)
+
+
+def wait_for_send_enabled(page, *, timeout_ms: int = 30000) -> None:
+    deadline = time.monotonic() + (timeout_ms / 1000)
+    button = page.get_by_role("button", name="Send message")
+    while time.monotonic() < deadline:
+        if button.is_enabled(timeout=1000):
+            return
+    raise TimeoutError("Timed out waiting for Send message button to enable")

--- a/tool/testing/playwright_chat_app_utils.py
+++ b/tool/testing/playwright_chat_app_utils.py
@@ -3,6 +3,8 @@ import platform
 import time
 from typing import Any, Callable
 
+from playwright.sync_api import TimeoutError as PlaywrightTimeoutError
+
 
 def emit(event: str, **data: Any) -> None:
     print(json.dumps({"event": event, **data}, ensure_ascii=False), flush=True)
@@ -106,6 +108,10 @@ def wait_for_send_enabled(page, *, timeout_ms: int = 30000) -> None:
     deadline = time.monotonic() + (timeout_ms / 1000)
     button = page.get_by_role("button", name="Send message")
     while time.monotonic() < deadline:
-        if button.is_enabled(timeout=1000):
-            return
+        try:
+            if button.is_enabled(timeout=250):
+                return
+        except PlaywrightTimeoutError:
+            pass
+        time.sleep(0.05)
     raise TimeoutError("Timed out waiting for Send message button to enable")


### PR DESCRIPTION
## Summary

- Polish the chat app shell, welcome state, model cards, and download progress UI.
- Switch the desktop chat app model directory to the package default model cache.
- Add a text-only/base-model download option so users can skip multimodal projectors.
- Tighten web model/projector CacheStorage handling so stale markers are synced against real cached assets.
- Fix WebGPU cache reuse for catalog URLs such as `?download=true`, while signed/tokenized URLs still bypass persistent cache.
- Prefer cached model streams before the large-model remote-fetch loader so cached GGUFs do not silently reload from network.
- Reuse cached LiteRT-LM web bundles by passing CacheStorage hits to `@litert-lm/core` as `Blob`s, including benign `?download=true` URLs.
- Gate chat app and LiteRT-LM web console output behind the selected Dart/native log levels, and skip the web LiteRT-LM warmup generation that made loading feel frozen.
- Extract model download UI state/lifecycle into a focused controller and harden Playwright chat input helpers.
- Address review follow-ups by keeping active download UI notifiers alive during state clears, enforcing mmproj cache-hit flag prerequisites, avoiding Playwright send-button busy polling, and centralizing persistent-cache URL sensitivity policy.

## Validation

- `dart analyze`
- `dart format --output=none --set-exit-if-changed .`
- `git diff --check`
- `flutter test` in `example/chat_app`
- `flutter test test/model_download_ui_controller_test.dart test/model_download_controller_adapter_test.dart test/manage_models_screen_download_test.dart test/unit_test.dart test/model_card_test.dart` in `example/chat_app`
- `dart test -p chrome --exclude-tags local-only`
- `dart test -p vm -j 1 --exclude-tags local-only`
- `dart test test/unit/core/cache_policy_test.dart test/unit/backends/webgpu/webgpu_backend_test.dart test/unit/backends/litert_lm/litert_lm_backend_web_test.dart -p chrome`
- `python3 -m py_compile tool/testing/playwright_chat_app_utils.py tool/testing/playwright_chat_app_real_model_smoke.py`
- `tool/testing/playwright_chat_app_real_model_smoke.py ... --expect-mmproj-cache-hit` without `--prefetch-mmproj-cache` exits with the expected parser error.
- `flutter build web --base-href=/example/chat_app/build/web/` in `example/chat_app`
- `dart run tool/testing/run_local_e2e.dart --scenario chat-app-web-mock-smoke --python .dart_tool/playwright-venv/bin/python`
- Browser GGUF cache probe: prefilled `stories15M.gguf?download=true` into CacheStorage, clicked Load Model, observed zero model URL network requests and runtime status `src cache` / `cache hit`.
- Browser LiteRT-LM cache probe: prefilled local `test_lm_smoke.litertlm?download=true` into CacheStorage, clicked Load Model, observed zero model URL network requests after prefill and only the Flutter loader debug console line. The test bundle still fails engine creation because that fixture is not supported by the LiteRT web streaming backend.

## Docs

- Updated `CHANGELOG.md` under `## Unreleased` for the chat app model-cache UX, web bundle cache reuse, text-only projector skip path, and load-progress polish.

## Notes

Large GGUF or LiteRT-LM bundles can still fetch if the browser refuses to store them in CacheStorage because of quota/storage limits. This PR fixes the cache-key/query mismatch and avoids bypassing an already cached model, but it cannot make a browser persist a model that CacheStorage rejects.