### PR TITLE
Update web runtime pins and multimodal regression coverage

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 ## Unreleased
 
+* Updated the runnable chat app's web runtimes to pinned WebGPU bridge assets
+  `v0.1.18` (llama.cpp `b9915`) and `@litert-lm/core@0.14.0`, keeping hosted
+  and local inference on reproducible runtime versions.
+
 * Improved the runnable chat app's model-cache UX by reusing cached GGUF and
   LiteRT-LM web bundles for benign catalog URLs such as `?download=true`,
   preserving browser model caches during app cache cleanup, adding a text-only

--- a/README.md
+++ b/README.md
@@ -135,7 +135,8 @@ Current default runtime pins:
 | --- | --- |
 | Native llama.cpp / GGUF | `leehack/llamadart-native@b9935` |
 | Native LiteRT-LM / `.litertlm` | `leehack/litert-lm-native@v0.14.0-native.1` |
-| Web llama.cpp / GGUF | `leehack/llama-web-bridge-assets@v0.1.17` |
+| Web llama.cpp / GGUF | `leehack/llama-web-bridge-assets@v0.1.18` |
+| Web LiteRT-LM / `.litertlm` | `@litert-lm/core@0.14.0` |
 
 ## Common Tasks
 

--- a/doc/webgpu_bridge.md
+++ b/doc/webgpu_bridge.md
@@ -19,7 +19,7 @@ pipelines.
    `https://cdn.jsdelivr.net/gh/leehack/llama-web-bridge-assets@<tag>/llama_webgpu_bridge.js`
 2. Local fallback: `./webgpu_bridge/llama_webgpu_bridge.js`
 
-Default pinned tag in the example is `v0.1.17`.
+Default pinned tag in the example is `v0.1.18`.
 
 For broader browser coverage in this repository, fetched/local assets are patched
 to a universal Safari-compatible gate by default (`MIN_SAFARI_VERSION=170400`).
@@ -32,7 +32,7 @@ model bytes.
 To vendor pinned assets into local app web files:
 
 ```bash
-WEBGPU_BRIDGE_ASSETS_TAG=v0.1.17 ./scripts/fetch_webgpu_bridge_assets.sh
+WEBGPU_BRIDGE_ASSETS_TAG=v0.1.18 ./scripts/fetch_webgpu_bridge_assets.sh
 ```
 
 Optional compatibility env vars:
@@ -113,7 +113,7 @@ You can override CDN source/version before the bridge loader runs:
 ```html
 <script>
   window.__llamadartBridgeAssetsRepo = 'leehack/llama-web-bridge-assets';
-  window.__llamadartBridgeAssetsTag = 'v0.1.17';
+  window.__llamadartBridgeAssetsTag = 'v0.1.18';
 </script>
 ```
 

--- a/example/chat_app/web/index.html
+++ b/example/chat_app/web/index.html
@@ -214,13 +214,13 @@
     const bridgeAssetsTag =
       typeof configuredTag === 'string' && configuredTag.length > 0
         ? configuredTag
-        : 'v0.1.17';
+        : 'v0.1.18';
     window.__llamadartLiteRtLmModuleUrl =
       typeof window.__llamadartLiteRtLmModuleUrl === 'string' &&
       window.__llamadartLiteRtLmModuleUrl.length > 0
         ? window.__llamadartLiteRtLmModuleUrl
-        : 'https://cdn.jsdelivr.net/npm/@litert-lm/core/+esm';
-    const localBridgeVersion = 'v0.1.17-local-b9699';
+        : 'https://cdn.jsdelivr.net/npm/@litert-lm/core@0.14.0/+esm';
+    const localBridgeVersion = 'v0.1.18-local-b9915';
     window.__llamadartBridgeLocalVersion = localBridgeVersion;
 
     const localBridgeUrl = `./webgpu_bridge/llama_webgpu_bridge.js?v=${localBridgeVersion}`;

--- a/lib/src/backends/litert_lm/litert_lm_backend_web.dart
+++ b/lib/src/backends/litert_lm/litert_lm_backend_web.dart
@@ -24,7 +24,7 @@ import '../backend.dart';
 /// This backend wraps the official `@litert-lm/core` browser API. Apps can
 /// preload the package and expose `window.LiteRtLmEngine = module.Engine`, or
 /// set `window.__llamadartLiteRtLmModuleUrl` to a module URL such as
-/// `https://cdn.jsdelivr.net/npm/@litert-lm/core/+esm`.
+/// `https://cdn.jsdelivr.net/npm/@litert-lm/core@0.14.0/+esm`.
 class LiteRtLmBackend
     implements
         LlamaBackend,

--- a/scripts/fetch_webgpu_bridge_assets.sh
+++ b/scripts/fetch_webgpu_bridge_assets.sh
@@ -4,7 +4,7 @@ set -euo pipefail
 ROOT_DIR="$(git rev-parse --show-toplevel)"
 OUT_DIR="${WEBGPU_BRIDGE_OUT_DIR:-$ROOT_DIR/example/chat_app/web/webgpu_bridge}"
 ASSETS_REPO="${WEBGPU_BRIDGE_ASSETS_REPO:-leehack/llama-web-bridge-assets}"
-ASSETS_TAG="${WEBGPU_BRIDGE_ASSETS_TAG:-v0.1.17}"
+ASSETS_TAG="${WEBGPU_BRIDGE_ASSETS_TAG:-v0.1.18}"
 CDN_BASE="${WEBGPU_BRIDGE_CDN_BASE:-https://cdn.jsdelivr.net/gh/${ASSETS_REPO}@${ASSETS_TAG}}"
 PATCH_SAFARI_COMPAT="${WEBGPU_BRIDGE_PATCH_SAFARI_COMPAT:-1}"
 MIN_SAFARI_VERSION="${WEBGPU_BRIDGE_MIN_SAFARI_VERSION:-170400}"
@@ -14,7 +14,7 @@ if [[ "${1:-}" == "--help" || "${1:-}" == "-h" ]]; then
 Downloads prebuilt WebGPU bridge assets into the chat_app web directory.
 
 Default source:
-  https://cdn.jsdelivr.net/gh/leehack/llama-web-bridge-assets@v0.1.17
+  https://cdn.jsdelivr.net/gh/leehack/llama-web-bridge-assets@v0.1.18
 
 Environment variables:
   WEBGPU_BRIDGE_ASSETS_REPO   Asset repo in owner/repo format
@@ -28,7 +28,7 @@ Usage:
   ./scripts/fetch_webgpu_bridge_assets.sh
 
 Examples:
-  WEBGPU_BRIDGE_ASSETS_TAG=v0.1.17 ./scripts/fetch_webgpu_bridge_assets.sh
+  WEBGPU_BRIDGE_ASSETS_TAG=v0.1.18 ./scripts/fetch_webgpu_bridge_assets.sh
   WEBGPU_BRIDGE_ASSETS_REPO=acme/llama-web-bridge-assets WEBGPU_BRIDGE_ASSETS_TAG=v2 ./scripts/fetch_webgpu_bridge_assets.sh
 USAGE
   exit 0

--- a/tool/testing/playwright_chat_app_benchmark.py
+++ b/tool/testing/playwright_chat_app_benchmark.py
@@ -457,7 +457,7 @@ def main() -> int:
           typeof window.__llamadartLiteRtLmModuleUrl === 'string' &&
           window.__llamadartLiteRtLmModuleUrl.length > 0
             ? window.__llamadartLiteRtLmModuleUrl
-            : 'https://cdn.jsdelivr.net/npm/@litert-lm/core/+esm';
+            : 'https://cdn.jsdelivr.net/npm/@litert-lm/core@0.14.0/+esm';
         const moduleSource = [
           'import * as mod from ' + JSON.stringify(originalModuleUrl) + ';',
           'const summarizeSettings = (settings) => {{',

--- a/tool/testing/playwright_chat_app_real_model_smoke.py
+++ b/tool/testing/playwright_chat_app_real_model_smoke.py
@@ -278,7 +278,7 @@ def main() -> int:
             typeof window.__llamadartLiteRtLmModuleUrl === 'string' &&
             window.__llamadartLiteRtLmModuleUrl.length > 0
               ? window.__llamadartLiteRtLmModuleUrl
-              : 'https://cdn.jsdelivr.net/npm/@litert-lm/core/+esm';
+              : 'https://cdn.jsdelivr.net/npm/@litert-lm/core@0.14.0/+esm';
           window.__llamadartLiteRtLmOriginalModuleUrl = originalModuleUrl;
           const moduleSource = [
             'import * as mod from ' + JSON.stringify(originalModuleUrl) + ';',

--- a/tool/testing/playwright_qwen_cpu_multimodal_smoke.py
+++ b/tool/testing/playwright_qwen_cpu_multimodal_smoke.py
@@ -244,6 +244,7 @@ def main() -> int:
                   version: window.__llamadartBridgeLocalVersion || null,
                   coi: window.crossOriginIsolated,
                   output: outputText.slice(0, 280),
+                  outputFull: outputText,
                   tokenCount,
                   timings,
                   debug: {
@@ -311,6 +312,7 @@ def main() -> int:
     print("[e2e] evaluation finished", flush=True)
 
     result: dict[str, Any] = payload.get("result", {})
+    full_output_text = result.pop("outputFull", None)
     gate_errors: list[str] = []
 
     debug = result.get("debug")
@@ -362,9 +364,8 @@ def main() -> int:
 
     expected_text = args.expect_text.strip()
     if result.get("ok") is True and expected_text:
-        output_text = result.get("output")
-        if not isinstance(output_text, str) or (
-            expected_text.casefold() not in output_text.casefold()
+        if not isinstance(full_output_text, str) or (
+            expected_text.casefold() not in full_output_text.casefold()
         ):
             gate_errors.append(
                 f"Multimodal output did not contain expected text: {expected_text!r}.",

--- a/tool/testing/playwright_qwen_cpu_multimodal_smoke.py
+++ b/tool/testing/playwright_qwen_cpu_multimodal_smoke.py
@@ -361,7 +361,7 @@ def main() -> int:
         )
 
     expected_text = args.expect_text.strip()
-    if expected_text:
+    if result.get("ok") is True and expected_text:
         output_text = result.get("output")
         if not isinstance(output_text, str) or (
             expected_text.casefold() not in output_text.casefold()

--- a/tool/testing/playwright_qwen_cpu_multimodal_smoke.py
+++ b/tool/testing/playwright_qwen_cpu_multimodal_smoke.py
@@ -30,6 +30,7 @@ def main() -> int:
     parser.add_argument("--max-first-token-latency-ms", type=int, default=0)
     parser.add_argument("--max-inference-ms", type=int, default=0)
     parser.add_argument("--min-token-count", type=int, default=0)
+    parser.add_argument("--expect-text", type=str, default="")
     parser.add_argument("--expect-n-gpu-layers", type=int, default=-1)
     parser.add_argument("--channel", type=str, default="chromium")
     parser.add_argument("--headed", action="store_true")
@@ -174,10 +175,11 @@ def main() -> int:
                     'what do you see?',
                     {
                       nPredict,
-                      temp: 0.6,
-                      topK: 20,
-                      topP: 0.95,
+                      temp: 0.0,
+                      topK: 1,
+                      topP: 1.0,
                       penalty: 1.0,
+                      seed: 42,
                       onToken: () => {
                         if (firstTokenAtMs === null) {
                           firstTokenAtMs = performance.now() - inferStart;
@@ -357,6 +359,16 @@ def main() -> int:
             f"Token count {token_count} is below required minimum "
             f"{args.min_token_count}.",
         )
+
+    expected_text = args.expect_text.strip()
+    if expected_text:
+        output_text = result.get("output")
+        if not isinstance(output_text, str) or (
+            expected_text.casefold() not in output_text.casefold()
+        ):
+            gate_errors.append(
+                f"Multimodal output did not contain expected text: {expected_text!r}.",
+            )
 
     if args.expect_n_gpu_layers >= 0:
         resolved_gpu_layers = None

--- a/tool/testing/run_webgpu_multimodal_regression_gate.sh
+++ b/tool/testing/run_webgpu_multimodal_regression_gate.sh
@@ -79,6 +79,8 @@ fi
 
 if [[ -n "${QWEN_MM_IMAGE_PATH:-}" ]]; then
   common_args+=(--image-path "${QWEN_MM_IMAGE_PATH}")
+else
+  common_args+=(--expect-text HELLO)
 fi
 
 echo "[gate] running CPU multimodal regression check"

--- a/tool/testing/run_webgpu_multimodal_regression_gate.sh
+++ b/tool/testing/run_webgpu_multimodal_regression_gate.sh
@@ -80,7 +80,7 @@ fi
 if [[ -n "${QWEN_MM_IMAGE_PATH:-}" ]]; then
   common_args+=(--image-path "${QWEN_MM_IMAGE_PATH}")
 else
-  common_args+=(--expect-text HELLO)
+  common_args+=(--expect-text "HELLO")
 fi
 
 echo "[gate] running CPU multimodal regression check"

--- a/website/docs/platforms/webgpu-bridge.md
+++ b/website/docs/platforms/webgpu-bridge.md
@@ -146,13 +146,13 @@ development validation, and CDN-first loading for normal hosted deployments:
 1. On localhost: local asset first, then CDN fallback.
 2. On hosted deployments: CDN asset first, then local fallback.
 
-The example currently pins bridge assets to `v0.1.17`, with local vendored assets
-identified as `v0.1.17-local-b9699`.
+The example currently pins bridge assets to `v0.1.18`, with local vendored assets
+identified as `v0.1.18-local-b9915`.
 
 Fetch pinned local assets with:
 
 ```bash
-WEBGPU_BRIDGE_ASSETS_TAG=v0.1.17 ./scripts/fetch_webgpu_bridge_assets.sh
+WEBGPU_BRIDGE_ASSETS_TAG=v0.1.18 ./scripts/fetch_webgpu_bridge_assets.sh
 ```
 
 To verify the loaded runtime in a browser console, inspect:
@@ -302,7 +302,7 @@ You can override bridge asset source/version before loader startup:
 ```html
 <script>
   window.__llamadartBridgeAssetsRepo = 'leehack/llama-web-bridge-assets';
-  window.__llamadartBridgeAssetsTag = 'v0.1.17';
+  window.__llamadartBridgeAssetsTag = 'v0.1.18';
   // Prefer local runtime even off localhost:
   // window.__llamadartPreferLocalBridgeRuntime = true;
   // Enable verbose bridge bootstrap console logs:


### PR DESCRIPTION
## Summary

- update the chat app's WebGPU bridge assets from `v0.1.17` to `v0.1.18` (llama.cpp `b9915`)
- pin the Web LiteRT-LM runtime to `@litert-lm/core@0.14.0` across the app and browser harnesses
- strengthen the Qwen multimodal regression gate with deterministic sampling and a semantic `HELLO` assertion for the synthetic fixture
- align current README, WebGPU documentation, fetch-script defaults, and changelog entries with the runtime pins

## Why

The chat app should use reproducible, current web runtimes rather than an unversioned LiteRT-LM import or the previous WebGPU asset release. The stronger multimodal gate ensures that a non-empty but visually incorrect response cannot pass the built-in synthetic-image check.

## User impact

Hosted and local chat app builds now resolve the same pinned WebGPU and LiteRT-LM versions. Existing runtime overrides remain supported. No public Dart API changes are included.

## Validation

- `dart analyze`
- `dart test -p vm -j 1 --exclude-tags local-only` (1,263 passed, 66 skipped)
- `dart test -p chrome --exclude-tags local-only` (703 passed, 1 skipped)
- `(cd example/chat_app && flutter test)` (140 passed)
- `./tool/docs/build_site.sh`
- `./tool/docs/validate_links.sh`
- bridge asset checksum verification and bootstrap smoke
- chat app mock and real-model browser smokes
- Qwen 3.5 multimodal inference on CPU and WebGPU, including semantic `HELLO` output
- Gemma 4 E2B GGUF inference through the memory64 WebGPU bridge
- Gemma 4 E2B LiteRT-LM inference through `@litert-lm/core@0.14.0`
- 94 MB GGUF cache smoke: one model request followed by `src cache` / `cache hit`

## Observations

- Large model cache writes reported `model_cache_store_failed` in the ephemeral Playwright profile, while the smaller fixture confirmed correct cache reuse. This is consistent with temporary browser quota limits and does not change the network fallback behavior.
- The local static-server Gemma GGUF smoke recovered from an aborted fetch-backed attempt by using streamed loading, then completed inference successfully.
