### PR TITLE
Modernize chat app UI and harden runtime state

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,10 @@
   response; and redacted signed model URL parameters from labels and generation
   errors.
 
+* Clarified the chat app's backend and GPU-layer controls, exposed the active
+  loaded backend beside its preference, and restored GPU offload when switching
+  from a zero-layer CPU configuration back to Auto or a GPU backend.
+
 ## 0.8.14
 
 * Updated the runnable chat app's web runtimes to pinned WebGPU bridge assets

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+## Unreleased
+
+* Redesigned the runnable chat app with a quieter responsive shell, compact
+  runtime details, full-screen mobile settings, streamlined message/composer
+  surfaces, accessible controls, protected conversation deletion, and
+  copy/regenerate actions for assistant responses.
+
 ## 0.8.14
 
 * Updated the runnable chat app's web runtimes to pinned WebGPU bridge assets

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,12 @@
   copy/regenerate actions for assistant responses. Model downloads now remain
   active when settings closes or switches between drawer and pinned layouts.
 
+* Hardened the runnable chat app for narrow windows, 200% text scaling, and
+  macOS assistive technology; removed stale assistant placeholders after empty
+  or failed generations; kept context accounting stable when regenerating a
+  response; and redacted signed model URL parameters from labels and generation
+  errors.
+
 ## 0.8.14
 
 * Updated the runnable chat app's web runtimes to pinned WebGPU bridge assets

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,8 @@
 * Redesigned the runnable chat app with a quieter responsive shell, compact
   runtime details, full-screen mobile settings, streamlined message/composer
   surfaces, accessible controls, protected conversation deletion, and
-  copy/regenerate actions for assistant responses.
+  copy/regenerate actions for assistant responses. Model downloads now remain
+  active when settings closes or switches between drawer and pinned layouts.
 
 ## 0.8.14
 

--- a/example/chat_app/README.md
+++ b/example/chat_app/README.md
@@ -17,7 +17,8 @@ A Flutter chat application demonstrating real-world usage of llamadart with UI.
 - 💾 Settings persistence
 - 🔇 Separate Dart vs native log level controls
 - 🔄 Streaming generation
-- 🎨 User and AI message bubbles
+- 🎨 Restrained user bubbles with readable, copyable assistant responses
+- 📊 Compact runtime status with detailed performance diagnostics on demand
 
 ## Setup
 
@@ -56,7 +57,8 @@ flutter test --run-skipped -t local-only \
 ```
 
 ### 2. Choose and Download a Model
-1. The app will open to a **Manage Models** screen.
+1. The app opens to the chat shell. Tap **Select model** in the welcome view or
+   the settings control in the top bar to open the model library.
    - Native mobile/desktop builds store downloaded model files under the app's
      application-specific cache `models` directory via `path_provider`; web builds use
      browser Cache Storage/origin-scoped runtime caches.
@@ -90,8 +92,9 @@ flutter test --run-skipped -t local-only \
      bundle is published.
 
 ### 3. Advanced Configuration (Optional)
-1. Tap the settings icon (⚙️) in the app bar.
-2. Adjust **GPU Layers**, **Context Size**, **Preferred Backend**, **Dart Log Level**, and **Native Log Level**.
+1. Tap the settings control in the top bar.
+2. Adjust **GPU Layers**, **Context Size**, and **Preferred Backend**. Expand
+   **Advanced** for Dart and native/bridge log levels.
    - Backend choices are concrete runtime-detected options (for example:
      CPU/Vulkan/CUDA for GGUF, or CPU/GPU/NPU where LiteRT-LM exposes them), not
      `Auto`.
@@ -387,8 +390,9 @@ await prefs.setInt('preferred_backend', backendIndex);
   transfer, but engine creation still has to initialize the large model and GPU
   resources on each load. Per-message token counts are also not shown for web
   LiteRT-LM models because the backend exposes no tokenizer API.
-- Runtime status chips expose execution mode/core/cache/worker fallback/runtime notes,
-  so non-COI or worker fallback perf constraints are visible in-app.
+- Runtime details expose execution mode, core, cache, worker fallback, and
+  runtime notes, so non-COI or worker fallback constraints remain visible
+  without crowding the conversation.
 - On web, multimodal projector loading is eager by default for stability: if an
   mmproj is configured, it is loaded together with the model.
 
@@ -399,8 +403,8 @@ await prefs.setInt('preferred_backend', backendIndex);
   prefers `CPU` for those two models.
 - Qwen3.5 `4B` is closer: `CPU` still wins on short prompts, but `Vulkan` is now
   much faster than before and may be worth comparing for longer generations.
-- Runtime chips now include native llama.cpp timing breakdowns: `p_eval`,
-  `eval`, `sample`, and `reuse`.
+- Runtime details include native llama.cpp timing breakdowns: `p_eval`, `eval`,
+  `sample`, and `reuse`.
 - Android text-only chat is stable even when `mmproj` is loaded.
 - Android real image prompting is currently recommended in `CPU` mode for
   Qwen3.5 `0.8B`; `Vulkan` multimodal is still not reliable enough.

--- a/example/chat_app/README.md
+++ b/example/chat_app/README.md
@@ -95,9 +95,11 @@ flutter test --run-skipped -t local-only \
 1. Tap the settings control in the top bar.
 2. Adjust **GPU Layers**, **Context Size**, and **Preferred Backend**. Expand
    **Advanced** for Dart and native/bridge log levels.
-   - Backend choices are concrete runtime-detected options (for example:
-     CPU/Vulkan/CUDA for GGUF, or CPU/GPU/NPU where LiteRT-LM exposes them), not
-     `Auto`.
+   - `Auto` selects the best supported runtime; on supported Macs it prefers
+     Metal. The selector also lists concrete runtime-detected options such as
+     CPU/Vulkan/CUDA for GGUF or CPU/GPU/NPU for LiteRT-LM.
+   - **GPU Layers** controls model offload separately: `0` runs on CPU, while
+     **Max** requests full GPU offload. Reload the model to apply changes.
 3. Optionally enable **Function Calling** and edit tool declarations depending on model/template support.
 4. Tap **Load Model** to apply changes.
 
@@ -280,8 +282,10 @@ await prefs.setInt('preferred_backend', backendIndex);
   `flutter run --dart-define=LLAMADART_CHAT_PARALLEL_DOWNLOAD=true`
 
 **Backend list/selection notes:**
-- The settings sheet shows detected runtime backends/devices, not only packaged modules.
-- Legacy saved `Auto` backend preferences are resolved to the best detected backend at runtime.
+- The settings sheet shows `Auto` plus detected runtime backends/devices, not
+  only packaged modules.
+- `Auto` backend preferences are resolved to the best detected backend at model
+  load time.
 
 
 **App crashes on startup:**

--- a/example/chat_app/lib/main.dart
+++ b/example/chat_app/lib/main.dart
@@ -55,6 +55,23 @@ class _MyAppState extends State<MyApp> {
 
   @override
   Widget build(BuildContext context) {
+    final darkColorScheme =
+        ColorScheme.fromSeed(
+          seedColor: const Color(0xFF9CB2FF),
+          brightness: Brightness.dark,
+        ).copyWith(
+          primary: const Color(0xFFAFC1FF),
+          onPrimary: const Color(0xFF14214A),
+          surface: const Color(0xFF0D1118),
+          surfaceContainerLowest: const Color(0xFF090C12),
+          surfaceContainerLow: const Color(0xFF11161F),
+          surfaceContainer: const Color(0xFF151A23),
+          surfaceContainerHigh: const Color(0xFF191F29),
+          surfaceContainerHighest: const Color(0xFF212834),
+          outline: const Color(0xFF566171),
+          outlineVariant: const Color(0xFF303845),
+        );
+
     return ChangeNotifierProvider.value(
       value: _chatProvider,
       child: MaterialApp(
@@ -71,11 +88,8 @@ class _MyAppState extends State<MyApp> {
           appBarTheme: const AppBarTheme(centerTitle: true, elevation: 0),
         ),
         darkTheme: ThemeData(
-          colorScheme: ColorScheme.fromSeed(
-            seedColor: const Color(0xFF5D89FF),
-            brightness: Brightness.dark,
-            surface: const Color(0xFF0B101A),
-          ),
+          colorScheme: darkColorScheme,
+          scaffoldBackgroundColor: darkColorScheme.surfaceContainerLowest,
           useMaterial3: true,
           fontFamilyFallback: _emojiFontFallback,
           textTheme: GoogleFonts.manropeTextTheme(ThemeData.dark().textTheme),
@@ -83,6 +97,15 @@ class _MyAppState extends State<MyApp> {
             centerTitle: true,
             elevation: 0,
             backgroundColor: Colors.transparent,
+          ),
+          cardTheme: const CardThemeData(elevation: 0),
+          drawerTheme: DrawerThemeData(
+            backgroundColor: darkColorScheme.surface,
+            scrimColor: Colors.black.withValues(alpha: 0.68),
+          ),
+          dividerTheme: DividerThemeData(
+            color: darkColorScheme.outlineVariant.withValues(alpha: 0.55),
+            thickness: 1,
           ),
         ),
         themeMode: ThemeMode.dark,

--- a/example/chat_app/lib/models/chat_message.dart
+++ b/example/chat_app/lib/models/chat_message.dart
@@ -12,6 +12,9 @@ class ChatMessage {
   final LlamaChatRole? role;
   int? tokenCount; // Cache token count for sliding window optimization
 
+  /// This response's contribution to the runtime context counter.
+  int? generatedTokenCount;
+
   ChatMessage({
     required String text,
     required this.isUser,
@@ -21,6 +24,7 @@ class ChatMessage {
     this.role,
     DateTime? timestamp,
     this.tokenCount,
+    this.generatedTokenCount,
   }) : text = sanitizeForTextLayout(text),
        timestamp = timestamp ?? DateTime.now();
 
@@ -57,6 +61,7 @@ class ChatMessage {
     LlamaChatRole? role,
     DateTime? timestamp,
     int? tokenCount,
+    int? generatedTokenCount,
   }) {
     return ChatMessage(
       text: text ?? this.text,
@@ -67,6 +72,7 @@ class ChatMessage {
       role: role ?? this.role,
       timestamp: timestamp ?? this.timestamp,
       tokenCount: tokenCount ?? this.tokenCount,
+      generatedTokenCount: generatedTokenCount ?? this.generatedTokenCount,
     );
   }
 }

--- a/example/chat_app/lib/providers/chat_provider.dart
+++ b/example/chat_app/lib/providers/chat_provider.dart
@@ -210,10 +210,10 @@ class ChatProvider extends ChangeNotifier {
     if (modelPath == null || modelPath.isEmpty) {
       return 'No model';
     }
-    final normalized = modelPath.replaceAll('\\', '/');
-    final pieces = normalized.split('/');
-    final file = pieces.isNotEmpty ? pieces.last : modelPath;
-    return file.split('?').first;
+    final withoutSensitiveSuffix = modelPath.split('?').first.split('#').first;
+    final normalized = withoutSensitiveSuffix.replaceAll('\\', '/');
+    final pieces = normalized.split('/').where((part) => part.isNotEmpty);
+    return pieces.isEmpty ? 'Selected model' : pieces.last;
   }
 
   bool get toolsEnabled => _settings.toolsEnabled;
@@ -1099,7 +1099,8 @@ class ChatProvider extends ChangeNotifier {
   Future<void> regenerateLastResponse() async {
     if (!canRegenerateLastResponse) return;
 
-    final replacedTokenCount = _messages.last.tokenCount ?? 0;
+    final replacedTokenCount =
+        _messages.last.generatedTokenCount ?? _messages.last.tokenCount ?? 0;
     var userIndex = -1;
     for (var index = _messages.length - 2; index >= 0; index--) {
       if (_messages[index].isUser && !_messages[index].isInfo) {
@@ -1478,7 +1479,9 @@ class ChatProvider extends ChangeNotifier {
           }
         }
       }
+      _removeEmptyAssistantPlaceholder();
     } catch (e) {
+      _removeEmptyAssistantPlaceholder();
       final errorText = e.toString();
       if (e is TimeoutException) {
         _chatService.cancelGeneration();
@@ -1549,7 +1552,9 @@ class ChatProvider extends ChangeNotifier {
           ),
         );
       } else {
-        _messages.add(ChatMessage(text: 'Error: $e', isUser: false));
+        _messages.add(
+          ChatMessage(text: 'Error: ${_formatDisplayError(e)}', isUser: false),
+        );
       }
     } finally {
       final generatedTokens = generationResult.generatedTokens;
@@ -1587,6 +1592,11 @@ class ChatProvider extends ChangeNotifier {
       }
 
       final effectiveGeneratedTokens = nativeEvalTokens ?? generatedTokens;
+      if (_messages.isNotEmpty &&
+          !_messages.last.isUser &&
+          !_messages.last.isInfo) {
+        _messages.last.generatedTokenCount = effectiveGeneratedTokens;
+      }
       if (nativeEvalTokens != null &&
           nativeEvalTokens != appliedGeneratedTokenDeltas) {
         _currentTokens = math.max(
@@ -1619,6 +1629,22 @@ class ChatProvider extends ChangeNotifier {
       _isGenerating = false;
       _syncActiveConversationSnapshot();
       notifyListeners();
+    }
+  }
+
+  void _removeEmptyAssistantPlaceholder() {
+    if (_messages.isEmpty) {
+      return;
+    }
+
+    final last = _messages.last;
+    final hasContentParts = last.parts?.isNotEmpty ?? false;
+    final text = last.text.trim();
+    if (!last.isUser &&
+        !last.isInfo &&
+        !hasContentParts &&
+        (text.isEmpty || text == '...')) {
+      _messages.removeLast();
     }
   }
 

--- a/example/chat_app/lib/providers/chat_provider.dart
+++ b/example/chat_app/lib/providers/chat_provider.dart
@@ -1553,7 +1553,11 @@ class ChatProvider extends ChangeNotifier {
         );
       } else {
         _messages.add(
-          ChatMessage(text: 'Error: ${_formatDisplayError(e)}', isUser: false),
+          ChatMessage(
+            text: 'Error: ${_formatDisplayError(e)}',
+            isUser: false,
+            isInfo: true,
+          ),
         );
       }
     } finally {

--- a/example/chat_app/lib/providers/chat_provider.dart
+++ b/example/chat_app/lib/providers/chat_provider.dart
@@ -137,6 +137,29 @@ class ChatProvider extends ChangeNotifier {
   double get loadingProgress => _loadingProgress;
   bool get isLoaded => _isLoaded;
   bool get isGenerating => _isGenerating;
+
+  /// Whether the latest plain assistant response can be generated again.
+  bool get canRegenerateLastResponse {
+    if (_isGenerating ||
+        _session == null ||
+        !_chatService.engine.isReady ||
+        _messages.length < 2) {
+      return false;
+    }
+
+    final assistant = _messages.last;
+    if (assistant.isUser ||
+        assistant.isInfo ||
+        assistant.isToolCall ||
+        assistant.role == LlamaChatRole.tool) {
+      return false;
+    }
+
+    return _messages
+        .take(_messages.length - 1)
+        .any((message) => message.isUser && !message.isInfo);
+  }
+
   bool get supportsVision => _supportsVision;
   bool get supportsAudio => _supportsAudio;
   bool get templateSupportsTools => _templateSupportsTools;
@@ -1072,6 +1095,56 @@ class ChatProvider extends ChangeNotifier {
     await _generateResponse(text, parts: parts.isEmpty ? null : parts);
   }
 
+  /// Removes the latest plain assistant response and generates a replacement.
+  Future<void> regenerateLastResponse() async {
+    if (!canRegenerateLastResponse) return;
+
+    final replacedTokenCount = _messages.last.tokenCount ?? 0;
+    var userIndex = -1;
+    for (var index = _messages.length - 2; index >= 0; index--) {
+      if (_messages[index].isUser && !_messages[index].isInfo) {
+        userIndex = index;
+        break;
+      }
+    }
+    if (userIndex < 0) return;
+
+    final userMessage = _messages[userIndex];
+    final mediaParts = userMessage.parts
+        ?.where((part) => part is! LlamaTextContent)
+        .toList(growable: false);
+    if (mediaParts != null &&
+        mediaParts.isNotEmpty &&
+        !await _ensureMultimodalProjectorForMedia(mediaParts)) {
+      return;
+    }
+
+    _messages.removeLast();
+    _currentTokens = math.max(0, _currentTokens - replacedTokenCount);
+    _lastFirstTokenLatencyMs = null;
+    _lastGenerationLatencyMs = null;
+    _clearGenerationMetrics();
+
+    final history = _settings.singleTurnMode
+        ? const <ChatMessage>[]
+        : _messages.take(userIndex);
+    _session = _chatSessionService.rebuildFromMessages(
+      engine: _chatService.engine,
+      contextSize: _settings.contextSize,
+      systemPrompt: _sessionSystemPrompt(),
+      messages: history,
+    );
+    _isGenerating = true;
+    _syncActiveConversationSnapshot();
+    notifyListeners();
+
+    await _yieldUiFrame();
+    await _generateResponse(
+      userMessage.text,
+      parts: mediaParts == null || mediaParts.isEmpty ? null : mediaParts,
+    );
+  }
+
   Map<String, dynamic>? _thinkingTemplateKwargs() {
     if (_settings.thinkingEnabled && _settings.thinkingBudgetTokens <= 0) {
       return null;
@@ -1392,16 +1465,16 @@ class ChatProvider extends ChangeNotifier {
             debugBadges: debugBadges,
           );
           // Some backends (e.g. LiteRT-LM on web) don't expose tokenizer
-          // operations, so getTokenCount throws. The count is only a cached
-          // hint, so swallow the unsupported case instead of failing the turn.
+          // operations, so retain the generated-token count as the cache hint
+          // instead of failing the turn.
           try {
             _messages.last.tokenCount = await _chatService.engine.getTokenCount(
               finalText,
             );
           } on LlamaUnsupportedException {
-            // Backend can't tokenize; leave the cached count unset.
+            _messages.last.tokenCount = generationResult.generatedTokens;
           } on UnsupportedError {
-            // Same as above for backends that surface the raw Dart error.
+            _messages.last.tokenCount = generationResult.generatedTokens;
           }
         }
       }

--- a/example/chat_app/lib/providers/chat_provider.dart
+++ b/example/chat_app/lib/providers/chat_provider.dart
@@ -2314,11 +2314,19 @@ class ChatProvider extends ChangeNotifier {
   }
 
   Future<void> updatePreferredBackend(GpuBackend backend) {
-    _updateSettings(_settings.copyWith(preferredBackend: backend));
+    final restoresGpuOffload =
+        backend != GpuBackend.cpu && _settings.gpuLayers == 0;
+    _updateSettings(
+      _settings.copyWith(
+        preferredBackend: backend,
+        gpuLayers: restoresGpuOffload ? 99 : _settings.gpuLayers,
+      ),
+    );
     _messages.add(
       ChatMessage(
-        text:
-            'Backend preference set to ${backend.name}. Reload model to apply.',
+        text: restoresGpuOffload
+            ? 'Backend preference set to ${backend.name}. GPU offload restored to Max; reload model to apply.'
+            : 'Backend preference set to ${backend.name}. Reload model to apply.',
         isUser: false,
         isInfo: true,
       ),

--- a/example/chat_app/lib/screens/app_shell_screen.dart
+++ b/example/chat_app/lib/screens/app_shell_screen.dart
@@ -17,13 +17,62 @@ class AppShellScreen extends StatefulWidget {
 
 class _AppShellScreenState extends State<AppShellScreen> {
   final GlobalKey<ScaffoldState> _scaffoldKey = GlobalKey<ScaffoldState>();
+  bool _pinnedSettingsOpen = false;
 
   void _startNewConversation() {
     context.read<ChatProvider>().createConversation();
   }
 
-  void _openSettingsPanel() {
+  void _openSettingsPanel({required bool canPin}) {
+    if (canPin) {
+      setState(() {
+        _pinnedSettingsOpen = true;
+      });
+      return;
+    }
+
     _scaffoldKey.currentState?.openEndDrawer();
+  }
+
+  void _toggleSettingsPanel({required bool canPin}) {
+    if (canPin) {
+      setState(() {
+        _pinnedSettingsOpen = !_pinnedSettingsOpen;
+      });
+      return;
+    }
+
+    _scaffoldKey.currentState?.openEndDrawer();
+  }
+
+  Future<void> _confirmDeleteConversation(
+    String conversationId,
+    String conversationTitle,
+  ) async {
+    final shouldDelete = await showDialog<bool>(
+      context: context,
+      builder: (context) => AlertDialog(
+        title: const Text('Delete conversation?'),
+        content: Text('“$conversationTitle” will be permanently removed.'),
+        actions: [
+          TextButton(
+            onPressed: () => Navigator.of(context).pop(false),
+            child: const Text('Cancel'),
+          ),
+          FilledButton(
+            onPressed: () => Navigator.of(context).pop(true),
+            style: FilledButton.styleFrom(
+              backgroundColor: Theme.of(context).colorScheme.error,
+              foregroundColor: Theme.of(context).colorScheme.onError,
+            ),
+            child: const Text('Delete'),
+          ),
+        ],
+      ),
+    );
+
+    if (shouldDelete != true || !mounted) return;
+    await context.read<ChatProvider>().deleteConversation(conversationId);
   }
 
   @override
@@ -31,8 +80,9 @@ class _AppShellScreenState extends State<AppShellScreen> {
     return LayoutBuilder(
       builder: (context, constraints) {
         final isDesktop = constraints.maxWidth >= 1040;
-        final showPinnedSettingsPanel = constraints.maxWidth >= 1360;
-        final showSlidingSettings = !showPinnedSettingsPanel;
+        final canPinSettingsPanel = constraints.maxWidth >= 1600;
+        final showPinnedSettingsPanel =
+            canPinSettingsPanel && _pinnedSettingsOpen;
 
         return Scaffold(
           key: _scaffoldKey,
@@ -42,47 +92,68 @@ class _AppShellScreenState extends State<AppShellScreen> {
                   child: SafeArea(
                     child: _ShellSidebar(
                       onNewConversation: _startNewConversation,
+                      onDeleteConversation: _confirmDeleteConversation,
                       onConversationActivated: () {
                         Navigator.of(context).pop();
                       },
                     ),
                   ),
                 ),
-          endDrawer: showSlidingSettings
-              ? const Drawer(
+          endDrawer: canPinSettingsPanel
+              ? null
+              : Drawer(
+                  width: constraints.maxWidth < 720
+                      ? constraints.maxWidth
+                      : 420,
                   child: SafeArea(
-                    child: ManageModelsScreen(embeddedPanel: true),
+                    child: Column(
+                      children: [
+                        if (constraints.maxWidth < 720)
+                          Padding(
+                            padding: const EdgeInsets.fromLTRB(8, 6, 12, 0),
+                            child: Row(
+                              children: [
+                                IconButton(
+                                  onPressed: () => Navigator.of(context).pop(),
+                                  tooltip: 'Close settings',
+                                  icon: const Icon(Icons.close_rounded),
+                                ),
+                                const SizedBox(width: 4),
+                                Text(
+                                  'Settings',
+                                  style: Theme.of(context).textTheme.titleLarge
+                                      ?.copyWith(fontWeight: FontWeight.w700),
+                                ),
+                              ],
+                            ),
+                          ),
+                        const Expanded(
+                          child: ManageModelsScreen(embeddedPanel: true),
+                        ),
+                      ],
+                    ),
                   ),
-                )
-              : null,
+                ),
           body: Container(
-            decoration: const BoxDecoration(
-              gradient: LinearGradient(
-                begin: Alignment.topCenter,
-                end: Alignment.bottomCenter,
-                colors: [
-                  Color(0xFF0A0E17),
-                  Color(0xFF090D15),
-                  Color(0xFF070B13),
-                ],
-              ),
-            ),
+            color: Theme.of(context).colorScheme.surfaceContainerLowest,
             child: Column(
               children: [
                 _ShellTopBar(
                   showMenuButton: !isDesktop,
-                  showSettingsButton: showSlidingSettings,
+                  settingsPanelOpen: showPinnedSettingsPanel,
                   onMenuPressed: () => _scaffoldKey.currentState?.openDrawer(),
-                  onOpenSettings: _openSettingsPanel,
+                  onOpenSettings: () =>
+                      _toggleSettingsPanel(canPin: canPinSettingsPanel),
                 ),
                 Expanded(
                   child: Row(
                     children: [
                       if (isDesktop)
                         SizedBox(
-                          width: 292,
+                          width: 248,
                           child: _ShellSidebar(
                             onNewConversation: _startNewConversation,
+                            onDeleteConversation: _confirmDeleteConversation,
                           ),
                         ),
                       if (isDesktop)
@@ -95,10 +166,10 @@ class _AppShellScreenState extends State<AppShellScreen> {
                       Expanded(
                         child: Padding(
                           padding: EdgeInsets.fromLTRB(
-                            isDesktop ? 20 : 10,
+                            isDesktop ? 16 : 8,
+                            8,
+                            isDesktop ? 16 : 8,
                             10,
-                            isDesktop ? 20 : 10,
-                            14,
                           ),
                           child: ClipRRect(
                             borderRadius: BorderRadius.circular(
@@ -106,26 +177,19 @@ class _AppShellScreenState extends State<AppShellScreen> {
                             ),
                             child: DecoratedBox(
                               decoration: BoxDecoration(
+                                color: Theme.of(context).colorScheme.surface,
                                 border: Border.all(
                                   color: Theme.of(context)
                                       .colorScheme
                                       .outlineVariant
                                       .withValues(alpha: 0.35),
                                 ),
-                                gradient: const LinearGradient(
-                                  begin: Alignment.topLeft,
-                                  end: Alignment.bottomRight,
-                                  colors: [
-                                    Color(0xCC101826),
-                                    Color(0xCC0C1422),
-                                  ],
-                                ),
                               ),
                               child: ChatScreen(
-                                onOpenModelSelection: showSlidingSettings
-                                    ? _openSettingsPanel
-                                    : null,
-                                showModelSelectionAction: showSlidingSettings,
+                                onOpenModelSelection: () => _openSettingsPanel(
+                                  canPin: canPinSettingsPanel,
+                                ),
+                                showModelSelectionAction: true,
                               ),
                             ),
                           ),
@@ -140,7 +204,7 @@ class _AppShellScreenState extends State<AppShellScreen> {
                         ),
                       if (showPinnedSettingsPanel)
                         SizedBox(
-                          width: 430,
+                          width: 380,
                           child: Padding(
                             padding: const EdgeInsets.fromLTRB(12, 10, 14, 14),
                             child: ClipRRect(
@@ -178,13 +242,13 @@ class _AppShellScreenState extends State<AppShellScreen> {
 
 class _ShellTopBar extends StatelessWidget {
   final bool showMenuButton;
-  final bool showSettingsButton;
+  final bool settingsPanelOpen;
   final VoidCallback onMenuPressed;
   final VoidCallback onOpenSettings;
 
   const _ShellTopBar({
     required this.showMenuButton,
-    required this.showSettingsButton,
+    required this.settingsPanelOpen,
     required this.onMenuPressed,
     required this.onOpenSettings,
   });
@@ -208,34 +272,32 @@ class _ShellTopBar extends StatelessWidget {
       child: Row(
         children: [
           if (showMenuButton)
-            Semantics(
-              button: true,
-              label: 'Open navigation menu',
-              child: IconButton(
-                onPressed: onMenuPressed,
-                icon: const Icon(Icons.menu_rounded),
-                tooltip: 'Open navigation menu',
-              ),
+            IconButton(
+              onPressed: onMenuPressed,
+              icon: const Icon(Icons.menu_rounded),
+              tooltip: 'Open navigation menu',
             ),
           const SizedBox(width: 6),
-          Text(
-            'llamadart chat',
-            style: Theme.of(context).textTheme.headlineSmall?.copyWith(
-              fontWeight: FontWeight.w800,
-              letterSpacing: 0,
-            ),
-          ),
-          const Spacer(),
-          if (showSettingsButton)
-            Semantics(
-              button: true,
-              label: 'Open model and inference settings',
-              child: IconButton(
-                onPressed: onOpenSettings,
-                tooltip: 'Open model and inference settings',
-                icon: const Icon(Icons.tune_rounded),
+          Expanded(
+            child: Text(
+              'llamadart chat',
+              maxLines: 1,
+              overflow: TextOverflow.ellipsis,
+              style: Theme.of(context).textTheme.headlineSmall?.copyWith(
+                fontWeight: FontWeight.w800,
+                letterSpacing: 0,
               ),
             ),
+          ),
+          IconButton(
+            onPressed: onOpenSettings,
+            tooltip: settingsPanelOpen
+                ? 'Close model and inference settings'
+                : 'Open model and inference settings',
+            icon: Icon(
+              settingsPanelOpen ? Icons.close_rounded : Icons.tune_rounded,
+            ),
+          ),
         ],
       ),
     );
@@ -249,10 +311,13 @@ class _ShellSidebar extends StatelessWidget {
   static final Uri _pubDevUri = Uri.parse('https://pub.dev/packages/llamadart');
 
   final VoidCallback onNewConversation;
+  final Future<void> Function(String conversationId, String conversationTitle)
+  onDeleteConversation;
   final VoidCallback? onConversationActivated;
 
   const _ShellSidebar({
     required this.onNewConversation,
+    required this.onDeleteConversation,
     this.onConversationActivated,
   });
 
@@ -303,7 +368,10 @@ class _ShellSidebar extends StatelessWidget {
                         onConversationActivated?.call();
                       },
                       onDelete: () => unawaited(
-                        provider.deleteConversation(conversation.id),
+                        onDeleteConversation(
+                          conversation.id,
+                          conversation.title,
+                        ),
                       ),
                     );
                   },
@@ -427,12 +495,11 @@ class _ConversationTileState extends State<_ConversationTile> {
                 ),
               ),
               if (widget.canDelete)
-                AnimatedOpacity(
-                  opacity: (_hovered || widget.selected) ? 1.0 : 0.0,
-                  duration: const Duration(milliseconds: 120),
-                  child: Semantics(
-                    button: true,
-                    label: 'Delete conversation',
+                IgnorePointer(
+                  ignoring: !_hovered && !widget.selected,
+                  child: AnimatedOpacity(
+                    opacity: (_hovered || widget.selected) ? 1.0 : 0.0,
+                    duration: const Duration(milliseconds: 120),
                     child: IconButton(
                       onPressed: widget.onDelete,
                       visualDensity: VisualDensity.compact,

--- a/example/chat_app/lib/screens/app_shell_screen.dart
+++ b/example/chat_app/lib/screens/app_shell_screen.dart
@@ -1,5 +1,6 @@
 import 'dart:async';
 
+import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
 import 'package:provider/provider.dart';
 import 'package:url_launcher/url_launcher.dart';
@@ -124,13 +125,24 @@ class _AppShellScreenState extends State<AppShellScreen> {
                                 IconButton(
                                   onPressed: () => Navigator.of(context).pop(),
                                   tooltip: 'Close settings',
-                                  icon: const Icon(Icons.close_rounded),
+                                  icon: const Icon(
+                                    Icons.close_rounded,
+                                    semanticLabel: kIsWeb
+                                        ? null
+                                        : 'Close settings',
+                                  ),
                                 ),
                                 const SizedBox(width: 4),
-                                Text(
-                                  'Settings',
-                                  style: Theme.of(context).textTheme.titleLarge
-                                      ?.copyWith(fontWeight: FontWeight.w700),
+                                Expanded(
+                                  child: Text(
+                                    'Settings',
+                                    maxLines: 1,
+                                    overflow: TextOverflow.ellipsis,
+                                    style: Theme.of(context)
+                                        .textTheme
+                                        .titleLarge
+                                        ?.copyWith(fontWeight: FontWeight.w700),
+                                  ),
                                 ),
                               ],
                             ),
@@ -268,6 +280,9 @@ class _ShellTopBar extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     final topInset = MediaQuery.paddingOf(context).top;
+    final settingsActionLabel = settingsPanelOpen
+        ? 'Close model and inference settings'
+        : 'Open model and inference settings';
 
     return Container(
       padding: EdgeInsets.fromLTRB(12, topInset + 10, 12, 10),
@@ -286,7 +301,10 @@ class _ShellTopBar extends StatelessWidget {
           if (showMenuButton)
             IconButton(
               onPressed: onMenuPressed,
-              icon: const Icon(Icons.menu_rounded),
+              icon: const Icon(
+                Icons.menu_rounded,
+                semanticLabel: kIsWeb ? null : 'Open navigation menu',
+              ),
               tooltip: 'Open navigation menu',
             ),
           const SizedBox(width: 6),
@@ -303,11 +321,10 @@ class _ShellTopBar extends StatelessWidget {
           ),
           IconButton(
             onPressed: onOpenSettings,
-            tooltip: settingsPanelOpen
-                ? 'Close model and inference settings'
-                : 'Open model and inference settings',
+            tooltip: settingsActionLabel,
             icon: Icon(
               settingsPanelOpen ? Icons.close_rounded : Icons.tune_rounded,
+              semanticLabel: kIsWeb ? null : settingsActionLabel,
             ),
           ),
         ],
@@ -520,6 +537,7 @@ class _ConversationTileState extends State<_ConversationTile> {
                       icon: Icon(
                         Icons.delete_outline_rounded,
                         color: colorScheme.error,
+                        semanticLabel: kIsWeb ? null : 'Delete conversation',
                       ),
                     ),
                   ),

--- a/example/chat_app/lib/screens/app_shell_screen.dart
+++ b/example/chat_app/lib/screens/app_shell_screen.dart
@@ -5,6 +5,7 @@ import 'package:provider/provider.dart';
 import 'package:url_launcher/url_launcher.dart';
 
 import '../providers/chat_provider.dart';
+import '../services/model_download_ui_controller.dart';
 import 'chat_screen.dart';
 import 'manage_models_screen.dart';
 
@@ -17,7 +18,14 @@ class AppShellScreen extends StatefulWidget {
 
 class _AppShellScreenState extends State<AppShellScreen> {
   final GlobalKey<ScaffoldState> _scaffoldKey = GlobalKey<ScaffoldState>();
+  final ModelDownloadUiController _downloadUi = ModelDownloadUiController();
   bool _pinnedSettingsOpen = false;
+
+  @override
+  void dispose() {
+    _downloadUi.dispose();
+    super.dispose();
+  }
 
   void _startNewConversation() {
     context.read<ChatProvider>().createConversation();
@@ -127,8 +135,11 @@ class _AppShellScreenState extends State<AppShellScreen> {
                               ],
                             ),
                           ),
-                        const Expanded(
-                          child: ManageModelsScreen(embeddedPanel: true),
+                        Expanded(
+                          child: ManageModelsScreen(
+                            embeddedPanel: true,
+                            downloadUiController: _downloadUi,
+                          ),
                         ),
                       ],
                     ),
@@ -221,8 +232,9 @@ class _AppShellScreenState extends State<AppShellScreen> {
                                         .withValues(alpha: 0.35),
                                   ),
                                 ),
-                                child: const ManageModelsScreen(
+                                child: ManageModelsScreen(
                                   embeddedPanel: true,
+                                  downloadUiController: _downloadUi,
                                 ),
                               ),
                             ),

--- a/example/chat_app/lib/screens/chat_screen.dart
+++ b/example/chat_app/lib/screens/chat_screen.dart
@@ -1,3 +1,5 @@
+import 'dart:async';
+
 import 'package:flutter/material.dart';
 import 'package:provider/provider.dart';
 
@@ -171,24 +173,14 @@ class _ChatScreenState extends State<ChatScreen> {
 
   @override
   Widget build(BuildContext context) {
-    final colorScheme = Theme.of(context).colorScheme;
-
     return Container(
-      decoration: BoxDecoration(
-        gradient: LinearGradient(
-          begin: Alignment.topCenter,
-          end: Alignment.bottomCenter,
-          colors: [
-            colorScheme.surfaceContainerLowest.withValues(alpha: 0.94),
-            colorScheme.surface,
-          ],
-        ),
-      ),
+      color: Colors.transparent,
       child: Stack(
         children: [
           Column(
             children: [
               const PruningIndicator(),
+              const RuntimeStatusPanel(),
               Expanded(
                 child: Consumer<ChatProvider>(
                   builder: (context, provider, _) {
@@ -206,11 +198,9 @@ class _ChatScreenState extends State<ChatScreen> {
                       );
                     }
 
-                    final topPadding = provider.isReady ? 88.0 : 28.0;
-
                     return ListView.builder(
                       controller: _scrollController,
-                      padding: EdgeInsets.fromLTRB(16, topPadding, 16, 24),
+                      padding: const EdgeInsets.fromLTRB(16, 16, 16, 24),
                       itemCount: provider.messages.length,
                       itemBuilder: (context, index) {
                         final message = provider.messages[index];
@@ -229,6 +219,12 @@ class _ChatScreenState extends State<ChatScreen> {
                           message: message,
                           isNextSame: isNextSame,
                           isStreaming: isStreamingMessage,
+                          onRegenerate:
+                              index == provider.messages.length - 1 &&
+                                  provider.canRegenerateLastResponse
+                              ? () =>
+                                    unawaited(provider.regenerateLastResponse())
+                              : null,
                         );
                       },
                     );
@@ -241,12 +237,6 @@ class _ChatScreenState extends State<ChatScreen> {
                 focusNode: _focusNode,
               ),
             ],
-          ),
-          const Positioned(
-            top: 8,
-            left: 0,
-            right: 0,
-            child: RuntimeStatusPanel(),
           ),
           if (_showScrollToBottom)
             Positioned(

--- a/example/chat_app/lib/screens/chat_screen.dart
+++ b/example/chat_app/lib/screens/chat_screen.dart
@@ -1,5 +1,6 @@
 import 'dart:async';
 
+import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
 import 'package:provider/provider.dart';
 
@@ -246,7 +247,10 @@ class _ChatScreenState extends State<ChatScreen> {
                 heroTag: 'scroll-to-bottom',
                 onPressed: _scrollToBottom,
                 tooltip: 'Jump to latest',
-                child: const Icon(Icons.keyboard_arrow_down_rounded),
+                child: const Icon(
+                  Icons.keyboard_arrow_down_rounded,
+                  semanticLabel: kIsWeb ? null : 'Jump to latest',
+                ),
               ),
             ),
         ],

--- a/example/chat_app/lib/screens/chat_screen.dart
+++ b/example/chat_app/lib/screens/chat_screen.dart
@@ -185,7 +185,8 @@ class _ChatScreenState extends State<ChatScreen> {
               Expanded(
                 child: Consumer<ChatProvider>(
                   builder: (context, provider, _) {
-                    if (provider.messages.isEmpty) {
+                    final messages = provider.messages;
+                    if (messages.isEmpty) {
                       return WelcomeView(
                         isInitializing: provider.isInitializing,
                         error: provider.error,
@@ -202,26 +203,25 @@ class _ChatScreenState extends State<ChatScreen> {
                     return ListView.builder(
                       controller: _scrollController,
                       padding: const EdgeInsets.fromLTRB(16, 16, 16, 24),
-                      itemCount: provider.messages.length,
+                      itemCount: messages.length,
                       itemBuilder: (context, index) {
-                        final message = provider.messages[index];
+                        final message = messages[index];
                         var isNextSame = false;
-                        if (index + 1 < provider.messages.length) {
+                        if (index + 1 < messages.length) {
                           isNextSame =
-                              provider.messages[index + 1].isUser ==
-                              message.isUser;
+                              messages[index + 1].isUser == message.isUser;
                         }
                         final isStreamingMessage =
                             provider.isGenerating &&
                             !message.isUser &&
                             !message.isInfo &&
-                            index == provider.messages.length - 1;
+                            index == messages.length - 1;
                         return MessageBubble(
                           message: message,
                           isNextSame: isNextSame,
                           isStreaming: isStreamingMessage,
                           onRegenerate:
-                              index == provider.messages.length - 1 &&
+                              index == messages.length - 1 &&
                                   provider.canRegenerateLastResponse
                               ? () =>
                                     unawaited(provider.regenerateLastResponse())

--- a/example/chat_app/lib/screens/manage_models_screen.dart
+++ b/example/chat_app/lib/screens/manage_models_screen.dart
@@ -63,6 +63,7 @@ class _ManageModelsScreenState extends State<ManageModelsScreen>
   bool _showModelLibrary = true;
   bool _modelParametersExpanded = false;
   bool _inferenceParametersExpanded = false;
+  bool _advancedExpanded = false;
 
   @override
   void initState() {
@@ -1837,13 +1838,6 @@ class _ManageModelsScreenState extends State<ManageModelsScreen>
               ),
             ),
             const SizedBox(height: 24),
-            Text(
-              'Diagnostics',
-              style: Theme.of(
-                context,
-              ).textTheme.headlineSmall?.copyWith(fontWeight: FontWeight.w700),
-            ),
-            const SizedBox(height: 12),
             Container(
               padding: const EdgeInsets.all(16),
               decoration: BoxDecoration(
@@ -1855,53 +1849,78 @@ class _ManageModelsScreenState extends State<ManageModelsScreen>
                   ).colorScheme.outlineVariant.withValues(alpha: 0.45),
                 ),
               ),
-              child: Column(
-                children: [
-                  DropdownButtonFormField<LlamaLogLevel>(
-                    initialValue: provider.dartLogLevel,
-                    decoration: const InputDecoration(
-                      labelText: 'Dart log level',
+              child: Theme(
+                data: Theme.of(
+                  context,
+                ).copyWith(dividerColor: Colors.transparent),
+                child: ExpansionTile(
+                  initiallyExpanded: _advancedExpanded,
+                  onExpansionChanged: (expanded) {
+                    setState(() {
+                      _advancedExpanded = expanded;
+                    });
+                  },
+                  tilePadding: EdgeInsets.zero,
+                  childrenPadding: const EdgeInsets.only(top: 8),
+                  shape: const RoundedRectangleBorder(),
+                  collapsedShape: const RoundedRectangleBorder(),
+                  title: Text(
+                    'Advanced',
+                    style: Theme.of(context).textTheme.titleLarge?.copyWith(
+                      fontWeight: FontWeight.w700,
                     ),
-                    items: LlamaLogLevel.values
-                        .map(
-                          (level) => DropdownMenuItem<LlamaLogLevel>(
-                            value: level,
-                            child: Text(_logLevelLabel(level)),
-                          ),
-                        )
-                        .toList(growable: false),
-                    onChanged: (value) {
-                      if (value != null) {
-                        provider.updateLogLevel(value);
-                      }
-                    },
                   ),
-                  const SizedBox(height: 10),
-                  DropdownButtonFormField<LlamaLogLevel>(
-                    initialValue: provider.nativeLogLevel,
-                    decoration: InputDecoration(
-                      labelText: kIsWeb
-                          ? 'Bridge/runtime log level'
-                          : 'Native log level',
-                      helperText: kIsWeb
-                          ? 'Applies to bridge/core logs. For startup diagnostics set window.__llamadartBridgeBootstrapVerbose = true; for pthread warnings align window.__llamadartBridgeThreadPoolSize.'
-                          : null,
+                  subtitle: Text(
+                    'Diagnostics and runtime logging',
+                    style: Theme.of(context).textTheme.bodySmall,
+                  ),
+                  children: [
+                    DropdownButtonFormField<LlamaLogLevel>(
+                      initialValue: provider.dartLogLevel,
+                      decoration: const InputDecoration(
+                        labelText: 'Dart log level',
+                      ),
+                      items: LlamaLogLevel.values
+                          .map(
+                            (level) => DropdownMenuItem<LlamaLogLevel>(
+                              value: level,
+                              child: Text(_logLevelLabel(level)),
+                            ),
+                          )
+                          .toList(growable: false),
+                      onChanged: (value) {
+                        if (value != null) {
+                          provider.updateLogLevel(value);
+                        }
+                      },
                     ),
-                    items: LlamaLogLevel.values
-                        .map(
-                          (level) => DropdownMenuItem<LlamaLogLevel>(
-                            value: level,
-                            child: Text(_logLevelLabel(level)),
-                          ),
-                        )
-                        .toList(growable: false),
-                    onChanged: (value) {
-                      if (value != null) {
-                        provider.updateNativeLogLevel(value);
-                      }
-                    },
-                  ),
-                ],
+                    const SizedBox(height: 10),
+                    DropdownButtonFormField<LlamaLogLevel>(
+                      initialValue: provider.nativeLogLevel,
+                      decoration: InputDecoration(
+                        labelText: kIsWeb
+                            ? 'Bridge/runtime log level'
+                            : 'Native log level',
+                        helperText: kIsWeb
+                            ? 'Applies to bridge/core logs. For startup diagnostics set window.__llamadartBridgeBootstrapVerbose = true; for pthread warnings align window.__llamadartBridgeThreadPoolSize.'
+                            : null,
+                      ),
+                      items: LlamaLogLevel.values
+                          .map(
+                            (level) => DropdownMenuItem<LlamaLogLevel>(
+                              value: level,
+                              child: Text(_logLevelLabel(level)),
+                            ),
+                          )
+                          .toList(growable: false),
+                      onChanged: (value) {
+                        if (value != null) {
+                          provider.updateNativeLogLevel(value);
+                        }
+                      },
+                    ),
+                  ],
+                ),
               ),
             ),
           ],

--- a/example/chat_app/lib/screens/manage_models_screen.dart
+++ b/example/chat_app/lib/screens/manage_models_screen.dart
@@ -1975,7 +1975,7 @@ class _ManageModelsScreenState extends State<ManageModelsScreen>
     return BackendUtils.availableBackends(
       devices: provider.availableDevices,
       activeBackend: provider.activeBackend,
-      includeAutoOnWeb: true,
+      includeAuto: true,
     );
   }
 

--- a/example/chat_app/lib/screens/manage_models_screen.dart
+++ b/example/chat_app/lib/screens/manage_models_screen.dart
@@ -29,6 +29,9 @@ class ManageModelsScreen extends StatefulWidget {
   final List<DownloadableModel>? initialModels;
   final bool? showModelLibraryInitially;
 
+  /// App-owned download state that outlives transient drawer and panel views.
+  final ModelDownloadUiController? downloadUiController;
+
   const ManageModelsScreen({
     super.key,
     this.onModelActivated,
@@ -36,6 +39,7 @@ class ManageModelsScreen extends StatefulWidget {
     this.modelService,
     this.initialModels,
     this.showModelLibraryInitially,
+    this.downloadUiController,
   });
 
   @override
@@ -55,7 +59,9 @@ class _ManageModelsScreenState extends State<ManageModelsScreen>
 
   final Map<String, ModelProfileCacheState> _cacheStateByFile = {};
   final Map<String, bool> _includeProjectorByFile = {};
-  final ModelDownloadUiController _downloadUi = ModelDownloadUiController();
+  late final ModelDownloadUiController _downloadUi;
+  late final bool _ownsDownloadUi;
+  StreamSubscription<String>? _downloadFinishedSubscription;
 
   Set<String> _downloadedFiles = {};
   String? _modelsDir;
@@ -70,6 +76,11 @@ class _ManageModelsScreenState extends State<ManageModelsScreen>
     super.initState();
     WidgetsBinding.instance.addObserver(this);
     _modelService = widget.modelService ?? ModelService();
+    _downloadUi = widget.downloadUiController ?? ModelDownloadUiController();
+    _ownsDownloadUi = widget.downloadUiController == null;
+    _downloadFinishedSubscription = _downloadUi.downloadsFinished.listen(
+      _handleDownloadFinished,
+    );
     _models.addAll(_initialModelCatalog());
     _showModelLibrary = widget.showModelLibraryInitially ?? false;
     _initModelService();
@@ -120,6 +131,20 @@ class _ManageModelsScreenState extends State<ManageModelsScreen>
     );
     for (final entry in entries) {
       _cacheStateByFile[entry.key] = entry.value;
+    }
+  }
+
+  Future<void> _handleDownloadFinished(String filename) async {
+    final model = _models
+        .where((model) => model.filename == filename)
+        .firstOrNull;
+    if (model == null) {
+      return;
+    }
+
+    await _refreshDownloadedModelState(cacheModels: <DownloadableModel>[model]);
+    if (mounted) {
+      setState(() {});
     }
   }
 
@@ -636,9 +661,6 @@ class _ManageModelsScreenState extends State<ManageModelsScreen>
     DownloadableModel model,
     ModelDownloadTaskSnapshot snapshot,
   ) {
-    if (!mounted) {
-      return;
-    }
     _updateDownloadUiState(
       model.filename,
       isDownloading: snapshot.isRunning,
@@ -682,9 +704,6 @@ class _ManageModelsScreenState extends State<ManageModelsScreen>
         useWebSources: kIsWeb,
         includeProjector: shouldIncludeProjector,
         onProgressDetail: (detail) {
-          if (!mounted) {
-            return;
-          }
           _downloadUi.updateDownloadRate(model.filename, detail);
           _updateDownloadUiState(
             model.filename,
@@ -715,11 +734,10 @@ class _ManageModelsScreenState extends State<ManageModelsScreen>
         clearTask: true,
       );
       _clearDownloadTracking(model.filename);
-      await _refreshDownloadedModelState();
+      _downloadUi.notifyDownloadFinished(model.filename);
       if (!mounted) {
         return;
       }
-      setState(() {});
       final successAction = shouldIncludeProjector
           ? 'downloaded successfully'
           : 'downloaded for text-only chat';
@@ -744,12 +762,10 @@ class _ManageModelsScreenState extends State<ManageModelsScreen>
       if (!isCancel) {
         _clearDownloadTracking(model.filename);
       }
-
-      await _refreshDownloadedModelState();
+      _downloadUi.notifyDownloadFinished(model.filename);
       if (!mounted) {
         return;
       }
-      setState(() {});
 
       ScaffoldMessenger.of(context).showSnackBar(
         SnackBar(
@@ -1974,7 +1990,10 @@ class _ManageModelsScreenState extends State<ManageModelsScreen>
   @override
   void dispose() {
     WidgetsBinding.instance.removeObserver(this);
-    _downloadUi.dispose();
+    unawaited(_downloadFinishedSubscription?.cancel());
+    if (_ownsDownloadUi) {
+      _downloadUi.dispose();
+    }
     super.dispose();
   }
 }

--- a/example/chat_app/lib/screens/manage_models_screen.dart
+++ b/example/chat_app/lib/screens/manage_models_screen.dart
@@ -723,9 +723,6 @@ class _ManageModelsScreenState extends State<ManageModelsScreen>
       );
 
       await controller.start(manager.source);
-      if (!mounted) {
-        return;
-      }
       _updateDownloadUiState(
         model.filename,
         isDownloading: false,
@@ -745,9 +742,6 @@ class _ManageModelsScreenState extends State<ManageModelsScreen>
         context,
       ).showSnackBar(SnackBar(content: Text('${model.name} $successAction.')));
     } catch (error) {
-      if (!mounted) {
-        return;
-      }
       final snapshot = controller?.snapshot;
       final isCancel =
           snapshot?.stage == ModelDownloadTaskStage.cancelled ||

--- a/example/chat_app/lib/screens/manage_models_screen.dart
+++ b/example/chat_app/lib/screens/manage_models_screen.dart
@@ -2379,7 +2379,10 @@ class _PopularModelsDiscoverySheetState
                           unawaited(_load(forceRefresh: true));
                         },
                   tooltip: 'Refresh popularity',
-                  icon: const Icon(Icons.refresh_rounded),
+                  icon: const Icon(
+                    Icons.refresh_rounded,
+                    semanticLabel: kIsWeb ? null : 'Refresh popularity',
+                  ),
                 ),
               ],
             ),
@@ -2429,7 +2432,10 @@ class _PopularModelsDiscoverySheetState
                                 });
                                 _scheduleRefresh();
                               },
-                              icon: const Icon(Icons.clear_rounded),
+                              icon: const Icon(
+                                Icons.clear_rounded,
+                                semanticLabel: kIsWeb ? null : 'Clear search',
+                              ),
                             ),
                     ),
                   ),

--- a/example/chat_app/lib/screens/manage_models_screen.dart
+++ b/example/chat_app/lib/screens/manage_models_screen.dart
@@ -1170,13 +1170,15 @@ class _ManageModelsScreenState extends State<ManageModelsScreen>
         final threadBatchLabel = provider.numberOfThreadsBatch == 0
             ? '(auto detected)'
             : provider.numberOfThreadsBatch.toString();
-        final isAutoGpuLayers = provider.gpuLayers >= 99;
-        final gpuLayersLabel = isAutoGpuLayers
-            ? 'Auto'
+        final isMaximumGpuLayers = provider.gpuLayers >= 99;
+        final gpuLayersLabel = isMaximumGpuLayers
+            ? 'Max'
             : provider.gpuLayers.toString();
-        final gpuLayersSliderValue = isAutoGpuLayers
+        final gpuLayersSliderValue = isMaximumGpuLayers
             ? 99.0
             : provider.gpuLayers.clamp(0, 98).toDouble();
+        final gpuOffloadDisabled =
+            selectedBackend != GpuBackend.cpu && provider.gpuLayers == 0;
         final hasLoadProgress =
             provider.loadingProgress > 0 && provider.loadingProgress < 1;
         final loadProgressLabel = hasLoadProgress
@@ -1574,6 +1576,19 @@ class _ManageModelsScreenState extends State<ManageModelsScreen>
                         }
                       },
                     ),
+                    const SizedBox(height: 8),
+                    Align(
+                      alignment: Alignment.centerLeft,
+                      child: Text(
+                        provider.isLoaded
+                            ? 'Active backend: ${provider.activeBackend}'
+                            : 'Active backend is shown after the model loads.',
+                        style: Theme.of(context).textTheme.bodySmall?.copyWith(
+                          color: Theme.of(context).colorScheme.onSurfaceVariant,
+                          fontWeight: FontWeight.w600,
+                        ),
+                      ),
+                    ),
                     const SizedBox(height: 10),
                     Align(
                       alignment: Alignment.centerLeft,
@@ -1644,12 +1659,17 @@ class _ManageModelsScreenState extends State<ManageModelsScreen>
                     Align(
                       alignment: Alignment.centerLeft,
                       child: Text(
-                        hasMmprojPath
-                            ? 'mmproj is configured for this model. Use Text only to disable it, or Load mmproj to attach it without a full reload. '
-                                  'Set GPU layers to 99 for Auto. Runtime values apply on next model load.'
-                            : 'Set GPU layers to 99 for Auto. Runtime values apply on next model load.',
+                        [
+                          if (hasMmprojPath)
+                            'mmproj is configured for this model. Use Text only to disable it, or Load mmproj to attach it without a full reload.',
+                          if (gpuOffloadDisabled)
+                            'GPU layers is 0, so inference will run on CPU. Increase it or choose Max to enable GPU offload.',
+                          'Auto selects Metal on supported Macs. GPU layers controls how much of the model is offloaded; Max requests full offload. Changes apply on next model load.',
+                        ].join(' '),
                         style: Theme.of(context).textTheme.bodySmall?.copyWith(
-                          color: Theme.of(context).colorScheme.onSurfaceVariant,
+                          color: gpuOffloadDisabled
+                              ? Theme.of(context).colorScheme.error
+                              : Theme.of(context).colorScheme.onSurfaceVariant,
                         ),
                       ),
                     ),

--- a/example/chat_app/lib/services/model_download_ui_controller.dart
+++ b/example/chat_app/lib/services/model_download_ui_controller.dart
@@ -5,6 +5,7 @@ import 'package:llamadart/llamadart.dart' hide ModelDownloadProgress;
 
 import 'model_service_base.dart';
 
+/// Owns model-download tasks and their presentation state for the chat app.
 class ModelDownloadUiController {
   final Map<String, ValueNotifier<ModelDownloadUiState>> _uiStateByFile = {};
   final Map<String, int> _lastDownloadedBytes = {};
@@ -13,6 +14,22 @@ class ModelDownloadUiController {
   final Map<String, ModelDownloadController> _downloadControllers = {};
   final Map<String, StreamSubscription<ModelDownloadTaskSnapshot>>
   _downloadSubscriptions = {};
+  final StreamController<String> _downloadsFinished =
+      StreamController<String>.broadcast(sync: true);
+  bool _isDisposed = false;
+
+  /// Emits a filename whenever a download succeeds, fails, or is cancelled.
+  ///
+  /// Screens use this to refresh persistent cache state even when the widget
+  /// that started the transfer has already been replaced.
+  Stream<String> get downloadsFinished => _downloadsFinished.stream;
+
+  /// Notifies active views that the cached state for [filename] may have changed.
+  void notifyDownloadFinished(String filename) {
+    if (!_isDisposed && !_downloadsFinished.isClosed) {
+      _downloadsFinished.add(filename);
+    }
+  }
 
   ValueNotifier<ModelDownloadUiState> listenableFor(String filename) {
     return _uiStateByFile.putIfAbsent(
@@ -48,6 +65,9 @@ class ModelDownloadUiController {
     bool clearTask = false,
     bool clearProgress = false,
   }) {
+    if (_isDisposed) {
+      return;
+    }
     final notifier = listenableFor(filename);
     final current = notifier.value;
     notifier.value = current.copyWith(
@@ -61,6 +81,9 @@ class ModelDownloadUiController {
   }
 
   void updateDownloadRate(String filename, ModelDownloadProgress detail) {
+    if (_isDisposed) {
+      return;
+    }
     final now = DateTime.now();
     final previousBytes = _lastDownloadedBytes[filename];
     final previousSampleAt = _lastDownloadSampleAt[filename];
@@ -165,6 +188,10 @@ class ModelDownloadUiController {
   }
 
   void dispose() {
+    if (_isDisposed) {
+      return;
+    }
+    _isDisposed = true;
     pauseActiveDownloads();
     for (final subscription in _downloadSubscriptions.values) {
       unawaited(subscription.cancel());
@@ -179,6 +206,7 @@ class ModelDownloadUiController {
     }
     _uiStateByFile.clear();
     clearRateTracking();
+    unawaited(_downloadsFinished.close());
   }
 }
 

--- a/example/chat_app/lib/utils/backend_utils.dart
+++ b/example/chat_app/lib/utils/backend_utils.dart
@@ -137,10 +137,10 @@ class BackendUtils {
   static List<GpuBackend> availableBackends({
     required Iterable<String> devices,
     String? activeBackend,
-    bool includeAutoOnWeb = false,
+    bool includeAuto = false,
   }) {
     final backends = <GpuBackend>{GpuBackend.cpu};
-    if (includeAutoOnWeb) {
+    if (includeAuto) {
       backends.add(GpuBackend.auto);
     }
 

--- a/example/chat_app/lib/widgets/chat_input.dart
+++ b/example/chat_app/lib/widgets/chat_input.dart
@@ -72,7 +72,8 @@ class _ChatInputState extends State<ChatInput> {
       builder: (context, provider, _) {
         final isGenerating = provider.isGenerating;
         final isReady = provider.isReady;
-        final hasAttachments = provider.stagedParts.isNotEmpty;
+        final stagedParts = provider.stagedParts;
+        final hasAttachments = stagedParts.isNotEmpty;
         final canSubmit =
             !isGenerating && isReady && (_hasDraftText || hasAttachments);
         final sendActionLabel = isGenerating
@@ -112,8 +113,8 @@ class _ChatInputState extends State<ChatInput> {
                       _buildFunctionCallingRow(context, provider),
                       const SizedBox(height: 10),
                     ],
-                    if (provider.stagedParts.isNotEmpty)
-                      _buildStagedPartsStrip(context, provider),
+                    if (hasAttachments)
+                      _buildStagedPartsStrip(context, provider, stagedParts),
                     Row(
                       crossAxisAlignment: CrossAxisAlignment.end,
                       children: [
@@ -216,7 +217,11 @@ class _ChatInputState extends State<ChatInput> {
     );
   }
 
-  Widget _buildStagedPartsStrip(BuildContext context, ChatProvider provider) {
+  Widget _buildStagedPartsStrip(
+    BuildContext context,
+    ChatProvider provider,
+    List<LlamaContentPart> stagedParts,
+  ) {
     final colorScheme = Theme.of(context).colorScheme;
 
     return Container(
@@ -224,10 +229,10 @@ class _ChatInputState extends State<ChatInput> {
       margin: const EdgeInsets.only(bottom: 12),
       child: ListView.separated(
         scrollDirection: Axis.horizontal,
-        itemCount: provider.stagedParts.length,
+        itemCount: stagedParts.length,
         separatorBuilder: (context, index) => const SizedBox(width: 8),
         itemBuilder: (context, index) {
-          final part = provider.stagedParts[index];
+          final part = stagedParts[index];
           return Stack(
             children: [
               Container(

--- a/example/chat_app/lib/widgets/chat_input.dart
+++ b/example/chat_app/lib/widgets/chat_input.dart
@@ -60,9 +60,8 @@ class _ChatInputState extends State<ChatInput> {
     });
   }
 
-  bool _showDesktopShortcutsHint(TargetPlatform platform) {
-    return kIsWeb ||
-        platform == TargetPlatform.macOS ||
+  bool _supportsDesktopShortcuts(TargetPlatform platform) {
+    return platform == TargetPlatform.macOS ||
         platform == TargetPlatform.windows ||
         platform == TargetPlatform.linux;
   }
@@ -77,11 +76,10 @@ class _ChatInputState extends State<ChatInput> {
         final canSubmit =
             !isGenerating && isReady && (_hasDraftText || hasAttachments);
         final colorScheme = Theme.of(context).colorScheme;
-        final showShortcutHint = _showDesktopShortcutsHint(
-          Theme.of(context).platform,
-        );
         final width = MediaQuery.sizeOf(context).width;
         final isDesktop = width >= 900;
+        final useDesktopShortcuts =
+            isDesktop && _supportsDesktopShortcuts(Theme.of(context).platform);
         final safeBottom = MediaQuery.paddingOf(context).bottom;
 
         return Container(
@@ -91,31 +89,18 @@ class _ChatInputState extends State<ChatInput> {
             isDesktop ? 22 : 12,
             (isDesktop ? 14 : 10) + safeBottom,
           ),
-          child: Column(
-            mainAxisSize: MainAxisSize.min,
-            children: [
-              Container(
+          child: Align(
+            alignment: Alignment.bottomCenter,
+            child: ConstrainedBox(
+              constraints: const BoxConstraints(maxWidth: 920),
+              child: Container(
                 padding: const EdgeInsets.fromLTRB(10, 10, 10, 10),
                 decoration: BoxDecoration(
-                  gradient: LinearGradient(
-                    begin: Alignment.topLeft,
-                    end: Alignment.bottomRight,
-                    colors: [
-                      colorScheme.surfaceContainerLow.withValues(alpha: 0.92),
-                      colorScheme.surfaceContainerHigh.withValues(alpha: 0.9),
-                    ],
-                  ),
-                  borderRadius: BorderRadius.circular(isDesktop ? 26 : 20),
+                  color: colorScheme.surfaceContainerLow,
+                  borderRadius: BorderRadius.circular(isDesktop ? 20 : 18),
                   border: Border.all(
-                    color: colorScheme.outlineVariant.withValues(alpha: 0.45),
+                    color: colorScheme.outlineVariant.withValues(alpha: 0.5),
                   ),
-                  boxShadow: [
-                    BoxShadow(
-                      color: Colors.black.withValues(alpha: 0.24),
-                      blurRadius: 20,
-                      offset: const Offset(0, 10),
-                    ),
-                  ],
                 ),
                 child: Column(
                   mainAxisSize: MainAxisSize.min,
@@ -132,64 +117,48 @@ class _ChatInputState extends State<ChatInput> {
                         if (provider.canAttachMedia)
                           _buildAttachmentMenu(context, provider),
                         Expanded(
-                          child: Container(
-                            decoration: BoxDecoration(
-                              color: colorScheme.surface.withValues(
-                                alpha: 0.68,
-                              ),
-                              borderRadius: BorderRadius.circular(16),
-                              border: Border.all(
-                                color: colorScheme.outlineVariant.withValues(
-                                  alpha: 0.42,
-                                ),
-                              ),
-                            ),
-                            child: CallbackShortcuts(
-                              bindings: {
-                                const SingleActivator(
-                                  LogicalKeyboardKey.enter,
-                                  control: true,
-                                  includeRepeats: false,
-                                ): () {
-                                  if (canSubmit) {
-                                    widget.onSend();
-                                  }
-                                },
-                                const SingleActivator(
-                                  LogicalKeyboardKey.enter,
-                                  meta: true,
-                                  includeRepeats: false,
-                                ): () {
-                                  if (canSubmit) {
-                                    widget.onSend();
-                                  }
-                                },
+                          child: CallbackShortcuts(
+                            bindings: {
+                              const SingleActivator(
+                                LogicalKeyboardKey.enter,
+                                control: true,
+                                includeRepeats: false,
+                              ): () {
+                                if (canSubmit) {
+                                  widget.onSend();
+                                }
                               },
-                              child: TextField(
-                                controller: widget.controller,
-                                focusNode: widget.focusNode,
-                                enabled: isReady,
-                                maxLines: 6,
-                                minLines: 1,
-                                textCapitalization:
-                                    TextCapitalization.sentences,
-                                textInputAction: showShortcutHint
-                                    ? TextInputAction.newline
-                                    : TextInputAction.send,
-                                onSubmitted: (_) {
-                                  if (!showShortcutHint && canSubmit) {
-                                    widget.onSend();
-                                  }
-                                },
-                                decoration: InputDecoration(
-                                  hintText: showShortcutHint
-                                      ? 'Start typing a prompt, use option + enter to append'
-                                      : 'Type a message...',
-                                  border: InputBorder.none,
-                                  contentPadding: const EdgeInsets.symmetric(
-                                    horizontal: 14,
-                                    vertical: 12,
-                                  ),
+                              const SingleActivator(
+                                LogicalKeyboardKey.enter,
+                                meta: true,
+                                includeRepeats: false,
+                              ): () {
+                                if (canSubmit) {
+                                  widget.onSend();
+                                }
+                              },
+                            },
+                            child: TextField(
+                              controller: widget.controller,
+                              focusNode: widget.focusNode,
+                              enabled: isReady,
+                              maxLines: 6,
+                              minLines: 1,
+                              textCapitalization: TextCapitalization.sentences,
+                              textInputAction: useDesktopShortcuts
+                                  ? TextInputAction.newline
+                                  : TextInputAction.send,
+                              onSubmitted: (_) {
+                                if (!useDesktopShortcuts && canSubmit) {
+                                  widget.onSend();
+                                }
+                              },
+                              decoration: const InputDecoration(
+                                hintText: 'Ask anything…',
+                                border: InputBorder.none,
+                                contentPadding: EdgeInsets.symmetric(
+                                  horizontal: 12,
+                                  vertical: 12,
                                 ),
                               ),
                             ),
@@ -201,10 +170,12 @@ class _ChatInputState extends State<ChatInput> {
                           width: 44,
                           height: 44,
                           decoration: BoxDecoration(
-                            color: canSubmit
+                            color: isGenerating
+                                ? colorScheme.errorContainer
+                                : canSubmit
                                 ? colorScheme.primary
                                 : colorScheme.surfaceContainerHighest,
-                            borderRadius: BorderRadius.circular(12),
+                            shape: BoxShape.circle,
                           ),
                           child: IconButton(
                             tooltip: isGenerating
@@ -216,7 +187,7 @@ class _ChatInputState extends State<ChatInput> {
                             icon: isGenerating
                                 ? Icon(
                                     Icons.stop_rounded,
-                                    color: colorScheme.error,
+                                    color: colorScheme.onErrorContainer,
                                   )
                                 : Icon(
                                     Icons.arrow_upward_rounded,
@@ -231,23 +202,7 @@ class _ChatInputState extends State<ChatInput> {
                   ],
                 ),
               ),
-              if (showShortcutHint)
-                Padding(
-                  padding: const EdgeInsets.only(top: 8, right: 4),
-                  child: Align(
-                    alignment: Alignment.centerRight,
-                    child: Text(
-                      'Tip: Cmd/Ctrl + Enter to send',
-                      style: TextStyle(
-                        fontSize: 11,
-                        color: colorScheme.onSurfaceVariant.withValues(
-                          alpha: 0.9,
-                        ),
-                      ),
-                    ),
-                  ),
-                ),
-            ],
+            ),
           ),
         );
       },

--- a/example/chat_app/lib/widgets/chat_input.dart
+++ b/example/chat_app/lib/widgets/chat_input.dart
@@ -75,6 +75,9 @@ class _ChatInputState extends State<ChatInput> {
         final hasAttachments = provider.stagedParts.isNotEmpty;
         final canSubmit =
             !isGenerating && isReady && (_hasDraftText || hasAttachments);
+        final sendActionLabel = isGenerating
+            ? 'Stop generation'
+            : 'Send message';
         final colorScheme = Theme.of(context).colorScheme;
         final width = MediaQuery.sizeOf(context).width;
         final isDesktop = width >= 900;
@@ -178,9 +181,7 @@ class _ChatInputState extends State<ChatInput> {
                             shape: BoxShape.circle,
                           ),
                           child: IconButton(
-                            tooltip: isGenerating
-                                ? 'Stop generation'
-                                : 'Send message',
+                            tooltip: sendActionLabel,
                             onPressed: isGenerating
                                 ? () => provider.stopGeneration()
                                 : (canSubmit ? widget.onSend : null),
@@ -188,12 +189,18 @@ class _ChatInputState extends State<ChatInput> {
                                 ? Icon(
                                     Icons.stop_rounded,
                                     color: colorScheme.onErrorContainer,
+                                    semanticLabel: kIsWeb
+                                        ? null
+                                        : sendActionLabel,
                                   )
                                 : Icon(
                                     Icons.arrow_upward_rounded,
                                     color: canSubmit
                                         ? colorScheme.onPrimary
                                         : colorScheme.onSurfaceVariant,
+                                    semanticLabel: kIsWeb
+                                        ? null
+                                        : sendActionLabel,
                                   ),
                           ),
                         ),
@@ -244,7 +251,11 @@ class _ChatInputState extends State<ChatInput> {
                     minimumSize: const Size(24, 24),
                   ),
                   onPressed: () => provider.removeStagedPart(index),
-                  icon: const Icon(Icons.close_rounded, size: 14),
+                  icon: const Icon(
+                    Icons.close_rounded,
+                    size: 14,
+                    semanticLabel: kIsWeb ? null : 'Remove attachment',
+                  ),
                   tooltip: 'Remove attachment',
                 ),
               ),
@@ -340,7 +351,11 @@ class _ChatInputState extends State<ChatInput> {
         !provider.supportsAudio;
 
     return PopupMenuButton<String>(
-      icon: Icon(Icons.add_circle_outline_rounded, color: colorScheme.primary),
+      icon: Icon(
+        Icons.add_circle_outline_rounded,
+        color: colorScheme.primary,
+        semanticLabel: kIsWeb ? null : 'Add attachment',
+      ),
       tooltip: 'Add attachment',
       onSelected: (value) {
         if (value == 'image') {

--- a/example/chat_app/lib/widgets/message_bubble.dart
+++ b/example/chat_app/lib/widgets/message_bubble.dart
@@ -2,6 +2,7 @@ import 'dart:io';
 
 import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
 import 'package:flutter_markdown/flutter_markdown.dart';
 import 'package:llamadart/llamadart.dart';
 
@@ -18,12 +19,14 @@ class MessageBubble extends StatelessWidget {
   final ChatMessage message;
   final bool isNextSame;
   final bool isStreaming;
+  final VoidCallback? onRegenerate;
 
   const MessageBubble({
     super.key,
     required this.message,
     required this.isNextSame,
     this.isStreaming = false,
+    this.onRegenerate,
   });
 
   @override
@@ -51,18 +54,18 @@ class MessageBubble extends StatelessWidget {
 
     final bubbleColor = isUser
         ? Color.alphaBlend(
-            colorScheme.primary.withValues(alpha: 0.22),
+            colorScheme.primary.withValues(alpha: 0.18),
             colorScheme.surfaceContainerHighest,
           )
-        : colorScheme.surfaceContainerHigh.withValues(alpha: 0.72);
+        : Colors.transparent;
     final textColor = colorScheme.onSurface;
 
-    const borderRadius = 24.0;
+    const borderRadius = 18.0;
     final border = BorderRadius.only(
       topLeft: const Radius.circular(borderRadius),
       topRight: const Radius.circular(borderRadius),
-      bottomLeft: Radius.circular(isUser ? borderRadius : 8),
-      bottomRight: Radius.circular(isUser ? 8 : borderRadius),
+      bottomLeft: Radius.circular(isUser ? borderRadius : 4),
+      bottomRight: Radius.circular(isUser ? 4 : borderRadius),
     );
 
     final thinkingTextRaw = message.thinkingText;
@@ -102,9 +105,7 @@ class MessageBubble extends StatelessWidget {
                     ? _buildStreamingTextBubble(
                         context,
                         messageText,
-                        bubbleColor: bubbleColor,
                         textColor: textColor,
-                        border: border,
                       )
                     : _buildResponseBubble(
                         context,
@@ -114,6 +115,15 @@ class MessageBubble extends StatelessWidget {
                         border: border,
                         isUser: isUser,
                       ),
+              if (!isUser &&
+                  !isTypingPlaceholder &&
+                  !isStreaming &&
+                  !message.isToolCall &&
+                  messageText.isNotEmpty)
+                _AssistantActions(
+                  text: messageText,
+                  onRegenerate: onRegenerate,
+                ),
             ],
           ),
         ),
@@ -130,19 +140,11 @@ class MessageBubble extends StatelessWidget {
   }
 
   Widget _buildRoleAndTimeLabel(BuildContext context, {required bool isUser}) {
-    final colorScheme = Theme.of(context).colorScheme;
-    final roleLabel = isUser ? 'User' : 'Model';
-
     return Padding(
       padding: const EdgeInsets.only(bottom: 6),
-      child: Text(
-        '$roleLabel  •  ${_formatTimestamp(context)}',
-        style: TextStyle(
-          fontSize: 12,
-          color: colorScheme.onSurfaceVariant.withValues(alpha: 0.9),
-          fontWeight: FontWeight.w500,
-          letterSpacing: 0.15,
-        ),
+      child: _MessageMeta(
+        roleLabel: isUser ? 'You' : 'llamadart',
+        timestamp: _formatTimestamp(context),
       ),
     );
   }
@@ -242,23 +244,18 @@ class MessageBubble extends StatelessWidget {
     final safeText = sanitizeForTextLayout(text);
 
     return Container(
-      padding: const EdgeInsets.symmetric(horizontal: 18, vertical: 14),
-      decoration: BoxDecoration(
-        color: bubbleColor,
-        borderRadius: border,
-        border: Border.all(
-          color: colorScheme.outlineVariant.withValues(
-            alpha: isUser ? 0.2 : 0.35,
-          ),
-        ),
-        boxShadow: [
-          BoxShadow(
-            color: Colors.black.withValues(alpha: 0.16),
-            blurRadius: 14,
-            offset: const Offset(0, 6),
-          ),
-        ],
-      ),
+      padding: isUser
+          ? const EdgeInsets.symmetric(horizontal: 16, vertical: 12)
+          : EdgeInsets.zero,
+      decoration: isUser
+          ? BoxDecoration(
+              color: bubbleColor,
+              borderRadius: border,
+              border: Border.all(
+                color: colorScheme.outlineVariant.withValues(alpha: 0.24),
+              ),
+            )
+          : null,
       child: SelectableText(
         safeText,
         style: TextStyle(
@@ -282,23 +279,18 @@ class MessageBubble extends StatelessWidget {
     final safeText = sanitizeForTextLayout(text);
 
     return Container(
-      padding: const EdgeInsets.symmetric(horizontal: 18, vertical: 14),
-      decoration: BoxDecoration(
-        color: bubbleColor,
-        borderRadius: border,
-        border: Border.all(
-          color: colorScheme.outlineVariant.withValues(
-            alpha: isUser ? 0.2 : 0.35,
-          ),
-        ),
-        boxShadow: [
-          BoxShadow(
-            color: Colors.black.withValues(alpha: 0.16),
-            blurRadius: 14,
-            offset: const Offset(0, 6),
-          ),
-        ],
-      ),
+      padding: isUser
+          ? const EdgeInsets.symmetric(horizontal: 16, vertical: 12)
+          : EdgeInsets.zero,
+      decoration: isUser
+          ? BoxDecoration(
+              color: bubbleColor,
+              borderRadius: border,
+              border: Border.all(
+                color: colorScheme.outlineVariant.withValues(alpha: 0.24),
+              ),
+            )
+          : null,
       child: MarkdownBody(
         data: safeText,
         selectable: true,
@@ -358,29 +350,12 @@ class MessageBubble extends StatelessWidget {
   Widget _buildStreamingTextBubble(
     BuildContext context,
     String text, {
-    required Color bubbleColor,
     required Color textColor,
-    required BorderRadius border,
   }) {
-    final colorScheme = Theme.of(context).colorScheme;
     final safeText = sanitizeForTextLayout(text);
 
-    return Container(
-      padding: const EdgeInsets.symmetric(horizontal: 18, vertical: 14),
-      decoration: BoxDecoration(
-        color: bubbleColor,
-        borderRadius: border,
-        border: Border.all(
-          color: colorScheme.outlineVariant.withValues(alpha: 0.35),
-        ),
-        boxShadow: [
-          BoxShadow(
-            color: Colors.black.withValues(alpha: 0.16),
-            blurRadius: 14,
-            offset: const Offset(0, 6),
-          ),
-        ],
-      ),
+    return Padding(
+      padding: EdgeInsets.zero,
       child: Text(
         safeText,
         style: TextStyle(
@@ -393,18 +368,9 @@ class MessageBubble extends StatelessWidget {
   }
 
   Widget _buildTypingBubble(BuildContext context) {
-    final colorScheme = Theme.of(context).colorScheme;
-
-    return Container(
-      padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 12),
-      decoration: BoxDecoration(
-        color: colorScheme.surfaceContainerHigh.withValues(alpha: 0.78),
-        borderRadius: BorderRadius.circular(20),
-        border: Border.all(
-          color: colorScheme.outlineVariant.withValues(alpha: 0.4),
-        ),
-      ),
-      child: const _TypingDots(),
+    return const Padding(
+      padding: EdgeInsets.symmetric(vertical: 10),
+      child: _TypingDots(),
     );
   }
 
@@ -551,6 +517,127 @@ class MessageBubble extends StatelessWidget {
             ),
           ),
         ],
+      ),
+    );
+  }
+}
+
+class _AssistantActions extends StatefulWidget {
+  final String text;
+  final VoidCallback? onRegenerate;
+
+  const _AssistantActions({required this.text, this.onRegenerate});
+
+  @override
+  State<_AssistantActions> createState() => _AssistantActionsState();
+}
+
+class _AssistantActionsState extends State<_AssistantActions> {
+  bool _hovered = false;
+
+  Future<void> _copyResponse() async {
+    await Clipboard.setData(ClipboardData(text: widget.text));
+    if (!mounted) return;
+
+    final messenger = ScaffoldMessenger.maybeOf(context);
+    messenger
+      ?..hideCurrentSnackBar()
+      ..showSnackBar(
+        const SnackBar(
+          content: Text('Response copied'),
+          duration: Duration(milliseconds: 1400),
+        ),
+      );
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final colorScheme = Theme.of(context).colorScheme;
+
+    return MouseRegion(
+      onEnter: (_) => setState(() => _hovered = true),
+      onExit: (_) => setState(() => _hovered = false),
+      child: AnimatedOpacity(
+        opacity: _hovered ? 1 : 0.55,
+        duration: const Duration(milliseconds: 140),
+        child: Padding(
+          padding: const EdgeInsets.only(top: 4),
+          child: Row(
+            mainAxisSize: MainAxisSize.min,
+            children: [
+              IconButton(
+                onPressed: _copyResponse,
+                tooltip: 'Copy response',
+                visualDensity: VisualDensity.compact,
+                iconSize: 17,
+                color: colorScheme.onSurfaceVariant,
+                icon: const Icon(Icons.content_copy_rounded),
+              ),
+              if (widget.onRegenerate != null)
+                IconButton(
+                  onPressed: widget.onRegenerate,
+                  tooltip: 'Regenerate response',
+                  visualDensity: VisualDensity.compact,
+                  iconSize: 18,
+                  color: colorScheme.onSurfaceVariant,
+                  icon: const Icon(Icons.refresh_rounded),
+                ),
+            ],
+          ),
+        ),
+      ),
+    );
+  }
+}
+
+class _MessageMeta extends StatefulWidget {
+  final String roleLabel;
+  final String timestamp;
+
+  const _MessageMeta({required this.roleLabel, required this.timestamp});
+
+  @override
+  State<_MessageMeta> createState() => _MessageMetaState();
+}
+
+class _MessageMetaState extends State<_MessageMeta> {
+  bool _showTimestamp = false;
+
+  void _setTimestampVisible(bool visible) {
+    if (_showTimestamp == visible) return;
+    setState(() {
+      _showTimestamp = visible;
+    });
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final colorScheme = Theme.of(context).colorScheme;
+
+    return MouseRegion(
+      onEnter: (_) => _setTimestampVisible(true),
+      onExit: (_) => _setTimestampVisible(false),
+      child: GestureDetector(
+        behavior: HitTestBehavior.opaque,
+        onLongPress: () => _setTimestampVisible(!_showTimestamp),
+        child: Tooltip(
+          message: widget.timestamp,
+          child: AnimatedSize(
+            duration: const Duration(milliseconds: 140),
+            curve: Curves.easeOutCubic,
+            child: Text(
+              _showTimestamp
+                  ? '${widget.roleLabel}  ·  ${widget.timestamp}'
+                  : widget.roleLabel,
+              style: TextStyle(
+                fontSize: 12,
+                color: colorScheme.onSurfaceVariant,
+                fontWeight: FontWeight.w600,
+                letterSpacing: 0.1,
+              ),
+            ),
+          ),
+        ),
       ),
     );
   }

--- a/example/chat_app/lib/widgets/message_bubble.dart
+++ b/example/chat_app/lib/widgets/message_bubble.dart
@@ -571,7 +571,10 @@ class _AssistantActionsState extends State<_AssistantActions> {
                 visualDensity: VisualDensity.compact,
                 iconSize: 17,
                 color: colorScheme.onSurfaceVariant,
-                icon: const Icon(Icons.content_copy_rounded),
+                icon: const Icon(
+                  Icons.content_copy_rounded,
+                  semanticLabel: kIsWeb ? null : 'Copy response',
+                ),
               ),
               if (widget.onRegenerate != null)
                 IconButton(
@@ -580,7 +583,10 @@ class _AssistantActionsState extends State<_AssistantActions> {
                   visualDensity: VisualDensity.compact,
                   iconSize: 18,
                   color: colorScheme.onSurfaceVariant,
-                  icon: const Icon(Icons.refresh_rounded),
+                  icon: const Icon(
+                    Icons.refresh_rounded,
+                    semanticLabel: kIsWeb ? null : 'Regenerate response',
+                  ),
                 ),
             ],
           ),

--- a/example/chat_app/lib/widgets/message_bubble.dart
+++ b/example/chat_app/lib/widgets/message_bubble.dart
@@ -536,16 +536,26 @@ class _AssistantActionsState extends State<_AssistantActions> {
   bool _hovered = false;
 
   Future<void> _copyResponse() async {
-    await Clipboard.setData(ClipboardData(text: widget.text));
+    try {
+      await Clipboard.setData(ClipboardData(text: widget.text));
+    } catch (_) {
+      if (!mounted) return;
+      _showCopyFeedback('Could not copy response');
+      return;
+    }
     if (!mounted) return;
 
+    _showCopyFeedback('Response copied');
+  }
+
+  void _showCopyFeedback(String message) {
     final messenger = ScaffoldMessenger.maybeOf(context);
     messenger
       ?..hideCurrentSnackBar()
       ..showSnackBar(
-        const SnackBar(
-          content: Text('Response copied'),
-          duration: Duration(milliseconds: 1400),
+        SnackBar(
+          content: Text(message),
+          duration: const Duration(milliseconds: 1400),
         ),
       );
   }

--- a/example/chat_app/lib/widgets/model_card.dart
+++ b/example/chat_app/lib/widgets/model_card.dart
@@ -81,6 +81,16 @@ class ModelCard extends StatelessWidget {
         canLoadModel && isProjectorMissing && includeProjector;
     final willLoadTextOnly = canLoadModel && isProjectorMissing;
     final clampedProgress = progress.clamp(0.0, 1.0).toDouble();
+    final deleteActionLabel = progress > 0 && !isDownloaded
+        ? 'Cancel & Discard'
+        : hasPartialCache
+        ? 'Delete cached assets'
+        : model.multimodalProjectorSourceFor(web: isWeb) == null
+        ? 'Delete Model'
+        : 'Delete model and mmproj';
+    final downloadToggleLabel = isDownloading
+        ? 'Pause Download'
+        : 'Resume Download';
 
     return Container(
       decoration: BoxDecoration(
@@ -211,15 +221,10 @@ class ModelCard extends StatelessWidget {
                   icon: Icon(
                     Icons.delete_outline_rounded,
                     color: colorScheme.error,
+                    semanticLabel: kIsWeb ? null : deleteActionLabel,
                   ),
                   onPressed: onDelete,
-                  tooltip: progress > 0 && !isDownloaded
-                      ? 'Cancel & Discard'
-                      : hasPartialCache
-                      ? 'Delete cached assets'
-                      : model.multimodalProjectorSourceFor(web: isWeb) == null
-                      ? 'Delete Model'
-                      : 'Delete model and mmproj',
+                  tooltip: deleteActionLabel,
                 ),
             ],
           ),
@@ -403,11 +408,10 @@ class ModelCard extends StatelessWidget {
                           color: isDownloading
                               ? colorScheme.primary
                               : Colors.orange,
+                          semanticLabel: kIsWeb ? null : downloadToggleLabel,
                         ),
                         onPressed: isDownloading ? onCancel : onDownload,
-                        tooltip: isDownloading
-                            ? 'Pause Download'
-                            : 'Resume Download',
+                        tooltip: downloadToggleLabel,
                       ),
                     ),
                   ],
@@ -699,12 +703,16 @@ class ModelCard extends StatelessWidget {
         children: [
           Icon(icon, size: 12, color: foreground),
           const SizedBox(width: 4),
-          Text(
-            label,
-            style: TextStyle(
-              fontSize: 12,
-              color: foreground,
-              fontWeight: FontWeight.w600,
+          Flexible(
+            child: Text(
+              label,
+              maxLines: 1,
+              overflow: TextOverflow.ellipsis,
+              style: TextStyle(
+                fontSize: 12,
+                color: foreground,
+                fontWeight: FontWeight.w600,
+              ),
             ),
           ),
         ],
@@ -742,12 +750,16 @@ class ModelCard extends StatelessWidget {
         children: [
           Icon(icon, size: 12, color: foreground),
           const SizedBox(width: 4),
-          Text(
-            label,
-            style: TextStyle(
-              fontSize: 11,
-              color: foreground,
-              fontWeight: FontWeight.w500,
+          Flexible(
+            child: Text(
+              label,
+              maxLines: 1,
+              overflow: TextOverflow.ellipsis,
+              style: TextStyle(
+                fontSize: 11,
+                color: foreground,
+                fontWeight: FontWeight.w500,
+              ),
             ),
           ),
           const SizedBox(width: 4),

--- a/example/chat_app/lib/widgets/model_card.dart
+++ b/example/chat_app/lib/widgets/model_card.dart
@@ -469,7 +469,7 @@ class ModelCard extends StatelessWidget {
                               style: const TextStyle(fontSize: 13),
                             ),
                             Text(
-                              gpuLayers >= 99 ? 'Auto' : gpuLayers.toString(),
+                              gpuLayers >= 99 ? 'Max' : gpuLayers.toString(),
                               style: TextStyle(
                                 fontSize: 13,
                                 fontWeight: FontWeight.bold,
@@ -485,13 +485,11 @@ class ModelCard extends StatelessWidget {
                           min: 0,
                           max: 99,
                           divisions: 99,
-                          label: gpuLayers >= 99
-                              ? 'Auto'
-                              : gpuLayers.toString(),
+                          label: gpuLayers >= 99 ? 'Max' : gpuLayers.toString(),
                           onChanged: (v) => onGpuLayersChanged(v.round()),
                         ),
                         Text(
-                          'Set to 99 for Auto',
+                          'Max requests full GPU offload',
                           style: TextStyle(
                             fontSize: 11,
                             color: colorScheme.onSurfaceVariant.withValues(

--- a/example/chat_app/lib/widgets/model_card.dart
+++ b/example/chat_app/lib/widgets/model_card.dart
@@ -1,6 +1,5 @@
 import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
-import 'package:google_fonts/google_fonts.dart';
 import '../models/downloadable_model.dart';
 import '../services/model_service_base.dart';
 
@@ -104,7 +103,7 @@ class ModelCard extends StatelessWidget {
                   children: [
                     Text(
                       model.name,
-                      style: GoogleFonts.outfit(
+                      style: TextStyle(
                         fontSize: 18,
                         fontWeight: FontWeight.bold,
                         color: colorScheme.onSurface,
@@ -227,7 +226,7 @@ class ModelCard extends StatelessWidget {
           const SizedBox(height: 12),
           Text(
             model.description,
-            style: GoogleFonts.outfit(
+            style: TextStyle(
               color: colorScheme.onSurfaceVariant,
               fontSize: 14,
               height: 1.4,
@@ -247,7 +246,7 @@ class ModelCard extends StatelessWidget {
               ),
               child: Text(
                 partialCacheMessage,
-                style: GoogleFonts.outfit(
+                style: TextStyle(
                   fontSize: 12,
                   height: 1.3,
                   color: colorScheme.onSecondaryContainer,
@@ -272,7 +271,7 @@ class ModelCard extends StatelessWidget {
                 isWebLiteRtLmModel
                     ? 'Web warning: very large LiteRT-LM model. Browser memory limits may still prevent engine initialization.'
                     : 'Web warning: very large model. Download can succeed, but browser memory limits may still prevent loading.',
-                style: GoogleFonts.outfit(
+                style: TextStyle(
                   fontSize: 12,
                   height: 1.3,
                   color: colorScheme.onSurface,
@@ -449,10 +448,7 @@ class ModelCard extends StatelessWidget {
                 child: ExpansionTile(
                   title: Text(
                     'Advanced Settings (Selected)',
-                    style: GoogleFonts.outfit(
-                      fontSize: 14,
-                      fontWeight: FontWeight.w600,
-                    ),
+                    style: TextStyle(fontSize: 14, fontWeight: FontWeight.w600),
                   ),
                   tilePadding: EdgeInsets.zero,
                   childrenPadding: const EdgeInsets.only(bottom: 16),
@@ -466,11 +462,11 @@ class ModelCard extends StatelessWidget {
                           children: [
                             Text(
                               'GPU Offloading (Layers)',
-                              style: GoogleFonts.outfit(fontSize: 13),
+                              style: const TextStyle(fontSize: 13),
                             ),
                             Text(
                               gpuLayers >= 99 ? 'Auto' : gpuLayers.toString(),
-                              style: GoogleFonts.outfit(
+                              style: TextStyle(
                                 fontSize: 13,
                                 fontWeight: FontWeight.bold,
                                 color: colorScheme.primary,
@@ -505,11 +501,11 @@ class ModelCard extends StatelessWidget {
                           children: [
                             Text(
                               'Context Size (Tokens)',
-                              style: GoogleFonts.outfit(fontSize: 13),
+                              style: const TextStyle(fontSize: 13),
                             ),
                             Text(
                               contextSize.toString(),
-                              style: GoogleFonts.outfit(
+                              style: TextStyle(
                                 fontSize: 13,
                                 fontWeight: FontWeight.bold,
                                 color: colorScheme.primary,

--- a/example/chat_app/lib/widgets/runtime_status_panel.dart
+++ b/example/chat_app/lib/widgets/runtime_status_panel.dart
@@ -1,3 +1,4 @@
+import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
 import 'package:llamadart/llamadart.dart';
 import 'package:provider/provider.dart';
@@ -279,7 +280,10 @@ class RuntimeStatusPanel extends StatelessWidget {
                   IconButton(
                     onPressed: () => Navigator.of(context).pop(),
                     tooltip: 'Close runtime details',
-                    icon: const Icon(Icons.close_rounded),
+                    icon: const Icon(
+                      Icons.close_rounded,
+                      semanticLabel: kIsWeb ? null : 'Close runtime details',
+                    ),
                   ),
                 ],
               ),

--- a/example/chat_app/lib/widgets/runtime_status_panel.dart
+++ b/example/chat_app/lib/widgets/runtime_status_panel.dart
@@ -4,299 +4,422 @@ import 'package:provider/provider.dart';
 
 import '../providers/chat_provider.dart';
 
+typedef _RuntimeStatus = ({
+  bool isReady,
+  String activeBackend,
+  String activeModelName,
+  int currentTokens,
+  int contextLimit,
+  double? tokensPerSecond,
+  double? decodeTokensPerSecond,
+  int? firstTokenLatencyMs,
+  int? generationLatencyMs,
+  int? nativePromptEvalMs,
+  int? nativeEvalMs,
+  int? nativeSampleMs,
+  int? nativePromptEvalTokens,
+  int? nativeEvalTokens,
+  int? nativeReusedGraphs,
+  int? runtimeGpuLayers,
+  int? runtimeThreads,
+  int? runtimeThreadPoolSize,
+  bool hasConfiguredMmproj,
+  bool isMmprojLoaded,
+  String? runtimeExecution,
+  String? runtimeCoreVariant,
+  String? runtimeWorkerFallbackReason,
+  String? runtimeModelSource,
+  String? runtimeModelCacheState,
+  String? runtimeNotes,
+});
+
 class RuntimeStatusPanel extends StatelessWidget {
   const RuntimeStatusPanel({super.key});
 
   @override
   Widget build(BuildContext context) {
-    return Selector<
-      ChatProvider,
-      (
-        bool,
-        String,
-        String,
-        int,
-        int,
-        double?,
-        double?,
-        int?,
-        int?,
-        int?,
-        int?,
-        int?,
-        int?,
-        int?,
-        int?,
-        int?,
-        int?,
-        int?,
-        bool,
-        bool,
-        String?,
-        String?,
-        String?,
-        String?,
-        String?,
-        String?,
-      )
-    >(
+    return Selector<ChatProvider, _RuntimeStatus>(
       selector: (_, provider) => (
-        provider.isReady,
-        provider.activeBackend,
-        provider.activeModelName,
-        provider.currentTokens,
-        provider.contextLimit,
-        provider.lastTokensPerSecond,
-        provider.lastDecodeTokensPerSecond,
-        provider.lastFirstTokenLatencyMs,
-        provider.lastGenerationLatencyMs,
-        provider.lastNativePromptEvalMs,
-        provider.lastNativeEvalMs,
-        provider.lastNativeSampleMs,
-        provider.lastNativePromptEvalTokens,
-        provider.lastNativeEvalTokens,
-        provider.lastNativeReusedGraphs,
-        provider.runtimeGpuLayers,
-        provider.runtimeThreads,
-        provider.runtimeThreadPoolSize,
-        provider.hasConfiguredMmproj,
-        provider.isMmprojLoaded,
-        provider.runtimeExecution,
-        provider.runtimeCoreVariant,
-        provider.runtimeWorkerFallbackReason,
-        provider.runtimeModelSource,
-        provider.runtimeModelCacheState,
-        provider.runtimeNotes,
+        isReady: provider.isReady,
+        activeBackend: provider.activeBackend,
+        activeModelName: provider.activeModelName,
+        currentTokens: provider.currentTokens,
+        contextLimit: provider.contextLimit,
+        tokensPerSecond: provider.lastTokensPerSecond,
+        decodeTokensPerSecond: provider.lastDecodeTokensPerSecond,
+        firstTokenLatencyMs: provider.lastFirstTokenLatencyMs,
+        generationLatencyMs: provider.lastGenerationLatencyMs,
+        nativePromptEvalMs: provider.lastNativePromptEvalMs,
+        nativeEvalMs: provider.lastNativeEvalMs,
+        nativeSampleMs: provider.lastNativeSampleMs,
+        nativePromptEvalTokens: provider.lastNativePromptEvalTokens,
+        nativeEvalTokens: provider.lastNativeEvalTokens,
+        nativeReusedGraphs: provider.lastNativeReusedGraphs,
+        runtimeGpuLayers: provider.runtimeGpuLayers,
+        runtimeThreads: provider.runtimeThreads,
+        runtimeThreadPoolSize: provider.runtimeThreadPoolSize,
+        hasConfiguredMmproj: provider.hasConfiguredMmproj,
+        isMmprojLoaded: provider.isMmprojLoaded,
+        runtimeExecution: provider.runtimeExecution,
+        runtimeCoreVariant: provider.runtimeCoreVariant,
+        runtimeWorkerFallbackReason: provider.runtimeWorkerFallbackReason,
+        runtimeModelSource: provider.runtimeModelSource,
+        runtimeModelCacheState: provider.runtimeModelCacheState,
+        runtimeNotes: provider.runtimeNotes,
       ),
-      builder: (context, data, _) {
-        final (
-          isReady,
-          activeBackend,
-          activeModelName,
-          currentTokens,
-          contextLimit,
-          tokensPerSecond,
-          decodeTokensPerSecond,
-          firstTokenLatencyMs,
-          generationLatencyMs,
-          nativePromptEvalMs,
-          nativeEvalMs,
-          nativeSampleMs,
-          nativePromptEvalTokens,
-          nativeEvalTokens,
-          nativeReusedGraphs,
-          runtimeGpuLayers,
-          runtimeThreads,
-          runtimeThreadPoolSize,
-          hasConfiguredMmproj,
-          isMmprojLoaded,
-          runtimeExecution,
-          runtimeCoreVariant,
-          runtimeWorkerFallbackReason,
-          runtimeModelSource,
-          runtimeModelCacheState,
-          runtimeNotes,
-        ) = data;
-
-        if (!isReady) {
+      builder: (context, status, _) {
+        if (!status.isReady) {
           return const SizedBox.shrink();
         }
-        final isLiteRtLmModel = activeModelName.toLowerCase().endsWith(
-          '.litertlm',
-        );
 
         return Padding(
-          padding: const EdgeInsets.fromLTRB(14, 8, 14, 0),
-          child: Wrap(
-            spacing: 8,
-            runSpacing: 8,
-            children: [
-              _chip(context, icon: Icons.memory_rounded, text: activeBackend),
-              _chip(
-                context,
-                icon: Icons.model_training_outlined,
-                text: activeModelName,
-              ),
-              _chip(
-                context,
-                icon: Icons.data_usage_rounded,
-                text: '$currentTokens/$contextLimit tok',
-              ),
-              if (tokensPerSecond != null)
-                _chip(
-                  context,
-                  icon: Icons.speed_rounded,
-                  text: 'avg ${tokensPerSecond.toStringAsFixed(1)} tok/s',
-                ),
-              if (decodeTokensPerSecond != null)
-                _chip(
-                  context,
-                  icon: Icons.rocket_launch_rounded,
-                  text:
-                      'decode ${decodeTokensPerSecond.toStringAsFixed(1)} tok/s',
-                ),
-              if (firstTokenLatencyMs != null)
-                _chip(
-                  context,
-                  icon: Icons.bolt_rounded,
-                  text: 'first ${firstTokenLatencyMs}ms',
-                ),
-              if (generationLatencyMs != null)
-                _chip(
-                  context,
-                  icon: Icons.timer_outlined,
-                  text: 'total ${generationLatencyMs}ms',
-                ),
-              if (nativePromptEvalMs != null)
-                _chip(
-                  context,
-                  icon: Icons.input_rounded,
-                  text: nativePromptEvalTokens != null
-                      ? 'p_eval ${nativePromptEvalMs}ms/$nativePromptEvalTokens tok'
-                      : 'p_eval ${nativePromptEvalMs}ms',
-                ),
-              if (nativeEvalMs != null)
-                _chip(
-                  context,
-                  icon: Icons.auto_awesome_rounded,
-                  text: nativeEvalTokens != null
-                      ? 'eval ${nativeEvalMs}ms/$nativeEvalTokens tok'
-                      : 'eval ${nativeEvalMs}ms',
-                ),
-              if (nativeSampleMs != null)
-                _chip(
-                  context,
-                  icon: Icons.tune_rounded,
-                  text: 'sample ${nativeSampleMs}ms',
-                ),
-              if (nativeReusedGraphs != null)
-                _chip(
-                  context,
-                  icon: Icons.repeat_rounded,
-                  text: 'reuse $nativeReusedGraphs',
-                ),
-              if (runtimeGpuLayers != null)
-                _chip(
-                  context,
-                  icon: Icons.layers_rounded,
-                  text:
-                      isLiteRtLmModel &&
-                          runtimeGpuLayers >= ModelParams.maxGpuLayers
-                      ? 'gpu max'
-                      : 'layers $runtimeGpuLayers',
-                ),
-              if (runtimeThreads != null)
-                _chip(
-                  context,
-                  icon: Icons.alt_route_rounded,
-                  text: 'threads $runtimeThreads',
-                ),
-              if (runtimeThreadPoolSize != null)
-                _chip(
-                  context,
-                  icon: Icons.hub_outlined,
-                  text: 'pool $runtimeThreadPoolSize',
-                ),
-              if (isMmprojLoaded)
-                _chip(
-                  context,
-                  icon: Icons.visibility_rounded,
-                  text: 'mmproj loaded',
-                )
-              else if (hasConfiguredMmproj)
-                _chip(
-                  context,
-                  icon: Icons.visibility_outlined,
-                  text: 'mmproj cfg',
-                ),
-              if (runtimeExecution != null)
-                _chip(
-                  context,
-                  icon: Icons.settings_ethernet_rounded,
-                  text: 'exec ${_shortText(runtimeExecution)}',
-                ),
-              if (runtimeCoreVariant != null)
-                _chip(
-                  context,
-                  icon: Icons.developer_board_rounded,
-                  text: 'core ${_shortText(runtimeCoreVariant)}',
-                ),
-              if (runtimeModelSource != null)
-                _chip(
-                  context,
-                  icon: Icons.cloud_queue_rounded,
-                  text: 'src ${_shortText(runtimeModelSource)}',
-                ),
-              if (runtimeModelCacheState != null)
-                _chip(
-                  context,
-                  icon: Icons.inventory_2_outlined,
-                  text: 'cache ${_shortText(runtimeModelCacheState)}',
-                ),
-              if (runtimeWorkerFallbackReason != null)
-                _chip(
-                  context,
-                  icon: Icons.warning_amber_rounded,
-                  text: 'worker ${_shortText(runtimeWorkerFallbackReason)}',
-                ),
-              if (runtimeNotes != null)
-                _chip(
-                  context,
-                  icon: Icons.info_outline_rounded,
-                  text: 'notes ${_shortText(runtimeNotes)}',
-                ),
-            ],
+          padding: const EdgeInsets.fromLTRB(14, 10, 14, 4),
+          child: _RuntimeSummaryBar(
+            status: status,
+            onPressed: () =>
+                _showRuntimeDetails(context, _buildMetrics(status)),
           ),
         );
       },
     );
   }
 
-  String _shortText(String text, {int maxLength = 42}) {
-    final normalized = text
+  List<_RuntimeMetric> _buildMetrics(_RuntimeStatus status) {
+    final metrics = <_RuntimeMetric>[
+      _RuntimeMetric(
+        icon: Icons.memory_rounded,
+        label: 'Backend',
+        value: status.activeBackend,
+      ),
+      _RuntimeMetric(
+        icon: Icons.model_training_outlined,
+        label: 'Model',
+        value: status.activeModelName,
+      ),
+      _RuntimeMetric(
+        icon: Icons.data_usage_rounded,
+        label: 'Context',
+        value: '${status.currentTokens}/${status.contextLimit} tokens',
+      ),
+    ];
+
+    void add(
+      IconData icon,
+      String label,
+      Object? value, {
+      String Function(Object value)? format,
+    }) {
+      if (value == null) return;
+      metrics.add(
+        _RuntimeMetric(
+          icon: icon,
+          label: label,
+          value: format?.call(value) ?? value.toString(),
+        ),
+      );
+    }
+
+    add(
+      Icons.speed_rounded,
+      'Average speed',
+      status.tokensPerSecond,
+      format: (value) => '${(value as double).toStringAsFixed(1)} tok/s',
+    );
+    add(
+      Icons.rocket_launch_rounded,
+      'Decode speed',
+      status.decodeTokensPerSecond,
+      format: (value) => '${(value as double).toStringAsFixed(1)} tok/s',
+    );
+    add(
+      Icons.bolt_rounded,
+      'First token',
+      status.firstTokenLatencyMs,
+      format: (value) => '$value ms',
+    );
+    add(
+      Icons.timer_outlined,
+      'Generation',
+      status.generationLatencyMs,
+      format: (value) => '$value ms',
+    );
+    add(
+      Icons.input_rounded,
+      'Prompt evaluation',
+      status.nativePromptEvalMs,
+      format: (value) => status.nativePromptEvalTokens == null
+          ? '$value ms'
+          : '$value ms · ${status.nativePromptEvalTokens} tokens',
+    );
+    add(
+      Icons.auto_awesome_rounded,
+      'Native evaluation',
+      status.nativeEvalMs,
+      format: (value) => status.nativeEvalTokens == null
+          ? '$value ms'
+          : '$value ms · ${status.nativeEvalTokens} tokens',
+    );
+    add(
+      Icons.tune_rounded,
+      'Sampling',
+      status.nativeSampleMs,
+      format: (value) => '$value ms',
+    );
+    add(Icons.repeat_rounded, 'Reused graphs', status.nativeReusedGraphs);
+
+    final isLiteRtLmModel = status.activeModelName.toLowerCase().endsWith(
+      '.litertlm',
+    );
+    add(
+      Icons.layers_rounded,
+      'GPU layers',
+      status.runtimeGpuLayers,
+      format: (value) =>
+          isLiteRtLmModel && (value as int) >= ModelParams.maxGpuLayers
+          ? 'Maximum'
+          : value.toString(),
+    );
+    add(Icons.alt_route_rounded, 'Runtime threads', status.runtimeThreads);
+    add(Icons.hub_outlined, 'Thread pool', status.runtimeThreadPoolSize);
+
+    if (status.isMmprojLoaded) {
+      metrics.add(
+        const _RuntimeMetric(
+          icon: Icons.visibility_rounded,
+          label: 'Multimodal projector',
+          value: 'Loaded',
+        ),
+      );
+    } else if (status.hasConfiguredMmproj) {
+      metrics.add(
+        const _RuntimeMetric(
+          icon: Icons.visibility_outlined,
+          label: 'Multimodal projector',
+          value: 'Configured',
+        ),
+      );
+    }
+
+    add(
+      Icons.settings_ethernet_rounded,
+      'Execution',
+      status.runtimeExecution,
+      format: (value) => _normalizedText(value as String),
+    );
+    add(
+      Icons.developer_board_rounded,
+      'Core',
+      status.runtimeCoreVariant,
+      format: (value) => _normalizedText(value as String),
+    );
+    add(
+      Icons.cloud_queue_rounded,
+      'Model source',
+      status.runtimeModelSource,
+      format: (value) => _normalizedText(value as String),
+    );
+    add(
+      Icons.inventory_2_outlined,
+      'Model cache',
+      status.runtimeModelCacheState,
+      format: (value) => _normalizedText(value as String),
+    );
+    add(
+      Icons.warning_amber_rounded,
+      'Worker fallback',
+      status.runtimeWorkerFallbackReason,
+      format: (value) => _normalizedText(value as String),
+    );
+    add(
+      Icons.info_outline_rounded,
+      'Runtime notes',
+      status.runtimeNotes,
+      format: (value) => _normalizedText(value as String),
+    );
+
+    return metrics;
+  }
+
+  String _normalizedText(String text) {
+    return text
         .replaceAll(';', ', ')
         .replaceAll('_', ' ')
         .replaceAll(RegExp(r'\s+'), ' ')
         .trim();
-    if (normalized.length <= maxLength) {
-      return normalized;
-    }
-
-    return '${normalized.substring(0, maxLength - 3)}...';
   }
 
-  Widget _chip(
-    BuildContext context, {
-    required IconData icon,
-    required String text,
-  }) {
+  Future<void> _showRuntimeDetails(
+    BuildContext context,
+    List<_RuntimeMetric> metrics,
+  ) {
     final colorScheme = Theme.of(context).colorScheme;
 
-    return Container(
-      padding: const EdgeInsets.symmetric(horizontal: 10, vertical: 6),
-      decoration: BoxDecoration(
-        color: colorScheme.surfaceContainerLow.withValues(alpha: 0.82),
-        borderRadius: BorderRadius.circular(999),
-        border: Border.all(
-          color: colorScheme.outlineVariant.withValues(alpha: 0.45),
-        ),
-      ),
-      child: Row(
-        mainAxisSize: MainAxisSize.min,
-        children: [
-          Icon(icon, size: 13, color: colorScheme.onSurfaceVariant),
-          const SizedBox(width: 5),
-          Text(
-            text,
-            style: TextStyle(
-              fontSize: 11,
-              height: 1,
-              fontWeight: FontWeight.w600,
-              color: colorScheme.onSurface,
+    return showModalBottomSheet<void>(
+      context: context,
+      useSafeArea: true,
+      showDragHandle: true,
+      isScrollControlled: true,
+      backgroundColor: colorScheme.surface,
+      builder: (context) => FractionallySizedBox(
+        heightFactor: 0.72,
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            Padding(
+              padding: const EdgeInsets.fromLTRB(24, 4, 16, 16),
+              child: Row(
+                children: [
+                  Expanded(
+                    child: Text(
+                      'Runtime details',
+                      style: Theme.of(context).textTheme.headlineSmall
+                          ?.copyWith(fontWeight: FontWeight.w700),
+                    ),
+                  ),
+                  IconButton(
+                    onPressed: () => Navigator.of(context).pop(),
+                    tooltip: 'Close runtime details',
+                    icon: const Icon(Icons.close_rounded),
+                  ),
+                ],
+              ),
             ),
-          ),
-        ],
+            Expanded(
+              child: ListView.separated(
+                padding: const EdgeInsets.fromLTRB(16, 0, 16, 24),
+                itemCount: metrics.length,
+                separatorBuilder: (_, _) => Divider(
+                  height: 1,
+                  color: colorScheme.outlineVariant.withValues(alpha: 0.4),
+                ),
+                itemBuilder: (context, index) {
+                  final metric = metrics[index];
+                  return ListTile(
+                    leading: Icon(
+                      metric.icon,
+                      size: 19,
+                      color: colorScheme.primary,
+                    ),
+                    title: Text(metric.label),
+                    subtitle: Text(metric.value),
+                    contentPadding: const EdgeInsets.symmetric(horizontal: 8),
+                  );
+                },
+              ),
+            ),
+          ],
+        ),
       ),
     );
   }
+}
+
+class _RuntimeSummaryBar extends StatelessWidget {
+  final _RuntimeStatus status;
+  final VoidCallback onPressed;
+
+  const _RuntimeSummaryBar({required this.status, required this.onPressed});
+
+  @override
+  Widget build(BuildContext context) {
+    final colorScheme = Theme.of(context).colorScheme;
+
+    return Semantics(
+      button: true,
+      onTap: onPressed,
+      label: 'Open runtime details',
+      value:
+          '${status.activeBackend}, ${status.activeModelName}, '
+          '${status.currentTokens} of ${status.contextLimit} tokens',
+      child: ExcludeSemantics(
+        child: Material(
+          color: colorScheme.surfaceContainerLow,
+          shape: RoundedRectangleBorder(
+            borderRadius: BorderRadius.circular(14),
+            side: BorderSide(
+              color: colorScheme.outlineVariant.withValues(alpha: 0.38),
+            ),
+          ),
+          clipBehavior: Clip.antiAlias,
+          child: InkWell(
+            onTap: onPressed,
+            child: Padding(
+              padding: const EdgeInsets.fromLTRB(12, 9, 8, 9),
+              child: LayoutBuilder(
+                builder: (context, constraints) {
+                  final showPerformance = constraints.maxWidth >= 620;
+                  return Row(
+                    children: [
+                      Container(
+                        width: 7,
+                        height: 7,
+                        decoration: BoxDecoration(
+                          color: colorScheme.primary,
+                          shape: BoxShape.circle,
+                          boxShadow: [
+                            BoxShadow(
+                              color: colorScheme.primary.withValues(alpha: 0.4),
+                              blurRadius: 7,
+                            ),
+                          ],
+                        ),
+                      ),
+                      const SizedBox(width: 9),
+                      Expanded(
+                        child: Text(
+                          '${status.activeBackend}  ·  ${status.activeModelName}',
+                          maxLines: 1,
+                          overflow: TextOverflow.ellipsis,
+                          style: Theme.of(context).textTheme.labelLarge
+                              ?.copyWith(fontWeight: FontWeight.w600),
+                        ),
+                      ),
+                      if (showPerformance &&
+                          status.tokensPerSecond != null) ...[
+                        const SizedBox(width: 12),
+                        Text(
+                          '${status.tokensPerSecond!.toStringAsFixed(1)} tok/s',
+                          style: Theme.of(context).textTheme.labelMedium
+                              ?.copyWith(color: colorScheme.onSurfaceVariant),
+                        ),
+                      ],
+                      const SizedBox(width: 12),
+                      Text(
+                        '${status.currentTokens}/${status.contextLimit}',
+                        style: Theme.of(context).textTheme.labelMedium
+                            ?.copyWith(
+                              color: colorScheme.onSurfaceVariant,
+                              fontFeatures: const [
+                                FontFeature.tabularFigures(),
+                              ],
+                            ),
+                      ),
+                      const SizedBox(width: 2),
+                      Icon(
+                        Icons.chevron_right_rounded,
+                        size: 20,
+                        color: colorScheme.onSurfaceVariant,
+                      ),
+                    ],
+                  );
+                },
+              ),
+            ),
+          ),
+        ),
+      ),
+    );
+  }
+}
+
+class _RuntimeMetric {
+  final IconData icon;
+  final String label;
+  final String value;
+
+  const _RuntimeMetric({
+    required this.icon,
+    required this.label,
+    required this.value,
+  });
 }

--- a/example/chat_app/lib/widgets/welcome_view.dart
+++ b/example/chat_app/lib/widgets/welcome_view.dart
@@ -23,99 +23,90 @@ class WelcomeView extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     if (isInitializing) {
-      return Center(
-        child: ConstrainedBox(
-          constraints: const BoxConstraints(maxWidth: 420),
-          child: Padding(
-            padding: const EdgeInsets.all(24),
-            child: Column(
-              mainAxisSize: MainAxisSize.min,
-              children: [
-                if (loadingProgress > 0)
-                  ClipRRect(
-                    borderRadius: BorderRadius.circular(999),
-                    child: LinearProgressIndicator(
-                      value: loadingProgress,
-                      minHeight: 8,
-                    ),
-                  )
-                else
-                  const CircularProgressIndicator(),
-                const SizedBox(height: 18),
-                Text(
-                  loadingProgress > 0
-                      ? 'Loading model ${(loadingProgress * 100).toStringAsFixed(0)}%'
-                      : 'Loading model...',
-                  style: TextStyle(
-                    fontSize: 16,
-                    fontWeight: FontWeight.w600,
-                    color: Theme.of(context).colorScheme.secondary,
-                  ),
+      return _ScrollableWelcomeContent(
+        maxWidth: 420,
+        child: Column(
+          mainAxisSize: MainAxisSize.min,
+          children: [
+            if (loadingProgress > 0)
+              ClipRRect(
+                borderRadius: BorderRadius.circular(999),
+                child: LinearProgressIndicator(
+                  value: loadingProgress,
+                  minHeight: 8,
                 ),
-              ],
+              )
+            else
+              const CircularProgressIndicator(),
+            const SizedBox(height: 18),
+            Text(
+              loadingProgress > 0
+                  ? 'Loading model ${(loadingProgress * 100).toStringAsFixed(0)}%'
+                  : 'Loading model...',
+              textAlign: TextAlign.center,
+              style: TextStyle(
+                fontSize: 16,
+                fontWeight: FontWeight.w600,
+                color: Theme.of(context).colorScheme.secondary,
+              ),
             ),
-          ),
+          ],
         ),
       );
     }
 
     final colorScheme = Theme.of(context).colorScheme;
-    final selectedModelName = modelPath?.split('/').last;
+    final selectedModelName = _displayModelName(modelPath);
 
     if (error != null) {
-      return Center(
-        child: ConstrainedBox(
-          constraints: const BoxConstraints(maxWidth: 520),
-          child: Container(
-            margin: const EdgeInsets.all(24),
-            padding: const EdgeInsets.all(20),
-            decoration: BoxDecoration(
-              color: colorScheme.errorContainer.withValues(alpha: 0.5),
-              borderRadius: BorderRadius.circular(16),
-              border: Border.all(
-                color: colorScheme.error.withValues(alpha: 0.2),
+      return _ScrollableWelcomeContent(
+        maxWidth: 520,
+        child: Container(
+          padding: const EdgeInsets.all(20),
+          decoration: BoxDecoration(
+            color: colorScheme.errorContainer.withValues(alpha: 0.5),
+            borderRadius: BorderRadius.circular(16),
+            border: Border.all(color: colorScheme.error.withValues(alpha: 0.2)),
+          ),
+          child: Column(
+            mainAxisSize: MainAxisSize.min,
+            children: [
+              Icon(Icons.error_rounded, size: 40, color: colorScheme.error),
+              const SizedBox(height: 14),
+              Text(
+                'Model failed to load',
+                style: TextStyle(
+                  fontSize: 18,
+                  fontWeight: FontWeight.bold,
+                  color: colorScheme.error,
+                ),
               ),
-            ),
-            child: Column(
-              mainAxisSize: MainAxisSize.min,
-              children: [
-                Icon(Icons.error_rounded, size: 40, color: colorScheme.error),
-                const SizedBox(height: 14),
-                Text(
-                  'Model failed to load',
-                  style: TextStyle(
-                    fontSize: 18,
-                    fontWeight: FontWeight.bold,
-                    color: colorScheme.error,
+              const SizedBox(height: 8),
+              Text(
+                error!,
+                textAlign: TextAlign.center,
+                style: TextStyle(color: colorScheme.onErrorContainer),
+              ),
+              const SizedBox(height: 18),
+              Wrap(
+                spacing: 10,
+                runSpacing: 10,
+                alignment: WrapAlignment.center,
+                children: [
+                  FilledButton.icon(
+                    onPressed: onRetry,
+                    icon: const Icon(Icons.refresh_rounded),
+                    label: const Text('Retry'),
                   ),
-                ),
-                const SizedBox(height: 8),
-                Text(
-                  error!,
-                  textAlign: TextAlign.center,
-                  style: TextStyle(color: colorScheme.onErrorContainer),
-                ),
-                const SizedBox(height: 18),
-                Wrap(
-                  spacing: 10,
-                  runSpacing: 10,
-                  alignment: WrapAlignment.center,
-                  children: [
-                    FilledButton.icon(
-                      onPressed: onRetry,
-                      icon: const Icon(Icons.refresh_rounded),
-                      label: const Text('Retry'),
+                  if (onSelectModel != null)
+                    OutlinedButton.icon(
+                      onPressed: onSelectModel,
+                      icon: const Icon(Icons.tune_rounded),
+                      label: const Text('Change model'),
                     ),
-                    if (onSelectModel != null)
-                      OutlinedButton.icon(
-                        onPressed: onSelectModel,
-                        icon: const Icon(Icons.tune_rounded),
-                        label: const Text('Change model'),
-                      ),
-                  ],
-                ),
-              ],
-            ),
+                ],
+              ),
+            ],
           ),
         ),
       );
@@ -123,105 +114,139 @@ class WelcomeView extends StatelessWidget {
 
     final canSelectModel = onSelectModel != null;
 
-    return Center(
-      child: ConstrainedBox(
-        constraints: const BoxConstraints(maxWidth: 520),
-        child: Padding(
-          padding: const EdgeInsets.all(24),
-          child: Column(
-            mainAxisSize: MainAxisSize.min,
-            children: [
-              Container(
-                padding: const EdgeInsets.all(18),
-                decoration: BoxDecoration(
-                  color: colorScheme.primaryContainer.withValues(alpha: 0.25),
-                  borderRadius: BorderRadius.circular(18),
-                  border: Border.all(
-                    color: colorScheme.outlineVariant.withValues(alpha: 0.35),
-                  ),
-                ),
-                child: Icon(
-                  Icons.chat_bubble_outline_rounded,
-                  size: 42,
-                  color: colorScheme.primary,
-                ),
+    return _ScrollableWelcomeContent(
+      maxWidth: 520,
+      child: Column(
+        mainAxisSize: MainAxisSize.min,
+        children: [
+          Container(
+            padding: const EdgeInsets.all(18),
+            decoration: BoxDecoration(
+              color: colorScheme.primaryContainer.withValues(alpha: 0.25),
+              borderRadius: BorderRadius.circular(18),
+              border: Border.all(
+                color: colorScheme.outlineVariant.withValues(alpha: 0.35),
               ),
-              const SizedBox(height: 22),
-              Text(
-                isLoaded ? 'Ready to chat' : 'Load a model to begin',
-                textAlign: TextAlign.center,
-                style: const TextStyle(
-                  fontSize: 24,
-                  fontWeight: FontWeight.bold,
-                ),
-              ),
-              const SizedBox(height: 12),
-              Container(
-                width: double.infinity,
-                padding: const EdgeInsets.symmetric(
-                  horizontal: 14,
-                  vertical: 12,
-                ),
-                decoration: BoxDecoration(
-                  color: colorScheme.surfaceContainerHighest.withValues(
-                    alpha: 0.36,
-                  ),
-                  borderRadius: BorderRadius.circular(12),
-                  border: Border.all(
-                    color: colorScheme.outlineVariant.withValues(alpha: 0.35),
-                  ),
-                ),
-                child: Row(
-                  children: [
-                    Icon(
-                      selectedModelName == null
-                          ? Icons.folder_open_rounded
-                          : Icons.sd_storage_outlined,
-                      size: 18,
-                      color: colorScheme.secondary,
-                    ),
-                    const SizedBox(width: 10),
-                    Expanded(
-                      child: Text(
-                        selectedModelName ?? 'No model selected',
-                        maxLines: 1,
-                        overflow: TextOverflow.ellipsis,
-                        style: TextStyle(color: colorScheme.onSurfaceVariant),
-                      ),
-                    ),
-                  ],
-                ),
-              ),
-              const SizedBox(height: 20),
-              if (!isLoaded && (canSelectModel || modelPath != null))
-                Wrap(
-                  spacing: 10,
-                  runSpacing: 10,
-                  alignment: WrapAlignment.center,
-                  children: [
-                    FilledButton.icon(
-                      onPressed: modelPath == null ? onSelectModel : onRetry,
-                      icon: Icon(
-                        modelPath == null
-                            ? Icons.file_open_rounded
-                            : Icons.power_settings_new_rounded,
-                      ),
-                      label: Text(
-                        modelPath == null ? 'Select model' : 'Load model',
-                      ),
-                    ),
-                    if (modelPath != null && canSelectModel)
-                      OutlinedButton.icon(
-                        onPressed: onSelectModel,
-                        icon: const Icon(Icons.tune_rounded),
-                        label: const Text('Change model'),
-                      ),
-                  ],
-                ),
-            ],
+            ),
+            child: Icon(
+              Icons.chat_bubble_outline_rounded,
+              size: 42,
+              color: colorScheme.primary,
+            ),
           ),
-        ),
+          const SizedBox(height: 22),
+          Text(
+            isLoaded ? 'Ready to chat' : 'Load a model to begin',
+            textAlign: TextAlign.center,
+            style: const TextStyle(fontSize: 24, fontWeight: FontWeight.bold),
+          ),
+          const SizedBox(height: 12),
+          Container(
+            width: double.infinity,
+            padding: const EdgeInsets.symmetric(horizontal: 14, vertical: 12),
+            decoration: BoxDecoration(
+              color: colorScheme.surfaceContainerHighest.withValues(
+                alpha: 0.36,
+              ),
+              borderRadius: BorderRadius.circular(12),
+              border: Border.all(
+                color: colorScheme.outlineVariant.withValues(alpha: 0.35),
+              ),
+            ),
+            child: Row(
+              children: [
+                Icon(
+                  selectedModelName == null
+                      ? Icons.folder_open_rounded
+                      : Icons.sd_storage_outlined,
+                  size: 18,
+                  color: colorScheme.secondary,
+                ),
+                const SizedBox(width: 10),
+                Expanded(
+                  child: Text(
+                    selectedModelName ?? 'No model selected',
+                    maxLines: 1,
+                    overflow: TextOverflow.ellipsis,
+                    style: TextStyle(color: colorScheme.onSurfaceVariant),
+                  ),
+                ),
+              ],
+            ),
+          ),
+          const SizedBox(height: 20),
+          if (!isLoaded && (canSelectModel || modelPath != null))
+            Wrap(
+              spacing: 10,
+              runSpacing: 10,
+              alignment: WrapAlignment.center,
+              children: [
+                FilledButton.icon(
+                  onPressed: modelPath == null ? onSelectModel : onRetry,
+                  icon: Icon(
+                    modelPath == null
+                        ? Icons.file_open_rounded
+                        : Icons.power_settings_new_rounded,
+                  ),
+                  label: Text(
+                    modelPath == null ? 'Select model' : 'Load model',
+                  ),
+                ),
+                if (modelPath != null && canSelectModel)
+                  OutlinedButton.icon(
+                    onPressed: onSelectModel,
+                    icon: const Icon(Icons.tune_rounded),
+                    label: const Text('Change model'),
+                  ),
+              ],
+            ),
+        ],
       ),
+    );
+  }
+
+  String? _displayModelName(String? pathOrUrl) {
+    if (pathOrUrl == null || pathOrUrl.isEmpty) {
+      return null;
+    }
+
+    final withoutSensitiveSuffix = pathOrUrl.split('?').first.split('#').first;
+    final normalized = withoutSensitiveSuffix.replaceAll('\\', '/');
+    final parts = normalized.split('/').where((part) => part.isNotEmpty);
+    return parts.isEmpty ? 'Selected model' : parts.last;
+  }
+}
+
+class _ScrollableWelcomeContent extends StatelessWidget {
+  final double maxWidth;
+  final Widget child;
+
+  const _ScrollableWelcomeContent({
+    required this.maxWidth,
+    required this.child,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    return LayoutBuilder(
+      builder: (context, constraints) {
+        final minHeight = constraints.hasBoundedHeight
+            ? (constraints.maxHeight - 48).clamp(0.0, double.infinity)
+            : 0.0;
+
+        return SingleChildScrollView(
+          padding: const EdgeInsets.all(24),
+          child: ConstrainedBox(
+            constraints: BoxConstraints(minHeight: minHeight),
+            child: Center(
+              child: ConstrainedBox(
+                constraints: BoxConstraints(maxWidth: maxWidth),
+                child: child,
+              ),
+            ),
+          ),
+        );
+      },
     );
   }
 }

--- a/example/chat_app/lib/widgets/welcome_view.dart
+++ b/example/chat_app/lib/widgets/welcome_view.dart
@@ -1,5 +1,4 @@
 import 'package:flutter/material.dart';
-import 'package:google_fonts/google_fonts.dart';
 
 class WelcomeView extends StatelessWidget {
   final bool isInitializing;
@@ -47,7 +46,7 @@ class WelcomeView extends StatelessWidget {
                   loadingProgress > 0
                       ? 'Loading model ${(loadingProgress * 100).toStringAsFixed(0)}%'
                       : 'Loading model...',
-                  style: GoogleFonts.outfit(
+                  style: TextStyle(
                     fontSize: 16,
                     fontWeight: FontWeight.w600,
                     color: Theme.of(context).colorScheme.secondary,
@@ -84,7 +83,7 @@ class WelcomeView extends StatelessWidget {
                 const SizedBox(height: 14),
                 Text(
                   'Model failed to load',
-                  style: GoogleFonts.outfit(
+                  style: TextStyle(
                     fontSize: 18,
                     fontWeight: FontWeight.bold,
                     color: colorScheme.error,
@@ -151,7 +150,7 @@ class WelcomeView extends StatelessWidget {
               Text(
                 isLoaded ? 'Ready to chat' : 'Load a model to begin',
                 textAlign: TextAlign.center,
-                style: GoogleFonts.outfit(
+                style: const TextStyle(
                   fontSize: 24,
                   fontWeight: FontWeight.bold,
                 ),

--- a/example/chat_app/test/app_shell_screen_test.dart
+++ b/example/chat_app/test/app_shell_screen_test.dart
@@ -135,6 +135,118 @@ void main() {
       expect(tester.takeException(), isNull);
     });
 
+    testWidgets('icon-only shell actions expose accessible names', (
+      tester,
+    ) async {
+      final oldSize = tester.view.physicalSize;
+      final oldRatio = tester.view.devicePixelRatio;
+      tester.view
+        ..physicalSize = const Size(390, 844)
+        ..devicePixelRatio = 1.0;
+      addTearDown(() {
+        tester.view
+          ..physicalSize = oldSize
+          ..devicePixelRatio = oldRatio;
+      });
+      final semantics = tester.ensureSemantics();
+
+      final provider = ChatProvider(
+        chatService: MockChatService(),
+        settingsService: MockSettingsService(),
+        initialSettings: const ChatSettings(modelPath: 'test_model.gguf'),
+      );
+      addTearDown(provider.dispose);
+
+      await tester.pumpWidget(
+        ChangeNotifierProvider<ChatProvider>.value(
+          value: provider,
+          child: const MaterialApp(home: AppShellScreen()),
+        ),
+      );
+      await tester.pumpAndSettle();
+
+      expect(find.bySemanticsLabel('Open navigation menu'), findsOneWidget);
+      expect(
+        find.bySemanticsLabel('Open model and inference settings'),
+        findsOneWidget,
+      );
+      expect(find.bySemanticsLabel('Send message'), findsOneWidget);
+      semantics.dispose();
+    });
+
+    testWidgets('settings survives responsive breakpoints at large text', (
+      tester,
+    ) async {
+      final oldSize = tester.view.physicalSize;
+      final oldRatio = tester.view.devicePixelRatio;
+      addTearDown(() {
+        tester.view
+          ..physicalSize = oldSize
+          ..devicePixelRatio = oldRatio;
+      });
+
+      final provider = ChatProvider(
+        chatService: MockChatService(),
+        settingsService: MockSettingsService(),
+        initialSettings: const ChatSettings(modelPath: 'test_model.gguf'),
+      );
+      addTearDown(provider.dispose);
+
+      const sizes = <Size>[
+        Size(320, 640),
+        Size(719, 780),
+        Size(720, 780),
+        Size(1039, 820),
+        Size(1040, 820),
+        Size(1599, 900),
+        Size(1600, 900),
+      ];
+
+      for (final size in sizes) {
+        tester.view
+          ..physicalSize = size
+          ..devicePixelRatio = 1.0;
+
+        await tester.pumpWidget(
+          ChangeNotifierProvider<ChatProvider>.value(
+            value: provider,
+            child: MaterialApp(
+              key: ValueKey<double>(size.width),
+              home: MediaQuery(
+                data: MediaQueryData(
+                  size: size,
+                  textScaler: const TextScaler.linear(2.0),
+                ),
+                child: AppShellScreen(key: ValueKey<double>(size.width)),
+              ),
+            ),
+          ),
+        );
+        await tester.pumpAndSettle();
+
+        await tester.tap(
+          find.byTooltip('Open model and inference settings').first,
+        );
+        await tester.pumpAndSettle();
+
+        expect(
+          tester.takeException(),
+          isNull,
+          reason: 'Unexpected layout exception at ${size.width}px',
+        );
+        expect(find.text('Model parameters'), findsOneWidget);
+
+        await tester.tap(find.text('Manage models'));
+        await tester.pump(const Duration(milliseconds: 100));
+        expect(
+          tester.takeException(),
+          isNull,
+          reason: 'Model library overflowed at ${size.width}px',
+        );
+        expect(find.text('Add GGUF (HF)'), findsOneWidget);
+      }
+    });
+
     testWidgets('confirms before deleting a conversation', (tester) async {
       final oldSize = tester.view.physicalSize;
       final oldRatio = tester.view.devicePixelRatio;

--- a/example/chat_app/test/app_shell_screen_test.dart
+++ b/example/chat_app/test/app_shell_screen_test.dart
@@ -35,7 +35,10 @@ void main() {
       final provider = ChatProvider(
         chatService: MockChatService(),
         settingsService: MockSettingsService(),
-        initialSettings: const ChatSettings(modelPath: 'test_model.gguf'),
+        initialSettings: const ChatSettings(
+          modelPath: 'test_model.gguf',
+          gpuLayers: 99,
+        ),
       );
 
       await tester.pumpWidget(
@@ -61,6 +64,25 @@ void main() {
       );
       await tester.pumpAndSettle();
       expect(find.text('Inference parameters'), findsOneWidget);
+
+      await tester.tap(find.text('Model parameters'));
+      await tester.pumpAndSettle();
+      expect(find.text('Max'), findsOneWidget);
+      expect(
+        find.textContaining('Auto selects Metal on supported Macs.'),
+        findsOneWidget,
+      );
+      expect(
+        find.textContaining('Set GPU layers to 99 for Auto'),
+        findsNothing,
+      );
+
+      provider.updateGpuLayers(0);
+      await tester.pump(const Duration(milliseconds: 300));
+      expect(
+        find.textContaining('GPU layers is 0, so inference will run on CPU.'),
+        findsOneWidget,
+      );
     });
 
     testWidgets('shows change model action when settings panel is hidden', (

--- a/example/chat_app/test/app_shell_screen_test.dart
+++ b/example/chat_app/test/app_shell_screen_test.dart
@@ -16,7 +16,7 @@ void main() {
       TestWidgetsFlutterBinding.ensureInitialized();
     });
 
-    testWidgets('shows desktop shell and opens manage models view', (
+    testWidgets('keeps desktop settings opt-in and opens manage models view', (
       tester,
     ) async {
       final oldSize = tester.view.physicalSize;
@@ -49,9 +49,18 @@ void main() {
 
       expect(find.text('llamadart chat'), findsOneWidget);
       expect(find.text('New conversation'), findsWidgets);
+      expect(find.text('Inference parameters'), findsNothing);
+      expect(find.text('Change model'), findsOneWidget);
+      expect(
+        find.byTooltip('Open model and inference settings'),
+        findsOneWidget,
+      );
 
+      await tester.tap(
+        find.byTooltip('Open model and inference settings').first,
+      );
+      await tester.pumpAndSettle();
       expect(find.text('Inference parameters'), findsOneWidget);
-      expect(find.text('Change model'), findsNothing);
     });
 
     testWidgets('shows change model action when settings panel is hidden', (
@@ -86,6 +95,100 @@ void main() {
       await tester.pumpAndSettle();
 
       expect(find.text('Change model'), findsOneWidget);
+    });
+
+    testWidgets('uses a full-width settings view on mobile', (tester) async {
+      final oldSize = tester.view.physicalSize;
+      final oldRatio = tester.view.devicePixelRatio;
+
+      tester.view
+        ..physicalSize = const Size(390, 844)
+        ..devicePixelRatio = 1.0;
+
+      addTearDown(() {
+        tester.view
+          ..physicalSize = oldSize
+          ..devicePixelRatio = oldRatio;
+      });
+
+      final provider = ChatProvider(
+        chatService: MockChatService(),
+        settingsService: MockSettingsService(),
+        initialSettings: const ChatSettings(modelPath: 'test_model.gguf'),
+      );
+
+      await tester.pumpWidget(
+        ChangeNotifierProvider<ChatProvider>.value(
+          value: provider,
+          child: const MaterialApp(home: AppShellScreen()),
+        ),
+      );
+      await tester.pumpAndSettle();
+
+      await tester.tap(
+        find.byTooltip('Open model and inference settings').first,
+      );
+      await tester.pumpAndSettle();
+
+      expect(find.text('Settings'), findsOneWidget);
+      expect(find.byTooltip('Close settings'), findsOneWidget);
+      expect(tester.takeException(), isNull);
+    });
+
+    testWidgets('confirms before deleting a conversation', (tester) async {
+      final oldSize = tester.view.physicalSize;
+      final oldRatio = tester.view.devicePixelRatio;
+      tester.view
+        ..physicalSize = const Size(1440, 920)
+        ..devicePixelRatio = 1.0;
+      addTearDown(() {
+        tester.view
+          ..physicalSize = oldSize
+          ..devicePixelRatio = oldRatio;
+      });
+
+      final provider = ChatProvider(
+        chatService: MockChatService(),
+        settingsService: MockSettingsService(),
+        initialSettings: const ChatSettings(modelPath: 'test_model.gguf'),
+      )..createConversation();
+      addTearDown(provider.dispose);
+
+      await tester.pumpWidget(
+        ChangeNotifierProvider<ChatProvider>.value(
+          value: provider,
+          child: const MaterialApp(home: AppShellScreen()),
+        ),
+      );
+      await tester.pumpAndSettle();
+
+      expect(provider.conversations, hasLength(2));
+      void pressDelete() {
+        final deleteButton = tester.widget<IconButton>(
+          find
+              .ancestor(
+                of: find.byTooltip('Delete conversation').first,
+                matching: find.byType(IconButton),
+              )
+              .first,
+        );
+        deleteButton.onPressed!();
+      }
+
+      pressDelete();
+      await tester.pumpAndSettle();
+
+      expect(find.text('Delete conversation?'), findsOneWidget);
+      await tester.tap(find.widgetWithText(TextButton, 'Cancel'));
+      await tester.pumpAndSettle();
+      expect(provider.conversations, hasLength(2));
+
+      pressDelete();
+      await tester.pumpAndSettle();
+      await tester.tap(find.widgetWithText(FilledButton, 'Delete'));
+      await tester.pumpAndSettle();
+
+      expect(provider.conversations, hasLength(1));
     });
   });
 }

--- a/example/chat_app/test/backend_utils_test.dart
+++ b/example/chat_app/test/backend_utils_test.dart
@@ -106,7 +106,7 @@ void main() {
       final available = BackendUtils.availableBackends(
         devices: const <String>['metal', 'cpu'],
         activeBackend: 'cuda',
-        includeAutoOnWeb: true,
+        includeAuto: true,
       );
 
       expect(

--- a/example/chat_app/test/chat_input_test.dart
+++ b/example/chat_app/test/chat_input_test.dart
@@ -42,6 +42,49 @@ void main() {
     await tester.enterText(find.byType(TextField), 'draft next prompt');
     expect(controller.text, 'draft next prompt');
   });
+
+  testWidgets('uses mobile submit behavior without desktop shortcut copy', (
+    tester,
+  ) async {
+    final oldSize = tester.view.physicalSize;
+    final oldRatio = tester.view.devicePixelRatio;
+    tester.view
+      ..physicalSize = const Size(390, 844)
+      ..devicePixelRatio = 1.0;
+    addTearDown(() {
+      tester.view
+        ..physicalSize = oldSize
+        ..devicePixelRatio = oldRatio;
+    });
+
+    final provider = _GeneratingReadyProvider();
+    addTearDown(provider.dispose);
+    final controller = TextEditingController();
+    final focusNode = FocusNode();
+    addTearDown(controller.dispose);
+    addTearDown(focusNode.dispose);
+
+    await tester.pumpWidget(
+      ChangeNotifierProvider<ChatProvider>.value(
+        value: provider,
+        child: MaterialApp(
+          home: Scaffold(
+            body: ChatInput(
+              controller: controller,
+              focusNode: focusNode,
+              onSend: () {},
+            ),
+          ),
+        ),
+      ),
+    );
+
+    final textField = tester.widget<TextField>(find.byType(TextField));
+    expect(textField.textInputAction, TextInputAction.send);
+    expect(find.textContaining('Cmd/Ctrl'), findsNothing);
+    expect(find.textContaining('option + enter'), findsNothing);
+    expect(find.text('Ask anything…'), findsOneWidget);
+  });
 }
 
 class _GeneratingReadyProvider extends ChatProvider {

--- a/example/chat_app/test/manage_models_screen_download_test.dart
+++ b/example/chat_app/test/manage_models_screen_download_test.dart
@@ -201,9 +201,59 @@ void main() {
         expect(find.text('Downloading model'), findsOneWidget);
         expect(find.text('25%'), findsOneWidget);
 
+        String? finishedFilename;
+        final finishedSubscription = downloadUi.downloadsFinished.listen(
+          (filename) => finishedFilename = filename,
+        );
+        addTearDown(finishedSubscription.cancel);
         await tester.tap(find.byTooltip('Pause Download'));
         await tester.pump(const Duration(milliseconds: 150));
         await modelService.downloadCancelled.future.timeout(_testTimeout);
+        expect(finishedFilename, model.filename);
+      },
+    );
+
+    testWidgets(
+      'replacement screen refreshes when app-owned download completes',
+      (tester) async {
+        SharedPreferences.setMockInitialValues({});
+        final model = _remoteModel();
+        final modelService = _HoldingModelService();
+        final downloadUi = ModelDownloadUiController();
+        addTearDown(downloadUi.dispose);
+
+        await _pumpScreen(
+          tester,
+          modelService: modelService,
+          models: [model],
+          downloadUiController: downloadUi,
+        );
+
+        await tester.tap(find.text('Download'));
+        await modelService.downloadStarted.future.timeout(_testTimeout);
+        await tester.pump();
+
+        await _pumpScreen(
+          tester,
+          modelService: modelService,
+          models: [model],
+          downloadUiController: downloadUi,
+        );
+        expect(find.text('Downloading model'), findsOneWidget);
+
+        String? finishedFilename;
+        final finishedSubscription = downloadUi.downloadsFinished.listen(
+          (filename) => finishedFilename = filename,
+        );
+        addTearDown(finishedSubscription.cancel);
+        modelService.completeDownload();
+        await tester.pump(const Duration(milliseconds: 20));
+        await modelService.downloadCompleted.future.timeout(_testTimeout);
+        await tester.pump(const Duration(milliseconds: 300));
+
+        expect(finishedFilename, model.filename);
+        expect(find.text('Use this model'), findsOneWidget);
+        expect(find.text('Downloading model'), findsNothing);
       },
     );
 
@@ -436,12 +486,20 @@ class _HoldingModelService implements ModelService {
 
   final Completer<void> downloadStarted = Completer<void>();
   final Completer<void> downloadCancelled = Completer<void>();
+  final Completer<void> downloadCompleted = Completer<void>();
+  final Completer<void> _finishDownload = Completer<void>();
   final Set<String> downloadedFiles;
   final Set<String>? cachedAssetKeys;
 
   int downloadCalls = 0;
   int deleteCalls = 0;
   CancelToken? lastCancelToken;
+
+  void completeDownload() {
+    if (!_finishDownload.isCompleted) {
+      _finishDownload.complete();
+    }
+  }
 
   @override
   Future<String> getModelsDirectory() async => '/models';
@@ -503,8 +561,17 @@ class _HoldingModelService implements ModelService {
       downloadStarted.complete();
     }
 
-    while (!cancelToken.isCancelled) {
+    while (!cancelToken.isCancelled && !_finishDownload.isCompleted) {
       await Future<void>.delayed(const Duration(milliseconds: 10));
+    }
+    if (_finishDownload.isCompleted && !cancelToken.isCancelled) {
+      downloadedFiles.add(model.filename);
+      onProgress(1);
+      onSuccess(model.filename);
+      if (!downloadCompleted.isCompleted) {
+        downloadCompleted.complete();
+      }
+      return;
     }
     if (!downloadCancelled.isCompleted) {
       downloadCancelled.complete();

--- a/example/chat_app/test/manage_models_screen_download_test.dart
+++ b/example/chat_app/test/manage_models_screen_download_test.dart
@@ -8,6 +8,7 @@ import 'package:flutter_test/flutter_test.dart';
 import 'package:llamadart_chat_example/models/downloadable_model.dart';
 import 'package:llamadart_chat_example/providers/chat_provider.dart';
 import 'package:llamadart_chat_example/screens/manage_models_screen.dart';
+import 'package:llamadart_chat_example/services/model_download_ui_controller.dart';
 import 'package:llamadart_chat_example/services/model_service_base.dart';
 import 'package:provider/provider.dart';
 import 'package:shared_preferences/shared_preferences.dart';
@@ -163,6 +164,48 @@ void main() {
 
       expect(modelService.lastCancelToken?.isCancelled, isTrue);
     });
+
+    testWidgets(
+      'app-owned download continues when the transient screen is replaced',
+      (tester) async {
+        SharedPreferences.setMockInitialValues({});
+        final model = _remoteModel();
+        final modelService = _HoldingModelService();
+        final downloadUi = ModelDownloadUiController();
+        addTearDown(downloadUi.dispose);
+
+        await _pumpScreen(
+          tester,
+          modelService: modelService,
+          models: [model],
+          downloadUiController: downloadUi,
+        );
+
+        await tester.tap(find.text('Download'));
+        await modelService.downloadStarted.future.timeout(_testTimeout);
+        await tester.pump();
+
+        await tester.pumpWidget(const SizedBox.shrink());
+        await tester.pump(const Duration(milliseconds: 150));
+
+        expect(modelService.lastCancelToken?.isCancelled, isFalse);
+        expect(modelService.downloadCancelled.isCompleted, isFalse);
+
+        await _pumpScreen(
+          tester,
+          modelService: modelService,
+          models: [model],
+          downloadUiController: downloadUi,
+        );
+
+        expect(find.text('Downloading model'), findsOneWidget);
+        expect(find.text('25%'), findsOneWidget);
+
+        await tester.tap(find.byTooltip('Pause Download'));
+        await tester.pump(const Duration(milliseconds: 150));
+        await modelService.downloadCancelled.future.timeout(_testTimeout);
+      },
+    );
 
     testWidgets(
       'selection warns when runtime lacks advertised vision support',
@@ -330,6 +373,7 @@ Future<void> _pumpScreen(
   required _HoldingModelService modelService,
   required List<DownloadableModel> models,
   ChatProvider? provider,
+  ModelDownloadUiController? downloadUiController,
 }) async {
   final effectiveProvider =
       provider ??
@@ -351,6 +395,7 @@ Future<void> _pumpScreen(
             modelService: modelService,
             initialModels: models,
             showModelLibraryInitially: true,
+            downloadUiController: downloadUiController,
           ),
         ),
       ),

--- a/example/chat_app/test/message_bubble_test.dart
+++ b/example/chat_app/test/message_bubble_test.dart
@@ -44,4 +44,35 @@ void main() {
     await tester.tap(find.byTooltip('Regenerate response'));
     expect(regenerateCalls, 1);
   });
+
+  testWidgets('copy failure shows feedback without throwing', (tester) async {
+    TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
+        .setMockMethodCallHandler(SystemChannels.platform, (call) async {
+          if (call.method == 'Clipboard.setData') {
+            throw PlatformException(code: 'clipboard-denied');
+          }
+          return null;
+        });
+    addTearDown(() {
+      TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
+          .setMockMethodCallHandler(SystemChannels.platform, null);
+    });
+
+    await tester.pumpWidget(
+      MaterialApp(
+        home: Scaffold(
+          body: MessageBubble(
+            message: ChatMessage(text: 'A concise answer', isUser: false),
+            isNextSame: false,
+          ),
+        ),
+      ),
+    );
+
+    await tester.tap(find.byTooltip('Copy response'));
+    await tester.pump();
+
+    expect(find.text('Could not copy response'), findsOneWidget);
+    expect(tester.takeException(), isNull);
+  });
 }

--- a/example/chat_app/test/message_bubble_test.dart
+++ b/example/chat_app/test/message_bubble_test.dart
@@ -1,0 +1,47 @@
+import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:llamadart_chat_example/models/chat_message.dart';
+import 'package:llamadart_chat_example/widgets/message_bubble.dart';
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  testWidgets('assistant actions copy and regenerate', (tester) async {
+    MethodCall? clipboardCall;
+    TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
+        .setMockMethodCallHandler(SystemChannels.platform, (call) async {
+          if (call.method == 'Clipboard.setData') {
+            clipboardCall = call;
+          }
+          return null;
+        });
+    addTearDown(() {
+      TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
+          .setMockMethodCallHandler(SystemChannels.platform, null);
+    });
+
+    var regenerateCalls = 0;
+    await tester.pumpWidget(
+      MaterialApp(
+        home: Scaffold(
+          body: MessageBubble(
+            message: ChatMessage(text: 'A concise answer', isUser: false),
+            isNextSame: false,
+            onRegenerate: () => regenerateCalls += 1,
+          ),
+        ),
+      ),
+    );
+
+    await tester.tap(find.byTooltip('Copy response'));
+    await tester.pump();
+    expect(clipboardCall?.arguments, <String, dynamic>{
+      'text': 'A concise answer',
+    });
+    expect(find.text('Response copied'), findsOneWidget);
+
+    await tester.tap(find.byTooltip('Regenerate response'));
+    expect(regenerateCalls, 1);
+  });
+}

--- a/example/chat_app/test/model_card_test.dart
+++ b/example/chat_app/test/model_card_test.dart
@@ -206,6 +206,28 @@ void main() {
     expect(find.text('Download Projector'), findsOneWidget);
     expect(find.text('Use Text Only'), findsOneWidget);
   });
+
+  testWidgets('maximum GPU layers is not labeled as backend Auto', (
+    tester,
+  ) async {
+    await _pumpCard(
+      tester,
+      model: _ggufModel(),
+      isWeb: false,
+      isDownloaded: true,
+      isSelected: true,
+      gpuLayers: 99,
+      onSelect: () {},
+      onDownload: () {},
+    );
+
+    await tester.tap(find.text('Advanced Settings (Selected)'));
+    await tester.pumpAndSettle();
+
+    expect(find.text('Max'), findsOneWidget);
+    expect(find.text('Max requests full GPU offload'), findsOneWidget);
+    expect(find.text('Set to 99 for Auto'), findsNothing);
+  });
 }
 
 Future<void> _pumpCard(
@@ -224,6 +246,8 @@ Future<void> _pumpCard(
   bool includeProjector = true,
   ValueChanged<bool>? onIncludeProjectorChanged,
   double textScale = 1.0,
+  bool isSelected = false,
+  int gpuLayers = 0,
 }) async {
   await tester.pumpWidget(
     MaterialApp(
@@ -244,8 +268,8 @@ Future<void> _pumpCard(
             downloadStatusLabel: downloadStatusLabel,
             downloadTransferLabel: downloadTransferLabel,
             isWeb: isWeb,
-            isSelected: false,
-            gpuLayers: 0,
+            isSelected: isSelected,
+            gpuLayers: gpuLayers,
             contextSize: 2048,
             onGpuLayersChanged: (_) {},
             onContextSizeChanged: (_) {},

--- a/example/chat_app/test/model_card_test.dart
+++ b/example/chat_app/test/model_card_test.dart
@@ -170,6 +170,42 @@ void main() {
     expect(tester.takeException(), isNull);
     expect(find.byTooltip('Pause Download'), findsOneWidget);
   });
+
+  testWidgets('multimodal actions reflow on narrow large-text cards', (
+    tester,
+  ) async {
+    tester.view.physicalSize = const Size(320, 1200);
+    tester.view.devicePixelRatio = 1.0;
+    addTearDown(tester.view.resetPhysicalSize);
+    addTearDown(tester.view.resetDevicePixelRatio);
+
+    await _pumpCard(
+      tester,
+      model: _vlmModel(),
+      isWeb: false,
+      isDownloaded: false,
+      cacheState: const ModelProfileCacheState(
+        model: ModelAssetCacheState(
+          role: ModelAssetRole.model,
+          label: 'model.gguf',
+          isAvailable: true,
+        ),
+        multimodalProjector: ModelAssetCacheState(
+          role: ModelAssetRole.multimodalProjector,
+          label: 'mmproj.gguf',
+          isAvailable: false,
+        ),
+      ),
+      textScale: 2.0,
+      onSelect: () {},
+      onDownload: () {},
+      onIncludeProjectorChanged: (_) {},
+    );
+
+    expect(tester.takeException(), isNull);
+    expect(find.text('Download Projector'), findsOneWidget);
+    expect(find.text('Use Text Only'), findsOneWidget);
+  });
 }
 
 Future<void> _pumpCard(
@@ -187,9 +223,16 @@ Future<void> _pumpCard(
   VoidCallback? onDelete,
   bool includeProjector = true,
   ValueChanged<bool>? onIncludeProjectorChanged,
+  double textScale = 1.0,
 }) async {
   await tester.pumpWidget(
     MaterialApp(
+      builder: (context, child) => MediaQuery(
+        data: MediaQuery.of(
+          context,
+        ).copyWith(textScaler: TextScaler.linear(textScale)),
+        child: child!,
+      ),
       home: Scaffold(
         body: SingleChildScrollView(
           child: ModelCard(

--- a/example/chat_app/test/runtime_status_panel_test.dart
+++ b/example/chat_app/test/runtime_status_panel_test.dart
@@ -1,0 +1,86 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:llamadart_chat_example/models/chat_settings.dart';
+import 'package:llamadart_chat_example/providers/chat_provider.dart';
+import 'package:llamadart_chat_example/widgets/runtime_status_panel.dart';
+import 'package:provider/provider.dart';
+
+import 'mocks.dart';
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  testWidgets('stays compact at narrow width and opens runtime details', (
+    tester,
+  ) async {
+    final oldSize = tester.view.physicalSize;
+    final oldRatio = tester.view.devicePixelRatio;
+    tester.view
+      ..physicalSize = const Size(320, 640)
+      ..devicePixelRatio = 1.0;
+    addTearDown(() {
+      tester.view
+        ..physicalSize = oldSize
+        ..devicePixelRatio = oldRatio;
+    });
+
+    final provider = _ReadyRuntimeProvider();
+    addTearDown(provider.dispose);
+
+    await tester.pumpWidget(
+      ChangeNotifierProvider<ChatProvider>.value(
+        value: provider,
+        child: MaterialApp(
+          home: MediaQuery(
+            data: const MediaQueryData(
+              size: Size(320, 640),
+              textScaler: TextScaler.linear(1.5),
+            ),
+            child: const Scaffold(body: RuntimeStatusPanel()),
+          ),
+        ),
+      ),
+    );
+
+    expect(find.bySemanticsLabel('Open runtime details'), findsOneWidget);
+    expect(tester.takeException(), isNull);
+
+    await tester.tap(find.bySemanticsLabel('Open runtime details'));
+    await tester.pumpAndSettle();
+
+    expect(find.text('Runtime details'), findsOneWidget);
+    expect(find.text('Average speed'), findsOneWidget);
+    expect(find.text('mock bridge, echo'), findsOneWidget);
+    expect(tester.takeException(), isNull);
+  });
+}
+
+class _ReadyRuntimeProvider extends ChatProvider {
+  _ReadyRuntimeProvider()
+    : super(
+        chatService: MockChatService(),
+        settingsService: MockSettingsService(),
+        initialSettings: const ChatSettings(modelPath: 'mock-qwen.gguf'),
+      );
+
+  @override
+  bool get isReady => true;
+
+  @override
+  String get activeBackend => 'WEBGPU';
+
+  @override
+  String get activeModelName => 'mock-qwen.gguf';
+
+  @override
+  int get currentTokens => 25;
+
+  @override
+  int get contextLimit => 4096;
+
+  @override
+  double? get lastTokensPerSecond => 86.2;
+
+  @override
+  String? get runtimeNotes => 'mock_bridge;echo';
+}

--- a/example/chat_app/test/unit_test.dart
+++ b/example/chat_app/test/unit_test.dart
@@ -425,10 +425,12 @@ void main() {
       await failingProvider.loadModel();
       await failingProvider.sendMessage('Hello');
 
-      final errorMessage = failingProvider.messages.last.text;
-      expect(errorMessage, contains('https://example.com/model.gguf'));
-      expect(errorMessage, isNot(contains('token=secret')));
-      expect(errorMessage, isNot(contains('signed-fragment')));
+      final errorMessage = failingProvider.messages.last;
+      expect(errorMessage.isInfo, isTrue);
+      expect(failingProvider.canRegenerateLastResponse, isFalse);
+      expect(errorMessage.text, contains('https://example.com/model.gguf'));
+      expect(errorMessage.text, isNot(contains('token=secret')));
+      expect(errorMessage.text, isNot(contains('signed-fragment')));
     });
 
     test(

--- a/example/chat_app/test/unit_test.dart
+++ b/example/chat_app/test/unit_test.dart
@@ -898,6 +898,25 @@ void main() {
       expect(provider.activeBackend, backendBeforeChange);
     });
 
+    test(
+      'switching from zero-layer CPU to auto restores GPU offload',
+      () async {
+        provider.updateGpuLayers(0);
+        await provider.updatePreferredBackend(GpuBackend.cpu);
+        final backendBeforeChange = provider.activeBackend;
+
+        await provider.updatePreferredBackend(GpuBackend.auto);
+
+        expect(provider.settings.preferredBackend, GpuBackend.auto);
+        expect(provider.settings.gpuLayers, 99);
+        expect(provider.activeBackend, backendBeforeChange);
+        expect(
+          provider.messages.last.text,
+          contains('GPU offload restored to Max'),
+        );
+      },
+    );
+
     test('applyModelPreset updates generation and tool settings', () {
       const model = DownloadableModel(
         name: 'Preset model',

--- a/example/chat_app/test/unit_test.dart
+++ b/example/chat_app/test/unit_test.dart
@@ -46,6 +46,20 @@ void main() {
       expect(provider.settings.toolsEnabled, isFalse);
     });
 
+    test('active model name omits remote URL credentials', () {
+      final credentialedProvider = ChatProvider(
+        chatService: MockChatService(),
+        settingsService: MockSettingsService(),
+        initialSettings: const ChatSettings(
+          modelPath:
+              'https://example.com/models/tiny.gguf?token=secret#signed-fragment',
+        ),
+      );
+      addTearDown(credentialedProvider.dispose);
+
+      expect(credentialedProvider.activeModelName, 'tiny.gguf');
+    });
+
     test('loadModel success', () async {
       await provider.loadModel();
 
@@ -367,6 +381,54 @@ void main() {
       // MockLlamaEngine.create yields once. So 1 generated token.
       // ChatProvider _currentTokens only tracks generated tokens.
       expect(provider.currentTokens, 1);
+    });
+
+    test('empty generation does not leave a ghost assistant row', () async {
+      final emptyEngine = MockLlamaEngine()..createChunkContents = const [];
+      final emptyProvider = ChatProvider(
+        chatService: MockChatService(engine: emptyEngine),
+        settingsService: mockSettingsService,
+        initialSettings: const ChatSettings(modelPath: 'test_model.gguf'),
+      );
+      addTearDown(emptyProvider.dispose);
+
+      await emptyProvider.loadModel();
+      await emptyProvider.sendMessage('Hello');
+
+      expect(
+        emptyProvider.messages.where((message) => message.isUser),
+        hasLength(1),
+      );
+      expect(
+        emptyProvider.messages.where(
+          (message) => !message.isUser && !message.isInfo,
+        ),
+        isEmpty,
+      );
+    });
+
+    test('generation errors redact credentialed URLs', () async {
+      final failingProvider = ChatProvider(
+        chatService: MockChatService(
+          engine: _FailingCreateEngine(
+            Exception(
+              'Request failed for '
+              'https://example.com/model.gguf?token=secret#signed-fragment',
+            ),
+          ),
+        ),
+        settingsService: mockSettingsService,
+        initialSettings: const ChatSettings(modelPath: 'test_model.gguf'),
+      );
+      addTearDown(failingProvider.dispose);
+
+      await failingProvider.loadModel();
+      await failingProvider.sendMessage('Hello');
+
+      final errorMessage = failingProvider.messages.last.text;
+      expect(errorMessage, contains('https://example.com/model.gguf'));
+      expect(errorMessage, isNot(contains('token=secret')));
+      expect(errorMessage, isNot(contains('signed-fragment')));
     });
 
     test(
@@ -719,6 +781,7 @@ void main() {
         hasLength(1),
       );
       final firstGenerationTokens = provider.currentTokens;
+      expect(provider.messages.last.generatedTokenCount, firstGenerationTokens);
 
       mockEngine.createChunkContents = const ['Replacement response'];
       await provider.regenerateLastResponse();
@@ -766,7 +829,12 @@ void main() {
     test(
       'shows multimodal context overflow guidance on prompt eval failure',
       () async {
-        final engine = _MultimodalPromptEvalFailureEngine();
+        final engine = _FailingCreateEngine(
+          Exception(
+            'Multimodal prompt evaluation failed: 1. '
+            'The active context window may be too small for this image and conversation history.',
+          ),
+        );
         final customProvider = ChatProvider(
           chatService: MockChatService(engine: engine),
           settingsService: mockSettingsService,
@@ -780,6 +848,12 @@ void main() {
         expect(
           infoMessage.text,
           contains('exceeded the active context window'),
+        );
+        expect(
+          customProvider.messages.any(
+            (message) => !message.isUser && message.text.trim() == '...',
+          ),
+          isFalse,
         );
       },
     );
@@ -1240,28 +1314,6 @@ class _ThinkingControlCaptureEngine extends MockLlamaEngine {
   }
 }
 
-class _MultimodalPromptEvalFailureEngine extends MockLlamaEngine {
-  @override
-  Stream<LlamaCompletionChunk> create(
-    List<LlamaChatMessage> messages, {
-    GenerationParams? params,
-    List<ToolDefinition>? tools,
-    ToolChoice? toolChoice,
-    bool parallelToolCalls = false,
-    bool enableThinking = true,
-    Map<String, dynamic>? responseFormat,
-    String? sourceLangCode,
-    String? targetLangCode,
-    Map<String, dynamic>? chatTemplateKwargs,
-    DateTime? templateNow,
-  }) {
-    throw Exception(
-      'Multimodal prompt evaluation failed: 1. '
-      'The active context window may be too small for this image and conversation history.',
-    );
-  }
-}
-
 class _MacFallbackEstimateEngine extends MockLlamaEngine {
   @override
   Future<({int total, int free})> getVramInfo() async => (total: 0, free: 0);
@@ -1290,6 +1342,29 @@ class _TokenizerlessEngine extends MockLlamaEngine {
 
   @override
   Future<int> getTokenCount(String text) async => throw tokenCountError;
+}
+
+class _FailingCreateEngine extends MockLlamaEngine {
+  _FailingCreateEngine(this.error);
+
+  final Object error;
+
+  @override
+  Stream<LlamaCompletionChunk> create(
+    List<LlamaChatMessage> messages, {
+    GenerationParams? params,
+    List<ToolDefinition>? tools,
+    ToolChoice? toolChoice,
+    bool parallelToolCalls = false,
+    bool enableThinking = true,
+    Map<String, dynamic>? responseFormat,
+    String? sourceLangCode,
+    String? targetLangCode,
+    Map<String, dynamic>? chatTemplateKwargs,
+    DateTime? templateNow,
+  }) {
+    throw error;
+  }
 }
 
 class _RecordingModelService

--- a/example/chat_app/test/unit_test.dart
+++ b/example/chat_app/test/unit_test.dart
@@ -436,6 +436,7 @@ void main() {
               .where((m) => !m.isUser && !m.isInfo)
               .last;
           expect(assistant.text, 'Hi there');
+          expect(assistant.tokenCount, greaterThan(0));
         }
       },
     );
@@ -704,6 +705,32 @@ void main() {
       provider.clearConversation();
 
       expect(provider.currentTokens, 0);
+    });
+
+    test('regenerate replaces the latest assistant response', () async {
+      await provider.loadModel();
+      mockEngine.createChunkContents = const ['First response'];
+      await provider.sendMessage('Hello');
+
+      expect(provider.canRegenerateLastResponse, isTrue);
+      expect(mockEngine.createCalls, 1);
+      expect(
+        provider.messages.where((message) => message.isUser),
+        hasLength(1),
+      );
+      final firstGenerationTokens = provider.currentTokens;
+
+      mockEngine.createChunkContents = const ['Replacement response'];
+      await provider.regenerateLastResponse();
+
+      expect(mockEngine.createCalls, 2);
+      expect(
+        provider.messages.where((message) => message.isUser),
+        hasLength(1),
+      );
+      expect(provider.messages.last.text, 'Replacement response');
+      expect(provider.canRegenerateLastResponse, isTrue);
+      expect(provider.currentTokens, firstGenerationTokens);
     });
 
     test('delete last conversation resets to a fresh one', () async {

--- a/example/chat_app/test/welcome_view_test.dart
+++ b/example/chat_app/test/welcome_view_test.dart
@@ -56,4 +56,21 @@ void main() {
     expect(find.widgetWithText(FilledButton, 'Select model'), findsNothing);
     expect(find.widgetWithText(OutlinedButton, 'Change model'), findsNothing);
   });
+
+  testWidgets('does not expose remote URL credentials in the model label', (
+    tester,
+  ) async {
+    await tester.pumpWidget(
+      buildSubject(
+        modelPath:
+            'https://example.com/models/tiny.gguf?token=secret#signed-fragment',
+        onSelectModel: () {},
+        onRetry: () {},
+      ),
+    );
+
+    expect(find.text('tiny.gguf'), findsOneWidget);
+    expect(find.textContaining('token=secret'), findsNothing);
+    expect(find.textContaining('signed-fragment'), findsNothing);
+  });
 }

--- a/website/docs/examples/chat-app.md
+++ b/website/docs/examples/chat-app.md
@@ -35,6 +35,9 @@ flutter test
 ## What it demonstrates
 
 - Real-time streaming chat UI.
+- Responsive conversation-first navigation with full-screen mobile settings.
+- Compact runtime status with detailed performance diagnostics on demand.
+- Copy and regenerate actions for plain assistant responses.
 - Model selection and download flow.
 - The runnable chat app wires `ModelDownloadController` into its model-management
   flow through a small adapter, so cache checks, progress, cancel, retry, and
@@ -69,7 +72,7 @@ audio input disabled for that model.
 
 On web, this example prefers local bridge assets on `localhost` for development
 validation and otherwise prefers CDN assets with local fallback. The runtime
-status panel exposes the active bridge/core variant, fallback reason, model
+details view exposes the active bridge/core variant, fallback reason, model
 source, cache state, and runtime notes so you can distinguish browser capability
 problems from model/configuration pressure.
 
@@ -98,8 +101,9 @@ against a small Qwen3.5 model.
   process; production apps that need guaranteed completion should use a
   foreground service or system download integration behind a custom
   `ModelDownloadManager`.
-- Runtime chips expose native llama.cpp timing breakdowns (`p_eval`, `eval`,
-  `sample`, `reuse`) so Android CPU vs Vulkan comparisons are visible in-app.
+- Runtime details expose native llama.cpp timing breakdowns (`p_eval`, `eval`,
+  `sample`, `reuse`) so Android CPU vs Vulkan comparisons remain visible
+  without crowding the conversation.
 - For general model/backend tuning workflow, use
   [Performance Tuning](../guides/performance-tuning) rather than treating these
   example defaults as universal rules.


### PR DESCRIPTION
## Summary
- Modernize the runnable Flutter chat app with a quieter responsive shell, compact runtime details, full-screen mobile settings, and streamlined message/composer surfaces.
- Keep model downloads alive while settings closes or switches between drawer and pinned layouts, including terminal refreshes after the initiating view is replaced.
- Add copy/regenerate actions, protected conversation deletion, narrow-window and large-text hardening, and signed-URL redaction.
- Clarify backend Auto versus GPU-layer Max, show the active loaded backend, restore GPU offload when leaving a zero-layer CPU configuration, and align model-card labels and docs.
- Reduce repeated defensive-list allocations while rendering messages and staged attachments.

## Production-readiness scope
- **User-facing scope:** Updated chat shell, model/settings workflow, runtime diagnostics, assistant actions, model-download continuity across responsive settings views, and clearer GPU/backend behavior.
- **Supported platforms/paths:** Flutter native desktop/mobile and Flutter Web UI paths. Native macOS Auto/CPU/Metal selection and deterministic WebGPU mock-bridge chat were exercised locally.
- **Unsupported or intentionally unavailable paths:** Foreground Dart downloads can still be suspended by the mobile OS when the entire app is backgrounded; the example preserves resumable partial files but does not claim guaranteed background transfer. Regenerate is limited to the latest plain assistant response.
- **Out of scope / follow-ups:** None.

## Completeness checklist
- [x] Declared scope is fully implemented, or explicitly reduced above.
- [x] Unsupported platform/option combinations fail loudly with actionable diagnostics or are clearly documented as unavailable.
- [x] Public API docs, README/website docs, examples, support matrices, and changelog entries are updated where relevant.
- [x] Regression coverage covers the original issues plus key negative paths.
- [x] Security/privacy review completed: signed query and fragment data is removed from model labels and user-facing errors.
- [x] Follow-up work that is useful but not required for this PR is tracked in GitHub Issues, or explicitly marked "None" above.

## PR type guidance
- **Feature PR:** UI/example/docs updates, responsive platform coverage, and happy/negative path tests are included.
- **Bugfix PR:** Download-view lifecycle, terminal download refresh, empty-generation placeholders, regeneration accounting, sensitive URL display, and zero-layer Auto behavior have targeted regression coverage.
- **Docs-only PR:** N/A; runtime behavior changes are included.

## Test Plan
- [x] `dart format --output=none --set-exit-if-changed .`
- [x] `dart analyze`
- [ ] `dart test -p vm -j 1 --exclude-tags local-only` — N/A for this example-only Flutter UI change; Flutter tests cover the affected package.
- [ ] `dart test -p chrome --exclude-tags local-only` — N/A; the built Flutter Web app was covered by the local Playwright smoke.
- [x] `cd example/chat_app && flutter analyze`
- [x] `cd example/chat_app && flutter test` — 158 tests passed.
- [x] `dart run tool/testing/run_local_e2e.dart --scenario chat-app-web-mock-smoke --python .venv-playwright/bin/python`
- [x] `./tool/docs/build_site.sh`
- [x] `./tool/docs/validate_links.sh`
- [x] Real macOS app smoke: FunctionGemma 270M loaded with Auto; runtime reported METAL. Auto → CPU → Auto reloads reported METAL → CPU → METAL, with 98 GPU layers selected by the memory estimator.

## Matrix Evidence
| Matrix row | Scope covered | Platform / model / backend | Result | Evidence / notes |
| --- | --- | --- | --- | --- |
| `static-format-analyze` | formatting and analyzer | Dart + Flutter | PASS | No formatting or analyzer findings |
| `docs-site` | website build and links | Docusaurus | PASS | Production build and broken-link validation passed |
| `examples-tests` | chat app behavior and responsive UI | Flutter test | PASS | 158 tests |
| `web-mock-chat-smoke` | built web app, model load, generation | Chromium / mock WebGPU bridge | PASS | Echo response completed |
| `macos-arm64-runtime-smoke` | backend preference and active runtime | macOS / FunctionGemma 270M / Metal + CPU | PASS | Auto and explicit CPU reloads verified in the running app |
| `chat-app-device-cache` | download continuity across settings layouts | Widget/controller regression coverage | PASS | Success and cancellation after initiating-view replacement both refresh app-owned state |

## Review Notes
- Independent review status: Deep QA and maintainability pass completed; all five Copilot review threads addressed and explicitly resolved.
- CI status / head SHA: CI running on `64ae90454`.
