### PR TITLE
Fix Web chat model loading and generation

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -3,6 +3,9 @@
 .github/dependabot.yml @leehack
 .github/pull_request_template.md @leehack
 .github/workflows/ @leehack
+scripts/build_chat_app_web.sh @leehack
+scripts/validate_chat_app_web_build.sh @leehack
+scripts/verify_chat_app_web_deployment.sh @leehack
 
 # Version, release, and native-runtime publication surfaces.
 pubspec.yaml @leehack

--- a/.github/workflows/chat_app_hf_pr_preview.yml
+++ b/.github/workflows/chat_app_hf_pr_preview.yml
@@ -9,7 +9,10 @@ on:
       - "lib/**"
       - "pubspec.yaml"
       - "pubspec.lock"
+      - "scripts/build_chat_app_web.sh"
       - "scripts/fetch_webgpu_bridge_assets.sh"
+      - "scripts/validate_chat_app_web_build.sh"
+      - "scripts/verify_chat_app_web_deployment.sh"
       - ".github/workflows/chat_app_hf_pr_preview.yml"
 
 permissions:
@@ -93,16 +96,11 @@ jobs:
         run: |
           (cd example/chat_app && flutter pub get)
 
-      - name: Build chat app web
-        if: ${{ github.event.action != 'closed' }}
-        run: |
-          (cd example/chat_app && flutter build web --release)
-
-      - name: Fetch pinned web bridge assets into build
+      - name: Build and validate chat app web
         if: ${{ github.event.action != 'closed' }}
         env:
-          WEBGPU_BRIDGE_OUT_DIR: ${{ github.workspace }}/example/chat_app/build/web/webgpu_bridge
-        run: ./scripts/fetch_webgpu_bridge_assets.sh
+          CHAT_APP_BUILD_SHA: ${{ github.event.pull_request.head.sha }}
+        run: ./scripts/build_chat_app_web.sh
 
       - name: Install Hugging Face Hub client
         run: python3 -m pip install --upgrade huggingface_hub
@@ -159,6 +157,12 @@ jobs:
               commit_message=f"deploy PR #{pr_number} {head_sha[:7]}",
           )
           PY
+
+      - name: Verify deployed preview artifact
+        if: ${{ github.event.action != 'closed' }}
+        run: |
+          ./scripts/verify_chat_app_web_deployment.sh \
+            "$APP_URL" "$PR_HEAD_SHA"
 
       - name: Delete preview Space
         if: ${{ github.event.action == 'closed' }}

--- a/.github/workflows/chat_app_hf_pr_preview.yml
+++ b/.github/workflows/chat_app_hf_pr_preview.yml
@@ -93,14 +93,16 @@ jobs:
         run: |
           (cd example/chat_app && flutter pub get)
 
-      - name: Fetch pinned web bridge assets
-        if: ${{ github.event.action != 'closed' }}
-        run: ./scripts/fetch_webgpu_bridge_assets.sh
-
       - name: Build chat app web
         if: ${{ github.event.action != 'closed' }}
         run: |
           (cd example/chat_app && flutter build web --release)
+
+      - name: Fetch pinned web bridge assets into build
+        if: ${{ github.event.action != 'closed' }}
+        env:
+          WEBGPU_BRIDGE_OUT_DIR: ${{ github.workspace }}/example/chat_app/build/web/webgpu_bridge
+        run: ./scripts/fetch_webgpu_bridge_assets.sh
 
       - name: Install Hugging Face Hub client
         run: python3 -m pip install --upgrade huggingface_hub

--- a/.github/workflows/chat_app_hf_static_deploy.yml
+++ b/.github/workflows/chat_app_hf_static_deploy.yml
@@ -5,7 +5,13 @@ on:
     branches: [master, main]
     paths:
       - "example/chat_app/**"
+      - "lib/**"
+      - "pubspec.yaml"
+      - "pubspec.lock"
+      - "scripts/build_chat_app_web.sh"
       - "scripts/fetch_webgpu_bridge_assets.sh"
+      - "scripts/validate_chat_app_web_build.sh"
+      - "scripts/verify_chat_app_web_deployment.sh"
       - ".github/workflows/chat_app_hf_static_deploy.yml"
   workflow_dispatch:
     inputs:
@@ -37,6 +43,9 @@ jobs:
         with:
           ref: ${{ github.event.inputs.deploy_ref || github.ref }}
 
+      - name: Record deployment source commit
+        run: echo "DEPLOY_SHA=$(git rev-parse HEAD)" >> "$GITHUB_ENV"
+
       - name: Setup Flutter
         uses: subosito/flutter-action@v2
         with:
@@ -61,20 +70,16 @@ jobs:
             exit 1
           fi
 
+          APP_HOST="$(printf '%s' "$SPACE_REPO" | tr '[:upper:]/' '[:lower:]-')"
           echo "space_repo=$SPACE_REPO" >> "$GITHUB_OUTPUT"
+          echo "app_url=https://${APP_HOST}.static.hf.space" >> "$GITHUB_OUTPUT"
 
       - name: Install dependencies
         run: |
           (cd example/chat_app && flutter pub get)
 
-      - name: Build chat app web
-        run: |
-          (cd example/chat_app && flutter build web --release)
-
-      - name: Fetch pinned web bridge assets into build
-        env:
-          WEBGPU_BRIDGE_OUT_DIR: ${{ github.workspace }}/example/chat_app/build/web/webgpu_bridge
-        run: ./scripts/fetch_webgpu_bridge_assets.sh
+      - name: Build and validate chat app web
+        run: CHAT_APP_BUILD_SHA="$DEPLOY_SHA" ./scripts/build_chat_app_web.sh
 
       - name: Install Hugging Face Hub client
         run: |
@@ -104,7 +109,7 @@ jobs:
             printf '%s\n' 'llamadart chat app static deployment.'
           } > "hf-space-sync/README.md"
 
-          SHORT_SHA="$(printf '%s' "$GITHUB_SHA" | cut -c1-7)"
+          SHORT_SHA="$(printf '%s' "$DEPLOY_SHA" | cut -c1-7)"
           export SHORT_SHA
 
           python3 - <<'PY'
@@ -131,3 +136,10 @@ jobs:
               delete_patterns=["*", "**/*"],
           )
           PY
+
+      - name: Verify deployed production artifact
+        env:
+          APP_URL: ${{ steps.target.outputs.app_url }}
+        run: |
+          ./scripts/verify_chat_app_web_deployment.sh \
+            "$APP_URL" "$DEPLOY_SHA"

--- a/.github/workflows/chat_app_hf_static_deploy.yml
+++ b/.github/workflows/chat_app_hf_static_deploy.yml
@@ -67,12 +67,14 @@ jobs:
         run: |
           (cd example/chat_app && flutter pub get)
 
-      - name: Fetch pinned web bridge assets
-        run: ./scripts/fetch_webgpu_bridge_assets.sh
-
       - name: Build chat app web
         run: |
           (cd example/chat_app && flutter build web --release)
+
+      - name: Fetch pinned web bridge assets into build
+        env:
+          WEBGPU_BRIDGE_OUT_DIR: ${{ github.workspace }}/example/chat_app/build/web/webgpu_bridge
+        run: ./scripts/fetch_webgpu_bridge_assets.sh
 
       - name: Install Hugging Face Hub client
         run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -217,12 +217,102 @@ jobs:
       - name: Run Browser tests
         run: dart test -p chrome --exclude-tags local-only
 
+  web-chat-contract:
+    name: Web Chat Contract
+    runs-on: ubuntu-latest
+    timeout-minutes: 40
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Setup Flutter
+        uses: subosito/flutter-action@v2
+        with:
+          channel: 'stable'
+          cache: true
+
+      - name: Setup Python
+        uses: actions/setup-python@v6
+        with:
+          python-version: '3.12'
+
+      - name: Install dependencies
+        run: |
+          flutter pub get
+          (cd example/chat_app && flutter pub get)
+
+      - name: Run chat app tests
+        working-directory: example/chat_app
+        run: |
+          flutter test
+          flutter test --platform chrome test/chat_generation_service_test.dart
+
+      - name: Build and validate deployable Web artifact
+        env:
+          CHAT_APP_BASE_HREF: /example/chat_app/build/web/
+          CHAT_APP_BUILD_SHA: ${{ github.sha }}
+        run: ./scripts/build_chat_app_web.sh
+
+      - name: Cache tiny GGUF browser model
+        id: web-tiny-gguf-cache
+        uses: actions/cache@v5
+        with:
+          path: .dart_tool/test_models/stories15M.gguf
+          key: tiny-gguf-stories15M-${{ runner.os }}-v1
+
+      - name: Download tiny GGUF browser model
+        if: steps.web-tiny-gguf-cache.outputs.cache-hit != 'true'
+        shell: bash
+        env:
+          HF_TOKEN: ${{ secrets.HF_TOKEN }}
+        run: |
+          mkdir -p .dart_tool/test_models
+          curl_args=(--fail --location --retry 8 --retry-all-errors --retry-delay 10)
+          if [[ -n "${HF_TOKEN:-}" ]]; then
+            curl_args+=(--header "Authorization: Bearer $HF_TOKEN")
+          fi
+          curl "${curl_args[@]}" \
+            "https://huggingface.co/ggml-org/tiny-llamas/resolve/main/stories15M.gguf" \
+            --output .dart_tool/test_models/stories15M.gguf
+
+      - name: Install Playwright Chromium
+        run: |
+          python -m venv .dart_tool/playwright-python
+          .dart_tool/playwright-python/bin/pip install "playwright==1.61.0"
+          .dart_tool/playwright-python/bin/python -m playwright install --with-deps chromium
+
+      - name: Run deterministic Web chat smoke
+        run: |
+          dart run tool/testing/run_local_e2e.dart \
+            --scenario chat-app-web-mock-smoke \
+            --skip-build
+
+      - name: Run real worker and GGUF browser smoke
+        run: |
+          dart run tool/testing/run_local_e2e.dart \
+            --scenario chat-app-web-real-model-smoke \
+            --skip-build \
+            --model-url \
+            "http://127.0.0.1:7358/.dart_tool/test_models/stories15M.gguf" \
+            --allow-any-response
+
+      - name: Upload Web contract diagnostics
+        if: ${{ failure() }}
+        uses: actions/upload-artifact@v6
+        with:
+          name: web-chat-contract-diagnostics
+          path: |
+            example/chat_app/build/web/llamadart-build.json
+            example/chat_app/build/web/webgpu_bridge/manifest.json
+            example/chat_app/build/web/webgpu_bridge/sha256sums.txt
+          if-no-files-found: ignore
+
   test-linux-web:
     name: Test Linux & Web (with Coverage)
     runs-on: ubuntu-latest
     needs:
       - test-linux-coverage
       - test-web
+      - web-chat-contract
     steps:
       - name: Confirm Linux coverage and Web tests passed
         run: echo "Linux VM coverage and Chrome tests passed."

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -147,6 +147,11 @@ helpers.
 Unsupported platform or option combinations must fail loudly with typed,
 actionable errors or be explicitly disabled/documented.
 
+LiteRT-LM Web streams directly and rejects native worker batching controls.
+Keep `streamBatchTokenThreshold` and `streamBatchByteThreshold` at their
+defaults on Web, and run chat-app parameter tests on both VM and Chrome when
+changing LiteRT-LM generation settings.
+
 ## Multi-Repo Ownership
 
 Many maintainer checkouts keep sibling repos one level above this repo:

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -140,8 +140,15 @@ behavior, verify the pinned asset tag/manifest, direct bridge calls, worker
 path, Dart interop wrapper, public engine API, docs, and examples together.
 
 Flutter Web builds exclude the gitignored generated bridge assets. Deployment
-and real-model Web E2E flows must fetch the pinned assets directly into
-`example/chat_app/build/web/webgpu_bridge` after `flutter build web`.
+and real-model Web E2E flows must use `scripts/build_chat_app_web.sh`, which
+builds the app, stages the pinned assets into the final output, and validates
+the runtime files and checksums. Use
+`scripts/validate_chat_app_web_build.sh` when intentionally reusing a build.
+
+The required `Web Chat Contract` CI job covers chat-app VM/Chrome tests, the
+deployable artifact, deterministic UI behavior, and a real worker/WASM/GGUF
+smoke. Keep it independent of large or availability-sensitive remote models;
+full Gemma 4 GGUF and LiteRT-LM Web smokes remain targeted validation.
 
 Document browser durability precisely. Web bridge filesystem paths may be
 virtual or in-memory unless the active bridge documents durable backing storage;

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -139,6 +139,10 @@ WebGPU bridge features are versioned runtime capabilities. When changing bridge
 behavior, verify the pinned asset tag/manifest, direct bridge calls, worker
 path, Dart interop wrapper, public engine API, docs, and examples together.
 
+Flutter Web builds exclude the gitignored generated bridge assets. Deployment
+and real-model Web E2E flows must fetch the pinned assets directly into
+`example/chat_app/build/web/webgpu_bridge` after `flutter build web`.
+
 Document browser durability precisely. Web bridge filesystem paths may be
 virtual or in-memory unless the active bridge documents durable backing storage;
 durable browser storage can require app-level export/import outside Dart file

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## Unreleased
+
+* Fixed Gemma 4 LiteRT-LM text generation in the Web chat app after model
+  loading completed successfully.
+
 ## 0.8.16
 
 * Updated the default llama.cpp native runtime to

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,9 @@
 * Fixed Gemma 4 LiteRT-LM text generation in the Web chat app after model
   loading completed successfully.
 
+* Restored GGUF loading in deployed Web chat apps by packaging the pinned
+  WebGPU runtime assets with Flutter Web builds.
+
 ## 0.8.16
 
 * Updated the default llama.cpp native runtime to

--- a/doc/testing_matrix.md
+++ b/doc/testing_matrix.md
@@ -74,6 +74,12 @@ Pick targeted rows based on the touched surface:
 | Chat app model cache/download/projector | `chat-app-device-cache` |
 | Example app, CLI, or server package | `examples-tests` |
 
+The required `Web Chat Contract` check runs the chat app tests on VM and
+Chrome, validates the final Flutter Web artifact, exercises deterministic UI
+behavior, and loads a tiny real GGUF through the packaged worker and WASM core.
+Large Gemma 4 GGUF and LiteRT-LM downloads remain targeted rows so transient
+model-host availability does not make every pull request flaky.
+
 ## Coverage Map
 
 The matrix is designed to cover these essential axes:
@@ -109,7 +115,7 @@ dart run tool/testing/test_matrix.dart --tier platform
 | iOS arm64/x86_64 simulator | `ios-simulator-smoke` | Manual/simulator runtime row. |
 | Android arm64 | `android-arm64-device-smoke` | Manual/device runtime row and release smoke plan. |
 | Android x64 | `android-x64-emulator-smoke` | Manual/emulator runtime row. |
-| Web browser | `web-chrome-runtime-smoke` | Chrome CI plus local WebGPU/LiteRT-LM web smokes. |
+| Web browser | `web-chrome-runtime-smoke` | Chrome CI plus the required real-GGUF `Web Chat Contract`; large WebGPU/LiteRT-LM smokes remain targeted. |
 
 Rows that say `hook-only` must not be used as full runtime proof. They only show
 that package/bundle selection is covered; PR evidence still needs a hardware or

--- a/example/chat_app/lib/services/chat_generation_service.dart
+++ b/example/chat_app/lib/services/chat_generation_service.dart
@@ -1,5 +1,6 @@
 import 'dart:async';
 
+import 'package:flutter/foundation.dart';
 import 'package:llamadart/llamadart.dart';
 
 import '../models/chat_settings.dart';
@@ -61,7 +62,7 @@ class ChatGenerationService {
       minP: isLiteRtLm ? defaults.minP : settings.minP,
       penalty: isLiteRtLm ? defaults.penalty : settings.penalty,
       stopSequences: const <String>[],
-      streamBatchTokenThreshold: isLiteRtLm
+      streamBatchTokenThreshold: isLiteRtLm && !kIsWeb
           ? 1
           : defaults.streamBatchTokenThreshold,
     );

--- a/example/chat_app/test/chat_generation_service_test.dart
+++ b/example/chat_app/test/chat_generation_service_test.dart
@@ -1,3 +1,4 @@
+import 'package:flutter/foundation.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:llamadart/llamadart.dart';
 import 'package:llamadart_chat_example/models/chat_settings.dart';
@@ -28,7 +29,7 @@ void main() {
       expect(params.stopSequences, isEmpty);
     });
 
-    test('omits unsupported minP/penalty for litert models', () {
+    test('uses platform-supported generation params for litert models', () {
       const defaults = GenerationParams();
       const settings = ChatSettings(
         modelPath: '/models/gemma.litertlm',
@@ -51,7 +52,12 @@ void main() {
       // reject the request with an UnsupportedError.
       expect(params.minP, defaults.minP);
       expect(params.penalty, defaults.penalty);
-      expect(params.streamBatchTokenThreshold, 1);
+      // Native LiteRT-LM needs immediate worker flushing. The Web backend
+      // streams directly and rejects non-default native batching controls.
+      expect(
+        params.streamBatchTokenThreshold,
+        kIsWeb ? defaults.streamBatchTokenThreshold : 1,
+      );
     });
 
     test('accumulates stream updates and metrics', () async {

--- a/scripts/build_chat_app_web.sh
+++ b/scripts/build_chat_app_web.sh
@@ -1,0 +1,22 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(git rev-parse --show-toplevel)"
+CHAT_APP_DIR="$ROOT_DIR/example/chat_app"
+BUILD_DIR="$CHAT_APP_DIR/build/web"
+BASE_HREF="${CHAT_APP_BASE_HREF:-/}"
+
+(
+  cd "$CHAT_APP_DIR"
+  flutter build web --release --base-href "$BASE_HREF"
+)
+
+WEBGPU_BRIDGE_OUT_DIR="$BUILD_DIR/webgpu_bridge" \
+  "$ROOT_DIR/scripts/fetch_webgpu_bridge_assets.sh"
+
+if [[ -n "${CHAT_APP_BUILD_SHA:-}" ]]; then
+  printf '{"commit":"%s"}\n' "$CHAT_APP_BUILD_SHA" \
+    > "$BUILD_DIR/llamadart-build.json"
+fi
+
+"$ROOT_DIR/scripts/validate_chat_app_web_build.sh" "$BUILD_DIR"

--- a/scripts/validate_chat_app_web_build.sh
+++ b/scripts/validate_chat_app_web_build.sh
@@ -1,0 +1,51 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(git rev-parse --show-toplevel)"
+BUILD_DIR="${1:-$ROOT_DIR/example/chat_app/build/web}"
+BRIDGE_DIR="$BUILD_DIR/webgpu_bridge"
+
+required_files=(
+  "index.html"
+  "flutter_bootstrap.js"
+  "main.dart.js"
+  "webgpu_bridge/llama_webgpu_bridge.js"
+  "webgpu_bridge/llama_webgpu_bridge_worker.js"
+  "webgpu_bridge/llama_webgpu_core.js"
+  "webgpu_bridge/llama_webgpu_core.wasm"
+  "webgpu_bridge/llama_webgpu_core_mem64.js"
+  "webgpu_bridge/llama_webgpu_core_mem64.wasm"
+  "webgpu_bridge/manifest.json"
+  "webgpu_bridge/sha256sums.txt"
+)
+
+for relative_path in "${required_files[@]}"; do
+  if [[ ! -s "$BUILD_DIR/$relative_path" ]]; then
+    echo "[chat-app-web] error: missing or empty build asset: $relative_path" >&2
+    exit 1
+  fi
+done
+
+for wasm_file in \
+  "$BRIDGE_DIR/llama_webgpu_core.wasm" \
+  "$BRIDGE_DIR/llama_webgpu_core_mem64.wasm"; do
+  magic="$(od -An -tx1 -N4 "$wasm_file" | tr -d '[:space:]')"
+  if [[ "$magic" != "0061736d" ]]; then
+    echo "[chat-app-web] error: invalid WebAssembly magic bytes: $wasm_file" >&2
+    exit 1
+  fi
+done
+
+(
+  cd "$BRIDGE_DIR"
+  if command -v sha256sum >/dev/null 2>&1; then
+    sha256sum -c sha256sums.txt
+  elif command -v shasum >/dev/null 2>&1; then
+    shasum -a 256 -c sha256sums.txt
+  else
+    echo "[chat-app-web] error: sha256sum or shasum is required" >&2
+    exit 1
+  fi
+)
+
+echo "[chat-app-web] validated build artifact: $BUILD_DIR"

--- a/scripts/verify_chat_app_web_deployment.sh
+++ b/scripts/verify_chat_app_web_deployment.sh
@@ -1,0 +1,57 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+if [[ $# -ne 2 ]]; then
+  echo "Usage: $0 <app-url> <expected-commit-sha>" >&2
+  exit 64
+fi
+
+APP_URL="${1%/}"
+EXPECTED_SHA="$2"
+BUILD_INFO_URL="$APP_URL/llamadart-build.json"
+MAX_ATTEMPTS="${CHAT_APP_DEPLOY_VERIFY_ATTEMPTS:-30}"
+RETRY_SECONDS="${CHAT_APP_DEPLOY_VERIFY_RETRY_SECONDS:-10}"
+
+matched=0
+for ((attempt = 1; attempt <= MAX_ATTEMPTS; attempt++)); do
+  build_info="$(curl -fsSL "$BUILD_INFO_URL?attempt=$attempt" 2>/dev/null || true)"
+  if [[ "$build_info" == *"\"commit\":\"$EXPECTED_SHA\""* ]]; then
+    matched=1
+    break
+  fi
+  echo "[chat-app-web] waiting for deployed commit $EXPECTED_SHA ($attempt/$MAX_ATTEMPTS)"
+  sleep "$RETRY_SECONDS"
+done
+
+if [[ "$matched" != "1" ]]; then
+  echo "[chat-app-web] error: deployed build did not reach commit $EXPECTED_SHA" >&2
+  exit 1
+fi
+
+required_urls=(
+  "$APP_URL/"
+  "$APP_URL/flutter_bootstrap.js"
+  "$APP_URL/main.dart.js"
+  "$APP_URL/webgpu_bridge/llama_webgpu_bridge.js"
+  "$APP_URL/webgpu_bridge/llama_webgpu_bridge_worker.js"
+  "$APP_URL/webgpu_bridge/llama_webgpu_core.js"
+  "$APP_URL/webgpu_bridge/llama_webgpu_core.wasm"
+  "$APP_URL/webgpu_bridge/llama_webgpu_core_mem64.js"
+  "$APP_URL/webgpu_bridge/llama_webgpu_core_mem64.wasm"
+)
+
+for asset_url in "${required_urls[@]}"; do
+  curl -fsSLI "$asset_url?commit=$EXPECTED_SHA" >/dev/null
+done
+
+headers="$(curl -fsSLI "$APP_URL/?commit=$EXPECTED_SHA")"
+for expected_header in \
+  'cross-origin-embedder-policy: require-corp' \
+  'cross-origin-opener-policy: same-origin'; do
+  if ! grep -qi "^$expected_header" <<<"$headers"; then
+    echo "[chat-app-web] error: missing deployment header: $expected_header" >&2
+    exit 1
+  fi
+done
+
+echo "[chat-app-web] verified deployed commit and runtime assets: $EXPECTED_SHA"

--- a/test/unit/tooling/run_local_e2e_test.dart
+++ b/test/unit/tooling/run_local_e2e_test.dart
@@ -83,6 +83,13 @@ void main() {
 
         expect(result.exitCode, 0);
         expect(result.stdout, contains('flutter build web'));
+        expect(
+          result.stdout,
+          contains(
+            'WEBGPU_BRIDGE_OUT_DIR=/repo/example/chat_app/build/web/webgpu_bridge '
+            'bash scripts/fetch_webgpu_bridge_assets.sh',
+          ),
+        );
         expect(result.stdout, contains('serve_static_with_headers.py'));
         expect(
           result.stdout,

--- a/test/unit/tooling/run_local_e2e_test.dart
+++ b/test/unit/tooling/run_local_e2e_test.dart
@@ -15,6 +15,7 @@ void main() {
       expect(result.exitCode, 0);
       expect(result.stdout, contains('--ngram-cache-build-text <txt>'));
       expect(result.stdout, contains('--ngram-token-max <n>'));
+      expect(result.stdout, contains('--allow-any-response'));
       expect(
         result.stdout,
         contains('defaults to the resolved benchmark prompt'),
@@ -76,18 +77,19 @@ void main() {
           'http://127.0.0.1:7358/models/tiny.gguf',
           '--expect',
           'ok',
+          '--allow-any-response',
           '--python',
           '/custom/python',
           '--dry-run',
         ], projectRoot: '/repo');
 
         expect(result.exitCode, 0);
-        expect(result.stdout, contains('flutter build web'));
+        expect(result.stdout, contains('scripts/build_chat_app_web.sh'));
         expect(
           result.stdout,
           contains(
-            'WEBGPU_BRIDGE_OUT_DIR=/repo/example/chat_app/build/web/webgpu_bridge '
-            'bash scripts/fetch_webgpu_bridge_assets.sh',
+            'CHAT_APP_BASE_HREF=/example/chat_app/build/web/ '
+            'bash scripts/build_chat_app_web.sh',
           ),
         );
         expect(result.stdout, contains('serve_static_with_headers.py'));
@@ -106,6 +108,7 @@ void main() {
           contains('--model-url http://127.0.0.1:7358/models/tiny.gguf'),
         );
         expect(result.stdout, contains('--expect ok'));
+        expect(result.stdout, contains('--allow-any-response'));
       },
     );
 
@@ -123,7 +126,7 @@ void main() {
         ], projectRoot: '/repo');
 
         expect(result.exitCode, 0);
-        expect(result.stdout, contains('flutter build web'));
+        expect(result.stdout, contains('scripts/build_chat_app_web.sh'));
         expect(result.stdout, contains('serve_static_with_headers.py'));
         expect(result.stdout, contains('playwright_chat_app_mock_smoke.py'));
         expect(
@@ -165,6 +168,10 @@ void main() {
 
       expect(result.exitCode, 0);
       expect(result.stdout, contains(pythonPath));
+      expect(
+        result.stdout,
+        contains('bash scripts/validate_chat_app_web_build.sh'),
+      );
       expect(
         result.stdout,
         contains('tool/testing/playwright_chat_app_real_model_smoke.py'),

--- a/tool/testing/run_local_e2e.dart
+++ b/tool/testing/run_local_e2e.dart
@@ -90,6 +90,7 @@ class LocalE2eRunContext {
     required this.ngramCacheBuildStaticPath,
     required this.ngramCacheBuildText,
     required this.expect,
+    required this.allowAnyResponse,
     required this.skipBuild,
   });
 
@@ -117,6 +118,7 @@ class LocalE2eRunContext {
   final String? ngramCacheBuildStaticPath;
   final String? ngramCacheBuildText;
   final String expect;
+  final bool allowAnyResponse;
   final bool skipBuild;
 
   String get chatAppDir => '$projectRoot/example/chat_app';
@@ -151,17 +153,22 @@ class LocalE2eScenario {
       stepsBuilder(context);
 }
 
-LocalE2eCommandStep _fetchWebGpuBridgeAssetsForBuild(
-  LocalE2eRunContext context,
-) => LocalE2eCommandStep(
-  workingDirectory: context.projectRoot,
-  executable: 'bash',
-  arguments: const ['scripts/fetch_webgpu_bridge_assets.sh'],
-  environment: {
-    'WEBGPU_BRIDGE_OUT_DIR': '${context.chatAppDir}/build/web/webgpu_bridge',
-  },
-  description: 'Fetch pinned WebGPU bridge assets into the web build',
-);
+LocalE2eCommandStep _prepareChatAppWebBuild(LocalE2eRunContext context) =>
+    LocalE2eCommandStep(
+      workingDirectory: context.projectRoot,
+      executable: 'bash',
+      arguments: [
+        context.skipBuild
+            ? 'scripts/validate_chat_app_web_build.sh'
+            : 'scripts/build_chat_app_web.sh',
+      ],
+      environment: context.skipBuild
+          ? const {}
+          : const {'CHAT_APP_BASE_HREF': '/example/chat_app/build/web/'},
+      description: context.skipBuild
+          ? 'Validate existing Flutter web chat app build'
+          : 'Build and validate Flutter web chat app',
+    );
 
 List<LocalE2eScenario> buildLocalE2eScenarios({String? projectRoot}) {
   return [
@@ -412,22 +419,16 @@ List<LocalE2eScenario> buildLocalE2eScenarios({String? projectRoot}) {
           'Build chat_app web and run the real-model Playwright smoke.',
       requiresDevice: false,
       stepsBuilder: (context) {
-        final steps = <LocalE2eCommandStep>[];
-        if (!context.skipBuild) {
-          steps.add(
-            LocalE2eCommandStep(
-              workingDirectory: context.chatAppDir,
-              executable: 'flutter',
-              arguments: const [
-                'build',
-                'web',
-                '--base-href=/example/chat_app/build/web/',
-              ],
-              description: 'Build Flutter web chat app',
-            ),
-          );
-        }
-        steps.add(_fetchWebGpuBridgeAssetsForBuild(context));
+        final steps = <LocalE2eCommandStep>[_prepareChatAppWebBuild(context)];
+        final smokeArguments = <String>[
+          'tool/testing/playwright_chat_app_real_model_smoke.py',
+          context.webBuildUrl,
+          '--model-url',
+          context.modelUrl ?? context.defaultModelUrl,
+          '--expect',
+          context.expect,
+          if (context.allowAnyResponse) '--allow-any-response',
+        ];
         steps.addAll([
           LocalE2eCommandStep(
             workingDirectory: context.projectRoot,
@@ -446,14 +447,7 @@ List<LocalE2eScenario> buildLocalE2eScenarios({String? projectRoot}) {
           LocalE2eCommandStep(
             workingDirectory: context.projectRoot,
             executable: context.python,
-            arguments: [
-              'tool/testing/playwright_chat_app_real_model_smoke.py',
-              context.webBuildUrl,
-              '--model-url',
-              context.modelUrl ?? context.defaultModelUrl,
-              '--expect',
-              context.expect,
-            ],
+            arguments: smokeArguments,
             description: 'Run Playwright real-model chat app smoke',
           ),
         ]);
@@ -467,21 +461,7 @@ List<LocalE2eScenario> buildLocalE2eScenarios({String? projectRoot}) {
           'Build chat_app web and run the deterministic mock-bridge smoke.',
       requiresDevice: false,
       stepsBuilder: (context) {
-        final steps = <LocalE2eCommandStep>[];
-        if (!context.skipBuild) {
-          steps.add(
-            LocalE2eCommandStep(
-              workingDirectory: context.chatAppDir,
-              executable: 'flutter',
-              arguments: const [
-                'build',
-                'web',
-                '--base-href=/example/chat_app/build/web/',
-              ],
-              description: 'Build Flutter web chat app',
-            ),
-          );
-        }
+        final steps = <LocalE2eCommandStep>[_prepareChatAppWebBuild(context)];
         final smokeArguments = <String>[
           'tool/testing/playwright_chat_app_mock_smoke.py',
           '${context.webBuildUrl}?llamadart_mock_bridge=echo',
@@ -520,21 +500,7 @@ List<LocalE2eScenario> buildLocalE2eScenarios({String? projectRoot}) {
       description: 'Build chat_app web and run Gemma 4 through LiteRT-LM JS.',
       requiresDevice: false,
       stepsBuilder: (context) {
-        final steps = <LocalE2eCommandStep>[];
-        if (!context.skipBuild) {
-          steps.add(
-            LocalE2eCommandStep(
-              workingDirectory: context.chatAppDir,
-              executable: 'flutter',
-              arguments: const [
-                'build',
-                'web',
-                '--base-href=/example/chat_app/build/web/',
-              ],
-              description: 'Build Flutter web chat app',
-            ),
-          );
-        }
+        final steps = <LocalE2eCommandStep>[_prepareChatAppWebBuild(context)];
         steps.addAll([
           LocalE2eCommandStep(
             workingDirectory: context.projectRoot,
@@ -593,22 +559,7 @@ List<LocalE2eScenario> buildLocalE2eScenarios({String? projectRoot}) {
           'WebGPU/llama.cpp with the mem64 core.',
       requiresDevice: false,
       stepsBuilder: (context) {
-        final steps = <LocalE2eCommandStep>[];
-        if (!context.skipBuild) {
-          steps.add(
-            LocalE2eCommandStep(
-              workingDirectory: context.chatAppDir,
-              executable: 'flutter',
-              arguments: const [
-                'build',
-                'web',
-                '--base-href=/example/chat_app/build/web/',
-              ],
-              description: 'Build Flutter web chat app',
-            ),
-          );
-        }
-        steps.add(_fetchWebGpuBridgeAssetsForBuild(context));
+        final steps = <LocalE2eCommandStep>[_prepareChatAppWebBuild(context)];
         steps.addAll([
           LocalE2eCommandStep(
             workingDirectory: context.projectRoot,
@@ -768,6 +719,7 @@ Future<LocalE2eResult> runLocalE2e(
     ngramCacheBuildStaticPath: parsed.ngramCacheBuildStaticPath,
     ngramCacheBuildText: parsed.ngramCacheBuildText,
     expect: parsed.expect,
+    allowAnyResponse: parsed.allowAnyResponse,
     skipBuild: parsed.skipBuild,
   );
   final steps = scenario.steps(context);
@@ -979,6 +931,7 @@ Options:
   --ngram-cache-build-text <txt> Optional source text for generated ngram-cache static file
                                  (defaults to the resolved benchmark prompt).
   --expect <text>                Expected response text for real-model web smoke.
+  --allow-any-response           Accept any non-empty real-model Web response.
   --skip-build                   Reuse an existing Flutter web build where supported.
   -h, --help                     Show this help.
 ''';
@@ -1012,6 +965,7 @@ class _ParsedArgs {
     required this.benchmarkWarmups,
     required this.draftTokenMaxList,
     required this.expect,
+    required this.allowAnyResponse,
     required this.skipBuild,
     this.scenario,
     this.modelPath,
@@ -1056,6 +1010,7 @@ class _ParsedArgs {
   final String? ngramCacheBuildStaticPath;
   final String? ngramCacheBuildText;
   final String expect;
+  final bool allowAnyResponse;
   final bool skipBuild;
 
   factory _ParsedArgs.parse(List<String> args) {
@@ -1075,6 +1030,7 @@ class _ParsedArgs {
     var benchmarkWarmups = '1';
     var draftTokenMaxList = '1,2';
     var expect = '4';
+    var allowAnyResponse = false;
     var skipBuild = false;
     String? scenario;
     String? modelPath;
@@ -1101,6 +1057,8 @@ class _ParsedArgs {
           dryRun = true;
         case '--skip-build':
           skipBuild = true;
+        case '--allow-any-response':
+          allowAnyResponse = true;
         case '--scenario':
           scenario = _readValue(args, ++index, arg);
         case '--device':
@@ -1184,6 +1142,7 @@ class _ParsedArgs {
       ngramCacheBuildStaticPath: ngramCacheBuildStaticPath,
       ngramCacheBuildText: ngramCacheBuildText,
       expect: expect,
+      allowAnyResponse: allowAnyResponse,
       skipBuild: skipBuild,
     );
   }

--- a/tool/testing/run_local_e2e.dart
+++ b/tool/testing/run_local_e2e.dart
@@ -151,6 +151,18 @@ class LocalE2eScenario {
       stepsBuilder(context);
 }
 
+LocalE2eCommandStep _fetchWebGpuBridgeAssetsForBuild(
+  LocalE2eRunContext context,
+) => LocalE2eCommandStep(
+  workingDirectory: context.projectRoot,
+  executable: 'bash',
+  arguments: const ['scripts/fetch_webgpu_bridge_assets.sh'],
+  environment: {
+    'WEBGPU_BRIDGE_OUT_DIR': '${context.chatAppDir}/build/web/webgpu_bridge',
+  },
+  description: 'Fetch pinned WebGPU bridge assets into the web build',
+);
+
 List<LocalE2eScenario> buildLocalE2eScenarios({String? projectRoot}) {
   return [
     LocalE2eScenario(
@@ -415,6 +427,7 @@ List<LocalE2eScenario> buildLocalE2eScenarios({String? projectRoot}) {
             ),
           );
         }
+        steps.add(_fetchWebGpuBridgeAssetsForBuild(context));
         steps.addAll([
           LocalE2eCommandStep(
             workingDirectory: context.projectRoot,
@@ -595,6 +608,7 @@ List<LocalE2eScenario> buildLocalE2eScenarios({String? projectRoot}) {
             ),
           );
         }
+        steps.add(_fetchWebGpuBridgeAssetsForBuild(context));
         steps.addAll([
           LocalE2eCommandStep(
             workingDirectory: context.projectRoot,

--- a/tool/testing/test_matrix.dart
+++ b/tool/testing/test_matrix.dart
@@ -243,7 +243,7 @@ const List<TestMatrixRow> testMatrixRows = <TestMatrixRow>[
   TestMatrixRow(
     id: 'web-mock-chat-smoke',
     tier: 'targeted',
-    mode: 'local-only',
+    mode: 'CI + local',
     covers: 'built Flutter web chat app with deterministic mock bridge',
     command:
         'dart run tool/testing/run_local_e2e.dart --scenario '
@@ -254,8 +254,9 @@ const List<TestMatrixRow> testMatrixRows = <TestMatrixRow>[
   TestMatrixRow(
     id: 'web-real-model-smoke',
     tier: 'targeted',
-    mode: 'local-only',
-    covers: 'built Flutter web chat app with real GGUF model URL',
+    mode: 'CI + local',
+    covers:
+        'built Flutter web chat app with real worker/WASM and GGUF model URL',
     command:
         'dart run tool/testing/run_local_e2e.dart --scenario '
         'chat-app-web-real-model-smoke --model-url <model-url> --expect 4',

--- a/website/docs/platforms/webgpu-bridge.md
+++ b/website/docs/platforms/webgpu-bridge.md
@@ -283,9 +283,10 @@ dart run tool/testing/run_local_e2e.dart --scenario chat-app-web-real-model-smok
   --expect 4
 ```
 
-The runner builds Flutter web with the matching `--base-href`, serves the repo
-root through `tool/testing/serve_static_with_headers.py`, and invokes the
-appropriate Playwright helper. `serve_static_with_headers.py` provides the
+The runner uses `scripts/build_chat_app_web.sh` to build Flutter web with the
+matching `--base-href` and package and validate the pinned bridge assets. It
+then serves the repo root through `tool/testing/serve_static_with_headers.py`
+and invokes the appropriate Playwright helper. The static server provides the
 COOP/COEP headers needed for large web model loads. When debugging the helper
 scripts directly, keep the `--base-href` value aligned with the URL path,
 otherwise Flutter and bridge assets are resolved from the wrong location.


### PR DESCRIPTION
## Summary

- keep native LiteRT-LM's one-token worker flush behavior while leaving Web batching controls at supported defaults
- package the pinned WebGPU bridge/core assets after Flutter Web builds so deployed GGUF loading does not hit missing local files
- make all Web build, E2E, preview, and production paths use one validated artifact builder
- add a required `Web Chat Contract` check with chat-app VM/Chrome tests, deterministic UI coverage, and real worker/WASM/GGUF inference
- verify preview and production deployments serve the expected commit, runtime assets, and isolation headers

## Root causes

1. The chat app set `streamBatchTokenThreshold` to `1` for every `.litertlm` model. Native workers need that prompt flush, but LiteRT-LM Web streams directly and rejects non-default native batching controls. The model loaded, then generation failed before the prompt reached `sendMessageStreaming`.
2. The generated WebGPU bridge assets are gitignored. `flutter build web` excludes them, so the deployed app could load the bridge entry point from the CDN but then requested missing local worker/core files and failed GGUF loading with 404s.
3. Real Web model smokes were local-only, the preview workflow stopped after upload, and production deployment did not trigger for root `lib/**` changes. Green CI therefore did not prove that the final hosted artifact could load and generate.

## User impact

- Gemma 4 LiteRT-LM generates text in the Web chat app again.
- Deployed Web chat builds include the pinned WebGPU runtime required to load and run GGUF models.
- Native LiteRT-LM retains immediate first-token streaming behavior.
- Future PRs must load a real GGUF through the packaged worker and WASM core before the Web contract passes.

Direct browser downloads from Hugging Face can still fail when HF's Xet/CAS storage delivery is unavailable. The required PR smoke uses the repository's cached tiny GGUF so an external model-host incident does not hide an application regression.

## Validation

- `flutter test` in `example/chat_app` (201 tests)
- `flutter test --platform chrome test/chat_generation_service_test.dart` (4 tests)
- `dart test -p vm -j 1 test/unit/tooling/run_local_e2e_test.dart` (23 tests)
- targeted Dart analysis and repository formatting
- `actionlint`, `shellcheck`, workflow YAML parsing, and `git diff --check`
- `scripts/build_chat_app_web.sh` produced and checksum-validated the deployable artifact
- deterministic built-app Playwright smoke: PASS
- Stories15M GGUF real browser contract: local bridge, worker, wasm32 core, and model requests all 200; loaded in 3.7s and generated text in 5.9s; no page errors or request failures
- real 1.87 GiB Gemma 4 LiteRT-LM Web smoke: generated `4`
- Qwen3.5 0.8B GGUF Web smoke through the pinned local bridge/core: generated `4`
- docs site build and link validation

## Notes

- Large Gemma 4 GGUF and LiteRT-LM Web smokes remain targeted checks; the required gate stays small and deterministic.
- `scripts/verify_chat_app_web_deployment.sh` polls the deployed SHA before checking the runtime asset URLs and COOP/COEP headers, avoiding false success against a stale preview.
