### PR TITLE
Add llama.cpp thinking budget control

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -195,6 +195,9 @@ procedure.
   above it for new PR entries.
 - Only move `Unreleased` entries into a numbered version section during an
   explicit release/version-bump task.
+- Keep changelog entries concise and user-facing: one short bullet per
+  independently useful change; put implementation details, validation, and
+  migration notes in PRs or maintainer docs instead.
 - Release prep PRs must not publish by themselves. After merge,
   `release_on_prep_merge.yml` is the publishing approval boundary.
 - Do not manually push companion or core release tags unless release automation

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,12 @@
   anchors while compacting completed exchanges, and reduce streaming
   accumulation overhead.
 
+* Added llama.cpp-style thinking-budget control through
+  `GenerationParams.thinkingBudget`. Native GGUF calls can cap generated
+  reasoning tokens while preserving lazy tool/structured-output grammar; other
+  backends reject the setting explicitly. The OpenAI-compatible server exposes
+  the same behavior as its documented `thinking_budget_tokens` extension.
+
 * Switched the OpenAI-compatible server example default to Unsloth's Qwen3.6
   27B `UD-Q4_K_XL` GGUF, added model-specific non-thinking and thinking sampler profiles,
   and documented its text-only / desktop-memory requirements. The server keeps

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,11 +33,8 @@
   anchors while compacting completed exchanges, and reduce streaming
   accumulation overhead.
 
-* Added llama.cpp-style thinking-budget control through
-  `GenerationParams.thinkingBudget`. Native GGUF calls can cap generated
-  reasoning tokens while preserving lazy tool/structured-output grammar; other
-  backends reject the setting explicitly. The OpenAI-compatible server exposes
-  the same behavior as its documented `thinking_budget_tokens` extension.
+* Added a llama.cpp thinking-token budget and the server's
+  `thinking_budget_tokens` extension.
 
 * Switched the OpenAI-compatible server example default to Unsloth's Qwen3.6
   27B `UD-Q4_K_XL` GGUF, added model-specific non-thinking and thinking sampler profiles,

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 ## Unreleased
 
+* Updated the default llama.cpp native runtime pin to
+  `leehack/llamadart-native@b9969-llamadart.1`, keeping the `b9969` llama.cpp
+  ABI/bindings while picking up wrapper fixes for native release
+  provenance and backend-selected speculative sampler acceptance. Refreshed
+  the `llamadart_llama_cpp_flutter` Apple SwiftPM checksum and aligned current
+  README/website native override docs.
+
 * Changed unset native decoder/generative context batching from full-context
   batches to llama.cpp-aligned caps of `n_batch = min(n_ctx, 2048)` and
   `n_ubatch = min(n_batch, 512)`. Explicit positive values remain supported,

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,11 +1,7 @@
 ## Unreleased
 
-* Updated the default llama.cpp native runtime pin to
-  `leehack/llamadart-native@b9969-llamadart.1`, keeping the `b9969` llama.cpp
-  ABI/bindings while picking up wrapper fixes for native release
-  provenance and backend-selected speculative sampler acceptance. Refreshed
-  the `llamadart_llama_cpp_flutter` Apple SwiftPM checksum and aligned current
-  README/website native override docs.
+* Updated the default llama.cpp runtime to
+  `leehack/llamadart-native@b9969-llamadart.1`.
 
 * Changed unset native decoder/generative context batching from full-context
   batches to llama.cpp-aligned caps of `n_batch = min(n_ctx, 2048)` and

--- a/README.md
+++ b/README.md
@@ -134,7 +134,7 @@ Current default runtime pins:
 
 | Runtime | Pin |
 | --- | --- |
-| Native llama.cpp / GGUF | `leehack/llamadart-native@b9935` |
+| Native llama.cpp / GGUF | `leehack/llamadart-native@b9969-llamadart.1` |
 | Native LiteRT-LM / `.litertlm` | `leehack/litert-lm-native@v0.14.0-native.2` |
 | Web llama.cpp / GGUF | `leehack/llama-web-bridge-assets@v0.1.18` |
 | Web LiteRT-LM / `.litertlm` | `@litert-lm/core@0.14.0` |

--- a/README.md
+++ b/README.md
@@ -25,9 +25,9 @@ models through LiteRT-LM.
 - `.litertlm` model loading and generation through LiteRT-LM.
 - Native Dart and Flutter targets with downloaded runtime assets.
 - Flutter Web through the experimental WebGPU bridge and LiteRT-LM web runtime.
-- Streaming chat completions, tool-call parsing, multimodal GGUF projectors,
-  structured JSON output, embeddings, LoRA, state persistence, and runtime
-  diagnostics where the active backend supports them.
+- Streaming chat completions, llama.cpp thinking budgets, tool-call parsing,
+  multimodal GGUF projectors, structured JSON output, embeddings, LoRA, state
+  persistence, and runtime diagnostics where the active backend supports them.
 
 Unsupported runtime/option combinations are rejected explicitly instead of
 silently degrading. Check the support matrix before relying on a capability for

--- a/example/llamadart_server/README.md
+++ b/example/llamadart_server/README.md
@@ -113,6 +113,17 @@ for thought-intensive requests while leaving room for the prompt in the
 16,384-token context. A request that ends during reasoning can correctly have
 `reasoning_content` but no final `content`.
 
+### Thinking budget (llama.cpp extension)
+
+`thinking_budget_tokens` is the same non-standard extension accepted by
+llama.cpp's server; it is not an OpenAI Chat Completions field. Send it only
+with `"enable_thinking": true`. It caps generated tokens within a reasoning
+block, while `max_tokens` still caps the whole completion. A value of `0`
+closes the initial reasoning block immediately, which is useful when a client
+wants a standard tool call without model reasoning. See Swagger's **Tool call:
+capped reasoning + function request (SSE)** example for a request that streams
+both `reasoning_content` and `tool_calls`.
+
 ## API Examples
 
 ### 0. OpenAPI and Swagger UI
@@ -189,8 +200,8 @@ minimal standard tool-result message does not need a `name` field.
 
 For a streaming tool call, accumulate `delta.tool_calls` fragments by index
 until the terminal `finish_reason` is `tool_calls`; then follow the same steps.
-The **Tool call: reasoning + function request (SSE)** Swagger example also
-demonstrates Qwen's optional `reasoning_content` stream.
+The **Tool call: capped reasoning + function request (SSE)** Swagger example
+also demonstrates Qwen's optional `reasoning_content` stream.
 
 ### 5. With API key
 

--- a/example/llamadart_server/lib/src/features/chat_completion/application/chat_completion_request_parser.dart
+++ b/example/llamadart_server/lib/src/features/chat_completion/application/chat_completion_request_parser.dart
@@ -6,6 +6,8 @@ import 'parser_support/chat_completion_field_readers.dart';
 import 'parser_support/chat_completion_message_parser.dart';
 import 'parser_support/chat_completion_tool_parser.dart';
 
+const int _maxThinkingBudgetTokens = 0x7fffffff;
+
 const GenerationParams _nonThinkingGenerationParams = GenerationParams(
   temp: 0.7,
   topK: 20,
@@ -76,16 +78,46 @@ OpenAiChatCompletionRequest parseChatCompletionRequest(
   }
 
   final maxTokens = readIntField(json['max_tokens'], 'max_tokens');
+  final thinkingBudgetTokens = readIntField(
+    json['thinking_budget_tokens'],
+    'thinking_budget_tokens',
+  );
   final temperature = readDoubleField(json['temperature'], 'temperature');
   final topP = readDoubleField(json['top_p'], 'top_p');
   final seed = readIntField(json['seed'], 'seed');
   final stops = parseStopSequences(json['stop']);
+
+  if (thinkingBudgetTokens != null && !enableThinking) {
+    throw OpenAiHttpException.invalidRequest(
+      '`thinking_budget_tokens` requires `enable_thinking = true`.',
+      param: 'thinking_budget_tokens',
+    );
+  }
+  if (thinkingBudgetTokens != null && thinkingBudgetTokens < 0) {
+    throw OpenAiHttpException.invalidRequest(
+      '`thinking_budget_tokens` must be greater than or equal to zero.',
+      param: 'thinking_budget_tokens',
+    );
+  }
+  if (thinkingBudgetTokens != null &&
+      thinkingBudgetTokens > _maxThinkingBudgetTokens) {
+    throw OpenAiHttpException.invalidRequest(
+      '`thinking_budget_tokens` must be less than or equal to '
+      '$_maxThinkingBudgetTokens.',
+      param: 'thinking_budget_tokens',
+    );
+  }
 
   var params = enableThinking
       ? _thinkingGenerationParams
       : _nonThinkingGenerationParams;
   if (maxTokens != null) {
     params = params.copyWith(maxTokens: maxTokens);
+  }
+  if (thinkingBudgetTokens != null) {
+    params = params.copyWith(
+      thinkingBudget: ThinkingBudget(maxTokens: thinkingBudgetTokens),
+    );
   }
   if (temperature != null) {
     params = params.copyWith(temp: temperature);

--- a/example/llamadart_server/lib/src/features/openai_api/presentation/docs/openapi_components/chat_schemas/request.dart
+++ b/example/llamadart_server/lib/src/features/openai_api/presentation/docs/openapi_components/chat_schemas/request.dart
@@ -38,6 +38,17 @@ Map<String, dynamic> buildChatRequestSchemas({required String modelId}) {
               'Enable model reasoning output in `reasoning_content`. '
               'Disabled by default for the default Qwen3.6 27B model.',
         },
+        'thinking_budget_tokens': <String, dynamic>{
+          'type': 'integer',
+          'minimum': 0,
+          'maximum': 2147483647,
+          'description':
+              'llama.cpp extension (not a standard OpenAI Chat Completions '
+              'field): maximum generated tokens inside each thinking block. '
+              'Requires `enable_thinking: true`; `0` closes the block '
+              'immediately. This is separate from `max_tokens`, which caps '
+              'the whole completion.',
+        },
         'parallel_tool_calls': <String, dynamic>{
           'type': 'boolean',
           'default': false,

--- a/example/llamadart_server/lib/src/features/openai_api/presentation/docs/openapi_paths/chat_paths.dart
+++ b/example/llamadart_server/lib/src/features/openai_api/presentation/docs/openapi_paths/chat_paths.dart
@@ -128,15 +128,17 @@ Map<String, dynamic> _buildChatRequestExamples(String modelId) {
       },
     },
     'tool_call_streaming_with_thinking': <String, dynamic>{
-      'summary': 'Tool call: reasoning + function request (SSE)',
+      'summary': 'Tool call: capped reasoning + function request (SSE)',
       'description':
-          'Qwen extension: this request streams `reasoning_content` before '
-          'the function call. Accumulate reasoning and `delta.tool_calls` '
-          'fragments independently until the stream finishes.',
+          'llama.cpp/Qwen extension: this request limits reasoning to 128 '
+          'tokens, then streams `reasoning_content` followed by the function '
+          'call. Accumulate reasoning and `delta.tool_calls` fragments '
+          'independently until the stream finishes.',
       'value': <String, dynamic>{
         'model': modelId,
         'stream': true,
         'enable_thinking': true,
+        'thinking_budget_tokens': 128,
         'temperature': 0,
         'max_tokens': 512,
         'messages': <Map<String, dynamic>>[

--- a/example/llamadart_server/test/openai_mapper_test.dart
+++ b/example/llamadart_server/test/openai_mapper_test.dart
@@ -66,6 +66,74 @@ void main() {
       expect(request.params.penalty, 1.0);
     });
 
+    test('parses llama.cpp thinking budget tokens', () {
+      final request = parseChatCompletionRequest(<String, dynamic>{
+        'model': 'llamadart-local',
+        'messages': <Map<String, dynamic>>[
+          <String, dynamic>{'role': 'user', 'content': 'Think briefly.'},
+        ],
+        'enable_thinking': true,
+        'thinking_budget_tokens': 128,
+      }, configuredModelId: 'llamadart-local');
+
+      expect(request.params.thinkingBudget?.maxTokens, 128);
+      expect(request.params.thinkingBudget?.startTag, isNull);
+      expect(request.params.thinkingBudget?.endTag, isNull);
+    });
+
+    test('accepts a zero thinking budget', () {
+      final request = parseChatCompletionRequest(<String, dynamic>{
+        'model': 'llamadart-local',
+        'messages': <Map<String, dynamic>>[
+          <String, dynamic>{'role': 'user', 'content': 'Do not think.'},
+        ],
+        'enable_thinking': true,
+        'thinking_budget_tokens': 0,
+      }, configuredModelId: 'llamadart-local');
+
+      expect(request.params.thinkingBudget?.maxTokens, 0);
+    });
+
+    test('rejects invalid thinking budget requests', () {
+      final withoutThinking = <String, dynamic>{
+        'model': 'llamadart-local',
+        'messages': <Map<String, dynamic>>[
+          <String, dynamic>{'role': 'user', 'content': 'Say hello.'},
+        ],
+        'thinking_budget_tokens': 64,
+      };
+      final negative = <String, dynamic>{
+        ...withoutThinking,
+        'enable_thinking': true,
+        'thinking_budget_tokens': -1,
+      };
+      final overflow = <String, dynamic>{
+        ...withoutThinking,
+        'enable_thinking': true,
+        'thinking_budget_tokens': 2147483648,
+      };
+
+      for (final request in <Map<String, dynamic>>[
+        withoutThinking,
+        negative,
+        overflow,
+      ]) {
+        expect(
+          () => parseChatCompletionRequest(
+            request,
+            configuredModelId: 'llamadart-local',
+          ),
+          throwsA(
+            isA<OpenAiHttpException>().having(
+              (OpenAiHttpException error) => error.param,
+              'param',
+              'thinking_budget_tokens',
+            ),
+          ),
+        );
+      }
+    });
+
     test('rejects a non-boolean thinking control', () {
       expect(
         () => parseChatCompletionRequest(<String, dynamic>{

--- a/example/llamadart_server/test/openai_server_integration_test.dart
+++ b/example/llamadart_server/test/openai_server_integration_test.dart
@@ -63,6 +63,11 @@ void main() {
       final properties = chatRequest['properties'] as Map<String, dynamic>;
       final thinking = properties['enable_thinking'] as Map<String, dynamic>;
       expect(thinking['default'], isFalse);
+      final thinkingBudget =
+          properties['thinking_budget_tokens'] as Map<String, dynamic>;
+      expect(thinkingBudget['minimum'], 0);
+      expect(thinkingBudget['maximum'], 2147483647);
+      expect(thinkingBudget['description'], contains('not a standard OpenAI'));
       final parallel =
           properties['parallel_tool_calls'] as Map<String, dynamic>;
       expect(parallel['default'], isFalse);
@@ -105,6 +110,7 @@ void main() {
       final thinkingSystem = thinkingMessages.first as Map<String, dynamic>;
       expect(thinkingValue['stream'], isTrue);
       expect(thinkingValue['enable_thinking'], isTrue);
+      expect(thinkingValue['thinking_budget_tokens'], 128);
       expect(thinkingValue['tool_choice'], 'auto');
       expect(thinkingSystem['content'], contains('must call get_weather'));
 

--- a/hook/build.dart
+++ b/hook/build.dart
@@ -13,7 +13,7 @@ import 'package:path/path.dart' as path;
 
 import 'package:llamadart/src/hook/native_bundle_config.dart';
 
-const _llamaCppTag = 'b9935';
+const _llamaCppTag = 'b9969-llamadart.1';
 const _nativeRepoSlug = 'leehack/llamadart-native';
 
 const _packageName = 'llamadart';

--- a/lib/src/backends/litert_lm/litert_lm_backend_web.dart
+++ b/lib/src/backends/litert_lm/litert_lm_backend_web.dart
@@ -1126,6 +1126,9 @@ class LiteRtLmBackend
     if (params.grammarLazy) {
       unsupported.add('grammarLazy');
     }
+    if (params.thinkingBudget != null) {
+      unsupported.add('thinkingBudget');
+    }
     if (params.grammarTriggers.isNotEmpty) {
       unsupported.add('grammarTriggers');
     }

--- a/lib/src/backends/litert_lm/litert_lm_service.dart
+++ b/lib/src/backends/litert_lm/litert_lm_service.dart
@@ -973,6 +973,9 @@ class LiteRtLmService {
     if (params.grammarLazy) {
       unsupported.add('grammarLazy');
     }
+    if (params.thinkingBudget != null) {
+      unsupported.add('thinkingBudget');
+    }
     if (params.grammarTriggers.isNotEmpty) {
       unsupported.add('grammarTriggers');
     }

--- a/lib/src/backends/llama_cpp/bindings.dart
+++ b/lib/src/backends/llama_cpp/bindings.dart
@@ -7737,6 +7737,31 @@ external int mtmd_helper_video_read_next(
 external void llama_dart_set_log_level(int level);
 
 @ffi.Native<
+  ffi.Pointer<llama_sampler> Function(
+    ffi.Pointer<llama_vocab>,
+    ffi.Pointer<ffi.Char>,
+    ffi.Pointer<ffi.Char>,
+    ffi.Pointer<ffi.Char>,
+    ffi.Int32,
+    ffi.Bool,
+    ffi.Pointer<llama_sampler>,
+    ffi.Pointer<llama_token>,
+    ffi.Int32,
+  )
+>()
+external ffi.Pointer<llama_sampler> llama_dart_sampler_init_reasoning_budget(
+  ffi.Pointer<llama_vocab> vocab,
+  ffi.Pointer<ffi.Char> start_tag,
+  ffi.Pointer<ffi.Char> end_tag,
+  ffi.Pointer<ffi.Char> forced_message,
+  int budget_tokens,
+  bool pause_grammar_while_reasoning,
+  ffi.Pointer<llama_sampler> grammar_sampler,
+  ffi.Pointer<llama_token> prompt_tokens,
+  int prompt_token_count,
+);
+
+@ffi.Native<
   ffi.Pointer<llama_dart_speculative> Function(
     ffi.Pointer<llama_model>,
     ffi.Pointer<llama_model>,
@@ -9258,91 +9283,89 @@ typedef llama_model_set_tensor_data_t =
 
 final class gguf_context extends ffi.Opaque {}
 
-final class _IO_marker extends ffi.Opaque {}
-
-typedef __off_t = ffi.Long;
-typedef Dart__off_t = int;
-typedef _IO_lock_t = ffi.Void;
-typedef Dart_IO_lock_t = void;
-typedef __off64_t = ffi.Long;
-typedef Dart__off64_t = int;
-
-final class _IO_codecvt extends ffi.Opaque {}
-
-final class _IO_wide_data extends ffi.Opaque {}
-
-final class _IO_FILE extends ffi.Struct {
-  @ffi.Int()
-  external int _flags;
-
-  external ffi.Pointer<ffi.Char> _IO_read_ptr;
-
-  external ffi.Pointer<ffi.Char> _IO_read_end;
-
-  external ffi.Pointer<ffi.Char> _IO_read_base;
-
-  external ffi.Pointer<ffi.Char> _IO_write_base;
-
-  external ffi.Pointer<ffi.Char> _IO_write_ptr;
-
-  external ffi.Pointer<ffi.Char> _IO_write_end;
-
-  external ffi.Pointer<ffi.Char> _IO_buf_base;
-
-  external ffi.Pointer<ffi.Char> _IO_buf_end;
-
-  external ffi.Pointer<ffi.Char> _IO_save_base;
-
-  external ffi.Pointer<ffi.Char> _IO_backup_base;
-
-  external ffi.Pointer<ffi.Char> _IO_save_end;
-
-  external ffi.Pointer<_IO_marker> _markers;
-
-  external ffi.Pointer<_IO_FILE> _chain;
+final class __sbuf extends ffi.Struct {
+  external ffi.Pointer<ffi.UnsignedChar> _base;
 
   @ffi.Int()
-  external int _fileno;
-
-  @ffi.Int()
-  external int _flags2;
-
-  @__off_t()
-  external int _old_offset;
-
-  @ffi.UnsignedShort()
-  external int _cur_column;
-
-  @ffi.SignedChar()
-  external int _vtable_offset;
-
-  @ffi.Array.multi([1])
-  external ffi.Array<ffi.Char> _shortbuf;
-
-  external ffi.Pointer<_IO_lock_t> _lock;
-
-  @__off64_t()
-  external int _offset;
-
-  external ffi.Pointer<_IO_codecvt> _codecvt;
-
-  external ffi.Pointer<_IO_wide_data> _wide_data;
-
-  external ffi.Pointer<_IO_FILE> _freeres_list;
-
-  external ffi.Pointer<ffi.Void> _freeres_buf;
-
-  @ffi.Size()
-  external int __pad5;
-
-  @ffi.Int()
-  external int _mode;
-
-  @ffi.Array.multi([20])
-  external ffi.Array<ffi.Char> _unused2;
+  external int _size;
 }
 
-typedef FILE = _IO_FILE;
+typedef __int64_t = ffi.LongLong;
+typedef Dart__int64_t = int;
+typedef __darwin_off_t = __int64_t;
+typedef fpos_t = __darwin_off_t;
+
+final class __sFILEX extends ffi.Opaque {}
+
+final class __sFILE extends ffi.Struct {
+  external ffi.Pointer<ffi.UnsignedChar> _p;
+
+  @ffi.Int()
+  external int _r;
+
+  @ffi.Int()
+  external int _w;
+
+  @ffi.Short()
+  external int _flags;
+
+  @ffi.Short()
+  external int _file;
+
+  external __sbuf _bf;
+
+  @ffi.Int()
+  external int _lbfsize;
+
+  external ffi.Pointer<ffi.Void> _cookie;
+
+  external ffi.Pointer<
+    ffi.NativeFunction<ffi.Int Function(ffi.Pointer<ffi.Void>)>
+  >
+  _close;
+
+  external ffi.Pointer<
+    ffi.NativeFunction<
+      ffi.Int Function(ffi.Pointer<ffi.Void>, ffi.Pointer<ffi.Char>, ffi.Int)
+    >
+  >
+  _read;
+
+  external ffi.Pointer<
+    ffi.NativeFunction<fpos_t Function(ffi.Pointer<ffi.Void>, fpos_t, ffi.Int)>
+  >
+  _seek;
+
+  external ffi.Pointer<
+    ffi.NativeFunction<
+      ffi.Int Function(ffi.Pointer<ffi.Void>, ffi.Pointer<ffi.Char>, ffi.Int)
+    >
+  >
+  _write;
+
+  external __sbuf _ub;
+
+  external ffi.Pointer<__sFILEX> _extra;
+
+  @ffi.Int()
+  external int _ur;
+
+  @ffi.Array.multi([3])
+  external ffi.Array<ffi.UnsignedChar> _ubuf;
+
+  @ffi.Array.multi([1])
+  external ffi.Array<ffi.UnsignedChar> _nbuf;
+
+  external __sbuf _lb;
+
+  @ffi.Int()
+  external int _blksize;
+
+  @fpos_t()
+  external int _offset;
+}
+
+typedef FILE = __sFILE;
 typedef llama_state_seq_flags = ffi.Uint32;
 typedef Dartllama_state_seq_flags = int;
 

--- a/lib/src/backends/llama_cpp/llama_cpp_backend.dart
+++ b/lib/src/backends/llama_cpp/llama_cpp_backend.dart
@@ -87,7 +87,11 @@ class NativeLlamaBackend
       case WorkerErrorKind.state:
         return LlamaStateException(response.message);
       case WorkerErrorKind.generic:
-        return Exception(response.message);
+        const exceptionPrefix = 'Exception: ';
+        final message = response.message.startsWith(exceptionPrefix)
+            ? response.message.substring(exceptionPrefix.length)
+            : response.message;
+        return Exception(message);
     }
   }
 

--- a/lib/src/backends/llama_cpp/llama_cpp_backend.dart
+++ b/lib/src/backends/llama_cpp/llama_cpp_backend.dart
@@ -8,6 +8,7 @@ import '../../core/models/config/gpu_backend.dart';
 import '../../core/models/config/gpu_device_info.dart';
 import '../../core/models/config/log_level.dart';
 import '../../core/models/diagnostics/model_file_type.dart';
+import '../../core/exceptions.dart';
 import '../../core/models/inference/model_params.dart';
 import '../../core/models/inference/generation_params.dart';
 import 'worker.dart';
@@ -68,9 +69,26 @@ class NativeLlamaBackend
       return;
     }
     if (response is ErrorResponse) {
-      throw Exception(response.message);
+      throw _workerError(response);
     }
     throw Exception('Unknown response during $operation');
+  }
+
+  Object _workerError(ErrorResponse response) {
+    switch (response.kind) {
+      case WorkerErrorKind.model:
+        return LlamaModelException(response.message);
+      case WorkerErrorKind.context:
+        return LlamaContextException(response.message);
+      case WorkerErrorKind.inference:
+        return LlamaInferenceException(response.message);
+      case WorkerErrorKind.unsupported:
+        return LlamaUnsupportedException(response.message);
+      case WorkerErrorKind.state:
+        return LlamaStateException(response.message);
+      case WorkerErrorKind.generic:
+        return Exception(response.message);
+    }
   }
 
   Future<void> _ensureIsolate() async {
@@ -146,7 +164,7 @@ class NativeLlamaBackend
     final res = await rp.first;
     rp.close();
     if (res is HandleResponse) return res.handle;
-    if (res is ErrorResponse) throw Exception(res.message);
+    if (res is ErrorResponse) throw _workerError(res);
     throw Exception("Unknown response during model load");
   }
 
@@ -177,7 +195,7 @@ class NativeLlamaBackend
     final res = await rp.first;
     rp.close();
     if (res is HandleResponse) return res.handle;
-    if (res is ErrorResponse) throw Exception(res.message);
+    if (res is ErrorResponse) throw _workerError(res);
     throw Exception("Unknown response during context creation");
   }
 
@@ -298,7 +316,7 @@ class NativeLlamaBackend
         freeToken();
       } else if (msg is ErrorResponse) {
         if (!controller.isClosed) {
-          controller.addError(Exception(msg.message));
+          controller.addError(_workerError(msg));
         }
         detachAndClose();
         freeToken();

--- a/lib/src/backends/llama_cpp/llama_cpp_service.dart
+++ b/lib/src/backends/llama_cpp/llama_cpp_service.dart
@@ -4231,12 +4231,6 @@ class LlamaCppService {
         params,
         hasMediaParts: hasMediaParts,
       );
-      if (thinkingBudgetConfig != null && params.isSpeculativeDecodingEnabled) {
-        throw LlamaUnsupportedException(
-          'llama.cpp thinking-budget control cannot be combined with '
-          'speculative decoding in llamadart.',
-        );
-      }
       final speculativeConfig = _resolveLlamaCppSpeculativeConfig(
         params,
         hasMediaParts: hasMediaParts,

--- a/lib/src/backends/llama_cpp/llama_cpp_service.dart
+++ b/lib/src/backends/llama_cpp/llama_cpp_service.dart
@@ -7,6 +7,7 @@ import 'dart:math' as math;
 import 'package:ffi/ffi.dart';
 import 'package:path/path.dart' as path;
 
+import '../../core/exceptions.dart';
 import '../../core/llama_logger.dart';
 import '../../core/models/chat/chat_message.dart';
 import '../../core/models/chat/chat_role.dart';
@@ -83,6 +84,30 @@ typedef _GgmlBackendDevMemoryDart =
     void Function(ggml_backend_dev_t, Pointer<Size>, Pointer<Size>);
 typedef _LlamaDartSetLogLevelNative = Void Function(Int32);
 typedef _LlamaDartSetLogLevelDart = void Function(int);
+typedef _LlamaDartReasoningBudgetInitNative =
+    Pointer<llama_sampler> Function(
+      Pointer<llama_vocab>,
+      Pointer<Char>,
+      Pointer<Char>,
+      Pointer<Char>,
+      Int32,
+      Bool,
+      Pointer<llama_sampler>,
+      Pointer<Int32>,
+      Int32,
+    );
+typedef _LlamaDartReasoningBudgetInitDart =
+    Pointer<llama_sampler> Function(
+      Pointer<llama_vocab>,
+      Pointer<Char>,
+      Pointer<Char>,
+      Pointer<Char>,
+      int,
+      bool,
+      Pointer<llama_sampler>,
+      Pointer<Int32>,
+      int,
+    );
 typedef _LlamaDartSpeculativeInitNative =
     Pointer<llama_dart_speculative> Function(
       Pointer<llama_model>,
@@ -640,6 +665,22 @@ final RegExp _linuxLlamadartProcMapsPattern = RegExp(
   r'/libllamadart\.so(?:\.\d+)?$',
 );
 
+const int _maxLlamaCppReasoningBudgetTokens = 0x7fffffff;
+
+class _LlamaCppThinkingBudgetConfig {
+  const _LlamaCppThinkingBudgetConfig({
+    required this.maxTokens,
+    required this.startTag,
+    required this.endTag,
+    required this.forcedMessage,
+  });
+
+  final int maxTokens;
+  final String startTag;
+  final String endTag;
+  final String forcedMessage;
+}
+
 class _LlamaCppSpeculativeConfig {
   const _LlamaCppSpeculativeConfig({
     required this.strategies,
@@ -816,6 +857,8 @@ class LlamaCppService {
   bool _mtmdFallbackLookupAttempted = false;
   bool _mtmdPrimarySymbolsUnavailable = false;
   _MtmdApi? _mtmdFallbackApi;
+  bool _reasoningBudgetApiLookupAttempted = false;
+  _ReasoningBudgetApi? _reasoningBudgetApi;
   bool _speculativeApiLookupAttempted = false;
   _SpeculativeApi? _speculativeApi;
   bool _mtpApiLookupAttempted = false;
@@ -2920,6 +2963,40 @@ class LlamaCppService {
     }
   }
 
+  _ReasoningBudgetApi _resolveReasoningBudgetApi() {
+    final cached = _reasoningBudgetApi;
+    if (cached != null) {
+      return cached;
+    }
+
+    if (_reasoningBudgetApiLookupAttempted) {
+      throw LlamaUnsupportedException(_reasoningBudgetUnavailableMessage());
+    }
+    _reasoningBudgetApiLookupAttempted = true;
+
+    for (final candidate in _llamadartWrapperLibraryCandidates()) {
+      try {
+        final library = DynamicLibrary.open(candidate);
+        final api = _ReasoningBudgetApi.tryLoad(library);
+        if (api != null) {
+          _reasoningBudgetApi = api;
+          return api;
+        }
+      } catch (_) {
+        continue;
+      }
+    }
+
+    throw LlamaUnsupportedException(_reasoningBudgetUnavailableMessage());
+  }
+
+  String _reasoningBudgetUnavailableMessage() {
+    return 'llama.cpp thinking-budget control is unavailable in this native '
+        'runtime bundle (missing llama_dart_sampler_init_reasoning_budget). '
+        'Update to a libllamadart build that includes the reasoning-budget '
+        'wrapper.';
+  }
+
   _SpeculativeApi _resolveSpeculativeApi() {
     final cached = _speculativeApi;
     if (cached != null) {
@@ -3761,6 +3838,59 @@ class LlamaCppService {
     _contexts.remove(handle)?.dispose();
   }
 
+  _LlamaCppThinkingBudgetConfig? _resolveLlamaCppThinkingBudgetConfig(
+    GenerationParams params, {
+    required bool hasMediaParts,
+  }) {
+    final budget = params.thinkingBudget;
+    if (budget == null) {
+      return null;
+    }
+    if (budget.maxTokens < 0) {
+      throw RangeError.value(
+        budget.maxTokens,
+        'thinkingBudget.maxTokens',
+        'must be non-negative for llama.cpp thinking-budget control',
+      );
+    }
+    if (budget.maxTokens > _maxLlamaCppReasoningBudgetTokens) {
+      throw RangeError.range(
+        budget.maxTokens,
+        0,
+        _maxLlamaCppReasoningBudgetTokens,
+        'thinkingBudget.maxTokens',
+        'must fit the signed 32-bit llama.cpp reasoning-budget limit',
+      );
+    }
+    if (hasMediaParts) {
+      throw LlamaUnsupportedException(
+        'llama.cpp thinking-budget control currently supports text-only '
+        'generation in llamadart because template prompt tokens must be '
+        'inspected by the native reasoning sampler.',
+      );
+    }
+
+    final startTag = budget.startTag;
+    final endTag = budget.endTag;
+    if (startTag == null ||
+        startTag.trim().isEmpty ||
+        endTag == null ||
+        endTag.trim().isEmpty) {
+      throw ArgumentError(
+        'GenerationParams.thinkingBudget requires non-empty startTag and '
+        'endTag for raw generation. LlamaEngine.create fills them from the '
+        'selected chat template automatically.',
+      );
+    }
+
+    return _LlamaCppThinkingBudgetConfig(
+      maxTokens: budget.maxTokens,
+      startTag: startTag,
+      endTag: endTag,
+      forcedMessage: budget.forcedMessage ?? '',
+    );
+  }
+
   _LlamaCppSpeculativeConfig? _resolveLlamaCppSpeculativeConfig(
     GenerationParams params, {
     required bool hasMediaParts,
@@ -3774,6 +3904,12 @@ class LlamaCppService {
       throw UnsupportedError(
         'llama.cpp speculative decoding currently supports text-only '
         'generation in llamadart.',
+      );
+    }
+    if (params.thinkingBudget != null) {
+      throw LlamaUnsupportedException(
+        'llama.cpp thinking-budget control cannot be combined with '
+        'speculative decoding in llamadart.',
       );
     }
     if (params.grammar != null) {
@@ -3949,6 +4085,14 @@ class LlamaCppService {
     )?.typeNames;
   }
 
+  /// Validates a llama.cpp thinking budget for unit tests.
+  void debugValidateThinkingBudgetForTesting(
+    GenerationParams params, {
+    bool hasMediaParts = false,
+  }) {
+    _resolveLlamaCppThinkingBudgetConfig(params, hasMediaParts: hasMediaParts);
+  }
+
   /// Resolves whether llama.cpp speculative prompt processing suppresses logits.
   bool debugSuppressesDraftProcessLogitsForTesting(
     GenerationParams params, {
@@ -4083,10 +4227,23 @@ class LlamaCppService {
       final hasMediaParts =
           parts?.any((p) => p is LlamaImageContent || p is LlamaAudioContent) ??
           false;
+      final thinkingBudgetConfig = _resolveLlamaCppThinkingBudgetConfig(
+        params,
+        hasMediaParts: hasMediaParts,
+      );
+      if (thinkingBudgetConfig != null && params.isSpeculativeDecodingEnabled) {
+        throw LlamaUnsupportedException(
+          'llama.cpp thinking-budget control cannot be combined with '
+          'speculative decoding in llamadart.',
+        );
+      }
       final speculativeConfig = _resolveLlamaCppSpeculativeConfig(
         params,
         hasMediaParts: hasMediaParts,
       );
+      final reasoningBudgetApi = thinkingBudgetConfig == null
+          ? null
+          : _resolveReasoningBudgetApi();
       // 1. Reset Context
       ctx = _resetContext(
         contextHandle,
@@ -4203,6 +4360,8 @@ class LlamaCppService {
         grammarPtr,
         rootPtr,
         lazyGrammarConfig,
+        thinkingBudgetConfig,
+        reasoningBudgetApi,
         initialTokens,
         tokensPtr,
       );
@@ -5220,6 +5379,8 @@ class LlamaCppService {
     Pointer<Utf8> grammarPtr,
     Pointer<Utf8> rootPtr,
     _LazyGrammarConfig? lazyGrammarConfig,
+    _LlamaCppThinkingBudgetConfig? thinkingBudgetConfig,
+    _ReasoningBudgetApi? reasoningBudgetApi,
     int initialTokens,
     Pointer<Int32> tokensPtr,
   ) {
@@ -5228,37 +5389,75 @@ class LlamaCppService {
     );
 
     final penaltyConfig = _resolvePenaltySamplerConfig(params);
-
-    llama_sampler_chain_add(
-      sampler,
-      llama_sampler_init_penalties(
-        penaltyConfig.lastN,
-        penaltyConfig.repeat,
-        penaltyConfig.frequency,
-        penaltyConfig.presence,
-      ),
+    final penaltiesSampler = llama_sampler_init_penalties(
+      penaltyConfig.lastN,
+      penaltyConfig.repeat,
+      penaltyConfig.frequency,
+      penaltyConfig.presence,
     );
+    llama_sampler_chain_add(sampler, penaltiesSampler);
 
+    Pointer<llama_sampler> grammarSampler = nullptr;
+    final useLazyGrammar = params.grammarLazy && lazyGrammarConfig != null;
     if (grammarPtr != nullptr) {
-      if (params.grammarLazy && lazyGrammarConfig != null) {
-        llama_sampler_chain_add(
-          sampler,
-          llama_sampler_init_grammar_lazy_patterns(
-            vocab,
-            grammarPtr.cast(),
-            rootPtr.cast(),
-            lazyGrammarConfig.triggerPatterns,
-            lazyGrammarConfig.numTriggerPatterns,
-            lazyGrammarConfig.triggerTokens,
-            lazyGrammarConfig.numTriggerTokens,
-          ),
+      if (useLazyGrammar) {
+        grammarSampler = llama_sampler_init_grammar_lazy_patterns(
+          vocab,
+          grammarPtr.cast(),
+          rootPtr.cast(),
+          lazyGrammarConfig.triggerPatterns,
+          lazyGrammarConfig.numTriggerPatterns,
+          lazyGrammarConfig.triggerTokens,
+          lazyGrammarConfig.numTriggerTokens,
         );
       } else {
-        llama_sampler_chain_add(
-          sampler,
-          llama_sampler_init_grammar(vocab, grammarPtr.cast(), rootPtr.cast()),
+        grammarSampler = llama_sampler_init_grammar(
+          vocab,
+          grammarPtr.cast(),
+          rootPtr.cast(),
         );
       }
+    }
+    if (grammarPtr != nullptr && grammarSampler == nullptr) {
+      llama_sampler_free(sampler);
+      throw LlamaInferenceException(
+        'llama.cpp failed to initialize the requested grammar sampler.',
+      );
+    }
+
+    if (thinkingBudgetConfig != null) {
+      final api = reasoningBudgetApi;
+      if (api == null) {
+        if (grammarSampler != nullptr) {
+          llama_sampler_free(grammarSampler);
+        }
+        llama_sampler_free(sampler);
+        throw StateError('Missing llama.cpp reasoning-budget sampler API.');
+      }
+      final budgetSampler = api.initSampler(
+        vocab: vocab,
+        config: thinkingBudgetConfig,
+        pauseGrammarDuringReasoning: grammarSampler != nullptr,
+        grammarSampler: grammarSampler,
+        promptTokens: tokensPtr,
+        promptTokenCount: initialTokens,
+      );
+      if (budgetSampler == nullptr) {
+        if (grammarSampler != nullptr) {
+          llama_sampler_free(grammarSampler);
+        }
+        llama_sampler_free(sampler);
+        throw LlamaUnsupportedException(
+          'llama.cpp could not initialize thinking-budget control. Verify '
+          'that the configured thinking tags are supported by the loaded '
+          'model vocabulary.',
+        );
+      }
+      // The native composite sampler owns grammarSampler after this point.
+      grammarSampler = nullptr;
+      llama_sampler_chain_add(sampler, budgetSampler);
+    } else if (grammarSampler != nullptr) {
+      llama_sampler_chain_add(sampler, grammarSampler);
     }
 
     llama_sampler_chain_add(sampler, llama_sampler_init_top_k(params.topK));
@@ -5279,8 +5478,17 @@ class LlamaCppService {
     }
 
     if (grammarPtr == nullptr && tokensPtr != nullptr && initialTokens > 0) {
-      for (int i = 0; i < initialTokens; i++) {
-        llama_sampler_accept(sampler, tokensPtr[i]);
+      if (thinkingBudgetConfig != null) {
+        // The composite sampler derives its reasoning state from the complete
+        // prompt rather than accepting it token by token, but prompt tokens
+        // still need to seed the repeat-penalty sampler as before.
+        for (int i = 0; i < initialTokens; i++) {
+          llama_sampler_accept(penaltiesSampler, tokensPtr[i]);
+        }
+      } else {
+        for (int i = 0; i < initialTokens; i++) {
+          llama_sampler_accept(sampler, tokensPtr[i]);
+        }
       }
     }
 
@@ -7941,6 +8149,56 @@ class _LazyGrammarConfig {
     }
     if (triggerTokens != nullptr) {
       malloc.free(triggerTokens);
+    }
+  }
+}
+
+class _ReasoningBudgetApi {
+  const _ReasoningBudgetApi({required this.init});
+
+  final _LlamaDartReasoningBudgetInitDart init;
+
+  Pointer<llama_sampler> initSampler({
+    required Pointer<llama_vocab> vocab,
+    required _LlamaCppThinkingBudgetConfig config,
+    required bool pauseGrammarDuringReasoning,
+    required Pointer<llama_sampler> grammarSampler,
+    required Pointer<Int32> promptTokens,
+    required int promptTokenCount,
+  }) {
+    final startTag = config.startTag.toNativeUtf8();
+    final endTag = config.endTag.toNativeUtf8();
+    final forcedMessage = config.forcedMessage.toNativeUtf8();
+    try {
+      return init(
+        vocab,
+        startTag.cast(),
+        endTag.cast(),
+        forcedMessage.cast(),
+        config.maxTokens,
+        pauseGrammarDuringReasoning,
+        grammarSampler,
+        promptTokens,
+        promptTokenCount,
+      );
+    } finally {
+      malloc.free(startTag);
+      malloc.free(endTag);
+      malloc.free(forcedMessage);
+    }
+  }
+
+  static _ReasoningBudgetApi? tryLoad(DynamicLibrary library) {
+    try {
+      return _ReasoningBudgetApi(
+        init: library
+            .lookupFunction<
+              _LlamaDartReasoningBudgetInitNative,
+              _LlamaDartReasoningBudgetInitDart
+            >('llama_dart_sampler_init_reasoning_budget'),
+      );
+    } catch (_) {
+      return null;
     }
   }
 }

--- a/lib/src/backends/llama_cpp/worker.dart
+++ b/lib/src/backends/llama_cpp/worker.dart
@@ -1,12 +1,32 @@
 import 'dart:async';
 import 'dart:isolate';
 
+import '../../core/exceptions.dart';
 import 'llama_cpp_service.dart';
 import 'stream_batcher.dart';
 import 'worker_messages.dart';
 
 // Re-export messages so native_backend.dart can see them via worker.dart if needed
 export 'worker_messages.dart';
+
+ErrorResponse _toErrorResponse(Object error) {
+  if (error is LlamaModelException) {
+    return ErrorResponse(error.message, kind: WorkerErrorKind.model);
+  }
+  if (error is LlamaContextException) {
+    return ErrorResponse(error.message, kind: WorkerErrorKind.context);
+  }
+  if (error is LlamaInferenceException) {
+    return ErrorResponse(error.message, kind: WorkerErrorKind.inference);
+  }
+  if (error is LlamaUnsupportedException) {
+    return ErrorResponse(error.message, kind: WorkerErrorKind.unsupported);
+  }
+  if (error is LlamaStateException) {
+    return ErrorResponse(error.message, kind: WorkerErrorKind.state);
+  }
+  return ErrorResponse(error.toString());
+}
 
 /// Entry point for the llama worker isolate.
 void llamaWorkerEntry(SendPort initialSendPort) {
@@ -154,8 +174,8 @@ void runLlamaWorkerForTesting(
                 }
 
                 message.sendPort.send(DoneResponse());
-              } catch (e) {
-                message.sendPort.send(ErrorResponse(e.toString()));
+              } catch (error) {
+                message.sendPort.send(_toErrorResponse(error));
               }
             }();
             activeGenerate = generateFuture;
@@ -312,8 +332,8 @@ void runLlamaWorkerForTesting(
             );
             message.sendPort.send(StateLoadFileResponse(tokens));
         }
-      } catch (e) {
-        message.sendPort.send(ErrorResponse(e.toString()));
+      } catch (error) {
+        message.sendPort.send(_toErrorResponse(error));
       }
     }
   });

--- a/lib/src/backends/llama_cpp/worker.dart
+++ b/lib/src/backends/llama_cpp/worker.dart
@@ -10,20 +10,24 @@ import 'worker_messages.dart';
 export 'worker_messages.dart';
 
 ErrorResponse _toErrorResponse(Object error) {
+  String messageFor(LlamaException error) => error.details == null
+      ? error.message
+      : '${error.message} (${error.details})';
+
   if (error is LlamaModelException) {
-    return ErrorResponse(error.message, kind: WorkerErrorKind.model);
+    return ErrorResponse(messageFor(error), kind: WorkerErrorKind.model);
   }
   if (error is LlamaContextException) {
-    return ErrorResponse(error.message, kind: WorkerErrorKind.context);
+    return ErrorResponse(messageFor(error), kind: WorkerErrorKind.context);
   }
   if (error is LlamaInferenceException) {
-    return ErrorResponse(error.message, kind: WorkerErrorKind.inference);
+    return ErrorResponse(messageFor(error), kind: WorkerErrorKind.inference);
   }
   if (error is LlamaUnsupportedException) {
     return ErrorResponse(error.message, kind: WorkerErrorKind.unsupported);
   }
   if (error is LlamaStateException) {
-    return ErrorResponse(error.message, kind: WorkerErrorKind.state);
+    return ErrorResponse(messageFor(error), kind: WorkerErrorKind.state);
   }
   return ErrorResponse(error.toString());
 }

--- a/lib/src/backends/llama_cpp/worker_messages.dart
+++ b/lib/src/backends/llama_cpp/worker_messages.dart
@@ -482,13 +482,37 @@ class StateLoadFileResponse {
   StateLoadFileResponse(this.tokens);
 }
 
-/// Response containing an error message.
+/// Category used to preserve llama.cpp worker failures across isolates.
+enum WorkerErrorKind {
+  /// An unclassified worker error.
+  generic,
+
+  /// Model loading or ownership failed.
+  model,
+
+  /// Context creation or ownership failed.
+  context,
+
+  /// Inference or token generation failed.
+  inference,
+
+  /// A requested operation is unavailable in the active native runtime.
+  unsupported,
+
+  /// The engine was not in a state that permits the operation.
+  state,
+}
+
+/// Response containing an error message and category.
 class ErrorResponse {
   /// The error message.
   final String message;
 
+  /// The category of error reported by the worker.
+  final WorkerErrorKind kind;
+
   /// Creates a new [ErrorResponse].
-  ErrorResponse(this.message);
+  ErrorResponse(this.message, {this.kind = WorkerErrorKind.generic});
 }
 
 /// Response containing backend name.

--- a/lib/src/backends/webgpu/webgpu_backend.dart
+++ b/lib/src/backends/webgpu/webgpu_backend.dart
@@ -1666,6 +1666,11 @@ class WebGpuLlamaBackend
     if (params.presencePenalty != 0.0) {
       throw UnsupportedError('WebGPU presence penalty is not supported yet.');
     }
+    if (params.thinkingBudget != null) {
+      throw UnsupportedError(
+        'WebGPU thinking-budget control is not supported yet.',
+      );
+    }
     if (params.isSpeculativeDecodingEnabled) {
       throw UnsupportedError(
         'WebGPU speculative decoding is not supported yet.',

--- a/lib/src/core/engine/chat_completion_request_planner.dart
+++ b/lib/src/core/engine/chat_completion_request_planner.dart
@@ -8,6 +8,7 @@ import '../models/chat/content_part.dart';
 import '../models/inference/generation_params.dart';
 import '../models/inference/tool_choice.dart';
 import '../models/tools/tool_definition.dart';
+import '../template/chat_template_engine.dart';
 
 /// Prepared generation inputs for a chat-completion request.
 ///
@@ -114,11 +115,16 @@ class ChatCompletionRequestPlanner {
       if (backendSupportsGrammarConstraints) ...templateResult.preservedTokens,
       ...?params?.preservedTokens,
     }.toList(growable: false);
+    final requestedThinkingBudget = params?.thinkingBudget;
+    final effectiveThinkingBudget = requestedThinkingBudget == null
+        ? null
+        : _resolveThinkingBudgetTags(requestedThinkingBudget, templateResult);
 
     final generationParams = (params ?? const GenerationParams()).copyWith(
       stopSequences: stops,
       grammar: effectiveGrammar,
       grammarLazy: effectiveGrammarLazy,
+      thinkingBudget: effectiveThinkingBudget,
       grammarTriggers: effectiveGrammarTriggers,
       preservedTokens: effectivePreservedTokens,
     );
@@ -158,6 +164,19 @@ class ChatCompletionRequestPlanner {
     );
     LlamaLogger.instance.debug(
       '  Thinking forced open: ${templateResult.thinkingForcedOpen}',
+    );
+  }
+
+  static ThinkingBudget _resolveThinkingBudgetTags(
+    ThinkingBudget budget,
+    LlamaChatTemplateResult templateResult,
+  ) {
+    final tags = ChatTemplateEngine.thinkingTagsFor(templateResult.format);
+    return ThinkingBudget(
+      maxTokens: budget.maxTokens,
+      startTag: budget.startTag ?? tags.startTag,
+      endTag: budget.endTag ?? tags.endTag,
+      forcedMessage: budget.forcedMessage,
     );
   }
 

--- a/lib/src/core/models/inference/generation_params.dart
+++ b/lib/src/core/models/inference/generation_params.dart
@@ -494,6 +494,38 @@ class SpeculativeDecodingConfig {
       strategies.isEmpty ? <SpeculativeDecodingStrategy>[strategy] : strategies;
 }
 
+/// Limits the generated tokens within a model's reasoning block.
+///
+/// This maps to llama.cpp's reasoning-budget sampler. A budget of zero closes
+/// the next reasoning block immediately; a positive value permits that many
+/// generated reasoning tokens before the sampler forces [endTag].
+/// llama.cpp accepts values from zero through 2,147,483,647.
+///
+/// [LlamaEngine.create] resolves omitted [startTag] and [endTag] from the
+/// rendered chat template. Callers using raw generation should supply both
+/// tags explicitly because models do not share a universal reasoning syntax.
+class ThinkingBudget {
+  /// Creates a thinking-token budget.
+  const ThinkingBudget({
+    required this.maxTokens,
+    this.startTag,
+    this.endTag,
+    this.forcedMessage,
+  }) : assert(maxTokens >= 0, 'maxTokens must be non-negative');
+
+  /// Maximum generated tokens allowed inside each reasoning block.
+  final int maxTokens;
+
+  /// Reasoning-block opening delimiter.
+  final String? startTag;
+
+  /// Reasoning-block closing delimiter forced when [maxTokens] is exhausted.
+  final String? endTag;
+
+  /// Optional text forced immediately before [endTag] after exhaustion.
+  final String? forcedMessage;
+}
+
 /// Parameters controlling the token sampling and generation process.
 class GenerationParams {
   /// Default prompt prefix reuse behavior for native generation.
@@ -551,6 +583,15 @@ class GenerationParams {
 
   /// Whether grammar should be lazily activated by triggers.
   final bool grammarLazy;
+
+  /// Optional llama.cpp-style limit for tokens generated inside a reasoning
+  /// block.
+  ///
+  /// The native llama.cpp backend pauses grammar constraints while budgeted
+  /// reasoning is active, then resumes tool-call or structured-output grammar
+  /// after reasoning has ended. Other backends reject this setting rather than
+  /// silently ignoring it.
+  final ThinkingBudget? thinkingBudget;
 
   /// Lazy grammar activation triggers.
   final List<GenerationGrammarTrigger> grammarTriggers;
@@ -612,6 +653,7 @@ class GenerationParams {
     this.stopSequences = const [],
     this.grammar,
     this.grammarLazy = false,
+    this.thinkingBudget,
     this.grammarTriggers = const [],
     this.preservedTokens = const [],
     this.grammarRoot = 'root',
@@ -649,6 +691,8 @@ class GenerationParams {
     List<String>? stopSequences,
     String? grammar,
     bool? grammarLazy,
+    ThinkingBudget? thinkingBudget,
+    bool clearThinkingBudget = false,
     List<GenerationGrammarTrigger>? grammarTriggers,
     List<String>? preservedTokens,
     String? grammarRoot,
@@ -671,6 +715,9 @@ class GenerationParams {
       stopSequences: stopSequences ?? this.stopSequences,
       grammar: grammar ?? this.grammar,
       grammarLazy: grammarLazy ?? this.grammarLazy,
+      thinkingBudget: clearThinkingBudget
+          ? null
+          : (thinkingBudget ?? this.thinkingBudget),
       grammarTriggers: grammarTriggers ?? this.grammarTriggers,
       preservedTokens: preservedTokens ?? this.preservedTokens,
       grammarRoot: grammarRoot ?? this.grammarRoot,

--- a/packages/llamadart_llama_cpp_flutter/CHANGELOG.md
+++ b/packages/llamadart_llama_cpp_flutter/CHANGELOG.md
@@ -1,3 +1,7 @@
+## Unreleased
+
+* Updated Apple SwiftPM native pin to `leehack/llamadart-native@b9969-llamadart.1`.
+
 ## 0.0.9
 
 * Updated Apple SwiftPM native pin to `leehack/llamadart-native@b9935`.

--- a/packages/llamadart_llama_cpp_flutter/README.md
+++ b/packages/llamadart_llama_cpp_flutter/README.md
@@ -16,7 +16,7 @@ dependencies:
 This package has no runtime Dart API of its own. Import `package:llamadart`
 normally from the core package and use `LlamaBackend()` / `LlamaEngine` there.
 
-The Apple SwiftPM manifest pins `leehack/llamadart-native@b9935`.
+The Apple SwiftPM manifest pins `leehack/llamadart-native@b9969-llamadart.1`.
 
 Source for this package lives in
 `packages/llamadart_llama_cpp_flutter` in the

--- a/packages/llamadart_llama_cpp_flutter/darwin/llamadart_llama_cpp_flutter/Package.swift
+++ b/packages/llamadart_llama_cpp_flutter/darwin/llamadart_llama_cpp_flutter/Package.swift
@@ -4,7 +4,7 @@ import PackageDescription
 
 let packageRoot = URL(fileURLWithPath: #filePath).deletingLastPathComponent()
 let artifactsRoot = packageRoot.appendingPathComponent("Artifacts")
-let llamaCppTag = "b9935"
+let llamaCppTag = "b9969-llamadart.1"
 
 func localArtifactPath(_ name: String) -> String? {
     let path = artifactsRoot.appendingPathComponent(name).path
@@ -47,7 +47,7 @@ let package = Package(
             repository: "leehack/llamadart-native",
             artifactName: "llamadart-native-apple-xcframework-\(llamaCppTag).zip",
             tag: llamaCppTag,
-            checksum: "2fbbfcb16ab726a30661032bdadfbbfa034401553abc30894b8c300f79613b07"
+            checksum: "2531e18916c443590830a4efcf264af04b36c078078d1d668b42d1a716092a0a"
         ),
         .target(
             name: "llamadart_llama_cpp_flutter",

--- a/test/unit/backends/litert_lm/litert_lm_backend_web_test.dart
+++ b/test/unit/backends/litert_lm/litert_lm_backend_web_test.dart
@@ -412,6 +412,39 @@ void main() {
     }
   });
 
+  test('rejects thinking budget on LiteRT-LM web', () async {
+    _installFakeEngine(chunks: <JSAny?>[]);
+
+    final backend = LiteRtLmBackend();
+    try {
+      final modelHandle = await backend.modelLoadFromUrl(
+        'https://example.com/model.litertlm',
+        const ModelParams(),
+      );
+      final contextHandle = await backend.contextCreate(
+        modelHandle,
+        const ModelParams(),
+      );
+
+      await expectLater(
+        backend.generate(
+          contextHandle,
+          'hello',
+          const GenerationParams(thinkingBudget: ThinkingBudget(maxTokens: 16)),
+        ),
+        emitsError(
+          isA<UnsupportedError>().having(
+            (error) => error.message.toString(),
+            'message',
+            contains('thinkingBudget'),
+          ),
+        ),
+      );
+    } finally {
+      await backend.dispose();
+    }
+  });
+
   test('rejects speculative decoding config on LiteRT-LM web', () async {
     _installFakeEngine(chunks: <JSAny?>[]);
 

--- a/test/unit/backends/litert_lm/litert_lm_service_test.dart
+++ b/test/unit/backends/litert_lm/litert_lm_service_test.dart
@@ -2163,6 +2163,21 @@ void main() {
         service.generate(
           contextHandle,
           'hello',
+          const GenerationParams(thinkingBudget: ThinkingBudget(maxTokens: 16)),
+        ),
+        emitsError(
+          isA<UnsupportedError>().having(
+            (error) => error.message.toString(),
+            'message',
+            contains('thinkingBudget'),
+          ),
+        ),
+      );
+
+      await expectLater(
+        service.generate(
+          contextHandle,
+          'hello',
           const GenerationParams(
             penalty: 1.0,
             presencePenalty: 1.5,

--- a/test/unit/backends/llama_cpp/llama_cpp_backend_test.dart
+++ b/test/unit/backends/llama_cpp/llama_cpp_backend_test.dart
@@ -7,6 +7,7 @@ import 'dart:isolate';
 import 'package:llamadart/src/backends/backend.dart';
 import 'package:llamadart/src/backends/llama_cpp/llama_cpp_backend.dart';
 import 'package:llamadart/src/backends/llama_cpp/worker_messages.dart';
+import 'package:llamadart/src/core/exceptions.dart';
 import 'package:llamadart/src/core/models/inference/generation_params.dart';
 import 'package:llamadart/src/core/models/inference/model_params.dart';
 import 'package:llamadart/src/core/models/config/log_level.dart';
@@ -155,9 +156,35 @@ void main() {
         <int>[66],
       ]);
 
-      expect(
+      await expectLater(
         backend.generate(1, 'boom', const GenerationParams()).drain<void>(),
         throwsException,
+      );
+
+      await expectLater(
+        backend
+            .generate(1, 'unsupported', const GenerationParams())
+            .drain<void>(),
+        throwsA(
+          isA<LlamaUnsupportedException>().having(
+            (error) => error.message,
+            'message',
+            contains('reasoning-budget wrapper'),
+          ),
+        ),
+      );
+
+      await expectLater(
+        backend
+            .generate(1, 'inference', const GenerationParams())
+            .drain<void>(),
+        throwsA(
+          isA<LlamaInferenceException>().having(
+            (error) => error.message,
+            'message',
+            contains('grammar sampler failed'),
+          ),
+        ),
       );
     });
 
@@ -397,6 +424,20 @@ class _FakeWorkerHarness {
         case GenerateRequest():
           if (message.prompt == 'boom') {
             message.sendPort.send(ErrorResponse('generation failed'));
+          } else if (message.prompt == 'unsupported') {
+            message.sendPort.send(
+              ErrorResponse(
+                'missing reasoning-budget wrapper',
+                kind: WorkerErrorKind.unsupported,
+              ),
+            );
+          } else if (message.prompt == 'inference') {
+            message.sendPort.send(
+              ErrorResponse(
+                'grammar sampler failed',
+                kind: WorkerErrorKind.inference,
+              ),
+            );
           } else if (message.prompt == 'pending') {
             // Hold open until the client cancels the stream.
           } else {

--- a/test/unit/backends/llama_cpp/llama_cpp_backend_test.dart
+++ b/test/unit/backends/llama_cpp/llama_cpp_backend_test.dart
@@ -158,7 +158,13 @@ void main() {
 
       await expectLater(
         backend.generate(1, 'boom', const GenerationParams()).drain<void>(),
-        throwsException,
+        throwsA(
+          isA<Exception>().having(
+            (error) => error.toString(),
+            'message',
+            'Exception: generation failed',
+          ),
+        ),
       );
 
       await expectLater(
@@ -423,7 +429,9 @@ class _FakeWorkerHarness {
           }
         case GenerateRequest():
           if (message.prompt == 'boom') {
-            message.sendPort.send(ErrorResponse('generation failed'));
+            message.sendPort.send(
+              ErrorResponse('Exception: generation failed'),
+            );
           } else if (message.prompt == 'unsupported') {
             message.sendPort.send(
               ErrorResponse(

--- a/test/unit/backends/llama_cpp/llama_cpp_service_test.dart
+++ b/test/unit/backends/llama_cpp/llama_cpp_service_test.dart
@@ -6,6 +6,7 @@ import 'dart:io';
 
 import 'package:ffi/ffi.dart';
 import 'package:llamadart/src/backends/llama_cpp/llama_cpp_service.dart';
+import 'package:llamadart/src/core/exceptions.dart';
 import 'package:llamadart/src/core/models/config/gpu_backend.dart';
 import 'package:llamadart/src/core/models/config/gpu_device_info.dart';
 import 'package:llamadart/src/core/models/inference/generation_params.dart';
@@ -167,6 +168,18 @@ void main() {
       );
 
       expect(typeNames, 'ngram-mod,draft-mtp');
+    });
+
+    test('rejects speculative decoding with a thinking budget', () {
+      expect(
+        () => service.debugResolveSpeculativeTypeNamesForTesting(
+          const GenerationParams(
+            thinkingBudget: ThinkingBudget(maxTokens: 64),
+            speculativeDecodingConfig: SpeculativeDecodingConfig.ngramMod(),
+          ),
+        ),
+        throwsA(isA<LlamaUnsupportedException>()),
+      );
     });
 
     test('uses ngram size M as native draft cap for map strategies', () {
@@ -404,6 +417,30 @@ void main() {
         'repeat': 1.0,
         'frequency': 0.0,
         'presence': 1.5,
+      },
+    );
+  });
+
+  group('thinking-budget validation', () {
+    test(
+      'rejects a token budget that exceeds the native signed 32-bit limit',
+      () {
+        final service = LlamaCppService();
+
+        expect(
+          () => service.debugValidateThinkingBudgetForTesting(
+            const GenerationParams(
+              thinkingBudget: ThinkingBudget(maxTokens: 2147483648),
+            ),
+          ),
+          throwsA(
+            isA<RangeError>().having(
+              (error) => error.toString(),
+              'message',
+              contains('signed 32-bit'),
+            ),
+          ),
+        );
       },
     );
   });

--- a/test/unit/backends/llama_cpp/worker_messages_test.dart
+++ b/test/unit/backends/llama_cpp/worker_messages_test.dart
@@ -148,6 +148,15 @@ void main() {
       expect(MetadataResponse({'a': 'b'}).metadata, {'a': 'b'});
       expect(GetContextSizeResponse(10).size, 10);
       expect(ErrorResponse('e').message, 'e');
+      expect(ErrorResponse('e').kind, WorkerErrorKind.generic);
+      expect(
+        ErrorResponse('unsupported', kind: WorkerErrorKind.unsupported).kind,
+        WorkerErrorKind.unsupported,
+      );
+      expect(
+        ErrorResponse('inference', kind: WorkerErrorKind.inference).kind,
+        WorkerErrorKind.inference,
+      );
       expect(BackendInfoResponse('n').name, 'n');
       expect(GpuSupportResponse(true).support, true);
       expect(

--- a/test/unit/backends/llama_cpp/worker_test.dart
+++ b/test/unit/backends/llama_cpp/worker_test.dart
@@ -184,6 +184,8 @@ void main() {
           final error = response as ErrorResponse;
           expect(error.kind, WorkerErrorKind.inference);
           expect(error.message, contains('grammar sampler failed'));
+          expect(error.message, contains('native grammar stack exhausted'));
+          expect(error.message, isNot(contains('LlamaException:')));
         } finally {
           await _disposeWorker(worker);
         }
@@ -491,6 +493,7 @@ class _InferenceGenerationLlamaCppService extends LlamaCppService {
   }) async* {
     throw LlamaInferenceException(
       'grammar sampler failed in this test runtime',
+      'native grammar stack exhausted',
     );
   }
 

--- a/test/unit/backends/llama_cpp/worker_test.dart
+++ b/test/unit/backends/llama_cpp/worker_test.dart
@@ -10,6 +10,7 @@ import 'package:llamadart/src/core/models/inference/generation_params.dart';
 import 'package:llamadart/src/core/models/inference/model_params.dart';
 import 'package:llamadart/src/backends/llama_cpp/llama_cpp_service.dart';
 import 'package:llamadart/src/backends/llama_cpp/worker.dart';
+import 'package:llamadart/src/core/exceptions.dart';
 import 'package:test/test.dart';
 
 void main() {
@@ -130,6 +131,64 @@ void main() {
         await _disposeWorker(worker);
       }
     });
+
+    test(
+      'preserves unsupported generation errors across worker messages',
+      () async {
+        final worker = await _startWorkerInCurrentIsolate(
+          _UnsupportedGenerationLlamaCppService(),
+        );
+
+        try {
+          final response = await _sendRequest(
+            worker.sendPort,
+            (sendPort) => GenerateRequest(
+              1,
+              'hello',
+              const GenerationParams(),
+              0,
+              sendPort,
+            ),
+          );
+
+          expect(response, isA<ErrorResponse>());
+          final error = response as ErrorResponse;
+          expect(error.kind, WorkerErrorKind.unsupported);
+          expect(error.message, contains('reasoning-budget wrapper'));
+        } finally {
+          await _disposeWorker(worker);
+        }
+      },
+    );
+
+    test(
+      'preserves inference generation errors across worker messages',
+      () async {
+        final worker = await _startWorkerInCurrentIsolate(
+          _InferenceGenerationLlamaCppService(),
+        );
+
+        try {
+          final response = await _sendRequest(
+            worker.sendPort,
+            (sendPort) => GenerateRequest(
+              1,
+              'hello',
+              const GenerationParams(),
+              0,
+              sendPort,
+            ),
+          );
+
+          expect(response, isA<ErrorResponse>());
+          final error = response as ErrorResponse;
+          expect(error.kind, WorkerErrorKind.inference);
+          expect(error.message, contains('grammar sampler failed'));
+        } finally {
+          await _disposeWorker(worker);
+        }
+      },
+    );
 
     test('waits for active generation before freeing native handles', () async {
       final service = _BlockingLlamaCppService();
@@ -389,4 +448,52 @@ class _BlockingLlamaCppService extends LlamaCppService {
   void dispose() {
     disposeCalls += 1;
   }
+}
+
+class _UnsupportedGenerationLlamaCppService extends LlamaCppService {
+  @override
+  void initializeBackend() {}
+
+  @override
+  void setLogLevel(LlamaLogLevel level) {}
+
+  @override
+  Stream<List<int>> generate(
+    int contextHandle,
+    String prompt,
+    GenerationParams params,
+    int cancelTokenAddress, {
+    List<LlamaContentPart>? parts,
+  }) async* {
+    throw LlamaUnsupportedException(
+      'missing reasoning-budget wrapper in this test runtime',
+    );
+  }
+
+  @override
+  void dispose() {}
+}
+
+class _InferenceGenerationLlamaCppService extends LlamaCppService {
+  @override
+  void initializeBackend() {}
+
+  @override
+  void setLogLevel(LlamaLogLevel level) {}
+
+  @override
+  Stream<List<int>> generate(
+    int contextHandle,
+    String prompt,
+    GenerationParams params,
+    int cancelTokenAddress, {
+    List<LlamaContentPart>? parts,
+  }) async* {
+    throw LlamaInferenceException(
+      'grammar sampler failed in this test runtime',
+    );
+  }
+
+  @override
+  void dispose() {}
 }

--- a/test/unit/backends/webgpu/webgpu_backend_test.dart
+++ b/test/unit/backends/webgpu/webgpu_backend_test.dart
@@ -931,6 +931,23 @@ void main() {
       );
     });
 
+    test('rejects thinking budget', () {
+      expect(
+        () => backend.generate(
+          1,
+          'Hello',
+          const GenerationParams(thinkingBudget: ThinkingBudget(maxTokens: 16)),
+        ),
+        throwsA(
+          isA<UnsupportedError>().having(
+            (error) => error.message.toString(),
+            'message',
+            contains('thinking-budget control'),
+          ),
+        ),
+      );
+    });
+
     test('rejects speculative decoding config', () {
       expect(
         () => backend.generate(

--- a/test/unit/core/engine/chat_completion_request_planner_test.dart
+++ b/test/unit/core/engine/chat_completion_request_planner_test.dart
@@ -65,6 +65,25 @@ void main() {
       );
     });
 
+    test('resolves omitted thinking-budget tags from the chat template', () {
+      final plan = ChatCompletionRequestPlanner.build(
+        backend: _NativeChatBackend(),
+        templateResult: const LlamaChatTemplateResult(prompt: 'prompt'),
+        messages: const [
+          LlamaChatMessage.fromText(role: LlamaChatRole.user, text: 'hello'),
+        ],
+        params: const GenerationParams(
+          thinkingBudget: ThinkingBudget(maxTokens: 64),
+        ),
+        toolChoice: ToolChoice.auto,
+        parallelToolCalls: false,
+      );
+
+      expect(plan.generationParams.thinkingBudget?.maxTokens, 64);
+      expect(plan.generationParams.thinkingBudget?.startTag, '<think>');
+      expect(plan.generationParams.thinkingBudget?.endTag, '</think>');
+    });
+
     test(
       'falls back to rendered prompt when native chat cannot satisfy policy',
       () {

--- a/test/unit/core/models/inference/generation_params_test.dart
+++ b/test/unit/core/models/inference/generation_params_test.dart
@@ -10,6 +10,11 @@ void main() {
       presencePenalty: 1.5,
       grammarRoot: 'main',
       grammarLazy: true,
+      thinkingBudget: const ThinkingBudget(
+        maxTokens: 64,
+        startTag: '<think>',
+        endTag: '</think>',
+      ),
       speculativeDecoding: true,
       speculativeDecodingConfig: const SpeculativeDecodingConfig.mtp(
         draftTokenMax: 3,
@@ -31,6 +36,9 @@ void main() {
     expect(updated.presencePenalty, 1.5);
     expect(updated.grammarRoot, 'main');
     expect(updated.grammarLazy, isTrue);
+    expect(updated.thinkingBudget?.maxTokens, 64);
+    expect(updated.thinkingBudget?.startTag, '<think>');
+    expect(updated.thinkingBudget?.endTag, '</think>');
     expect(updated.speculativeDecoding, isTrue);
     expect(updated.isSpeculativeDecodingEnabled, isTrue);
     expect(
@@ -47,6 +55,20 @@ void main() {
     expect(updated.streamBatchByteThreshold, 256);
     expect(updated.grammarTriggers, hasLength(1));
     expect(updated.preservedTokens, const ['<tool_call>']);
+  });
+
+  test('GenerationParams copyWith can clear thinking budget', () {
+    const params = GenerationParams(
+      thinkingBudget: ThinkingBudget(
+        maxTokens: 64,
+        startTag: '<think>',
+        endTag: '</think>',
+      ),
+    );
+
+    final updated = params.copyWith(clearThinkingBudget: true);
+
+    expect(updated.thinkingBudget, isNull);
   });
 
   test('GenerationParams defaults minP to zero', () {

--- a/tool/gguf_chat_features_smoke.dart
+++ b/tool/gguf_chat_features_smoke.dart
@@ -204,7 +204,7 @@ Future<void> main(List<String> args) async {
     _verifyToolCall(toolCallWithThinking);
     _verifyThinkingSeparation(toolCallWithThinkingBudget);
     _verifyToolCall(toolCallWithThinkingBudget);
-    _verifyNoThinking(toolCallWithZeroThinkingBudget);
+    _verifyThinkingSuppressedByZeroBudget(toolCallWithZeroThinkingBudget);
     _verifyToolCall(toolCallWithZeroThinkingBudget);
     if (multimodal != null) {
       _verifyHasOutput(multimodal);
@@ -308,6 +308,16 @@ void _verifyNoThinking(_ScenarioResult result) {
   if (result.thinking.trim().isNotEmpty) {
     throw StateError(
       '${result.name} scenario leaked thinking while enableThinking=false.',
+    );
+  }
+  _verifyNoThinkingMarkers(result);
+}
+
+void _verifyThinkingSuppressedByZeroBudget(_ScenarioResult result) {
+  _verifyHasOutput(result);
+  if (result.thinking.trim().isNotEmpty) {
+    throw StateError(
+      '${result.name} scenario emitted thinking despite thinkingBudget.maxTokens=0.',
     );
   }
   _verifyNoThinkingMarkers(result);

--- a/tool/gguf_chat_features_smoke.dart
+++ b/tool/gguf_chat_features_smoke.dart
@@ -134,6 +134,47 @@ Future<void> main(List<String> args) async {
       toolChoice: ToolChoice.required,
     );
 
+    final toolCallWithThinkingBudget = await _runScenario(
+      engine: engine,
+      name: 'toolCallWithThinkingBudget',
+      messages: const [
+        LlamaChatMessage.fromText(
+          role: LlamaChatRole.system,
+          text:
+              'Think briefly if the model supports a thinking channel, then call get_weather. Return only the tool call.',
+        ),
+        LlamaChatMessage.fromText(
+          role: LlamaChatRole.user,
+          text: 'Call get_weather with location Seoul.',
+        ),
+      ],
+      tools: [_weatherTool],
+      enableThinking: true,
+      maxTokens: 160,
+      thinkingBudget: const ThinkingBudget(maxTokens: 4),
+      toolChoice: ToolChoice.required,
+    );
+
+    final toolCallWithZeroThinkingBudget = await _runScenario(
+      engine: engine,
+      name: 'toolCallWithZeroThinkingBudget',
+      messages: const [
+        LlamaChatMessage.fromText(
+          role: LlamaChatRole.system,
+          text: 'You must call get_weather. Return only a tool call.',
+        ),
+        LlamaChatMessage.fromText(
+          role: LlamaChatRole.user,
+          text: 'Call get_weather with location Seoul.',
+        ),
+      ],
+      tools: [_weatherTool],
+      enableThinking: true,
+      maxTokens: 160,
+      thinkingBudget: const ThinkingBudget(maxTokens: 0),
+      toolChoice: ToolChoice.required,
+    );
+
     final multimodal = mmprojPath != null && imagePath != null
         ? await _runScenario(
             engine: engine,
@@ -161,6 +202,10 @@ Future<void> main(List<String> args) async {
     _verifyThinkingSeparation(toolCallWithThinking);
     _verifyToolCall(toolCallNoThinking);
     _verifyToolCall(toolCallWithThinking);
+    _verifyThinkingSeparation(toolCallWithThinkingBudget);
+    _verifyToolCall(toolCallWithThinkingBudget);
+    _verifyNoThinking(toolCallWithZeroThinkingBudget);
+    _verifyToolCall(toolCallWithZeroThinkingBudget);
     if (multimodal != null) {
       _verifyHasOutput(multimodal);
       _verifyNoThinking(multimodal);
@@ -174,6 +219,8 @@ Future<void> main(List<String> args) async {
       'thinking': thinking.toJson(),
       'toolCallNoThinking': toolCallNoThinking.toJson(),
       'toolCallWithThinking': toolCallWithThinking.toJson(),
+      'toolCallWithThinkingBudget': toolCallWithThinkingBudget.toJson(),
+      'toolCallWithZeroThinkingBudget': toolCallWithZeroThinkingBudget.toJson(),
       if (multimodal != null) 'multimodal': multimodal.toJson(),
     };
     print('RESULT gguf_chat_features ${jsonEncode(result)}');
@@ -194,6 +241,7 @@ Future<_ScenarioResult> _runScenario({
   required List<ToolDefinition> tools,
   required bool enableThinking,
   required int maxTokens,
+  ThinkingBudget? thinkingBudget,
   ToolChoice toolChoice = ToolChoice.auto,
 }) async {
   final content = StringBuffer();
@@ -207,7 +255,12 @@ Future<_ScenarioResult> _runScenario({
     tools: tools.isEmpty ? null : tools,
     toolChoice: toolChoice,
     enableThinking: enableThinking,
-    params: GenerationParams(maxTokens: maxTokens, temp: 0.0, seed: 1),
+    params: GenerationParams(
+      maxTokens: maxTokens,
+      temp: 0.0,
+      seed: 1,
+      thinkingBudget: thinkingBudget,
+    ),
   )) {
     chunks++;
     final choice = chunk.choices.first;

--- a/tool/testing/run_local_e2e.dart
+++ b/tool/testing/run_local_e2e.dart
@@ -198,7 +198,7 @@ List<LocalE2eScenario> buildLocalE2eScenarios({String? projectRoot}) {
       name: 'gguf-chat-features-smoke',
       group: LocalE2eScenarioGroup.dartLocalOnly,
       description:
-          'Run real GGUF chat, thinking-suppression, and tool-call smoke.',
+          'Run real GGUF chat, thinking-budget/suppression, and tool-call smoke.',
       requiresDevice: false,
       stepsBuilder: (context) {
         final arguments = <String>['run', 'tool/gguf_chat_features_smoke.dart'];

--- a/tool/testing/test_matrix.dart
+++ b/tool/testing/test_matrix.dart
@@ -164,8 +164,8 @@ const List<TestMatrixRow> testMatrixRows = <TestMatrixRow>[
     tier: 'targeted',
     mode: 'local-only',
     covers:
-        'real GGUF llama.cpp chat, thinking suppression, streaming tool '
-        'calls, optional multimodal input',
+        'real GGUF llama.cpp chat, thinking-budget/suppression, streaming '
+        'tool calls, optional multimodal input',
     command:
         'dart run tool/testing/run_local_e2e.dart --scenario '
         'gguf-chat-features-smoke --model-path <model.gguf> --backend auto '

--- a/website/docs/configuration/runtime-parameters.md
+++ b/website/docs/configuration/runtime-parameters.md
@@ -104,6 +104,7 @@ const params = GenerationParams(
   penalty: 1.1,
   presencePenalty: 0.0,
   stopSequences: ['</s>'],
+  thinkingBudget: null,
   speculativeDecoding: false,
   speculativeDecodingConfig: null,
 );
@@ -118,6 +119,11 @@ Important fields:
 - `presencePenalty`: llama.cpp-native presence penalty; `0.0` preserves the
   existing behavior. WebGPU and LiteRT-LM reject non-zero values rather than
   silently ignoring them.
+- `thinkingBudget`: native llama.cpp-only reasoning-token cap. Use
+  `ThinkingBudget(maxTokens: ...)` with `engine.create(...)` to use template
+  delimiters automatically, or specify `startTag` and `endTag` for raw
+  generation. `0` forces the end delimiter immediately; it is incompatible
+  with speculative decoding and unsupported backends reject it explicitly.
 - `speculativeDecoding` / `speculativeDecodingConfig`: opt-in backend-native
   speculative decoding. Native LiteRT-LM honors the legacy boolean flag.
   llama.cpp supports the upstream strategy surface:

--- a/website/docs/examples/llamadart-server.md
+++ b/website/docs/examples/llamadart-server.md
@@ -74,6 +74,16 @@ ends during reasoning can correctly have `reasoning_content` but no final
 presence-penalty recommendation is not exposed by this example and is not the
 same control as repetition penalty.
 
+### Thinking budget (llama.cpp extension)
+
+`thinking_budget_tokens` follows llama.cpp server behavior and is not a
+standard OpenAI Chat Completions field. Use it only with
+`"enable_thinking": true`. It limits generated tokens inside a reasoning
+block; `max_tokens` remains the cap for the full completion. Set it to `0` to
+close the initial reasoning block immediately. Swagger's **Tool call: capped
+reasoning + function request (SSE)** example streams both `reasoning_content`
+and standard `tool_calls` with a 128-token budget.
+
 ### Tool calling
 
 Function tools use the standard client-managed Chat Completions flow. The
@@ -90,8 +100,8 @@ Open `http://127.0.0.1:8080/docs` for ready-to-run Swagger examples:
 
 - **Tool call: request a function** — initial non-streaming function request.
 - **Tool call: request a function (SSE)** — streamed `tool_calls` deltas.
-- **Tool call: reasoning + function request (SSE)** — Qwen reasoning plus tool
-  deltas.
+- **Tool call: capped reasoning + function request (SSE)** — Qwen reasoning
+  plus tool deltas with a llama.cpp thinking budget.
 - **Tool call: submit the function result** — the second request after
   client-side execution.
 

--- a/website/docs/getting-started/installation.md
+++ b/website/docs/getting-started/installation.md
@@ -79,7 +79,7 @@ hooks:
     llamadart:
       # Optional. Defaults to llamadart's tested native runtime pin.
       # Use a leehack/llamadart-native release tag when testing another build.
-      llamadart_native_tag: b9935
+      llamadart_native_tag: b9969-llamadart.1
 
       # Optional. GitHub repository slug or github.com URL.
       llamadart_native_repository: leehack/llamadart-native
@@ -105,7 +105,7 @@ per-target module list.
 
 Native source overrides are for compatibility testing. They do not regenerate
 Dart FFI bindings or symbol lookups, so the selected binary still must be ABI-
-and symbol-compatible with the default `leehack/llamadart-native@b9935` runtime.
+and symbol-compatible with the default `leehack/llamadart-native@b9969-llamadart.1` runtime.
 
 Available native tags are published on the
 [`leehack/llamadart-native` releases page](https://github.com/leehack/llamadart-native/releases).
@@ -117,7 +117,7 @@ gh release list --repo leehack/llamadart-native --limit 20
 
 Before overriding, confirm the release includes the asset for your target. The
 hook downloads files named `llamadart-native-<bundle>-<tag>.tar.gz`, for example
-`llamadart-native-windows-x64-b9935.tar.gz`.
+`llamadart-native-windows-x64-b9969-llamadart.1.tar.gz`.
 For local testing, `llamadart_native_path` may point directly at a bundle
 archive, at an extracted bundle directory, or at a directory containing
 `<tag>/<bundle>/`, `<bundle>/`, or the expected archive file.

--- a/website/docs/guides/generation-and-streaming.md
+++ b/website/docs/guides/generation-and-streaming.md
@@ -92,6 +92,34 @@ await for (final chunk in engine.create(
 }
 ```
 
+## Thinking budget (native llama.cpp)
+
+For GGUF models with a thinking channel, `ThinkingBudget` maps to llama.cpp's
+reasoning-budget sampler. It counts generated tokens inside each reasoning
+block independently of `maxTokens`, which remains the cap for the entire
+completion.
+
+```dart
+await for (final chunk in engine.create(
+  messages,
+  enableThinking: true,
+  params: const GenerationParams(
+    maxTokens: 512,
+    thinkingBudget: ThinkingBudget(maxTokens: 128),
+  ),
+)) {
+  final thinking = chunk.choices.first.delta.thinking;
+  final text = chunk.choices.first.delta.content;
+  // Render each channel independently.
+}
+```
+
+`engine.create(...)` fills the start and end delimiters from recognized chat
+templates. Raw `engine.generate(...)` calls must provide both delimiters in
+`ThinkingBudget`. A budget of `0` immediately forces the end delimiter. This
+is supported by native llama.cpp text generation only; LiteRT-LM and WebGPU
+reject it explicitly, and it cannot be combined with speculative decoding.
+
 ## Structured JSON output
 
 Use `LlamaStructuredOutput` when you want strict JSON plus final validation and

--- a/website/docs/platforms/support-matrix.md
+++ b/website/docs/platforms/support-matrix.md
@@ -7,7 +7,7 @@ This page combines platform support, runtime-family selection, and
 backend-module configuration for
 `llamadart`.
 
-The native-assets hook currently pins `llamadart-native` tag `b9935` and
+The native-assets hook currently pins `llamadart-native` tag `b9969-llamadart.1` and
 `litert-lm-native` release `v0.14.0-native.2` (`hook/build.dart`). Apps can
 override the llama.cpp native GitHub source with
 `hooks.user_defines.llamadart.llamadart_native_tag` and
@@ -196,7 +196,7 @@ device/model bundle, use `cpu` or `gpu` for that artifact.
   a web load failure as a package bug. The [WebGPU Bridge](./webgpu-bridge)
   page has the browser-console probe and Flutter Web smoke-test path.
 
-## Current llama.cpp module availability by bundle (`b9935`)
+## Current llama.cpp module availability by bundle (`b9969-llamadart.1`)
 
 | Bundle key | Available backend modules in bundle |
 | --- | --- |
@@ -244,7 +244,7 @@ hooks:
   user_defines:
     llamadart:
       # Optional. Defaults to llamadart's tested native runtime pin.
-      llamadart_native_tag: b9935
+      llamadart_native_tag: b9969-llamadart.1
 
       # Optional. GitHub repository slug or github.com URL.
       llamadart_native_repository: leehack/llamadart-native

--- a/website/docs/platforms/support-matrix.md
+++ b/website/docs/platforms/support-matrix.md
@@ -178,6 +178,11 @@ device/model bundle, use `cpu` or `gpu` for that artifact.
 
 ## Runtime capability notes
 
+- **Thinking budgets** (`GenerationParams.thinkingBudget`) use llama.cpp's
+  reasoning-budget sampler on native text-only GGUF generation. `engine.create`
+  resolves known template delimiters automatically; raw generation requires
+  explicit delimiters. LiteRT-LM and WebGPU reject the setting, as does the
+  llama.cpp speculative-decoding path.
 - **State persistence** (`LlamaEngine.stateSaveFile(...)` /
   `stateLoadFile(...)`) is available on native backends and on WebGPU bridge
   assets `v0.1.15+` that expose `stateSaveFile` / `stateLoadFile` bridge APIs.


### PR DESCRIPTION
## Summary

- add `ThinkingBudget` to `GenerationParams` for llama.cpp reasoning-token caps
- resolve chat-template thinking delimiters automatically and reject unsupported backend or speculative-decoding combinations explicitly
- add the OpenAI-compatible `thinking_budget_tokens` extension plus Swagger and documentation examples for streaming reasoning followed by a tool call
- preserve typed native worker errors across isolates and bound the server/API field to the signed 32-bit native limit
- sync headers, Dart FFI bindings, runtime pins, and Apple SwiftPM checksum to published `leehack/llamadart-native@b9969-llamadart.1`

## Root cause

A required tool grammar was consuming the forced `</think>` delimiter from the reasoning-budget sampler, which could terminate native generation with an empty grammar stack. The paired native wrapper now pauses grammar during reasoning and resumes it only after the reasoning block ends.

## Validation

- native release workflow [succeeded](https://github.com/leehack/llamadart-native/actions/runs/29199569237); verified the published `b9969-llamadart.1` header, Apple, Android, Linux, macOS, and Windows assets plus checksums
- `dart analyze hook/build.dart lib/src/backends/llama_cpp/bindings.dart`
- `dart test test/unit/tooling/sync_native_release_pins_script_test.dart test/unit/hook/build_hook_integration_test.dart`
- real Qwen 3.5 0.8B Q4_K_M Metal smoke against the published runtime: normal, thinking-budget, and streaming tool-call paths passed; the 4-token budget yielded `get_weather({"location":"Seoul"})`

## Ready for review

The dependent native release is published and the package is pinned to it. No remaining release/pin blocker.