### PR TITLE
Prepare 0.8.14 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-## Unreleased
+## 0.8.14
 
 * Updated the runnable chat app's web runtimes to pinned WebGPU bridge assets
   `v0.1.18` (llama.cpp `b9915`) and `@litert-lm/core@0.14.0`, keeping hosted

--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ For Dart or Flutter apps:
 
 ```yaml
 dependencies:
-  llamadart: ^0.8.13
+  llamadart: ^0.8.14
 ```
 
 Flutter iOS/macOS apps that should link Apple XCFrameworks through Swift
@@ -57,8 +57,8 @@ Package Manager should also add the runtime companion packages they need:
 
 ```yaml
 dependencies:
-  llamadart: ^0.8.13
-  llamadart_llama_cpp_flutter: ^0.0.8 # GGUF / llama.cpp
+  llamadart: ^0.8.14
+  llamadart_llama_cpp_flutter: ^0.0.9 # GGUF / llama.cpp
   llamadart_litert_lm_flutter: ^0.0.4 # iOS .litertlm / LiteRT-LM
 ```
 

--- a/packages/llamadart_litert_lm_flutter/README.md
+++ b/packages/llamadart_litert_lm_flutter/README.md
@@ -12,7 +12,7 @@ for the selected architecture.
 
 ```yaml
 dependencies:
-  llamadart: ^0.8.13
+  llamadart: ^0.8.14
   llamadart_litert_lm_flutter: ^0.0.4
 ```
 

--- a/packages/llamadart_llama_cpp_flutter/CHANGELOG.md
+++ b/packages/llamadart_llama_cpp_flutter/CHANGELOG.md
@@ -1,4 +1,4 @@
-## Unreleased
+## 0.0.9
 
 * Updated Apple SwiftPM native pin to `leehack/llamadart-native@b9935`.
 

--- a/packages/llamadart_llama_cpp_flutter/README.md
+++ b/packages/llamadart_llama_cpp_flutter/README.md
@@ -9,8 +9,8 @@ core package's native-assets fallback.
 
 ```yaml
 dependencies:
-  llamadart: ^0.8.13
-  llamadart_llama_cpp_flutter: ^0.0.8
+  llamadart: ^0.8.14
+  llamadart_llama_cpp_flutter: ^0.0.9
 ```
 
 This package has no runtime Dart API of its own. Import `package:llamadart`

--- a/packages/llamadart_llama_cpp_flutter/pubspec.yaml
+++ b/packages/llamadart_llama_cpp_flutter/pubspec.yaml
@@ -1,6 +1,6 @@
 name: llamadart_llama_cpp_flutter
 description: Flutter Apple SwiftPM runtime companion package for llamadart llama.cpp and GGUF support.
-version: 0.0.8
+version: 0.0.9
 repository: https://github.com/leehack/llamadart/tree/main/packages/llamadart_llama_cpp_flutter
 homepage: https://github.com/leehack/llamadart
 issue_tracker: https://github.com/leehack/llamadart/issues

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: llamadart
 description: Dart and Flutter local LLM inference with llama.cpp GGUF and LiteRT-LM across native platforms and web.
-version: 0.8.13
+version: 0.8.14
 homepage: https://github.com/leehack/llamadart
 repository: https://github.com/leehack/llamadart
 issue_tracker: https://github.com/leehack/llamadart/issues

--- a/website/docs/changelog/recent-releases.md
+++ b/website/docs/changelog/recent-releases.md
@@ -7,6 +7,22 @@ For canonical full release notes, use:
 
 - [`CHANGELOG.md`](https://github.com/leehack/llamadart/blob/main/CHANGELOG.md)
 
+## 0.8.14
+
+- Improved the runnable chat app's web model-cache and loading experience by
+  reusing cached GGUF and LiteRT-LM bundles, preserving browser model caches
+  during app cache cleanup, allowing text-only downloads without a multimodal
+  projector, and polishing download/load progress states.
+
+- Updated the chat app's web runtimes to pinned WebGPU bridge assets `v0.1.18`
+  (llama.cpp `b9915`) and `@litert-lm/core@0.14.0` for reproducible hosted and
+  local inference.
+
+- Updated the default native llama.cpp runtime to
+  `leehack/llamadart-native@b9935`, regenerated matching Dart FFI bindings,
+  refreshed the Apple SwiftPM companion checksum, and aligned current runtime
+  documentation.
+
 ## 0.8.13
 
 - Fixed load lifecycle guards so repeated model loads preserve the active

--- a/website/docs/getting-started/installation.md
+++ b/website/docs/getting-started/installation.md
@@ -27,7 +27,7 @@ In Xcode, set `IPHONEOS_DEPLOYMENT_TARGET = 16.4` or
 
 ```yaml
 dependencies:
-  llamadart: ^0.8.13
+  llamadart: ^0.8.14
 ```
 
 For Flutter iOS/macOS apps that should link Apple XCFrameworks through Swift
@@ -35,8 +35,8 @@ Package Manager, also add the runtime companion packages you need:
 
 ```yaml
 dependencies:
-  llamadart: ^0.8.13
-  llamadart_llama_cpp_flutter: ^0.0.8 # GGUF / llama.cpp
+  llamadart: ^0.8.14
+  llamadart_llama_cpp_flutter: ^0.0.9 # GGUF / llama.cpp
   llamadart_litert_lm_flutter: ^0.0.4 # iOS .litertlm / LiteRT-LM
 ```
 


### PR DESCRIPTION
## Summary

- bump `llamadart` from `0.8.13` to `0.8.14`
- bump `llamadart_llama_cpp_flutter` from `0.0.8` to `0.0.9` for the `b9935` Apple SwiftPM runtime pin
- keep `llamadart_litert_lm_flutter` at `0.0.4` because its publishable package contents did not change
- promote the current changelog entries and align README, installation, companion, and recent-release documentation

## Release highlights

- native llama.cpp runtime update to `leehack/llamadart-native@b9935`
- improved chat-app web cache reuse, optional projector downloads, and model download/load UX
- pinned WebGPU bridge assets `v0.1.18` (llama.cpp `b9915`) and `@litert-lm/core@0.14.0`

Neither `llamadart 0.8.14` nor `llamadart_llama_cpp_flutter 0.0.9` exists on pub.dev, and neither release tag exists. Merging this release-prep PR is the publication approval boundary: `release_on_prep_merge.yml` should publish the missing companion first, then create the core tag and trigger pub.dev, docs-version, and GitHub Release automation.

## Validation

- post-merge `main` CI and LiteRT-LM smoke workflows passed on `9dda950a3`
- `git diff --check`
- `dart format --output=none --set-exit-if-changed .`
- `dart analyze`
- `dart run tool/testing/verify_release_docs_versions.dart`
- `./tool/docs/build_site.sh`
- `./tool/docs/validate_links.sh`
- `dart pub publish --dry-run` for `llamadart 0.8.14` (0 warnings)
- `flutter pub publish --dry-run` for `llamadart_llama_cpp_flutter 0.0.9` (0 warnings)
- `flutter pub global run pana . --exit-code-threshold 160` (160/160)
- `dart test -p vm test/unit/tooling/release_install_snippets_test.dart`
- `(cd packages/llamadart_llama_cpp_flutter && flutter test)`
