### PR TITLE
Prepare 0.8.16 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,57 +1,23 @@
-## Unreleased
+## 0.8.16
 
-* Updated the default llama.cpp native runtime pin to
-  `leehack/llamadart-native@b9982`, regenerated matching Dart FFI bindings, refreshed
-  the `llamadart_llama_cpp_flutter` Apple SwiftPM checksum, updated the
-  multimodal prompt bridge for the new explicit UTF-8 byte-length ABI, and
-  aligned current README/website native override docs.
+* Updated the default llama.cpp native runtime to
+  `leehack/llamadart-native@b9982`, including regenerated bindings and safer
+  multimodal UTF-8 prompt handling.
 
-* Changed unset native decoder/generative context batching from full-context
-  batches to llama.cpp-aligned caps of `n_batch = min(n_ctx, 2048)` and
-  `n_ubatch = min(n_batch, 512)`. Explicit positive values remain supported,
-  native encoder-only models retain full-context batching, and WebGPU preserves
-  its architecture-agnostic full-context fallback to avoid encoder regressions.
-* Reworked the TUI coding agent into a small Pi-style demo with one sequential
-  JSON loop, exactly `read`/`write`/`edit`/`bash`, a single-screen session, and
-  startup-only model selection, plus an optional read-only mode. It retains the
-  Qwen3.6 35B-A3B preset, shared model cache, cancellation and resource limits,
-  workspace-confined file tools, and an explicit unsandboxed-shell trust
-  boundary. The quality default now uses Unsloth `UD-Q4_K_M` with the
-  publisher-aligned non-thinking sampler, while `--thinking` opts into a larger
-  coding-focused reasoning profile. Model loading now delegates directly to
-  `LlamaEngine.loadModelSource`, replacing the example-specific downloader and
-  fuzzy repository resolver with the core local, HTTP, and exact `hf://` source
-  formats. Reasoning and normal answers now stream as separate transcript
-  channels, and final answers render with compact Markdown, syntax-highlighted
-  fenced code, solid code-block backgrounds, and no automatic block/message
-  spacer rows. Frame-coalesced presentation keeps long streams responsive, and
-  a lightweight single-window TurboVision theme restores the example's visual
-  identity without its former window manager. The example now targets Nocterm
-  `0.8.0`.
-* Added `GenerationParams.presencePenalty` for native llama.cpp sampling.
-  WebGPU and LiteRT-LM reject non-zero values until their runtimes expose an
-  equivalent control.
-* Made `ChatSession` context trimming reserve the requested output budget up to
-  half the active context, account for tool schemas, retain protocol turn
-  anchors while compacting completed exchanges, and reduce streaming
-  accumulation overhead.
+* Improved llama.cpp batching defaults and `ChatSession` context management for
+  more predictable generation under constrained contexts.
 
-* Added a llama.cpp thinking-token budget and the server's
-  `thinking_budget_tokens` extension.
+* Added llama.cpp `presencePenalty` sampling and thinking-budget controls,
+  including the server's `thinking_budget_tokens` extension. Unsupported
+  WebGPU and LiteRT-LM paths now fail explicitly.
 
-* Switched the OpenAI-compatible server example default to Unsloth's Qwen3.6
-  27B `UD-Q4_K_XL` GGUF, added model-specific non-thinking and thinking sampler profiles,
-  and documented its text-only / desktop-memory requirements. The server keeps
-  thinking opt-in through the `enable_thinking` request field and now uses
-  Relic 1.2.0.
+* Reworked the runnable TUI coding agent with a focused Pi-style workflow,
+  Unsloth Qwen3.6 defaults, shared model-source loading, and clearer reasoning
+  and final-answer presentation.
 
-* Removed the example server's nonstandard automatic tool-execution loop. Its
-  Chat Completions endpoint now consistently returns model-emitted `tool_calls`
-  for client-side execution, accepts standard assistant/tool follow-up
-  transcripts, honors named function `tool_choice`, and documents the full
-  request sequence with runnable Swagger examples. Server model inputs now load
-  through `LlamaEngine.loadModelSource(...)`, sharing the core runtime's source
-  resolution and cache behavior.
+* Improved the OpenAI-compatible server with standard client-managed tool-call
+  transcripts, named `tool_choice`, configurable thinking behavior, and shared
+  model-source loading.
 
 ## 0.8.15
 

--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ For Dart or Flutter apps:
 
 ```yaml
 dependencies:
-  llamadart: ^0.8.15
+  llamadart: ^0.8.16
 ```
 
 Flutter iOS/macOS apps that should link Apple XCFrameworks through Swift
@@ -57,9 +57,9 @@ Package Manager should also add the runtime companion packages they need:
 
 ```yaml
 dependencies:
-  llamadart: ^0.8.15
-  llamadart_llama_cpp_flutter: ^0.0.9 # GGUF / llama.cpp
-  llamadart_litert_lm_flutter: ^0.0.5 # Apple .litertlm / LiteRT-LM targets
+  llamadart: ^0.8.16
+  llamadart_llama_cpp_flutter: ^0.0.10 # GGUF / llama.cpp
+  llamadart_litert_lm_flutter: ^0.0.6 # Apple .litertlm / LiteRT-LM targets
 ```
 
 The LiteRT-LM companion manifest includes consolidated iOS and macOS SwiftPM

--- a/example/chat_app/pubspec.lock
+++ b/example/chat_app/pubspec.lock
@@ -357,7 +357,7 @@ packages:
       path: "../.."
       relative: true
     source: path
-    version: "0.8.15"
+    version: "0.8.16"
   logging:
     dependency: transitive
     description:

--- a/packages/llamadart_litert_lm_flutter/CHANGELOG.md
+++ b/packages/llamadart_litert_lm_flutter/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.0.6
+
+* Updated the install example for `llamadart` 0.8.16.
+
 ## 0.0.5
 
 * Updated Apple SwiftPM native pin to `leehack/litert-lm-native@v0.14.0-native.2`.

--- a/packages/llamadart_litert_lm_flutter/README.md
+++ b/packages/llamadart_litert_lm_flutter/README.md
@@ -12,8 +12,8 @@ runtime fallback.
 
 ```yaml
 dependencies:
-  llamadart: ^0.8.15
-  llamadart_litert_lm_flutter: ^0.0.5
+  llamadart: ^0.8.16
+  llamadart_litert_lm_flutter: ^0.0.6
 ```
 
 This package has no runtime Dart API of its own. Import `package:llamadart`

--- a/packages/llamadart_litert_lm_flutter/pubspec.yaml
+++ b/packages/llamadart_litert_lm_flutter/pubspec.yaml
@@ -1,6 +1,6 @@
 name: llamadart_litert_lm_flutter
 description: Flutter Apple SwiftPM runtime companion package for llamadart LiteRT-LM support.
-version: 0.0.5
+version: 0.0.6
 repository: https://github.com/leehack/llamadart/tree/main/packages/llamadart_litert_lm_flutter
 homepage: https://github.com/leehack/llamadart
 issue_tracker: https://github.com/leehack/llamadart/issues

--- a/packages/llamadart_llama_cpp_flutter/CHANGELOG.md
+++ b/packages/llamadart_llama_cpp_flutter/CHANGELOG.md
@@ -1,4 +1,4 @@
-## Unreleased
+## 0.0.10
 
 * Updated Apple SwiftPM native pin to `leehack/llamadart-native@b9982`.
 

--- a/packages/llamadart_llama_cpp_flutter/README.md
+++ b/packages/llamadart_llama_cpp_flutter/README.md
@@ -9,8 +9,8 @@ core package's native-assets fallback.
 
 ```yaml
 dependencies:
-  llamadart: ^0.8.15
-  llamadart_llama_cpp_flutter: ^0.0.9
+  llamadart: ^0.8.16
+  llamadart_llama_cpp_flutter: ^0.0.10
 ```
 
 This package has no runtime Dart API of its own. Import `package:llamadart`

--- a/packages/llamadart_llama_cpp_flutter/pubspec.yaml
+++ b/packages/llamadart_llama_cpp_flutter/pubspec.yaml
@@ -1,6 +1,6 @@
 name: llamadart_llama_cpp_flutter
 description: Flutter Apple SwiftPM runtime companion package for llamadart llama.cpp and GGUF support.
-version: 0.0.9
+version: 0.0.10
 repository: https://github.com/leehack/llamadart/tree/main/packages/llamadart_llama_cpp_flutter
 homepage: https://github.com/leehack/llamadart
 issue_tracker: https://github.com/leehack/llamadart/issues

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: llamadart
 description: Dart and Flutter local LLM inference with llama.cpp GGUF and LiteRT-LM across native platforms and web.
-version: 0.8.15
+version: 0.8.16
 homepage: https://github.com/leehack/llamadart
 repository: https://github.com/leehack/llamadart
 issue_tracker: https://github.com/leehack/llamadart/issues

--- a/website/docs/changelog/recent-releases.md
+++ b/website/docs/changelog/recent-releases.md
@@ -7,36 +7,19 @@ For canonical full release notes, use:
 
 - [`CHANGELOG.md`](https://github.com/leehack/llamadart/blob/main/CHANGELOG.md)
 
-## Unreleased
+## 0.8.16
 
-- Changed unset native decoder/generative context batching from full-context
-  batches to llama.cpp-aligned `2048` logical and `512` physical batch caps.
-  Explicit values remain supported, native encoder-only models retain
-  full-context batching, and WebGPU preserves its architecture-agnostic
-  full-context fallback to avoid encoder regressions.
-- Reworked the TUI coding agent into a small Pi-style demo with one sequential
-  JSON loop, exactly `read`/`write`/`edit`/`bash`, a single-screen session, and
-  startup-only model selection, plus an optional read-only mode. The Qwen3.6
-  preset, shared model cache, cancellation and resource limits,
-  workspace-confined file tools, and explicit unsandboxed-shell trust boundary
-  remain documented. Its default is now the Unsloth `UD-Q4_K_M` quant with the
-  publisher-aligned non-thinking sampler; `--thinking` enables a larger
-  coding-focused reasoning profile. Model loading now delegates directly to
-  `LlamaEngine.loadModelSource` instead of an example-specific downloader and
-  fuzzy repository resolver, using the core local, HTTP, and exact `hf://`
-  source formats. Reasoning and final-answer deltas now stream into separate
-  transcript channels, while answers use compact Markdown with syntax-highlighted
-  fenced code, solid code backgrounds, and no automatic block/message spacer
-  rows. Frame-coalesced presentation keeps long streams responsive, and a
-  lightweight single-window TurboVision theme restores the visual identity
-  without the former window manager. The example now uses Nocterm `0.8.0`.
-- Added native llama.cpp presence-penalty sampling through
-  `GenerationParams.presencePenalty`; unsupported WebGPU and LiteRT-LM paths
-  reject non-zero values explicitly.
-- Improved `ChatSession` context budgeting for configured output tokens (up to
-  half the active context) and tool schemas, compacted completed protocol
-  exchanges without dropping their task anchor, and reduced streamed-response
-  accumulation overhead.
+- Updated the default llama.cpp native runtime to `b9982`, including safer
+  multimodal UTF-8 prompt handling and refreshed Dart/SwiftPM bindings.
+- Improved llama.cpp batching defaults and `ChatSession` context management for
+  more predictable generation under constrained contexts.
+- Added llama.cpp presence-penalty sampling and thinking-budget controls;
+  unsupported WebGPU and LiteRT-LM paths now fail explicitly.
+- Reworked the runnable TUI coding agent with a focused Pi-style workflow,
+  Unsloth Qwen3.6 defaults, shared model-source loading, and clearer output.
+- Improved the OpenAI-compatible server with standard client-managed tool-call
+  transcripts, named `tool_choice`, configurable thinking behavior, and shared
+  model-source loading.
 
 ## 0.8.15
 

--- a/website/docs/getting-started/installation.md
+++ b/website/docs/getting-started/installation.md
@@ -27,7 +27,7 @@ In Xcode, set `IPHONEOS_DEPLOYMENT_TARGET = 16.4` or
 
 ```yaml
 dependencies:
-  llamadart: ^0.8.15
+  llamadart: ^0.8.16
 ```
 
 For Flutter iOS/macOS apps that should link Apple XCFrameworks through Swift
@@ -35,9 +35,9 @@ Package Manager, also add the runtime companion packages you need:
 
 ```yaml
 dependencies:
-  llamadart: ^0.8.15
-  llamadart_llama_cpp_flutter: ^0.0.9 # GGUF / llama.cpp
-  llamadart_litert_lm_flutter: ^0.0.5 # Apple .litertlm / LiteRT-LM targets
+  llamadart: ^0.8.16
+  llamadart_llama_cpp_flutter: ^0.0.10 # GGUF / llama.cpp
+  llamadart_litert_lm_flutter: ^0.0.6 # Apple .litertlm / LiteRT-LM targets
 ```
 
 The companion packages are published independently from the `packages/`


### PR DESCRIPTION
## Release prep

Prepares `llamadart 0.8.16`. Merging this guarded release-prep branch is the publication approval boundary.

### Versions

- `llamadart` `0.8.16`
- `llamadart_llama_cpp_flutter` `0.0.10` (native `b9982`)
- `llamadart_litert_lm_flutter` `0.0.6` (the updated core install example changes its publishable package content)

### Changes

- Moves the accumulated release notes into concise `0.8.16` sections.
- Updates current installation and companion-package documentation.
- Aligns the chat-app path lockfile with the core package version.

### Validation

- `dart run tool/testing/verify_release_docs_versions.dart`
- `dart test -p vm -j 1 --exclude-tags local-only`: 1,296 passed; 66 documented fixture-dependent skips
- `dart analyze lib test tool` clean (workspace-wide `dart analyze` still reports known unrelated nested-example dependency diagnostics)
- Formatting, docs build, and link validation
- Core and both companion `pub publish --dry-run` checks: zero warnings
- Native releases and referenced assets verified; cached Qwen multimodal E2E passed on CPU and Metal for the `b9982` native update

No packages, tags, or GitHub Release are published by this PR until it is merged.