### PR TITLE
Harden WebGPU remote fetch and bump bridge assets to v0.1.21

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## Unreleased
+
+* Disabled automatic WebGPU fetch-backed model loading by default. Streamed
+  loading remains the safe default; controlled range-capable deployments can
+  opt in explicitly.
+
 ## 0.8.17
 
 * Updated the default llama.cpp native runtime to

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@
   loading remains the safe default; controlled range-capable deployments can
   opt in explicitly.
 
+* Updated WebGPU bridge assets to `v0.1.21` (llama.cpp `b10099`), restoring
+  multimodal generation after recent upstream prompt-ingestion changes.
+
 ## 0.8.17
 
 * Updated the default llama.cpp native runtime to

--- a/README.md
+++ b/README.md
@@ -136,7 +136,7 @@ Current default runtime pins:
 | --- | --- |
 | Native llama.cpp / GGUF | `leehack/llamadart-native@b10075` |
 | Native LiteRT-LM / `.litertlm` | `leehack/litert-lm-native@v0.14.0-native.2` |
-| Web llama.cpp / GGUF | `leehack/llama-web-bridge-assets@v0.1.18` |
+| Web llama.cpp / GGUF | `leehack/llama-web-bridge-assets@v0.1.21` |
 | Web LiteRT-LM / `.litertlm` | `@litert-lm/core@0.14.0` |
 
 ## Common Tasks

--- a/doc/webgpu_bridge.md
+++ b/doc/webgpu_bridge.md
@@ -19,7 +19,7 @@ pipelines.
    `https://cdn.jsdelivr.net/gh/leehack/llama-web-bridge-assets@<tag>/llama_webgpu_bridge.js`
 2. Local fallback: `./webgpu_bridge/llama_webgpu_bridge.js`
 
-Default pinned tag in the example is `v0.1.18`.
+Default pinned tag in the example is `v0.1.21`.
 
 For broader browser coverage in this repository, fetched/local assets are patched
 to a universal Safari-compatible gate by default (`MIN_SAFARI_VERSION=170400`).
@@ -32,7 +32,7 @@ model bytes.
 To vendor pinned assets into local app web files:
 
 ```bash
-WEBGPU_BRIDGE_ASSETS_TAG=v0.1.18 ./scripts/fetch_webgpu_bridge_assets.sh
+WEBGPU_BRIDGE_ASSETS_TAG=v0.1.21 ./scripts/fetch_webgpu_bridge_assets.sh
 ```
 
 Optional compatibility env vars:
@@ -113,7 +113,7 @@ You can override CDN source/version before the bridge loader runs:
 ```html
 <script>
   window.__llamadartBridgeAssetsRepo = 'leehack/llama-web-bridge-assets';
-  window.__llamadartBridgeAssetsTag = 'v0.1.18';
+  window.__llamadartBridgeAssetsTag = 'v0.1.21';
 </script>
 ```
 

--- a/doc/webgpu_bridge.md
+++ b/doc/webgpu_bridge.md
@@ -187,9 +187,16 @@ window.LlamaWebGpuBridge = class LlamaWebGpuBridge {
 - `window.__llamadartBridgeEnableMem64` (default effectively off in chat app)
   - Set to `true` to prefer wasm64 core when available.
 - `window.__llamadartBridgeAllowAutoRemoteFetchBackend`
-  - Default `true`.
-  - Set to `false` to skip the auto fetch-backed pre-attempt and go straight to
-    streamed network staging.
+  - Default `false`; streamed network staging remains the safe default.
+  - Set to `true` only for a controlled origin that serves valid GGUF byte
+    ranges. This also permits Dart recovery paths to retry with fetch-backed
+    loading after a streamed staging failure.
+- `window.__llamadartBridgeForceRemoteFetchBackend`
+  - Default `false`.
+  - Set to `true` only for controlled diagnostics that must use fetch-backed
+    loading from the first attempt. Prefer
+    `__llamadartBridgeAllowAutoRemoteFetchBackend` for ordinary opt-in because
+    it preserves streamed loading when the fetch-backed path is unnecessary.
 - `window.__llamadartBridgeRemoteFetchChunkBytes`
   - Optional positive integer bytes.
   - Defaults to `4 * 1024 * 1024` in `llamadart` web backend; clamped to

--- a/example/chat_app/README.md
+++ b/example/chat_app/README.md
@@ -396,14 +396,22 @@ await prefs.setInt('preferred_backend', backendIndex);
 - On web, **Download** prefetches model/mmproj bytes into browser Cache Storage with progress.
 - Qwen3.5 `0.8B` WebGPU loads are capped to a low layer count for stable browser text output.
 - Qwen3.5 multimodal web runs currently use CPU-safe fallback for stability even when the text model was loaded with WebGPU acceleration.
-- For very large web models, runtime may switch to worker-thread fetch-backed loading to reduce contiguous allocation pressure; this path may bypass prefetch cache reuse.
+- Web models use streamed network staging by default. Controlled origins that
+  serve valid GGUF byte ranges can explicitly enable worker-thread
+  fetch-backed loading to reduce contiguous allocation pressure; this path may
+  bypass prefetch cache reuse.
 - If optional `llama_webgpu_core_mem64` bridge assets are present and supported by the browser, chat app bridge bootstrapping can prefer wasm64 core and transparently fall back to wasm32.
 - Large single-file web model loading requires cross-origin isolation
   (`window.crossOriginIsolated === true`).
 - Chat app defaults to wasm32-first for stability. You can opt into wasm64 preference with
   `window.__llamadartBridgeEnableMem64 = true` before bridge bootstrap.
-- You can skip auto fetch-backed pre-attempts by setting
-  `window.__llamadartBridgeAllowAutoRemoteFetchBackend = false` before bridge bootstrap.
+- Fetch-backed loading is disabled by default. Set
+  `window.__llamadartBridgeAllowAutoRemoteFetchBackend = true` before bridge
+  bootstrap only for a controlled range-capable model origin. This explicit
+  opt-in also permits fetch-backed recovery retries after streamed staging
+  failures. For diagnostics that must use fetch-backed loading from the first
+  attempt, set `window.__llamadartBridgeForceRemoteFetchBackend = true`;
+  prefer the automatic opt-in for ordinary deployments.
 - You can tune fetch-backed model read chunk size by setting
   `window.__llamadartBridgeRemoteFetchChunkBytes = <bytes>` before bridge bootstrap
   (default `4 * 1024 * 1024`, clamped to `4KiB..16MiB`).

--- a/example/chat_app/web/index.html
+++ b/example/chat_app/web/index.html
@@ -214,13 +214,13 @@
     const bridgeAssetsTag =
       typeof configuredTag === 'string' && configuredTag.length > 0
         ? configuredTag
-        : 'v0.1.18';
+        : 'v0.1.21';
     window.__llamadartLiteRtLmModuleUrl =
       typeof window.__llamadartLiteRtLmModuleUrl === 'string' &&
       window.__llamadartLiteRtLmModuleUrl.length > 0
         ? window.__llamadartLiteRtLmModuleUrl
         : 'https://cdn.jsdelivr.net/npm/@litert-lm/core@0.14.0/+esm';
-    const localBridgeVersion = 'v0.1.18-local-b9915';
+    const localBridgeVersion = 'v0.1.21-local-b10099';
     window.__llamadartBridgeLocalVersion = localBridgeVersion;
 
     const localBridgeUrl = `./webgpu_bridge/llama_webgpu_bridge.js?v=${localBridgeVersion}`;

--- a/lib/src/backends/webgpu/webgpu_backend.dart
+++ b/lib/src/backends/webgpu/webgpu_backend.dart
@@ -206,11 +206,13 @@ class WebGpuLlamaBackend
     final threadPoolSizeHint = _getGlobalPositiveInt(
       '__llamadartBridgeThreadPoolSize',
     );
+    // Keep native remote-fetch loading opt-in until malformed responses can be
+    // rejected without risking an unrecoverable core abort.
     final allowAutoRemoteFetchBackend =
         _getGlobalOptionalBool(
           '__llamadartBridgeAllowAutoRemoteFetchBackend',
         ) ??
-        true;
+        false;
 
     return WebGpuBridgeConfig(
       wasmUrl: wasmUrl?.toJS,
@@ -464,6 +466,22 @@ class WebGpuLlamaBackend
     }
 
     return null;
+  }
+
+  bool _isRemoteFetchBackendOptedIn() {
+    return _getGlobalOptionalBool(
+              '__llamadartBridgeAllowAutoRemoteFetchBackend',
+            ) ==
+            true ||
+        _getGlobalBool('__llamadartBridgeForceRemoteFetchBackend');
+  }
+
+  bool _runtimeNotesIndicateModelFsWriteFailure(String runtimeNotes) {
+    return runtimeNotes.contains('model_response_nostream') ||
+        runtimeNotes.contains('model_fs_write_bigint_error') ||
+        runtimeNotes.contains('model_fs_write_abort') ||
+        runtimeNotes.contains('model_fs_write_arraybuffer_oom') ||
+        runtimeNotes.contains('model_fs_write_failed');
   }
 
   String? _getBridgeUserAgent() {
@@ -757,6 +775,7 @@ class WebGpuLlamaBackend
   UnsupportedError? _normalizeBridgeRuntimeError(
     Object error, {
     Map<String, String>? runtimeHints,
+    bool remoteFetchBackendOptedIn = false,
   }) {
     final text = _errorText(error);
     final loweredText = text.toLowerCase();
@@ -782,6 +801,20 @@ class WebGpuLlamaBackend
     }
 
     final runtimeNotes = runtimeHints?['llamadart.webgpu.runtime_notes'] ?? '';
+    if (_runtimeNotesIndicateModelFsWriteFailure(runtimeNotes) &&
+        !remoteFetchBackendOptedIn) {
+      return UnsupportedError(
+        'Web model staging failed before the GGUF could be loaded safely. '
+        'Automatic fetch-backed loading is disabled by default because an '
+        'invalid remote response can abort the WebAssembly core. Try a '
+        'smaller or sharded GGUF, reduce browser memory pressure, or use the '
+        'native runtime. For a controlled origin that serves valid GGUF byte '
+        'ranges, explicitly set '
+        'window.__llamadartBridgeAllowAutoRemoteFetchBackend = true or '
+        'window.__llamadartBridgeForceRemoteFetchBackend = true before '
+        'loading.',
+      );
+    }
     final threadConstructorFailure =
         runtimeNotes.contains('threads_capped_no_coi') ||
         runtimeNotes.contains('thread_constructor_failed') ||
@@ -910,6 +943,7 @@ class WebGpuLlamaBackend
     // escalation paths below can still flip this to true as a last resort.
     _preferMemory64Override = _resolvePreferMemory64(params);
     _forceRemoteFetchBackendOverride = null;
+    final remoteFetchBackendOptedIn = _isRemoteFetchBackendOptedIn();
 
     final requestedThreads = params.numberOfThreads > 0
         ? params.numberOfThreads
@@ -1087,12 +1121,9 @@ class WebGpuLlamaBackend
         final coreVariant = runtimeHints['llamadart.webgpu.core_variant'];
         final runtimeNotes =
             runtimeHints['llamadart.webgpu.runtime_notes'] ?? '';
-        final fsWriteFailed =
-            runtimeNotes.contains('model_response_nostream') ||
-            runtimeNotes.contains('model_fs_write_bigint_error') ||
-            runtimeNotes.contains('model_fs_write_abort') ||
-            runtimeNotes.contains('model_fs_write_arraybuffer_oom') ||
-            runtimeNotes.contains('model_fs_write_failed');
+        final fsWriteFailed = _runtimeNotesIndicateModelFsWriteFailure(
+          runtimeNotes,
+        );
         final bigIntInteropError = _isBigIntInteropError(e);
         final remoteFetchAttempted = runtimeNotes.contains(
           'model_fetch_backend_attempt',
@@ -1128,6 +1159,7 @@ class WebGpuLlamaBackend
             remoteFetchAborted;
         final shouldRetryWithSmallerRemoteFetchChunks =
             remoteFetchChunkRetryCount < 10 &&
+            remoteFetchBackendOptedIn &&
             remoteFetchAttempted &&
             remoteFetchAborted &&
             forceRemoteFetchRequested &&
@@ -1211,25 +1243,31 @@ class WebGpuLlamaBackend
         if (shouldRetryWithWasm64) {
           retriedWithWasm64 = true;
           _preferMemory64Override = true;
-          _forceRemoteFetchBackendOverride =
-              (remoteFetchAttempted || remoteFetchBackendKnownUnstable)
-              ? false
-              : true;
+          final retryWithRemoteFetchBackend =
+              remoteFetchBackendOptedIn &&
+              !remoteFetchAttempted &&
+              !remoteFetchBackendKnownUnstable;
+          _forceRemoteFetchBackendOverride = retryWithRemoteFetchBackend;
           index = -1;
           _emitConsoleText(
             LlamaLogLevel.warn,
-            remoteFetchAttempted
+            retryWithRemoteFetchBackend
+                ? 'WebGpuLlamaBackend: wasm32 memory pressure detected; '
+                      'retrying with wasm64 core and explicitly enabled '
+                      'fetch-backed loading.'
+                : remoteFetchAttempted
                 ? 'WebGpuLlamaBackend: wasm32 memory pressure detected after '
                       'fetch-backed loading; retrying with wasm64 core and '
                       'streamed network loading.'
                 : 'WebGpuLlamaBackend: wasm32 memory pressure detected; '
-                      'retrying with wasm64 core and fetch-backed loading.',
+                      'retrying with wasm64 core and streamed network loading.',
           );
           continue;
         }
 
         if (fsWriteFailed && coreVariant == 'wasm64') {
-          if (!retriedAfterFsWriteFailureWithRemote) {
+          if (remoteFetchBackendOptedIn &&
+              !retriedAfterFsWriteFailureWithRemote) {
             retriedAfterFsWriteFailureWithRemote = true;
             _forceRemoteFetchBackendOverride = true;
             remoteFetchChunkBytesOverride = math.min(
@@ -1248,9 +1286,13 @@ class WebGpuLlamaBackend
 
           _emitConsoleText(
             LlamaLogLevel.warn,
-            'WebGpuLlamaBackend: wasm64 model staging failed; skipping '
-            'fallback ladder because additional nCtx/GPU/thread '
-            'reductions are unlikely to recover FS write failures.',
+            remoteFetchBackendOptedIn
+                ? 'WebGpuLlamaBackend: wasm64 model staging failed; skipping '
+                      'fallback ladder because additional nCtx/GPU/thread '
+                      'reductions are unlikely to recover FS write failures.'
+                : 'WebGpuLlamaBackend: wasm64 model staging failed; '
+                      'fetch-backed recovery requires explicit opt-in, so no '
+                      'unsafe remote-fetch retry will be attempted.',
           );
         }
 
@@ -1274,6 +1316,7 @@ class WebGpuLlamaBackend
         final normalized = _normalizeBridgeRuntimeError(
           e,
           runtimeHints: runtimeHints,
+          remoteFetchBackendOptedIn: remoteFetchBackendOptedIn,
         );
         if (normalized != null) {
           throw normalized;
@@ -1286,6 +1329,7 @@ class WebGpuLlamaBackend
       final normalized = _normalizeBridgeRuntimeError(
         lastError,
         runtimeHints: lastRuntimeHints,
+        remoteFetchBackendOptedIn: remoteFetchBackendOptedIn,
       );
       if (normalized != null) {
         throw normalized;

--- a/lib/src/backends/webgpu/webgpu_backend.dart
+++ b/lib/src/backends/webgpu/webgpu_backend.dart
@@ -206,13 +206,10 @@ class WebGpuLlamaBackend
     final threadPoolSizeHint = _getGlobalPositiveInt(
       '__llamadartBridgeThreadPoolSize',
     );
-    // Keep native remote-fetch loading opt-in until malformed responses can be
-    // rejected without risking an unrecoverable core abort.
-    final allowAutoRemoteFetchBackend =
-        _getGlobalOptionalBool(
-          '__llamadartBridgeAllowAutoRemoteFetchBackend',
-        ) ??
-        false;
+    // Keep bridge remote-fetch loading opt-in until malformed responses can be
+    // rejected without risking an unrecoverable core abort. Forced mode is an
+    // explicit opt-in and must enable the bridge capability end to end.
+    final allowAutoRemoteFetchBackend = _isRemoteFetchBackendOptedIn();
 
     return WebGpuBridgeConfig(
       wasmUrl: wasmUrl?.toJS,

--- a/lib/src/backends/webgpu/webgpu_backend.dart
+++ b/lib/src/backends/webgpu/webgpu_backend.dart
@@ -775,7 +775,7 @@ class WebGpuLlamaBackend
   UnsupportedError? _normalizeBridgeRuntimeError(
     Object error, {
     Map<String, String>? runtimeHints,
-    bool remoteFetchBackendOptedIn = false,
+    required bool remoteFetchBackendOptedIn,
   }) {
     final text = _errorText(error);
     final loweredText = text.toLowerCase();

--- a/scripts/fetch_webgpu_bridge_assets.sh
+++ b/scripts/fetch_webgpu_bridge_assets.sh
@@ -4,7 +4,7 @@ set -euo pipefail
 ROOT_DIR="$(git rev-parse --show-toplevel)"
 OUT_DIR="${WEBGPU_BRIDGE_OUT_DIR:-$ROOT_DIR/example/chat_app/web/webgpu_bridge}"
 ASSETS_REPO="${WEBGPU_BRIDGE_ASSETS_REPO:-leehack/llama-web-bridge-assets}"
-ASSETS_TAG="${WEBGPU_BRIDGE_ASSETS_TAG:-v0.1.18}"
+ASSETS_TAG="${WEBGPU_BRIDGE_ASSETS_TAG:-v0.1.21}"
 CDN_BASE="${WEBGPU_BRIDGE_CDN_BASE:-https://cdn.jsdelivr.net/gh/${ASSETS_REPO}@${ASSETS_TAG}}"
 PATCH_SAFARI_COMPAT="${WEBGPU_BRIDGE_PATCH_SAFARI_COMPAT:-1}"
 MIN_SAFARI_VERSION="${WEBGPU_BRIDGE_MIN_SAFARI_VERSION:-170400}"
@@ -14,7 +14,7 @@ if [[ "${1:-}" == "--help" || "${1:-}" == "-h" ]]; then
 Downloads prebuilt WebGPU bridge assets into the chat_app web directory.
 
 Default source:
-  https://cdn.jsdelivr.net/gh/leehack/llama-web-bridge-assets@v0.1.18
+  https://cdn.jsdelivr.net/gh/leehack/llama-web-bridge-assets@v0.1.21
 
 Environment variables:
   WEBGPU_BRIDGE_ASSETS_REPO   Asset repo in owner/repo format
@@ -28,7 +28,7 @@ Usage:
   ./scripts/fetch_webgpu_bridge_assets.sh
 
 Examples:
-  WEBGPU_BRIDGE_ASSETS_TAG=v0.1.18 ./scripts/fetch_webgpu_bridge_assets.sh
+  WEBGPU_BRIDGE_ASSETS_TAG=v0.1.21 ./scripts/fetch_webgpu_bridge_assets.sh
   WEBGPU_BRIDGE_ASSETS_REPO=acme/llama-web-bridge-assets WEBGPU_BRIDGE_ASSETS_TAG=v2 ./scripts/fetch_webgpu_bridge_assets.sh
 USAGE
   exit 0

--- a/test/integration/backends/webgpu/webgpu_engine_multimodal_browser_integration_test.dart
+++ b/test/integration/backends/webgpu/webgpu_engine_multimodal_browser_integration_test.dart
@@ -26,9 +26,13 @@ void main() {
     bool? lastLoadUseCache;
     var modelLoadCallCount = 0;
     var failFirstWasm32StagingAbort = false;
+    var failWasm64StagingUntilRemoteFetch = false;
     late List<bool?> bridgePreferMemory64Values;
+    late List<bool?> loadForceRemoteFetchValues;
 
     setUp(() {
+      globalContext.delete('__llamadartBridgeAllowAutoRemoteFetchBackend'.toJS);
+      globalContext.delete('__llamadartBridgeForceRemoteFetchBackend'.toJS);
       bridge = JSObject();
       mmLoaded = false;
       sawAudioPart = false;
@@ -41,12 +45,15 @@ void main() {
       lastLoadUseCache = null;
       modelLoadCallCount = 0;
       failFirstWasm32StagingAbort = false;
+      failWasm64StagingUntilRemoteFetch = false;
       bridgePreferMemory64Values = <bool?>[];
+      loadForceRemoteFetchValues = <bool?>[];
 
       bridge.setProperty(
         'loadModelFromUrl'.toJS,
         ((String url, JSObject? config) {
           modelLoadCallCount += 1;
+          bool? forceRemoteFetchBackend;
           if (config != null) {
             final nBatch = config.getProperty('nBatch'.toJS);
             final nUbatch = config.getProperty('nUbatch'.toJS);
@@ -60,8 +67,21 @@ void main() {
             lastLoadUseCache = useCache.isA<JSBoolean>()
                 ? (useCache as JSBoolean).toDart
                 : null;
+            final forceRemoteFetch = config.getProperty(
+              'forceRemoteFetchBackend'.toJS,
+            );
+            forceRemoteFetchBackend = forceRemoteFetch.isA<JSBoolean>()
+                ? (forceRemoteFetch as JSBoolean).toDart
+                : null;
           }
+          loadForceRemoteFetchValues.add(forceRemoteFetchBackend);
           if (failFirstWasm32StagingAbort && modelLoadCallCount == 1) {
+            return Future<void>.error(
+              Exception('Aborted(). Build with -sASSERTIONS for more info.'),
+            ).toJS;
+          }
+          if (failWasm64StagingUntilRemoteFetch &&
+              forceRemoteFetchBackend != true) {
             return Future<void>.error(
               Exception('Aborted(). Build with -sASSERTIONS for more info.'),
             ).toJS;
@@ -227,6 +247,16 @@ void main() {
               'core_wasm32_active;core_abort;model_fs_write_loaded:1073741824;model_fs_write_abort'
                   .toJS,
             );
+          } else if (failWasm64StagingUntilRemoteFetch &&
+              loadForceRemoteFetchValues.last != true) {
+            meta.setProperty(
+              'llamadart.webgpu.core_variant'.toJS,
+              'wasm64'.toJS,
+            );
+            meta.setProperty(
+              'llamadart.webgpu.runtime_notes'.toJS,
+              'core_wasm64_active;core_abort;model_fs_write_abort'.toJS,
+            );
           }
           return meta;
         }).toJS,
@@ -269,6 +299,8 @@ void main() {
 
     tearDown(() async {
       await engine.dispose();
+      globalContext.delete('__llamadartBridgeAllowAutoRemoteFetchBackend'.toJS);
+      globalContext.delete('__llamadartBridgeForceRemoteFetchBackend'.toJS);
     });
 
     test('WebGPU load bounds Gemma 4 batches for browser memory', () async {
@@ -296,7 +328,62 @@ void main() {
 
       expect(modelLoadCallCount, 2);
       expect(bridgePreferMemory64Values, <bool?>[null, true]);
+      expect(loadForceRemoteFetchValues, <bool?>[null, false]);
     });
+
+    test(
+      'WebGPU load does not force remote fetch after wasm64 staging failure',
+      () async {
+        failWasm64StagingUntilRemoteFetch = true;
+
+        await expectLater(
+          () => engine.loadModelFromUrl(
+            'https://example.com/large-model.gguf',
+            modelParams: const ModelParams(
+              contextSize: 4096,
+              gpuLayers: 99,
+              preferMemory64: true,
+            ),
+          ),
+          throwsA(
+            isA<LlamaUnsupportedException>().having(
+              (error) => error.toString(),
+              'message',
+              allOf(
+                contains('__llamadartBridgeAllowAutoRemoteFetchBackend = true'),
+                contains('valid GGUF byte ranges'),
+              ),
+            ),
+          ),
+        );
+
+        expect(modelLoadCallCount, 1);
+        expect(loadForceRemoteFetchValues, <bool?>[null]);
+      },
+    );
+
+    test(
+      'WebGPU load retries wasm64 staging failure after explicit opt-in',
+      () async {
+        globalContext.setProperty(
+          '__llamadartBridgeAllowAutoRemoteFetchBackend'.toJS,
+          true.toJS,
+        );
+        failWasm64StagingUntilRemoteFetch = true;
+
+        await engine.loadModelFromUrl(
+          'https://example.com/large-model.gguf',
+          modelParams: const ModelParams(
+            contextSize: 4096,
+            gpuLayers: 99,
+            preferMemory64: true,
+          ),
+        );
+
+        expect(modelLoadCallCount, 2);
+        expect(loadForceRemoteFetchValues, <bool?>[null, true]);
+      },
+    );
 
     test('WebGPU load keeps Qwen3.5 0.8B browser-safe batch tuning', () async {
       await engine.loadModelFromUrl(

--- a/test/unit/backends/webgpu/webgpu_backend_test.dart
+++ b/test/unit/backends/webgpu/webgpu_backend_test.dart
@@ -1287,6 +1287,13 @@ void main() {
         const ModelParams(),
       );
 
+      final config = lastBridgeConfig as JSObject?;
+      expect(config, isNotNull);
+      final allowAutoRemoteFetchBackend = config!.getProperty(
+        'allowAutoRemoteFetchBackend'.toJS,
+      );
+      expect(allowAutoRemoteFetchBackend.isA<JSBoolean>(), isTrue);
+      expect((allowAutoRemoteFetchBackend as JSBoolean).toDart, isTrue);
       expect(lastRequestedForceRemoteFetchBackend, isTrue);
     });
 

--- a/test/unit/backends/webgpu/webgpu_backend_test.dart
+++ b/test/unit/backends/webgpu/webgpu_backend_test.dart
@@ -79,6 +79,8 @@ void main() {
       globalContext.delete('__llamadartAllowSafariWebGpu'.toJS);
       globalContext.delete('__llamadartBridgeAdaptiveSafariGpu'.toJS);
       globalContext.delete('__llamadartBridgeRemoteFetchChunkBytes'.toJS);
+      globalContext.delete('__llamadartBridgeAllowAutoRemoteFetchBackend'.toJS);
+      globalContext.delete('__llamadartBridgeForceRemoteFetchBackend'.toJS);
       globalContext.delete('__llamadartBridgeThreadPoolSize'.toJS);
     }
 
@@ -1238,6 +1240,55 @@ void main() {
         expect((remoteFetchChunkBytes as JSNumber).toDartInt, 4 * 1024 * 1024);
       },
     );
+
+    test('keeps automatic remote fetch disabled by default', () async {
+      await backend.modelLoadFromUrl(
+        'https://example.com/model.gguf',
+        const ModelParams(),
+      );
+
+      final config = lastBridgeConfig as JSObject?;
+      expect(config, isNotNull);
+      final allowAutoRemoteFetchBackend = config!.getProperty(
+        'allowAutoRemoteFetchBackend'.toJS,
+      );
+      expect(allowAutoRemoteFetchBackend.isA<JSBoolean>(), isTrue);
+      expect((allowAutoRemoteFetchBackend as JSBoolean).toDart, isFalse);
+    });
+
+    test('allows explicit automatic remote fetch opt-in', () async {
+      globalContext.setProperty(
+        '__llamadartBridgeAllowAutoRemoteFetchBackend'.toJS,
+        true.toJS,
+      );
+
+      await backend.modelLoadFromUrl(
+        'https://example.com/model.gguf',
+        const ModelParams(),
+      );
+
+      final config = lastBridgeConfig as JSObject?;
+      expect(config, isNotNull);
+      final allowAutoRemoteFetchBackend = config!.getProperty(
+        'allowAutoRemoteFetchBackend'.toJS,
+      );
+      expect(allowAutoRemoteFetchBackend.isA<JSBoolean>(), isTrue);
+      expect((allowAutoRemoteFetchBackend as JSBoolean).toDart, isTrue);
+    });
+
+    test('allows explicit forced remote fetch opt-in', () async {
+      globalContext.setProperty(
+        '__llamadartBridgeForceRemoteFetchBackend'.toJS,
+        true.toJS,
+      );
+
+      await backend.modelLoadFromUrl(
+        'https://example.com/model.gguf',
+        const ModelParams(),
+      );
+
+      expect(lastRequestedForceRemoteFetchBackend, isTrue);
+    });
 
     test('uses global remote fetch chunk override in bridge config', () async {
       globalContext.setProperty(

--- a/tool/testing/playwright_chat_app_real_model_smoke.py
+++ b/tool/testing/playwright_chat_app_real_model_smoke.py
@@ -149,7 +149,22 @@ def main() -> int:
         default="bridge",
     )
     parser.add_argument("--mem64", action="store_true")
-    parser.add_argument("--disable-auto-remote-fetch", action="store_true")
+    remote_fetch_group = parser.add_mutually_exclusive_group()
+    remote_fetch_group.add_argument(
+        "--disable-auto-remote-fetch",
+        action="store_true",
+        help="Explicitly disable automatic fetch-backed model loading.",
+    )
+    remote_fetch_group.add_argument(
+        "--allow-auto-remote-fetch",
+        action="store_true",
+        help="Allow fetch-backed loading and recovery for a controlled origin.",
+    )
+    remote_fetch_group.add_argument(
+        "--force-remote-fetch",
+        action="store_true",
+        help="Force fetch-backed loading from the first attempt for diagnostics.",
+    )
     parser.add_argument(
         "--browser-angle",
         choices=["auto", "default", "metal", "vulkan"],
@@ -159,6 +174,30 @@ def main() -> int:
     args = parser.parse_args()
     if args.expect_mmproj_cache_hit and not args.prefetch_mmproj_cache:
         parser.error("--expect-mmproj-cache-hit requires --prefetch-mmproj-cache")
+
+    remote_fetch_mode = "default"
+    remote_fetch_init = """
+        delete window.__llamadartBridgeAllowAutoRemoteFetchBackend;
+        delete window.__llamadartBridgeForceRemoteFetchBackend;
+    """
+    if args.disable_auto_remote_fetch:
+        remote_fetch_mode = "disabled"
+        remote_fetch_init = """
+            window.__llamadartBridgeAllowAutoRemoteFetchBackend = false;
+            delete window.__llamadartBridgeForceRemoteFetchBackend;
+        """
+    elif args.allow_auto_remote_fetch:
+        remote_fetch_mode = "automatic"
+        remote_fetch_init = """
+            window.__llamadartBridgeAllowAutoRemoteFetchBackend = true;
+            delete window.__llamadartBridgeForceRemoteFetchBackend;
+        """
+    elif args.force_remote_fetch:
+        remote_fetch_mode = "forced"
+        remote_fetch_init = """
+            delete window.__llamadartBridgeAllowAutoRemoteFetchBackend;
+            window.__llamadartBridgeForceRemoteFetchBackend = true;
+        """
 
     console_logs: list[dict[str, str]] = []
     page_errors: list[str] = []
@@ -196,11 +235,7 @@ def main() -> int:
         window.__llamadartBridgeThreadPoolSize = {args.thread_pool_size};
         window.__llamadartBridgeEnableMem64 = {str(args.mem64).lower()};
         window.__llamadartBridgePreferMemory64 = {str(args.mem64).lower()};
-        {
-            "window.__llamadartBridgeAllowAutoRemoteFetchBackend = false;"
-            if args.disable_auto_remote_fetch
-            else "delete window.__llamadartBridgeAllowAutoRemoteFetchBackend;"
-        }
+        {remote_fetch_init}
         window.__llamadartRealBridgeLastResponse = null;
         window.__llamadartRealBridgeLastError = null;
         window.__llamadartRealLiteRtLmLastResponse = null;
@@ -549,6 +584,10 @@ def main() -> int:
               workerFallbackReason: window.__llamadartBridgeWorkerFallbackReason ?? null,
               loadError: window.__llamadartBridgeLoadError ?? null,
               threadPoolSize: window.__llamadartBridgeThreadPoolSize ?? null,
+              allowAutoRemoteFetchBackend:
+                window.__llamadartBridgeAllowAutoRemoteFetchBackend ?? null,
+              forceRemoteFetchBackend:
+                window.__llamadartBridgeForceRemoteFetchBackend ?? null,
               liteRtLmModuleUrl: window.__llamadartLiteRtLmModuleUrl ?? null,
               liteRtLmPatched: window.LiteRtLmEngine?.__llamadartRealE2ePatched ?? null,
             })"""
@@ -566,6 +605,7 @@ def main() -> int:
             mmprojUrl=args.mmproj_url,
             expectedText=args.expect,
             bridgeResponse=bridge_response,
+            remoteFetchMode=remote_fetch_mode,
             mmprojRequestCount=len(mmproj_requests),
             bridgeGlobals=bridge_globals,
             bodyTail=body_after_response[-1200:],

--- a/tool/testing/playwright_chat_app_real_model_smoke.py
+++ b/tool/testing/playwright_chat_app_real_model_smoke.py
@@ -196,8 +196,11 @@ def main() -> int:
         window.__llamadartBridgeThreadPoolSize = {args.thread_pool_size};
         window.__llamadartBridgeEnableMem64 = {str(args.mem64).lower()};
         window.__llamadartBridgePreferMemory64 = {str(args.mem64).lower()};
-        window.__llamadartBridgeAllowAutoRemoteFetchBackend =
-            {str(not args.disable_auto_remote_fetch).lower()};
+        {
+            "window.__llamadartBridgeAllowAutoRemoteFetchBackend = false;"
+            if args.disable_auto_remote_fetch
+            else "delete window.__llamadartBridgeAllowAutoRemoteFetchBackend;"
+        }
         window.__llamadartRealBridgeLastResponse = null;
         window.__llamadartRealBridgeLastError = null;
         window.__llamadartRealLiteRtLmLastResponse = null;

--- a/website/docs/changelog/recent-releases.md
+++ b/website/docs/changelog/recent-releases.md
@@ -12,6 +12,10 @@ For canonical full release notes, use:
 - Updated WebGPU bridge assets to `v0.1.21` (llama.cpp `b10099`), restoring
   multimodal generation after recent upstream prompt-ingestion changes.
 
+- Disabled automatic WebGPU fetch-backed model loading by default. Streamed
+  loading remains the safe default, with explicit opt-in available for
+  controlled range-capable deployments.
+
 ## 0.8.17
 
 - Updated the default llama.cpp native runtime to `b10075` with matching

--- a/website/docs/changelog/recent-releases.md
+++ b/website/docs/changelog/recent-releases.md
@@ -7,6 +7,11 @@ For canonical full release notes, use:
 
 - [`CHANGELOG.md`](https://github.com/leehack/llamadart/blob/main/CHANGELOG.md)
 
+## Unreleased
+
+- Updated WebGPU bridge assets to `v0.1.21` (llama.cpp `b10099`), restoring
+  multimodal generation after recent upstream prompt-ingestion changes.
+
 ## 0.8.17
 
 - Updated the default llama.cpp native runtime to `b10075` with matching

--- a/website/docs/platforms/webgpu-bridge.md
+++ b/website/docs/platforms/webgpu-bridge.md
@@ -146,13 +146,13 @@ development validation, and CDN-first loading for normal hosted deployments:
 1. On localhost: local asset first, then CDN fallback.
 2. On hosted deployments: CDN asset first, then local fallback.
 
-The example currently pins bridge assets to `v0.1.18`, with local vendored assets
-identified as `v0.1.18-local-b9915`.
+The example currently pins bridge assets to `v0.1.21`, with local vendored assets
+identified as `v0.1.21-local-b10099`.
 
 Fetch pinned local assets with:
 
 ```bash
-WEBGPU_BRIDGE_ASSETS_TAG=v0.1.18 ./scripts/fetch_webgpu_bridge_assets.sh
+WEBGPU_BRIDGE_ASSETS_TAG=v0.1.21 ./scripts/fetch_webgpu_bridge_assets.sh
 ```
 
 To verify the loaded runtime in a browser console, inspect:
@@ -309,7 +309,7 @@ You can override bridge asset source/version before loader startup:
 ```html
 <script>
   window.__llamadartBridgeAssetsRepo = 'leehack/llama-web-bridge-assets';
-  window.__llamadartBridgeAssetsTag = 'v0.1.18';
+  window.__llamadartBridgeAssetsTag = 'v0.1.21';
   // Prefer local runtime even off localhost:
   // window.__llamadartPreferLocalBridgeRuntime = true;
   // Enable verbose bridge bootstrap console logs:

--- a/website/docs/platforms/webgpu-bridge.md
+++ b/website/docs/platforms/webgpu-bridge.md
@@ -210,11 +210,17 @@ failure:
   browser output unless CPU is explicitly requested.
 - Legacy Safari bridge assets force CPU fallback unless adaptive Safari GPU probe
   support is present or `window.__llamadartAllowSafariWebGpu = true` is set.
-- wasm64/wasm32 and remote-fetch loader retries can happen automatically when
-  bridge metadata indicates an interop or memory-pressure problem. Large
-  wasm32 model-staging aborts, including virtual-filesystem write aborts during
-  remote model/projector setup, are treated as memory pressure and retried with
-  the wasm64 core when available.
+- wasm64/wasm32 retries can happen automatically when bridge metadata indicates
+  an interop or memory-pressure problem. Large wasm32 model-staging aborts,
+  including virtual-filesystem write aborts during remote model/projector
+  setup, are treated as memory pressure and retried with the wasm64 core when
+  available, using safe streamed loading by default.
+- Fetch-backed loading and recovery retries default to disabled. A controlled
+  origin that serves valid GGUF byte ranges can opt in explicitly with
+  `window.__llamadartBridgeAllowAutoRemoteFetchBackend = true`.
+- `window.__llamadartBridgeForceRemoteFetchBackend = true` forces fetch-backed
+  loading from the first attempt and is intended for controlled diagnostics.
+  Prefer the automatic opt-in for ordinary deployments.
 
 Fallback is not silent success for every unsupported condition. If the bridge
 cannot load, the browser blocks worker threads, or the model exceeds browser
@@ -310,7 +316,10 @@ You can override bridge asset source/version before loader startup:
   // window.__llamadartBridgeBootstrapVerbose = true;
   // Optional runtime knobs:
   // window.__llamadartBridgeEnableMem64 = false;
-  // window.__llamadartBridgeAllowAutoRemoteFetchBackend = false;
+  // Explicit opt-in for controlled range-capable GGUF origins:
+  // window.__llamadartBridgeAllowAutoRemoteFetchBackend = true;
+  // Force fetch-backed loading from the first attempt (diagnostics only):
+  // window.__llamadartBridgeForceRemoteFetchBackend = true;
   // window.__llamadartBridgeRemoteFetchChunkBytes = 4 * 1024 * 1024;
   // window.__llamadartBridgeThreadPoolSize = 2;
 </script>


### PR DESCRIPTION
## Summary

- keep WebGPU fetch-backed model loading disabled by default
- require explicit opt-in before Dart recovery paths force fetch-backed loading
- preserve streamed wasm64 recovery when opt-in is absent and surface an actionable typed error for unrecoverable staging failures
- bump the WebGPU runtime to `llama-web-bridge-assets@v0.1.21`, built from bridge commit `72af67e` and llama.cpp `b10099`
- restore Qwen/Gemma multimodal prompt ingestion through the newly published bridge runtime
- document automatic versus forced opt-in behavior

## Compatibility

This changes the implicit WebGPU loader default from enabled to disabled. Apps on controlled range-capable model origins can opt in with:

- `window.__llamadartBridgeAllowAutoRemoteFetchBackend = true` to permit automatic selection and recovery
- `window.__llamadartBridgeForceRemoteFetchBackend = true` to force fetch-backed loading from the first attempt for diagnostics

No public Dart API changes.

## Validation

- `dart analyze lib/src/backends/webgpu/webgpu_backend.dart test/unit/backends/webgpu/webgpu_backend_test.dart test/integration/backends/webgpu/webgpu_engine_multimodal_browser_integration_test.dart`
- `dart analyze` (full repository)
- `dart test -p chrome --exclude-tags local-only` (738 passed, 1 skipped)
- `dart test -p chrome test/unit/backends/webgpu/webgpu_backend_test.dart` (68 passed)
- `dart test -p chrome test/integration/backends/webgpu/webgpu_engine_multimodal_browser_integration_test.dart` (10 passed)
- `python3 -m py_compile tool/testing/playwright_chat_app_real_model_smoke.py`
- `./tool/docs/validate_links.sh`
- `dart run tool/testing/verify_release_docs_versions.dart`
- published `llama-web-bridge-assets@v0.1.21` manifest verified as bridge commit `72af67e406265329f62394eec4093c3f63ebc0ff` / llama.cpp `b10099`
- deployable Flutter Web build fetched, checksum-verified, packaged, and validated with published `v0.1.21`
- hosted PR preview verified as exact final llamadart head `f67be00ea`, bridge assets `v0.1.21`, bridge source `72af67e`, and llama.cpp `b10099`
- hosted Qwen3.5 0.8B image-attachment chat smoke at `ee86721f2` and 1024 context: generated an accurate image description; no console aborts, page errors, request failures, or bridge errors
- hosted Gemma 4 E2B mem64 chat smoke at `ee86721f2` in default remote-fetch mode with both opt-in globals absent: loaded and generated `4`; no console aborts, page errors, request failures, worker fallback, or load error
- hosted final-head forced-mode Qwen3.5 smoke: loaded and generated `4`; the optional `HEAD` size probe fell back to the bridge's range request as designed, with no bridge, load, or page error
- state-persistence and multimodal forwarding remain covered by the browser integration suite

## Scope

The unrelated local native `b10099` pin and package documentation changes were intentionally excluded from this PR.
