### PR TITLE
Prepare 0.8.17 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-## Unreleased
+## 0.8.17
 
 * Updated the default llama.cpp native runtime to
   `leehack/llamadart-native@b10075` with matching bindings and Apple artifacts.

--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ For Dart or Flutter apps:
 
 ```yaml
 dependencies:
-  llamadart: ^0.8.16
+  llamadart: ^0.8.17
 ```
 
 Flutter iOS/macOS apps that should link Apple XCFrameworks through Swift
@@ -57,9 +57,9 @@ Package Manager should also add the runtime companion packages they need:
 
 ```yaml
 dependencies:
-  llamadart: ^0.8.16
-  llamadart_llama_cpp_flutter: ^0.0.10 # GGUF / llama.cpp
-  llamadart_litert_lm_flutter: ^0.0.6 # Apple .litertlm / LiteRT-LM targets
+  llamadart: ^0.8.17
+  llamadart_llama_cpp_flutter: ^0.0.11 # GGUF / llama.cpp
+  llamadart_litert_lm_flutter: ^0.0.7 # Apple .litertlm / LiteRT-LM targets
 ```
 
 The LiteRT-LM companion manifest includes consolidated iOS and macOS SwiftPM

--- a/example/chat_app/pubspec.lock
+++ b/example/chat_app/pubspec.lock
@@ -357,7 +357,7 @@ packages:
       path: "../.."
       relative: true
     source: path
-    version: "0.8.16"
+    version: "0.8.17"
   logging:
     dependency: transitive
     description:

--- a/packages/llamadart_litert_lm_flutter/CHANGELOG.md
+++ b/packages/llamadart_litert_lm_flutter/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.0.7
+
+* Updated the install example for `llamadart` 0.8.17.
+
 ## 0.0.6
 
 * Updated the install example for `llamadart` 0.8.16.

--- a/packages/llamadart_litert_lm_flutter/README.md
+++ b/packages/llamadart_litert_lm_flutter/README.md
@@ -12,8 +12,8 @@ runtime fallback.
 
 ```yaml
 dependencies:
-  llamadart: ^0.8.16
-  llamadart_litert_lm_flutter: ^0.0.6
+  llamadart: ^0.8.17
+  llamadart_litert_lm_flutter: ^0.0.7
 ```
 
 This package has no runtime Dart API of its own. Import `package:llamadart`

--- a/packages/llamadart_litert_lm_flutter/pubspec.yaml
+++ b/packages/llamadart_litert_lm_flutter/pubspec.yaml
@@ -1,6 +1,6 @@
 name: llamadart_litert_lm_flutter
 description: Flutter Apple SwiftPM runtime companion package for llamadart LiteRT-LM support.
-version: 0.0.6
+version: 0.0.7
 repository: https://github.com/leehack/llamadart/tree/main/packages/llamadart_litert_lm_flutter
 homepage: https://github.com/leehack/llamadart
 issue_tracker: https://github.com/leehack/llamadart/issues

--- a/packages/llamadart_llama_cpp_flutter/CHANGELOG.md
+++ b/packages/llamadart_llama_cpp_flutter/CHANGELOG.md
@@ -1,4 +1,4 @@
-## Unreleased
+## 0.0.11
 
 * Updated Apple SwiftPM native pin to `leehack/llamadart-native@b10075`.
 

--- a/packages/llamadart_llama_cpp_flutter/README.md
+++ b/packages/llamadart_llama_cpp_flutter/README.md
@@ -9,8 +9,8 @@ core package's native-assets fallback.
 
 ```yaml
 dependencies:
-  llamadart: ^0.8.16
-  llamadart_llama_cpp_flutter: ^0.0.10
+  llamadart: ^0.8.17
+  llamadart_llama_cpp_flutter: ^0.0.11
 ```
 
 This package has no runtime Dart API of its own. Import `package:llamadart`

--- a/packages/llamadart_llama_cpp_flutter/pubspec.yaml
+++ b/packages/llamadart_llama_cpp_flutter/pubspec.yaml
@@ -1,6 +1,6 @@
 name: llamadart_llama_cpp_flutter
 description: Flutter Apple SwiftPM runtime companion package for llamadart llama.cpp and GGUF support.
-version: 0.0.10
+version: 0.0.11
 repository: https://github.com/leehack/llamadart/tree/main/packages/llamadart_llama_cpp_flutter
 homepage: https://github.com/leehack/llamadart
 issue_tracker: https://github.com/leehack/llamadart/issues

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: llamadart
 description: Dart and Flutter local LLM inference with llama.cpp GGUF and LiteRT-LM across native platforms and web.
-version: 0.8.16
+version: 0.8.17
 homepage: https://github.com/leehack/llamadart
 repository: https://github.com/leehack/llamadart
 issue_tracker: https://github.com/leehack/llamadart/issues

--- a/website/docs/changelog/recent-releases.md
+++ b/website/docs/changelog/recent-releases.md
@@ -7,6 +7,16 @@ For canonical full release notes, use:
 
 - [`CHANGELOG.md`](https://github.com/leehack/llamadart/blob/main/CHANGELOG.md)
 
+## 0.8.17
+
+- Updated the default llama.cpp native runtime to `b10075` with matching
+  bindings and Apple artifacts.
+- Added Tencent Hunyuan V3 chat-template, reasoning, and tool-call support.
+- Fixed Gemma 4 LiteRT-LM text generation in the Web chat app after model
+  loading completed successfully.
+- Restored GGUF loading in deployed Web chat apps by packaging the pinned
+  WebGPU runtime assets with Flutter Web builds.
+
 ## 0.8.16
 
 - Updated the default llama.cpp native runtime to `b9982`, including safer

--- a/website/docs/getting-started/installation.md
+++ b/website/docs/getting-started/installation.md
@@ -27,7 +27,7 @@ In Xcode, set `IPHONEOS_DEPLOYMENT_TARGET = 16.4` or
 
 ```yaml
 dependencies:
-  llamadart: ^0.8.16
+  llamadart: ^0.8.17
 ```
 
 For Flutter iOS/macOS apps that should link Apple XCFrameworks through Swift
@@ -35,9 +35,9 @@ Package Manager, also add the runtime companion packages you need:
 
 ```yaml
 dependencies:
-  llamadart: ^0.8.16
-  llamadart_llama_cpp_flutter: ^0.0.10 # GGUF / llama.cpp
-  llamadart_litert_lm_flutter: ^0.0.6 # Apple .litertlm / LiteRT-LM targets
+  llamadart: ^0.8.17
+  llamadart_llama_cpp_flutter: ^0.0.11 # GGUF / llama.cpp
+  llamadart_litert_lm_flutter: ^0.0.7 # Apple .litertlm / LiteRT-LM targets
 ```
 
 The companion packages are published independently from the `packages/`


### PR DESCRIPTION
## Summary
- Prepare llamadart 0.8.17 from the changes already merged since 0.8.16.
- Bump the Apple runtime companions to llamadart_llama_cpp_flutter 0.0.11 and llamadart_litert_lm_flutter 0.0.7.
- Promote the release notes and keep current install snippets aligned across the README, companion packages, and website.
- This PR does not publish by itself; merging it is the approval boundary for the guarded release automation.

## Release highlights
- Update the default llama.cpp native runtime to b10075 with matching bindings and Apple artifacts.
- Add Tencent Hunyuan V3 chat-template, reasoning, and tool-call support.
- Fix Gemma 4 LiteRT-LM text generation in the Web chat app after model loading.
- Restore deployed Web chat GGUF loading by packaging the pinned WebGPU runtime assets.

## Production-readiness scope
- **User-facing scope:** Publish the four already-merged release highlights above as llamadart 0.8.17.
- **Supported platforms/paths:** Existing native, Flutter Apple companion, LiteRT-LM Web, and WebGPU paths; this PR changes release metadata and current docs only.
- **Unsupported or intentionally unavailable paths:** Unchanged from main.
- **Out of scope / follow-ups:** None.

## Completeness checklist
- [x] Declared scope is fully implemented.
- [x] Unsupported platform/option behavior is unchanged and remains documented.
- [x] README, website docs, install snippets, companion docs, and changelogs are aligned.
- [x] Regression coverage for the released runtime changes was merged with the implementation PRs.
- [x] Security/privacy review completed; this release-only diff adds no secret-bearing data.
- [x] Follow-up work: None.

## PR type guidance
- **Release-prep PR:** version, changelog, install-snippet, and companion-package metadata only; no runtime behavior changes in this diff.

## Test Plan
- [x] dart format --output=none --set-exit-if-changed .
- [x] dart analyze
- [x] dart test -p vm -j 1 --exclude-tags local-only (1,366 passed, 1 skipped; includes native inference smoke)
- [x] dart test -p chrome --exclude-tags local-only (733 passed, 1 skipped)
- [x] dart run tool/testing/verify_release_docs_versions.dart
- [x] ./tool/docs/build_site.sh
- [x] ./tool/docs/validate_links.sh
- [x] Core and both companion flutter pub publish --dry-run checks (0 warnings each)
- [x] Both companion flutter analyze and flutter test suites
- [x] Verified 0.8.17, 0.0.11, and 0.0.7 are currently unclaimed on pub.dev
- [x] Verified the public b10075 native release includes the Apple XCFramework and all supported platform assets

## Matrix Evidence
| Matrix row | Scope covered | Platform / model / backend | Result | Evidence / notes |
| --- | --- | --- | --- | --- |
| release-companion-pub-gate | Companion availability before core tag | pub.dev / release automation | PASS | Target versions are absent as expected; post-merge automation publishes and verifies companions before tagging core. |
| release-representative-smokes | Representative package validation | macOS / native llama.cpp | PASS | VM suite completed the native model-load and generation smoke. |
| android-release-device-pool | Android device coverage | Android / native llama.cpp | N/A | Release-only metadata diff; implementation PR CI and prior runtime validation are unchanged. |

## Review Notes
- Independent review status: local release-surface and diff audit passed.
- CI status / head SHA: pending on d0a479044.
