### PR TITLE
Fix LiteRT-LM streaming and GPU packaging

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,18 @@
   mobile users can choose **Paste attachment**, and ordinary text paste remains
   unchanged.
 
+* Restored the runnable macOS chat app build phase that embeds and signs
+  LiteRT-LM runtime libraries inside the sandboxed app bundle, and enabled
+  LiteRT-LM Metal selection on iOS with the consolidated upstream runtime.
+  Updated the default LiteRT-LM runtime to
+  `leehack/litert-lm-native@v0.14.0-native.2`, which fixes Android GPU plugin
+  symbol resolution and uses the checksum-pinned official Apple XCFrameworks.
+
+* Fixed native LiteRT-LM generation incorrectly treating the requested maximum
+  response length as a forced benchmark decode count. Short responses no longer
+  wait for every allowed token before streaming, and LiteRT-LM chat flushes its
+  first token immediately.
+
 * Added an app-owned FIFO model-download queue to the runnable chat app. Only
   one model transfers at a time, queued cards show their position and can leave
   the queue independently, and a responsive shell progress pill keeps the

--- a/README.md
+++ b/README.md
@@ -134,7 +134,7 @@ Current default runtime pins:
 | Runtime | Pin |
 | --- | --- |
 | Native llama.cpp / GGUF | `leehack/llamadart-native@b9935` |
-| Native LiteRT-LM / `.litertlm` | `leehack/litert-lm-native@v0.14.0-native.1` |
+| Native LiteRT-LM / `.litertlm` | `leehack/litert-lm-native@v0.14.0-native.2` |
 | Web llama.cpp / GGUF | `leehack/llama-web-bridge-assets@v0.1.18` |
 | Web LiteRT-LM / `.litertlm` | `@litert-lm/core@0.14.0` |
 

--- a/example/chat_app/lib/services/chat_generation_service.dart
+++ b/example/chat_app/lib/services/chat_generation_service.dart
@@ -61,6 +61,9 @@ class ChatGenerationService {
       minP: isLiteRtLm ? defaults.minP : settings.minP,
       penalty: isLiteRtLm ? defaults.penalty : settings.penalty,
       stopSequences: const <String>[],
+      streamBatchTokenThreshold: isLiteRtLm
+          ? 1
+          : defaults.streamBatchTokenThreshold,
     );
   }
 

--- a/example/chat_app/macos/Runner.xcodeproj/project.pbxproj
+++ b/example/chat_app/macos/Runner.xcodeproj/project.pbxproj
@@ -349,7 +349,7 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/bash;
-			shellScript = "set -euo pipefail\nSCRIPT=\"$PROJECT_DIR/../../../tool/macos_litert_lm_prepare_app.sh\"\nif [ -x \"$SCRIPT\" ]; then\n  \"$SCRIPT\" \"$TARGET_BUILD_DIR/$WRAPPER_NAME\"\nelse\n  echo \"warning: LiteRT-LM prepare script not found: $SCRIPT\" >&2\nfi\n";
+			shellScript = "set -euo pipefail\nSCRIPT=\"$PROJECT_DIR/../../../tool/macos_litert_lm_prepare_app.sh\"\nif [ -f \"$SCRIPT\" ]; then\n  bash \"$SCRIPT\" \"$TARGET_BUILD_DIR/$WRAPPER_NAME\"\nelse\n  echo \"warning: LiteRT-LM prepare script not found: $SCRIPT\" >&2\nfi\n";
 		};
 /* End PBXShellScriptBuildPhase section */
 

--- a/example/chat_app/macos/Runner.xcodeproj/project.pbxproj
+++ b/example/chat_app/macos/Runner.xcodeproj/project.pbxproj
@@ -205,6 +205,7 @@
 				33CC10EB2044A3C60003C045 /* Resources */,
 				33CC110E2044A8840003C045 /* Bundle Framework */,
 				3399D490228B24CF009A79C7 /* ShellScript */,
+				A17E2C1B5C7747D5A3C40A23 /* Prepare LiteRT-LM Runtime */,
 			);
 			buildRules = (
 			);
@@ -330,6 +331,25 @@
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
 			shellScript = "\"$FLUTTER_ROOT\"/packages/flutter_tools/bin/macos_assemble.sh && touch Flutter/ephemeral/tripwire";
+		};
+		A17E2C1B5C7747D5A3C40A23 /* Prepare LiteRT-LM Runtime */ = {
+			isa = PBXShellScriptBuildPhase;
+			alwaysOutOfDate = 1;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputFileListPaths = (
+			);
+			inputPaths = (
+			);
+			name = "Prepare LiteRT-LM Runtime";
+			outputFileListPaths = (
+			);
+			outputPaths = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/bash;
+			shellScript = "set -euo pipefail\nSCRIPT=\"$PROJECT_DIR/../../../tool/macos_litert_lm_prepare_app.sh\"\nif [ -x \"$SCRIPT\" ]; then\n  \"$SCRIPT\" \"$TARGET_BUILD_DIR/$WRAPPER_NAME\"\nelse\n  echo \"warning: LiteRT-LM prepare script not found: $SCRIPT\" >&2\nfi\n";
 		};
 /* End PBXShellScriptBuildPhase section */
 

--- a/example/chat_app/test/chat_generation_service_test.dart
+++ b/example/chat_app/test/chat_generation_service_test.dart
@@ -51,6 +51,7 @@ void main() {
       // reject the request with an UnsupportedError.
       expect(params.minP, defaults.minP);
       expect(params.penalty, defaults.penalty);
+      expect(params.streamBatchTokenThreshold, 1);
     });
 
     test('accumulates stream updates and metrics', () async {

--- a/hook/build.dart
+++ b/hook/build.dart
@@ -26,7 +26,7 @@ const _cacheBaseDir = 'llamadart';
 const _bundleCacheDir = 'native_bundles';
 const _reportDir = 'llamadart_bin';
 const _allowLegacyLocalBundleEnv = 'LLAMADART_ALLOW_LEGACY_LOCAL_BUNDLES';
-const _litertLmVersion = '0.14.0-native.1';
+const _litertLmVersion = '0.14.0-native.2';
 const _litertLmNativeReleaseBaseUrl =
     'https://github.com/leehack/litert-lm-native/releases/download/'
     'v$_litertLmVersion';
@@ -51,7 +51,7 @@ final _litertLmBundles = Map.unmodifiable({
 const _litertLmBundleSpecs = <_LiteRtLmBundleSpec>[
   _LiteRtLmBundleSpec(
     'android-arm64',
-    sha256: '8550c394256343c3fd9e1c23ef667fb89dabdc378792c5e2fe133f3c3f92b4b2',
+    sha256: '0ea2d059ef4cb1c44181724cd6e96a4c5556c053649270c7384706359d4415e7',
     requiredLibraries: {
       'libGemmaModelConstraintProvider.so',
       'libLiteRtGpuAccelerator.so',
@@ -65,7 +65,7 @@ const _litertLmBundleSpecs = <_LiteRtLmBundleSpec>[
   ),
   _LiteRtLmBundleSpec(
     'android-x64',
-    sha256: '7a5df0d7e2ba9f4be2ddbdfe02043a41c1d29d4ea5dae334e3798063a9680830',
+    sha256: '07d1b875828361302791c40e58bcd6f634fdac0ce44a6dc18dc8cf526c33e686',
     requiredLibraries: {
       'libGemmaModelConstraintProvider.so',
       'libLiteRtGpuAccelerator.so',
@@ -79,51 +79,27 @@ const _litertLmBundleSpecs = <_LiteRtLmBundleSpec>[
   ),
   _LiteRtLmBundleSpec(
     'ios-arm64',
-    sha256: '154c746c9028dee6ec77ad451f97bf34227b08d6c22f7daf381c47c76312f9b3',
-    requiredLibraries: {
-      'LiteRtLm',
-      'CLiteRTLM',
-      'libLiteRtLm.dylib',
-      'libGemmaModelConstraintProvider.dylib',
-      'libLiteRt.dylib',
-      'libLiteRtMetalAccelerator.dylib',
-    },
+    sha256: 'c542d2776b56a6f0f8e9f41474d04ebb64703761b08ed4172212641255cb8c2f',
+    requiredLibraries: {'LiteRtLm', 'CLiteRTLM'},
   ),
   _LiteRtLmBundleSpec(
     'ios-arm64-sim',
-    sha256: '768d07af49d6715d4198ac35dc8f6f726cf3ba9ab46b465317aee54bfa65a050',
-    requiredLibraries: {
-      'LiteRtLm',
-      'CLiteRTLM',
-      'libLiteRtLm.dylib',
-      'libGemmaModelConstraintProvider.dylib',
-      'libLiteRt.dylib',
-      'libLiteRtMetalAccelerator.dylib',
-    },
+    sha256: '9b96d44dbeeae922346125c656cd1acc9a854c6a035ac8182a0d3e66a79e0003',
+    requiredLibraries: {'LiteRtLm', 'CLiteRTLM'},
   ),
   _LiteRtLmBundleSpec(
     'macos-arm64',
-    sha256: 'bcc179b68763f300631d53516a4e234c9cc2cb1b3e482db73080a7af74c5c12f',
-    requiredLibraries: {
-      'libLiteRtLm.dylib',
-      'libCLiteRTLM_mac.dylib',
-      'libGemmaModelConstraintProvider.dylib',
-      'libLiteRt.dylib',
-      'libLiteRtMetalAccelerator.dylib',
-      'libLiteRtTopKMetalSampler.dylib',
-      'libLiteRtTopKWebGpuSampler.dylib',
-      'libLiteRtWebGpuAccelerator.dylib',
-      'libwebgpu_dawn.dylib',
-    },
+    sha256: '7165bc8c9a7bb6fe3ea32b2cbc0ccc49e9b6c86d14c911bb7dc670fc1a254c2d',
+    requiredLibraries: {'libLiteRtLm.dylib', 'libCLiteRTLM_mac.dylib'},
   ),
   _LiteRtLmBundleSpec(
     'macos-x64',
-    sha256: '4ae3b52f830e6a8c75e352ca068ad8c02370b791b067ac299901e83df262bf91',
+    sha256: 'ad2644d55e8b8577a9cd09263178bdadcad897c85e557d4be0ecd57da54588de',
     requiredLibraries: {'libLiteRtLm.dylib', 'libCLiteRTLM_mac.dylib'},
   ),
   _LiteRtLmBundleSpec(
     'linux-arm64',
-    sha256: 'f532ea78f15f460834a6096c76e11c977f1b1f868d1f5882e3cf4953ff1ced6c',
+    sha256: '72da739c7f3b125c55f3357a923cdfde3d02a53ba6a5837a296c27c6b47137d4',
     requiredLibraries: {
       'libGemmaModelConstraintProvider.so',
       'libLiteRt.so',
@@ -135,7 +111,7 @@ const _litertLmBundleSpecs = <_LiteRtLmBundleSpec>[
   ),
   _LiteRtLmBundleSpec(
     'linux-x64',
-    sha256: '25b717027f7e6355f9964bee4c931e7b90482b395d355cb7f9bc2ed3b64bca42',
+    sha256: '71b36a9f0ca0a64ee285f243a0a6562a603df10a2f5cd61ede31078d5c75b972',
     requiredLibraries: {
       'libGemmaModelConstraintProvider.so',
       'libLiteRt.so',
@@ -147,7 +123,7 @@ const _litertLmBundleSpecs = <_LiteRtLmBundleSpec>[
   ),
   _LiteRtLmBundleSpec(
     'windows-x64',
-    sha256: '20b26520e82424845282b5ab2c675236473505398df7e6ee9fad0cb6c91405a7',
+    sha256: '3139f3b8b3f35c7fadf6d3978c25e39a89b732e19b7b0f8be95c7b9dc4e341bc',
     requiredLibraries: {
       'LiteRtLm.dll',
       'libGemmaModelConstraintProvider.dll',
@@ -737,6 +713,9 @@ Future<void> _emitLiteRtLmAssets({
   final libraryPaths = _collectDynamicLibraryPaths(
     bundleDir,
     additionalFileNames: bundleSpec.requiredLibraries,
+    onlyFileNames: code.targetOS == OS.iOS
+        ? bundleSpec.requiredLibraries
+        : null,
   );
   if (libraryPaths.isEmpty) {
     log.warning('LiteRT-LM bundle had no dynamic libraries.');
@@ -1597,6 +1576,7 @@ List<String> _localBundleCandidates({
 List<String> _collectDynamicLibraryPaths(
   Directory directory, {
   Set<String> additionalFileNames = const {},
+  Set<String>? onlyFileNames,
 }) {
   if (!directory.existsSync()) {
     return const [];
@@ -1607,7 +1587,11 @@ List<String> _collectDynamicLibraryPaths(
     if (entity is! File) {
       continue;
     }
-    final fileName = path.basename(entity.path).toLowerCase();
+    final baseName = path.basename(entity.path);
+    if (onlyFileNames != null && !onlyFileNames.contains(baseName)) {
+      continue;
+    }
+    final fileName = baseName.toLowerCase();
     final extension = path.extension(entity.path).toLowerCase();
     if (_dynamicLibraryExtensions.contains(extension) ||
         additionalFileNames.contains(path.basename(entity.path)) ||

--- a/lib/src/backends/litert_lm/litert_lm_platform.dart
+++ b/lib/src/backends/litert_lm/litert_lm_platform.dart
@@ -18,7 +18,7 @@ List<String> liteRtLmAvailableNativeBackendsForCurrentPlatform() {
       liteRtLmNpuBackend,
     ];
   }
-  if (Platform.isMacOS) {
+  if (Platform.isIOS || Platform.isMacOS) {
     return const <String>[liteRtLmCpuBackend, liteRtLmGpuBackend];
   }
   return const <String>[liteRtLmCpuBackend];
@@ -26,7 +26,7 @@ List<String> liteRtLmAvailableNativeBackendsForCurrentPlatform() {
 
 /// Returns the native LiteRT-LM backend used for automatic selection.
 String liteRtLmDefaultNativeBackendForCurrentPlatform() {
-  if (Platform.isAndroid || Platform.isMacOS) {
+  if (Platform.isAndroid || Platform.isIOS || Platform.isMacOS) {
     return liteRtLmGpuBackend;
   }
   return liteRtLmCpuBackend;
@@ -34,7 +34,7 @@ String liteRtLmDefaultNativeBackendForCurrentPlatform() {
 
 /// Returns whether the current native LiteRT-LM target exposes a GPU backend.
 bool liteRtLmNativeGpuSupportedOnCurrentPlatform() {
-  return Platform.isMacOS || Platform.isAndroid;
+  return Platform.isAndroid || Platform.isIOS || Platform.isMacOS;
 }
 
 /// Normalizes an optional direct LiteRT-LM native backend override.

--- a/lib/src/backends/litert_lm/litert_lm_runtime.dart
+++ b/lib/src/backends/litert_lm/litert_lm_runtime.dart
@@ -9,7 +9,7 @@ import 'package:path/path.dart' as path;
 
 import '../../core/models/inference/model_params.dart';
 
-const _litertLmVersion = '0.14.0-native.1';
+const _litertLmVersion = '0.14.0-native.2';
 const _litertLmLibDirEnv = 'LLAMADART_LITERT_LM_LIB_DIR';
 const _liteRtLmIosNativeAsset = 'package:llamadart/litert_lm_LiteRtLm';
 const _processLibraryCandidate = '<process>';
@@ -59,18 +59,7 @@ List<String> liteRtLmMacOsCacheDirectoryCandidatesForAbi(Abi abi) {
 /// native-assets cache directories.
 List<String> liteRtLmMacOsRequiredLibrariesForAbi(Abi abi) {
   return switch (abi) {
-    Abi.macosArm64 => const <String>[
-      'libLiteRtLm.dylib',
-      'libCLiteRTLM_mac.dylib',
-      'libGemmaModelConstraintProvider.dylib',
-      'libLiteRt.dylib',
-      'libLiteRtMetalAccelerator.dylib',
-      'libLiteRtTopKMetalSampler.dylib',
-      'libLiteRtTopKWebGpuSampler.dylib',
-      'libLiteRtWebGpuAccelerator.dylib',
-      'libwebgpu_dawn.dylib',
-    ],
-    Abi.macosX64 => const <String>[
+    Abi.macosArm64 || Abi.macosX64 => const <String>[
       'libLiteRtLm.dylib',
       'libCLiteRTLM_mac.dylib',
     ],
@@ -234,20 +223,7 @@ Directory? _directoryFromPackageConfigRootUri(
 /// framework directories.
 List<String> liteRtLmMacOsRequiredFrameworksForAbi(Abi abi) {
   return switch (abi) {
-    Abi.macosArm64 => const <String>[
-      'GemmaModelConstraintProvider.framework/Versions/A/'
-          'GemmaModelConstraintProvider',
-      'LiteRt.framework/Versions/A/LiteRt',
-      'LiteRtLm.framework/Versions/A/LiteRtLm',
-      'LiteRtMetalAccelerator.framework/Versions/A/'
-          'LiteRtMetalAccelerator',
-      'LiteRtTopKMetalSampler.framework/Versions/A/'
-          'LiteRtTopKMetalSampler',
-      'LiteRtTopKWebGpuSampler.framework/Versions/A/'
-          'LiteRtTopKWebGpuSampler',
-      'LiteRtWebGpuAccelerator.framework/Versions/A/'
-          'LiteRtWebGpuAccelerator',
-    ],
+    Abi.macosArm64 ||
     Abi.macosX64 => const <String>['LiteRtLm.framework/Versions/A/LiteRtLm'],
     _ => const <String>[],
   };
@@ -257,20 +233,7 @@ List<String> liteRtLmMacOsRequiredFrameworksForAbi(Abi abi) {
 /// Apple SPM layout in macOS app bundles.
 List<String> liteRtLmMacOsRequiredNativeSpmFilesForAbi(Abi abi) {
   return switch (abi) {
-    Abi.macosArm64 => const <String>[
-      'GemmaModelConstraintProvider.framework/Versions/A/'
-          'GemmaModelConstraintProvider',
-      'LiteRtLm.framework/Versions/A/LiteRtLm',
-      'libCLiteRTLM_mac.dylib',
-      'libGemmaModelConstraintProvider.dylib',
-      'libLiteRt.dylib',
-      'libLiteRtMetalAccelerator.dylib',
-      'libLiteRtTopKMetalSampler.dylib',
-      'libLiteRtTopKWebGpuSampler.dylib',
-      'libLiteRtWebGpuAccelerator.dylib',
-      'libwebgpu_dawn.dylib',
-    ],
-    Abi.macosX64 => const <String>[
+    Abi.macosArm64 || Abi.macosX64 => const <String>[
       'LiteRtLm.framework/Versions/A/LiteRtLm',
       'libCLiteRTLM_mac.dylib',
     ],
@@ -481,12 +444,15 @@ class LiteRtLmRuntimeClient {
   List<String> _liteRtLmCompanionLibraryPaths = const <String>[];
   Pointer<_LiteRtLmEngine>? _engine;
   Pointer<_LiteRtLmConversation>? _conversation;
+  int _defaultMaxOutputTokens = 256;
 
   /// Initializes the native LiteRT-LM engine for a `.litertlm` model bundle.
   ///
   /// [visionBackend] and [audioBackend] enable the native media executors for
   /// multimodal bundles. [maxNumImages] configures the image preprocessor
-  /// capacity for conversations that may include image inputs.
+  /// capacity for conversations that may include image inputs. [outputTokens]
+  /// is the per-request fallback when generation does not provide an explicit
+  /// maximum; it is not an upstream benchmark decode-step count.
   Future<void> initialize({
     required String modelPath,
     String backend = 'gpu',
@@ -560,6 +526,7 @@ class LiteRtLmRuntimeClient {
     final resolvedAudioBackend = audioBackend == null
         ? null
         : _normalizeLiteRtLmRuntimeBackend(audioBackend, name: 'audioBackend');
+    _defaultMaxOutputTokens = outputTokens;
 
     _ensureLibrariesLoaded();
     final bindings = _bindings!;
@@ -591,8 +558,10 @@ class LiteRtLmRuntimeClient {
         throw StateError('litert_lm_engine_settings_create returned null');
       }
       bindings.engineSettingsSetMaxNumTokens(settings, maxTokens);
+      // Benchmarking exposes real prefill/decode metrics. Do not set
+      // num_decode_tokens here: upstream defines it as a forced benchmark step
+      // count, not a response limit. Per-request maxOutputTokens handles that.
       bindings.engineSettingsEnableBenchmark(settings);
-      bindings.engineSettingsSetNumDecodeTokens(settings, outputTokens);
       bindings.engineSettingsSetEnableSpeculativeDecoding(
         settings,
         speculativeDecoding,
@@ -906,6 +875,7 @@ class LiteRtLmRuntimeClient {
     int? visualTokenBudget,
     int? maxOutputTokens,
   }) {
+    final resolvedMaxOutputTokens = maxOutputTokens ?? _defaultMaxOutputTokens;
     if (visualTokenBudget != null && visualTokenBudget <= 0) {
       throw ArgumentError.value(
         visualTokenBudget,
@@ -913,9 +883,9 @@ class LiteRtLmRuntimeClient {
         'must be positive when provided',
       );
     }
-    if (maxOutputTokens != null && maxOutputTokens <= 0) {
+    if (resolvedMaxOutputTokens <= 0) {
       throw ArgumentError.value(
-        maxOutputTokens,
+        resolvedMaxOutputTokens,
         'maxOutputTokens',
         'must be positive when provided',
       );
@@ -931,14 +901,14 @@ class LiteRtLmRuntimeClient {
         messageJson,
         extraContextJson: extraContextJson,
         visualTokenBudget: visualTokenBudget,
-        maxOutputTokens: maxOutputTokens,
+        maxOutputTokens: resolvedMaxOutputTokens,
       );
     }
     return _generateStreamingMessageJson(
       messageJson,
       extraContextJson: extraContextJson,
       visualTokenBudget: visualTokenBudget,
-      maxOutputTokens: maxOutputTokens,
+      maxOutputTokens: resolvedMaxOutputTokens,
     );
   }
 
@@ -1267,6 +1237,7 @@ class LiteRtLmRuntimeClient {
       bindings.engineDelete(engine);
     }
     _engine = null;
+    _defaultMaxOutputTokens = 256;
   }
 
   void _ensureLibrariesLoaded() {
@@ -2171,12 +2142,6 @@ class _LiteRtLmBindings {
         Void Function(Pointer<_LiteRtLmEngineSettings>, Int),
         void Function(Pointer<_LiteRtLmEngineSettings>, int)
       >('litert_lm_engine_settings_set_num_prefill_tokens');
-
-  late final engineSettingsSetNumDecodeTokens = _library
-      .lookupFunction<
-        Void Function(Pointer<_LiteRtLmEngineSettings>, Int),
-        void Function(Pointer<_LiteRtLmEngineSettings>, int)
-      >('litert_lm_engine_settings_set_num_decode_tokens');
 
   late final engineSettingsSetMaxNumImages = _library
       .lookupFunction<

--- a/lib/src/backends/litert_lm/litert_lm_runtime_stub.dart
+++ b/lib/src/backends/litert_lm/litert_lm_runtime_stub.dart
@@ -68,6 +68,9 @@ class LiteRtLmRuntimeClient {
   }
 
   /// Initializes the native LiteRT-LM engine.
+  ///
+  /// [outputTokens] is the fallback per-request output limit, not a benchmark
+  /// decode-step count.
   Future<void> initialize({
     required String modelPath,
     String backend = 'gpu',

--- a/lib/src/backends/litert_lm/litert_lm_service.dart
+++ b/lib/src/backends/litert_lm/litert_lm_service.dart
@@ -36,7 +36,6 @@ class LiteRtLmService {
   ModelParams? _modelParams;
   String? _modelPath;
   String? _activeBackend;
-  int? _activeOutputTokens;
   bool? _activeSpeculativeDecoding;
   int? _activeMaxNumImages;
   bool? _activeVisionEnabled;
@@ -83,7 +82,6 @@ class LiteRtLmService {
     _modelPath = path;
     _modelParams = params;
     _activeBackend = resolvedBackend;
-    _activeOutputTokens = null;
     _activeSpeculativeDecoding = null;
     _modelHandle = _nextModelHandle++;
     _contextHandle = null;
@@ -102,7 +100,6 @@ class LiteRtLmService {
     _modelPath = null;
     _modelParams = null;
     _activeBackend = null;
-    _activeOutputTokens = null;
     _activeSpeculativeDecoding = null;
     _modelHandle = null;
     _contextHandle = null;
@@ -529,7 +526,6 @@ class LiteRtLmService {
   void _disposeContextRuntimeState() {
     _client?.dispose();
     _client = null;
-    _activeOutputTokens = null;
     _activeSpeculativeDecoding = null;
     _activeMaxNumImages = null;
     _activeVisionEnabled = null;
@@ -544,7 +540,6 @@ class LiteRtLmService {
     bool? enableAudio,
   }) {
     return _ensureClientForRuntime(
-      outputTokens: params.maxTokens,
       speculativeDecoding: params.isSpeculativeDecodingEnabled,
       maxNumImages: maxNumImages,
       enableVision: maxNumImages != null,
@@ -553,7 +548,6 @@ class LiteRtLmService {
   }
 
   Future<LiteRtLmRuntimeClient> _ensureClientForRuntime({
-    int? outputTokens,
     bool? speculativeDecoding,
     int? maxNumImages,
     bool? enableVision,
@@ -565,8 +559,6 @@ class LiteRtLmService {
       throw StateError('No LiteRT-LM model is loaded.');
     }
 
-    final resolvedOutputTokens =
-        outputTokens ?? _activeOutputTokens ?? GenerationParams().maxTokens;
     final resolvedSpeculativeDecoding =
         speculativeDecoding ?? _activeSpeculativeDecoding ?? false;
     final resolvedMaxNumImages = maxNumImages ?? _activeMaxNumImages;
@@ -575,7 +567,6 @@ class LiteRtLmService {
     final backend = _activeBackend ?? _backendNameFor(modelParams);
     final existing = _client;
     if (existing != null &&
-        (outputTokens == null || _activeOutputTokens == resolvedOutputTokens) &&
         (speculativeDecoding == null ||
             _activeSpeculativeDecoding == resolvedSpeculativeDecoding) &&
         (maxNumImages == null || _activeMaxNumImages == resolvedMaxNumImages) &&
@@ -588,7 +579,6 @@ class LiteRtLmService {
 
     existing?.dispose();
     _client = null;
-    _activeOutputTokens = null;
     _activeSpeculativeDecoding = null;
     _activeMaxNumImages = null;
     _activeVisionEnabled = null;
@@ -608,7 +598,6 @@ class LiteRtLmService {
             : null,
         audioBackend: resolvedAudioEnabled ? _mediaBackendName(backend) : null,
         maxTokens: modelParams.contextSize,
-        outputTokens: resolvedOutputTokens,
         maxNumImages: resolvedMaxNumImages,
         cacheDir: _defaultCacheDir(),
         speculativeDecoding: resolvedSpeculativeDecoding,
@@ -631,7 +620,6 @@ class LiteRtLmService {
       rethrow;
     }
     _client = client;
-    _activeOutputTokens = resolvedOutputTokens;
     _activeSpeculativeDecoding = resolvedSpeculativeDecoding;
     _activeMaxNumImages = resolvedMaxNumImages;
     _activeVisionEnabled = resolvedVisionEnabled;

--- a/packages/llamadart_litert_lm_flutter/CHANGELOG.md
+++ b/packages/llamadart_litert_lm_flutter/CHANGELOG.md
@@ -1,3 +1,10 @@
+## Unreleased
+
+* Updated Apple SwiftPM native pin to `leehack/litert-lm-native@v0.14.0-native.2`.
+
+* Replaced the separate iOS Gemma provider target with the consolidated
+  upstream runtime and enabled the complete macOS SwiftPM artifact set.
+
 ## 0.0.4
 
 * Added the `GemmaModelConstraintProvider` SwiftPM binary target required by

--- a/packages/llamadart_litert_lm_flutter/README.md
+++ b/packages/llamadart_litert_lm_flutter/README.md
@@ -4,11 +4,11 @@ Flutter Apple Swift Package Manager companion package for
 [`llamadart`](https://pub.dev/packages/llamadart) `.litertlm` / LiteRT-LM
 support.
 
-Add this package to a Flutter iOS app when the app should link the prebuilt
+Add the published package to a Flutter iOS app when it should link the prebuilt
 LiteRT-LM Apple XCFrameworks through SwiftPM instead of relying on the core
-package's native-assets fallback. Flutter macOS `.litertlm` builds currently
-keep the core native-assets fallback when the SwiftPM artifact set is incomplete
-for the selected architecture.
+package's native-assets fallback. This unreleased source also restores the
+complete macOS SwiftPM target set; published `0.0.4` still uses the core
+native-assets fallback on macOS until the next companion release.
 
 ```yaml
 dependencies:
@@ -19,7 +19,7 @@ dependencies:
 This package has no runtime Dart API of its own. Import `package:llamadart`
 normally from the core package and use `LlamaBackend()` / `LlamaEngine` there.
 
-The Apple SwiftPM manifest pins `leehack/litert-lm-native@v0.14.0-native.1`.
+The Apple SwiftPM manifest pins `leehack/litert-lm-native@v0.14.0-native.2`.
 
 Source for this package lives in
 `packages/llamadart_litert_lm_flutter` in the

--- a/packages/llamadart_litert_lm_flutter/darwin/llamadart_litert_lm_flutter/Package.swift
+++ b/packages/llamadart_litert_lm_flutter/darwin/llamadart_litert_lm_flutter/Package.swift
@@ -4,7 +4,7 @@ import PackageDescription
 
 let packageRoot = URL(fileURLWithPath: #filePath).deletingLastPathComponent()
 let artifactsRoot = packageRoot.appendingPathComponent("Artifacts")
-let liteRtLmTag = "v0.14.0-native.1"
+let liteRtLmTag = "v0.14.0-native.2"
 
 func localArtifactPath(_ name: String) -> String? {
     let path = artifactsRoot.appendingPathComponent(name).path
@@ -47,34 +47,31 @@ let package = Package(
             repository: "leehack/litert-lm-native",
             artifactName: "litert-lm-native-apple-LiteRtLm-xcframework-\(liteRtLmTag).zip",
             tag: liteRtLmTag,
-            checksum: "f1d319d07564647d567d4d4c8da6e10b303a7178a92c5d59f0d360f77a682edd"
+            checksum: "3412410db1cf0d343371db9a4af711710db3ddfed14ec7f95d673dd16a1b0cbe"
         ),
         nativeRepoBinaryTarget(
             name: "CLiteRTLM",
             repository: "leehack/litert-lm-native",
             artifactName: "litert-lm-native-apple-CLiteRTLM-xcframework-\(liteRtLmTag).zip",
             tag: liteRtLmTag,
-            checksum: "f9b8b0dc9cc7ea1cef919e075a512806342395538a1996f8be2e267737d62312"
+            checksum: "1d0663baa5df3d29ab845dfd034783289e7c4f9f5f27dbfcb9beb3c762dc6cdd"
         ),
         nativeRepoBinaryTarget(
-            name: "GemmaModelConstraintProvider",
+            name: "CLiteRTLMMac",
             repository: "leehack/litert-lm-native",
-            artifactName: "litert-lm-native-apple-GemmaModelConstraintProvider-xcframework-\(liteRtLmTag).zip",
+            artifactName: "litert-lm-native-apple-CLiteRTLMMac-xcframework-\(liteRtLmTag).zip",
             tag: liteRtLmTag,
-            checksum: "5abce5c59149bca419f1cdffdd2b6e2fbca355dae21cd0ae94253788ac35e597"
+            checksum: "a889c3fea5b2fce522c84b429a6552ed3cb9e21a51ba00d04dceeae8c33143e5"
         ),
         .target(
             name: "llamadart_litert_lm_flutter",
             dependencies: [
-                .target(name: "LiteRtLm", condition: .when(platforms: [.iOS])),
-                .target(
-                    name: "GemmaModelConstraintProvider",
-                    condition: .when(platforms: [.iOS])
-                ),
-                .target(name: "CLiteRTLM", condition: .when(platforms: [.iOS]))
+                .target(name: "LiteRtLm", condition: .when(platforms: [.iOS, .macOS])),
+                .target(name: "CLiteRTLM", condition: .when(platforms: [.iOS])),
+                .target(name: "CLiteRTLMMac", condition: .when(platforms: [.macOS]))
             ],
             linkerSettings: [
-                .unsafeFlags(["-Xlinker", "-reexport_framework", "-Xlinker", "LiteRtLm"], .when(platforms: [.iOS])),
+                .unsafeFlags(["-Xlinker", "-reexport_framework", "-Xlinker", "LiteRtLm"], .when(platforms: [.iOS, .macOS])),
                 .unsafeFlags(["-Xlinker", "-reexport_framework", "-Xlinker", "CLiteRTLM"], .when(platforms: [.iOS]))
             ]
         )

--- a/packages/llamadart_litert_lm_flutter/darwin/llamadart_litert_lm_flutter/Sources/llamadart_litert_lm_flutter/LlamadartLiteRtLmPlugin.swift
+++ b/packages/llamadart_litert_lm_flutter/darwin/llamadart_litert_lm_flutter/Sources/llamadart_litert_lm_flutter/LlamadartLiteRtLmPlugin.swift
@@ -6,6 +6,7 @@ import CLiteRTLM
 #elseif os(macOS)
 import FlutterMacOS
 import Cocoa
+import LiteRtLm
 #endif
 
 public class LlamadartLiteRtLmPlugin: NSObject, FlutterPlugin {

--- a/packages/llamadart_litert_lm_flutter/test/llamadart_litert_lm_flutter_test.dart
+++ b/packages/llamadart_litert_lm_flutter/test/llamadart_litert_lm_flutter_test.dart
@@ -14,22 +14,22 @@ void main() {
     ).readAsStringSync();
 
     expect(manifest, contains('name: "llamadart-litert-lm-flutter"'));
-    expect(manifest, contains('name: "GemmaModelConstraintProvider"'));
-    expect(
-      manifest,
-      contains('name: "LiteRtLm", condition: .when(platforms: [.iOS])'),
-    );
+    expect(manifest, isNot(contains('name: "GemmaModelConstraintProvider"')));
+    expect(manifest, contains('name: "CLiteRTLMMac"'));
     expect(
       manifest,
       contains(
-        'name: "GemmaModelConstraintProvider",\n'
-        '                    condition: .when(platforms: [.iOS])',
+        'name: "LiteRtLm", condition: '
+        '.when(platforms: [.iOS, .macOS])',
       ),
     );
-    expect(manifest, isNot(contains('name: "CLiteRTLMMac"')));
+    expect(
+      manifest,
+      contains('name: "CLiteRTLMMac", condition: .when(platforms: [.macOS])'),
+    );
   });
 
-  test('does not import LiteRT-LM binaries on macOS', () {
+  test('imports the primary LiteRT-LM runtime on macOS', () {
     final pluginSource = File(
       'darwin/llamadart_litert_lm_flutter/Sources/'
       'llamadart_litert_lm_flutter/LlamadartLiteRtLmPlugin.swift',
@@ -39,6 +39,6 @@ void main() {
       r'#elseif os\(macOS\)([\s\S]*?)#endif',
     ).firstMatch(pluginSource);
     expect(macosBlock, isNotNull);
-    expect(macosBlock!.group(1), isNot(contains('import LiteRtLm')));
+    expect(macosBlock!.group(1), contains('import LiteRtLm'));
   });
 }

--- a/test/unit/backends/litert_lm/litert_lm_platform_test.dart
+++ b/test/unit/backends/litert_lm/litert_lm_platform_test.dart
@@ -38,7 +38,7 @@ void main() {
       return;
     }
 
-    if (Platform.isMacOS) {
+    if (Platform.isIOS || Platform.isMacOS) {
       expect(available, const <String>[liteRtLmCpuBackend, liteRtLmGpuBackend]);
       expect(liteRtLmDefaultNativeBackendForCurrentPlatform(), 'gpu');
       expect(liteRtLmNativeGpuSupportedOnCurrentPlatform(), isTrue);

--- a/test/unit/backends/litert_lm/litert_lm_runtime_test.dart
+++ b/test/unit/backends/litert_lm/litert_lm_runtime_test.dart
@@ -169,13 +169,6 @@ void main() {
     expect(liteRtLmMacOsRequiredLibrariesForAbi(Abi.macosArm64), const <String>[
       'libLiteRtLm.dylib',
       'libCLiteRTLM_mac.dylib',
-      'libGemmaModelConstraintProvider.dylib',
-      'libLiteRt.dylib',
-      'libLiteRtMetalAccelerator.dylib',
-      'libLiteRtTopKMetalSampler.dylib',
-      'libLiteRtTopKWebGpuSampler.dylib',
-      'libLiteRtWebGpuAccelerator.dylib',
-      'libwebgpu_dawn.dylib',
     ]);
     expect(liteRtLmMacOsRequiredLibrariesForAbi(Abi.macosX64), const <String>[
       'libLiteRtLm.dylib',
@@ -207,20 +200,7 @@ void main() {
   test('macOS LiteRT-LM app framework validation follows runtime ABI', () {
     expect(
       liteRtLmMacOsRequiredFrameworksForAbi(Abi.macosArm64),
-      const <String>[
-        'GemmaModelConstraintProvider.framework/Versions/A/'
-            'GemmaModelConstraintProvider',
-        'LiteRt.framework/Versions/A/LiteRt',
-        'LiteRtLm.framework/Versions/A/LiteRtLm',
-        'LiteRtMetalAccelerator.framework/Versions/A/'
-            'LiteRtMetalAccelerator',
-        'LiteRtTopKMetalSampler.framework/Versions/A/'
-            'LiteRtTopKMetalSampler',
-        'LiteRtTopKWebGpuSampler.framework/Versions/A/'
-            'LiteRtTopKWebGpuSampler',
-        'LiteRtWebGpuAccelerator.framework/Versions/A/'
-            'LiteRtWebGpuAccelerator',
-      ],
+      const <String>['LiteRtLm.framework/Versions/A/LiteRtLm'],
     );
     expect(liteRtLmMacOsRequiredFrameworksForAbi(Abi.macosX64), const <String>[
       'LiteRtLm.framework/Versions/A/LiteRtLm',
@@ -232,17 +212,8 @@ void main() {
     expect(
       liteRtLmMacOsRequiredNativeSpmFilesForAbi(Abi.macosArm64),
       const <String>[
-        'GemmaModelConstraintProvider.framework/Versions/A/'
-            'GemmaModelConstraintProvider',
         'LiteRtLm.framework/Versions/A/LiteRtLm',
         'libCLiteRTLM_mac.dylib',
-        'libGemmaModelConstraintProvider.dylib',
-        'libLiteRt.dylib',
-        'libLiteRtMetalAccelerator.dylib',
-        'libLiteRtTopKMetalSampler.dylib',
-        'libLiteRtTopKWebGpuSampler.dylib',
-        'libLiteRtWebGpuAccelerator.dylib',
-        'libwebgpu_dawn.dylib',
       ],
     );
     expect(
@@ -261,7 +232,6 @@ void main() {
 
     final arm64Dir = Directory('${root.path}/arm64')..createSync();
     File('${arm64Dir.path}/libLiteRtLm.dylib').createSync();
-    File('${arm64Dir.path}/libCLiteRTLM_mac.dylib').createSync();
 
     expect(
       liteRtLmIsMacOsCacheDirectoryForAbi(arm64Dir, Abi.macosArm64),

--- a/test/unit/backends/litert_lm/litert_lm_service_test.dart
+++ b/test/unit/backends/litert_lm/litert_lm_service_test.dart
@@ -1200,7 +1200,7 @@ void main() {
             .generate(
               contextHandle,
               'hello',
-              const GenerationParams(maxTokens: 7),
+              const GenerationParams(maxTokens: 7, speculativeDecoding: true),
             )
             .drain<void>(),
         throwsA(
@@ -1349,7 +1349,7 @@ void main() {
       expect(fakeClient.lastModelPath, modelFile.path);
       expect(fakeClient.lastBackend, 'cpu');
       expect(fakeClient.lastMaxTokens, 3072);
-      expect(fakeClient.lastOutputTokens, 7);
+      expect(fakeClient.lastOutputTokens, 256);
       expect(fakeClient.lastMaxOutputTokens, 7);
       expect(fakeClient.lastTemperature, 0.3);
       expect(fakeClient.lastTopK, 5);
@@ -1477,7 +1477,7 @@ void main() {
       await fakeClient.generated.close();
 
       expect(await chunksFuture, [utf8.encode('native response')]);
-      expect(fakeClient.lastOutputTokens, 7);
+      expect(fakeClient.lastOutputTokens, 256);
       expect(fakeClient.lastTemperature, 0.3);
       expect(fakeClient.lastTopK, 5);
       expect(fakeClient.lastTopP, 0.4);
@@ -1593,6 +1593,59 @@ void main() {
       }
     },
   );
+
+  test('changes response limits without recreating the client', () async {
+    final fakeClient = _FakeLiteRtLmRuntimeClient();
+    var clientCreations = 0;
+    final service = LiteRtLmService(
+      clientFactory: () {
+        clientCreations++;
+        return fakeClient;
+      },
+    );
+
+    try {
+      final modelHandle = await service.loadModel(
+        modelFile.path,
+        const ModelParams(contextSize: 3072, preferredBackend: GpuBackend.cpu),
+      );
+      final contextHandle = service.createContext(
+        modelHandle,
+        const ModelParams(contextSize: 3072, preferredBackend: GpuBackend.cpu),
+      );
+
+      final first = service
+          .generate(
+            contextHandle,
+            'short',
+            const GenerationParams(maxTokens: 2),
+          )
+          .toList();
+      await fakeClient.generateStarted.future;
+      fakeClient.generated.add('one');
+      await fakeClient.generated.close();
+      await first;
+
+      fakeClient.generated = StreamController<String>();
+      final second = service
+          .generate(
+            contextHandle,
+            'long allowance',
+            const GenerationParams(maxTokens: 1024),
+          )
+          .toList();
+      await Future<void>.delayed(Duration.zero);
+      fakeClient.generated.add('two');
+      await fakeClient.generated.close();
+      await second;
+
+      expect(clientCreations, 1);
+      expect(fakeClient.lastOutputTokens, 256);
+      expect(fakeClient.lastMaxOutputTokens, 1024);
+    } finally {
+      service.dispose();
+    }
+  });
 
   test(
     'recreates LiteRT-LM client when audio media needs an executor',
@@ -1872,7 +1925,7 @@ void main() {
       await firstSubscription.asFuture<void>();
 
       expect(service.getPerformanceContext(contextHandle), isNotNull);
-      expect(fakeClient.lastOutputTokens, 2);
+      expect(fakeClient.lastOutputTokens, 256);
       expect(fakeClient.createConversationCount, 1);
       expect(fakeClient.generateCount, 1);
 
@@ -1894,7 +1947,7 @@ void main() {
       expect(zeroChunks, isEmpty);
       expect(negativeChunks, isEmpty);
       expect(service.getPerformanceContext(contextHandle), isNull);
-      expect(fakeClient.lastOutputTokens, 2);
+      expect(fakeClient.lastOutputTokens, 256);
       expect(fakeClient.createConversationCount, 1);
       expect(fakeClient.generateCount, 1);
     } finally {
@@ -2359,7 +2412,7 @@ class _FakeLiteRtLmRuntimeClient extends LiteRtLmRuntimeClient {
 
   final Completer<void> initializeStarted = Completer<void>();
   final Completer<void> generateStarted = Completer<void>();
-  final StreamController<String> generated = StreamController<String>();
+  StreamController<String> generated = StreamController<String>();
   final Completer<void>? _initializeBlocker;
   final Object? initializeError;
   String? lastModelPath;

--- a/test/unit/hook/build_hook_litert_lm_integration_test.dart
+++ b/test/unit/hook/build_hook_litert_lm_integration_test.dart
@@ -127,7 +127,10 @@ void main() {
       iosDeviceLitertBundleDir,
       iosArm64SimLitertBundleDir,
     ]) {
-      await _writeBundleLibraries(directory, _iosLiteRtLibraries);
+      await _writeBundleLibraries(directory, [
+        ..._iosLiteRtLibraries,
+        'libLegacySplitRuntime.dylib',
+      ]);
     }
   });
 
@@ -286,6 +289,13 @@ void main() {
           for (final assetName in _iosLiteRtAssetNames) {
             expect(codeAssetIds, contains('package:llamadart/$assetName'));
           }
+          expect(
+            codeAssetIds.where((id) => id.contains('/litert_lm_')).toSet(),
+            {
+              for (final assetName in _iosLiteRtAssetNames)
+                'package:llamadart/$assetName',
+            },
+          );
           expect(
             codeAssets.every(
               (asset) => asset.linkMode is DynamicLoadingBundled,
@@ -787,34 +797,16 @@ const List<String> _androidLiteRtLibraries = [
   'libwebgpu_dawn.so',
 ];
 
-const List<String> _iosLiteRtLibraries = [
-  'LiteRtLm',
-  'CLiteRTLM',
-  'libLiteRtLm.dylib',
-  'libGemmaModelConstraintProvider.dylib',
-  'libLiteRt.dylib',
-  'libLiteRtMetalAccelerator.dylib',
-];
+const List<String> _iosLiteRtLibraries = ['LiteRtLm', 'CLiteRTLM'];
 
 const List<String> _iosLiteRtAssetNames = [
   'litert_lm_LiteRtLm',
   'litert_lm_CLiteRTLM',
-  'litert_lm_libLiteRtLm',
-  'litert_lm_libGemmaModelConstraintProvider',
-  'litert_lm_libLiteRt',
-  'litert_lm_libLiteRtMetalAccelerator',
 ];
 
 const List<String> _macosArm64LiteRtLibraries = [
   'libLiteRtLm.dylib',
   'libCLiteRTLM_mac.dylib',
-  'libGemmaModelConstraintProvider.dylib',
-  'libLiteRt.dylib',
-  'libLiteRtMetalAccelerator.dylib',
-  'libLiteRtTopKMetalSampler.dylib',
-  'libLiteRtTopKWebGpuSampler.dylib',
-  'libLiteRtWebGpuAccelerator.dylib',
-  'libwebgpu_dawn.dylib',
 ];
 
 const List<String> _macosX64LiteRtLibraries = [

--- a/test/unit/tooling/macos_litert_lm_prepare_app_script_test.dart
+++ b/test/unit/tooling/macos_litert_lm_prepare_app_script_test.dart
@@ -8,6 +8,29 @@ import 'package:test/test.dart';
 
 void main() {
   group('macos_litert_lm_prepare_app.sh', () {
+    test('chat app embeds the macOS runtime after Flutter assembly', () {
+      final project = File(
+        path.join(
+          'example',
+          'chat_app',
+          'macos',
+          'Runner.xcodeproj',
+          'project.pbxproj',
+        ),
+      ).readAsStringSync();
+
+      final flutterEmbed = project.indexOf(
+        '3399D490228B24CF009A79C7 /* ShellScript */',
+      );
+      final prepareRuntime = project.indexOf(
+        'A17E2C1B5C7747D5A3C40A23 /* Prepare LiteRT-LM Runtime */',
+      );
+
+      expect(flutterEmbed, greaterThanOrEqualTo(0));
+      expect(prepareRuntime, greaterThan(flutterEmbed));
+      expect(project, contains('tool/macos_litert_lm_prepare_app.sh'));
+    });
+
     test(
       'rejects incomplete explicit arm64 runtime directories',
       () async {
@@ -24,12 +47,7 @@ void main() {
 
         expect(result.exitCode, 2);
         expect(result.stderr, contains('library directory is incomplete'));
-        expect(
-          result.stderr,
-          contains('libGemmaModelConstraintProvider.dylib'),
-        );
         expect(result.stderr, contains('libCLiteRTLM_mac.dylib'));
-        expect(result.stderr, contains('libwebgpu_dawn.dylib'));
         expect(
           Directory(
             path.join(appDir.path, 'Contents', 'Frameworks'),
@@ -171,9 +189,6 @@ void main() {
           path.join(frameworksDir.path, 'LiteRtLm.framework', 'Versions', 'A'),
         )..createSync(recursive: true);
         await File(path.join(liteRtLmDir.path, 'LiteRtLm')).create();
-        await File(
-          path.join(frameworksDir.path, 'libCLiteRTLM_mac.dylib'),
-        ).create();
 
         final result = await _runPrepareApp(appDir, libDir, arch: 'arm64');
 
@@ -184,7 +199,7 @@ void main() {
             path.join(
               frameworksDir.path,
               'LiteRtLmRuntime',
-              'libwebgpu_dawn.dylib',
+              'libCLiteRTLM_mac.dylib',
             ),
           ).existsSync(),
           isTrue,
@@ -259,14 +274,7 @@ Future<ProcessResult> _runPrepareApp(
 
 const List<String> _arm64Libraries = [
   'libCLiteRTLM_mac.dylib',
-  'libGemmaModelConstraintProvider.dylib',
-  'libLiteRt.dylib',
   'libLiteRtLm.dylib',
-  'libLiteRtMetalAccelerator.dylib',
-  'libLiteRtTopKMetalSampler.dylib',
-  'libLiteRtTopKWebGpuSampler.dylib',
-  'libLiteRtWebGpuAccelerator.dylib',
-  'libwebgpu_dawn.dylib',
 ];
 
 const List<String> _oldFrameworks = [

--- a/test/unit/tooling/macos_litert_lm_prepare_app_script_test.dart
+++ b/test/unit/tooling/macos_litert_lm_prepare_app_script_test.dart
@@ -19,16 +19,36 @@ void main() {
         ),
       ).readAsStringSync();
 
-      final flutterEmbed = project.indexOf(
-        '3399D490228B24CF009A79C7 /* ShellScript */',
+      final nativeTargetsStart = project.indexOf(
+        '/* Begin PBXNativeTarget section */',
       );
-      final prepareRuntime = project.indexOf(
-        'A17E2C1B5C7747D5A3C40A23 /* Prepare LiteRT-LM Runtime */',
+      expect(nativeTargetsStart, greaterThanOrEqualTo(0));
+      final runnerTargetStart = project.indexOf(
+        '/* Runner */ = {',
+        nativeTargetsStart,
+      );
+      final runnerBuildPhasesEnd = project.indexOf(
+        'buildRules = (',
+        runnerTargetStart,
+      );
+      expect(runnerTargetStart, greaterThanOrEqualTo(0));
+      expect(runnerBuildPhasesEnd, greaterThan(runnerTargetStart));
+
+      final runnerBuildPhases = project.substring(
+        runnerTargetStart,
+        runnerBuildPhasesEnd,
+      );
+      final flutterEmbed = runnerBuildPhases.indexOf('/* ShellScript */');
+      final prepareRuntime = runnerBuildPhases.indexOf(
+        '/* Prepare LiteRT-LM Runtime */',
       );
 
       expect(flutterEmbed, greaterThanOrEqualTo(0));
       expect(prepareRuntime, greaterThan(flutterEmbed));
+      expect(project, contains('macos_assemble.sh embed'));
       expect(project, contains('tool/macos_litert_lm_prepare_app.sh'));
+      expect(project, contains(r'if [ -f \"$SCRIPT\" ]'));
+      expect(project, contains(r'bash \"$SCRIPT\"'));
     });
 
     test(

--- a/test/unit/tooling/sync_native_release_pins_script_test.dart
+++ b/test/unit/tooling/sync_native_release_pins_script_test.dart
@@ -45,6 +45,16 @@ const _litertLmBundleSpecs = <_LiteRtLmBundleSpec>[
     await litertRuntimeDart.writeAsString('''
 const _litertLmVersion = '1.0.0';
 ''');
+    final macosPrepareScript = File(
+      path.join(root.path, 'tool', 'macos_litert_lm_prepare_app.sh'),
+    );
+    await macosPrepareScript.parent.create(recursive: true);
+    await macosPrepareScript.writeAsString('''
+paths=(
+  ".dart_tool/llamadart/litert_lm/1.0.0/macos_arm64"
+  ".dart_tool/llamadart/litert_lm/1.0.0/macos/arm64"
+)
+''');
     await _writePackageSwift(
       root,
       'packages/llamadart_llama_cpp_flutter/darwin/'
@@ -131,6 +141,10 @@ const _litertLmVersion = '1.0.0';
       litertRuntimeDartText,
       contains("const _litertLmVersion = '9.9.9';"),
     );
+    final macosPrepareText = await macosPrepareScript.readAsString();
+    expect(macosPrepareText, contains('litert_lm/9.9.9/macos_arm64'));
+    expect(macosPrepareText, contains('litert_lm/9.9.9/macos/arm64'));
+    expect(macosPrepareText, isNot(contains('litert_lm/1.0.0/')));
 
     final llamaSwift = await File(
       path.join(
@@ -549,8 +563,8 @@ String _hex(String character) => List.filled(64, character).join();
 const Map<String, (String, String)> _litertAppleTargets = {
   'LiteRtLm': ('litert-lm-native-apple-LiteRtLm-xcframework-{tag}.zip', '3'),
   'CLiteRTLM': ('litert-lm-native-apple-CLiteRTLM-xcframework-{tag}.zip', '4'),
-  'GemmaModelConstraintProvider': (
-    'litert-lm-native-apple-GemmaModelConstraintProvider-xcframework-{tag}.zip',
+  'CLiteRTLMMac': (
+    'litert-lm-native-apple-CLiteRTLMMac-xcframework-{tag}.zip',
     '8',
   ),
 };

--- a/tool/macos_litert_lm_prepare_app.sh
+++ b/tool/macos_litert_lm_prepare_app.sh
@@ -25,25 +25,9 @@ resolve_litert_arch() {
 LITERT_ARCH="$(resolve_litert_arch)"
 
 required_libraries() {
-  case "$LITERT_ARCH" in
-    arm64)
-      printf '%s\n' \
-        "libCLiteRTLM_mac.dylib" \
-        "libGemmaModelConstraintProvider.dylib" \
-        "libLiteRt.dylib" \
-        "libLiteRtLm.dylib" \
-        "libLiteRtMetalAccelerator.dylib" \
-        "libLiteRtTopKMetalSampler.dylib" \
-        "libLiteRtTopKWebGpuSampler.dylib" \
-        "libLiteRtWebGpuAccelerator.dylib" \
-        "libwebgpu_dawn.dylib"
-      ;;
-    x64)
-      printf '%s\n' \
-        "libCLiteRTLM_mac.dylib" \
-        "libLiteRtLm.dylib"
-      ;;
-  esac
+  printf '%s\n' \
+    "libCLiteRTLM_mac.dylib" \
+    "libLiteRtLm.dylib"
 }
 
 validate_litert_dir() {
@@ -73,26 +57,9 @@ validate_litert_dir() {
 }
 
 required_native_spm_files() {
-  case "$LITERT_ARCH" in
-    arm64)
-      printf '%s\n' \
-        "GemmaModelConstraintProvider.framework/Versions/A/GemmaModelConstraintProvider" \
-        "LiteRtLm.framework/Versions/A/LiteRtLm" \
-        "libCLiteRTLM_mac.dylib" \
-        "libGemmaModelConstraintProvider.dylib" \
-        "libLiteRt.dylib" \
-        "libLiteRtMetalAccelerator.dylib" \
-        "libLiteRtTopKMetalSampler.dylib" \
-        "libLiteRtTopKWebGpuSampler.dylib" \
-        "libLiteRtWebGpuAccelerator.dylib" \
-        "libwebgpu_dawn.dylib"
-      ;;
-    x64)
-      printf '%s\n' \
-        "LiteRtLm.framework/Versions/A/LiteRtLm" \
-        "libCLiteRTLM_mac.dylib"
-      ;;
-  esac
+  printf '%s\n' \
+    "LiteRtLm.framework/Versions/A/LiteRtLm" \
+    "libCLiteRTLM_mac.dylib"
 }
 
 has_complete_native_spm_runtime() {
@@ -117,8 +84,8 @@ resolve_litert_dir() {
   fi
 
   local candidates=(
-    "$ROOT_DIR/.dart_tool/llamadart/litert_lm/0.14.0-native.1/macos_$LITERT_ARCH"
-    "$ROOT_DIR/.dart_tool/llamadart/litert_lm/0.14.0-native.1/macos/$LITERT_ARCH"
+    "$ROOT_DIR/.dart_tool/llamadart/litert_lm/0.14.0-native.2/macos_$LITERT_ARCH"
+    "$ROOT_DIR/.dart_tool/llamadart/litert_lm/0.14.0-native.2/macos/$LITERT_ARCH"
   )
   local candidate
   for candidate in "${candidates[@]}"; do

--- a/tool/native/sync_native_release_pins.py
+++ b/tool/native/sync_native_release_pins.py
@@ -28,6 +28,7 @@ DEFAULT_LITERT_LM_PACKAGE_SWIFT = (
 DEFAULT_LITERT_LM_RUNTIME_DART = (
     "lib/src/backends/litert_lm/litert_lm_runtime.dart"
 )
+DEFAULT_LITERT_LM_MACOS_PREPARE_SCRIPT = "tool/macos_litert_lm_prepare_app.sh"
 DEFAULT_LLAMA_CPP_PROJECT_DOCS = (
     "README.md",
     "website/docs/getting-started/installation.md",
@@ -47,6 +48,7 @@ def main() -> int:
     llama_cpp_package_swift_path = repo_root / args.llama_cpp_package_swift
     litert_lm_package_swift_path = repo_root / args.litert_lm_package_swift
     litert_lm_runtime_dart_path = repo_root / args.litert_lm_runtime_dart
+    litert_lm_macos_prepare_path = repo_root / args.litert_lm_macos_prepare_script
     changelog_path = repo_root / DEFAULT_CHANGELOG
     llama_cpp_project_doc_paths = [
         repo_root / relative_path for relative_path in DEFAULT_LLAMA_CPP_PROJECT_DOCS
@@ -150,6 +152,18 @@ def main() -> int:
             f"const _litertLmVersion = '{litert_version}';",
             "LiteRT-LM Dart runtime version",
         )
+        if litert_lm_macos_prepare_path.exists():
+            prepare_text = litert_lm_macos_prepare_path.read_text(encoding="utf-8")
+            updated_prepare_text, replacement_count = re.subn(
+                r"(/litert_lm/)[^/]+(/macos(?:_|/))",
+                rf"\g<1>{litert_version}\g<2>",
+                prepare_text,
+            )
+            if replacement_count == 0:
+                raise ReleaseError(
+                    "Could not replace LiteRT-LM version in macOS prepare script"
+                )
+            pending_writes[litert_lm_macos_prepare_path] = updated_prepare_text
         for bundle in litert_lm_bundle_names(hook_text):
             checksum = release_asset_checksum(
                 release,
@@ -280,6 +294,14 @@ def parse_args() -> argparse.Namespace:
         help=(
             "Path to the LiteRT-LM Dart runtime version pin relative "
             "to repo root."
+        ),
+    )
+    parser.add_argument(
+        "--litert-lm-macos-prepare-script",
+        default=DEFAULT_LITERT_LM_MACOS_PREPARE_SCRIPT,
+        help=(
+            "Path to the LiteRT-LM macOS app preparation script relative "
+            "to repo root. Skipped if the file does not exist."
         ),
     )
     parser.add_argument(

--- a/website/docs/changelog/recent-releases.md
+++ b/website/docs/changelog/recent-releases.md
@@ -30,6 +30,12 @@ For canonical full release notes, use:
   model fits and reduces context before selecting partial offload under memory
   pressure. Auto intent persists separately from resolved values so each model
   load, including after an app restart, recalculates current device headroom.
+- Fixed native LiteRT-LM response limits being misapplied as forced benchmark
+  decode counts. Short answers now stream without waiting for the full token
+  allowance, and the chat app flushes the first LiteRT-LM token immediately.
+- Updated the default native LiteRT-LM runtime to `v0.14.0-native.2`, fixing
+  Android GPU plugin symbol resolution and using the checksum-pinned official
+  Apple XCFrameworks for Metal-capable iOS and macOS packaging.
 
 ## 0.8.14
 

--- a/website/docs/guides/backend-selection.md
+++ b/website/docs/guides/backend-selection.md
@@ -67,7 +67,7 @@ JavaScript runtime.
 | Capability | llama.cpp / GGUF | LiteRT-LM / `.litertlm` |
 | --- | --- | --- |
 | Native Android | CPU, Vulkan, optional OpenCL modules | CPU, GPU, Android-only NPU selector |
-| Native iOS/macOS | Consolidated CPU + Metal runtime | iOS CPU; macOS CPU/GPU |
+| Native iOS/macOS | Consolidated CPU + Metal runtime | CPU/GPU |
 | Native Linux/Windows | CPU, Vulkan, and target-specific optional modules | CPU in the current pinned runtime |
 | Web | llama.cpp WebGPU/CPU bridge for GGUF URLs | `@litert-lm/core` for web-compatible `.litertlm` URLs |
 | Embeddings | Supported on native; supported on web bridge assets with embedding APIs | Not exposed by current LiteRT-LM APIs |

--- a/website/docs/platforms/support-matrix.md
+++ b/website/docs/platforms/support-matrix.md
@@ -8,7 +8,7 @@ backend-module configuration for
 `llamadart`.
 
 The native-assets hook currently pins `llamadart-native` tag `b9935` and
-`litert-lm-native` release `v0.14.0-native.1` (`hook/build.dart`). Apps can
+`litert-lm-native` release `v0.14.0-native.2` (`hook/build.dart`). Apps can
 override the llama.cpp native GitHub source with
 `hooks.user_defines.llamadart.llamadart_native_tag` and
 `hooks.user_defines.llamadart.llamadart_native_repository`, or use a local
@@ -76,9 +76,9 @@ checksum verification, explicit cache policy changes, custom cache directories,
 disabled resume, and custom retry counts.
 
 Select LiteRT-LM CPU/GPU/NPU with `ModelParams.liteRtLmBackend`.
-`LiteRtLmBackendPreference.auto` currently maps to GPU on Android, macOS, and
-web, and CPU on other LiteRT-LM targets. NPU selection is Android native only;
-web rejects it explicitly.
+`LiteRtLmBackendPreference.auto` currently maps to GPU on Android, iOS, macOS,
+and web, and CPU on other LiteRT-LM targets. NPU selection is Android native
+only; web rejects it explicitly.
 
 ## Configuring native runtime families
 
@@ -120,14 +120,14 @@ Explicitly selecting `litert_lm` for a target without a pinned LiteRT-LM
 runtime fails during the build hook instead of producing an app that cannot
 load `.litertlm` models.
 
-## LiteRT-LM runtime coverage (`v0.14.0-native.1`)
+## LiteRT-LM runtime coverage (`v0.14.0-native.2`)
 
 | Platform target | LiteRT-LM bundle key | Selectable backends | Status |
 | --- | --- | --- | --- |
 | Android arm64 | `android-arm64` | `cpu`, `gpu`, `npu` | CPU/GPU supported. NPU is selectable only for compatible device/model/runtime deployments and may require a packaged LiteRT dispatch directory. |
 | Android x64 | `android-x64` | `cpu`, `gpu`, `npu` | CPU/GPU supported for emulator/test targets; NPU is deployment-specific and not validated for generic emulators. |
-| iOS arm64 (device) | `ios-arm64` | `cpu` | Supported |
-| iOS arm64 (simulator) | `ios-arm64-sim` | `cpu` | Supported |
+| iOS arm64 (device) | `ios-arm64` | `cpu`, `gpu` | Supported |
+| iOS arm64 (simulator) | `ios-arm64-sim` | `cpu`, `gpu` | Supported |
 | iOS x86_64 (simulator) | Not published | N/A | Unsupported; exclude `litert_lm` for this target |
 | macOS arm64 | `macos-arm64` | `cpu`, `gpu` | Supported |
 | macOS x86_64 | `macos-x64` | `cpu`, `gpu` | Supported |
@@ -156,7 +156,7 @@ as a multi-turn `ChatSession` or tool-calling backend yet.
 instead of silently ignoring llama.cpp-only settings.
 
 Native LiteRT-LM exposes these load-time runtime controls through
-`ModelParams`. Nullable fields keep the pinned `v0.14.0-native.1` runtime
+`ModelParams`. Nullable fields keep the pinned `v0.14.0-native.2` runtime
 default.
 
 | Native C API | Dart field | Support decision |


### PR DESCRIPTION
## Summary
- Fix LiteRT-LM response limits being passed to the upstream forced benchmark decode setting; request limits now use the per-generation `maxOutputTokens` option, so EOS completes immediately.
- Flush the first LiteRT-LM chat token immediately and avoid rebuilding the runtime client when only the response limit changes.
- Update the native runtime to `v0.14.0-native.2`, which exports Android GPU plugin symbols globally and uses the checksum-pinned official Apple runtime.
- Enable LiteRT-LM GPU/Auto on iOS, restore macOS app runtime embedding, and reduce Apple packaging to the consolidated runtime libraries.
- Update runtime pin tooling, companion SwiftPM targets, README, support matrix, changelogs, and backend-selection docs.

## Production-readiness scope
- **User-facing scope:** Native LiteRT-LM responses can use allowances such as 1024 tokens without being forced to decode that many tokens; Android GPU no longer stalls from unresolved plugin symbols; iOS and macOS can select Metal.
- **Supported platforms/paths:** Flutter chat app and core native LiteRT-LM paths on Android arm64, iOS arm64, and macOS arm64; Apple SwiftPM also covers macOS x64 artifacts.
- **Unsupported or intentionally unavailable paths:** iOS x86_64 simulator remains unavailable because no runtime artifact is published. NPU remains Android-only and deployment/model-specific. Web behavior is unchanged.
- **Out of scope / follow-ups:** Cold model initialization remains runtime/model dependent (about 31 s on the tested Pixel and 16 s on the tested iPad); this PR removes the post-EOS/forced-decode wait, not model loading cost. No merge-blocking follow-up.

## Completeness checklist
- [x] Declared scope is fully implemented, or explicitly reduced above.
- [x] Unsupported platform/option combinations fail loudly with actionable diagnostics or are clearly documented as unavailable.
- [x] Public API docs, README/website docs, examples, support matrices, and changelog entries are updated where relevant.
- [x] Regression coverage covers the original issue plus key negative/version-skew paths where relevant.
- [x] Security/privacy review completed: no secrets, bearer tokens, signed URLs, or raw secret-bearing paths leak through logs, cache keys, metadata, errors, or snapshots.
- [x] Follow-up work that is useful but not required for this PR is tracked in GitHub Issues, or explicitly marked "None" above.

## PR type guidance
- **Bugfix PR:** The upstream engine setting was a forced benchmark decode count, not a response cap. Regression tests verify per-request output limits, client reuse, immediate stream flushing, consolidated platform assets, and incomplete-cache rejection.

## Test Plan
- [x] Changed Dart files pass `dart format --output=none --set-exit-if-changed`.
- [x] Focused `dart analyze` for all changed core/hook/test paths: no issues.
- [x] Focused VM regression suite: 145 tests passed.
- [x] Chat app Flutter tests: 4 passed.
- [x] LiteRT-LM companion Flutter tests: 3 passed.
- [x] `./tool/docs/build_site.sh` and `./tool/docs/validate_links.sh`.
- [x] `dart run tool/testing/verify_release_docs_versions.dart`.
- [ ] Full repository `dart analyze`: not used because independently managed examples do not have all package dependencies resolved from the root; all changed paths were analyzed directly.
- [ ] Chrome tests: N/A; native-only runtime and packaging change.

## Matrix Evidence
| Matrix row | Scope covered | Platform / model / backend | Result | Evidence / notes |
| --- | --- | --- | --- | --- |
| Android release/device smoke | Native packaging, GPU load, 1024-token allowance, EOS completion | Pixel 9 Pro / Gemma 4 E2B / GPU | PASS | APK has `DF_1_GLOBAL`; warmed run completed in 337 ms with EOS and no forced-token wait. |
| iOS release/device smoke | Consolidated runtime, Metal symbols, generation | iPad / Gemma 4 E2B / GPU | PASS | Signed 64.1 MB app installed/launched; warm first token about 0.7 s; GPU smoke completed in 592 ms. |
| macOS release/runtime smoke | Runtime embedding, signing, Metal, 1024-token allowance | Apple Silicon Mac / Gemma 4 E2B / GPU | PASS | Signed app contains only two consolidated LiteRT-LM dylibs; warm generation completed in 124 ms. |
| Native runtime release | Android visibility and Apple official artifacts | `litert-lm-native@v0.14.0-native.2` | PASS | All 9 release build/package jobs passed; consumer pins and checksums updated. |
| Docs | Public runtime/platform contract | Docusaurus | PASS | Static build and strict link validation passed. |

## Review Notes
- Independent review status: PR-readiness code, optimization, regression, and docs pass completed locally.
- CI status / head SHA: all review comments resolved; all 13 GitHub checks passed for `dd5991ade`.