### PR TITLE
Fix chat app Hugging Face deploy workflow

### DIFF
--- a/.github/workflows/chat_app_hf_static_deploy.yml
+++ b/.github/workflows/chat_app_hf_static_deploy.yml
@@ -76,7 +76,7 @@ jobs:
 
       - name: Install Hugging Face Hub client
         run: |
-          python -m pip install --upgrade "huggingface_hub>=0.36.0"
+          python3 -m pip install --upgrade "huggingface_hub>=0.36.0"
 
       - name: Deploy to Hugging Face Space
         env:
@@ -105,7 +105,7 @@ jobs:
           SHORT_SHA="$(printf '%s' "$GITHUB_SHA" | cut -c1-7)"
           export SHORT_SHA
 
-          python - <<'PY'
+          python3 - <<'PY'
           import os
 
           from huggingface_hub import HfApi

--- a/.github/workflows/chat_app_hf_static_deploy.yml
+++ b/.github/workflows/chat_app_hf_static_deploy.yml
@@ -74,20 +74,14 @@ jobs:
         run: |
           (cd example/chat_app && flutter build web --release)
 
-      - name: Install Hugging Face CLI
+      - name: Install Hugging Face Hub client
         run: |
-          if ! command -v hf >/dev/null 2>&1; then
-            curl -LsSf https://hf.co/cli/install.sh | bash
-            echo "$HOME/.local/bin" >> "$GITHUB_PATH"
-          fi
+          python -m pip install --upgrade "huggingface_hub>=0.36.0"
 
       - name: Deploy to Hugging Face Space
         env:
           SPACE_REPO: ${{ steps.target.outputs.space_repo }}
         run: |
-          export PATH="$HOME/.local/bin:$PATH"
-          hf version
-
           rm -rf hf-space-sync
           mkdir -p hf-space-sync
 
@@ -109,9 +103,29 @@ jobs:
           } > "hf-space-sync/README.md"
 
           SHORT_SHA="$(printf '%s' "$GITHUB_SHA" | cut -c1-7)"
-          hf upload "$SPACE_REPO" "hf-space-sync/" "." \
-            --repo-type space \
-            --revision main \
-            --token "$HF_TOKEN" \
-            --delete "*" \
-            --commit-message "chore: deploy chat app ${SHORT_SHA}"
+          export SHORT_SHA
+
+          python - <<'PY'
+          import os
+
+          from huggingface_hub import HfApi
+
+          api = HfApi(token=os.environ["HF_TOKEN"])
+          space_repo = os.environ["SPACE_REPO"]
+          short_sha = os.environ["SHORT_SHA"]
+
+          api.create_repo(
+              repo_id=space_repo,
+              repo_type="space",
+              space_sdk="static",
+              exist_ok=True,
+          )
+          api.upload_folder(
+              repo_id=space_repo,
+              repo_type="space",
+              folder_path="hf-space-sync",
+              revision="main",
+              commit_message=f"chore: deploy chat app {short_sha}",
+              delete_patterns=["*", "**/*"],
+          )
+          PY

--- a/.github/workflows/chat_app_hf_static_deploy.yml
+++ b/.github/workflows/chat_app_hf_static_deploy.yml
@@ -76,7 +76,7 @@ jobs:
 
       - name: Install Hugging Face Hub client
         run: |
-          python3 -m pip install --upgrade "huggingface_hub>=0.36.0"
+          python3 -m pip install --upgrade "huggingface_hub>=0.36.0,<0.37.0"
 
       - name: Deploy to Hugging Face Space
         env:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -106,7 +106,7 @@ jobs:
             --exclude='build' \
             --exclude='pubspec.lock' \
             ./ "$tmp_package/"
-          (cd "$tmp_package" && dart pub publish --dry-run)
+          (cd "$tmp_package" && flutter pub publish --dry-run)
 
   docs-check:
     name: Docs Build Check

--- a/hook/build.dart
+++ b/hook/build.dart
@@ -1,4 +1,4 @@
-import 'dart:async' show TimeoutException;
+import 'dart:async' show Completer, Timer, TimeoutException, unawaited;
 import 'dart:convert' show utf8;
 import 'dart:io';
 
@@ -1814,9 +1814,19 @@ Future<void> _downloadRuntimeBundleOnce({
     final request = http.Request('GET', Uri.parse(url));
     request.headers[HttpHeaders.acceptHeader] = 'application/octet-stream';
     request.headers[HttpHeaders.userAgentHeader] = 'llamadart-build-hook';
-    final response = await client
-        .send(request)
-        .timeout(_runtimeBundleDownloadRequestTimeout);
+    final sendFuture = client.send(request);
+    unawaited(sendFuture.then<void>((_) {}, onError: (_, _) {}));
+    final response = await sendFuture.timeout(
+      _runtimeBundleDownloadRequestTimeout,
+      onTimeout: () {
+        client.close();
+        throw TimeoutException(
+          'Runtime bundle request timed out after '
+          '${_runtimeBundleDownloadRequestTimeout.inSeconds}s.',
+          _runtimeBundleDownloadRequestTimeout,
+        );
+      },
+    );
 
     if (response.statusCode != 200) {
       throw _RuntimeBundleDownloadHttpException(url, response.statusCode);
@@ -1825,9 +1835,12 @@ Future<void> _downloadRuntimeBundleOnce({
     final sink = temporaryDestination.openWrite();
     var sinkClosed = false;
     try {
-      await response.stream
-          .pipe(sink)
-          .timeout(_runtimeBundleDownloadTransferTimeout);
+      await _writeRuntimeBundleResponse(
+        stream: response.stream,
+        sink: sink,
+        timeout: _runtimeBundleDownloadTransferTimeout,
+      );
+      await sink.close();
       sinkClosed = true;
     } finally {
       if (!sinkClosed) {
@@ -1844,6 +1857,48 @@ Future<void> _downloadRuntimeBundleOnce({
     if (temporaryDestination.existsSync()) {
       await temporaryDestination.delete();
     }
+  }
+}
+
+Future<void> _writeRuntimeBundleResponse({
+  required Stream<List<int>> stream,
+  required IOSink sink,
+  required Duration timeout,
+}) async {
+  final completed = Completer<void>();
+  late final subscription = stream.listen(
+    sink.add,
+    onError: (Object error, StackTrace stackTrace) {
+      if (!completed.isCompleted) {
+        completed.completeError(error, stackTrace);
+      }
+    },
+    onDone: () {
+      if (!completed.isCompleted) {
+        completed.complete();
+      }
+    },
+    cancelOnError: true,
+  );
+  final timeoutTimer = Timer(timeout, () {
+    final timeoutError = TimeoutException(
+      'Runtime bundle body download timed out after ${timeout.inSeconds}s.',
+      timeout,
+    );
+    final timeoutStackTrace = StackTrace.current;
+    unawaited(
+      subscription.cancel().catchError((_) {}).whenComplete(() {
+        if (!completed.isCompleted) {
+          completed.completeError(timeoutError, timeoutStackTrace);
+        }
+      }),
+    );
+  });
+
+  try {
+    await completed.future;
+  } finally {
+    timeoutTimer.cancel();
   }
 }
 

--- a/hook/build.dart
+++ b/hook/build.dart
@@ -1922,7 +1922,6 @@ Future<bool> _downloadRuntimeBundleWithCurl({
       '--location',
       '--retry',
       '5',
-      '--retry-all-errors',
       '--retry-delay',
       '3',
       '--connect-timeout',

--- a/hook/build.dart
+++ b/hook/build.dart
@@ -1757,16 +1757,17 @@ Future<void> _downloadRuntimeBundle({
       return;
     } on Exception catch (error) {
       lastError = error;
-      final shouldRetry =
-          attempt < _runtimeBundleDownloadMaxAttempts &&
-          _isRetryableRuntimeBundleDownloadError(error);
-      if (!shouldRetry) {
+      final isRetryable = _isRetryableRuntimeBundleDownloadError(error);
+      if (!isRetryable) {
         if (attempt == 1) {
           rethrow;
         }
         throw Exception(
           'Failed to download $url after $attempt attempts: $error',
         );
+      }
+      if (attempt == _runtimeBundleDownloadMaxAttempts) {
+        break;
       }
 
       if (destination.existsSync()) {
@@ -1782,6 +1783,17 @@ Future<void> _downloadRuntimeBundle({
       );
       await Future<void>.delayed(retryDelay);
     }
+  }
+
+  if (lastError != null &&
+      await _downloadRuntimeBundleWithCurl(
+        url: url,
+        destination: destination,
+        description: description,
+        log: log,
+      )) {
+    log.info('Saved $description to ${destination.path}');
+    return;
   }
 
   throw Exception(
@@ -1802,6 +1814,8 @@ Future<void> _downloadRuntimeBundleOnce({
     }
 
     final request = http.Request('GET', Uri.parse(url));
+    request.headers[HttpHeaders.acceptHeader] = 'application/octet-stream';
+    request.headers[HttpHeaders.userAgentHeader] = 'llamadart-build-hook';
     final response = await client
         .send(request)
         .timeout(_runtimeBundleDownloadRequestTimeout);
@@ -1827,6 +1841,66 @@ Future<void> _downloadRuntimeBundleOnce({
     await temporaryDestination.rename(destination.path);
   } finally {
     client.close();
+    if (temporaryDestination.existsSync()) {
+      await temporaryDestination.delete();
+    }
+  }
+}
+
+Future<bool> _downloadRuntimeBundleWithCurl({
+  required String url,
+  required File destination,
+  required String description,
+  required Logger log,
+}) async {
+  final temporaryDestination = File('${destination.path}.curl.tmp');
+  try {
+    if (temporaryDestination.existsSync()) {
+      await temporaryDestination.delete();
+    }
+
+    log.warning(
+      'Trying curl fallback for $description after Dart HTTP retries failed.',
+    );
+    final result = await Process.run('curl', [
+      '--fail',
+      '--location',
+      '--retry',
+      '5',
+      '--retry-all-errors',
+      '--retry-delay',
+      '3',
+      '--connect-timeout',
+      '30',
+      '--max-time',
+      '600',
+      '--silent',
+      '--show-error',
+      '--header',
+      'Accept: application/octet-stream',
+      '--header',
+      'User-Agent: llamadart-build-hook',
+      '--output',
+      temporaryDestination.path,
+      url,
+    ]);
+    if (result.exitCode != 0) {
+      log.warning(
+        'curl fallback failed for $description with exit code '
+        '${result.exitCode}: ${result.stderr}',
+      );
+      return false;
+    }
+
+    if (destination.existsSync()) {
+      await destination.delete();
+    }
+    await temporaryDestination.rename(destination.path);
+    return true;
+  } on ProcessException catch (error) {
+    log.warning('curl fallback unavailable for $description: $error');
+    return false;
+  } finally {
     if (temporaryDestination.existsSync()) {
       await temporaryDestination.delete();
     }

--- a/hook/build.dart
+++ b/hook/build.dart
@@ -32,6 +32,7 @@ const _litertLmNativeReleaseBaseUrl =
 const _litertLmCacheDir = 'litert_lm';
 const _runtimeBundleDownloadMaxAttempts = 5;
 const _runtimeBundleDownloadRequestTimeout = Duration(seconds: 60);
+const _runtimeBundleDownloadTransferTimeout = Duration(minutes: 10);
 const _runtimeBundleDownloadRetryBaseDelay = Duration(seconds: 3);
 
 final _litertLmBundles = Map.unmodifiable({
@@ -1824,7 +1825,9 @@ Future<void> _downloadRuntimeBundleOnce({
     final sink = temporaryDestination.openWrite();
     var sinkClosed = false;
     try {
-      await response.stream.pipe(sink);
+      await response.stream
+          .pipe(sink)
+          .timeout(_runtimeBundleDownloadTransferTimeout);
       sinkClosed = true;
     } finally {
       if (!sinkClosed) {

--- a/hook/build.dart
+++ b/hook/build.dart
@@ -1,3 +1,4 @@
+import 'dart:async' show TimeoutException;
 import 'dart:convert' show utf8;
 import 'dart:io';
 
@@ -29,6 +30,9 @@ const _litertLmNativeReleaseBaseUrl =
     'https://github.com/leehack/litert-lm-native/releases/download/'
     'v$_litertLmVersion';
 const _litertLmCacheDir = 'litert_lm';
+const _runtimeBundleDownloadMaxAttempts = 5;
+const _runtimeBundleDownloadRequestTimeout = Duration(seconds: 60);
+const _runtimeBundleDownloadRetryBaseDelay = Duration(seconds: 3);
 
 final _litertLmBundles = Map.unmodifiable({
   for (final bundle in _litertLmBundleSpecs) bundle.bundle: bundle,
@@ -989,13 +993,12 @@ Future<void> _downloadLiteRtLmArchive({
   required Logger log,
 }) async {
   log.info('Downloading LiteRT-LM bundle from ${bundleSpec.releaseUrl}');
-  final response = await http.get(Uri.parse(bundleSpec.releaseUrl));
-  if (response.statusCode != 200) {
-    throw Exception(
-      'Failed to download LiteRT-LM bundle: HTTP ${response.statusCode}',
-    );
-  }
-  await destination.writeAsBytes(response.bodyBytes);
+  await _downloadRuntimeBundle(
+    url: bundleSpec.releaseUrl,
+    destination: destination,
+    description: 'LiteRT-LM bundle',
+    log: log,
+  );
 }
 
 bool _isLiteRtLmEntrySelected(
@@ -1726,27 +1729,131 @@ Future<void> _downloadReleaseAsset({
       'https://github.com/$repository/releases/download/$nativeTag/$assetName';
   log.info('Downloading native bundle: $url');
 
-  final destination = File(destinationPath);
+  await _downloadRuntimeBundle(
+    url: url,
+    destination: File(destinationPath),
+    description: 'native bundle',
+    log: log,
+  );
+}
+
+Future<void> _downloadRuntimeBundle({
+  required String url,
+  required File destination,
+  required String description,
+  required Logger log,
+}) async {
   await destination.parent.create(recursive: true);
 
-  final client = http.Client();
-  try {
-    final request = http.Request('GET', Uri.parse(url));
-    final response = await client.send(request);
+  Exception? lastError;
+  for (
+    var attempt = 1;
+    attempt <= _runtimeBundleDownloadMaxAttempts;
+    attempt++
+  ) {
+    try {
+      await _downloadRuntimeBundleOnce(url: url, destination: destination);
+      log.info('Saved $description to ${destination.path}');
+      return;
+    } on Exception catch (error) {
+      lastError = error;
+      final shouldRetry =
+          attempt < _runtimeBundleDownloadMaxAttempts &&
+          _isRetryableRuntimeBundleDownloadError(error);
+      if (!shouldRetry) {
+        if (attempt == 1) {
+          rethrow;
+        }
+        throw Exception(
+          'Failed to download $url after $attempt attempts: $error',
+        );
+      }
 
-    if (response.statusCode != 200) {
-      throw Exception('Failed to download $url (${response.statusCode}).');
+      if (destination.existsSync()) {
+        await destination.delete();
+      }
+      final retryDelay = Duration(
+        seconds: _runtimeBundleDownloadRetryBaseDelay.inSeconds * attempt,
+      );
+      log.warning(
+        '$description download failed ($error); retrying in '
+        '${retryDelay.inSeconds}s '
+        '(attempt ${attempt + 1}/$_runtimeBundleDownloadMaxAttempts).',
+      );
+      await Future<void>.delayed(retryDelay);
     }
-
-    final sink = destination.openWrite();
-    await response.stream.pipe(sink);
-    await sink.flush();
-    await sink.close();
-  } finally {
-    client.close();
   }
 
-  log.info('Saved native bundle to $destinationPath');
+  throw Exception(
+    'Failed to download $url after $_runtimeBundleDownloadMaxAttempts attempts: '
+    '$lastError',
+  );
+}
+
+Future<void> _downloadRuntimeBundleOnce({
+  required String url,
+  required File destination,
+}) async {
+  final client = http.Client();
+  final temporaryDestination = File('${destination.path}.tmp');
+  try {
+    if (temporaryDestination.existsSync()) {
+      await temporaryDestination.delete();
+    }
+
+    final request = http.Request('GET', Uri.parse(url));
+    final response = await client
+        .send(request)
+        .timeout(_runtimeBundleDownloadRequestTimeout);
+
+    if (response.statusCode != 200) {
+      throw _RuntimeBundleDownloadHttpException(url, response.statusCode);
+    }
+
+    final sink = temporaryDestination.openWrite();
+    var sinkClosed = false;
+    try {
+      await response.stream.pipe(sink);
+      sinkClosed = true;
+    } finally {
+      if (!sinkClosed) {
+        await sink.close();
+      }
+    }
+
+    if (destination.existsSync()) {
+      await destination.delete();
+    }
+    await temporaryDestination.rename(destination.path);
+  } finally {
+    client.close();
+    if (temporaryDestination.existsSync()) {
+      await temporaryDestination.delete();
+    }
+  }
+}
+
+bool _isRetryableRuntimeBundleDownloadError(Exception error) {
+  if (error is _RuntimeBundleDownloadHttpException) {
+    return error.statusCode == 408 ||
+        error.statusCode == 429 ||
+        (error.statusCode >= 500 && error.statusCode < 600);
+  }
+  return error is http.ClientException ||
+      error is SocketException ||
+      error is HandshakeException ||
+      error is HttpException ||
+      error is TimeoutException;
+}
+
+final class _RuntimeBundleDownloadHttpException implements Exception {
+  const _RuntimeBundleDownloadHttpException(this.url, this.statusCode);
+
+  final String url;
+  final int statusCode;
+
+  @override
+  String toString() => 'Failed to download $url ($statusCode).';
 }
 
 Future<void> _extractArchive({

--- a/hook/build.dart
+++ b/hook/build.dart
@@ -1,4 +1,5 @@
-import 'dart:async' show Completer, Timer, TimeoutException, unawaited;
+import 'dart:async'
+    show Completer, StreamSubscription, Timer, TimeoutException, unawaited;
 import 'dart:convert' show utf8;
 import 'dart:io';
 
@@ -34,6 +35,14 @@ const _runtimeBundleDownloadMaxAttempts = 5;
 const _runtimeBundleDownloadRequestTimeout = Duration(seconds: 60);
 const _runtimeBundleDownloadTransferTimeout = Duration(minutes: 10);
 const _runtimeBundleDownloadRetryBaseDelay = Duration(seconds: 3);
+
+typedef RuntimeBundleDownloadFallbackForTesting =
+    Future<bool> Function({
+      required String url,
+      required File destination,
+      required String description,
+      required Logger log,
+    });
 
 final _litertLmBundles = Map.unmodifiable({
   for (final bundle in _litertLmBundleSpecs) bundle.bundle: bundle,
@@ -1743,17 +1752,26 @@ Future<void> _downloadRuntimeBundle({
   required File destination,
   required String description,
   required Logger log,
+  int maxAttempts = _runtimeBundleDownloadMaxAttempts,
+  Duration requestTimeout = _runtimeBundleDownloadRequestTimeout,
+  Duration transferTimeout = _runtimeBundleDownloadTransferTimeout,
+  Duration retryBaseDelay = _runtimeBundleDownloadRetryBaseDelay,
+  bool useCurlFallback = true,
+  http.Client Function()? createClient,
+  RuntimeBundleDownloadFallbackForTesting? curlFallback,
 }) async {
   await destination.parent.create(recursive: true);
 
   Exception? lastError;
-  for (
-    var attempt = 1;
-    attempt <= _runtimeBundleDownloadMaxAttempts;
-    attempt++
-  ) {
+  for (var attempt = 1; attempt <= maxAttempts; attempt++) {
     try {
-      await _downloadRuntimeBundleOnce(url: url, destination: destination);
+      await _downloadRuntimeBundleOnce(
+        url: url,
+        destination: destination,
+        requestTimeout: requestTimeout,
+        transferTimeout: transferTimeout,
+        createClient: createClient,
+      );
       log.info('Saved $description to ${destination.path}');
       return;
     } on Exception catch (error) {
@@ -1767,24 +1785,25 @@ Future<void> _downloadRuntimeBundle({
           'Failed to download $url after $attempt attempts: $error',
         );
       }
-      if (attempt == _runtimeBundleDownloadMaxAttempts) {
+      if (attempt == maxAttempts) {
         break;
       }
 
       final retryDelay = Duration(
-        seconds: _runtimeBundleDownloadRetryBaseDelay.inSeconds * attempt,
+        microseconds: retryBaseDelay.inMicroseconds * attempt,
       );
       log.warning(
         '$description download failed ($error); retrying in '
         '${retryDelay.inSeconds}s '
-        '(attempt ${attempt + 1}/$_runtimeBundleDownloadMaxAttempts).',
+        '(attempt ${attempt + 1}/$maxAttempts).',
       );
       await Future<void>.delayed(retryDelay);
     }
   }
 
-  if (lastError != null &&
-      await _downloadRuntimeBundleWithCurl(
+  if (useCurlFallback &&
+      lastError != null &&
+      await (curlFallback ?? _downloadRuntimeBundleWithCurl)(
         url: url,
         destination: destination,
         description: description,
@@ -1795,16 +1814,18 @@ Future<void> _downloadRuntimeBundle({
   }
 
   throw Exception(
-    'Failed to download $url after $_runtimeBundleDownloadMaxAttempts attempts: '
-    '$lastError',
+    'Failed to download $url after $maxAttempts attempts: $lastError',
   );
 }
 
 Future<void> _downloadRuntimeBundleOnce({
   required String url,
   required File destination,
+  required Duration requestTimeout,
+  required Duration transferTimeout,
+  required http.Client Function()? createClient,
 }) async {
-  final client = http.Client();
+  final client = (createClient ?? http.Client.new)();
   final temporaryDestination = File('${destination.path}.tmp');
   try {
     if (temporaryDestination.existsSync()) {
@@ -1817,17 +1838,16 @@ Future<void> _downloadRuntimeBundleOnce({
     final sendFuture = client.send(request);
     unawaited(sendFuture.then<void>((_) {}, onError: (_, _) {}));
     final response = await sendFuture.timeout(
-      _runtimeBundleDownloadRequestTimeout,
+      requestTimeout,
       onTimeout: () {
         client.close();
         throw TimeoutException(
           'Runtime bundle request timed out after '
-          '${_runtimeBundleDownloadRequestTimeout.inSeconds}s.',
-          _runtimeBundleDownloadRequestTimeout,
+          '${requestTimeout.inSeconds}s.',
+          requestTimeout,
         );
       },
     );
-
     if (response.statusCode != 200) {
       throw _RuntimeBundleDownloadHttpException(url, response.statusCode);
     }
@@ -1838,7 +1858,7 @@ Future<void> _downloadRuntimeBundleOnce({
       await _writeRuntimeBundleResponse(
         stream: response.stream,
         sink: sink,
-        timeout: _runtimeBundleDownloadTransferTimeout,
+        timeout: transferTimeout,
       );
       await sink.close();
       sinkClosed = true;
@@ -1860,14 +1880,49 @@ Future<void> _downloadRuntimeBundleOnce({
   }
 }
 
+/// Downloads a runtime bundle through the hardened build-hook download path.
+///
+/// This is intended for hook tests that need shorter retry delays and timeouts;
+/// production code should use the build hook entrypoint.
+Future<void> downloadRuntimeBundleForTesting({
+  required String url,
+  required File destination,
+  required String description,
+  required Logger log,
+  int maxAttempts = _runtimeBundleDownloadMaxAttempts,
+  Duration requestTimeout = _runtimeBundleDownloadRequestTimeout,
+  Duration transferTimeout = _runtimeBundleDownloadTransferTimeout,
+  Duration retryBaseDelay = _runtimeBundleDownloadRetryBaseDelay,
+  bool useCurlFallback = false,
+  http.Client Function()? createClient,
+  RuntimeBundleDownloadFallbackForTesting? curlFallback,
+}) {
+  return _downloadRuntimeBundle(
+    url: url,
+    destination: destination,
+    description: description,
+    log: log,
+    maxAttempts: maxAttempts,
+    requestTimeout: requestTimeout,
+    transferTimeout: transferTimeout,
+    retryBaseDelay: retryBaseDelay,
+    useCurlFallback: useCurlFallback,
+    createClient: createClient,
+    curlFallback: curlFallback,
+  );
+}
+
 Future<void> _writeRuntimeBundleResponse({
   required Stream<List<int>> stream,
   required IOSink sink,
   required Duration timeout,
 }) async {
   final completed = Completer<void>();
-  late final subscription = stream.listen(
-    sink.add,
+  late final StreamSubscription<List<int>> subscription;
+  subscription = stream.listen(
+    (chunk) {
+      sink.add(chunk);
+    },
     onError: (Object error, StackTrace stackTrace) {
       if (!completed.isCompleted) {
         completed.completeError(error, stackTrace);

--- a/hook/build.dart
+++ b/hook/build.dart
@@ -1770,9 +1770,6 @@ Future<void> _downloadRuntimeBundle({
         break;
       }
 
-      if (destination.existsSync()) {
-        await destination.delete();
-      }
       final retryDelay = Duration(
         seconds: _runtimeBundleDownloadRetryBaseDelay.inSeconds * attempt,
       );

--- a/hook/build.dart
+++ b/hook/build.dart
@@ -1864,7 +1864,11 @@ Future<void> _downloadRuntimeBundleOnce({
       sinkClosed = true;
     } finally {
       if (!sinkClosed) {
-        await sink.close();
+        try {
+          await sink.close();
+        } catch (_) {
+          // Preserve the original write or close failure; this is cleanup.
+        }
       }
     }
 

--- a/test/unit/hook/build_hook_download_test.dart
+++ b/test/unit/hook/build_hook_download_test.dart
@@ -1,0 +1,194 @@
+@TestOn('vm')
+library;
+
+import 'dart:async';
+import 'dart:collection';
+import 'dart:io';
+
+import 'package:http/http.dart' as http;
+import 'package:logging/logging.dart';
+import 'package:path/path.dart' as path;
+import 'package:test/test.dart';
+
+import '../../../hook/build.dart' as build_hook;
+
+void main() {
+  late Directory tempDir;
+  late Logger log;
+
+  setUp(() async {
+    tempDir = await Directory.systemTemp.createTemp('llamadart-download-test-');
+    log = Logger('llamadart-download-test');
+  });
+
+  tearDown(() async {
+    if (tempDir.existsSync()) {
+      await tempDir.delete(recursive: true);
+    }
+  });
+
+  test('runtime bundle download retries transient HTTP failures', () async {
+    final requests = <http.BaseRequest>[];
+    final clients = Queue<http.Client>.from([
+      _FakeClient((request) async {
+        requests.add(request);
+        return http.StreamedResponse(
+          const Stream<List<int>>.empty(),
+          HttpStatus.internalServerError,
+        );
+      }),
+      _FakeClient((request) async {
+        requests.add(request);
+        return http.StreamedResponse(
+          http.ByteStream.fromBytes('downloaded-bundle'.codeUnits),
+          HttpStatus.ok,
+        );
+      }),
+    ]);
+
+    final destination = File(path.join(tempDir.path, 'bundle.tar.gz'));
+    await build_hook.downloadRuntimeBundleForTesting(
+      url: 'https://example.test/bundle.tar.gz',
+      destination: destination,
+      description: 'test bundle',
+      log: log,
+      maxAttempts: 2,
+      retryBaseDelay: Duration.zero,
+      createClient: clients.removeFirst,
+    );
+
+    expect(requests, hasLength(2));
+    expect(await destination.readAsString(), 'downloaded-bundle');
+    expect(File('${destination.path}.tmp').existsSync(), isFalse);
+    expect(
+      requests.map((request) => request.headers[HttpHeaders.acceptHeader]),
+      everyElement('application/octet-stream'),
+    );
+    expect(
+      requests.map((request) => request.headers[HttpHeaders.userAgentHeader]),
+      everyElement('llamadart-build-hook'),
+    );
+  });
+
+  test('runtime bundle request timeout preserves destination', () async {
+    final destination = File(path.join(tempDir.path, 'bundle.tar.gz'));
+    await destination.writeAsString('cached-bundle');
+
+    await expectLater(
+      build_hook.downloadRuntimeBundleForTesting(
+        url: 'https://example.test/bundle.tar.gz',
+        destination: destination,
+        description: 'test bundle',
+        log: log,
+        maxAttempts: 1,
+        requestTimeout: const Duration(milliseconds: 50),
+        createClient: () =>
+            _FakeClient((_) => Completer<http.StreamedResponse>().future),
+      ),
+      throwsA(isA<Exception>()),
+    );
+
+    expect(await destination.readAsString(), 'cached-bundle');
+    expect(File('${destination.path}.tmp').existsSync(), isFalse);
+  });
+
+  test('runtime bundle download preserves destination on failure', () async {
+    final destination = File(path.join(tempDir.path, 'bundle.tar.gz'));
+    await destination.writeAsString('cached-bundle');
+
+    await expectLater(
+      build_hook.downloadRuntimeBundleForTesting(
+        url: 'https://example.test/bundle.tar.gz',
+        destination: destination,
+        description: 'test bundle',
+        log: log,
+        maxAttempts: 1,
+        createClient: () => _FakeClient((_) async {
+          return http.StreamedResponse(
+            const Stream<List<int>>.empty(),
+            HttpStatus.badGateway,
+          );
+        }),
+      ),
+      throwsA(isA<Exception>()),
+    );
+
+    expect(await destination.readAsString(), 'cached-bundle');
+    expect(File('${destination.path}.tmp').existsSync(), isFalse);
+  });
+
+  test('runtime bundle download uses fallback after HTTP retries', () async {
+    var fallbackCalled = false;
+    final destination = File(path.join(tempDir.path, 'bundle.tar.gz'));
+
+    await build_hook.downloadRuntimeBundleForTesting(
+      url: 'https://example.test/bundle.tar.gz',
+      destination: destination,
+      description: 'test bundle',
+      log: log,
+      maxAttempts: 1,
+      useCurlFallback: true,
+      createClient: () => _FakeClient((_) async {
+        return http.StreamedResponse(
+          const Stream<List<int>>.empty(),
+          HttpStatus.gatewayTimeout,
+        );
+      }),
+      curlFallback:
+          ({
+            required url,
+            required destination,
+            required description,
+            required log,
+          }) async {
+            fallbackCalled = true;
+            expect(url, 'https://example.test/bundle.tar.gz');
+            expect(description, 'test bundle');
+            await destination.writeAsString('fallback-bundle');
+            return true;
+          },
+    );
+
+    expect(fallbackCalled, isTrue);
+    expect(await destination.readAsString(), 'fallback-bundle');
+    expect(File('${destination.path}.tmp').existsSync(), isFalse);
+  });
+
+  test('runtime bundle body timeout cleans up partial download', () async {
+    final controller = StreamController<List<int>>();
+    addTearDown(controller.close);
+
+    final destination = File(path.join(tempDir.path, 'bundle.tar.gz'));
+    await destination.writeAsString('cached-bundle');
+
+    await expectLater(
+      build_hook.downloadRuntimeBundleForTesting(
+        url: 'https://example.test/bundle.tar.gz',
+        destination: destination,
+        description: 'test bundle',
+        log: log,
+        maxAttempts: 1,
+        transferTimeout: const Duration(milliseconds: 50),
+        createClient: () => _FakeClient((_) async {
+          scheduleMicrotask(() => controller.add('partial'.codeUnits));
+          return http.StreamedResponse(controller.stream, HttpStatus.ok);
+        }),
+      ),
+      throwsA(isA<Exception>()),
+    );
+
+    expect(await destination.readAsString(), 'cached-bundle');
+    expect(File('${destination.path}.tmp').existsSync(), isFalse);
+  });
+}
+
+final class _FakeClient extends http.BaseClient {
+  _FakeClient(this._send);
+
+  final Future<http.StreamedResponse> Function(http.BaseRequest request) _send;
+
+  @override
+  Future<http.StreamedResponse> send(http.BaseRequest request) {
+    return _send(request);
+  }
+}


### PR DESCRIPTION
## Summary
- replace the chat app HF deploy step's `hf upload` path with the `huggingface_hub` Python API, create/reuse the target Space with `space_sdk="static"`, and pin the client to the compatible `0.36.x` range
- switch companion Flutter plugin publish dry-runs to `flutter pub publish --dry-run`, matching the package type and avoiding macOS runner PATH failures for `dart`
- harden runtime bundle downloads in `hook/build.dart` with retryable HTTP/network handling, temp-file writes, request/body timeouts, explicit download headers, and a portable `curl` fallback
- fix the hardened body stream writer so the subscription starts immediately, preserve original write/close errors during cleanup, and add hook tests for retry, timeout, cache preservation, and fallback behavior

## Validation
- `actionlint .github/workflows/chat_app_hf_static_deploy.yml .github/workflows/ci.yml`
- embedded Python upload snippet syntax check
- `dart analyze hook/build.dart test/unit/hook/build_hook_download_test.dart`
- `dart test -p vm test/unit/hook/build_hook_download_test.dart --chain-stack-traces -r expanded`
- `dart test -p vm --coverage=coverage-download-test test/unit/hook/build_hook_download_test.dart`
- `dart test -p vm test/unit/hook/build_hook_download_test.dart test/unit/hook/build_hook_linux_integration_test.dart test/unit/hook/build_hook_integration_test.dart test/unit/hook/build_hook_litert_lm_integration_test.dart`
- local temp-copy dry runs with `flutter pub publish --dry-run` for both companion packages
- CI passed on latest PR head: https://github.com/leehack/llamadart/actions/runs/29037805279 and https://github.com/leehack/llamadart/actions/runs/29037805189
- manual `chat_app_hf_static_deploy.yml` workflow passed on latest PR head: https://github.com/leehack/llamadart/actions/runs/29038201877
- `git diff --check`

## Notes
- Follow-up to the post-merge deploy failure after #290. The failed run reached the deploy step, then `hf upload` called Hugging Face `/api/repos/create` and returned `402 Payment Required` because the create path did not declare a static Space SDK.
- The runtime-bundle download hardening is included because CI then exposed repeated transient `504` responses from GitHub release asset downloads while validating this fix.
- Runtime docs are unchanged; this PR changes workflow behavior and build-hook download durability, not public APIs.
