### PR TITLE
Update native llama.cpp to b10255

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 ## Unreleased
 
+* Updated the default llama.cpp native runtime to
+  `leehack/llamadart-native@b10255`, adding explicit bundled-MTP loading and
+  automatic model-specific token suppression alongside recent model,
+  multimodal, speculative-decoding, and backend improvements. Regenerated the
+  matching Dart FFI bindings, migrated model loading to llama.cpp's load-mode
+  ABI, and refreshed the Apple SwiftPM checksum and current runtime-pin docs.
+
 * Disabled automatic WebGPU fetch-backed model loading by default. Streamed
   loading remains the safe default; controlled range-capable deployments can
   opt in explicitly.

--- a/README.md
+++ b/README.md
@@ -134,7 +134,7 @@ Current default runtime pins:
 
 | Runtime | Pin |
 | --- | --- |
-| Native llama.cpp / GGUF | `leehack/llamadart-native@b10075` |
+| Native llama.cpp / GGUF | `leehack/llamadart-native@b10255` |
 | Native LiteRT-LM / `.litertlm` | `leehack/litert-lm-native@v0.14.0-native.2` |
 | Web llama.cpp / GGUF | `leehack/llama-web-bridge-assets@v0.1.21` |
 | Web LiteRT-LM / `.litertlm` | `@litert-lm/core@0.14.0` |

--- a/doc/testing_matrix.md
+++ b/doc/testing_matrix.md
@@ -180,9 +180,11 @@ dart run tool/testing/run_local_e2e.dart \
   --ngram-cache-build-static-path /tmp/llamadart-ngram-cache.bin
 ```
 
-In the local E2E scenario, draft-model strategies require
-`--draft-model-path`; the n-gram cache strategy can use existing cache paths or
-build a static cache with `--ngram-cache-build-static-path`.
+In the local E2E scenario, external draft-model strategies require
+`--draft-model-path`. Bundled MTP uses `draft-mtp` without that option; the
+runner then loads the target with `ModelParams.loadMtp` automatically. The
+n-gram cache strategy can use existing cache paths or build a static cache with
+`--ngram-cache-build-static-path`.
 For `ngram-simple`, `ngram-map-k`, and `ngram-map-k4v`, `--ngram-size-m`
 sweeps the effective n-gram draft length; `--draft-token-max` is still useful
 for draft-model, ngram-cache, and mixed draft-model cases. Use

--- a/hook/build.dart
+++ b/hook/build.dart
@@ -13,7 +13,7 @@ import 'package:path/path.dart' as path;
 
 import 'package:llamadart/src/hook/native_bundle_config.dart';
 
-const _llamaCppTag = 'b10075';
+const _llamaCppTag = 'b10255';
 const _nativeRepoSlug = 'leehack/llamadart-native';
 
 const _packageName = 'llamadart';

--- a/lib/src/backends/llama_cpp/bindings.dart
+++ b/lib/src/backends/llama_cpp/bindings.dart
@@ -30,6 +30,22 @@ ffi.Pointer<ffi.Char> llama_flash_attn_type_name(
   llama_flash_attn_type flash_attn_type,
 ) => _llama_flash_attn_type_name(flash_attn_type.value);
 
+@ffi.Native<ffi.Pointer<ffi.Char> Function(ffi.UnsignedInt)>(
+  symbol: 'llama_load_mode_name',
+)
+external ffi.Pointer<ffi.Char> _llama_load_mode_name(int load_mode);
+
+ffi.Pointer<ffi.Char> llama_load_mode_name(llama_load_mode load_mode) =>
+    _llama_load_mode_name(load_mode.value);
+
+@ffi.Native<ffi.UnsignedInt Function(ffi.Pointer<ffi.Char>)>(
+  symbol: 'llama_load_mode_from_str',
+)
+external int _llama_load_mode_from_str(ffi.Pointer<ffi.Char> str);
+
+llama_load_mode llama_load_mode_from_str(ffi.Pointer<ffi.Char> str) =>
+    llama_load_mode.fromValue(_llama_load_mode_from_str(str));
+
 @ffi.Native<llama_model_params Function()>()
 external llama_model_params llama_model_default_params();
 
@@ -1032,6 +1048,17 @@ external bool llama_vocab_get_add_eos(ffi.Pointer<llama_vocab> vocab);
 
 @ffi.Native<ffi.Bool Function(ffi.Pointer<llama_vocab>)>()
 external bool llama_vocab_get_add_sep(ffi.Pointer<llama_vocab> vocab);
+
+@ffi.Native<
+  ffi.Pointer<llama_token> Function(
+    ffi.Pointer<llama_vocab>,
+    ffi.Pointer<ffi.Int32>,
+  )
+>()
+external ffi.Pointer<llama_token> llama_vocab_get_suppress_tokens(
+  ffi.Pointer<llama_vocab> vocab,
+  ffi.Pointer<ffi.Int32> n_suppress_tokens,
+);
 
 @ffi.Native<llama_token Function(ffi.Pointer<llama_vocab>)>()
 external int llama_vocab_fim_pre(ffi.Pointer<llama_vocab> vocab);
@@ -8519,6 +8546,9 @@ final class llama_sampler_data extends ffi.Struct {
   external ffi.Pointer<ggml_tensor> sampled;
 
   external ffi.Pointer<ggml_tensor> candidates;
+
+  @ffi.Int64()
+  external int n_vocab;
 }
 
 final class llama_sampler_i extends ffi.Struct {
@@ -8909,6 +8939,26 @@ enum llama_split_mode {
   };
 }
 
+enum llama_load_mode {
+  LLAMA_LOAD_MODE_NONE(0),
+  LLAMA_LOAD_MODE_MMAP(1),
+  LLAMA_LOAD_MODE_MLOCK(2),
+  LLAMA_LOAD_MODE_MMAP_MLOCK(3),
+  LLAMA_LOAD_MODE_DIRECT_IO(4);
+
+  final int value;
+  const llama_load_mode(this.value);
+
+  static llama_load_mode fromValue(int value) => switch (value) {
+    0 => LLAMA_LOAD_MODE_NONE,
+    1 => LLAMA_LOAD_MODE_MMAP,
+    2 => LLAMA_LOAD_MODE_MLOCK,
+    3 => LLAMA_LOAD_MODE_MMAP_MLOCK,
+    4 => LLAMA_LOAD_MODE_DIRECT_IO,
+    _ => throw ArgumentError('Unknown value for llama_load_mode: $value'),
+  };
+}
+
 enum llama_context_type {
   LLAMA_CONTEXT_TYPE_DEFAULT(0),
   LLAMA_CONTEXT_TYPE_MTP(1);
@@ -9052,6 +9102,11 @@ final class llama_model_params extends ffi.Struct {
   llama_split_mode get split_mode =>
       llama_split_mode.fromValue(split_modeAsInt);
 
+  @ffi.UnsignedInt()
+  external int load_modeAsInt;
+
+  llama_load_mode get load_mode => llama_load_mode.fromValue(load_modeAsInt);
+
   @ffi.Int32()
   external int main_gpu;
 
@@ -9067,15 +9122,6 @@ final class llama_model_params extends ffi.Struct {
   external bool vocab_only;
 
   @ffi.Bool()
-  external bool use_mmap;
-
-  @ffi.Bool()
-  external bool use_direct_io;
-
-  @ffi.Bool()
-  external bool use_mlock;
-
-  @ffi.Bool()
   external bool check_tensors;
 
   @ffi.Bool()
@@ -9086,6 +9132,9 @@ final class llama_model_params extends ffi.Struct {
 
   @ffi.Bool()
   external bool no_alloc;
+
+  @ffi.Bool()
+  external bool load_mtp;
 }
 
 final class llama_sampler_seq_config extends ffi.Struct {
@@ -9366,91 +9415,89 @@ typedef llama_model_set_tensor_data_t =
 
 final class gguf_context extends ffi.Opaque {}
 
-final class _IO_marker extends ffi.Opaque {}
-
-typedef __off_t = ffi.Long;
-typedef Dart__off_t = int;
-typedef _IO_lock_t = ffi.Void;
-typedef Dart_IO_lock_t = void;
-typedef __off64_t = ffi.Long;
-typedef Dart__off64_t = int;
-
-final class _IO_codecvt extends ffi.Opaque {}
-
-final class _IO_wide_data extends ffi.Opaque {}
-
-final class _IO_FILE extends ffi.Struct {
-  @ffi.Int()
-  external int _flags;
-
-  external ffi.Pointer<ffi.Char> _IO_read_ptr;
-
-  external ffi.Pointer<ffi.Char> _IO_read_end;
-
-  external ffi.Pointer<ffi.Char> _IO_read_base;
-
-  external ffi.Pointer<ffi.Char> _IO_write_base;
-
-  external ffi.Pointer<ffi.Char> _IO_write_ptr;
-
-  external ffi.Pointer<ffi.Char> _IO_write_end;
-
-  external ffi.Pointer<ffi.Char> _IO_buf_base;
-
-  external ffi.Pointer<ffi.Char> _IO_buf_end;
-
-  external ffi.Pointer<ffi.Char> _IO_save_base;
-
-  external ffi.Pointer<ffi.Char> _IO_backup_base;
-
-  external ffi.Pointer<ffi.Char> _IO_save_end;
-
-  external ffi.Pointer<_IO_marker> _markers;
-
-  external ffi.Pointer<_IO_FILE> _chain;
+final class __sbuf extends ffi.Struct {
+  external ffi.Pointer<ffi.UnsignedChar> _base;
 
   @ffi.Int()
-  external int _fileno;
-
-  @ffi.Int()
-  external int _flags2;
-
-  @__off_t()
-  external int _old_offset;
-
-  @ffi.UnsignedShort()
-  external int _cur_column;
-
-  @ffi.SignedChar()
-  external int _vtable_offset;
-
-  @ffi.Array.multi([1])
-  external ffi.Array<ffi.Char> _shortbuf;
-
-  external ffi.Pointer<_IO_lock_t> _lock;
-
-  @__off64_t()
-  external int _offset;
-
-  external ffi.Pointer<_IO_codecvt> _codecvt;
-
-  external ffi.Pointer<_IO_wide_data> _wide_data;
-
-  external ffi.Pointer<_IO_FILE> _freeres_list;
-
-  external ffi.Pointer<ffi.Void> _freeres_buf;
-
-  @ffi.Size()
-  external int __pad5;
-
-  @ffi.Int()
-  external int _mode;
-
-  @ffi.Array.multi([20])
-  external ffi.Array<ffi.Char> _unused2;
+  external int _size;
 }
 
-typedef FILE = _IO_FILE;
+typedef __int64_t = ffi.LongLong;
+typedef Dart__int64_t = int;
+typedef __darwin_off_t = __int64_t;
+typedef fpos_t = __darwin_off_t;
+
+final class __sFILEX extends ffi.Opaque {}
+
+final class __sFILE extends ffi.Struct {
+  external ffi.Pointer<ffi.UnsignedChar> _p;
+
+  @ffi.Int()
+  external int _r;
+
+  @ffi.Int()
+  external int _w;
+
+  @ffi.Short()
+  external int _flags;
+
+  @ffi.Short()
+  external int _file;
+
+  external __sbuf _bf;
+
+  @ffi.Int()
+  external int _lbfsize;
+
+  external ffi.Pointer<ffi.Void> _cookie;
+
+  external ffi.Pointer<
+    ffi.NativeFunction<ffi.Int Function(ffi.Pointer<ffi.Void>)>
+  >
+  _close;
+
+  external ffi.Pointer<
+    ffi.NativeFunction<
+      ffi.Int Function(ffi.Pointer<ffi.Void>, ffi.Pointer<ffi.Char>, ffi.Int)
+    >
+  >
+  _read;
+
+  external ffi.Pointer<
+    ffi.NativeFunction<fpos_t Function(ffi.Pointer<ffi.Void>, fpos_t, ffi.Int)>
+  >
+  _seek;
+
+  external ffi.Pointer<
+    ffi.NativeFunction<
+      ffi.Int Function(ffi.Pointer<ffi.Void>, ffi.Pointer<ffi.Char>, ffi.Int)
+    >
+  >
+  _write;
+
+  external __sbuf _ub;
+
+  external ffi.Pointer<__sFILEX> _extra;
+
+  @ffi.Int()
+  external int _ur;
+
+  @ffi.Array.multi([3])
+  external ffi.Array<ffi.UnsignedChar> _ubuf;
+
+  @ffi.Array.multi([1])
+  external ffi.Array<ffi.UnsignedChar> _nbuf;
+
+  external __sbuf _lb;
+
+  @ffi.Int()
+  external int _blksize;
+
+  @fpos_t()
+  external int _offset;
+}
+
+typedef FILE = __sFILE;
 typedef llama_state_seq_flags = ffi.Uint32;
 typedef Dartllama_state_seq_flags = int;
 

--- a/lib/src/backends/llama_cpp/llama_cpp_service.dart
+++ b/lib/src/backends/llama_cpp/llama_cpp_service.dart
@@ -1941,8 +1941,9 @@ class LlamaCppService {
       );
     }
 
+    final model = _createModelWrapper(modelPtr, sourcePath: modelPath);
     final handle = _getHandle();
-    _models[handle] = _LlamaModelWrapper(modelPtr, sourcePath: modelPath);
+    _models[handle] = model;
     _loraAdapters[handle] = {};
     _modelToMtmdUseGpu[handle] = mtmdUseGpu;
     final resolvedBackend = _resolveBackendNameForLoad(
@@ -2054,7 +2055,7 @@ class LlamaCppService {
       );
     }
 
-    final wrapper = _LlamaModelWrapper(modelPtr, sourcePath: draftModelPath);
+    final wrapper = _createModelWrapper(modelPtr, sourcePath: draftModelPath);
     _speculativeDraftModels[cacheKey] = wrapper;
     _modelToSpeculativeDraftModelKeys
         .putIfAbsent(targetModelHandle, () => <String>{})
@@ -2091,6 +2092,24 @@ class LlamaCppService {
         return _resolveExplicitBackendName(GpuBackend.opencl, backendInfo);
       case GpuBackend.hip:
         return _resolveExplicitBackendName(GpuBackend.hip, backendInfo);
+    }
+  }
+
+  _LlamaModelWrapper _createModelWrapper(
+    Pointer<llama_model> modelPointer, {
+    required String sourcePath,
+  }) {
+    try {
+      final vocab = llama_model_get_vocab(modelPointer);
+      return _LlamaModelWrapper(
+        modelPointer,
+        sourcePath: sourcePath,
+        vocabSize: llama_vocab_n_tokens(vocab),
+        suppressedTokens: readModelSuppressTokens(vocab),
+      );
+    } catch (_) {
+      llama_model_free(modelPointer);
+      rethrow;
     }
   }
 
@@ -4388,6 +4407,8 @@ class LlamaCppService {
       sampler = _initializeSampler(
         params,
         vocab,
+        model.vocabSize,
+        model.suppressedTokens,
         grammarPtr,
         rootPtr,
         lazyGrammarConfig,
@@ -5408,6 +5429,8 @@ class LlamaCppService {
   Pointer<llama_sampler> _initializeSampler(
     GenerationParams params,
     Pointer<llama_vocab> vocab,
+    int vocabSize,
+    List<int> suppressedTokens,
     Pointer<Utf8> grammarPtr,
     Pointer<Utf8> rootPtr,
     _LazyGrammarConfig? lazyGrammarConfig,
@@ -5429,29 +5452,18 @@ class LlamaCppService {
     );
     llama_sampler_chain_add(sampler, penaltiesSampler);
 
-    final suppressCountPtr = calloc<Int32>();
-    try {
-      final suppressTokens = llama_vocab_get_suppress_tokens(
-        vocab,
-        suppressCountPtr,
+    if (suppressedTokens.isNotEmpty) {
+      final suppressSampler = createSuppressTokensSampler(
+        vocabSize,
+        suppressedTokens,
       );
-      final suppressCount = suppressCountPtr.value;
-      if (suppressTokens != nullptr && suppressCount > 0) {
-        final suppressSampler = createSuppressTokensSampler(
-          llama_vocab_n_tokens(vocab),
-          <int>[for (int i = 0; i < suppressCount; i++) suppressTokens[i]],
+      if (suppressSampler == nullptr) {
+        llama_sampler_free(sampler);
+        throw LlamaInferenceException(
+          'llama.cpp failed to initialize model-specific suppressed tokens.',
         );
-        if (suppressSampler == nullptr) {
-          llama_sampler_free(sampler);
-          throw LlamaInferenceException(
-            'llama.cpp failed to initialize model-specific suppressed '
-            'tokens.',
-          );
-        }
-        llama_sampler_chain_add(sampler, suppressSampler);
       }
-    } finally {
-      calloc.free(suppressCountPtr);
+      llama_sampler_chain_add(sampler, suppressSampler);
     }
 
     Pointer<llama_sampler> grammarSampler = nullptr;
@@ -8916,7 +8928,14 @@ class _LlamaLoraWrapper {
 class _LlamaModelWrapper {
   final Pointer<llama_model> pointer;
   final String? sourcePath;
-  _LlamaModelWrapper(this.pointer, {this.sourcePath});
+  final int vocabSize;
+  final List<int> suppressedTokens;
+  _LlamaModelWrapper(
+    this.pointer, {
+    this.sourcePath,
+    required this.vocabSize,
+    required this.suppressedTokens,
+  });
   void dispose() {
     llama_model_free(pointer);
   }

--- a/lib/src/backends/llama_cpp/llama_cpp_service.dart
+++ b/lib/src/backends/llama_cpp/llama_cpp_service.dart
@@ -731,6 +731,8 @@ class _LlamaCppSpeculativeConfig {
         strategy == SpeculativeDecodingStrategy.draftDflash,
   );
 
+  bool get usesMtp => strategies.contains(SpeculativeDecodingStrategy.mtp);
+
   bool get suppressDraftProcessLogits => strategies.any(
     (strategy) =>
         strategy == SpeculativeDecodingStrategy.draftSimple ||
@@ -1979,16 +1981,18 @@ class LlamaCppService {
     int targetModelHandle,
     String draftModelPath,
     int resolvedGpuLayers,
+    bool loadMtp,
   ) {
     final normalizedPath = File(draftModelPath).absolute.path;
-    return '$targetModelHandle\x00$normalizedPath\x00$resolvedGpuLayers';
+    return '$targetModelHandle\x00$normalizedPath\x00$resolvedGpuLayers\x00$loadMtp';
   }
 
   _LlamaModelWrapper _loadSpeculativeDraftModel(
     int targetModelHandle,
     String draftModelPath,
-    String label,
-  ) {
+    String label, {
+    required bool loadMtp,
+  }) {
     final modelFileSize = _validateGgufModelFile(draftModelPath, label);
     final targetModelParams =
         _modelLoadParams[targetModelHandle] ?? const ModelParams();
@@ -2011,6 +2015,7 @@ class LlamaCppService {
       targetModelHandle,
       draftModelPath,
       draftGpuLayers,
+      loadMtp,
     );
 
     final cached = _speculativeDraftModels[cacheKey];
@@ -2026,7 +2031,7 @@ class LlamaCppService {
     mparams.n_gpu_layers = draftGpuLayers;
     mparams.split_modeAsInt = targetModelParams.splitMode.llamaCppValue;
     mparams.main_gpu = targetModelParams.mainGpu;
-    applyModelParams(mparams, targetModelParams);
+    applyModelParams(mparams, targetModelParams.copyWith(loadMtp: loadMtp));
     if (preferredDevices != null) {
       mparams.devices = preferredDevices;
     }
@@ -4085,6 +4090,33 @@ class LlamaCppService {
     )?.typeNames;
   }
 
+  void _validateMtpModelLoad(
+    _LlamaCppSpeculativeConfig? config,
+    ModelParams modelParams,
+  ) {
+    if (config?.usesMtp == true &&
+        config?.draftModelPath == null &&
+        !modelParams.loadMtp) {
+      throw LlamaUnsupportedException(
+        'Bundled MTP speculative decoding requires the model to be loaded '
+        'with ModelParams(loadMtp: true). Reload the target model with MTP '
+        'tensors enabled, or provide a compatible external draftModelPath.',
+      );
+    }
+  }
+
+  /// Validates bundled MTP model-loading requirements for unit tests.
+  void debugValidateMtpModelLoadForTesting(
+    GenerationParams params,
+    ModelParams modelParams, {
+    bool hasMediaParts = false,
+  }) {
+    _validateMtpModelLoad(
+      _resolveLlamaCppSpeculativeConfig(params, hasMediaParts: hasMediaParts),
+      modelParams,
+    );
+  }
+
   /// Validates a llama.cpp thinking budget for unit tests.
   void debugValidateThinkingBudgetForTesting(
     GenerationParams params, {
@@ -4235,6 +4267,10 @@ class LlamaCppService {
         params,
         hasMediaParts: hasMediaParts,
       );
+      _validateMtpModelLoad(
+        speculativeConfig,
+        _modelLoadParams[modelHandle] ?? const ModelParams(),
+      );
       final reasoningBudgetApi = thinkingBudgetConfig == null
           ? null
           : _resolveReasoningBudgetApi();
@@ -4269,6 +4305,7 @@ class LlamaCppService {
                 modelHandle,
                 draftModelPath,
                 'speculative draft model',
+                loadMtp: speculativeConfig.usesMtp,
               );
         speculativeSession = speculativeApi.initSession(
           targetModel: model.pointer,
@@ -5391,6 +5428,31 @@ class LlamaCppService {
       penaltyConfig.presence,
     );
     llama_sampler_chain_add(sampler, penaltiesSampler);
+
+    final suppressCountPtr = calloc<Int32>();
+    try {
+      final suppressTokens = llama_vocab_get_suppress_tokens(
+        vocab,
+        suppressCountPtr,
+      );
+      final suppressCount = suppressCountPtr.value;
+      if (suppressTokens != nullptr && suppressCount > 0) {
+        final suppressSampler = createSuppressTokensSampler(
+          llama_vocab_n_tokens(vocab),
+          <int>[for (int i = 0; i < suppressCount; i++) suppressTokens[i]],
+        );
+        if (suppressSampler == nullptr) {
+          llama_sampler_free(sampler);
+          throw LlamaInferenceException(
+            'llama.cpp failed to initialize model-specific suppressed '
+            'tokens.',
+          );
+        }
+        llama_sampler_chain_add(sampler, suppressSampler);
+      }
+    } finally {
+      calloc.free(suppressCountPtr);
+    }
 
     Pointer<llama_sampler> grammarSampler = nullptr;
     final useLazyGrammar = params.grammarLazy && lazyGrammarConfig != null;

--- a/lib/src/backends/llama_cpp/load_param_helpers.dart
+++ b/lib/src/backends/llama_cpp/load_param_helpers.dart
@@ -2,6 +2,10 @@
 // they can be unit-tested without going through `LlamaEngine.loadModel`,
 // which is integration-level and needs a real model file.
 
+import 'dart:ffi';
+
+import 'package:ffi/ffi.dart';
+
 import '../../core/models/config/flash_attention.dart';
 import '../../core/models/config/kv_cache_type.dart';
 import '../../core/models/config/llama_cpp_param_values.dart'
@@ -18,12 +22,43 @@ ggml_type ggmlTypeFor(KvCacheType type) {
   return ggml_type.fromValue(llama_cpp_values.ggmlTypeValueFor(type));
 }
 
+/// Creates a llama.cpp logit-bias sampler that suppresses [tokens].
+///
+/// The native sampler copies the bias entries before this function releases
+/// its temporary allocation. Returns `nullptr` when [tokens] is empty.
+Pointer<llama_sampler> createSuppressTokensSampler(
+  int vocabSize,
+  List<int> tokens,
+) {
+  if (tokens.isEmpty) {
+    return nullptr;
+  }
+
+  final biases = calloc<llama_logit_bias>(tokens.length);
+  try {
+    for (int i = 0; i < tokens.length; i++) {
+      biases[i]
+        ..token = tokens[i]
+        ..bias = double.negativeInfinity;
+    }
+    return llama_sampler_init_logit_bias(vocabSize, tokens.length, biases);
+  } finally {
+    calloc.free(biases);
+  }
+}
+
 /// Applies the user-controlled fields of [params] to a freshly-defaulted
 /// `llama_model_params` struct. Pure function: caller is responsible for
 /// initialising and freeing the struct.
 void applyModelParams(llama_model_params mparams, ModelParams params) {
-  mparams.use_mmap = params.useMmap;
-  mparams.use_mlock = params.useMlock;
+  final loadMode = switch ((params.useMmap, params.useMlock)) {
+    (false, false) => llama_load_mode.LLAMA_LOAD_MODE_NONE,
+    (true, false) => llama_load_mode.LLAMA_LOAD_MODE_MMAP,
+    (false, true) => llama_load_mode.LLAMA_LOAD_MODE_MLOCK,
+    (true, true) => llama_load_mode.LLAMA_LOAD_MODE_MMAP_MLOCK,
+  };
+  mparams.load_modeAsInt = loadMode.value;
+  mparams.load_mtp = params.loadMtp;
 }
 
 /// Applies the user-controlled fields of [params] to a `llama_context_params`

--- a/lib/src/backends/llama_cpp/load_param_helpers.dart
+++ b/lib/src/backends/llama_cpp/load_param_helpers.dart
@@ -1,6 +1,6 @@
-// Pure helpers for the load path. Kept here (vs inlined in the service) so
-// they can be unit-tested without going through `LlamaEngine.loadModel`,
-// which is integration-level and needs a real model file.
+// Focused helpers for native model loading and sampler setup. Kept here (vs
+// inlined in the service) so they can be unit-tested without going through
+// `LlamaEngine.loadModel`, which is integration-level and needs a real model.
 
 import 'dart:ffi';
 
@@ -44,6 +44,36 @@ Pointer<llama_sampler> createSuppressTokensSampler(
     return llama_sampler_init_logit_bias(vocabSize, tokens.length, biases);
   } finally {
     calloc.free(biases);
+  }
+}
+
+/// Signature used to read model-defined suppress-token metadata from llama.cpp.
+typedef SuppressTokensGetter =
+    Pointer<llama_token> Function(Pointer<llama_vocab>, Pointer<Int32>);
+
+/// Copies model-defined suppress-token metadata into an immutable Dart list.
+///
+/// Call this once while initializing a loaded model, then reuse the returned
+/// list when constructing sampler chains. The native token pointer remains
+/// owned by llama.cpp.
+List<int> readModelSuppressTokens(
+  Pointer<llama_vocab> vocab, {
+  SuppressTokensGetter? getSuppressTokens,
+}) {
+  final countPointer = calloc<Int32>();
+  try {
+    final tokensPointer =
+        (getSuppressTokens ?? llama_vocab_get_suppress_tokens)(
+          vocab,
+          countPointer,
+        );
+    final count = countPointer.value;
+    if (tokensPointer == nullptr || count <= 0) {
+      return const <int>[];
+    }
+    return List<int>.unmodifiable(tokensPointer.asTypedList(count));
+  } finally {
+    calloc.free(countPointer);
   }
 }
 

--- a/lib/src/core/models/inference/model_params.dart
+++ b/lib/src/core/models/inference/model_params.dart
@@ -215,11 +215,24 @@ class ModelParams {
   /// architectures.
   final int speculativeRollbackTokenMax;
 
-  /// `llama_model_params.use_mmap`. Default `true`.
+  /// Whether llama.cpp should memory-map model weights. Default `true`.
+  ///
+  /// Combined with [useMlock] and mapped to `llama_model_params.load_mode`.
   final bool useMmap;
 
-  /// `llama_model_params.use_mlock`. Default `false`.
+  /// Whether llama.cpp should lock model weights in memory. Default `false`.
+  ///
+  /// Combined with [useMmap] and mapped to `llama_model_params.load_mode`.
   final bool useMlock;
+
+  /// Whether llama.cpp should load bundled multi-token prediction tensors.
+  ///
+  /// Defaults to `false` to avoid the additional memory cost for callers that
+  /// do not use MTP speculative decoding. Set this before loading a model when
+  /// `SpeculativeDecodingStrategy.mtp` will use MTP tensors embedded in the
+  /// target GGUF. Explicit external MTP draft models are loaded as MTP
+  /// automatically.
+  final bool loadMtp;
 
   /// `llama_context_params.flash_attn_type`. User-explicit values override
   /// the platform/backend heuristic.
@@ -294,6 +307,7 @@ class ModelParams {
     this.speculativeRollbackTokenMax = 0,
     this.useMmap = true,
     this.useMlock = false,
+    this.loadMtp = false,
     this.flashAttention = FlashAttention.auto,
     this.cacheTypeK = KvCacheType.f16,
     this.cacheTypeV = KvCacheType.f16,
@@ -376,6 +390,7 @@ class ModelParams {
     int? speculativeRollbackTokenMax,
     bool? useMmap,
     bool? useMlock,
+    bool? loadMtp,
     FlashAttention? flashAttention,
     KvCacheType? cacheTypeK,
     KvCacheType? cacheTypeV,
@@ -424,6 +439,7 @@ class ModelParams {
           speculativeRollbackTokenMax ?? this.speculativeRollbackTokenMax,
       useMmap: useMmap ?? this.useMmap,
       useMlock: useMlock ?? this.useMlock,
+      loadMtp: loadMtp ?? this.loadMtp,
       flashAttention: flashAttention ?? this.flashAttention,
       cacheTypeK: cacheTypeK ?? this.cacheTypeK,
       cacheTypeV: cacheTypeV ?? this.cacheTypeV,

--- a/packages/llamadart_llama_cpp_flutter/CHANGELOG.md
+++ b/packages/llamadart_llama_cpp_flutter/CHANGELOG.md
@@ -1,3 +1,7 @@
+## Unreleased
+
+* Updated Apple SwiftPM native pin to `leehack/llamadart-native@b10255`.
+
 ## 0.0.11
 
 * Updated Apple SwiftPM native pin to `leehack/llamadart-native@b10075`.

--- a/packages/llamadart_llama_cpp_flutter/README.md
+++ b/packages/llamadart_llama_cpp_flutter/README.md
@@ -16,7 +16,7 @@ dependencies:
 This package has no runtime Dart API of its own. Import `package:llamadart`
 normally from the core package and use `LlamaBackend()` / `LlamaEngine` there.
 
-The Apple SwiftPM manifest pins `leehack/llamadart-native@b10075`.
+The Apple SwiftPM manifest pins `leehack/llamadart-native@b10255`.
 
 Source for this package lives in
 `packages/llamadart_llama_cpp_flutter` in the

--- a/packages/llamadart_llama_cpp_flutter/darwin/llamadart_llama_cpp_flutter/Package.swift
+++ b/packages/llamadart_llama_cpp_flutter/darwin/llamadart_llama_cpp_flutter/Package.swift
@@ -4,7 +4,7 @@ import PackageDescription
 
 let packageRoot = URL(fileURLWithPath: #filePath).deletingLastPathComponent()
 let artifactsRoot = packageRoot.appendingPathComponent("Artifacts")
-let llamaCppTag = "b10075"
+let llamaCppTag = "b10255"
 
 func localArtifactPath(_ name: String) -> String? {
     let path = artifactsRoot.appendingPathComponent(name).path
@@ -47,7 +47,7 @@ let package = Package(
             repository: "leehack/llamadart-native",
             artifactName: "llamadart-native-apple-xcframework-\(llamaCppTag).zip",
             tag: llamaCppTag,
-            checksum: "ebf16d33d41fc0e89ab4215c2d876815581034ff0089fc5222fa06f1cf5383cd"
+            checksum: "3167cf79774ae057c305698ee8402ecc506654dc901dfba94a49490330727b7a"
         ),
         .target(
             name: "llamadart_llama_cpp_flutter",

--- a/test/unit/backends/llama_cpp/llama_cpp_service_test.dart
+++ b/test/unit/backends/llama_cpp/llama_cpp_service_test.dart
@@ -323,6 +323,47 @@ void main() {
       );
     });
 
+    test('requires loadMtp for bundled MTP tensors', () {
+      const generationParams = GenerationParams(
+        speculativeDecodingConfig: SpeculativeDecodingConfig.mtp(),
+      );
+
+      expect(
+        () => service.debugValidateMtpModelLoadForTesting(
+          generationParams,
+          const ModelParams(),
+        ),
+        throwsA(
+          isA<LlamaUnsupportedException>().having(
+            (error) => error.message,
+            'message',
+            contains('ModelParams(loadMtp: true)'),
+          ),
+        ),
+      );
+      expect(
+        () => service.debugValidateMtpModelLoadForTesting(
+          generationParams,
+          const ModelParams(loadMtp: true),
+        ),
+        returnsNormally,
+      );
+    });
+
+    test('external MTP draft does not require target bundled tensors', () {
+      expect(
+        () => service.debugValidateMtpModelLoadForTesting(
+          const GenerationParams(
+            speculativeDecodingConfig: SpeculativeDecodingConfig.mtp(
+              draftModelPath: 'draft.gguf',
+            ),
+          ),
+          const ModelParams(),
+        ),
+        returnsNormally,
+      );
+    });
+
     test('temporarily zeros and restores suppressed batch logits', () {
       final logits = malloc<Int8>(3);
       addTearDown(() => malloc.free(logits));

--- a/test/unit/backends/llama_cpp/load_param_helpers_test.dart
+++ b/test/unit/backends/llama_cpp/load_param_helpers_test.dart
@@ -106,25 +106,100 @@ void main() {
   });
 
   group('applyModelParams', () {
-    test('writes use_mmap and use_mlock from params', () {
+    test('maps mmap and mlock combinations to llama.cpp load modes', () {
+      final cases = <({bool useMmap, bool useMlock, llama_load_mode expected})>[
+        (
+          useMmap: false,
+          useMlock: false,
+          expected: llama_load_mode.LLAMA_LOAD_MODE_NONE,
+        ),
+        (
+          useMmap: true,
+          useMlock: false,
+          expected: llama_load_mode.LLAMA_LOAD_MODE_MMAP,
+        ),
+        (
+          useMmap: false,
+          useMlock: true,
+          expected: llama_load_mode.LLAMA_LOAD_MODE_MLOCK,
+        ),
+        (
+          useMmap: true,
+          useMlock: true,
+          expected: llama_load_mode.LLAMA_LOAD_MODE_MMAP_MLOCK,
+        ),
+      ];
+
+      for (final testCase in cases) {
+        final m = calloc<llama_model_params>();
+        try {
+          applyModelParams(
+            m.ref,
+            ModelParams(useMmap: testCase.useMmap, useMlock: testCase.useMlock),
+          );
+          expect(m.ref.load_mode, testCase.expected);
+        } finally {
+          calloc.free(m);
+        }
+      }
+    });
+
+    test('default ModelParams selects mmap load mode', () {
       final m = calloc<llama_model_params>();
       try {
-        applyModelParams(m.ref, ModelParams(useMmap: false, useMlock: true));
-        expect(m.ref.use_mmap, isFalse);
-        expect(m.ref.use_mlock, isTrue);
+        applyModelParams(m.ref, ModelParams());
+        expect(m.ref.load_mode, llama_load_mode.LLAMA_LOAD_MODE_MMAP);
+        expect(m.ref.load_mtp, isFalse);
       } finally {
         calloc.free(m);
       }
     });
 
-    test('default ModelParams writes mmap=true, mlock=false', () {
+    test('maps the bundled MTP loading opt-in', () {
       final m = calloc<llama_model_params>();
       try {
-        applyModelParams(m.ref, ModelParams());
-        expect(m.ref.use_mmap, isTrue);
-        expect(m.ref.use_mlock, isFalse);
+        applyModelParams(m.ref, const ModelParams(loadMtp: true));
+        expect(m.ref.load_mtp, isTrue);
       } finally {
         calloc.free(m);
+      }
+    });
+  });
+
+  group('createSuppressTokensSampler', () {
+    test('returns nullptr for an empty token list', () {
+      expect(createSuppressTokensSampler(4, const []), nullptr);
+    });
+
+    test('sets model-suppressed token logits to negative infinity', () {
+      final sampler = createSuppressTokensSampler(4, const [1, 3]);
+      expect(sampler, isNot(nullptr));
+
+      final candidates = calloc<llama_token_data>(4);
+      final candidateArray = calloc<llama_token_data_array>();
+      try {
+        for (int i = 0; i < 4; i++) {
+          candidates[i]
+            ..id = i
+            ..logit = i.toDouble()
+            ..p = 0;
+        }
+        candidateArray.ref
+          ..data = candidates
+          ..size = 4
+          ..selected = -1
+          ..sorted = false;
+
+        llama_sampler_apply(sampler, candidateArray);
+
+        expect(candidates[0].logit, 0);
+        expect(candidates[1].logit, double.negativeInfinity);
+        expect(candidates[2].logit, 2);
+        expect(candidates[3].logit, double.negativeInfinity);
+      } finally {
+        calloc.free(candidateArray);
+        calloc.free(candidates);
+        llama_sampler_free(sampler);
       }
     });
   });

--- a/test/unit/backends/llama_cpp/load_param_helpers_test.dart
+++ b/test/unit/backends/llama_cpp/load_param_helpers_test.dart
@@ -204,6 +204,43 @@ void main() {
     });
   });
 
+  group('readModelSuppressTokens', () {
+    test('copies metadata once into an immutable Dart list', () {
+      final nativeTokens = calloc<llama_token>(2);
+      addTearDown(() => calloc.free(nativeTokens));
+      nativeTokens[0] = 1;
+      nativeTokens[1] = 3;
+      var calls = 0;
+
+      final tokens = readModelSuppressTokens(
+        nullptr,
+        getSuppressTokens: (_, countPointer) {
+          calls++;
+          countPointer.value = 2;
+          return nativeTokens;
+        },
+      );
+
+      nativeTokens[0] = 2;
+      expect(calls, 1);
+      expect(tokens, const <int>[1, 3]);
+      expect(() => tokens.add(4), throwsUnsupportedError);
+    });
+
+    test('returns the shared empty list when metadata is absent', () {
+      final tokens = readModelSuppressTokens(
+        nullptr,
+        getSuppressTokens: (_, countPointer) {
+          countPointer.value = 0;
+          return nullptr;
+        },
+      );
+
+      expect(tokens, isEmpty);
+      expect(() => tokens.add(1), throwsUnsupportedError);
+    });
+  });
+
   group('applyContextParams', () {
     test('writes type_k/type_v from cacheTypeK/V', () {
       final c = calloc<llama_context_params>();

--- a/test/unit/core/models/inference/model_params_test.dart
+++ b/test/unit/core/models/inference/model_params_test.dart
@@ -29,6 +29,7 @@ void main() {
     expect(params.speculativeRollbackTokenMax, 0);
     expect(params.useMmap, isTrue);
     expect(params.useMlock, isFalse);
+    expect(params.loadMtp, isFalse);
     expect(params.flashAttention, FlashAttention.auto);
     expect(params.cacheTypeK, KvCacheType.f16);
     expect(params.cacheTypeV, KvCacheType.f16);
@@ -114,6 +115,7 @@ void main() {
     const params = ModelParams(
       useMmap: false,
       useMlock: true,
+      loadMtp: true,
       flashAttention: FlashAttention.enabled,
       cacheTypeK: KvCacheType.q8_0,
       cacheTypeV: KvCacheType.q8_0,
@@ -124,6 +126,7 @@ void main() {
 
     expect(params.useMmap, isFalse);
     expect(params.useMlock, isTrue);
+    expect(params.loadMtp, isTrue);
     expect(params.flashAttention, FlashAttention.enabled);
     expect(params.cacheTypeK, KvCacheType.q8_0);
     expect(params.cacheTypeV, KvCacheType.q8_0);
@@ -137,6 +140,7 @@ void main() {
     final updated = params.copyWith(
       useMmap: false,
       useMlock: true,
+      loadMtp: true,
       flashAttention: FlashAttention.enabled,
       cacheTypeK: KvCacheType.q4_0,
       cacheTypeV: KvCacheType.q8_0,
@@ -147,6 +151,7 @@ void main() {
 
     expect(updated.useMmap, isFalse);
     expect(updated.useMlock, isTrue);
+    expect(updated.loadMtp, isTrue);
     expect(updated.flashAttention, FlashAttention.enabled);
     expect(updated.cacheTypeK, KvCacheType.q4_0);
     expect(updated.cacheTypeV, KvCacheType.q8_0);
@@ -176,6 +181,7 @@ void main() {
       speculativeRollbackTokenMax: 3,
       useMmap: false,
       useMlock: true,
+      loadMtp: true,
       flashAttention: FlashAttention.enabled,
       cacheTypeK: KvCacheType.q8_0,
       cacheTypeV: KvCacheType.q8_0,
@@ -208,6 +214,7 @@ void main() {
     expect(updated.speculativeRollbackTokenMax, 3);
     expect(updated.useMmap, isFalse);
     expect(updated.useMlock, isTrue);
+    expect(updated.loadMtp, isTrue);
     expect(updated.flashAttention, FlashAttention.enabled);
     expect(updated.cacheTypeK, KvCacheType.q8_0);
     expect(updated.cacheTypeV, KvCacheType.q8_0);

--- a/test/unit/tooling/llama_cpp_speculative_benchmark_test.dart
+++ b/test/unit/tooling/llama_cpp_speculative_benchmark_test.dart
@@ -143,6 +143,29 @@ void main() {
       expect(capacity, 64);
     });
 
+    test('loads bundled MTP only when no external draft is supplied', () {
+      expect(
+        speculative_benchmark.debugShouldLoadBundledMtpForTesting(const [
+          '--model',
+          'target.gguf',
+          '--cases',
+          'baseline,draft-mtp',
+        ]),
+        isTrue,
+      );
+      expect(
+        speculative_benchmark.debugShouldLoadBundledMtpForTesting(const [
+          '--model',
+          'target.gguf',
+          '--draft-model',
+          'mtp.gguf',
+          '--cases',
+          'baseline,draft-mtp',
+        ]),
+        isFalse,
+      );
+    });
+
     test('rejects non-positive ngram token max', () async {
       final result = await Process.run(Platform.resolvedExecutable, [
         '--disable-dart-dev',

--- a/test/unit/tooling/test_matrix_test.dart
+++ b/test/unit/tooling/test_matrix_test.dart
@@ -101,8 +101,9 @@ void main() {
       );
       expect(
         table,
-        contains('Draft-model strategies require --draft-model-path'),
+        contains('External draft-model strategies require --draft-model-path'),
       );
+      expect(table, contains('bundled MTP omits it'));
       expect(table, contains('ngram-cache can use'));
       expect(table, isNot(contains('LLAMADART_MTP_BENCHMARK')));
       expect(table, isNot(contains('llama_cpp_mtp_benchmark.dart')));

--- a/tool/testing/llama_cpp_speculative_benchmark.dart
+++ b/tool/testing/llama_cpp_speculative_benchmark.dart
@@ -13,6 +13,7 @@ Future<void> main(List<String> arguments) async {
   }
 
   final benchmarkCases = _buildBenchmarkCases(options);
+  final loadBundledMtp = _shouldLoadBundledMtp(options, benchmarkCases);
   final baselineModelParams = ModelParams(
     contextSize: options.contextSize,
     preferredBackend: options.preferredBackend,
@@ -22,6 +23,7 @@ Future<void> main(List<String> arguments) async {
     batchSize: options.batchSize,
     microBatchSize: options.microBatchSize,
     flashAttention: options.flashAttention,
+    loadMtp: loadBundledMtp,
   );
   final speculativeModelParams = baselineModelParams.copyWith(
     speculativeRollbackTokenMax: options.maxSpeculativeDraftCapacity,
@@ -381,6 +383,24 @@ List<String> debugBuildBenchmarkCaseNamesForTesting(List<String> arguments) {
 /// Intended for unit tests of option semantics.
 int debugResolveSpeculativeRollbackCapacityForTesting(List<String> arguments) {
   return _BenchmarkOptions.parse(arguments).maxSpeculativeDraftCapacity;
+}
+
+/// Resolves whether the target model must load bundled MTP tensors.
+///
+/// Intended for unit tests of load-time benchmark semantics.
+bool debugShouldLoadBundledMtpForTesting(List<String> arguments) {
+  final options = _BenchmarkOptions.parse(arguments);
+  return _shouldLoadBundledMtp(options, _buildBenchmarkCases(options));
+}
+
+bool _shouldLoadBundledMtp(
+  _BenchmarkOptions options,
+  List<_BenchmarkCase> benchmarkCases,
+) {
+  return options.draftModelPath == null &&
+      benchmarkCases.any(
+        (benchmarkCase) => benchmarkCase.strategies.contains('draft-mtp'),
+      );
 }
 
 void _addCase(
@@ -1521,7 +1541,8 @@ Case selection:
   --cases all                          Every supported case; draft-model cases
                                        require --draft-model.
   --draft-model <draft.gguf>           Draft model for draft-simple, eagle3,
-                                       dflash, and mixed draft-simple cases.
+                                       dflash, external MTP, and mixed
+                                       draft-model cases. Omit for bundled MTP.
   --draft-token-max <list>             Comma-separated draft-token depths for
                                        draft-model, ngram-mod, and ngram-cache
                                        cases. Default: 1,2.

--- a/tool/testing/test_matrix.dart
+++ b/tool/testing/test_matrix.dart
@@ -141,8 +141,8 @@ const List<TestMatrixRow> testMatrixRows = <TestMatrixRow>[
     tier: 'targeted',
     mode: 'local-only',
     covers:
-        'real GGUF llama.cpp speculative decoding baseline, n-gram, '
-        'draft-model, and cache throughput/acceptance metrics',
+        'real GGUF llama.cpp speculative decoding baseline, bundled MTP, '
+        'n-gram, draft-model, and cache throughput/acceptance metrics',
     command:
         'dart run tool/testing/run_local_e2e.dart --scenario '
         'llama-cpp-speculative-benchmark --model-path <model.gguf> '
@@ -155,8 +155,9 @@ const List<TestMatrixRow> testMatrixRows = <TestMatrixRow>[
         '/tmp/llamadart-ngram-cache.bin',
     useWhen:
         'llama.cpp speculative decoding strategy, wrapper, rollback, or '
-        'performance changes. Draft-model strategies require '
-        '--draft-model-path in the local E2E scenario; ngram-cache can use '
+        'performance changes. External draft-model strategies require '
+        '--draft-model-path in the local E2E scenario; bundled MTP omits it '
+        'and enables ModelParams.loadMtp; ngram-cache can use '
         'an existing cache path or --ngram-cache-build-static-path.',
   ),
   TestMatrixRow(

--- a/website/docs/changelog/recent-releases.md
+++ b/website/docs/changelog/recent-releases.md
@@ -9,6 +9,11 @@ For canonical full release notes, use:
 
 ## Unreleased
 
+- Updated native llama.cpp to `b10255`, adding explicit bundled-MTP loading,
+  automatic model-specific token suppression, and recent model, multimodal,
+  speculative-decoding, and backend improvements, with matching load-mode
+  bindings and Apple artifacts.
+
 - Updated WebGPU bridge assets to `v0.1.21` (llama.cpp `b10099`), restoring
   multimodal generation after recent upstream prompt-ingestion changes.
 

--- a/website/docs/configuration/runtime-parameters.md
+++ b/website/docs/configuration/runtime-parameters.md
@@ -54,6 +54,11 @@ Important fields:
   values are preserved within `n_ubatch <= n_batch <= n_ctx`.
 - `maxParallelSequences`: max sequence slots (`n_seq_max`) for parallel
   sequence workloads (for example, batched embeddings).
+- `loadMtp` (native llama.cpp only): load MTP tensors embedded in the target
+  GGUF. It defaults to `false` because these tensors consume extra memory. Set
+  it to `true` before model loading when `SpeculativeDecodingConfig.mtp(...)`
+  will run without an external `draftModelPath`; explicitly supplied MTP draft
+  models are loaded as MTP automatically.
 - `chatTemplate`: optional template override.
 - `preferMemory64` (web/WebGPU only): prefer the 64-bit (wasm64/mem64) bridge
   core. The default 32-bit core has a 4 GiB address-space limit, but large

--- a/website/docs/getting-started/installation.md
+++ b/website/docs/getting-started/installation.md
@@ -79,7 +79,7 @@ hooks:
     llamadart:
       # Optional. Defaults to llamadart's tested native runtime pin.
       # Use a leehack/llamadart-native release tag when testing another build.
-      llamadart_native_tag: b10075
+      llamadart_native_tag: b10255
 
       # Optional. GitHub repository slug or github.com URL.
       llamadart_native_repository: leehack/llamadart-native
@@ -105,7 +105,7 @@ per-target module list.
 
 Native source overrides are for compatibility testing. They do not regenerate
 Dart FFI bindings or symbol lookups, so the selected binary still must be ABI-
-and symbol-compatible with the default `leehack/llamadart-native@b10075` runtime.
+and symbol-compatible with the default `leehack/llamadart-native@b10255` runtime.
 
 Available native tags are published on the
 [`leehack/llamadart-native` releases page](https://github.com/leehack/llamadart-native/releases).
@@ -117,7 +117,7 @@ gh release list --repo leehack/llamadart-native --limit 20
 
 Before overriding, confirm the release includes the asset for your target. The
 hook downloads files named `llamadart-native-<bundle>-<tag>.tar.gz`, for example
-`llamadart-native-windows-x64-b10075.tar.gz`.
+`llamadart-native-windows-x64-b10255.tar.gz`.
 For local testing, `llamadart_native_path` may point directly at a bundle
 archive, at an extracted bundle directory, or at a directory containing
 `<tag>/<bundle>/`, `<bundle>/`, or the expected archive file.

--- a/website/docs/guides/performance-tuning.md
+++ b/website/docs/guides/performance-tuning.md
@@ -89,6 +89,10 @@ Guidelines:
   paths.
 - `batchSize`, `microBatchSize`: scheduler/batching controls for native and web
   runtimes.
+- `loadMtp`: native llama.cpp opt-in for MTP tensors embedded in the target
+  GGUF. Keep it `false` unless bundled MTP will be used, because loading the
+  extra tensors increases model memory. External MTP draft models are enabled
+  automatically when supplied through `draftModelPath`.
 - `maxParallelSequences`: relevant for embedding or true multi-sequence
   workloads, not regular single-turn chat.
 
@@ -283,8 +287,9 @@ dart run tool/testing/native_embedding_sweep.dart \
   --csv-out embedding_speedup.csv
 ```
 
-For the speculative benchmark runner, draft-model strategies require
-`--draft-model`; the n-gram cache strategy requires cache paths. Current
+For the speculative benchmark runner, external draft-model strategies require
+`--draft-model`; bundled MTP omits it and automatically loads the target's MTP
+tensors. The n-gram cache strategy requires cache paths. Current
 measured llama.cpp n-gram parity results, including exact upstream comparison
 commands, are recorded in [Backend Benchmarks](./backend-benchmarks).
 

--- a/website/docs/platforms/support-matrix.md
+++ b/website/docs/platforms/support-matrix.md
@@ -7,7 +7,7 @@ This page combines platform support, runtime-family selection, and
 backend-module configuration for
 `llamadart`.
 
-The native-assets hook currently pins `llamadart-native` tag `b10075` and
+The native-assets hook currently pins `llamadart-native` tag `b10255` and
 `litert-lm-native` release `v0.14.0-native.2` (`hook/build.dart`). Apps can
 override the llama.cpp native GitHub source with
 `hooks.user_defines.llamadart.llamadart_native_tag` and
@@ -196,7 +196,7 @@ device/model bundle, use `cpu` or `gpu` for that artifact.
   a web load failure as a package bug. The [WebGPU Bridge](./webgpu-bridge)
   page has the browser-console probe and Flutter Web smoke-test path.
 
-## Current llama.cpp module availability by bundle (`b10075`)
+## Current llama.cpp module availability by bundle (`b10255`)
 
 | Bundle key | Available backend modules in bundle |
 | --- | --- |
@@ -244,7 +244,7 @@ hooks:
   user_defines:
     llamadart:
       # Optional. Defaults to llamadart's tested native runtime pin.
-      llamadart_native_tag: b10075
+      llamadart_native_tag: b10255
 
       # Optional. GitHub repository slug or github.com URL.
       llamadart_native_repository: leehack/llamadart-native


### PR DESCRIPTION
## Summary

- Update the default native llama.cpp artifact from `llamadart-native@b10075` to the latest consumable `b10255`, regenerate the exact Dart FFI bindings, migrate `useMmap` / `useMlock` to llama.cpp's load-mode ABI, and refresh the Apple SwiftPM checksum.
- Add opt-in `ModelParams.loadMtp` support for GGUFs with bundled multi-token-prediction tensors. Bundled MTP now fails early with an actionable error unless the target was loaded with that option; explicit external MTP draft models are enabled automatically.
- Cache model-defined suppress-token metadata once per loaded model and apply it through llama.cpp's logit-bias sampler, avoiding repeated FFI queries and Dart-list allocation during generation. Update the speculative benchmark, test matrix, changelog, README, and website documentation.

## Why

llama.cpp b10255 adds `llama_model_params.load_mtp` and `llama_vocab_get_suppress_tokens`, so the previous bindings cannot safely consume the current companion artifact. The public Dart API already exposes MTP speculative decoding, but bundled MTP tensors now require an explicit load-time opt-in upstream.

## User impact

- Models with bundled MTP layers can be used through a documented, memory-conscious opt-in.
- External MTP draft models remain straightforward to use.
- Models that publish suppress-token metadata automatically avoid sampling those tokens.
- Existing mmap/mlock behavior is preserved across llama.cpp's new load-mode ABI.

## Validation

- `dart format --output=none --set-exit-if-changed lib test tool hook`
- `dart analyze lib test tool hook`
- `dart test -p vm -j 1 --exclude-tags local-only`: 1,309 passed, 66 fixture/model-dependent skips
- Native symbol, real tiny-model inference, and state-persistence integration tests
- `dart run tool/testing/verify_release_docs_versions.dart`
- `./tool/docs/build_site.sh`
- `./tool/docs/validate_links.sh`
- SwiftPM manifest parsing and independent checksum verification of the published b10255 Apple XCFramework:
  `3167cf79774ae057c305698ee8402ecc506654dc901dfba94a49490330727b7a`

### Real-model checks

Qwen3.5 0.8B MTP GGUF on an M4 Max covered bundled MTP, explicit external MTP, three repeated generations on one Metal context, mixed MTP+n-gram, and the existing n-gram strategies. Deterministic output hashes matched baseline, accepted MTP drafts were non-zero, and replay remained zero.

The exact review-fix head `ab14eca85` was revalidated with real native models on an M4 Max/Metal. Bundled Qwen3.5 0.8B MTP generated 32 tokens with the same `13e9bbf3` output hash as baseline, accepted 16/28 drafted tokens (57.1%), and replayed zero tokens. Gemma 4 E2B Q4_K_S loaded and generated 24 tokens successfully at 41.2 tok/s.

For this small model, MTP was correctness-clean but slower than baseline: baseline median was 228.0 tok/s, while bundled MTP was about 146.7-155.4 tok/s with 72.6%-82.4% acceptance. This PR therefore keeps MTP explicitly opt-in and makes no universal acceleration claim.

Three available real GGUFs exposed zero suppress-token metadata. The native vocabulary query was exercised against those models, and suppress-token application is covered with the real b10255 sampler API, but model-backed end-to-end suppression remains pending a published GGUF carrying that metadata.

## Scope

The WebGPU v0.1.25 pin update is intentionally excluded and will be proposed separately. Raw llama.cpp has advanced beyond b10255, but b10255 remains the newest published `llamadart-native` artifact.