### PR TITLE
Update WebGPU bridge assets to v0.1.25

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,8 +11,8 @@
   loading remains the safe default; controlled range-capable deployments can
   opt in explicitly.
 
-* Updated WebGPU bridge assets to `v0.1.21` (llama.cpp `b10099`), restoring
-  multimodal generation after recent upstream prompt-ingestion changes.
+* Updated WebGPU bridge assets to `v0.1.25` (llama.cpp `b10255`), refreshing
+  both WebAssembly runtimes while preserving the existing bridge API.
 
 ## 0.8.17
 

--- a/README.md
+++ b/README.md
@@ -136,7 +136,7 @@ Current default runtime pins:
 | --- | --- |
 | Native llama.cpp / GGUF | `leehack/llamadart-native@b10255` |
 | Native LiteRT-LM / `.litertlm` | `leehack/litert-lm-native@v0.14.0-native.2` |
-| Web llama.cpp / GGUF | `leehack/llama-web-bridge-assets@v0.1.21` |
+| Web llama.cpp / GGUF | `leehack/llama-web-bridge-assets@v0.1.25` |
 | Web LiteRT-LM / `.litertlm` | `@litert-lm/core@0.14.0` |
 
 ## Common Tasks

--- a/doc/webgpu_bridge.md
+++ b/doc/webgpu_bridge.md
@@ -19,7 +19,7 @@ pipelines.
    `https://cdn.jsdelivr.net/gh/leehack/llama-web-bridge-assets@<tag>/llama_webgpu_bridge.js`
 2. Local fallback: `./webgpu_bridge/llama_webgpu_bridge.js`
 
-Default pinned tag in the example is `v0.1.21`.
+Default pinned tag in the example is `v0.1.25`.
 
 For broader browser coverage in this repository, fetched/local assets are patched
 to a universal Safari-compatible gate by default (`MIN_SAFARI_VERSION=170400`).
@@ -32,7 +32,7 @@ model bytes.
 To vendor pinned assets into local app web files:
 
 ```bash
-WEBGPU_BRIDGE_ASSETS_TAG=v0.1.21 ./scripts/fetch_webgpu_bridge_assets.sh
+WEBGPU_BRIDGE_ASSETS_TAG=v0.1.25 ./scripts/fetch_webgpu_bridge_assets.sh
 ```
 
 Optional compatibility env vars:
@@ -113,7 +113,7 @@ You can override CDN source/version before the bridge loader runs:
 ```html
 <script>
   window.__llamadartBridgeAssetsRepo = 'leehack/llama-web-bridge-assets';
-  window.__llamadartBridgeAssetsTag = 'v0.1.21';
+  window.__llamadartBridgeAssetsTag = 'v0.1.25';
 </script>
 ```
 

--- a/example/chat_app/web/index.html
+++ b/example/chat_app/web/index.html
@@ -214,13 +214,13 @@
     const bridgeAssetsTag =
       typeof configuredTag === 'string' && configuredTag.length > 0
         ? configuredTag
-        : 'v0.1.21';
+        : 'v0.1.25';
     window.__llamadartLiteRtLmModuleUrl =
       typeof window.__llamadartLiteRtLmModuleUrl === 'string' &&
       window.__llamadartLiteRtLmModuleUrl.length > 0
         ? window.__llamadartLiteRtLmModuleUrl
         : 'https://cdn.jsdelivr.net/npm/@litert-lm/core@0.14.0/+esm';
-    const localBridgeVersion = 'v0.1.21-local-b10099';
+    const localBridgeVersion = 'v0.1.25-local-b10255';
     window.__llamadartBridgeLocalVersion = localBridgeVersion;
 
     const localBridgeUrl = `./webgpu_bridge/llama_webgpu_bridge.js?v=${localBridgeVersion}`;

--- a/scripts/fetch_webgpu_bridge_assets.sh
+++ b/scripts/fetch_webgpu_bridge_assets.sh
@@ -4,7 +4,7 @@ set -euo pipefail
 ROOT_DIR="$(git rev-parse --show-toplevel)"
 OUT_DIR="${WEBGPU_BRIDGE_OUT_DIR:-$ROOT_DIR/example/chat_app/web/webgpu_bridge}"
 ASSETS_REPO="${WEBGPU_BRIDGE_ASSETS_REPO:-leehack/llama-web-bridge-assets}"
-ASSETS_TAG="${WEBGPU_BRIDGE_ASSETS_TAG:-v0.1.21}"
+ASSETS_TAG="${WEBGPU_BRIDGE_ASSETS_TAG:-v0.1.25}"
 CDN_BASE="${WEBGPU_BRIDGE_CDN_BASE:-https://cdn.jsdelivr.net/gh/${ASSETS_REPO}@${ASSETS_TAG}}"
 PATCH_SAFARI_COMPAT="${WEBGPU_BRIDGE_PATCH_SAFARI_COMPAT:-1}"
 MIN_SAFARI_VERSION="${WEBGPU_BRIDGE_MIN_SAFARI_VERSION:-170400}"
@@ -14,7 +14,7 @@ if [[ "${1:-}" == "--help" || "${1:-}" == "-h" ]]; then
 Downloads prebuilt WebGPU bridge assets into the chat_app web directory.
 
 Default source:
-  https://cdn.jsdelivr.net/gh/leehack/llama-web-bridge-assets@v0.1.21
+  https://cdn.jsdelivr.net/gh/leehack/llama-web-bridge-assets@v0.1.25
 
 Environment variables:
   WEBGPU_BRIDGE_ASSETS_REPO   Asset repo in owner/repo format
@@ -28,7 +28,7 @@ Usage:
   ./scripts/fetch_webgpu_bridge_assets.sh
 
 Examples:
-  WEBGPU_BRIDGE_ASSETS_TAG=v0.1.21 ./scripts/fetch_webgpu_bridge_assets.sh
+  WEBGPU_BRIDGE_ASSETS_TAG=v0.1.25 ./scripts/fetch_webgpu_bridge_assets.sh
   WEBGPU_BRIDGE_ASSETS_REPO=acme/llama-web-bridge-assets WEBGPU_BRIDGE_ASSETS_TAG=v2 ./scripts/fetch_webgpu_bridge_assets.sh
 USAGE
   exit 0

--- a/website/docs/changelog/recent-releases.md
+++ b/website/docs/changelog/recent-releases.md
@@ -14,8 +14,8 @@ For canonical full release notes, use:
   speculative-decoding, and backend improvements, with matching load-mode
   bindings and Apple artifacts.
 
-- Updated WebGPU bridge assets to `v0.1.21` (llama.cpp `b10099`), restoring
-  multimodal generation after recent upstream prompt-ingestion changes.
+- Updated WebGPU bridge assets to `v0.1.25` (llama.cpp `b10255`), refreshing
+  both WebAssembly runtimes while preserving the existing bridge API.
 
 - Disabled automatic WebGPU fetch-backed model loading by default. Streamed
   loading remains the safe default, with explicit opt-in available for

--- a/website/docs/platforms/webgpu-bridge.md
+++ b/website/docs/platforms/webgpu-bridge.md
@@ -146,13 +146,13 @@ development validation, and CDN-first loading for normal hosted deployments:
 1. On localhost: local asset first, then CDN fallback.
 2. On hosted deployments: CDN asset first, then local fallback.
 
-The example currently pins bridge assets to `v0.1.21`, with local vendored assets
-identified as `v0.1.21-local-b10099`.
+The example currently pins bridge assets to `v0.1.25`, with local vendored assets
+identified as `v0.1.25-local-b10255`.
 
 Fetch pinned local assets with:
 
 ```bash
-WEBGPU_BRIDGE_ASSETS_TAG=v0.1.21 ./scripts/fetch_webgpu_bridge_assets.sh
+WEBGPU_BRIDGE_ASSETS_TAG=v0.1.25 ./scripts/fetch_webgpu_bridge_assets.sh
 ```
 
 To verify the loaded runtime in a browser console, inspect:
@@ -309,7 +309,7 @@ You can override bridge asset source/version before loader startup:
 ```html
 <script>
   window.__llamadartBridgeAssetsRepo = 'leehack/llama-web-bridge-assets';
-  window.__llamadartBridgeAssetsTag = 'v0.1.21';
+  window.__llamadartBridgeAssetsTag = 'v0.1.25';
   // Prefer local runtime even off localhost:
   // window.__llamadartPreferLocalBridgeRuntime = true;
   // Enable verbose bridge bootstrap console logs:


### PR DESCRIPTION
## Summary

- Update every live WebGPU bridge loader, fetch default, cache-busting identifier, and current documentation surface from `llama-web-bridge-assets@v0.1.21` / llama.cpp `b10099` to `v0.1.25` / `b10255`.
- Refresh the current runtime-pin table and unreleased changelog entries.
- Keep the bridge API and Dart-facing behavior unchanged; this is a published wasm/runtime refresh.

## Why

`v0.1.25` is the latest published consumable Web artifact and aligns the Web llama.cpp runtime with the native b10255 runtime now on `main`. The release preserves the existing bridge JS/worker API while refreshing the wasm32 and memory64 runtimes.

## Scope

- Pin and documentation changes only.
- No Web bridge source changes.
- No new Dart API.
- No release or package version bump.

## Validation

Current rebased head:

- `git diff --check origin/main...HEAD`
- `bash -n scripts/fetch_webgpu_bridge_assets.sh`
- `dart run tool/testing/verify_release_docs_versions.dart`
- `./tool/docs/validate_links.sh`
- `./scripts/build_chat_app_web.sh`
  - downloaded published `v0.1.25` assets
  - verified bridge, worker, TypeScript, wasm32, and memory64 checksums
  - built and validated the deployable Flutter Web artifact

Published-candidate runtime validation:

- Full root Chrome suite: 738 tests
- Chat app VM suite: 201 tests
- Exact chat app Chrome contract: 4 tests
- Deterministic mock and real worker/WASM chat smokes
- Direct and worker state save/load round trips
- Qwen3.5 multimodal on CPU and WebGPU with identical correct output and no fallback
- Gemma 4 E2B through the memory64 runtime, returning the expected `4` with no page or request errors

## Notes

The runtime asset pin remains independently versioned from the native companion release. Future llama.cpp updates should continue to land only after their corresponding Web artifact is published and model-backed browser validation passes.
