### PR TITLE
Prepare 0.8.15 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-## Unreleased
+## 0.8.15
 
 * Added clipboard media attachments to the runnable chat app. Desktop and web
   users can paste screenshots or copied image/audio files with `Cmd/Ctrl+V`,

--- a/README.md
+++ b/README.md
@@ -59,12 +59,13 @@ Package Manager should also add the runtime companion packages they need:
 dependencies:
   llamadart: ^0.8.15
   llamadart_llama_cpp_flutter: ^0.0.9 # GGUF / llama.cpp
-  llamadart_litert_lm_flutter: ^0.0.5 # iOS .litertlm / LiteRT-LM
+  llamadart_litert_lm_flutter: ^0.0.5 # Apple .litertlm / LiteRT-LM targets
 ```
 
-The LiteRT-LM companion links the consolidated iOS runtime through SwiftPM.
-Flutter macOS LiteRT-LM builds currently keep the core package's native-assets
-fallback while the hook path remains responsible for the complete runtime.
+The LiteRT-LM companion manifest includes consolidated iOS and macOS SwiftPM
+runtime targets. Llamadart uses that SwiftPM path for iOS; Flutter macOS
+LiteRT-LM builds currently keep the core package's native-assets fallback while
+the hook path remains responsible for the complete runtime.
 
 Then run:
 

--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ For Dart or Flutter apps:
 
 ```yaml
 dependencies:
-  llamadart: ^0.8.14
+  llamadart: ^0.8.15
 ```
 
 Flutter iOS/macOS apps that should link Apple XCFrameworks through Swift
@@ -57,14 +57,14 @@ Package Manager should also add the runtime companion packages they need:
 
 ```yaml
 dependencies:
-  llamadart: ^0.8.14
+  llamadart: ^0.8.15
   llamadart_llama_cpp_flutter: ^0.0.9 # GGUF / llama.cpp
-  llamadart_litert_lm_flutter: ^0.0.4 # iOS .litertlm / LiteRT-LM
+  llamadart_litert_lm_flutter: ^0.0.5 # .litertlm / LiteRT-LM
 ```
 
-At the current LiteRT-LM native pin, Flutter macOS `.litertlm` builds keep
-using the core native-assets fallback when the SwiftPM artifact set is
-incomplete for the selected architecture.
+The LiteRT-LM companion links the consolidated Apple runtime through SwiftPM
+on supported iOS and macOS architectures. Without the companion, the core
+package uses its native-assets fallback.
 
 Then run:
 

--- a/README.md
+++ b/README.md
@@ -59,12 +59,12 @@ Package Manager should also add the runtime companion packages they need:
 dependencies:
   llamadart: ^0.8.15
   llamadart_llama_cpp_flutter: ^0.0.9 # GGUF / llama.cpp
-  llamadart_litert_lm_flutter: ^0.0.5 # .litertlm / LiteRT-LM
+  llamadart_litert_lm_flutter: ^0.0.5 # iOS .litertlm / LiteRT-LM
 ```
 
-The LiteRT-LM companion links the consolidated Apple runtime through SwiftPM
-on supported iOS and macOS architectures. Without the companion, the core
-package uses its native-assets fallback.
+The LiteRT-LM companion links the consolidated iOS runtime through SwiftPM.
+Flutter macOS LiteRT-LM builds currently keep the core package's native-assets
+fallback while the hook path remains responsible for the complete runtime.
 
 Then run:
 

--- a/example/chat_app/pubspec.lock
+++ b/example/chat_app/pubspec.lock
@@ -357,7 +357,7 @@ packages:
       path: "../.."
       relative: true
     source: path
-    version: "0.8.14"
+    version: "0.8.15"
   logging:
     dependency: transitive
     description:

--- a/packages/llamadart_litert_lm_flutter/CHANGELOG.md
+++ b/packages/llamadart_litert_lm_flutter/CHANGELOG.md
@@ -1,4 +1,4 @@
-## Unreleased
+## 0.0.5
 
 * Updated Apple SwiftPM native pin to `leehack/litert-lm-native@v0.14.0-native.2`.
 

--- a/packages/llamadart_litert_lm_flutter/README.md
+++ b/packages/llamadart_litert_lm_flutter/README.md
@@ -4,16 +4,14 @@ Flutter Apple Swift Package Manager companion package for
 [`llamadart`](https://pub.dev/packages/llamadart) `.litertlm` / LiteRT-LM
 support.
 
-Add the published package to a Flutter iOS app when it should link the prebuilt
+Add the package to a Flutter iOS or macOS app when it should link the prebuilt
 LiteRT-LM Apple XCFrameworks through SwiftPM instead of relying on the core
-package's native-assets fallback. This unreleased source also restores the
-complete macOS SwiftPM target set; published `0.0.4` still uses the core
-native-assets fallback on macOS until the next companion release.
+package's native-assets fallback.
 
 ```yaml
 dependencies:
-  llamadart: ^0.8.14
-  llamadart_litert_lm_flutter: ^0.0.4
+  llamadart: ^0.8.15
+  llamadart_litert_lm_flutter: ^0.0.5
 ```
 
 This package has no runtime Dart API of its own. Import `package:llamadart`

--- a/packages/llamadart_litert_lm_flutter/README.md
+++ b/packages/llamadart_litert_lm_flutter/README.md
@@ -4,9 +4,11 @@ Flutter Apple Swift Package Manager companion package for
 [`llamadart`](https://pub.dev/packages/llamadart) `.litertlm` / LiteRT-LM
 support.
 
-Add the package to a Flutter iOS or macOS app when it should link the prebuilt
-LiteRT-LM Apple XCFrameworks through SwiftPM instead of relying on the core
-package's native-assets fallback.
+Add the package to a Flutter iOS app when it should link the prebuilt LiteRT-LM
+Apple XCFrameworks through SwiftPM instead of relying on the core package's
+native-assets fallback. The manifest includes the complete macOS target set,
+but llamadart's Flutter macOS hook path currently keeps the core native-assets
+runtime fallback.
 
 ```yaml
 dependencies:

--- a/packages/llamadart_litert_lm_flutter/example/README.md
+++ b/packages/llamadart_litert_lm_flutter/example/README.md
@@ -1,6 +1,4 @@
 # Example
 
-Add `llamadart_litert_lm_flutter` beside `llamadart` in a Flutter iOS app to
-enable SwiftPM-linked LiteRT-LM / `.litertlm` runtime frameworks. Flutter macOS
-LiteRT-LM builds currently keep the core native-assets fallback when the SwiftPM
-artifact set is incomplete for the selected architecture.
+Add `llamadart_litert_lm_flutter` beside `llamadart` in a Flutter iOS or macOS
+app to enable SwiftPM-linked LiteRT-LM / `.litertlm` runtime frameworks.

--- a/packages/llamadart_litert_lm_flutter/example/README.md
+++ b/packages/llamadart_litert_lm_flutter/example/README.md
@@ -1,4 +1,5 @@
 # Example
 
-Add `llamadart_litert_lm_flutter` beside `llamadart` in a Flutter iOS or macOS
-app to enable SwiftPM-linked LiteRT-LM / `.litertlm` runtime frameworks.
+Add `llamadart_litert_lm_flutter` beside `llamadart` in a Flutter iOS app to
+enable SwiftPM-linked LiteRT-LM / `.litertlm` runtime frameworks. Flutter
+macOS LiteRT-LM builds currently use the core package's native-assets fallback.

--- a/packages/llamadart_litert_lm_flutter/pubspec.yaml
+++ b/packages/llamadart_litert_lm_flutter/pubspec.yaml
@@ -1,6 +1,6 @@
 name: llamadart_litert_lm_flutter
 description: Flutter Apple SwiftPM runtime companion package for llamadart LiteRT-LM support.
-version: 0.0.4
+version: 0.0.5
 repository: https://github.com/leehack/llamadart/tree/main/packages/llamadart_litert_lm_flutter
 homepage: https://github.com/leehack/llamadart
 issue_tracker: https://github.com/leehack/llamadart/issues

--- a/packages/llamadart_llama_cpp_flutter/README.md
+++ b/packages/llamadart_llama_cpp_flutter/README.md
@@ -9,7 +9,7 @@ core package's native-assets fallback.
 
 ```yaml
 dependencies:
-  llamadart: ^0.8.14
+  llamadart: ^0.8.15
   llamadart_llama_cpp_flutter: ^0.0.9
 ```
 

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: llamadart
 description: Dart and Flutter local LLM inference with llama.cpp GGUF and LiteRT-LM across native platforms and web.
-version: 0.8.14
+version: 0.8.15
 homepage: https://github.com/leehack/llamadart
 repository: https://github.com/leehack/llamadart
 issue_tracker: https://github.com/leehack/llamadart/issues

--- a/website/docs/changelog/recent-releases.md
+++ b/website/docs/changelog/recent-releases.md
@@ -7,7 +7,7 @@ For canonical full release notes, use:
 
 - [`CHANGELOG.md`](https://github.com/leehack/llamadart/blob/main/CHANGELOG.md)
 
-## Unreleased
+## 0.8.15
 
 - Added clipboard media attachments to the runnable chat app, including
   `Cmd/Ctrl+V` screenshots and copied image/audio files on desktop and web plus

--- a/website/docs/getting-started/installation.md
+++ b/website/docs/getting-started/installation.md
@@ -37,14 +37,14 @@ Package Manager, also add the runtime companion packages you need:
 dependencies:
   llamadart: ^0.8.15
   llamadart_llama_cpp_flutter: ^0.0.9 # GGUF / llama.cpp
-  llamadart_litert_lm_flutter: ^0.0.5 # .litertlm / LiteRT-LM
+  llamadart_litert_lm_flutter: ^0.0.5 # iOS .litertlm / LiteRT-LM
 ```
 
 The companion packages are published independently from the `packages/`
 subdirectories in the main `llamadart` repository.
-The LiteRT-LM companion links the consolidated Apple runtime through SwiftPM
-on supported iOS and macOS architectures. Without the companion, the core
-package uses its native-assets fallback.
+The LiteRT-LM companion links the consolidated iOS runtime through SwiftPM.
+Flutter macOS LiteRT-LM builds currently keep the core package's native-assets
+fallback while the hook path remains responsible for the complete runtime.
 
 Then resolve packages:
 

--- a/website/docs/getting-started/installation.md
+++ b/website/docs/getting-started/installation.md
@@ -27,7 +27,7 @@ In Xcode, set `IPHONEOS_DEPLOYMENT_TARGET = 16.4` or
 
 ```yaml
 dependencies:
-  llamadart: ^0.8.14
+  llamadart: ^0.8.15
 ```
 
 For Flutter iOS/macOS apps that should link Apple XCFrameworks through Swift
@@ -35,16 +35,16 @@ Package Manager, also add the runtime companion packages you need:
 
 ```yaml
 dependencies:
-  llamadart: ^0.8.14
+  llamadart: ^0.8.15
   llamadart_llama_cpp_flutter: ^0.0.9 # GGUF / llama.cpp
-  llamadart_litert_lm_flutter: ^0.0.4 # iOS .litertlm / LiteRT-LM
+  llamadart_litert_lm_flutter: ^0.0.5 # .litertlm / LiteRT-LM
 ```
 
 The companion packages are published independently from the `packages/`
 subdirectories in the main `llamadart` repository.
-At the current LiteRT-LM native pin, Flutter macOS `.litertlm` builds keep the
-core native-assets fallback when the SwiftPM artifact set is incomplete for the
-selected architecture.
+The LiteRT-LM companion links the consolidated Apple runtime through SwiftPM
+on supported iOS and macOS architectures. Without the companion, the core
+package uses its native-assets fallback.
 
 Then resolve packages:
 

--- a/website/docs/getting-started/installation.md
+++ b/website/docs/getting-started/installation.md
@@ -37,14 +37,15 @@ Package Manager, also add the runtime companion packages you need:
 dependencies:
   llamadart: ^0.8.15
   llamadart_llama_cpp_flutter: ^0.0.9 # GGUF / llama.cpp
-  llamadart_litert_lm_flutter: ^0.0.5 # iOS .litertlm / LiteRT-LM
+  llamadart_litert_lm_flutter: ^0.0.5 # Apple .litertlm / LiteRT-LM targets
 ```
 
 The companion packages are published independently from the `packages/`
 subdirectories in the main `llamadart` repository.
-The LiteRT-LM companion links the consolidated iOS runtime through SwiftPM.
-Flutter macOS LiteRT-LM builds currently keep the core package's native-assets
-fallback while the hook path remains responsible for the complete runtime.
+The LiteRT-LM companion manifest includes consolidated iOS and macOS SwiftPM
+runtime targets. Llamadart uses that SwiftPM path for iOS; Flutter macOS
+LiteRT-LM builds currently keep the core package's native-assets fallback while
+the hook path remains responsible for the complete runtime.
 
 Then resolve packages:
 

--- a/website/docs/guides/backend-selection.md
+++ b/website/docs/guides/backend-selection.md
@@ -115,11 +115,10 @@ runtime. It does not enable or disable LiteRT-LM.
 `linux-x64`, etc.); exact target keys override OS keys. Use `all` or `both` to
 include every available runtime family for a target.
 
-For Flutter iOS apps, installed companion packages choose the SwiftPM runtime
-families and win over this setting. Flutter macOS LiteRT-LM builds keep the
-native-assets fallback when the current SwiftPM artifact set is incomplete for
-the selected architecture. For non-Flutter projects and non-Apple targets,
-`llamadart_native_runtimes` remains the selector.
+For Flutter Apple apps, installed companion packages choose the SwiftPM runtime
+families and win over this setting. Without a matching companion package, the
+core native-assets fallback remains available. For non-Flutter projects and
+non-Apple targets, `llamadart_native_runtimes` remains the selector.
 
 ## Parameter Differences
 

--- a/website/docs/guides/backend-selection.md
+++ b/website/docs/guides/backend-selection.md
@@ -115,10 +115,11 @@ runtime. It does not enable or disable LiteRT-LM.
 `linux-x64`, etc.); exact target keys override OS keys. Use `all` or `both` to
 include every available runtime family for a target.
 
-For Flutter Apple apps, installed companion packages choose the SwiftPM runtime
-families and win over this setting. Without a matching companion package, the
-core native-assets fallback remains available. For non-Flutter projects and
-non-Apple targets, `llamadart_native_runtimes` remains the selector.
+For Flutter iOS apps, installed companion packages choose the SwiftPM runtime
+families and win over this setting. Flutter macOS LiteRT-LM builds currently
+keep the core native-assets fallback while the hook path remains responsible
+for the complete runtime. For non-Flutter projects and non-Apple targets,
+`llamadart_native_runtimes` remains the selector.
 
 ## Parameter Differences
 

--- a/website/docs/platforms/native-build-hooks.md
+++ b/website/docs/platforms/native-build-hooks.md
@@ -95,9 +95,9 @@ are present:
 
 For Flutter iOS apps, installed companion packages decide the Apple SPM runtime
 families and win over `llamadart_native_runtimes`. Flutter macOS LiteRT-LM
-builds use the core native-assets fallback when the current SwiftPM artifact set
-is incomplete for the selected architecture. If neither companion package is
-installed, the core native-assets fallback is used.
+builds currently use the core native-assets fallback while the hook path remains
+responsible for the complete runtime. If neither companion package is installed,
+the core native-assets fallback is used.
 
 For non-Flutter projects and non-Apple targets, `llamadart_native_runtimes`
 remains the selector even if a companion package is accidentally present in the

--- a/website/docs/platforms/support-matrix.md
+++ b/website/docs/platforms/support-matrix.md
@@ -325,10 +325,12 @@ no valid entries remain, selection falls back to `cpu_profile` (or default
   consolidated.
 - Flutter Apple apps use Swift Package Manager only through runtime companion
   packages: `llamadart_llama_cpp_flutter` for GGUF/llama.cpp and
-  `llamadart_litert_lm_flutter` for iOS and macOS `.litertlm`/LiteRT-LM.
-- For Flutter Apple apps, installed companion packages choose the Apple SPM
-  runtime families and win over `llamadart_native_runtimes`. If a matching
-  companion package is not installed, the core native-assets fallback is used.
+  `llamadart_litert_lm_flutter` for iOS `.litertlm`/LiteRT-LM.
+- For Flutter iOS apps, installed companion packages choose the Apple SPM
+  runtime families and win over `llamadart_native_runtimes`. Flutter macOS
+  LiteRT-LM builds currently use the core native-assets fallback while the hook
+  path remains responsible for the complete runtime. If neither companion
+  package is installed, the core native-assets fallback is used.
 - For non-Flutter projects and non-Apple targets, `llamadart_native_runtimes`
   remains the selector even if a Flutter companion package is accidentally
   present in dependencies.

--- a/website/docs/platforms/support-matrix.md
+++ b/website/docs/platforms/support-matrix.md
@@ -325,12 +325,10 @@ no valid entries remain, selection falls back to `cpu_profile` (or default
   consolidated.
 - Flutter Apple apps use Swift Package Manager only through runtime companion
   packages: `llamadart_llama_cpp_flutter` for GGUF/llama.cpp and
-  `llamadart_litert_lm_flutter` for iOS `.litertlm`/LiteRT-LM.
-- For Flutter iOS apps, installed companion packages choose the Apple SPM
-  runtime families and win over `llamadart_native_runtimes`. Flutter macOS
-  LiteRT-LM builds use the core native-assets fallback when the current SwiftPM
-  artifact set is incomplete for the selected architecture. If neither companion
-  package is installed, the core native-assets fallback is used.
+  `llamadart_litert_lm_flutter` for iOS and macOS `.litertlm`/LiteRT-LM.
+- For Flutter Apple apps, installed companion packages choose the Apple SPM
+  runtime families and win over `llamadart_native_runtimes`. If a matching
+  companion package is not installed, the core native-assets fallback is used.
 - For non-Flutter projects and non-Apple targets, `llamadart_native_runtimes`
   remains the selector even if a Flutter companion package is accidentally
   present in dependencies.


### PR DESCRIPTION
## Summary
- prepare `llamadart 0.8.15` from the accumulated Unreleased changes
- prepare `llamadart_litert_lm_flutter 0.0.5` for the consolidated iOS/macOS SwiftPM runtime
- keep `llamadart_llama_cpp_flutter 0.0.9` and native llama.cpp `b9935` unchanged
- update current install snippets, the chat app path lockfile, release notes, and current Apple runtime guidance

## Production-readiness scope
- **User-facing scope:** Publish the LiteRT-LM streaming/runtime fixes and the accumulated chat app model-library, download, attachment, Auto tuning, and UI improvements.
- **Supported platforms/paths:** Core Dart/Flutter package across documented platforms; LiteRT-LM SwiftPM companion on supported iOS and macOS architectures.
- **Unsupported or intentionally unavailable paths:** iOS x86_64 LiteRT-LM simulator remains unavailable because no native runtime artifact is published. Platform limitations remain documented.
- **Out of scope / follow-ups:** No llama.cpp runtime bump in this release. `b9935` remains the validated pin.

## Completeness checklist
- [x] Declared scope is fully implemented.
- [x] Unsupported platform/option combinations remain documented.
- [x] README, installation docs, support matrix, backend guide, changelogs, and package versions are aligned.
- [x] Regression coverage from the merged implementation PRs is retained.
- [x] No secrets, signed URLs, caches, or generated build output are included.
- [x] No required follow-up is left inside this release scope.

## Release versions
| Package | Current | Prepared |
| --- | ---: | ---: |
| `llamadart` | 0.8.14 | **0.8.15** |
| `llamadart_litert_lm_flutter` | 0.0.4 | **0.0.5** |
| `llamadart_llama_cpp_flutter` | 0.0.9 | 0.0.9 (unchanged) |

Both prepared versions currently return 404 from their pub.dev version endpoints, so there is no version collision.

## Test Plan
- [x] `dart format --output=none --set-exit-if-changed .`
- [x] Focused `dart analyze lib test hook tool`: no issues
- [x] VM suite: 1,265 passed, 66 expected skips; native inference smoke passed
- [x] Chrome suite: 703 passed, 1 expected skip
- [x] Chat app Flutter suite: 201 passed
- [x] LiteRT-LM companion suite: 3 passed
- [x] `dart run tool/testing/verify_release_docs_versions.dart`
- [x] `dart pub publish --dry-run`: 0 warnings, 1 MB archive
- [x] Isolated `flutter pub publish --dry-run` for LiteRT-LM companion: 0 warnings, 3 KB archive
- [x] `./tool/docs/build_site.sh`
- [x] `./tool/docs/validate_links.sh`
- [x] `git diff --check`

The root-wide analyzer sees missing dependencies in separately managed example packages when they have not each run their own package resolution. All changed/code-owned paths were analyzed directly; CI installs its complete matrix.

## Matrix Evidence
| Matrix row | Scope covered | Platform / model / backend | Result | Evidence / notes |
| --- | --- | --- | --- | --- |
| release-companion-pub-gate | Version availability and publish order | pub.dev / LiteRT-LM companion | PASS | 0.0.5 is unused; post-merge workflow publishes it before the core tag. |
| release-representative-smokes | Native/browser/package behavior | macOS VM + Chrome | PASS | Full VM/Chrome suites and real native inference smoke passed. |
| Android/iOS/macOS LiteRT-LM | Runtime fixes being released | Pixel 9 Pro, iPad, Apple Silicon Mac | PASS | Validated in merged PR #297 with real Gemma 4 E2B runs. |
| Windows x64 LiteRT-LM | Published native runtime CPU path | GitHub Windows x64 VM / Qwen3 0.6B | PASS | Real library load and inference passed in PR #297 CI. |
| Docs | Current version and runtime contract | Docusaurus | PASS | Build and strict link validation passed. |

## Publication boundary
Merging this release-prep PR is explicit approval to publish. The post-merge workflow will:

1. tag and publish `llamadart_litert_lm_flutter 0.0.5`
2. wait until that companion version is available on pub.dev
3. create `v0.8.15`
4. publish the core package and GitHub Release
5. cut and deploy versioned docs

## Review Notes
- Independent review status: release scope, package archives, docs, cleanup, and regression evidence reviewed locally.
- CI status / head SHA: all required checks passed for `48a05b542`.