### PR TITLE
Improve chat model library, downloads, and runtime tuning

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,24 @@
 ## Unreleased
 
+* Added an app-owned FIFO model-download queue to the runnable chat app. Only
+  one model transfers at a time, queued cards show their position and can leave
+  the queue independently, and a responsive shell progress pill keeps the
+  active download visible after the settings panel closes.
+
+* Replaced the runnable chat app's broad built-in model catalog with a focused
+  Unsloth-first set. Added cross-platform Gemma 4 E4B plus native-desktop Gemma
+  4 12B/26B-A4B/31B and Qwen3.6 35B-A3B presets. The model library now promotes
+  downloaded models, supports name/capability search and Mobile & Web/Desktop
+  filters, explains incompatible choices, and uses quieter cards with compact
+  compatibility, capability, and recommended-setting summaries. Custom entries
+  retain independent remove-from-library and downloaded-file actions.
+
+* Enabled Gemma 4 audio attachments in the runnable chat app for the current
+  native GGUF projector and LiteRT-LM bundle, while keeping LiteRT-LM Web
+  correctly text-only. Model capability settings now distinguish direct media
+  input from external `mmproj` input and persist that distinction across app
+  launches.
+
 * Redesigned the runnable chat app with a quieter responsive shell, compact
   runtime details, full-screen mobile settings, streamlined message/composer
   surfaces, accessible controls, protected conversation deletion, and
@@ -14,7 +33,12 @@
 
 * Clarified the chat app's backend and GPU-layer controls, exposed the active
   loaded backend beside its preference, and restored GPU offload when switching
-  from a zero-layer CPU configuration back to Auto or a GPU backend.
+  from a zero-layer CPU configuration back to Auto or a GPU backend. Native
+  **Max** now maps to full llama.cpp offload, while Auto uses model size,
+  available device memory, safe system headroom, and requested context to choose
+  full or partial offload and only reduces context when the model does not fit.
+  Auto intent now persists separately from resolved layer/context values so
+  device headroom is recalculated on every model load and after app restarts.
 
 ## 0.8.14
 

--- a/example/chat_app/README.md
+++ b/example/chat_app/README.md
@@ -62,16 +62,35 @@ flutter test --run-skipped -t local-only \
    - Native mobile/desktop builds store downloaded model files under the app's
      application-specific cache `models` directory via `path_provider`; web builds use
      browser Cache Storage/origin-scoped runtime caches.
-2. Select one of the pre-configured models (for example: FunctionGemma 270M, Qwen3.5 0.8B/2B/4B/9B, Llama 3.2 3B, Gemma 3/3n, DeepSeek R1 distills).
-   - Qwen3.5 presets now use Unsloth `Q4_K_M` GGUFs across platforms.
-   - Quick picks: `0.8B` for web/older phones, `2B` for mobile + low-RAM laptops, `4B` for most native desktop/laptop runs, `9B` for desktop-class devices with more headroom.
-   - Qwen3.5 small presets default to non-thinking mode for smoother latency and fewer reasoning loops; turn thinking on only when you need extra reasoning.
-3. Tap the **Download** icon. The app uses `Dio` to download the model directly to your device's app-specific cache directory.
+2. Select one of the focused pre-configured models:
+   - Cross-platform: FunctionGemma 270M, Qwen3.5 0.8B, Gemma 4 E2B
+     GGUF, Gemma 4 E2B LiteRT-LM, and Gemma 4 E4B GGUF.
+   - Native desktop: Gemma 4 12B, Gemma 4 26B A4B, Gemma 4 31B,
+     and Qwen3.6 35B A3B.
+   - All built-in GGUF presets use [Unsloth distributions](https://huggingface.co/unsloth)
+     and show that source in the model card. The LiteRT-LM preset uses the
+     `litert-community` distribution because Unsloth does not publish the
+     required `.litertlm` bundle.
+   - The library opens with the current platform selected. Use the Mobile, Web,
+     and Desktop filters to compare compatible presets; unavailable models are
+     clearly disabled when browsing another platform. Downloaded models appear
+     first, and search matches names, filenames, descriptions, distributions,
+     and capabilities such as vision or tools.
+   - Gemma 4 E4B remains available across platforms because it is an
+     edge/mobile-capable model, although its memory requirement still makes it
+     appropriate only for capable devices.
+   - Cards keep size, RAM, platform, capabilities, and the recommended context
+     visible while leaving detailed sampling controls in the inference settings.
+   - Custom and discovered models have a compact actions menu. **Remove from
+     library** removes only the saved entry; downloaded-file deletion remains
+     a separate action, with an explicit combined option in the confirmation.
+3. Tap the **Download** icon. The app uses `Dio` to download the model directly to your device's app-specific cache directory. Additional model downloads enter a FIFO queue and start one at a time. A persistent progress pill remains in the app header when settings is closed; tap it to reopen download details.
 4. Once downloaded, tap **Select** to load the model.
    - Gemma 4 E2B is included as a GGUF + `mmproj` bundle. In the current
-     `llama.cpp` mtmd path used here, that projector exposes vision support but
-     not audio support, so the chat UI keeps image input enabled and audio input
-     disabled for this model.
+     native `llama.cpp` mtmd path used here, that projector exposes image,
+     audio, and video input. Audio remains experimental upstream; start with
+     short mono clips for the most reliable results. Web keeps audio
+     runtime-gated until the loaded bridge reports support.
    - LiteRT-LM `.litertlm` presets, when present, use the same model library
      flow. The example `pubspec.yaml` enables the `litert_lm` native runtime
      family for supported native targets, while Web builds load web-compatible
@@ -98,8 +117,16 @@ flutter test --run-skipped -t local-only \
    - `Auto` selects the best supported runtime; on supported Macs it prefers
      Metal. The selector also lists concrete runtime-detected options such as
      CPU/Vulkan/CUDA for GGUF or CPU/GPU/NPU for LiteRT-LM.
+   - For native GGUF models, Auto combines the selected model size, current
+     device-memory availability, system headroom, and requested context. It
+     prefers full offload and preserves the preset context when they fit,
+     reducing context before falling back to partial offload under pressure.
+     Auto intent is persisted separately from the resolved values, so the app
+     recalculates available headroom on every model load and after a restart.
    - **GPU Layers** controls model offload separately: `0` runs on CPU, while
-     **Max** requests full GPU offload. Reload the model to apply changes.
+     **Max** enables Auto tuning when the backend is Auto and requests full GPU
+     offload when it fits. Choosing a lower layer count makes it a fixed manual
+     setting. Reload the model to apply changes.
 3. Optionally enable **Function Calling** and edit tool declarations depending on model/template support.
 4. Tap **Load Model** to apply changes.
 
@@ -252,21 +279,24 @@ await prefs.setInt('preferred_backend', backendIndex);
   OS, or model bundle; fall back to GPU or CPU when the runtime reports that
   engine creation is unsupported.
 
-**Multimodal instability or decode crashes (Qwen3.5 VLMs):**
-- Keep Qwen3.5 model defaults unless you are tuning carefully (`0.8B` uses `Context Size` 4096; `2B`/`4B`/`9B` use 8192; all ship with `Max Tokens` 1024).
+**Multimodal instability or decode crashes (Qwen VLMs):**
+- Keep the bundled model defaults unless you are tuning carefully. Qwen3.5
+  0.8B uses `Context Size` 4096 and `Max Tokens` 1024; the native-desktop
+  Qwen3.6 35B A3B preset uses 16384 and 4096 respectively.
 - The chat app now downscales picked multimodal images to a `384px` max edge before staging them, which reduces prompt/context pressure on Android, iOS, macOS, and Web.
 - Start a fresh conversation before large image prompts to avoid context-slot pressure.
 - If a follow-up turn after an image reports that the active context window was exceeded, retry with a smaller image, a larger `Context Size`, or fewer earlier image turns in the same chat.
-- If crashes persist on lower-memory devices, keep thinking off, switch to the 0.8B/2B variants, or disable multimodal for that run.
+- If crashes persist on lower-memory devices, keep thinking off, switch to
+  Qwen3.5 0.8B, or disable multimodal for that run.
 
 **Gemma 4 audio does not appear in the attachment menu:**
-- This is expected with the currently published Gemma 4 GGUF projector assets
-  used by the chat app.
-- The Gemma 4 E2B/E4B family supports audio in principle, but the current
-  `llama.cpp` mtmd projector path exposed to `llamadart` reports `vision=true`
-  and `audio=false` for the shipped `mmproj` files.
-- Image input should still work for Gemma 4 once the matching projector is
-  loaded.
+- For the GGUF preset, confirm the matching `mmproj` finished downloading and
+  loaded successfully. The current projector reports both `vision=true` and
+  `audio=true` on the pinned native runtime.
+- Native Gemma 4 LiteRT-LM consumes audio directly from its `.litertlm` bundle
+  and does not need an `mmproj`. LiteRT-LM Web remains text-only.
+- Audio input is experimental in `llama.cpp`. Prefer mono 16 kHz WAV input and
+  keep initial clips under 30 seconds.
 
 **`Invalid argument(s): string is not well-formed UTF-16` in Flutter painting:**
 - This indicates malformed streamed text (broken surrogate pair) reached text rendering.
@@ -276,6 +306,8 @@ await prefs.setInt('preferred_backend', backendIndex);
 **Slow model downloads on iOS/Android:**
 - Run on a release/profile build (`flutter run --release`) for realistic transfer performance.
 - Large multimodal bundles download both model and mmproj files; expect two-stage transfer.
+- Model downloads run sequentially. Queued cards show their position and can be
+  removed from the queue without interrupting the active transfer.
 - Optional Hugging Face auth can improve throughput/rate-limits:
   `flutter run --dart-define=HF_TOKEN=<your_token>`
 - Optional experimental parallel range downloader for large files:
@@ -402,11 +434,8 @@ await prefs.setInt('preferred_backend', backendIndex);
 
 ### Android Qwen Notes
 
-- On recent Pixel-class Android devices, Qwen3.5 `0.8B` and `2B` currently run
-  faster in `CPU` mode than `Vulkan` in this app, so the Android preset flow now
-  prefers `CPU` for those two models.
-- Qwen3.5 `4B` is closer: `CPU` still wins on short prompts, but `Vulkan` is now
-  much faster than before and may be worth comparing for longer generations.
+- On recent Pixel-class Android devices, Qwen3.5 `0.8B` currently runs faster
+  in `CPU` mode than `Vulkan` in this app, so its Android preset prefers `CPU`.
 - Runtime details include native llama.cpp timing breakdowns: `p_eval`, `eval`,
   `sample`, and `reuse`.
 - Android text-only chat is stable even when `mmproj` is loaded.

--- a/example/chat_app/lib/models/chat_settings.dart
+++ b/example/chat_app/lib/models/chat_settings.dart
@@ -12,6 +12,18 @@ class ChatSettings {
   final int contextSize;
   final int maxTokens;
   final int gpuLayers;
+
+  /// Whether native Auto should recompute GPU layers and context headroom on
+  /// every model load. Resolved values remain visible in [gpuLayers] and
+  /// [contextSize], while this flag preserves the user's Auto intent across
+  /// app restarts.
+  final bool autoTuneModelParams;
+
+  /// Context requested by the user or model preset while Auto tuning is
+  /// active. [contextSize] can hold a lower resolved value under memory
+  /// pressure without losing the target for a later model load.
+  final int? autoTuneRequestedContextSize;
+
   final int numberOfThreads;
   final int numberOfThreadsBatch;
 
@@ -26,9 +38,18 @@ class ChatSettings {
   final int thinkingBudgetTokens;
   final bool singleTurnMode;
 
-  /// Approximate selected-model size in bytes (web only), forwarded to
-  /// `ModelParams.modelBytesHint` so the WebGPU backend can pick the mem64 core
-  /// up front for large models. `null`/`0` when unknown.
+  /// Capabilities declared by the selected model profile for the active
+  /// platform. Runtime projector probes can add to these capabilities.
+  final bool modelSupportsVision;
+  final bool modelSupportsAudio;
+
+  /// Whether media is consumed directly by the model backend instead of an
+  /// external multimodal projector.
+  final bool directMediaInput;
+
+  /// Approximate selected-model size in bytes. Native Auto uses it for memory
+  /// planning; Web forwards it to `ModelParams.modelBytesHint` so WebGPU can
+  /// select the mem64 core before loading large models. `null`/`0` when unknown.
   final int? modelBytesHint;
 
   const ChatSettings({
@@ -43,6 +64,8 @@ class ChatSettings {
     this.contextSize = 4096,
     this.maxTokens = 4096,
     this.gpuLayers = 32,
+    this.autoTuneModelParams = false,
+    this.autoTuneRequestedContextSize,
     this.numberOfThreads = 0,
     this.numberOfThreadsBatch = 0,
     this.logLevel = LlamaLogLevel.none,
@@ -52,6 +75,9 @@ class ChatSettings {
     this.thinkingEnabled = true,
     this.thinkingBudgetTokens = 0,
     this.singleTurnMode = false,
+    this.modelSupportsVision = false,
+    this.modelSupportsAudio = false,
+    this.directMediaInput = false,
     this.modelBytesHint,
   });
 
@@ -67,6 +93,8 @@ class ChatSettings {
     int? contextSize,
     int? maxTokens,
     int? gpuLayers,
+    bool? autoTuneModelParams,
+    int? autoTuneRequestedContextSize,
     int? numberOfThreads,
     int? numberOfThreadsBatch,
     LlamaLogLevel? logLevel,
@@ -76,6 +104,9 @@ class ChatSettings {
     bool? thinkingEnabled,
     int? thinkingBudgetTokens,
     bool? singleTurnMode,
+    bool? modelSupportsVision,
+    bool? modelSupportsAudio,
+    bool? directMediaInput,
     int? modelBytesHint,
   }) {
     return ChatSettings(
@@ -90,6 +121,9 @@ class ChatSettings {
       contextSize: contextSize ?? this.contextSize,
       maxTokens: maxTokens ?? this.maxTokens,
       gpuLayers: gpuLayers ?? this.gpuLayers,
+      autoTuneModelParams: autoTuneModelParams ?? this.autoTuneModelParams,
+      autoTuneRequestedContextSize:
+          autoTuneRequestedContextSize ?? this.autoTuneRequestedContextSize,
       numberOfThreads: numberOfThreads ?? this.numberOfThreads,
       numberOfThreadsBatch: numberOfThreadsBatch ?? this.numberOfThreadsBatch,
       logLevel: logLevel ?? this.logLevel,
@@ -99,6 +133,9 @@ class ChatSettings {
       thinkingEnabled: thinkingEnabled ?? this.thinkingEnabled,
       thinkingBudgetTokens: thinkingBudgetTokens ?? this.thinkingBudgetTokens,
       singleTurnMode: singleTurnMode ?? this.singleTurnMode,
+      modelSupportsVision: modelSupportsVision ?? this.modelSupportsVision,
+      modelSupportsAudio: modelSupportsAudio ?? this.modelSupportsAudio,
+      directMediaInput: directMediaInput ?? this.directMediaInput,
       modelBytesHint: modelBytesHint ?? this.modelBytesHint,
     );
   }

--- a/example/chat_app/lib/models/downloadable_model.dart
+++ b/example/chat_app/lib/models/downloadable_model.dart
@@ -21,6 +21,10 @@ String _assetCacheKey(String canonicalKey) {
 
 enum ModelAssetRole { model, multimodalProjector }
 
+enum ModelMediaInputMode { externalProjector, direct, none }
+
+enum ModelAvailability { all, nativeDesktop }
+
 abstract class ModelAssetSource {
   const ModelAssetSource();
 
@@ -186,8 +190,15 @@ class DownloadableModel {
   final bool supportsVision;
   final bool supportsAudio;
   final bool supportsVideo;
+  final bool? webSupportsVision;
+  final bool? webSupportsAudio;
+  final bool? webSupportsVideo;
+  final ModelMediaInputMode mediaInputMode;
+  final ModelMediaInputMode? webMediaInputMode;
   final bool supportsToolCalling;
   final bool supportsThinking;
+  final String? distribution;
+  final ModelAvailability availability;
   final ModelAssetSource? _modelSourceOverride;
   final ModelAssetSource? _multimodalProjectorSourceOverride;
   final ModelAssetSource? _webModelSourceOverride;
@@ -213,8 +224,15 @@ class DownloadableModel {
     this.supportsVision = false,
     this.supportsAudio = false,
     this.supportsVideo = false,
+    this.webSupportsVision,
+    this.webSupportsAudio,
+    this.webSupportsVideo,
+    this.mediaInputMode = ModelMediaInputMode.externalProjector,
+    this.webMediaInputMode,
     this.supportsToolCalling = false,
     this.supportsThinking = false,
+    this.distribution,
+    this.availability = ModelAvailability.all,
     this.minRamGb = 2,
     this.preset = const ModelPreset(),
   }) : id = filename,
@@ -236,8 +254,15 @@ class DownloadableModel {
     this.supportsVision = false,
     this.supportsAudio = false,
     this.supportsVideo = false,
+    this.webSupportsVision,
+    this.webSupportsAudio,
+    this.webSupportsVideo,
+    this.mediaInputMode = ModelMediaInputMode.externalProjector,
+    this.webMediaInputMode,
     this.supportsToolCalling = false,
     this.supportsThinking = false,
+    this.distribution,
+    this.availability = ModelAvailability.all,
     this.minRamGb = 2,
     this.preset = const ModelPreset(),
   }) : id = id ?? modelSource.displayName,
@@ -313,19 +338,50 @@ class DownloadableModel {
     supportsThinking: supportsThinking,
   );
 
+  bool supportsVisionFor({required bool web}) =>
+      web ? webSupportsVision ?? supportsVision : supportsVision;
+
+  bool supportsAudioFor({required bool web}) =>
+      web ? webSupportsAudio ?? supportsAudio : supportsAudio;
+
+  bool supportsVideoFor({required bool web}) =>
+      web ? webSupportsVideo ?? supportsVideo : supportsVideo;
+
+  ModelMediaInputMode mediaInputModeFor({required bool web}) =>
+      web ? webMediaInputMode ?? mediaInputMode : mediaInputMode;
+
+  bool isMultimodalFor({required bool web}) =>
+      supportsVisionFor(web: web) || supportsAudioFor(web: web);
+
   bool get isMultimodal => supportsVision || supportsAudio;
 
   String get sizeMb => (sizeBytes / (1024 * 1024)).toStringAsFixed(1);
 
+  String sizeLabelFor({required bool web}) {
+    final bytes = sizeBytesFor(web: web);
+    final gibibytes = bytes / (1024 * 1024 * 1024);
+    if (gibibytes >= 1) {
+      final digits = gibibytes >= 10 ? 1 : 2;
+      return '${gibibytes.toStringAsFixed(digits)} GB';
+    }
+    return '${(bytes / (1024 * 1024)).toStringAsFixed(0)} MB';
+  }
+
+  bool get isNativeDesktopOnly =>
+      availability == ModelAvailability.nativeDesktop;
+
+  bool isAvailableFor({required bool web, required bool mobile}) =>
+      availability == ModelAvailability.all || (!web && !mobile);
+
   static const List<DownloadableModel> defaultModels = [
     DownloadableModel(
       name: 'FunctionGemma 270M',
-      description:
-          '🛠️ Tiny tools model (253MB) • Great function-calling demo.',
+      description: 'Tiny specialist for function calling and tool-use demos.',
       url:
           'https://huggingface.co/unsloth/functiongemma-270m-it-GGUF/resolve/main/functiongemma-270m-it-Q4_K_M.gguf?download=true',
       filename: 'functiongemma-270m-it-Q4_K_M.gguf',
       sizeBytes: 253127904,
+      distribution: 'Unsloth',
       minRamGb: 2,
       supportsToolCalling: true,
       preset: ModelPreset(
@@ -338,8 +394,7 @@ class DownloadableModel {
     ),
     DownloadableModel(
       name: 'Qwen3.5 0.8B Instruct',
-      description:
-          '🆕 Unsloth Q4_K_M bundle (720MB) • Consistent Qwen pick across web, mobile, and native with tuned non-thinking defaults.',
+      description: 'Small general assistant with tools, reasoning, and vision.',
       url:
           'https://huggingface.co/unsloth/Qwen3.5-0.8B-GGUF/resolve/main/Qwen3.5-0.8B-Q4_K_M.gguf?download=true',
       filename: 'Qwen3.5-0.8B-Q4_K_M.gguf',
@@ -347,6 +402,7 @@ class DownloadableModel {
           'https://huggingface.co/unsloth/Qwen3.5-0.8B-GGUF/resolve/main/mmproj-F16.gguf?download=true',
       mmprojFilename: 'Qwen3.5-0.8B-mmproj-F16.gguf',
       sizeBytes: 754903104,
+      distribution: 'Unsloth',
       minRamGb: 3,
       supportsVision: true,
       supportsToolCalling: true,
@@ -362,109 +418,9 @@ class DownloadableModel {
       ),
     ),
     DownloadableModel(
-      name: 'Llama 3.2 1B Instruct',
-      description: '🧰 General + tools (808MB) • Reliable everyday assistant.',
-      url:
-          'https://huggingface.co/bartowski/Llama-3.2-1B-Instruct-GGUF/resolve/main/Llama-3.2-1B-Instruct-Q4_K_M.gguf?download=true',
-      filename: 'Llama-3.2-1B-Instruct-Q4_K_M.gguf',
-      sizeBytes: 807694464,
-      minRamGb: 3,
-      supportsToolCalling: true,
-      preset: ModelPreset(
-        temperature: 0.2,
-        topK: 40,
-        topP: 0.9,
-        contextSize: 8192,
-        maxTokens: 2048,
-      ),
-    ),
-    DownloadableModel(
-      name: 'Gemma 3 1B it',
-      description:
-          '🧩 Gemma template (806MB) • Lightweight multilingual baseline.',
-      url:
-          'https://huggingface.co/ggml-org/gemma-3-1b-it-GGUF/resolve/main/gemma-3-1b-it-Q4_K_M.gguf?download=true',
-      filename: 'gemma-3-1b-it-Q4_K_M.gguf',
-      sizeBytes: 806058240,
-      minRamGb: 3,
-      preset: ModelPreset(
-        temperature: 0.7,
-        topK: 40,
-        topP: 0.9,
-        contextSize: 8192,
-        maxTokens: 2048,
-      ),
-    ),
-    DownloadableModel(
-      name: 'LFM2.5 1.2B Instruct',
-      description: '🌊 LFM baseline (731MB) • Popular small Liquid text model.',
-      url:
-          'https://huggingface.co/LiquidAI/LFM2.5-1.2B-Instruct-GGUF/resolve/main/LFM2.5-1.2B-Instruct-Q4_K_M.gguf?download=true',
-      filename: 'LFM2.5-1.2B-Instruct-Q4_K_M.gguf',
-      sizeBytes: 730895168,
-      minRamGb: 3,
-      preset: ModelPreset(
-        temperature: 0.2,
-        topK: 40,
-        topP: 0.9,
-        contextSize: 8192,
-        maxTokens: 2048,
-      ),
-    ),
-    DownloadableModel(
-      name: 'Qwen3.5 2B Instruct',
-      description:
-          '🆕 Unsloth Q4_K_M bundle (1.85GB) • Better Qwen quality with one cross-platform quant for web, mobile, and laptops.',
-      url:
-          'https://huggingface.co/unsloth/Qwen3.5-2B-GGUF/resolve/main/Qwen3.5-2B-Q4_K_M.gguf?download=true',
-      filename: 'Qwen3.5-2B-Q4_K_M.gguf',
-      mmprojUrl:
-          'https://huggingface.co/unsloth/Qwen3.5-2B-GGUF/resolve/main/mmproj-F16.gguf?download=true',
-      mmprojFilename: 'Qwen3.5-2B-mmproj-F16.gguf',
-      sizeBytes: 1983861664,
-      minRamGb: 5,
-      supportsVision: true,
-      supportsToolCalling: true,
-      supportsThinking: true,
-      preset: ModelPreset(
-        temperature: 0.7,
-        topK: 20,
-        topP: 0.8,
-        penalty: 1.0,
-        contextSize: 8192,
-        maxTokens: 1024,
-        thinkingEnabled: false,
-      ),
-    ),
-    DownloadableModel(
-      name: 'Qwen3.5 4B Instruct',
-      description:
-          '🆕 Unsloth Q4_K_M bundle (3.29GB) • Best Qwen balance when you want one quant across web and native targets.',
-      url:
-          'https://huggingface.co/unsloth/Qwen3.5-4B-GGUF/resolve/main/Qwen3.5-4B-Q4_K_M.gguf?download=true',
-      filename: 'Qwen3.5-4B-Q4_K_M.gguf',
-      mmprojUrl:
-          'https://huggingface.co/unsloth/Qwen3.5-4B-GGUF/resolve/main/mmproj-F16.gguf?download=true',
-      mmprojFilename: 'Qwen3.5-4B-mmproj-F16.gguf',
-      sizeBytes: 3529359968,
-      minRamGb: 8,
-      supportsVision: true,
-      supportsToolCalling: true,
-      supportsThinking: true,
-      preset: ModelPreset(
-        temperature: 0.7,
-        topK: 20,
-        topP: 0.8,
-        penalty: 1.0,
-        contextSize: 8192,
-        maxTokens: 1024,
-        thinkingEnabled: false,
-      ),
-    ),
-    DownloadableModel(
       name: 'Gemma 4 E2B it',
       description:
-          '🧪 Multimodal Gemma 4 vision bundle (2.83GB + 940MB mmproj) • Supports image input; audio support is not advertised by the current projector/runtime path.',
+          'Compact multimodal assistant for image, audio, and video input.',
       url:
           'https://huggingface.co/unsloth/gemma-4-E2B-it-GGUF/resolve/main/gemma-4-E2B-it-Q4_K_S.gguf?download=true',
       filename: 'gemma-4-E2B-it-Q4_K_S.gguf',
@@ -472,9 +428,11 @@ class DownloadableModel {
           'https://huggingface.co/unsloth/gemma-4-E2B-it-GGUF/resolve/main/mmproj-F16.gguf?download=true',
       mmprojFilename: 'gemma-4-E2B-it-mmproj-F16.gguf',
       sizeBytes: 3043927168,
+      distribution: 'Unsloth',
       minRamGb: 8,
       supportsVision: true,
-      supportsAudio: false,
+      supportsAudio: true,
+      webSupportsAudio: false,
       supportsVideo: true,
       supportsToolCalling: true,
       supportsThinking: true,
@@ -491,7 +449,7 @@ class DownloadableModel {
     DownloadableModel(
       name: 'Gemma 4 E2B LiteRT-LM',
       description:
-          '⚡ LiteRT-LM Gemma 4 text bundle (2.41GB native, 1.87GB web) • Use this for llama.cpp vs LiteRT-LM comparisons.',
+          'Optimized LiteRT-LM variant with native audio and text-only Web support.',
       url:
           'https://huggingface.co/litert-community/gemma-4-E2B-it-litert-lm/resolve/main/gemma-4-E2B-it.litertlm?download=true',
       filename: 'gemma-4-E2B-it.litertlm',
@@ -503,7 +461,12 @@ class DownloadableModel {
         filename: 'gemma-4-E2B-it-web.litertlm',
         sizeBytes: 2008432640,
       ),
+      distribution: 'LiteRT Community',
       minRamGb: 8,
+      supportsAudio: true,
+      webSupportsAudio: false,
+      mediaInputMode: ModelMediaInputMode.direct,
+      webMediaInputMode: ModelMediaInputMode.none,
       supportsThinking: true,
       preset: ModelPreset(
         temperature: 0.7,
@@ -515,134 +478,133 @@ class DownloadableModel {
       ),
     ),
     DownloadableModel(
-      name: 'LFM2.5 1.2B Thinking',
+      name: 'Gemma 4 E4B it',
       description:
-          '🧠 Reasoning-focused LFM (731MB) • Good compact thinking model.',
+          'Higher-quality multimodal model for capable edge and desktop devices.',
       url:
-          'https://huggingface.co/LiquidAI/LFM2.5-1.2B-Thinking-GGUF/resolve/main/LFM2.5-1.2B-Thinking-Q4_K_M.gguf?download=true',
-      filename: 'LFM2.5-1.2B-Thinking-Q4_K_M.gguf',
-      sizeBytes: 730895360,
-      minRamGb: 3,
+          'https://huggingface.co/unsloth/gemma-4-E4B-it-GGUF/resolve/main/gemma-4-E4B-it-Q4_K_S.gguf?download=true',
+      filename: 'gemma-4-E4B-it-Q4_K_S.gguf',
+      mmprojUrl:
+          'https://huggingface.co/unsloth/gemma-4-E4B-it-GGUF/resolve/main/mmproj-F16.gguf?download=true',
+      mmprojFilename: 'gemma-4-E4B-it-mmproj-F16.gguf',
+      sizeBytes: 4844848288,
+      distribution: 'Unsloth',
+      minRamGb: 12,
+      supportsVision: true,
+      supportsAudio: true,
+      webSupportsAudio: false,
+      supportsVideo: true,
+      supportsToolCalling: true,
       supportsThinking: true,
       preset: ModelPreset(
-        temperature: 0.05,
-        topK: 50,
-        topP: 0.1,
+        temperature: 0.7,
+        topK: 64,
+        topP: 0.95,
+        penalty: 1.0,
+        contextSize: 8192,
+        maxTokens: 2048,
+        thinkingEnabled: false,
+      ),
+    ),
+    DownloadableModel(
+      name: 'Gemma 4 12B it',
+      description:
+          'Strong multimodal reasoning for higher-memory desktop systems.',
+      url:
+          'https://huggingface.co/unsloth/gemma-4-12b-it-GGUF/resolve/main/gemma-4-12b-it-Q4_K_S.gguf?download=true',
+      filename: 'gemma-4-12b-it-Q4_K_S.gguf',
+      mmprojUrl:
+          'https://huggingface.co/unsloth/gemma-4-12b-it-GGUF/resolve/main/mmproj-F16.gguf?download=true',
+      mmprojFilename: 'gemma-4-12b-it-mmproj-F16.gguf',
+      sizeBytes: 6764524960,
+      distribution: 'Unsloth',
+      availability: ModelAvailability.nativeDesktop,
+      minRamGb: 16,
+      supportsVision: true,
+      supportsAudio: true,
+      supportsVideo: true,
+      supportsToolCalling: true,
+      supportsThinking: true,
+      preset: ModelPreset(
+        temperature: 0.7,
+        topK: 64,
+        topP: 0.95,
+        penalty: 1.0,
+        contextSize: 8192,
+        maxTokens: 2048,
+        thinkingEnabled: false,
+      ),
+    ),
+    DownloadableModel(
+      name: 'Gemma 4 26B A4B it',
+      description:
+          'Efficient mixture-of-experts model for reasoning, coding, and vision.',
+      url:
+          'https://huggingface.co/unsloth/gemma-4-26B-A4B-it-GGUF/resolve/main/gemma-4-26B-A4B-it-UD-Q4_K_S.gguf?download=true',
+      filename: 'gemma-4-26B-A4B-it-UD-Q4_K_S.gguf',
+      mmprojUrl:
+          'https://huggingface.co/unsloth/gemma-4-26B-A4B-it-GGUF/resolve/main/mmproj-F16.gguf?download=true',
+      mmprojFilename: 'gemma-4-26B-A4B-it-mmproj-F16.gguf',
+      sizeBytes: 16487608096,
+      distribution: 'Unsloth',
+      availability: ModelAvailability.nativeDesktop,
+      minRamGb: 24,
+      supportsVision: true,
+      supportsVideo: true,
+      supportsToolCalling: true,
+      supportsThinking: true,
+      preset: ModelPreset(
+        temperature: 0.7,
+        topK: 64,
+        topP: 0.95,
+        penalty: 1.0,
         contextSize: 16384,
         maxTokens: 4096,
+        thinkingEnabled: false,
       ),
     ),
     DownloadableModel(
-      name: 'SmolVLM 500M Instruct',
+      name: 'Gemma 4 31B it',
       description:
-          '👁️ Vision bundle (636MB) • Proven lightweight image understanding.',
+          'Highest-quality dense Gemma tier for high-memory workstations.',
       url:
-          'https://huggingface.co/ggml-org/SmolVLM-500M-Instruct-GGUF/resolve/main/SmolVLM-500M-Instruct-Q8_0.gguf?download=true',
-      filename: 'SmolVLM-500M-Instruct-Q8_0.gguf',
+          'https://huggingface.co/unsloth/gemma-4-31B-it-GGUF/resolve/main/gemma-4-31B-it-Q4_K_S.gguf?download=true',
+      filename: 'gemma-4-31B-it-Q4_K_S.gguf',
       mmprojUrl:
-          'https://huggingface.co/ggml-org/SmolVLM-500M-Instruct-GGUF/resolve/main/mmproj-SmolVLM-500M-Instruct-f16.gguf?download=true',
-      mmprojFilename: 'mmproj-SmolVLM-500M-Instruct-f16.gguf',
-      sizeBytes: 636275712,
-      minRamGb: 3,
+          'https://huggingface.co/unsloth/gemma-4-31B-it-GGUF/resolve/main/mmproj-F16.gguf?download=true',
+      mmprojFilename: 'gemma-4-31B-it-mmproj-F16.gguf',
+      sizeBytes: 17399833600,
+      distribution: 'Unsloth',
+      availability: ModelAvailability.nativeDesktop,
+      minRamGb: 32,
       supportsVision: true,
-      preset: ModelPreset(
-        temperature: 0.2,
-        topK: 40,
-        topP: 0.9,
-        contextSize: 4096,
-        maxTokens: 1024,
-      ),
-    ),
-    DownloadableModel(
-      name: 'LFM2-VL 450M',
-      description:
-          '🖼️ Tiny VLM bundle (323MB) • Fast multimodal demo for mobile.',
-      url:
-          'https://huggingface.co/LiquidAI/LFM2-VL-450M-GGUF/resolve/main/LFM2-VL-450M-Q4_0.gguf?download=true',
-      filename: 'LFM2-VL-450M-Q4_0.gguf',
-      mmprojUrl:
-          'https://huggingface.co/LiquidAI/LFM2-VL-450M-GGUF/resolve/main/mmproj-LFM2-VL-450M-Q8_0.gguf?download=true',
-      mmprojFilename: 'mmproj-LFM2-VL-450M-Q8_0.gguf',
-      sizeBytes: 323197440,
-      minRamGb: 2,
-      supportsVision: true,
-      preset: ModelPreset(
-        temperature: 0.2,
-        topK: 40,
-        topP: 0.9,
-        contextSize: 8192,
-        maxTokens: 1024,
-      ),
-    ),
-    DownloadableModel(
-      name: 'Ultravox v0.5 1B',
-      description:
-          '🎤 Audio bundle (2.18GB) • Reliable speech understanding demo.',
-      url:
-          'https://huggingface.co/ggml-org/ultravox-v0_5-llama-3_2-1b-GGUF/resolve/main/Llama-3.2-1B-Instruct-Q4_K_M.gguf?download=true',
-      filename: 'ultravox-v0.5-1b-q4_k_m.gguf',
-      mmprojUrl:
-          'https://huggingface.co/ggml-org/ultravox-v0_5-llama-3_2-1b-GGUF/resolve/main/mmproj-ultravox-v0_5-llama-3_2-1b-f16.gguf?download=true',
-      mmprojFilename: 'mmproj-ultravox-v0_5-llama-3_2-1b-f16.gguf',
-      sizeBytes: 2178818080,
-      minRamGb: 4,
-      supportsAudio: true,
-      preset: ModelPreset(
-        temperature: 0.2,
-        topK: 40,
-        topP: 0.9,
-        contextSize: 4096,
-        maxTokens: 1024,
-      ),
-    ),
-    DownloadableModel(
-      name: 'Llama 3.2 3B Instruct',
-      description:
-          '🏠 Balanced large model (2.02GB) • Strong general assistant.',
-      url:
-          'https://huggingface.co/bartowski/Llama-3.2-3B-Instruct-GGUF/resolve/main/Llama-3.2-3B-Instruct-Q4_K_M.gguf?download=true',
-      filename: 'Llama-3.2-3B-Instruct-Q4_K_M.gguf',
-      sizeBytes: 2019377696,
-      minRamGb: 4,
+      supportsVideo: true,
       supportsToolCalling: true,
+      supportsThinking: true,
       preset: ModelPreset(
-        temperature: 0.2,
-        topK: 40,
-        topP: 0.9,
-        contextSize: 8192,
-        maxTokens: 2048,
+        temperature: 0.7,
+        topK: 64,
+        topP: 0.95,
+        penalty: 1.0,
+        contextSize: 16384,
+        maxTokens: 4096,
+        thinkingEnabled: false,
       ),
     ),
     DownloadableModel(
-      name: 'Meta-Llama 3.1 8B Instruct',
+      name: 'Qwen3.6 35B A3B',
       description:
-          '🚀 Flagship quality (4.92GB) • Popular large model benchmark.',
+          'Fast mixture-of-experts model for coding, agentic workflows, and vision.',
       url:
-          'https://huggingface.co/bartowski/Meta-Llama-3.1-8B-Instruct-GGUF/resolve/main/Meta-Llama-3.1-8B-Instruct-Q4_K_M.gguf?download=true',
-      filename: 'Meta-Llama-3.1-8B-Instruct-Q4_K_M.gguf',
-      sizeBytes: 4920739232,
-      minRamGb: 8,
-      supportsToolCalling: true,
-      preset: ModelPreset(
-        temperature: 0.2,
-        topK: 40,
-        topP: 0.9,
-        contextSize: 8192,
-        maxTokens: 2048,
-      ),
-    ),
-    DownloadableModel(
-      name: 'Qwen3.5 9B Instruct',
-      description:
-          '🆕 Unsloth Q4_K_M bundle (6.32GB) • Highest-quality Qwen preset with the same quant family across platforms.',
-      url:
-          'https://huggingface.co/unsloth/Qwen3.5-9B-GGUF/resolve/main/Qwen3.5-9B-Q4_K_M.gguf?download=true',
-      filename: 'Qwen3.5-9B-Q4_K_M.gguf',
+          'https://huggingface.co/unsloth/Qwen3.6-35B-A3B-GGUF/resolve/main/Qwen3.6-35B-A3B-UD-Q4_K_S.gguf?download=true',
+      filename: 'Qwen3.6-35B-A3B-UD-Q4_K_S.gguf',
       mmprojUrl:
-          'https://huggingface.co/unsloth/Qwen3.5-9B-GGUF/resolve/main/mmproj-F16.gguf?download=true',
-      mmprojFilename: 'Qwen3.5-9B-mmproj-F16.gguf',
-      sizeBytes: 6784286240,
-      minRamGb: 12,
+          'https://huggingface.co/unsloth/Qwen3.6-35B-A3B-GGUF/resolve/main/mmproj-F16.gguf?download=true',
+      mmprojFilename: 'Qwen3.6-35B-A3B-mmproj-F16.gguf',
+      sizeBytes: 20893015008,
+      distribution: 'Unsloth',
+      availability: ModelAvailability.nativeDesktop,
+      minRamGb: 32,
       supportsVision: true,
       supportsToolCalling: true,
       supportsThinking: true,
@@ -651,8 +613,8 @@ class DownloadableModel {
         topK: 20,
         topP: 0.8,
         penalty: 1.0,
-        contextSize: 8192,
-        maxTokens: 1024,
+        contextSize: 16384,
+        maxTokens: 4096,
         thinkingEnabled: false,
       ),
     ),

--- a/example/chat_app/lib/providers/chat_provider.dart
+++ b/example/chat_app/lib/providers/chat_provider.dart
@@ -958,7 +958,11 @@ class ChatProvider extends ChangeNotifier {
           normalizedModelPath.contains('gemma-4') ||
           normalizedModelPath.contains('gemma_4') ||
           normalizedModelPath.contains('gemma4');
-      if (isGemma4 && _mmprojLoaded && _supportsVision && !_supportsAudio) {
+      if (isGemma4 &&
+          _settings.modelSupportsAudio &&
+          _mmprojLoaded &&
+          _supportsVision &&
+          !_supportsAudio) {
         _addInfoMessage(
           'This Gemma 4 GGUF projector currently exposes vision only in the '
           'llama.cpp mtmd runtime. Image input is available, but audio input is disabled.',

--- a/example/chat_app/lib/providers/chat_provider.dart
+++ b/example/chat_app/lib/providers/chat_provider.dart
@@ -172,6 +172,7 @@ class ChatProvider extends ChangeNotifier {
   double get penalty => _settings.penalty;
   int get contextSize => _settings.contextSize;
   int get gpuLayers => _settings.gpuLayers;
+  bool get autoTuneModelParams => _settings.autoTuneModelParams;
   int get numberOfThreads => _settings.numberOfThreads;
   int get numberOfThreadsBatch => _settings.numberOfThreadsBatch;
   LlamaLogLevel get dartLogLevel => _settings.logLevel;
@@ -782,17 +783,6 @@ class ChatProvider extends ChangeNotifier {
 
     updateLoadingUi(0.04, forceNotify: true);
 
-    // Estimate dynamic settings only when backend preference remains Auto.
-    if (!_isLiteRtLmModelPath(_settings.modelPath) &&
-        _settings.preferredBackend == GpuBackend.auto &&
-        (_settings.gpuLayers == 32 || _settings.gpuLayers == 99)) {
-      try {
-        await estimateDynamicSettings();
-      } catch (e) {
-        _logDart(LlamaLogLevel.warn, "Dynamic estimation failed: $e");
-      }
-    }
-
     updateLoadingUi(0.1);
 
     try {
@@ -803,6 +793,20 @@ class ChatProvider extends ChangeNotifier {
       await _chatService.engine.setNativeLogLevel(_settings.nativeLogLevel);
       if (_chatService.engine.isReady) {
         await _chatService.unloadModel();
+      }
+
+      // Measure device headroom after unloading the previous model; otherwise
+      // a model switch can make Auto look artificially memory-constrained.
+      if (!_isLiteRtLmModelPath(_settings.modelPath) &&
+          _settings.preferredBackend == GpuBackend.auto &&
+          (_settings.autoTuneModelParams ||
+              _settings.gpuLayers == 32 ||
+              _settings.gpuLayers >= 99)) {
+        try {
+          await estimateDynamicSettings();
+        } catch (e) {
+          _logDart(LlamaLogLevel.warn, "Dynamic estimation failed: $e");
+        }
       }
       updateLoadingUi(0.14);
 
@@ -907,11 +911,17 @@ class ChatProvider extends ChangeNotifier {
       final inferredCapabilities = _inferMultimodalCapabilities(metadata);
       final runtimeSupportsVision = await _chatService.engine.supportsVision;
       final runtimeSupportsAudio = await _chatService.engine.supportsAudio;
+      final declaredDirectVision =
+          _settings.directMediaInput && _settings.modelSupportsVision;
+      final declaredDirectAudio =
+          _settings.directMediaInput && _settings.modelSupportsAudio;
       _supportsVision =
           runtimeSupportsVision ||
+          declaredDirectVision ||
           (!_mmprojLoaded && inferredCapabilities.supportsVision);
       _supportsAudio =
           runtimeSupportsAudio ||
+          declaredDirectAudio ||
           (!_mmprojLoaded && inferredCapabilities.supportsAudio);
       _updateThinkingControlSupport(metadata);
       _updateToolTemplateSupport(metadata);
@@ -1242,6 +1252,24 @@ class ChatProvider extends ChangeNotifier {
     );
     if (!needsMultimodal) {
       return true;
+    }
+
+    if (_settings.directMediaInput) {
+      final needsVision = parts.any((part) => part is LlamaImageContent);
+      final needsAudio = parts.any((part) => part is LlamaAudioContent);
+      final missing = <String>[
+        if (needsVision && !_supportsVision) 'image',
+        if (needsAudio && !_supportsAudio) 'audio',
+      ];
+      if (missing.isEmpty) {
+        return true;
+      }
+
+      _addInfoMessage(
+        'The active model backend does not support ${missing.join(' or ')} input on this platform.',
+      );
+      notifyListeners();
+      return false;
     }
 
     if (_mmprojLoaded) {
@@ -1986,14 +2014,28 @@ class ChatProvider extends ChangeNotifier {
       _updateSettings(_settings.copyWith(penalty: value.clamp(0.8, 2.0)));
   void updateContextSize(int value) {
     final effectiveContextSize = value == 0 ? 0 : value.clamp(512, 32768);
-    _updateSettings(_settings.copyWith(contextSize: effectiveContextSize));
+    _updateSettings(
+      _settings.copyWith(
+        contextSize: effectiveContextSize,
+        autoTuneRequestedContextSize: effectiveContextSize,
+      ),
+    );
   }
 
   void updateMaxTokens(int value) =>
       _updateSettings(_settings.copyWith(maxTokens: value.clamp(512, 32768)));
   void updateGpuLayers(int value) {
     final normalized = value >= 99 ? 99 : value.clamp(0, 98);
-    _updateSettings(_settings.copyWith(gpuLayers: normalized));
+    _updateSettings(
+      _settings.copyWith(
+        gpuLayers: normalized,
+        autoTuneModelParams:
+            _settings.preferredBackend == GpuBackend.auto && normalized >= 99,
+        autoTuneRequestedContextSize: normalized >= 99
+            ? _settings.autoTuneRequestedContextSize ?? _settings.contextSize
+            : _settings.autoTuneRequestedContextSize,
+      ),
+    );
   }
 
   void updateNumberOfThreads(int value) =>
@@ -2086,17 +2128,20 @@ class ChatProvider extends ChangeNotifier {
   }
 
   void updateModelPath(String path) {
-    _updateSettings(_settings.copyWith(modelPath: path));
+    _updateSettings(
+      _settings.copyWith(
+        modelPath: path,
+        modelSupportsVision: false,
+        modelSupportsAudio: false,
+        directMediaInput: false,
+      ),
+    );
   }
 
   /// Apply model-specific recommended generation and runtime parameters.
   void applyModelPreset(DownloadableModel model) {
     final shouldKeepToolsEnabled =
         model.supportsToolCalling && _settings.toolsEnabled;
-    const androidCpuPreferredQwenModels = <String>{
-      'Qwen3.5 0.8B Instruct',
-      'Qwen3.5 2B Instruct',
-    };
     final shouldUseReducedAndroidContext =
         !kIsWeb &&
         defaultTargetPlatform == TargetPlatform.android &&
@@ -2104,10 +2149,11 @@ class ChatProvider extends ChangeNotifier {
     final shouldPreferCpuOnAndroid =
         !kIsWeb &&
         defaultTargetPlatform == TargetPlatform.android &&
-        androidCpuPreferredQwenModels.contains(model.name) &&
+        model.name == 'Qwen3.5 0.8B Instruct' &&
         (_settings.preferredBackend == GpuBackend.auto ||
             _settings.preferredBackend == GpuBackend.vulkan ||
             _settings.preferredBackend == GpuBackend.cpu);
+    final mediaInputMode = model.mediaInputModeFor(web: kIsWeb);
 
     _updateSettings(
       _settings.copyWith(
@@ -2121,6 +2167,13 @@ class ChatProvider extends ChangeNotifier {
             : model.preset.contextSize,
         maxTokens: model.preset.maxTokens,
         gpuLayers: shouldPreferCpuOnAndroid ? 0 : model.preset.gpuLayers,
+        autoTuneModelParams:
+            !shouldPreferCpuOnAndroid &&
+            _settings.preferredBackend == GpuBackend.auto &&
+            model.preset.gpuLayers >= 99,
+        autoTuneRequestedContextSize: shouldUseReducedAndroidContext
+            ? 2048
+            : model.preset.contextSize,
         preferredBackend: shouldPreferCpuOnAndroid
             ? GpuBackend.cpu
             : _settings.preferredBackend,
@@ -2128,16 +2181,18 @@ class ChatProvider extends ChangeNotifier {
         thinkingEnabled: model.preset.thinkingEnabled,
         thinkingBudgetTokens: model.preset.thinkingBudgetTokens,
         singleTurnMode: false,
-        // Web only: forward the known model size so the WebGPU backend can
-        // select the mem64 core up front for large models (size-driven, not a
-        // hardcoded model-name list).
-        modelBytesHint: kIsWeb ? model.sizeBytesFor(web: true) : null,
+        modelSupportsVision: model.supportsVisionFor(web: kIsWeb),
+        modelSupportsAudio: model.supportsAudioFor(web: kIsWeb),
+        directMediaInput: mediaInputMode == ModelMediaInputMode.direct,
+        // Auto uses the size for native memory planning; WebGPU also uses it
+        // to select the mem64 core before loading large models.
+        modelBytesHint: model.sizeBytesFor(web: kIsWeb),
       ),
     );
 
     if (shouldPreferCpuOnAndroid) {
       _addInfoMessage(
-        'On Android, Qwen3.5 0.8B/2B currently run faster and more reliably in CPU mode than Vulkan. You can switch back manually in Inference settings if you want to compare.',
+        'On Android, Qwen3.5 0.8B currently runs faster and more reliably in CPU mode than Vulkan. You can switch back manually in Inference settings if you want to compare.',
       );
       notifyListeners();
     }
@@ -2324,6 +2379,12 @@ class ChatProvider extends ChangeNotifier {
       _settings.copyWith(
         preferredBackend: backend,
         gpuLayers: restoresGpuOffload ? 99 : _settings.gpuLayers,
+        autoTuneModelParams:
+            backend == GpuBackend.auto &&
+            (restoresGpuOffload || _settings.autoTuneModelParams),
+        autoTuneRequestedContextSize: backend == GpuBackend.auto
+            ? _settings.autoTuneRequestedContextSize ?? _settings.contextSize
+            : _settings.autoTuneRequestedContextSize,
       ),
     );
     _messages.add(
@@ -2391,12 +2452,19 @@ class ChatProvider extends ChangeNotifier {
     try {
       final vram = await _chatService.engine.getVramInfo();
       final backendInfo = await _getAvailableBackendInfoBestEffort();
+      final catalogModel = _downloadableModelForCurrentSettings();
+      final modelBytes =
+          _settings.modelBytesHint ??
+          catalogModel?.sizeBytesFor(web: kIsWeb) ??
+          0;
       final estimate = _runtimeProfileService.estimateDynamicSettings(
         totalVramBytes: vram.total,
         freeVramBytes: vram.free,
         isWeb: kIsWeb,
         preferredBackend: _settings.preferredBackend,
-        currentContextSize: _settings.contextSize,
+        currentContextSize:
+            _settings.autoTuneRequestedContextSize ?? _settings.contextSize,
+        modelBytes: modelBytes,
         backendInfo: backendInfo,
       );
 

--- a/example/chat_app/lib/screens/app_shell_screen.dart
+++ b/example/chat_app/lib/screens/app_shell_screen.dart
@@ -178,6 +178,8 @@ class _AppShellScreenState extends State<AppShellScreen> {
                   showMenuButton: !isDesktop,
                   settingsPanelOpen: showPinnedSettingsPanel,
                   onMenuPressed: () => _scaffoldKey.currentState?.openDrawer(),
+                  onOpenDownloadDetails: () =>
+                      _openSettingsPanel(canPin: canPinSettingsPanel),
                   onOpenSettings: () =>
                       _toggleSettingsPanel(canPin: canPinSettingsPanel),
                 ),
@@ -282,6 +284,7 @@ class _ShellTopBar extends StatelessWidget {
   final bool showMenuButton;
   final bool settingsPanelOpen;
   final VoidCallback onMenuPressed;
+  final VoidCallback onOpenDownloadDetails;
   final VoidCallback onOpenSettings;
 
   const _ShellTopBar({
@@ -289,6 +292,7 @@ class _ShellTopBar extends StatelessWidget {
     required this.showMenuButton,
     required this.settingsPanelOpen,
     required this.onMenuPressed,
+    required this.onOpenDownloadDetails,
     required this.onOpenSettings,
   });
 
@@ -336,7 +340,7 @@ class _ShellTopBar extends StatelessWidget {
           ),
           _DownloadActivityButton(
             controller: downloadUi,
-            onPressed: onOpenSettings,
+            onPressed: onOpenDownloadDetails,
           ),
           const SizedBox(width: 6),
           IconButton(

--- a/example/chat_app/lib/screens/app_shell_screen.dart
+++ b/example/chat_app/lib/screens/app_shell_screen.dart
@@ -11,7 +11,9 @@ import 'chat_screen.dart';
 import 'manage_models_screen.dart';
 
 class AppShellScreen extends StatefulWidget {
-  const AppShellScreen({super.key});
+  final ModelDownloadUiController? downloadUiController;
+
+  const AppShellScreen({super.key, this.downloadUiController});
 
   @override
   State<AppShellScreen> createState() => _AppShellScreenState();
@@ -19,12 +21,22 @@ class AppShellScreen extends StatefulWidget {
 
 class _AppShellScreenState extends State<AppShellScreen> {
   final GlobalKey<ScaffoldState> _scaffoldKey = GlobalKey<ScaffoldState>();
-  final ModelDownloadUiController _downloadUi = ModelDownloadUiController();
+  late final ModelDownloadUiController _downloadUi;
+  late final bool _ownsDownloadUi;
   bool _pinnedSettingsOpen = false;
 
   @override
+  void initState() {
+    super.initState();
+    _downloadUi = widget.downloadUiController ?? ModelDownloadUiController();
+    _ownsDownloadUi = widget.downloadUiController == null;
+  }
+
+  @override
   void dispose() {
-    _downloadUi.dispose();
+    if (_ownsDownloadUi) {
+      _downloadUi.dispose();
+    }
     super.dispose();
   }
 
@@ -162,6 +174,7 @@ class _AppShellScreenState extends State<AppShellScreen> {
             child: Column(
               children: [
                 _ShellTopBar(
+                  downloadUi: _downloadUi,
                   showMenuButton: !isDesktop,
                   settingsPanelOpen: showPinnedSettingsPanel,
                   onMenuPressed: () => _scaffoldKey.currentState?.openDrawer(),
@@ -265,12 +278,14 @@ class _AppShellScreenState extends State<AppShellScreen> {
 }
 
 class _ShellTopBar extends StatelessWidget {
+  final ModelDownloadUiController downloadUi;
   final bool showMenuButton;
   final bool settingsPanelOpen;
   final VoidCallback onMenuPressed;
   final VoidCallback onOpenSettings;
 
   const _ShellTopBar({
+    required this.downloadUi,
     required this.showMenuButton,
     required this.settingsPanelOpen,
     required this.onMenuPressed,
@@ -319,6 +334,11 @@ class _ShellTopBar extends StatelessWidget {
               ),
             ),
           ),
+          _DownloadActivityButton(
+            controller: downloadUi,
+            onPressed: onOpenSettings,
+          ),
+          const SizedBox(width: 6),
           IconButton(
             onPressed: onOpenSettings,
             tooltip: settingsActionLabel,
@@ -329,6 +349,158 @@ class _ShellTopBar extends StatelessWidget {
           ),
         ],
       ),
+    );
+  }
+}
+
+class _DownloadActivityButton extends StatelessWidget {
+  final ModelDownloadUiController controller;
+  final VoidCallback onPressed;
+
+  const _DownloadActivityButton({
+    required this.controller,
+    required this.onPressed,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    return AnimatedBuilder(
+      animation: controller,
+      builder: (context, _) {
+        if (!controller.hasPendingDownloads) {
+          return const SizedBox.shrink();
+        }
+
+        final colorScheme = Theme.of(context).colorScheme;
+        final filename = controller.activeFilename;
+        final state = controller.activeState;
+        final progress = state?.progress.clamp(0.0, 1.0) ?? 0.0;
+        final displayName = controller.activeDisplayName ?? filename ?? 'Model';
+        final detail = state?.detail;
+        final stageLabel = detail != null
+            ? downloadStageLabel(detail, isWeb: kIsWeb)
+            : downloadTaskLabel(state?.task, isWeb: kIsWeb) ??
+                  (kIsWeb ? 'Preparing cache' : 'Preparing download');
+        final queuedCount = controller.queuedCount;
+        final width = MediaQuery.sizeOf(context).width;
+        final textScale = MediaQuery.textScalerOf(context).scale(1);
+        final compact = width < 720 || textScale > 1.4;
+        final percentLabel = '${(progress * 100).toStringAsFixed(0)}%';
+        final semanticsLabel = [
+          '$stageLabel for $displayName, $percentLabel',
+          if (queuedCount > 0) '$queuedCount queued',
+        ].join(', ');
+
+        return Semantics(
+          button: true,
+          label: semanticsLabel,
+          child: Tooltip(
+            message: '$semanticsLabel. Open download details.',
+            child: Material(
+              color: colorScheme.primaryContainer.withValues(alpha: 0.58),
+              borderRadius: BorderRadius.circular(10),
+              child: InkWell(
+                onTap: onPressed,
+                borderRadius: BorderRadius.circular(10),
+                child: Padding(
+                  padding: EdgeInsets.symmetric(
+                    horizontal: compact ? 8 : 10,
+                    vertical: 7,
+                  ),
+                  child: Row(
+                    mainAxisSize: MainAxisSize.min,
+                    children: [
+                      SizedBox(
+                        width: 24,
+                        height: 24,
+                        child: Stack(
+                          alignment: Alignment.center,
+                          children: [
+                            CircularProgressIndicator(
+                              value: progress > 0 ? progress : null,
+                              strokeWidth: 2.5,
+                              color: colorScheme.primary,
+                              backgroundColor: colorScheme.primary.withValues(
+                                alpha: 0.16,
+                              ),
+                            ),
+                            Icon(
+                              Icons.arrow_downward_rounded,
+                              size: 13,
+                              color: colorScheme.onPrimaryContainer,
+                            ),
+                          ],
+                        ),
+                      ),
+                      const SizedBox(width: 8),
+                      if (compact)
+                        Text(
+                          percentLabel,
+                          style: TextStyle(
+                            color: colorScheme.onPrimaryContainer,
+                            fontSize: 12,
+                            fontWeight: FontWeight.w700,
+                          ),
+                        )
+                      else
+                        ConstrainedBox(
+                          constraints: const BoxConstraints(maxWidth: 190),
+                          child: Column(
+                            mainAxisSize: MainAxisSize.min,
+                            crossAxisAlignment: CrossAxisAlignment.start,
+                            children: [
+                              Text(
+                                displayName,
+                                maxLines: 1,
+                                overflow: TextOverflow.ellipsis,
+                                style: TextStyle(
+                                  color: colorScheme.onPrimaryContainer,
+                                  fontSize: 12,
+                                  fontWeight: FontWeight.w700,
+                                ),
+                              ),
+                              Text(
+                                '$stageLabel • $percentLabel',
+                                maxLines: 1,
+                                overflow: TextOverflow.ellipsis,
+                                style: TextStyle(
+                                  color: colorScheme.onPrimaryContainer
+                                      .withValues(alpha: 0.76),
+                                  fontSize: 10,
+                                ),
+                              ),
+                            ],
+                          ),
+                        ),
+                      if (queuedCount > 0) ...[
+                        const SizedBox(width: 7),
+                        Container(
+                          padding: const EdgeInsets.symmetric(
+                            horizontal: 6,
+                            vertical: 2,
+                          ),
+                          decoration: BoxDecoration(
+                            color: colorScheme.primary,
+                            borderRadius: BorderRadius.circular(999),
+                          ),
+                          child: Text(
+                            compact ? '+$queuedCount' : '$queuedCount queued',
+                            style: TextStyle(
+                              color: colorScheme.onPrimary,
+                              fontSize: 10,
+                              fontWeight: FontWeight.w800,
+                            ),
+                          ),
+                        ),
+                      ],
+                    ],
+                  ),
+                ),
+              ),
+            ),
+          ),
+        );
+      },
     );
   }
 }

--- a/example/chat_app/lib/screens/manage_models_screen.dart
+++ b/example/chat_app/lib/screens/manage_models_screen.dart
@@ -814,11 +814,15 @@ class _ManageModelsScreenState extends State<ManageModelsScreen>
       subscription = controller.snapshots.listen(
         (snapshot) => _handleDownloadSnapshot(model, snapshot),
       );
-      _downloadUi.registerDownload(
+      final registered = _downloadUi.registerDownload(
         filename: model.filename,
         controller: controller,
         subscription: subscription,
       );
+      if (!registered) {
+        _downloadUi.completeActiveDownload(model.filename);
+        return;
+      }
 
       await controller.start(manager.source);
       _updateDownloadUiState(

--- a/example/chat_app/lib/screens/manage_models_screen.dart
+++ b/example/chat_app/lib/screens/manage_models_screen.dart
@@ -19,6 +19,12 @@ import '../utils/backend_utils.dart';
 import '../widgets/model_card.dart';
 import '../widgets/tool_declarations_dialog.dart';
 
+enum _CustomModelRemoval { entryOnly, entryAndFiles }
+
+enum _ModelPlatformFilter { all, mobileAndWeb, desktop }
+
+enum _ModelLibraryMenuAction { removeAll }
+
 class ManageModelsScreen extends StatefulWidget {
   final VoidCallback? onModelActivated;
   final bool embeddedPanel;
@@ -54,6 +60,7 @@ class _ManageModelsScreenState extends State<ManageModelsScreen>
   late final ModelService _modelService;
   final HuggingFaceModelDiscoveryService _hfDiscoveryService =
       HuggingFaceModelDiscoveryService();
+  final TextEditingController _modelSearchController = TextEditingController();
   final List<DownloadableModel> _models = <DownloadableModel>[];
   final List<DownloadableModel> _customModels = <DownloadableModel>[];
 
@@ -70,6 +77,8 @@ class _ManageModelsScreenState extends State<ManageModelsScreen>
   bool _modelParametersExpanded = false;
   bool _inferenceParametersExpanded = false;
   bool _advancedExpanded = false;
+  String _modelSearchQuery = '';
+  late _ModelPlatformFilter _modelPlatformFilter;
 
   @override
   void initState() {
@@ -81,6 +90,7 @@ class _ManageModelsScreenState extends State<ManageModelsScreen>
     _downloadFinishedSubscription = _downloadUi.downloadsFinished.listen(
       _handleDownloadFinished,
     );
+    _modelPlatformFilter = _currentPlatformFilter;
     _models.addAll(_initialModelCatalog());
     _showModelLibrary = widget.showModelLibraryInitially ?? false;
     _initModelService();
@@ -90,6 +100,71 @@ class _ManageModelsScreenState extends State<ManageModelsScreen>
     return List<DownloadableModel>.from(
       widget.initialModels ?? DownloadableModel.defaultModels,
     );
+  }
+
+  bool get _isMobilePlatform =>
+      !kIsWeb &&
+      (defaultTargetPlatform == TargetPlatform.android ||
+          defaultTargetPlatform == TargetPlatform.iOS);
+
+  _ModelPlatformFilter get _currentPlatformFilter {
+    if (kIsWeb || _isMobilePlatform) {
+      return _ModelPlatformFilter.mobileAndWeb;
+    }
+    return _ModelPlatformFilter.desktop;
+  }
+
+  bool _isAvailableOnCurrentPlatform(DownloadableModel model) {
+    return model.isAvailableFor(web: kIsWeb, mobile: _isMobilePlatform);
+  }
+
+  bool _matchesPlatformFilter(DownloadableModel model) {
+    return switch (_modelPlatformFilter) {
+      _ModelPlatformFilter.all => true,
+      _ModelPlatformFilter.mobileAndWeb => model.isAvailableFor(
+        web: true,
+        mobile: false,
+      ),
+      _ModelPlatformFilter.desktop => model.isAvailableFor(
+        web: false,
+        mobile: false,
+      ),
+    };
+  }
+
+  bool _matchesModelSearch(DownloadableModel model) {
+    final query = _modelSearchQuery.trim().toLowerCase();
+    if (query.isEmpty) {
+      return true;
+    }
+    final searchable = <String>[
+      model.name,
+      model.description,
+      model.distribution ?? '',
+      model.filename,
+      if (model.supportsToolCalling) 'tools function calling',
+      if (model.supportsThinking) 'thinking reasoning',
+      if (model.supportsVisionFor(web: kIsWeb)) 'vision image',
+      if (model.supportsAudioFor(web: kIsWeb)) 'audio voice',
+      if (model.supportsVideoFor(web: kIsWeb)) 'video',
+    ].join(' ').toLowerCase();
+    return query.split(RegExp(r'\s+')).every(searchable.contains);
+  }
+
+  bool _isModelDownloaded(DownloadableModel model) {
+    return _downloadedFiles.contains(model.filename) ||
+        (_cacheStateByFile[model.filename]?.model.isAvailable ?? false);
+  }
+
+  List<DownloadableModel> _visibleModels() {
+    final visible = _models
+        .where(_matchesPlatformFilter)
+        .where(_matchesModelSearch)
+        .toList(growable: false);
+    return [
+      ...visible.where(_isModelDownloaded),
+      ...visible.where((model) => !_isModelDownloaded(model)),
+    ];
   }
 
   @override
@@ -676,27 +751,34 @@ class _ManageModelsScreenState extends State<ManageModelsScreen>
     if (!kIsWeb && _modelsDir == null) {
       return;
     }
-    if (_downloadUi.isRunning(model.filename)) {
+    if (_downloadUi.isPending(model.filename)) {
       return;
     }
 
-    await _disposeDownloadController(model.filename);
+    final shouldIncludeProjector =
+        includeProjector ?? _includeProjectorFor(model);
+    final ready = await _downloadUi.enqueueDownload(
+      filename: model.filename,
+      displayName: model.name,
+    );
+    if (!ready) {
+      return;
+    }
 
     ModelDownloadController? controller;
     StreamSubscription<ModelDownloadTaskSnapshot>? subscription;
 
-    _updateDownloadUiState(
-      model.filename,
-      isDownloading: true,
-      clearDetail: true,
-      clearTask: true,
-      clearProgress: true,
-    );
-    _clearDownloadTracking(model.filename);
-
     try {
-      final shouldIncludeProjector =
-          includeProjector ?? _includeProjectorFor(model);
+      await _disposeDownloadController(model.filename);
+      _updateDownloadUiState(
+        model.filename,
+        isDownloading: true,
+        clearDetail: true,
+        clearTask: true,
+        clearProgress: true,
+      );
+      _clearDownloadTracking(model.filename);
+
       final manager = ChatAppModelDownloadManager(
         modelService: _modelService,
         model: model,
@@ -773,6 +855,7 @@ class _ManageModelsScreenState extends State<ManageModelsScreen>
         ),
       );
     } finally {
+      _downloadUi.completeActiveDownload(model.filename);
       await _disposeDownloadController(
         model.filename,
         controller: controller,
@@ -805,7 +888,9 @@ class _ManageModelsScreenState extends State<ManageModelsScreen>
     provider.updateModelPath(pathOrUrl);
     provider.applyModelPreset(model);
 
-    if (model.isMultimodal) {
+    if (model.isMultimodalFor(web: kIsWeb) &&
+        model.mediaInputModeFor(web: kIsWeb) ==
+            ModelMediaInputMode.externalProjector) {
       final mmprojPath = _resolveMmprojPathForModel(model);
       final mmprojSource = model.multimodalProjectorSourceFor(web: kIsWeb);
       final projectorIsAvailable =
@@ -875,6 +960,77 @@ class _ManageModelsScreenState extends State<ManageModelsScreen>
     if (!mounted) return;
 
     setState(() {});
+  }
+
+  Future<void> _removeCustomModelEntry(DownloadableModel model) async {
+    final isCustom = _customModels.any(
+      (entry) => entry.filename == model.filename && entry.url == model.url,
+    );
+    if (!isCustom) {
+      return;
+    }
+
+    final cacheState = _cacheStateByFile[model.filename];
+    final hasCachedAssets =
+        _downloadedFiles.contains(model.filename) ||
+        (cacheState?.availableAssetLabels.isNotEmpty ?? false);
+    final removal = await showDialog<_CustomModelRemoval>(
+      context: context,
+      builder: (context) => AlertDialog(
+        title: const Text('Remove from library?'),
+        content: Text(
+          hasCachedAssets
+              ? 'Remove ${model.name} from your model library? You can keep its downloaded files or delete them too.'
+              : 'Remove ${model.name} from your model library?',
+        ),
+        actions: [
+          TextButton(
+            onPressed: () => Navigator.of(context).pop(),
+            child: const Text('Cancel'),
+          ),
+          if (hasCachedAssets)
+            TextButton(
+              onPressed: () =>
+                  Navigator.of(context).pop(_CustomModelRemoval.entryOnly),
+              child: const Text('Remove only'),
+            ),
+          FilledButton(
+            onPressed: () => Navigator.of(context).pop(
+              hasCachedAssets
+                  ? _CustomModelRemoval.entryAndFiles
+                  : _CustomModelRemoval.entryOnly,
+            ),
+            child: Text(hasCachedAssets ? 'Delete files & remove' : 'Remove'),
+          ),
+        ],
+      ),
+    );
+    if (removal == null || !mounted) {
+      return;
+    }
+
+    if (removal == _CustomModelRemoval.entryAndFiles) {
+      await _deleteModel(model);
+      if (!mounted) {
+        return;
+      }
+    }
+
+    setState(() {
+      _models.removeWhere(
+        (entry) => entry.filename == model.filename && entry.url == model.url,
+      );
+      _customModels.removeWhere(
+        (entry) => entry.filename == model.filename && entry.url == model.url,
+      );
+    });
+    await _saveCustomModels();
+    if (!mounted) {
+      return;
+    }
+    ScaffoldMessenger.of(context).showSnackBar(
+      SnackBar(content: Text('Removed ${model.name} from the library.')),
+    );
   }
 
   Future<void> _removeAllModels() async {
@@ -1044,7 +1200,9 @@ class _ManageModelsScreenState extends State<ManageModelsScreen>
   }
 
   String? _resolveMmprojPathForModel(DownloadableModel model) {
-    if (!model.isMultimodal) {
+    if (!model.isMultimodalFor(web: kIsWeb) ||
+        model.mediaInputModeFor(web: kIsWeb) !=
+            ModelMediaInputMode.externalProjector) {
       return null;
     }
 
@@ -1053,7 +1211,8 @@ class _ManageModelsScreenState extends State<ManageModelsScreen>
       return _resolveAssetLoadReference(source);
     }
 
-    return model.supportsVision || model.supportsAudio
+    return model.supportsVisionFor(web: kIsWeb) ||
+            model.supportsAudioFor(web: kIsWeb)
         ? _resolveModelLoadReference(model)
         : null;
   }
@@ -1063,8 +1222,10 @@ class _ManageModelsScreenState extends State<ManageModelsScreen>
     ChatProvider provider,
   ) {
     final missing = <String>[
-      if (model.supportsVision && !provider.supportsVision) 'vision',
-      if (model.supportsAudio && !provider.supportsAudio) 'audio',
+      if (model.supportsVisionFor(web: kIsWeb) && !provider.supportsVision)
+        'vision',
+      if (model.supportsAudioFor(web: kIsWeb) && !provider.supportsAudio)
+        'audio',
     ];
     if (missing.isEmpty) {
       return null;
@@ -1144,7 +1305,8 @@ class _ManageModelsScreenState extends State<ManageModelsScreen>
         final isWide = width >= 980 && !isEmbedded;
         final horizontalPadding = isEmbedded ? 12.0 : (isWide ? 28.0 : 16.0);
         final selectedModel = _findSelectedModel(provider);
-        final selectedModelMmprojPath = selectedModel == null
+        final selectedModelMmprojPath =
+            selectedModel == null || (!kIsWeb && _modelsDir == null)
             ? null
             : _resolveMmprojPathForModel(selectedModel);
         final selectedBackend = _resolveSelectedBackend(provider);
@@ -1165,7 +1327,11 @@ class _ManageModelsScreenState extends State<ManageModelsScreen>
             ? '(auto detected)'
             : provider.numberOfThreadsBatch.toString();
         final isMaximumGpuLayers = provider.gpuLayers >= 99;
-        final gpuLayersLabel = isMaximumGpuLayers
+        final gpuLayersLabel = provider.autoTuneModelParams
+            ? isMaximumGpuLayers
+                  ? 'Auto · Max'
+                  : 'Auto · ${provider.gpuLayers}'
+            : isMaximumGpuLayers
             ? 'Max'
             : provider.gpuLayers.toString();
         final gpuLayersSliderValue = isMaximumGpuLayers
@@ -1178,6 +1344,10 @@ class _ManageModelsScreenState extends State<ManageModelsScreen>
         final loadProgressLabel = hasLoadProgress
             ? '${(provider.loadingProgress * 100).toStringAsFixed(0)}%'
             : null;
+        final visibleModels = _visibleModels();
+        final visibleDownloadedCount = visibleModels
+            .where(_isModelDownloaded)
+            .length;
 
         return ListView(
           padding: EdgeInsets.fromLTRB(
@@ -1296,38 +1466,159 @@ class _ManageModelsScreenState extends State<ManageModelsScreen>
                     ),
                   ),
                   if (_showModelLibrary) ...[
-                    const SizedBox(height: 8),
-                    Column(
-                      crossAxisAlignment: CrossAxisAlignment.stretch,
+                    const SizedBox(height: 14),
+                    Row(
+                      children: [
+                        Expanded(
+                          child: Text(
+                            'Model library',
+                            style: Theme.of(context).textTheme.titleMedium
+                                ?.copyWith(fontWeight: FontWeight.w700),
+                          ),
+                        ),
+                        Text(
+                          visibleDownloadedCount == 0
+                              ? '${visibleModels.length} models'
+                              : '$visibleDownloadedCount downloaded · ${visibleModels.length} total',
+                          style: Theme.of(context).textTheme.bodySmall
+                              ?.copyWith(
+                                color: Theme.of(
+                                  context,
+                                ).colorScheme.onSurfaceVariant,
+                              ),
+                        ),
+                        const SizedBox(width: 4),
+                        PopupMenuButton<_ModelLibraryMenuAction>(
+                          tooltip: 'Model library actions',
+                          icon: const Icon(Icons.more_horiz_rounded),
+                          onSelected: (action) {
+                            switch (action) {
+                              case _ModelLibraryMenuAction.removeAll:
+                                unawaited(_removeAllModels());
+                            }
+                          },
+                          itemBuilder: (context) => [
+                            PopupMenuItem(
+                              value: _ModelLibraryMenuAction.removeAll,
+                              child: Row(
+                                children: [
+                                  Icon(
+                                    Icons.delete_sweep_outlined,
+                                    size: 19,
+                                    color: Theme.of(context).colorScheme.error,
+                                  ),
+                                  const SizedBox(width: 10),
+                                  Text(
+                                    'Remove all models',
+                                    style: TextStyle(
+                                      color: Theme.of(
+                                        context,
+                                      ).colorScheme.error,
+                                    ),
+                                  ),
+                                ],
+                              ),
+                            ),
+                          ],
+                        ),
+                      ],
+                    ),
+                    const SizedBox(height: 10),
+                    TextField(
+                      controller: _modelSearchController,
+                      onChanged: (value) {
+                        setState(() {
+                          _modelSearchQuery = value;
+                        });
+                      },
+                      textInputAction: TextInputAction.search,
+                      decoration: InputDecoration(
+                        hintText: 'Search models or capabilities',
+                        prefixIcon: const Icon(Icons.search_rounded),
+                        suffixIcon: _modelSearchQuery.isEmpty
+                            ? null
+                            : IconButton(
+                                onPressed: () {
+                                  FocusScope.of(context).unfocus();
+                                  _modelSearchController.clear();
+                                  setState(() {
+                                    _modelSearchQuery = '';
+                                  });
+                                },
+                                tooltip: 'Clear model search',
+                                icon: const Icon(Icons.close_rounded),
+                              ),
+                        filled: true,
+                        fillColor: Theme.of(
+                          context,
+                        ).colorScheme.surfaceContainerLowest,
+                        border: OutlineInputBorder(
+                          borderRadius: BorderRadius.circular(12),
+                          borderSide: BorderSide.none,
+                        ),
+                        contentPadding: const EdgeInsets.symmetric(
+                          horizontal: 12,
+                          vertical: 12,
+                        ),
+                      ),
+                    ),
+                    const SizedBox(height: 10),
+                    SingleChildScrollView(
+                      scrollDirection: Axis.horizontal,
+                      child: Row(
+                        children: _ModelPlatformFilter.values
+                            .map((filter) {
+                              final (label, icon) = switch (filter) {
+                                _ModelPlatformFilter.all => (
+                                  'All',
+                                  Icons.apps_rounded,
+                                ),
+                                _ModelPlatformFilter.mobileAndWeb => (
+                                  'Mobile & Web',
+                                  Icons.smartphone_rounded,
+                                ),
+                                _ModelPlatformFilter.desktop => (
+                                  'Desktop',
+                                  Icons.desktop_mac_outlined,
+                                ),
+                              };
+                              return Padding(
+                                padding: const EdgeInsets.only(right: 8),
+                                child: ChoiceChip(
+                                  selected: _modelPlatformFilter == filter,
+                                  materialTapTargetSize:
+                                      MaterialTapTargetSize.shrinkWrap,
+                                  visualDensity: VisualDensity.compact,
+                                  labelPadding: const EdgeInsets.symmetric(
+                                    horizontal: 4,
+                                  ),
+                                  onSelected: (_) {
+                                    setState(() {
+                                      _modelPlatformFilter = filter;
+                                    });
+                                  },
+                                  avatar: Icon(icon, size: 16),
+                                  label: Text(label),
+                                ),
+                              );
+                            })
+                            .toList(growable: false),
+                      ),
+                    ),
+                    const SizedBox(height: 10),
+                    Wrap(
+                      spacing: 8,
+                      runSpacing: 8,
                       children: [
                         OutlinedButton.icon(
-                          style: OutlinedButton.styleFrom(
-                            minimumSize: const Size.fromHeight(44),
-                            alignment: Alignment.centerLeft,
-                          ),
                           onPressed: _showDiscoverPopularModelsDialog,
                           icon: const Icon(Icons.auto_awesome_rounded),
-                          label: const Text('Discover popular'),
+                          label: const Text('Discover'),
                         ),
-                        const SizedBox(height: 8),
                         OutlinedButton.icon(
-                          style: OutlinedButton.styleFrom(
-                            minimumSize: const Size.fromHeight(44),
-                            alignment: Alignment.centerLeft,
-                          ),
                           onPressed: _showAddHuggingFaceDialog,
                           icon: const Icon(Icons.add_link_rounded),
-                          label: const Text('Add GGUF (HF)'),
-                        ),
-                        const SizedBox(height: 8),
-                        OutlinedButton.icon(
-                          style: OutlinedButton.styleFrom(
-                            minimumSize: const Size.fromHeight(44),
-                            alignment: Alignment.centerLeft,
-                          ),
-                          onPressed: _removeAllModels,
-                          icon: const Icon(Icons.delete_sweep_outlined),
-                          label: const Text('Remove all'),
+                          label: const Text('Add model'),
                         ),
                       ],
                     ),
@@ -1336,8 +1627,39 @@ class _ManageModelsScreenState extends State<ManageModelsScreen>
                         padding: EdgeInsets.symmetric(vertical: 40),
                         child: Center(child: CircularProgressIndicator()),
                       )
+                    else if (visibleModels.isEmpty)
+                      Padding(
+                        padding: const EdgeInsets.symmetric(vertical: 32),
+                        child: Column(
+                          children: [
+                            Icon(
+                              Icons.search_off_rounded,
+                              size: 32,
+                              color: Theme.of(
+                                context,
+                              ).colorScheme.onSurfaceVariant,
+                            ),
+                            const SizedBox(height: 10),
+                            Text(
+                              'No models match these filters',
+                              style: Theme.of(context).textTheme.titleSmall,
+                            ),
+                            const SizedBox(height: 4),
+                            Text(
+                              'Try another platform or a broader search.',
+                              textAlign: TextAlign.center,
+                              style: Theme.of(context).textTheme.bodySmall
+                                  ?.copyWith(
+                                    color: Theme.of(
+                                      context,
+                                    ).colorScheme.onSurfaceVariant,
+                                  ),
+                            ),
+                          ],
+                        ),
+                      )
                     else
-                      ..._models.map((model) {
+                      ...visibleModels.map((model) {
                         final selectedPath = _resolveModelLoadReference(model);
                         final isActivating = _activatingModel == model.filename;
                         final downloadStateListenable = _downloadUi
@@ -1351,6 +1673,9 @@ class _ManageModelsScreenState extends State<ManageModelsScreen>
                               downloadState.task,
                               isWeb: kIsWeb,
                             );
+                            final queueLabel = downloadState.isQueued
+                                ? 'Queued${downloadState.queuePosition == null ? '' : ' (#${downloadState.queuePosition})'}'
+                                : null;
 
                             final card = ModelCard(
                               model: model,
@@ -1359,9 +1684,11 @@ class _ManageModelsScreenState extends State<ManageModelsScreen>
                               ),
                               cacheState: _cacheStateByFile[model.filename],
                               isDownloading: downloadState.isDownloading,
+                              isQueued: downloadState.isQueued,
+                              queuePosition: downloadState.queuePosition,
                               progress: downloadState.progress,
                               downloadStatusLabel: detail == null
-                                  ? taskLabel
+                                  ? (queueLabel ?? taskLabel)
                                   : downloadStageLabel(detail, isWeb: kIsWeb),
                               downloadTransferLabel: detail == null
                                   ? null
@@ -1370,6 +1697,8 @@ class _ManageModelsScreenState extends State<ManageModelsScreen>
                                       detail,
                                     ),
                               isWeb: kIsWeb,
+                              isAvailableOnCurrentPlatform:
+                                  _isAvailableOnCurrentPlatform(model),
                               isSelected: provider.modelPath == selectedPath,
                               gpuLayers: provider.gpuLayers,
                               contextSize: provider.contextSize,
@@ -1381,6 +1710,9 @@ class _ManageModelsScreenState extends State<ManageModelsScreen>
                               onDownload: () =>
                                   unawaited(_downloadModel(model)),
                               onDelete: () => unawaited(_deleteModel(model)),
+                              isCustom: _customModels.contains(model),
+                              onRemoveFromLibrary: () =>
+                                  unawaited(_removeCustomModelEntry(model)),
                               onCancel: () => _cancelDownload(model),
                               includeProjector: _includeProjectorFor(model),
                               onIncludeProjectorChanged: (value) =>
@@ -1658,7 +1990,9 @@ class _ManageModelsScreenState extends State<ManageModelsScreen>
                             'mmproj is configured for this model. Use Text only to disable it, or Load mmproj to attach it without a full reload.',
                           if (gpuOffloadDisabled)
                             'GPU layers is 0, so inference will run on CPU. Increase it or choose Max to enable GPU offload.',
-                          'Auto selects Metal on supported Macs. GPU layers controls how much of the model is offloaded; Max requests full offload. Changes apply on next model load.',
+                          provider.autoTuneModelParams
+                              ? 'Auto tuning recalculates GPU layers and context headroom on every model load. Auto selects Metal on supported Macs.'
+                              : 'GPU layers controls how much of the model is offloaded; Max enables Auto tuning with the Auto backend. Changes apply on next model load.',
                         ].join(' '),
                         style: Theme.of(context).textTheme.bodySmall?.copyWith(
                           color: gpuOffloadDisabled
@@ -2004,6 +2338,7 @@ class _ManageModelsScreenState extends State<ManageModelsScreen>
   @override
   void dispose() {
     WidgetsBinding.instance.removeObserver(this);
+    _modelSearchController.dispose();
     unawaited(_downloadFinishedSubscription?.cancel());
     if (_ownsDownloadUi) {
       _downloadUi.dispose();
@@ -2335,7 +2670,7 @@ class _PopularModelsDiscoverySheetState
     }
 
     if (entry.model.sizeBytes > 0) {
-      details.add('${entry.model.sizeMb} MB');
+      details.add(entry.model.sizeLabelFor(web: kIsWeb));
     }
 
     if (entry.model.minRamGb > 0) {
@@ -2622,11 +2957,15 @@ class _PopularModelsDiscoverySheetState
                                           spacing: 6,
                                           runSpacing: 6,
                                           children: [
-                                            if (model.supportsVision)
+                                            if (model.supportsVisionFor(
+                                              web: kIsWeb,
+                                            ))
                                               const _CapabilityPill(
                                                 label: 'Vision',
                                               ),
-                                            if (model.supportsAudio)
+                                            if (model.supportsAudioFor(
+                                              web: kIsWeb,
+                                            ))
                                               const _CapabilityPill(
                                                 label: 'Audio',
                                               ),

--- a/example/chat_app/lib/screens/manage_models_screen.dart
+++ b/example/chat_app/lib/screens/manage_models_screen.dart
@@ -769,12 +769,23 @@ class _ManageModelsScreenState extends State<ManageModelsScreen>
     if (!ready) {
       return;
     }
+    if (!_downloadUi.canRegisterDownload(model.filename)) {
+      _downloadUi.completeActiveDownload(model.filename);
+      return;
+    }
+
+    await _disposeDownloadController(model.filename);
+    // The user may cancel while the previous controller is being disposed,
+    // before this attempt has registered a cancellable controller.
+    if (!_downloadUi.canRegisterDownload(model.filename)) {
+      _downloadUi.completeActiveDownload(model.filename);
+      return;
+    }
 
     ModelDownloadController? controller;
     StreamSubscription<ModelDownloadTaskSnapshot>? subscription;
 
     try {
-      await _disposeDownloadController(model.filename);
       _updateDownloadUiState(
         model.filename,
         isDownloading: true,

--- a/example/chat_app/lib/screens/manage_models_screen.dart
+++ b/example/chat_app/lib/screens/manage_models_screen.dart
@@ -1347,7 +1347,9 @@ class _ManageModelsScreenState extends State<ManageModelsScreen>
             ? '(auto detected)'
             : provider.numberOfThreadsBatch.toString();
         final isMaximumGpuLayers = provider.gpuLayers >= 99;
-        final gpuLayersLabel = provider.autoTuneModelParams
+        final isAutoTuning =
+            selectedBackend == GpuBackend.auto && provider.autoTuneModelParams;
+        final gpuLayersLabel = isAutoTuning
             ? isMaximumGpuLayers
                   ? 'Auto · Max'
                   : 'Auto · ${provider.gpuLayers}'
@@ -2005,7 +2007,7 @@ class _ManageModelsScreenState extends State<ManageModelsScreen>
                             'mmproj is configured for this model. Use Text only to disable it, or Load mmproj to attach it without a full reload.',
                           if (gpuOffloadDisabled)
                             'GPU layers is 0, so inference will run on CPU. Increase it or choose Max to enable GPU offload.',
-                          provider.autoTuneModelParams
+                          isAutoTuning
                               ? 'Auto tuning recalculates GPU layers and context headroom on every model load. Auto selects Metal on supported Macs.'
                               : 'GPU layers controls how much of the model is offloaded; Max enables Auto tuning with the Auto backend. Changes apply on next model load.',
                         ].join(' '),

--- a/example/chat_app/lib/screens/manage_models_screen.dart
+++ b/example/chat_app/lib/screens/manage_models_screen.dart
@@ -137,6 +137,11 @@ class _ManageModelsScreenState extends State<ManageModelsScreen>
     if (query.isEmpty) {
       return true;
     }
+    // A Web user can browse the Desktop catalog. In that scope, search the
+    // native capability profile rather than hiding features unavailable only
+    // in the browser runtime.
+    final useWebCapabilities =
+        kIsWeb && _modelPlatformFilter != _ModelPlatformFilter.desktop;
     final searchable = <String>[
       model.name,
       model.description,
@@ -144,9 +149,9 @@ class _ManageModelsScreenState extends State<ManageModelsScreen>
       model.filename,
       if (model.supportsToolCalling) 'tools function calling',
       if (model.supportsThinking) 'thinking reasoning',
-      if (model.supportsVisionFor(web: kIsWeb)) 'vision image',
-      if (model.supportsAudioFor(web: kIsWeb)) 'audio voice',
-      if (model.supportsVideoFor(web: kIsWeb)) 'video',
+      if (model.supportsVisionFor(web: useWebCapabilities)) 'vision image',
+      if (model.supportsAudioFor(web: useWebCapabilities)) 'audio voice',
+      if (model.supportsVideoFor(web: useWebCapabilities)) 'video',
     ].join(' ').toLowerCase();
     return query.split(RegExp(r'\s+')).every(searchable.contains);
   }

--- a/example/chat_app/lib/screens/manage_models_screen.dart
+++ b/example/chat_app/lib/screens/manage_models_screen.dart
@@ -1071,6 +1071,7 @@ class _ManageModelsScreenState extends State<ManageModelsScreen>
     final provider = context.read<ChatProvider>();
 
     _pauseActiveDownloads();
+    await _downloadUi.disposeDownloads();
 
     final snapshot = List<DownloadableModel>.from(_models);
     for (final model in snapshot) {
@@ -1084,7 +1085,6 @@ class _ManageModelsScreenState extends State<ManageModelsScreen>
     _downloadUi.clearUiState();
     _downloadUi.clearRateTracking();
     _includeProjectorByFile.clear();
-    await _downloadUi.disposeDownloads();
     await _refreshDownloadedModelState(clearCacheStates: true);
 
     await _saveCustomModels();
@@ -1491,12 +1491,7 @@ class _ManageModelsScreenState extends State<ManageModelsScreen>
                         PopupMenuButton<_ModelLibraryMenuAction>(
                           tooltip: 'Model library actions',
                           icon: const Icon(Icons.more_horiz_rounded),
-                          onSelected: (action) {
-                            switch (action) {
-                              case _ModelLibraryMenuAction.removeAll:
-                                unawaited(_removeAllModels());
-                            }
-                          },
+                          onSelected: (_) => unawaited(_removeAllModels()),
                           itemBuilder: (context) => [
                             PopupMenuItem(
                               value: _ModelLibraryMenuAction.removeAll,

--- a/example/chat_app/lib/services/chat_service.dart
+++ b/example/chat_app/lib/services/chat_service.dart
@@ -172,6 +172,11 @@ class ChatService {
         !kIsWeb && defaultTargetPlatform == TargetPlatform.android;
     final isLiteRtLm = _isLiteRtLmModel(settings.modelPath);
     final usesGpuBackend = settings.preferredBackend != GpuBackend.cpu;
+    final resolvedGpuLayers = !usesGpuBackend
+        ? 0
+        : !kIsWeb && settings.gpuLayers >= 99
+        ? ModelParams.maxGpuLayers
+        : settings.gpuLayers;
     final usesVulkanBackend =
         settings.preferredBackend == GpuBackend.vulkan ||
         settings.preferredBackend == GpuBackend.auto;
@@ -233,7 +238,7 @@ class ChatService {
     final int? modelBytesHint = kIsWeb && hint > 0 ? hint : null;
 
     return ModelParams(
-      gpuLayers: settings.gpuLayers,
+      gpuLayers: resolvedGpuLayers,
       preferredBackend: settings.preferredBackend,
       contextSize: settings.contextSize,
       numberOfThreads: resolvedThreads,

--- a/example/chat_app/lib/services/model_download_ui_controller.dart
+++ b/example/chat_app/lib/services/model_download_ui_controller.dart
@@ -338,6 +338,9 @@ class ModelDownloadUiController extends ChangeNotifier {
     updateState(
       request.filename,
       isDownloading: true,
+      clearProgress: true,
+      clearDetail: true,
+      clearTask: true,
       clearQueue: true,
       notifyGlobalListeners: false,
     );
@@ -352,6 +355,9 @@ class ModelDownloadUiController extends ChangeNotifier {
       updateState(
         request.filename,
         isDownloading: false,
+        clearProgress: true,
+        clearDetail: true,
+        clearTask: true,
         isQueued: true,
         queuePosition: index + 1,
         notifyGlobalListeners: false,

--- a/example/chat_app/lib/services/model_download_ui_controller.dart
+++ b/example/chat_app/lib/services/model_download_ui_controller.dart
@@ -263,6 +263,20 @@ class ModelDownloadUiController extends ChangeNotifier {
 
   Future<void> disposeDownloads() async {
     _clearQueuedDownloads();
+    final activeFilename = _activeFilename;
+    _activeFilename = null;
+    _displayNameByFile.clear();
+    if (activeFilename != null) {
+      updateState(
+        activeFilename,
+        isDownloading: false,
+        clearProgress: true,
+        clearDetail: true,
+        clearTask: true,
+        clearQueue: true,
+        notifyGlobalListeners: false,
+      );
+    }
     for (final subscription in _downloadSubscriptions.values) {
       await subscription.cancel();
     }

--- a/example/chat_app/lib/services/model_download_ui_controller.dart
+++ b/example/chat_app/lib/services/model_download_ui_controller.dart
@@ -109,16 +109,18 @@ class ModelDownloadUiController extends ChangeNotifier {
     _notifyGlobalListeners();
   }
 
-  void registerDownload({
+  bool registerDownload({
     required String filename,
     required ModelDownloadController controller,
     required StreamSubscription<ModelDownloadTaskSnapshot> subscription,
   }) {
+    if (!canRegisterDownload(filename)) {
+      return false;
+    }
     _downloadControllers[filename] = controller;
     _downloadSubscriptions[filename] = subscription;
-    if (_activeFilename == filename) {
-      _registeredActiveDownloads.add(filename);
-    }
+    _registeredActiveDownloads.add(filename);
+    return true;
   }
 
   /// Whether the promoted request may register its low-level controller.

--- a/example/chat_app/lib/services/model_download_ui_controller.dart
+++ b/example/chat_app/lib/services/model_download_ui_controller.dart
@@ -18,6 +18,8 @@ class ModelDownloadUiController extends ChangeNotifier {
       StreamController<String>.broadcast(sync: true);
   final List<_QueuedDownloadRequest> _queue = [];
   final Map<String, String> _displayNameByFile = {};
+  final Set<String> _registeredActiveDownloads = {};
+  final Set<String> _cancelledBeforeRegistration = {};
   String? _activeFilename;
   bool _isDisposed = false;
 
@@ -92,6 +94,8 @@ class ModelDownloadUiController extends ChangeNotifier {
     if (_activeFilename != filename) {
       return;
     }
+    _registeredActiveDownloads.remove(filename);
+    _cancelledBeforeRegistration.remove(filename);
     _activeFilename = null;
     _displayNameByFile.remove(filename);
     updateState(
@@ -112,6 +116,16 @@ class ModelDownloadUiController extends ChangeNotifier {
   }) {
     _downloadControllers[filename] = controller;
     _downloadSubscriptions[filename] = subscription;
+    if (_activeFilename == filename) {
+      _registeredActiveDownloads.add(filename);
+    }
+  }
+
+  /// Whether the promoted request may register its low-level controller.
+  bool canRegisterDownload(String filename) {
+    return !_isDisposed &&
+        _activeFilename == filename &&
+        !_cancelledBeforeRegistration.contains(filename);
   }
 
   void updateState(
@@ -230,6 +244,23 @@ class ModelDownloadUiController extends ChangeNotifier {
       _notifyGlobalListeners();
       return;
     }
+    if (_activeFilename == filename &&
+        !_registeredActiveDownloads.contains(filename)) {
+      // The queue promotes a request before the screen can register its
+      // low-level controller. Preserve the active slot until the screen
+      // observes this cancellation, preventing a same-file retry from racing
+      // the old attempt's cleanup.
+      _cancelledBeforeRegistration.add(filename);
+      updateState(
+        filename,
+        isDownloading: false,
+        clearProgress: true,
+        clearDetail: true,
+        clearTask: true,
+        clearQueue: true,
+      );
+      return;
+    }
     _downloadControllers[filename]?.cancel();
   }
 
@@ -255,6 +286,7 @@ class ModelDownloadUiController extends ChangeNotifier {
 
     final currentController = _downloadControllers[filename];
     if (controller == null || identical(currentController, controller)) {
+      _registeredActiveDownloads.remove(filename);
       await _downloadControllers.remove(filename)?.dispose();
     } else {
       await controller.dispose();
@@ -266,6 +298,8 @@ class ModelDownloadUiController extends ChangeNotifier {
     final activeFilename = _activeFilename;
     _activeFilename = null;
     _displayNameByFile.clear();
+    _registeredActiveDownloads.clear();
+    _cancelledBeforeRegistration.clear();
     if (activeFilename != null) {
       updateState(
         activeFilename,
@@ -367,6 +401,8 @@ class ModelDownloadUiController extends ChangeNotifier {
       unawaited(controller.dispose());
     }
     _downloadControllers.clear();
+    _registeredActiveDownloads.clear();
+    _cancelledBeforeRegistration.clear();
     for (final notifier in _uiStateByFile.values) {
       notifier.dispose();
     }

--- a/example/chat_app/lib/services/model_download_ui_controller.dart
+++ b/example/chat_app/lib/services/model_download_ui_controller.dart
@@ -6,7 +6,7 @@ import 'package:llamadart/llamadart.dart' hide ModelDownloadProgress;
 import 'model_service_base.dart';
 
 /// Owns model-download tasks and their presentation state for the chat app.
-class ModelDownloadUiController {
+class ModelDownloadUiController extends ChangeNotifier {
   final Map<String, ValueNotifier<ModelDownloadUiState>> _uiStateByFile = {};
   final Map<String, int> _lastDownloadedBytes = {};
   final Map<String, DateTime> _lastDownloadSampleAt = {};
@@ -16,7 +16,24 @@ class ModelDownloadUiController {
   _downloadSubscriptions = {};
   final StreamController<String> _downloadsFinished =
       StreamController<String>.broadcast(sync: true);
+  final List<_QueuedDownloadRequest> _queue = [];
+  final Map<String, String> _displayNameByFile = {};
+  String? _activeFilename;
   bool _isDisposed = false;
+
+  String? get activeFilename => _activeFilename;
+
+  String? get activeDisplayName =>
+      _activeFilename == null ? null : _displayNameByFile[_activeFilename!];
+
+  ModelDownloadUiState? get activeState =>
+      _activeFilename == null ? null : _uiStateByFile[_activeFilename!]?.value;
+
+  int get queuedCount => _queue.length;
+
+  int get pendingCount => (_activeFilename == null ? 0 : 1) + _queue.length;
+
+  bool get hasPendingDownloads => pendingCount > 0;
 
   /// Emits a filename whenever a download succeeds, fails, or is cancelled.
   ///
@@ -46,6 +63,48 @@ class ModelDownloadUiController {
     return _downloadControllers[filename]?.snapshot.isRunning ?? false;
   }
 
+  bool isQueued(String filename) {
+    return _queue.any((request) => request.filename == filename);
+  }
+
+  bool isPending(String filename) {
+    return _activeFilename == filename || isQueued(filename);
+  }
+
+  Future<bool> enqueueDownload({
+    required String filename,
+    required String displayName,
+  }) {
+    if (_isDisposed || isPending(filename)) {
+      return Future.value(false);
+    }
+
+    final request = _QueuedDownloadRequest(filename: filename);
+    _displayNameByFile[filename] = displayName;
+    _queue.add(request);
+    _startNextDownload();
+    _syncQueuedStates();
+    _notifyGlobalListeners();
+    return request.ready.future;
+  }
+
+  void completeActiveDownload(String filename) {
+    if (_activeFilename != filename) {
+      return;
+    }
+    _activeFilename = null;
+    _displayNameByFile.remove(filename);
+    updateState(
+      filename,
+      isDownloading: false,
+      clearQueue: true,
+      notifyGlobalListeners: false,
+    );
+    _startNextDownload();
+    _syncQueuedStates();
+    _notifyGlobalListeners();
+  }
+
   void registerDownload({
     required String filename,
     required ModelDownloadController controller,
@@ -64,6 +123,10 @@ class ModelDownloadUiController {
     bool clearDetail = false,
     bool clearTask = false,
     bool clearProgress = false,
+    bool? isQueued,
+    int? queuePosition,
+    bool clearQueue = false,
+    bool notifyGlobalListeners = true,
   }) {
     if (_isDisposed) {
       return;
@@ -77,7 +140,13 @@ class ModelDownloadUiController {
       task: task,
       clearDetail: clearDetail,
       clearTask: clearTask,
+      isQueued: isQueued,
+      queuePosition: queuePosition,
+      clearQueue: clearQueue,
     );
+    if (notifyGlobalListeners) {
+      _notifyGlobalListeners();
+    }
   }
 
   void updateDownloadRate(String filename, ModelDownloadProgress detail) {
@@ -139,6 +208,28 @@ class ModelDownloadUiController {
   }
 
   void cancel(String filename) {
+    final queuedIndex = _queue.indexWhere(
+      (request) => request.filename == filename,
+    );
+    if (queuedIndex >= 0) {
+      final request = _queue.removeAt(queuedIndex);
+      _displayNameByFile.remove(filename);
+      if (!request.ready.isCompleted) {
+        request.ready.complete(false);
+      }
+      updateState(
+        filename,
+        isDownloading: false,
+        clearProgress: true,
+        clearDetail: true,
+        clearTask: true,
+        clearQueue: true,
+        notifyGlobalListeners: false,
+      );
+      _syncQueuedStates();
+      _notifyGlobalListeners();
+      return;
+    }
     _downloadControllers[filename]?.cancel();
   }
 
@@ -171,6 +262,7 @@ class ModelDownloadUiController {
   }
 
   Future<void> disposeDownloads() async {
+    _clearQueuedDownloads();
     for (final subscription in _downloadSubscriptions.values) {
       await subscription.cancel();
     }
@@ -179,20 +271,80 @@ class ModelDownloadUiController {
       await controller.dispose();
     }
     _downloadControllers.clear();
+    _notifyGlobalListeners();
   }
 
   void clearUiState() {
     for (final notifier in _uiStateByFile.values) {
       notifier.value = const ModelDownloadUiState();
     }
+    _notifyGlobalListeners();
   }
 
+  void _startNextDownload() {
+    if (_isDisposed || _activeFilename != null || _queue.isEmpty) {
+      return;
+    }
+    final request = _queue.removeAt(0);
+    _activeFilename = request.filename;
+    updateState(
+      request.filename,
+      isDownloading: true,
+      clearQueue: true,
+      notifyGlobalListeners: false,
+    );
+    if (!request.ready.isCompleted) {
+      request.ready.complete(true);
+    }
+  }
+
+  void _syncQueuedStates() {
+    for (var index = 0; index < _queue.length; index += 1) {
+      final request = _queue[index];
+      updateState(
+        request.filename,
+        isDownloading: false,
+        isQueued: true,
+        queuePosition: index + 1,
+        notifyGlobalListeners: false,
+      );
+    }
+  }
+
+  void _clearQueuedDownloads() {
+    final queued = List<_QueuedDownloadRequest>.from(_queue);
+    _queue.clear();
+    for (final request in queued) {
+      _displayNameByFile.remove(request.filename);
+      if (!request.ready.isCompleted) {
+        request.ready.complete(false);
+      }
+      updateState(
+        request.filename,
+        isDownloading: false,
+        clearProgress: true,
+        clearDetail: true,
+        clearTask: true,
+        clearQueue: true,
+        notifyGlobalListeners: false,
+      );
+    }
+  }
+
+  void _notifyGlobalListeners() {
+    if (!_isDisposed) {
+      notifyListeners();
+    }
+  }
+
+  @override
   void dispose() {
     if (_isDisposed) {
       return;
     }
     _isDisposed = true;
     pauseActiveDownloads();
+    _clearQueuedDownloads();
     for (final subscription in _downloadSubscriptions.values) {
       unawaited(subscription.cancel());
     }
@@ -207,7 +359,15 @@ class ModelDownloadUiController {
     _uiStateByFile.clear();
     clearRateTracking();
     unawaited(_downloadsFinished.close());
+    super.dispose();
   }
+}
+
+class _QueuedDownloadRequest {
+  final String filename;
+  final Completer<bool> ready = Completer<bool>();
+
+  _QueuedDownloadRequest({required this.filename});
 }
 
 class ModelDownloadUiState {
@@ -215,12 +375,16 @@ class ModelDownloadUiState {
   final double progress;
   final ModelDownloadProgress? detail;
   final ModelDownloadTaskSnapshot? task;
+  final bool isQueued;
+  final int? queuePosition;
 
   const ModelDownloadUiState({
     this.isDownloading = false,
     this.progress = 0.0,
     this.detail,
     this.task,
+    this.isQueued = false,
+    this.queuePosition,
   });
 
   ModelDownloadUiState copyWith({
@@ -230,6 +394,9 @@ class ModelDownloadUiState {
     ModelDownloadTaskSnapshot? task,
     bool clearDetail = false,
     bool clearTask = false,
+    bool? isQueued,
+    int? queuePosition,
+    bool clearQueue = false,
   }) {
     final normalizedProgress =
         ((progress ?? this.progress).clamp(0.0, 1.0) as num).toDouble();
@@ -239,6 +406,8 @@ class ModelDownloadUiState {
       progress: normalizedProgress,
       detail: clearDetail ? null : (detail ?? this.detail),
       task: clearTask ? null : (task ?? this.task),
+      isQueued: clearQueue ? false : (isQueued ?? this.isQueued),
+      queuePosition: clearQueue ? null : (queuePosition ?? this.queuePosition),
     );
   }
 }

--- a/example/chat_app/lib/services/runtime_profile_service.dart
+++ b/example/chat_app/lib/services/runtime_profile_service.dart
@@ -1,3 +1,5 @@
+import 'dart:math' as math;
+
 import 'package:llamadart/llamadart.dart';
 
 import '../utils/backend_utils.dart';
@@ -73,8 +75,16 @@ class RuntimeProfileService {
     required bool isWeb,
     required GpuBackend preferredBackend,
     required int currentContextSize,
+    int modelBytes = 0,
     String? backendInfo,
   }) {
+    final requestedContext = currentContextSize <= 0
+        ? 4096
+        : currentContextSize.clamp(2048, 32768).toInt();
+    if (preferredBackend == GpuBackend.cpu) {
+      return (gpuLayers: 0, contextSize: requestedContext);
+    }
+
     if (totalVramBytes <= 0) {
       return (
         gpuLayers: _fallbackEstimatedGpuLayers(
@@ -82,27 +92,68 @@ class RuntimeProfileService {
           preferredBackend: preferredBackend,
           backendInfo: backendInfo,
         ),
-        contextSize: currentContextSize == 0
-            ? 4096
-            : currentContextSize.clamp(2048, 32768),
+        contextSize: requestedContext,
       );
     }
 
     final freeVramGb = freeVramBytes / (1024 * 1024 * 1024);
-    var recommendedLayers = (freeVramGb * 24).round();
-    if (recommendedLayers > 98) {
-      recommendedLayers = 98;
-    }
-    if (recommendedLayers < 0) {
-      recommendedLayers = 0;
-    }
-
-    var recommendedContext = 4096;
-    if (freeVramGb < 2.0) {
-      recommendedContext = 2048;
+    if (isWeb || modelBytes <= 0) {
+      final recommendedLayers = (freeVramGb * 24).round().clamp(0, 98);
+      return (
+        gpuLayers: recommendedLayers,
+        contextSize: freeVramGb < 2 ? 2048 : math.min(requestedContext, 4096),
+      );
     }
 
-    return (gpuLayers: recommendedLayers, contextSize: recommendedContext);
+    // Device memory can be unified with system RAM (Apple Silicon) or
+    // dedicated VRAM. Keep both a percentage reserve and current-free-memory
+    // reserve so Auto does not crowd out the OS and other applications.
+    final reportedFree = freeVramBytes > 0
+        ? math.min(freeVramBytes, totalVramBytes)
+        : totalVramBytes;
+    final safeBudget = math.min(
+      (reportedFree * 0.90).floor(),
+      (totalVramBytes * 0.80).floor(),
+    );
+
+    var recommendedContext = requestedContext;
+    while (recommendedContext > 4096 &&
+        _estimatedRuntimeBytes(modelBytes, recommendedContext) > safeBudget) {
+      recommendedContext = math.max(4096, recommendedContext ~/ 2);
+    }
+
+    final requiredBytes = _estimatedRuntimeBytes(
+      modelBytes,
+      recommendedContext,
+    );
+    if (requiredBytes <= safeBudget) {
+      return (
+        gpuLayers: ModelParams.maxGpuLayers,
+        contextSize: recommendedContext,
+      );
+    }
+
+    final runtimeOverhead = _estimatedRuntimeOverhead(recommendedContext);
+    final availableWeightBytes = math.max(0, safeBudget - runtimeOverhead);
+    final reservedWeightBytes = (modelBytes * 1.18).ceil();
+    final offloadRatio = reservedWeightBytes <= 0
+        ? 0.0
+        : (availableWeightBytes / reservedWeightBytes).clamp(0.0, 1.0);
+    return (
+      gpuLayers: (offloadRatio * 98).floor().clamp(0, 98),
+      contextSize: recommendedContext,
+    );
+  }
+
+  int _estimatedRuntimeBytes(int modelBytes, int contextSize) {
+    return (modelBytes * 1.18).ceil() + _estimatedRuntimeOverhead(contextSize);
+  }
+
+  int _estimatedRuntimeOverhead(int contextSize) {
+    const gib = 1024 * 1024 * 1024;
+    const contextChunkBytes = 512 * 1024 * 1024;
+    final contextChunks = math.max(1, (contextSize / 4096).ceil());
+    return gib + (contextChunks * contextChunkBytes);
   }
 
   int _fallbackEstimatedGpuLayers({

--- a/example/chat_app/lib/services/settings_service.dart
+++ b/example/chat_app/lib/services/settings_service.dart
@@ -1,3 +1,4 @@
+import 'package:flutter/foundation.dart';
 import 'package:shared_preferences/shared_preferences.dart';
 
 import 'package:llamadart/llamadart.dart';
@@ -16,6 +17,9 @@ class SettingsService {
   static const _keyContext = 'context_size';
   static const _keyMaxTokens = 'max_tokens';
   static const _keyGpuLayers = 'gpu_layers';
+  static const _keyAutoTuneModelParams = 'auto_tune_model_params';
+  static const _keyAutoTuneRequestedContext =
+      'auto_tune_requested_context_size';
   static const _keyThreads = 'threads';
   static const _keyThreadsBatch = 'threads_batch';
   static const _keyLogLevel = 'log_level';
@@ -25,6 +29,9 @@ class SettingsService {
   static const _keyThinkingEnabled = 'thinking_enabled';
   static const _keyThinkingBudgetTokens = 'thinking_budget_tokens';
   static const _keySingleTurnMode = 'single_turn_mode';
+  static const _keyModelSupportsVision = 'model_supports_vision';
+  static const _keyModelSupportsAudio = 'model_supports_audio';
+  static const _keyDirectMediaInput = 'direct_media_input';
   static const _keyModelBytesHint = 'model_bytes_hint';
 
   static const Map<String, String> _modelPathMigrations = {
@@ -45,6 +52,20 @@ class SettingsService {
     return LlamaLogLevel.values[index];
   }
 
+  bool _isNativeGemma4LiteRtLm(String? modelPath) {
+    if (kIsWeb || modelPath == null) {
+      return false;
+    }
+    final normalized = modelPath
+        .split('?')
+        .first
+        .split('#')
+        .first
+        .toLowerCase();
+    return normalized.endsWith('.litertlm') &&
+        (normalized.contains('gemma-4') || normalized.contains('gemma4'));
+  }
+
   Future<ChatSettings> loadSettings() async {
     final prefs = await SharedPreferences.getInstance();
     final savedModelPath = prefs.getString(_keyModelPath);
@@ -62,12 +83,14 @@ class SettingsService {
         ? GpuBackend.values[backendIndex]
         : GpuBackend.auto;
     final savedContextSize = prefs.getInt(_keyContext);
+    final savedGpuLayers = prefs.getInt(_keyGpuLayers);
     final effectiveContextSize = switch (savedContextSize) {
       null => 4096,
       0 => 0,
       < 512 => 4096,
       _ => savedContextSize,
     };
+    final migrateNativeGemma4Audio = _isNativeGemma4LiteRtLm(migratedModelPath);
 
     return ChatSettings(
       modelPath: migratedModelPath,
@@ -80,7 +103,15 @@ class SettingsService {
       penalty: prefs.getDouble(_keyPenalty) ?? 1.1,
       contextSize: effectiveContextSize,
       maxTokens: prefs.getInt(_keyMaxTokens) ?? 4096,
-      gpuLayers: prefs.getInt(_keyGpuLayers) ?? 32,
+      gpuLayers: savedGpuLayers ?? 32,
+      autoTuneModelParams:
+          prefs.getBool(_keyAutoTuneModelParams) ??
+          (preferredBackend == GpuBackend.auto &&
+              (savedGpuLayers == null ||
+                  savedGpuLayers == 32 ||
+                  savedGpuLayers >= 99)),
+      autoTuneRequestedContextSize:
+          prefs.getInt(_keyAutoTuneRequestedContext) ?? effectiveContextSize,
       numberOfThreads: prefs.getInt(_keyThreads) ?? 0,
       numberOfThreadsBatch: prefs.getInt(_keyThreadsBatch) ?? 0,
       logLevel: _parseLogLevel(prefs.getInt(_keyLogLevel), LlamaLogLevel.none),
@@ -93,6 +124,11 @@ class SettingsService {
       thinkingEnabled: prefs.getBool(_keyThinkingEnabled) ?? true,
       thinkingBudgetTokens: prefs.getInt(_keyThinkingBudgetTokens) ?? 0,
       singleTurnMode: prefs.getBool(_keySingleTurnMode) ?? false,
+      modelSupportsVision: prefs.getBool(_keyModelSupportsVision) ?? false,
+      modelSupportsAudio:
+          prefs.getBool(_keyModelSupportsAudio) ?? migrateNativeGemma4Audio,
+      directMediaInput:
+          prefs.getBool(_keyDirectMediaInput) ?? migrateNativeGemma4Audio,
       modelBytesHint: prefs.getInt(_keyModelBytesHint),
     );
   }
@@ -116,6 +152,16 @@ class SettingsService {
     await prefs.setInt(_keyContext, settings.contextSize);
     await prefs.setInt(_keyMaxTokens, settings.maxTokens);
     await prefs.setInt(_keyGpuLayers, settings.gpuLayers);
+    await prefs.setBool(_keyAutoTuneModelParams, settings.autoTuneModelParams);
+    final autoTuneRequestedContextSize = settings.autoTuneRequestedContextSize;
+    if (autoTuneRequestedContextSize != null) {
+      await prefs.setInt(
+        _keyAutoTuneRequestedContext,
+        autoTuneRequestedContextSize,
+      );
+    } else {
+      await prefs.remove(_keyAutoTuneRequestedContext);
+    }
     await prefs.setInt(_keyThreads, settings.numberOfThreads);
     await prefs.setInt(_keyThreadsBatch, settings.numberOfThreadsBatch);
     await prefs.setInt(_keyLogLevel, settings.logLevel.index);
@@ -125,6 +171,9 @@ class SettingsService {
     await prefs.setBool(_keyThinkingEnabled, settings.thinkingEnabled);
     await prefs.setInt(_keyThinkingBudgetTokens, settings.thinkingBudgetTokens);
     await prefs.setBool(_keySingleTurnMode, settings.singleTurnMode);
+    await prefs.setBool(_keyModelSupportsVision, settings.modelSupportsVision);
+    await prefs.setBool(_keyModelSupportsAudio, settings.modelSupportsAudio);
+    await prefs.setBool(_keyDirectMediaInput, settings.directMediaInput);
     final modelBytesHint = settings.modelBytesHint;
     if (modelBytesHint != null && modelBytesHint > 0) {
       await prefs.setInt(_keyModelBytesHint, modelBytesHint);

--- a/example/chat_app/lib/widgets/model_card.dart
+++ b/example/chat_app/lib/widgets/model_card.dart
@@ -284,11 +284,10 @@ class ModelCard extends StatelessWidget {
                   tooltip: 'Model actions',
                   icon: const Icon(Icons.more_horiz_rounded),
                   onSelected: (action) {
-                    switch (action) {
-                      case _ModelCardMenuAction.removeFromLibrary:
-                        onRemoveFromLibrary?.call();
-                      case _ModelCardMenuAction.deleteCachedAssets:
-                        onDelete();
+                    if (action == _ModelCardMenuAction.removeFromLibrary) {
+                      onRemoveFromLibrary?.call();
+                    } else {
+                      onDelete();
                     }
                   },
                   itemBuilder: (context) => [

--- a/example/chat_app/lib/widgets/model_card.dart
+++ b/example/chat_app/lib/widgets/model_card.dart
@@ -3,15 +3,20 @@ import 'package:flutter/material.dart';
 import '../models/downloadable_model.dart';
 import '../services/model_service_base.dart';
 
+enum _ModelCardMenuAction { removeFromLibrary, deleteCachedAssets }
+
 class ModelCard extends StatelessWidget {
   final DownloadableModel model;
   final bool isDownloaded;
   final ModelProfileCacheState? cacheState;
   final bool isDownloading;
+  final bool isQueued;
+  final int? queuePosition;
   final double progress;
   final String? downloadStatusLabel;
   final String? downloadTransferLabel;
   final bool isWeb;
+  final bool isAvailableOnCurrentPlatform;
   final bool isSelected;
   final int gpuLayers;
   final int contextSize;
@@ -20,6 +25,8 @@ class ModelCard extends StatelessWidget {
   final VoidCallback? onSelect;
   final VoidCallback onDownload;
   final VoidCallback onDelete;
+  final bool isCustom;
+  final VoidCallback? onRemoveFromLibrary;
   final VoidCallback? onCancel;
   final bool includeProjector;
   final ValueChanged<bool>? onIncludeProjectorChanged;
@@ -30,10 +37,13 @@ class ModelCard extends StatelessWidget {
     required this.isDownloaded,
     this.cacheState,
     required this.isDownloading,
+    this.isQueued = false,
+    this.queuePosition,
     required this.progress,
     this.downloadStatusLabel,
     this.downloadTransferLabel,
     required this.isWeb,
+    this.isAvailableOnCurrentPlatform = true,
     required this.isSelected,
     required this.gpuLayers,
     required this.contextSize,
@@ -42,6 +52,8 @@ class ModelCard extends StatelessWidget {
     required this.onSelect,
     required this.onDownload,
     required this.onDelete,
+    this.isCustom = false,
+    this.onRemoveFromLibrary,
     this.onCancel,
     this.includeProjector = true,
     this.onIncludeProjectorChanged,
@@ -73,6 +85,7 @@ class ModelCard extends StatelessWidget {
         (defaultTargetPlatform == TargetPlatform.android ||
             defaultTargetPlatform == TargetPlatform.iOS);
     final shouldShowProjectorOption =
+        isAvailableOnCurrentPlatform &&
         isProjectorMissing &&
         !isDownloading &&
         onIncludeProjectorChanged != null &&
@@ -91,13 +104,21 @@ class ModelCard extends StatelessWidget {
     final downloadToggleLabel = isDownloading
         ? 'Pause Download'
         : 'Resume Download';
+    final platformLabel = model.isNativeDesktopOnly
+        ? 'Desktop'
+        : 'All platforms';
+    final unavailableLabel = model.isNativeDesktopOnly
+        ? 'Available on desktop'
+        : 'Unavailable on this platform';
 
     return Container(
       decoration: BoxDecoration(
-        color: colorScheme.surfaceContainer,
-        borderRadius: BorderRadius.circular(8),
+        color: colorScheme.surfaceContainerLow,
+        borderRadius: BorderRadius.circular(16),
         border: Border.all(
-          color: colorScheme.outlineVariant.withValues(alpha: 0.24),
+          color: isSelected
+              ? colorScheme.primary.withValues(alpha: 0.55)
+              : colorScheme.outlineVariant.withValues(alpha: 0.38),
         ),
       ),
       padding: const EdgeInsets.all(16),
@@ -115,35 +136,67 @@ class ModelCard extends StatelessWidget {
                       model.name,
                       style: TextStyle(
                         fontSize: 18,
-                        fontWeight: FontWeight.bold,
+                        fontWeight: FontWeight.w700,
                         color: colorScheme.onSurface,
                       ),
                     ),
-                    const SizedBox(height: 4),
+                    if (model.distribution case final distribution?) ...[
+                      const SizedBox(height: 3),
+                      Text(
+                        '$distribution distribution',
+                        style: TextStyle(
+                          fontSize: 12,
+                          color: colorScheme.onSurfaceVariant,
+                        ),
+                      ),
+                    ],
+                    if (isSelected || isDownloaded) ...[
+                      const SizedBox(height: 8),
+                      Wrap(
+                        spacing: 6,
+                        runSpacing: 6,
+                        children: [
+                          if (isSelected)
+                            _buildStatusChip(
+                              context,
+                              icon: Icons.check_circle_rounded,
+                              label: 'Selected',
+                              emphasize: true,
+                            ),
+                          if (isDownloaded)
+                            _buildStatusChip(
+                              context,
+                              icon: Icons.download_done_rounded,
+                              label: isWeb ? 'Cached' : 'Downloaded',
+                            ),
+                        ],
+                      ),
+                    ],
+                    const SizedBox(height: 10),
                     Wrap(
-                      spacing: 8,
-                      runSpacing: 8,
+                      spacing: 6,
+                      runSpacing: 6,
                       children: [
                         _buildMetaChip(
                           context,
                           icon: Icons.sd_storage_outlined,
-                          label: '${model.sizeMb} MB',
+                          label: model.sizeLabelFor(web: isWeb),
                         ),
                         _buildMetaChip(
                           context,
                           icon: Icons.memory_rounded,
                           label: '${model.minRamGb} GB RAM',
                         ),
-                        if (isSelected)
-                          _buildMetaChip(
-                            context,
-                            icon: Icons.check_circle_outline_rounded,
-                            label: 'Selected',
-                            emphasize: true,
-                          ),
+                        _buildMetaChip(
+                          context,
+                          icon: model.isNativeDesktopOnly
+                              ? Icons.desktop_mac_outlined
+                              : Icons.devices_rounded,
+                          label: platformLabel,
+                        ),
                       ],
                     ),
-                    if (cacheState != null) ...[
+                    if (cacheState != null && cacheState!.hasPartialAssets) ...[
                       const SizedBox(height: 10),
                       Wrap(
                         spacing: 8,
@@ -190,21 +243,21 @@ class ModelCard extends StatelessWidget {
                             label: 'Thinking',
                             supported: true,
                           ),
-                        if (model.supportsVision)
+                        if (model.supportsVisionFor(web: isWeb))
                           _buildCapabilityChip(
                             context,
                             icon: Icons.visibility_outlined,
                             label: 'Vision',
                             supported: true,
                           ),
-                        if (model.supportsAudio)
+                        if (model.supportsAudioFor(web: isWeb))
                           _buildCapabilityChip(
                             context,
                             icon: Icons.mic_none_rounded,
                             label: 'Audio',
                             supported: true,
                           ),
-                        if (model.supportsVideo)
+                        if (model.supportsVideoFor(web: isWeb))
                           _buildCapabilityChip(
                             context,
                             icon: Icons.videocam_outlined,
@@ -216,7 +269,48 @@ class ModelCard extends StatelessWidget {
                   ],
                 ),
               ),
-              if (hasAnyCachedAsset || (progress > 0 && !isDownloaded))
+              if (!isQueued && progress > 0 && !isDownloaded)
+                IconButton(
+                  icon: Icon(
+                    Icons.delete_outline_rounded,
+                    color: colorScheme.error,
+                    semanticLabel: kIsWeb ? null : deleteActionLabel,
+                  ),
+                  onPressed: onDelete,
+                  tooltip: deleteActionLabel,
+                )
+              else if (!isDownloading && !isQueued && isCustom)
+                PopupMenuButton<_ModelCardMenuAction>(
+                  tooltip: 'Model actions',
+                  icon: const Icon(Icons.more_horiz_rounded),
+                  onSelected: (action) {
+                    switch (action) {
+                      case _ModelCardMenuAction.removeFromLibrary:
+                        onRemoveFromLibrary?.call();
+                      case _ModelCardMenuAction.deleteCachedAssets:
+                        onDelete();
+                    }
+                  },
+                  itemBuilder: (context) => [
+                    const PopupMenuItem(
+                      value: _ModelCardMenuAction.removeFromLibrary,
+                      child: _ModelMenuItem(
+                        icon: Icons.remove_circle_outline_rounded,
+                        label: 'Remove from library',
+                      ),
+                    ),
+                    if (hasAnyCachedAsset)
+                      const PopupMenuItem(
+                        value: _ModelCardMenuAction.deleteCachedAssets,
+                        child: _ModelMenuItem(
+                          icon: Icons.delete_outline_rounded,
+                          label: 'Delete downloaded files',
+                          destructive: true,
+                        ),
+                      ),
+                  ],
+                )
+              else if (hasAnyCachedAsset)
                 IconButton(
                   icon: Icon(
                     Icons.delete_outline_rounded,
@@ -231,12 +325,46 @@ class ModelCard extends StatelessWidget {
           const SizedBox(height: 12),
           Text(
             model.description,
+            maxLines: 3,
+            overflow: TextOverflow.ellipsis,
             style: TextStyle(
               color: colorScheme.onSurfaceVariant,
               fontSize: 14,
               height: 1.4,
             ),
           ),
+          if (!isAvailableOnCurrentPlatform) ...[
+            const SizedBox(height: 10),
+            Container(
+              width: double.infinity,
+              padding: const EdgeInsets.symmetric(horizontal: 10, vertical: 8),
+              decoration: BoxDecoration(
+                color: colorScheme.surfaceContainerHighest.withValues(
+                  alpha: 0.55,
+                ),
+                borderRadius: BorderRadius.circular(10),
+              ),
+              child: Row(
+                children: [
+                  Icon(
+                    Icons.info_outline_rounded,
+                    size: 17,
+                    color: colorScheme.onSurfaceVariant,
+                  ),
+                  const SizedBox(width: 8),
+                  Expanded(
+                    child: Text(
+                      '$unavailableLabel. Switch platforms to use this model.',
+                      style: TextStyle(
+                        fontSize: 12,
+                        color: colorScheme.onSurfaceVariant,
+                      ),
+                    ),
+                  ),
+                ],
+              ),
+            ),
+          ],
           if (partialCacheMessage != null) ...[
             const SizedBox(height: 10),
             Container(
@@ -330,27 +458,73 @@ class ModelCard extends StatelessWidget {
             ),
             const SizedBox(height: 12),
           ],
-          Wrap(
-            spacing: 8,
-            runSpacing: 8,
+          Row(
             children: [
-              _buildParamChip(
-                context,
-                label: 'T ${model.preset.temperature.toStringAsFixed(2)}',
+              Icon(
+                Icons.tune_rounded,
+                size: 15,
+                color: colorScheme.onSurfaceVariant,
               ),
-              _buildParamChip(context, label: 'K ${model.preset.topK}'),
-              _buildParamChip(
-                context,
-                label: 'P ${model.preset.topP.toStringAsFixed(2)}',
+              const SizedBox(width: 7),
+              Expanded(
+                child: Text(
+                  'Recommended · ${_formatTokenCount(model.preset.contextSize)} context · ${_formatTokenCount(model.preset.maxTokens)} output',
+                  maxLines: 1,
+                  overflow: TextOverflow.ellipsis,
+                  style: TextStyle(
+                    fontSize: 11,
+                    color: colorScheme.onSurfaceVariant,
+                  ),
+                ),
               ),
-              _buildParamChip(
-                context,
-                label: 'Ctx ${model.preset.contextSize}',
-              ),
-              _buildParamChip(context, label: 'Gen ${model.preset.maxTokens}'),
             ],
           ),
           const SizedBox(height: 16),
+          if (isQueued) ...[
+            Container(
+              padding: const EdgeInsets.fromLTRB(12, 10, 8, 10),
+              decoration: BoxDecoration(
+                color: colorScheme.secondaryContainer.withValues(alpha: 0.45),
+                borderRadius: BorderRadius.circular(8),
+                border: Border.all(
+                  color: colorScheme.outlineVariant.withValues(alpha: 0.45),
+                ),
+              ),
+              child: Row(
+                children: [
+                  Icon(
+                    Icons.format_list_numbered_rounded,
+                    size: 18,
+                    color: colorScheme.onSecondaryContainer,
+                  ),
+                  const SizedBox(width: 10),
+                  Expanded(
+                    child: Text(
+                      queuePosition == null
+                          ? 'Queued for download'
+                          : 'Queued for download • Position $queuePosition',
+                      maxLines: 2,
+                      overflow: TextOverflow.ellipsis,
+                      style: TextStyle(
+                        fontSize: 12,
+                        color: colorScheme.onSecondaryContainer,
+                        fontWeight: FontWeight.w600,
+                      ),
+                    ),
+                  ),
+                  IconButton(
+                    onPressed: onCancel,
+                    tooltip: 'Remove from download queue',
+                    icon: Icon(
+                      Icons.close_rounded,
+                      size: 18,
+                      color: colorScheme.onSecondaryContainer,
+                    ),
+                  ),
+                ],
+              ),
+            ),
+          ],
           if (isDownloading || (progress > 0 && !isDownloaded)) ...[
             ClipRRect(
               borderRadius: BorderRadius.circular(4),
@@ -442,7 +616,7 @@ class ModelCard extends StatelessWidget {
               ),
             ],
           ],
-          if (!isDownloading) ...[
+          if (!isDownloading && !isQueued) ...[
             if (isDownloaded && !isWeb && isSelected) ...[
               const SizedBox(height: 16),
               Theme(
@@ -545,7 +719,19 @@ class ModelCard extends StatelessWidget {
             const SizedBox(height: 16),
             SizedBox(
               width: double.infinity,
-              child: canLoadModel
+              child: !isAvailableOnCurrentPlatform
+                  ? OutlinedButton.icon(
+                      onPressed: null,
+                      icon: const Icon(Icons.block_rounded, size: 18),
+                      label: Text(unavailableLabel),
+                      style: OutlinedButton.styleFrom(
+                        padding: const EdgeInsets.symmetric(vertical: 16),
+                        shape: RoundedRectangleBorder(
+                          borderRadius: BorderRadius.circular(10),
+                        ),
+                      ),
+                    )
+                  : canLoadModel
                   ? FilledButton.icon(
                       onPressed: onSelect,
                       icon: Icon(
@@ -676,6 +862,50 @@ class ModelCard extends StatelessWidget {
     return value[0].toUpperCase() + value.substring(1);
   }
 
+  String _formatTokenCount(int value) {
+    if (value >= 1024 && value % 1024 == 0) {
+      return '${value ~/ 1024}K';
+    }
+    return value.toString();
+  }
+
+  Widget _buildStatusChip(
+    BuildContext context, {
+    required IconData icon,
+    required String label,
+    bool emphasize = false,
+  }) {
+    final colorScheme = Theme.of(context).colorScheme;
+    final background = emphasize
+        ? colorScheme.primaryContainer
+        : colorScheme.tertiaryContainer.withValues(alpha: 0.65);
+    final foreground = emphasize
+        ? colorScheme.onPrimaryContainer
+        : colorScheme.onTertiaryContainer;
+    return Container(
+      padding: const EdgeInsets.symmetric(horizontal: 8, vertical: 4),
+      decoration: BoxDecoration(
+        color: background,
+        borderRadius: BorderRadius.circular(999),
+      ),
+      child: Row(
+        mainAxisSize: MainAxisSize.min,
+        children: [
+          Icon(icon, size: 13, color: foreground),
+          const SizedBox(width: 4),
+          Text(
+            label,
+            style: TextStyle(
+              fontSize: 11,
+              color: foreground,
+              fontWeight: FontWeight.w700,
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+
   Widget _buildMetaChip(
     BuildContext context, {
     required IconData icon,
@@ -760,33 +990,39 @@ class ModelCard extends StatelessWidget {
               ),
             ),
           ),
-          const SizedBox(width: 4),
-          Icon(
-            supported ? Icons.check_rounded : Icons.close_rounded,
-            size: 12,
-            color: foreground,
-          ),
         ],
       ),
     );
   }
+}
 
-  Widget _buildParamChip(BuildContext context, {required String label}) {
-    final colorScheme = Theme.of(context).colorScheme;
-    return Container(
-      padding: const EdgeInsets.symmetric(horizontal: 8, vertical: 4),
-      decoration: BoxDecoration(
-        color: colorScheme.tertiaryContainer.withValues(alpha: 0.45),
-        borderRadius: BorderRadius.circular(6),
-      ),
-      child: Text(
-        label,
-        style: TextStyle(
-          fontSize: 11,
-          color: colorScheme.onTertiaryContainer,
-          fontWeight: FontWeight.w500,
+class _ModelMenuItem extends StatelessWidget {
+  const _ModelMenuItem({
+    required this.icon,
+    required this.label,
+    this.destructive = false,
+  });
+
+  final IconData icon;
+  final String label;
+  final bool destructive;
+
+  @override
+  Widget build(BuildContext context) {
+    final color = destructive ? Theme.of(context).colorScheme.error : null;
+    return Row(
+      children: [
+        Icon(icon, size: 19, color: color),
+        const SizedBox(width: 12),
+        Expanded(
+          child: Text(
+            label,
+            maxLines: 1,
+            overflow: TextOverflow.ellipsis,
+            style: TextStyle(color: color),
+          ),
         ),
-      ),
+      ],
     );
   }
 }

--- a/example/chat_app/test/app_shell_screen_test.dart
+++ b/example/chat_app/test/app_shell_screen_test.dart
@@ -1,5 +1,6 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
+import 'package:llamadart/llamadart.dart' show GpuBackend;
 import 'package:provider/provider.dart';
 
 import 'package:llamadart_chat_example/models/chat_settings.dart';
@@ -191,6 +192,25 @@ void main() {
         find.textContaining('GPU layers is 0, so inference will run on CPU.'),
         findsOneWidget,
       );
+
+      provider.updateGpuLayers(99);
+      await provider.updatePreferredBackend(GpuBackend.cpu);
+      await tester.pumpAndSettle();
+      expect(find.text('Auto · Max'), findsNothing);
+      expect(find.text('Max'), findsOneWidget);
+      expect(
+        find.textContaining(
+          'Auto tuning recalculates GPU layers and context headroom',
+        ),
+        findsNothing,
+      );
+      expect(
+        find.textContaining(
+          'GPU layers controls how much of the model is offloaded',
+        ),
+        findsOneWidget,
+      );
+      await tester.pump(const Duration(milliseconds: 300));
     });
 
     testWidgets('shows change model action when settings panel is hidden', (

--- a/example/chat_app/test/app_shell_screen_test.dart
+++ b/example/chat_app/test/app_shell_screen_test.dart
@@ -73,6 +73,54 @@ void main() {
       downloadUi.completeActiveDownload('active.gguf');
     });
 
+    testWidgets('download activity keeps an open pinned settings panel open', (
+      tester,
+    ) async {
+      final oldSize = tester.view.physicalSize;
+      final oldRatio = tester.view.devicePixelRatio;
+      tester.view
+        ..physicalSize = const Size(1800, 900)
+        ..devicePixelRatio = 1.0;
+      addTearDown(() {
+        tester.view
+          ..physicalSize = oldSize
+          ..devicePixelRatio = oldRatio;
+      });
+
+      final provider = ChatProvider(
+        chatService: MockChatService(),
+        settingsService: MockSettingsService(),
+      );
+      addTearDown(provider.dispose);
+      final downloadUi = ModelDownloadUiController();
+      addTearDown(downloadUi.dispose);
+      await downloadUi.enqueueDownload(
+        filename: 'active.gguf',
+        displayName: 'Active model',
+      );
+      downloadUi.updateState('active.gguf', progress: 0.1);
+
+      await tester.pumpWidget(
+        ChangeNotifierProvider<ChatProvider>.value(
+          value: provider,
+          child: MaterialApp(
+            home: AppShellScreen(downloadUiController: downloadUi),
+          ),
+        ),
+      );
+      await tester.pumpAndSettle();
+
+      await tester.tap(find.byTooltip('Open model and inference settings'));
+      await tester.pumpAndSettle();
+      expect(find.text('Model parameters'), findsOneWidget);
+
+      await tester.tap(find.text('Active model'));
+      await tester.pumpAndSettle();
+      expect(find.text('Model parameters'), findsOneWidget);
+
+      downloadUi.completeActiveDownload('active.gguf');
+    });
+
     testWidgets('keeps desktop settings opt-in and opens manage models view', (
       tester,
     ) async {

--- a/example/chat_app/test/app_shell_screen_test.dart
+++ b/example/chat_app/test/app_shell_screen_test.dart
@@ -5,6 +5,7 @@ import 'package:provider/provider.dart';
 import 'package:llamadart_chat_example/models/chat_settings.dart';
 import 'package:llamadart_chat_example/providers/chat_provider.dart';
 import 'package:llamadart_chat_example/screens/app_shell_screen.dart';
+import 'package:llamadart_chat_example/services/model_download_ui_controller.dart';
 
 import 'mocks.dart';
 
@@ -14,6 +15,62 @@ void main() {
   group('AppShellScreen', () {
     setUp(() {
       TestWidgetsFlutterBinding.ensureInitialized();
+    });
+
+    testWidgets('keeps active download progress visible outside settings', (
+      tester,
+    ) async {
+      final oldSize = tester.view.physicalSize;
+      final oldRatio = tester.view.devicePixelRatio;
+      tester.view
+        ..physicalSize = const Size(854, 700)
+        ..devicePixelRatio = 1.0;
+      addTearDown(() {
+        tester.view
+          ..physicalSize = oldSize
+          ..devicePixelRatio = oldRatio;
+      });
+
+      final provider = ChatProvider(
+        chatService: MockChatService(),
+        settingsService: MockSettingsService(),
+      );
+      addTearDown(provider.dispose);
+      final downloadUi = ModelDownloadUiController();
+      addTearDown(downloadUi.dispose);
+      await downloadUi.enqueueDownload(
+        filename: 'active.gguf',
+        displayName: 'Active model',
+      );
+      downloadUi.updateState('active.gguf', progress: 0.42);
+
+      await tester.pumpWidget(
+        ChangeNotifierProvider<ChatProvider>.value(
+          value: provider,
+          child: MaterialApp(
+            home: AppShellScreen(downloadUiController: downloadUi),
+          ),
+        ),
+      );
+      await tester.pumpAndSettle();
+
+      expect(find.text('Active model'), findsOneWidget);
+      expect(find.textContaining('42%'), findsOneWidget);
+
+      final queued = downloadUi.enqueueDownload(
+        filename: 'queued.gguf',
+        displayName: 'Queued model',
+      );
+      await tester.pump();
+      expect(find.text('1 queued'), findsOneWidget);
+
+      await tester.tap(find.textContaining('42%'));
+      await tester.pumpAndSettle();
+      expect(find.text('Model parameters'), findsOneWidget);
+
+      downloadUi.cancel('queued.gguf');
+      expect(await queued, isFalse);
+      downloadUi.completeActiveDownload('active.gguf');
     });
 
     testWidgets('keeps desktop settings opt-in and opens manage models view', (
@@ -38,6 +95,7 @@ void main() {
         initialSettings: const ChatSettings(
           modelPath: 'test_model.gguf',
           gpuLayers: 99,
+          autoTuneModelParams: true,
         ),
       );
 
@@ -67,9 +125,11 @@ void main() {
 
       await tester.tap(find.text('Model parameters'));
       await tester.pumpAndSettle();
-      expect(find.text('Max'), findsOneWidget);
+      expect(find.text('Auto · Max'), findsOneWidget);
       expect(
-        find.textContaining('Auto selects Metal on supported Macs.'),
+        find.textContaining(
+          'Auto tuning recalculates GPU layers and context headroom',
+        ),
         findsOneWidget,
       );
       expect(
@@ -265,7 +325,7 @@ void main() {
           isNull,
           reason: 'Model library overflowed at ${size.width}px',
         );
-        expect(find.text('Add GGUF (HF)'), findsOneWidget);
+        expect(find.text('Add model'), findsOneWidget);
       }
     });
 

--- a/example/chat_app/test/chat_input_test.dart
+++ b/example/chat_app/test/chat_input_test.dart
@@ -85,6 +85,48 @@ void main() {
     expect(find.textContaining('option + enter'), findsNothing);
     expect(find.text('Ask anything…'), findsOneWidget);
   });
+
+  testWidgets('shows audio attachment for direct-media native models', (
+    tester,
+  ) async {
+    final provider = ChatProvider(
+      chatService: MockChatService(),
+      settingsService: MockSettingsService(),
+      initialSettings: const ChatSettings(
+        modelPath: 'gemma-4-E2B-it.litertlm',
+        modelSupportsAudio: true,
+        directMediaInput: true,
+      ),
+    );
+    addTearDown(provider.dispose);
+    await provider.loadModel();
+
+    final controller = TextEditingController();
+    final focusNode = FocusNode();
+    addTearDown(controller.dispose);
+    addTearDown(focusNode.dispose);
+
+    await tester.pumpWidget(
+      ChangeNotifierProvider<ChatProvider>.value(
+        value: provider,
+        child: MaterialApp(
+          home: Scaffold(
+            body: ChatInput(
+              controller: controller,
+              focusNode: focusNode,
+              onSend: () {},
+            ),
+          ),
+        ),
+      ),
+    );
+
+    await tester.tap(find.byTooltip('Add attachment'));
+    await tester.pumpAndSettle();
+
+    expect(find.text('Attach Audio'), findsOneWidget);
+    expect(find.text('Attach Image'), findsNothing);
+  });
 }
 
 class _GeneratingReadyProvider extends ChatProvider {

--- a/example/chat_app/test/chat_service_test.dart
+++ b/example/chat_app/test/chat_service_test.dart
@@ -106,6 +106,42 @@ void main() {
       expect(engine.lastModelParams!.numberOfThreadsBatch, 0);
     });
 
+    test('maps the UI Max sentinel to full native GPU offload', () async {
+      debugDefaultTargetPlatformOverride = TargetPlatform.macOS;
+      final engine = MockLlamaEngine();
+      final service = ChatService(engine: engine);
+
+      await service.init(
+        const ChatSettings(
+          modelPath: 'gemma-4-31B-it-Q4_K_S.gguf',
+          preferredBackend: GpuBackend.metal,
+          contextSize: 16384,
+          gpuLayers: 99,
+        ),
+        eagerLoadMultimodalProjector: false,
+      );
+
+      expect(engine.lastModelParams, isNotNull);
+      expect(engine.lastModelParams!.gpuLayers, ModelParams.maxGpuLayers);
+      expect(engine.lastModelParams!.contextSize, 16384);
+    });
+
+    test('explicit CPU overrides a stale Max layer value', () async {
+      final engine = MockLlamaEngine();
+      final service = ChatService(engine: engine);
+
+      await service.init(
+        const ChatSettings(
+          modelPath: 'model.gguf',
+          preferredBackend: GpuBackend.cpu,
+          gpuLayers: 99,
+        ),
+        eagerLoadMultimodalProjector: false,
+      );
+
+      expect(engine.lastModelParams!.gpuLayers, 0);
+    });
+
     test(
       'does not apply llama.cpp Android tuning to LiteRT-LM models',
       () async {

--- a/example/chat_app/test/manage_models_screen_download_test.dart
+++ b/example/chat_app/test/manage_models_screen_download_test.dart
@@ -5,6 +5,7 @@ import 'package:dio/dio.dart';
 import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
+import 'package:llamadart_chat_example/models/chat_settings.dart';
 import 'package:llamadart_chat_example/models/downloadable_model.dart';
 import 'package:llamadart_chat_example/providers/chat_provider.dart';
 import 'package:llamadart_chat_example/screens/manage_models_screen.dart';
@@ -19,6 +20,185 @@ void main() {
   TestWidgetsFlutterBinding.ensureInitialized();
 
   group('ManageModelsScreen model download controller wiring', () {
+    testWidgets('uncached custom model can be removed from library', (
+      tester,
+    ) async {
+      final model = _remoteModel();
+      SharedPreferences.setMockInitialValues({
+        'custom_hf_models_v1': [
+          jsonEncode({
+            'name': model.name,
+            'description': model.description,
+            'url': model.url,
+            'filename': model.filename,
+            'sizeBytes': model.sizeBytes,
+          }),
+        ],
+      });
+
+      await _pumpScreen(
+        tester,
+        modelService: _HoldingModelService(),
+        models: const [],
+      );
+
+      expect(find.text(model.name), findsOneWidget);
+      await tester.tap(find.byTooltip('Model actions'));
+      await tester.pumpAndSettle();
+      await tester.tap(find.text('Remove from library'));
+      await tester.pumpAndSettle();
+
+      expect(find.text('Remove from library?'), findsOneWidget);
+      expect(find.text('Delete files & remove'), findsNothing);
+      await tester.tap(find.widgetWithText(FilledButton, 'Remove'));
+      await tester.pumpAndSettle();
+
+      expect(find.text(model.name), findsNothing);
+      final prefs = await SharedPreferences.getInstance();
+      expect(prefs.getStringList('custom_hf_models_v1'), isEmpty);
+    });
+
+    testWidgets('selected multimodal model waits for models directory', (
+      tester,
+    ) async {
+      SharedPreferences.setMockInitialValues({});
+      final directory = Completer<String>();
+      final model = _remoteVisionModel();
+      final provider = ChatProvider(
+        chatService: MockChatService(),
+        settingsService: MockSettingsService(),
+        initialSettings: ChatSettings(modelPath: '/models/${model.filename}'),
+      );
+      addTearDown(provider.dispose);
+
+      await _pumpScreen(
+        tester,
+        modelService: _HoldingModelService(
+          modelsDirectoryFuture: directory.future,
+        ),
+        models: [model],
+        provider: provider,
+        settle: false,
+      );
+
+      expect(tester.takeException(), isNull);
+      expect(find.byType(CircularProgressIndicator), findsOneWidget);
+
+      directory.complete('/models');
+      await tester.pumpAndSettle();
+
+      expect(tester.takeException(), isNull);
+      expect(find.text(model.name), findsOneWidget);
+    });
+
+    testWidgets('desktop-only presets are hidden on mobile', (tester) async {
+      final mobileModel = _remoteModel();
+      const desktopModel = DownloadableModel(
+        name: 'Desktop Test Model',
+        description: 'Large fake desktop model.',
+        url: 'https://example.com/desktop.gguf',
+        filename: 'desktop.gguf',
+        sizeBytes: 20,
+        availability: ModelAvailability.nativeDesktop,
+      );
+
+      debugDefaultTargetPlatformOverride = TargetPlatform.android;
+      try {
+        SharedPreferences.setMockInitialValues({});
+        await _pumpScreen(
+          tester,
+          modelService: _HoldingModelService(),
+          models: [mobileModel, desktopModel],
+        );
+
+        expect(find.text(mobileModel.name), findsOneWidget);
+        expect(find.text(desktopModel.name), findsNothing);
+
+        await tester.tap(find.widgetWithText(ChoiceChip, 'Desktop'));
+        await tester.pumpAndSettle();
+        expect(find.text(desktopModel.name), findsOneWidget);
+        expect(find.text('Available on desktop'), findsOneWidget);
+
+        await tester.pumpWidget(const SizedBox.shrink());
+        await tester.pumpAndSettle();
+        debugDefaultTargetPlatformOverride = TargetPlatform.macOS;
+        await _pumpScreen(
+          tester,
+          modelService: _HoldingModelService(),
+          models: [mobileModel, desktopModel],
+        );
+
+        expect(find.text(desktopModel.name), findsOneWidget);
+      } finally {
+        debugDefaultTargetPlatformOverride = null;
+      }
+    });
+
+    testWidgets('downloaded models are promoted ahead of catalog order', (
+      tester,
+    ) async {
+      SharedPreferences.setMockInitialValues({});
+      final available = _remoteModel();
+      final downloaded = _secondRemoteModel();
+
+      await _pumpScreen(
+        tester,
+        modelService: _HoldingModelService(
+          downloadedFiles: {downloaded.filename},
+        ),
+        models: [available, downloaded],
+      );
+
+      expect(find.text('1 downloaded · 2 total'), findsOneWidget);
+      expect(
+        tester.getTopLeft(find.text(downloaded.name)).dy,
+        lessThan(tester.getTopLeft(find.text(available.name)).dy),
+      );
+      expect(find.text('Downloaded'), findsOneWidget);
+    });
+
+    testWidgets('platform and capability search narrow the model library', (
+      tester,
+    ) async {
+      SharedPreferences.setMockInitialValues({});
+      final general = _remoteModel();
+      final vision = _remoteVisionModel();
+      const desktop = DownloadableModel(
+        name: 'Desktop Specialist',
+        description: 'Large desktop-only model.',
+        url: 'https://example.com/desktop.gguf',
+        filename: 'desktop.gguf',
+        sizeBytes: 20,
+        availability: ModelAvailability.nativeDesktop,
+      );
+
+      await _pumpScreen(
+        tester,
+        modelService: _HoldingModelService(),
+        models: [general, vision, desktop],
+      );
+
+      expect(find.widgetWithText(ChoiceChip, 'Mobile & Web'), findsOneWidget);
+      expect(find.widgetWithText(ChoiceChip, 'Mobile'), findsNothing);
+      expect(find.widgetWithText(ChoiceChip, 'Web'), findsNothing);
+
+      await tester.tap(find.widgetWithText(ChoiceChip, 'Desktop'));
+      await tester.pumpAndSettle();
+      expect(find.text(desktop.name), findsOneWidget);
+      await tester.tap(find.widgetWithText(ChoiceChip, 'Mobile & Web'));
+      await tester.pumpAndSettle();
+      expect(find.text(desktop.name), findsNothing);
+
+      await tester.enterText(find.byType(TextField).first, 'vision');
+      await tester.pump();
+      expect(find.text(vision.name), findsOneWidget);
+      expect(find.text(general.name), findsNothing);
+
+      await tester.tap(find.byTooltip('Clear model search'));
+      await tester.pump();
+      expect(find.text(general.name), findsOneWidget);
+    });
+
     testWidgets('pause button cancels the active controller download', (
       tester,
     ) async {
@@ -33,7 +213,7 @@ void main() {
         expect(find.text(model.name), findsOneWidget);
         expect(find.text('Download'), findsOneWidget);
 
-        await tester.tap(find.text('Download'));
+        await _tapVisible(tester, find.text('Download'));
         await modelService.downloadStarted.future.timeout(_testTimeout);
         await tester.pump();
 
@@ -42,7 +222,7 @@ void main() {
         expect(find.text('25%'), findsOneWidget);
         expect(find.textContaining('Keep the app open'), findsOneWidget);
 
-        await tester.tap(find.byTooltip('Pause Download'));
+        await _tapVisible(tester, find.byTooltip('Pause Download'));
         await tester.pump(const Duration(milliseconds: 150));
         await modelService.downloadCancelled.future.timeout(_testTimeout);
         await tester.pump();
@@ -65,7 +245,7 @@ void main() {
 
         await _pumpScreen(tester, modelService: modelService, models: [model]);
 
-        await tester.tap(find.text('Download'));
+        await _tapVisible(tester, find.text('Download'));
         await modelService.downloadStarted.future.timeout(_testTimeout);
         await tester.pump();
 
@@ -103,7 +283,7 @@ void main() {
 
         await _pumpScreen(tester, modelService: modelService, models: [model]);
 
-        await tester.tap(find.text('Download'));
+        await _tapVisible(tester, find.text('Download'));
         await modelService.downloadStarted.future.timeout(_testTimeout);
         await tester.pump();
 
@@ -128,11 +308,11 @@ void main() {
 
       await _pumpScreen(tester, modelService: modelService, models: [model]);
 
-      await tester.tap(find.text('Download'));
+      await _tapVisible(tester, find.text('Download'));
       await modelService.downloadStarted.future.timeout(_testTimeout);
       await tester.pump();
 
-      await tester.tap(find.byTooltip('Cancel & Discard'));
+      await _tapVisible(tester, find.byTooltip('Cancel & Discard'));
       await tester.pump(const Duration(milliseconds: 150));
       await modelService.downloadCancelled.future.timeout(_testTimeout);
       await tester.pump();
@@ -154,7 +334,7 @@ void main() {
         models: [_remoteModel()],
       );
 
-      await tester.tap(find.text('Download'));
+      await _tapVisible(tester, find.text('Download'));
       await modelService.downloadStarted.future.timeout(_testTimeout);
       await tester.pump();
 
@@ -181,7 +361,7 @@ void main() {
           downloadUiController: downloadUi,
         );
 
-        await tester.tap(find.text('Download'));
+        await _tapVisible(tester, find.text('Download'));
         await modelService.downloadStarted.future.timeout(_testTimeout);
         await tester.pump();
 
@@ -206,7 +386,7 @@ void main() {
           (filename) => finishedFilename = filename,
         );
         addTearDown(finishedSubscription.cancel);
-        await tester.tap(find.byTooltip('Pause Download'));
+        await _tapVisible(tester, find.byTooltip('Pause Download'));
         await tester.pump(const Duration(milliseconds: 150));
         await modelService.downloadCancelled.future.timeout(_testTimeout);
         expect(finishedFilename, model.filename);
@@ -229,7 +409,7 @@ void main() {
           downloadUiController: downloadUi,
         );
 
-        await tester.tap(find.text('Download'));
+        await _tapVisible(tester, find.text('Download'));
         await modelService.downloadStarted.future.timeout(_testTimeout);
         await tester.pump();
 
@@ -256,6 +436,57 @@ void main() {
         expect(find.text('Downloading model'), findsNothing);
       },
     );
+
+    testWidgets('second model waits while first download is active', (
+      tester,
+    ) async {
+      SharedPreferences.setMockInitialValues({});
+      final firstModel = _remoteModel();
+      final secondModel = _secondRemoteModel();
+      final modelService = _HoldingModelService();
+      final downloadUi = ModelDownloadUiController();
+      addTearDown(downloadUi.dispose);
+
+      await _pumpScreen(
+        tester,
+        modelService: modelService,
+        models: [firstModel, secondModel],
+        downloadUiController: downloadUi,
+      );
+
+      final downloadButtons = find.widgetWithText(OutlinedButton, 'Download');
+      expect(downloadButtons, findsNWidgets(2));
+      await _tapVisible(tester, downloadButtons.first);
+      await modelService.downloadStarted.future.timeout(_testTimeout);
+      await tester.pump();
+
+      final secondDownloadButton = find.widgetWithText(
+        OutlinedButton,
+        'Download',
+      );
+      expect(secondDownloadButton, findsOneWidget);
+      await tester.ensureVisible(secondDownloadButton);
+      await tester.pump();
+      await tester.tap(secondDownloadButton);
+      await tester.pump(const Duration(milliseconds: 50));
+
+      expect(modelService.downloadCalls, 1);
+      final queuedLabel = find.text('Queued for download • Position 1');
+      await tester.ensureVisible(queuedLabel);
+      await tester.pump();
+      expect(queuedLabel, findsOneWidget);
+
+      downloadUi.cancel(secondModel.filename);
+      downloadUi.cancel(firstModel.filename);
+      await tester.pump(const Duration(milliseconds: 150));
+      await modelService.downloadCancelled.future.timeout(_testTimeout);
+      for (var i = 0; i < 20 && downloadUi.hasPendingDownloads; i += 1) {
+        await tester.pump(const Duration(milliseconds: 50));
+      }
+
+      expect(modelService.downloadCalls, 1);
+      expect(downloadUi.hasPendingDownloads, isFalse);
+    });
 
     testWidgets(
       'selection warns when runtime lacks advertised vision support',
@@ -368,14 +599,14 @@ void main() {
 
       await _pumpScreen(tester, modelService: modelService, models: []);
 
-      await tester.tap(find.text('Add GGUF (HF)'));
+      await tester.tap(find.widgetWithText(OutlinedButton, 'Add model'));
       await tester.pumpAndSettle();
       await tester.enterText(
         find.widgetWithText(TextField, 'GGUF URL (Hugging Face)'),
         'https://huggingface.co/owner/repo/resolve/main/model.gguf?token=secret',
       );
 
-      await tester.tap(find.text('Add model'));
+      await tester.tap(find.widgetWithText(FilledButton, 'Add model'));
       await tester.pumpAndSettle();
 
       expect(find.text('Save credentialed URL?'), findsOneWidget);
@@ -398,7 +629,7 @@ void main() {
       expect(prefs.getStringList('custom_hf_models_v1'), isNull);
       expect(find.text('Add Hugging Face GGUF'), findsOneWidget);
 
-      await tester.tap(find.text('Add model'));
+      await tester.tap(find.widgetWithText(FilledButton, 'Add model'));
       await tester.pumpAndSettle();
       await tester.tap(find.text('Save anyway'));
       await tester.pumpAndSettle();
@@ -418,12 +649,19 @@ void main() {
 
 const _testTimeout = Duration(seconds: 2);
 
+Future<void> _tapVisible(WidgetTester tester, Finder finder) async {
+  await tester.ensureVisible(finder);
+  await tester.pump();
+  await tester.tap(finder);
+}
+
 Future<void> _pumpScreen(
   WidgetTester tester, {
   required _HoldingModelService modelService,
   required List<DownloadableModel> models,
   ChatProvider? provider,
   ModelDownloadUiController? downloadUiController,
+  bool settle = true,
 }) async {
   final effectiveProvider =
       provider ??
@@ -451,7 +689,11 @@ Future<void> _pumpScreen(
       ),
     ),
   );
-  await tester.pumpAndSettle();
+  if (settle) {
+    await tester.pumpAndSettle();
+  } else {
+    await tester.pump();
+  }
 }
 
 DownloadableModel _remoteModel() {
@@ -477,10 +719,21 @@ DownloadableModel _remoteVisionModel() {
   );
 }
 
+DownloadableModel _secondRemoteModel() {
+  return const DownloadableModel(
+    name: 'Second Test Model',
+    description: 'Another fake model for queue tests.',
+    url: 'https://example.com/second.gguf',
+    filename: 'second.gguf',
+    sizeBytes: 10,
+  );
+}
+
 class _HoldingModelService implements ModelService {
   _HoldingModelService({
     Set<String>? downloadedFiles,
     Set<String>? cachedAssetKeys,
+    this.modelsDirectoryFuture,
   }) : downloadedFiles = downloadedFiles ?? <String>{},
        cachedAssetKeys = cachedAssetKeys?.toSet();
 
@@ -490,6 +743,7 @@ class _HoldingModelService implements ModelService {
   final Completer<void> _finishDownload = Completer<void>();
   final Set<String> downloadedFiles;
   final Set<String>? cachedAssetKeys;
+  final Future<String>? modelsDirectoryFuture;
 
   int downloadCalls = 0;
   int deleteCalls = 0;
@@ -502,7 +756,8 @@ class _HoldingModelService implements ModelService {
   }
 
   @override
-  Future<String> getModelsDirectory() async => '/models';
+  Future<String> getModelsDirectory() async =>
+      await modelsDirectoryFuture ?? '/models';
 
   @override
   Future<Set<String>> getDownloadedModels(

--- a/example/chat_app/test/manage_models_screen_download_test.dart
+++ b/example/chat_app/test/manage_models_screen_download_test.dart
@@ -199,6 +199,34 @@ void main() {
       expect(find.text(general.name), findsOneWidget);
     });
 
+    testWidgets('desktop search uses native capability profile', (
+      tester,
+    ) async {
+      SharedPreferences.setMockInitialValues({});
+      const desktopAudio = DownloadableModel(
+        name: 'Desktop Audio Model',
+        description: 'Desktop model with native-only audio.',
+        url: 'https://example.com/desktop-audio.gguf',
+        filename: 'desktop-audio.gguf',
+        sizeBytes: 20,
+        availability: ModelAvailability.nativeDesktop,
+        supportsAudio: true,
+        webSupportsAudio: false,
+      );
+
+      await _pumpScreen(
+        tester,
+        modelService: _HoldingModelService(),
+        models: const [desktopAudio],
+      );
+
+      await tester.tap(find.widgetWithText(ChoiceChip, 'Desktop'));
+      await tester.enterText(find.byType(TextField).first, 'audio');
+      await tester.pump();
+
+      expect(find.text(desktopAudio.name), findsOneWidget);
+    });
+
     testWidgets('pause button cancels the active controller download', (
       tester,
     ) async {

--- a/example/chat_app/test/model_card_test.dart
+++ b/example/chat_app/test/model_card_test.dart
@@ -22,6 +22,7 @@ void main() {
 
     expect(find.text('Load & Cache Model'), findsOneWidget);
     expect(find.text('Cache Model'), findsNothing);
+    expect(find.text('All platforms'), findsOneWidget);
 
     await tester.tap(find.text('Load & Cache Model'));
     await tester.pump();
@@ -50,6 +51,133 @@ void main() {
     await tester.pump();
 
     expect(selectCalls, 1);
+  });
+
+  testWidgets('LiteRT-LM audio badge is native-only', (tester) async {
+    await _pumpCard(
+      tester,
+      model: _litertLmModel(),
+      isWeb: false,
+      isDownloaded: true,
+      onSelect: () {},
+      onDownload: () {},
+    );
+
+    expect(find.text('Audio'), findsOneWidget);
+
+    await _pumpCard(
+      tester,
+      model: _litertLmModel(),
+      isWeb: true,
+      isDownloaded: true,
+      onSelect: () {},
+      onDownload: () {},
+    );
+
+    expect(find.text('Audio'), findsNothing);
+  });
+
+  testWidgets('shows distribution, desktop scope, and readable large size', (
+    tester,
+  ) async {
+    await _pumpCard(
+      tester,
+      model: const DownloadableModel(
+        name: 'Desktop model',
+        description: 'Large desktop model',
+        url: 'https://huggingface.co/unsloth/model/resolve/main/model.gguf',
+        filename: 'model.gguf',
+        sizeBytes: 20 * 1024 * 1024 * 1024,
+        minRamGb: 32,
+        distribution: 'Unsloth',
+        availability: ModelAvailability.nativeDesktop,
+      ),
+      isWeb: false,
+      isDownloaded: false,
+      onSelect: () {},
+      onDownload: () {},
+    );
+
+    expect(find.text('20.0 GB'), findsOneWidget);
+    expect(find.text('Unsloth distribution'), findsOneWidget);
+    expect(find.text('Desktop'), findsOneWidget);
+  });
+
+  testWidgets('uncached custom models expose remove-from-library action', (
+    tester,
+  ) async {
+    var removeCalls = 0;
+
+    await _pumpCard(
+      tester,
+      model: _ggufModel(),
+      isWeb: false,
+      isDownloaded: false,
+      isCustom: true,
+      onSelect: () {},
+      onDownload: () {},
+      onRemoveFromLibrary: () => removeCalls += 1,
+    );
+
+    await tester.tap(find.byTooltip('Model actions'));
+    await tester.pumpAndSettle();
+
+    expect(find.text('Remove from library'), findsOneWidget);
+    expect(find.text('Delete downloaded files'), findsNothing);
+
+    await tester.tap(find.text('Remove from library'));
+    await tester.pumpAndSettle();
+    expect(removeCalls, 1);
+  });
+
+  testWidgets('cached custom models keep file deletion separate', (
+    tester,
+  ) async {
+    var deleteCalls = 0;
+
+    await _pumpCard(
+      tester,
+      model: _ggufModel(),
+      isWeb: false,
+      isDownloaded: true,
+      isCustom: true,
+      onSelect: () {},
+      onDownload: () {},
+      onDelete: () => deleteCalls += 1,
+      onRemoveFromLibrary: () {},
+    );
+
+    await tester.tap(find.byTooltip('Model actions'));
+    await tester.pumpAndSettle();
+
+    expect(find.text('Remove from library'), findsOneWidget);
+    expect(find.text('Delete downloaded files'), findsOneWidget);
+    await tester.tap(find.text('Delete downloaded files'));
+    await tester.pumpAndSettle();
+    expect(deleteCalls, 1);
+  });
+
+  testWidgets('queued model shows its position and can leave the queue', (
+    tester,
+  ) async {
+    var cancelCalls = 0;
+
+    await _pumpCard(
+      tester,
+      model: _ggufModel(),
+      isWeb: false,
+      isDownloaded: false,
+      isQueued: true,
+      queuePosition: 2,
+      onSelect: () {},
+      onDownload: () {},
+      onCancel: () => cancelCalls += 1,
+    );
+
+    expect(find.text('Queued for download • Position 2'), findsOneWidget);
+    expect(find.text('Download'), findsNothing);
+    await tester.tap(find.byTooltip('Remove from download queue'));
+    expect(cancelCalls, 1);
   });
 
   testWidgets('web GGUF presets still show the cache action before download', (
@@ -228,6 +356,37 @@ void main() {
     expect(find.text('Max requests full GPU offload'), findsOneWidget);
     expect(find.text('Set to 99 for Auto'), findsNothing);
   });
+
+  testWidgets('unavailable platform cards explain why actions are disabled', (
+    tester,
+  ) async {
+    await _pumpCard(
+      tester,
+      model: const DownloadableModel(
+        name: 'Desktop model',
+        description: 'Large desktop model',
+        url: 'https://example.com/desktop.gguf',
+        filename: 'desktop.gguf',
+        sizeBytes: 20,
+        availability: ModelAvailability.nativeDesktop,
+      ),
+      isWeb: false,
+      isDownloaded: false,
+      isAvailableOnCurrentPlatform: false,
+      onSelect: () {},
+      onDownload: () {},
+    );
+
+    expect(find.text('Available on desktop'), findsOneWidget);
+    expect(
+      find.textContaining('Switch platforms to use this model'),
+      findsOneWidget,
+    );
+    final button = tester.widget<OutlinedButton>(
+      find.widgetWithText(OutlinedButton, 'Available on desktop'),
+    );
+    expect(button.onPressed, isNull);
+  });
 }
 
 Future<void> _pumpCard(
@@ -237,16 +396,22 @@ Future<void> _pumpCard(
   required bool isDownloaded,
   ModelProfileCacheState? cacheState,
   bool isDownloading = false,
+  bool isQueued = false,
+  int? queuePosition,
   double progress = 0,
   String? downloadStatusLabel,
   String? downloadTransferLabel,
   required VoidCallback onSelect,
   required VoidCallback onDownload,
   VoidCallback? onDelete,
+  VoidCallback? onCancel,
+  bool isCustom = false,
+  VoidCallback? onRemoveFromLibrary,
   bool includeProjector = true,
   ValueChanged<bool>? onIncludeProjectorChanged,
   double textScale = 1.0,
   bool isSelected = false,
+  bool isAvailableOnCurrentPlatform = true,
   int gpuLayers = 0,
 }) async {
   await tester.pumpWidget(
@@ -264,10 +429,13 @@ Future<void> _pumpCard(
             isDownloaded: isDownloaded,
             cacheState: cacheState,
             isDownloading: isDownloading,
+            isQueued: isQueued,
+            queuePosition: queuePosition,
             progress: progress,
             downloadStatusLabel: downloadStatusLabel,
             downloadTransferLabel: downloadTransferLabel,
             isWeb: isWeb,
+            isAvailableOnCurrentPlatform: isAvailableOnCurrentPlatform,
             isSelected: isSelected,
             gpuLayers: gpuLayers,
             contextSize: 2048,
@@ -276,6 +444,9 @@ Future<void> _pumpCard(
             onSelect: onSelect,
             onDownload: onDownload,
             onDelete: onDelete ?? () {},
+            onCancel: onCancel,
+            isCustom: isCustom,
+            onRemoveFromLibrary: onRemoveFromLibrary,
             includeProjector: includeProjector,
             onIncludeProjectorChanged: onIncludeProjectorChanged,
           ),
@@ -309,6 +480,10 @@ DownloadableModel _litertLmModel() {
       filename: 'model-web.litertlm',
     ),
     sizeBytes: 10,
+    supportsAudio: true,
+    webSupportsAudio: false,
+    mediaInputMode: ModelMediaInputMode.direct,
+    webMediaInputMode: ModelMediaInputMode.none,
   );
 }
 

--- a/example/chat_app/test/model_download_ui_controller_test.dart
+++ b/example/chat_app/test/model_download_ui_controller_test.dart
@@ -60,6 +60,39 @@ void main() {
       expect(controller.pendingCount, 1);
     });
 
+    test(
+      'active download can be cancelled before controller registration',
+      () async {
+        final controller = ModelDownloadUiController();
+        addTearDown(controller.dispose);
+
+        await controller.enqueueDownload(
+          filename: 'active.gguf',
+          displayName: 'Active model',
+        );
+        final queued = controller.enqueueDownload(
+          filename: 'queued.gguf',
+          displayName: 'Queued model',
+        );
+
+        controller.cancel('active.gguf');
+
+        expect(
+          controller.listenableFor('active.gguf').value.isDownloading,
+          isFalse,
+        );
+        expect(controller.activeFilename, 'active.gguf');
+        expect(controller.canRegisterDownload('active.gguf'), isFalse);
+        controller.completeActiveDownload('active.gguf');
+        expect(await queued, isTrue);
+        expect(controller.activeFilename, 'queued.gguf');
+        expect(
+          controller.listenableFor('queued.gguf').value.isDownloading,
+          isTrue,
+        );
+      },
+    );
+
     test('queue mutations notify shell listeners once per operation', () async {
       final controller = ModelDownloadUiController();
       addTearDown(controller.dispose);

--- a/example/chat_app/test/model_download_ui_controller_test.dart
+++ b/example/chat_app/test/model_download_ui_controller_test.dart
@@ -1,5 +1,6 @@
 import 'package:flutter_test/flutter_test.dart';
 import 'package:llamadart_chat_example/services/model_download_ui_controller.dart';
+import 'package:llamadart_chat_example/services/model_service_base.dart';
 
 void main() {
   group('ModelDownloadUiController', () {
@@ -36,6 +37,42 @@ void main() {
       expect(controller.activeFilename, 'third.gguf');
       controller.completeActiveDownload('third.gguf');
       expect(controller.hasPendingDownloads, isFalse);
+    });
+
+    test('queue transitions clear stale transfer state', () async {
+      final controller = ModelDownloadUiController();
+      addTearDown(controller.dispose);
+      const staleDetail = ModelDownloadProgress(
+        overallProgress: 0.6,
+        downloadedBytes: 6,
+        totalBytes: 10,
+        stage: ModelDownloadStage.model,
+        stageIndex: 1,
+        stageCount: 1,
+        stageDownloadedBytes: 6,
+        stageTotalBytes: 10,
+      );
+
+      controller.updateState('active.gguf', progress: 0.6, detail: staleDetail);
+      await controller.enqueueDownload(
+        filename: 'active.gguf',
+        displayName: 'Active model',
+      );
+
+      final activeState = controller.listenableFor('active.gguf').value;
+      expect(activeState.progress, 0);
+      expect(activeState.detail, isNull);
+
+      controller.updateState('queued.gguf', progress: 0.6, detail: staleDetail);
+      controller.enqueueDownload(
+        filename: 'queued.gguf',
+        displayName: 'Queued model',
+      );
+
+      final queuedState = controller.listenableFor('queued.gguf').value;
+      expect(queuedState.isQueued, isTrue);
+      expect(queuedState.progress, 0);
+      expect(queuedState.detail, isNull);
     });
 
     test('queued download can be removed before it starts', () async {

--- a/example/chat_app/test/model_download_ui_controller_test.dart
+++ b/example/chat_app/test/model_download_ui_controller_test.dart
@@ -1,4 +1,5 @@
 import 'package:flutter_test/flutter_test.dart';
+import 'package:llamadart/llamadart.dart' show ModelDownloadController;
 import 'package:llamadart_chat_example/services/model_download_ui_controller.dart';
 import 'package:llamadart_chat_example/services/model_service_base.dart';
 
@@ -120,6 +121,18 @@ void main() {
         );
         expect(controller.activeFilename, 'active.gguf');
         expect(controller.canRegisterDownload('active.gguf'), isFalse);
+        final lowLevelController = ModelDownloadController();
+        final subscription = lowLevelController.snapshots.listen((_) {});
+        addTearDown(subscription.cancel);
+        addTearDown(lowLevelController.dispose);
+        expect(
+          controller.registerDownload(
+            filename: 'active.gguf',
+            controller: lowLevelController,
+            subscription: subscription,
+          ),
+          isFalse,
+        );
         controller.completeActiveDownload('active.gguf');
         expect(await queued, isTrue);
         expect(controller.activeFilename, 'queued.gguf');

--- a/example/chat_app/test/model_download_ui_controller_test.dart
+++ b/example/chat_app/test/model_download_ui_controller_test.dart
@@ -3,6 +3,89 @@ import 'package:llamadart_chat_example/services/model_download_ui_controller.dar
 
 void main() {
   group('ModelDownloadUiController', () {
+    test('runs queued downloads in FIFO order', () async {
+      final controller = ModelDownloadUiController();
+      addTearDown(controller.dispose);
+
+      final first = controller.enqueueDownload(
+        filename: 'first.gguf',
+        displayName: 'First model',
+      );
+      final second = controller.enqueueDownload(
+        filename: 'second.gguf',
+        displayName: 'Second model',
+      );
+      final third = controller.enqueueDownload(
+        filename: 'third.gguf',
+        displayName: 'Third model',
+      );
+
+      expect(await first, isTrue);
+      expect(controller.activeFilename, 'first.gguf');
+      expect(controller.queuedCount, 2);
+      expect(controller.listenableFor('second.gguf').value.queuePosition, 1);
+      expect(controller.listenableFor('third.gguf').value.queuePosition, 2);
+
+      controller.completeActiveDownload('first.gguf');
+      expect(await second, isTrue);
+      expect(controller.activeFilename, 'second.gguf');
+      expect(controller.listenableFor('third.gguf').value.queuePosition, 1);
+
+      controller.completeActiveDownload('second.gguf');
+      expect(await third, isTrue);
+      expect(controller.activeFilename, 'third.gguf');
+      controller.completeActiveDownload('third.gguf');
+      expect(controller.hasPendingDownloads, isFalse);
+    });
+
+    test('queued download can be removed before it starts', () async {
+      final controller = ModelDownloadUiController();
+      addTearDown(controller.dispose);
+
+      await controller.enqueueDownload(
+        filename: 'active.gguf',
+        displayName: 'Active model',
+      );
+      final queued = controller.enqueueDownload(
+        filename: 'queued.gguf',
+        displayName: 'Queued model',
+      );
+
+      expect(controller.isQueued('queued.gguf'), isTrue);
+      controller.cancel('queued.gguf');
+
+      expect(await queued, isFalse);
+      expect(controller.isQueued('queued.gguf'), isFalse);
+      expect(controller.listenableFor('queued.gguf').value.isQueued, isFalse);
+      expect(controller.pendingCount, 1);
+    });
+
+    test('queue mutations notify shell listeners once per operation', () async {
+      final controller = ModelDownloadUiController();
+      addTearDown(controller.dispose);
+      var notifications = 0;
+      controller.addListener(() => notifications += 1);
+
+      await controller.enqueueDownload(
+        filename: 'active.gguf',
+        displayName: 'Active model',
+      );
+      expect(notifications, 1);
+
+      final queued = controller.enqueueDownload(
+        filename: 'queued.gguf',
+        displayName: 'Queued model',
+      );
+      expect(notifications, 2);
+
+      controller.cancel('queued.gguf');
+      expect(await queued, isFalse);
+      expect(notifications, 3);
+
+      controller.completeActiveDownload('active.gguf');
+      expect(notifications, 4);
+    });
+
     test('clearUiState resets active notifiers without disposing them', () {
       final controller = ModelDownloadUiController();
       addTearDown(controller.dispose);

--- a/example/chat_app/test/model_download_ui_controller_test.dart
+++ b/example/chat_app/test/model_download_ui_controller_test.dart
@@ -86,6 +86,33 @@ void main() {
       expect(notifications, 4);
     });
 
+    test('disposeDownloads clears active and queued shell state', () async {
+      final controller = ModelDownloadUiController();
+      addTearDown(controller.dispose);
+
+      await controller.enqueueDownload(
+        filename: 'active.gguf',
+        displayName: 'Active model',
+      );
+      final queued = controller.enqueueDownload(
+        filename: 'queued.gguf',
+        displayName: 'Queued model',
+      );
+
+      await controller.disposeDownloads();
+
+      expect(await queued, isFalse);
+      expect(controller.activeFilename, isNull);
+      expect(controller.activeDisplayName, isNull);
+      expect(controller.pendingCount, 0);
+      expect(controller.hasPendingDownloads, isFalse);
+      expect(
+        controller.listenableFor('active.gguf').value.isDownloading,
+        isFalse,
+      );
+      expect(controller.listenableFor('queued.gguf').value.isQueued, isFalse);
+    });
+
     test('clearUiState resets active notifiers without disposing them', () {
       final controller = ModelDownloadUiController();
       addTearDown(controller.dispose);

--- a/example/chat_app/test/runtime_profile_service_test.dart
+++ b/example/chat_app/test/runtime_profile_service_test.dart
@@ -72,10 +72,39 @@ void main() {
         isWeb: false,
         preferredBackend: GpuBackend.auto,
         currentContextSize: 8192,
+        modelBytes: 3 * 1024 * 1024 * 1024,
       );
 
       expect(estimate.gpuLayers, greaterThan(0));
-      expect(estimate.contextSize, anyOf(2048, 4096));
+      expect(estimate.contextSize, 4096);
+    });
+
+    test('fully offloads a known model when memory has safe headroom', () {
+      final estimate = service.estimateDynamicSettings(
+        totalVramBytes: 64 * 1024 * 1024 * 1024,
+        freeVramBytes: 56 * 1024 * 1024 * 1024,
+        isWeb: false,
+        preferredBackend: GpuBackend.auto,
+        currentContextSize: 16384,
+        modelBytes: 20 * 1024 * 1024 * 1024,
+      );
+
+      expect(estimate.gpuLayers, ModelParams.maxGpuLayers);
+      expect(estimate.contextSize, 16384);
+    });
+
+    test('reduces context before choosing partial offload under pressure', () {
+      final estimate = service.estimateDynamicSettings(
+        totalVramBytes: 16 * 1024 * 1024 * 1024,
+        freeVramBytes: 12 * 1024 * 1024 * 1024,
+        isWeb: false,
+        preferredBackend: GpuBackend.auto,
+        currentContextSize: 16384,
+        modelBytes: 12 * 1024 * 1024 * 1024,
+      );
+
+      expect(estimate.gpuLayers, inInclusiveRange(1, 98));
+      expect(estimate.contextSize, 4096);
     });
   });
 }

--- a/example/chat_app/test/settings_service_test.dart
+++ b/example/chat_app/test/settings_service_test.dart
@@ -34,7 +34,42 @@ void main() {
       final settings = await service.loadSettings();
 
       expect(settings.preferredBackend, GpuBackend.auto);
+      expect(settings.autoTuneModelParams, isTrue);
     });
+
+    test('persists Auto intent after resolving partial GPU offload', () async {
+      final service = SettingsService();
+      const settings = ChatSettings(
+        preferredBackend: GpuBackend.auto,
+        gpuLayers: 66,
+        contextSize: 4096,
+        autoTuneModelParams: true,
+        autoTuneRequestedContextSize: 16384,
+      );
+
+      await service.saveSettings(settings);
+      final restored = await service.loadSettings();
+
+      expect(restored.gpuLayers, 66);
+      expect(restored.contextSize, 4096);
+      expect(restored.autoTuneModelParams, isTrue);
+      expect(restored.autoTuneRequestedContextSize, 16384);
+    });
+
+    test(
+      'does not infer Auto intent for a legacy manual layer value',
+      () async {
+        SharedPreferences.setMockInitialValues({
+          'preferred_backend': GpuBackend.auto.index,
+          'gpu_layers': 48,
+        });
+
+        final service = SettingsService();
+        final settings = await service.loadSettings();
+
+        expect(settings.autoTuneModelParams, isFalse);
+      },
+    );
 
     test('falls back to auto for invalid backend index', () async {
       SharedPreferences.setMockInitialValues({'preferred_backend': 999});
@@ -76,6 +111,37 @@ void main() {
 
       expect(prefs.getInt('context_size'), 0);
     });
+
+    test('persists direct model media capabilities', () async {
+      final service = SettingsService();
+      const settings = ChatSettings(
+        modelSupportsVision: false,
+        modelSupportsAudio: true,
+        directMediaInput: true,
+      );
+
+      await service.saveSettings(settings);
+      final restored = await service.loadSettings();
+
+      expect(restored.modelSupportsVision, isFalse);
+      expect(restored.modelSupportsAudio, isTrue);
+      expect(restored.directMediaInput, isTrue);
+    });
+
+    test(
+      'migrates existing native Gemma 4 LiteRT-LM selections to audio',
+      () async {
+        SharedPreferences.setMockInitialValues({
+          'model_path': '/models/gemma-4-E2B-it.litertlm',
+        });
+
+        final service = SettingsService();
+        final settings = await service.loadSettings();
+
+        expect(settings.modelSupportsAudio, isTrue);
+        expect(settings.directMediaInput, isTrue);
+      },
+    );
 
     test('migrates saved Unsloth UD Qwen model paths to Q4_K_M', () async {
       SharedPreferences.setMockInitialValues({

--- a/example/chat_app/test/unit_test.dart
+++ b/example/chat_app/test/unit_test.dart
@@ -874,6 +874,14 @@ void main() {
       expect(provider.settings.nativeLogLevel, LlamaLogLevel.warn);
     });
 
+    test('Max enables Auto tuning and a manual layer disables it', () {
+      provider.updateGpuLayers(99);
+      expect(provider.settings.autoTuneModelParams, isTrue);
+
+      provider.updateGpuLayers(48);
+      expect(provider.settings.autoTuneModelParams, isFalse);
+    });
+
     test('updateContextSize supports auto mode', () {
       provider.updateContextSize(0);
       expect(provider.settings.contextSize, 0);
@@ -945,7 +953,32 @@ void main() {
       expect(provider.settings.contextSize, 8192);
       expect(provider.settings.maxTokens, 512);
       expect(provider.settings.gpuLayers, 99);
+      expect(provider.settings.autoTuneModelParams, isTrue);
+      expect(provider.settings.modelBytesHint, model.sizeBytes);
       expect(provider.settings.toolsEnabled, isFalse);
+    });
+
+    test('persisted Auto intent re-estimates a partial prior result', () async {
+      final engine = _LargeMemoryEstimateEngine();
+      final customProvider = ChatProvider(
+        chatService: MockChatService(engine: engine),
+        settingsService: mockSettingsService,
+        initialSettings: const ChatSettings(
+          modelPath: 'large-model.gguf',
+          preferredBackend: GpuBackend.auto,
+          gpuLayers: 66,
+          contextSize: 4096,
+          modelBytesHint: 20 * 1024 * 1024 * 1024,
+          autoTuneModelParams: true,
+          autoTuneRequestedContextSize: 16384,
+        ),
+      );
+
+      await customProvider.loadModel();
+
+      expect(customProvider.settings.gpuLayers, ModelParams.maxGpuLayers);
+      expect(customProvider.settings.contextSize, 16384);
+      expect(customProvider.settings.autoTuneModelParams, isTrue);
     });
 
     test('applyModelPreset disables tools when unsupported', () {
@@ -1028,12 +1061,37 @@ void main() {
       },
     );
 
-    test('Qwen3.5 small presets use Unsloth Q4_K_M non-thinking defaults', () {
+    test('built-in catalog is focused and Unsloth-first', () {
+      expect(
+        DownloadableModel.defaultModels.map((model) => model.name),
+        orderedEquals(const [
+          'FunctionGemma 270M',
+          'Qwen3.5 0.8B Instruct',
+          'Gemma 4 E2B it',
+          'Gemma 4 E2B LiteRT-LM',
+          'Gemma 4 E4B it',
+          'Gemma 4 12B it',
+          'Gemma 4 26B A4B it',
+          'Gemma 4 31B it',
+          'Qwen3.6 35B A3B',
+        ]),
+      );
+
+      final ggufModels = DownloadableModel.defaultModels.where(
+        (model) => model.filename.endsWith('.gguf'),
+      );
+      for (final model in ggufModels) {
+        expect(model.distribution, 'Unsloth');
+        expect(model.url, contains('huggingface.co/unsloth/'));
+      }
+    });
+
+    test('Qwen3.5 0.8B uses Unsloth Q4_K_M non-thinking defaults', () {
       final qwenModels = DownloadableModel.defaultModels
           .where((model) => model.name.startsWith('Qwen3.5 '))
           .toList(growable: false);
 
-      expect(qwenModels, hasLength(4));
+      expect(qwenModels, hasLength(1));
 
       for (final model in qwenModels) {
         expect(model.url, contains('huggingface.co/unsloth/Qwen3.5-'));
@@ -1050,30 +1108,91 @@ void main() {
         (model) => model.name == 'Qwen3.5 0.8B Instruct',
       );
       expect(small.preset.contextSize, 4096);
-
-      final larger = qwenModels.where(
-        (model) => model.name != 'Qwen3.5 0.8B Instruct',
-      );
-      for (final model in larger) {
-        expect(model.preset.contextSize, 8192);
-      }
     });
 
-    test('applyModelPreset prefers CPU for Qwen3.5 0.8B and 2B on Android', () {
-      debugDefaultTargetPlatformOverride = TargetPlatform.android;
-      for (final modelName in const [
-        'Qwen3.5 0.8B Instruct',
-        'Qwen3.5 2B Instruct',
-      ]) {
-        final qwenModel = DownloadableModel.defaultModels.singleWhere(
-          (model) => model.name == modelName,
+    test('large models are native-desktop-only while Gemma E4B is not', () {
+      final desktopModels = DownloadableModel.defaultModels
+          .where((model) => model.isNativeDesktopOnly)
+          .toList(growable: false);
+
+      expect(
+        desktopModels.map((model) => model.name),
+        orderedEquals(const [
+          'Gemma 4 12B it',
+          'Gemma 4 26B A4B it',
+          'Gemma 4 31B it',
+          'Qwen3.6 35B A3B',
+        ]),
+      );
+      for (final model in desktopModels) {
+        expect(model.isAvailableFor(web: false, mobile: false), isTrue);
+        expect(model.isAvailableFor(web: false, mobile: true), isFalse);
+        expect(model.isAvailableFor(web: true, mobile: false), isFalse);
+      }
+
+      final gemmaE4b = DownloadableModel.defaultModels.singleWhere(
+        (model) => model.name == 'Gemma 4 E4B it',
+      );
+      expect(gemmaE4b.isNativeDesktopOnly, isFalse);
+      expect(gemmaE4b.isAvailableFor(web: false, mobile: true), isTrue);
+      expect(gemmaE4b.supportsAudioFor(web: false), isTrue);
+    });
+
+    test('Gemma 4 presets expose platform-specific audio capabilities', () {
+      final ggufModel = DownloadableModel.defaultModels.singleWhere(
+        (model) => model.name == 'Gemma 4 E2B it',
+      );
+      final liteRtModel = DownloadableModel.defaultModels.singleWhere(
+        (model) => model.name == 'Gemma 4 E2B LiteRT-LM',
+      );
+
+      expect(ggufModel.supportsAudioFor(web: false), isTrue);
+      expect(ggufModel.supportsAudioFor(web: true), isFalse);
+      expect(
+        ggufModel.mediaInputModeFor(web: false),
+        ModelMediaInputMode.externalProjector,
+      );
+      expect(liteRtModel.supportsAudioFor(web: false), isTrue);
+      expect(liteRtModel.supportsAudioFor(web: true), isFalse);
+      expect(
+        liteRtModel.mediaInputModeFor(web: false),
+        ModelMediaInputMode.direct,
+      );
+      expect(
+        liteRtModel.mediaInputModeFor(web: true),
+        ModelMediaInputMode.none,
+      );
+    });
+
+    test(
+      'native LiteRT-LM preset enables direct audio after model load',
+      () async {
+        final liteRtModel = DownloadableModel.defaultModels.singleWhere(
+          (model) => model.name == 'Gemma 4 E2B LiteRT-LM',
         );
 
-        provider.applyModelPreset(qwenModel);
+        provider.updateModelPath('gemma-4-E2B-it.litertlm');
+        provider.applyModelPreset(liteRtModel);
+        await provider.loadModel();
 
-        expect(provider.settings.preferredBackend, GpuBackend.cpu);
-        expect(provider.settings.gpuLayers, 0);
-      }
+        expect(provider.settings.modelSupportsAudio, isTrue);
+        expect(provider.settings.directMediaInput, isTrue);
+        expect(provider.supportsAudio, isTrue);
+        expect(provider.canAttachMedia, isTrue);
+        expect(provider.hasConfiguredMmproj, isFalse);
+      },
+    );
+
+    test('applyModelPreset prefers CPU for Qwen3.5 0.8B on Android', () {
+      debugDefaultTargetPlatformOverride = TargetPlatform.android;
+      final qwenModel = DownloadableModel.defaultModels.singleWhere(
+        (model) => model.name == 'Qwen3.5 0.8B Instruct',
+      );
+
+      provider.applyModelPreset(qwenModel);
+
+      expect(provider.settings.preferredBackend, GpuBackend.cpu);
+      expect(provider.settings.gpuLayers, 0);
     });
 
     test('applyModelPreset reduces Android context for Qwen3.5 0.8B', () {
@@ -1341,6 +1460,18 @@ class _MacFallbackEstimateEngine extends MockLlamaEngine {
 
   @override
   Future<String> getBackendName() async => 'CPU, METAL';
+
+  @override
+  Future<String> getAvailableBackends() async => 'CPU, METAL';
+}
+
+class _LargeMemoryEstimateEngine extends MockLlamaEngine {
+  @override
+  Future<({int total, int free})> getVramInfo() async =>
+      (total: 64 * 1024 * 1024 * 1024, free: 56 * 1024 * 1024 * 1024);
+
+  @override
+  Future<String> getBackendName() async => 'METAL';
 
   @override
   Future<String> getAvailableBackends() async => 'CPU, METAL';

--- a/example/chat_app/test/unit_test.dart
+++ b/example/chat_app/test/unit_test.dart
@@ -354,6 +354,36 @@ void main() {
       expect(mockEngine.unloadMultimodalProjectorCalls, 1);
     });
 
+    test(
+      'Gemma projector audio warning requires declared audio capability',
+      () async {
+        for (final declaresAudio in [false, true]) {
+          final gemmaProvider = ChatProvider(
+            chatService: MockChatService(engine: MockLlamaEngine()),
+            settingsService: mockSettingsService,
+            initialSettings: ChatSettings(
+              modelPath: 'gemma-4-test.gguf',
+              mmprojPath: 'gemma-4-mmproj.gguf',
+              modelSupportsVision: true,
+              modelSupportsAudio: declaresAudio,
+            ),
+          );
+          addTearDown(gemmaProvider.dispose);
+
+          await gemmaProvider.loadModel();
+
+          expect(
+            gemmaProvider.messages.any(
+              (message) => message.text.contains(
+                'Gemma 4 GGUF projector currently exposes vision only',
+              ),
+            ),
+            declaresAudio,
+          );
+        }
+      },
+    );
+
     test('loadModel failure', () async {
       final failingProvider = ChatProvider(
         chatService: mockChatService,

--- a/website/docs/changelog/recent-releases.md
+++ b/website/docs/changelog/recent-releases.md
@@ -7,6 +7,27 @@ For canonical full release notes, use:
 
 - [`CHANGELOG.md`](https://github.com/leehack/llamadart/blob/main/CHANGELOG.md)
 
+## Unreleased
+
+- Added an app-owned FIFO model-download queue to the runnable chat app, with
+  per-card queue positions/cancellation and a responsive shell progress pill
+  that remains visible after settings closes.
+- Replaced the runnable chat app's broad built-in catalog with a focused
+  Unsloth-first set. Added cross-platform Gemma 4 E4B plus native-desktop Gemma
+  4 12B/26B-A4B/31B and Qwen3.6 35B-A3B presets. Added downloaded-first ordering,
+  name/capability search, Mobile & Web/Desktop filters, clearer incompatible-model
+  states, quieter model cards, and independent remove-from-library and
+  downloaded-file actions for custom entries.
+- Enabled Gemma 4 audio attachments in the runnable chat app for the current
+  native GGUF projector and LiteRT-LM bundle while keeping LiteRT-LM Web
+  text-only. Persisted capability settings now distinguish direct model media
+  input from external `mmproj` input.
+- Made native GGUF Auto tuning model- and memory-aware. **Max** now requests
+  full llama.cpp offload, while Auto preserves the requested context when the
+  model fits and reduces context before selecting partial offload under memory
+  pressure. Auto intent persists separately from resolved values so each model
+  load, including after an app restart, recalculates current device headroom.
+
 ## 0.8.14
 
 - Improved the runnable chat app's web model-cache and loading experience by

--- a/website/docs/examples/chat-app.md
+++ b/website/docs/examples/chat-app.md
@@ -39,34 +39,78 @@ flutter test
 - Compact runtime status with detailed performance diagnostics on demand.
 - Copy and regenerate actions for plain assistant responses.
 - Model selection and download flow.
+- App-owned FIFO download scheduling, with queue positions and cancellation for
+  waiting items. A responsive progress pill remains visible in the shell after
+  the settings panel closes and reopens download details when tapped.
 - The runnable chat app wires `ModelDownloadController` into its model-management
   flow through a small adapter, so cache checks, progress, cancel, retry, and
   clear ready/failure states come from the same package helper app code can
   reuse. The adapter keeps the example's platform-specific service layer for
   multi-asset model + `mmproj` downloads and browser cache behavior.
 - On mobile, active downloads are treated as foreground work: the app no longer
-  cancels them just because Android/iOS reports a lifecycle pause, and the card
-  tells users to keep the app open. If the OS interrupts the socket anyway, the
-  next foreground download attempt reuses the partial file when the server
-  honors Range resume. A true sleep-proof UX should be built as an opt-in native
+  cancels them just because Android/iOS reports a lifecycle pause. The card
+  tells users to keep the app open, and shell-level progress remains visible
+  when settings closes. If the OS interrupts the socket anyway, the next
+  foreground download attempt reuses the partial file when the server honors
+  Range resume. A true sleep-proof UX should be built as an opt-in native
   background downloader/model-store manager and injected through
   `ModelDownloadManager`.
 - Runtime backend preference and GPU layer controls.
 - Persistent settings and split Dart/native logging controls.
 - Tool-calling toggles and model capability badges.
-- Runtime-verified multimodal capability gating after `mmproj` load. The app
-  hides unsupported attachment types even if a model family advertises broader
-  multimodal support.
+- Runtime-verified multimodal capability gating after `mmproj` load, plus
+  declared direct-media capabilities for native model bundles such as
+  LiteRT-LM. The app hides unsupported attachment types for the active platform.
 - Native and web `.litertlm` routing through LiteRT-LM. Native LiteRT-LM is
   enabled for supported targets; iOS x86_64 simulator and Windows arm64 remain
   GGUF-only because no matching LiteRT-LM native bundle is published.
 
+## Built-in model catalog
+
+The built-in library is intentionally small and Unsloth-first:
+
+- Cross-platform: FunctionGemma 270M, Qwen3.5 0.8B, Gemma 4 E2B GGUF,
+  Gemma 4 E2B LiteRT-LM, and Gemma 4 E4B GGUF.
+- Native desktop: Gemma 4 12B, Gemma 4 26B A4B, Gemma 4 31B, and
+  Qwen3.6 35B A3B.
+
+Every GGUF preset uses an [Unsloth distribution](https://huggingface.co/unsloth)
+and identifies Unsloth in the model card. The LiteRT-LM preset is the only
+exception because the required `.litertlm` artifacts are published by
+`litert-community`. The library defaults to the current platform, promotes
+downloaded models, and supports name/capability search plus Mobile, Web, and
+Desktop filters. Browsing another platform keeps incompatible model actions
+disabled and explains why. Gemma 4 E4B remains cross-platform because it is
+designed for capable edge/mobile devices as well as desktops.
+
+Model cards prioritize size, RAM, compatibility, capabilities, cache state, and
+the primary download/load action. Recommended context and output limits remain
+visible without repeating every sampling parameter on every card.
+
+Availability filters match the catalog's two actual platform tiers: **Mobile &
+Web** for portable models and **Desktop** for the complete native catalog.
+
+For native GGUF models, Auto runtime planning uses the selected model size,
+reported device memory, conservative system headroom, and requested context. It
+chooses full offload when the model fits, reduces context before partial
+offload when memory is tight, and maps the UI's **Max** setting to llama.cpp's
+full-offload sentinel. Auto intent is stored independently from its resolved
+layer and context values, so headroom is recalculated on every model load and
+after app restarts. Selecting a lower GPU-layer value disables that tuning and
+keeps the manual value fixed.
+
+Custom and discovered model cards expose a dedicated actions menu. Removing an
+entry from the library is separate from deleting its downloaded files, and the
+confirmation dialog offers both choices when cached assets exist.
+
 ## Gemma 4 note
 
-The download library includes a Gemma 4 E2B GGUF + projector pair. On the
-current `llama.cpp` mtmd path used by `llamadart`, that projector exposes
-vision support but not audio support, so the app keeps image input enabled and
-audio input disabled for that model.
+The download library includes Gemma 4 E2B, E4B, 12B, 26B A4B, and 31B GGUF
+tiers. E2B, E4B, and 12B expose image, audio, and video input on the current
+native `llama.cpp` mtmd path; 26B A4B and 31B expose image/video input but do
+not support audio. The native Gemma 4 E2B LiteRT-LM bundle accepts audio
+directly without an external projector. Web GGUF audio remains runtime-gated,
+and LiteRT-LM Web remains text-only.
 
 ## Web notes
 
@@ -93,8 +137,8 @@ against a small Qwen3.5 model.
 
 ## Android notes
 
-- Qwen3.5 `0.8B` and `2B` currently default to `CPU` on Android because that was
-  the fastest verified path on the maintainer Pixel test device.
+- Qwen3.5 `0.8B` currently defaults to `CPU` on Android because that was the
+  fastest verified path on the maintainer Pixel test device.
 - GGUF downloads in this example run through the app's foreground Dart process.
   Keep the app visible/unlocked for the most reliable download. The app avoids
   deliberately cancelling on screen lock, but Android can still suspend the

--- a/website/docs/guides/multimodal.md
+++ b/website/docs/guides/multimodal.md
@@ -90,14 +90,17 @@ final supportsAudio = await engine.supportsAudio;
 ```
 
 Always prefer these runtime checks over model-card assumptions. A loaded
-projector can expose only a subset of the family-level modalities. For example,
-the current Gemma 4 E2B/E4B GGUF projector path in `llama.cpp` mtmd exposes
-vision, but not audio, in `llamadart`.
+projector can expose only a subset of the family-level modalities. The current
+Gemma 4 E2B GGUF projector path in native `llama.cpp` mtmd reports both vision
+and audio support; audio remains experimental upstream. Web continues to rely
+on the loaded bridge's runtime capability report.
 
 For native LiteRT-LM `.litertlm` bundles, capability depends on the bundle's
 native template/model processors. `loadMultimodalProjector`,
 `loadMultimodalProjectorSource`, `supportsVision`, and `supportsAudio` are
-projector-oriented APIs and are not used by the LiteRT-LM bundle flow.
+projector-oriented APIs and are not used by the LiteRT-LM bundle flow. The chat
+app therefore uses the selected preset's platform-specific direct-media
+capabilities for native Gemma 4 LiteRT-LM audio.
 
 ## Web notes
 


### PR DESCRIPTION
## Summary

- modernize the chat app model library with downloaded-first ordering, capability search, simplified **Mobile & Web** / **Desktop** availability filters, clearer compatibility states, and quieter model cards
- focus the built-in catalog on nine Unsloth-first presets up to 35B, including Qwen3.6 and larger Gemma 4 desktop options, while preserving custom model removal
- move model downloads into app-owned FIFO state so progress remains visible when the settings panel closes or resizes and queued downloads run sequentially
- make native GGUF Auto tuning model- and memory-aware, map **Max** to full llama.cpp offload, and persist Auto intent plus requested context separately from resolved values across restarts
- align Gemma 4 audio/vision capability handling, runtime messaging, documentation, and changelog entries

## Why

The previous model library mixed platform tiers and repetitive metadata, download state was coupled too closely to transient settings UI, and Auto could persist a resolved partial profile as if it were a fixed manual setting. That made downloads hard to track and prevented later launches from recovering to a better Metal configuration when memory headroom improved.

## User impact

Users can find appropriate models faster, distinguish portable from desktop-only options, monitor and queue downloads outside the model panel, remove custom entries cleanly, and rely on Auto to recalculate the best available native configuration on every load.

## Validation

- `dart analyze`
- `flutter test` — 195 tests passed
- `dart format --output=none --set-exit-if-changed example/chat_app/lib example/chat_app/test`
- `git diff --check`
- `./tool/docs/validate_links.sh`
- real macOS smoke test on Apple M4 Max / 64 GB with Qwen3.6 35B: persisted `Auto · 66` / 4K state recovered after restart to Metal, 999 GPU layers, 16,384-token context, and loaded multimodal projector
- live UI verification of downloaded-first cards, search, FIFO download state, and the simplified `All` / `Mobile & Web` / `Desktop` filter




