### PR TITLE
Update LiteRT-LM runtimes to v0.15 and WebGPU bridge to v0.1.26

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,8 +11,8 @@
   `leehack/litert-lm-native@v0.15.0-native.1` and
   `@litert-lm/core@0.15.0`. The native artifact includes a corrected v0.15
   streaming callback bridge; incompatible callback runtimes now fail safely
-  before generation, and explicit macOS library overrides take precedence over
-  process-linked assets.
+  before generation, and concrete macOS app, framework, and cache libraries
+  take precedence over process-linked assets.
 
 * Updated the default llama.cpp native runtime to
   `leehack/llamadart-native@b10255`, adding explicit bundled-MTP loading and

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,7 +25,7 @@
   loading remains the safe default; controlled range-capable deployments can
   opt in explicitly.
 
-* Updated WebGPU bridge assets to `v0.1.25` (llama.cpp `b10255`), refreshing
+* Updated WebGPU bridge assets to `v0.1.26` (llama.cpp `b10276`), refreshing
   both WebAssembly runtimes while preserving the existing bridge API.
 
 ## 0.8.17

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@
   is not yet exposed through the public Dart API.
 
 * Updated the default LiteRT-LM runtimes to
-  `leehack/litert-lm-native@v0.15.0-native.1` and
+  `leehack/litert-lm-native@v0.15.0-native.2` and
   `@litert-lm/core@0.15.0`. The native artifact includes a corrected v0.15
   streaming callback bridge; incompatible callback runtimes now fail safely
   before generation, and concrete macOS app, framework, and cache libraries

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,10 +2,13 @@
 
 * Updated the default llama.cpp native runtime pin to
   `leehack/llamadart-native@b10276`, picking up Qwen3-TTS model-loading
-  primitives and recent runtime fixes. Regenerated matching Dart FFI bindings,
-  migrated the penalty sampler to the new vocabulary-sized ABI, and refreshed
-  the `llamadart_llama_cpp_flutter` Apple SwiftPM checksum. Speech generation
-  is not yet exposed through the public Dart API.
+  primitives, explicit bundled-MTP loading, automatic model-specific token
+  suppression, and recent model, multimodal, speculative-decoding, backend,
+  and runtime fixes. Regenerated matching Dart FFI bindings, migrated model
+  loading to llama.cpp's load-mode ABI and the penalty sampler to the new
+  vocabulary-sized ABI, and refreshed the `llamadart_llama_cpp_flutter` Apple
+  SwiftPM checksum. Speech generation is not yet exposed through the public
+  Dart API.
 
 * Updated the default LiteRT-LM runtimes to
   `leehack/litert-lm-native@v0.15.0-native.3` and
@@ -14,13 +17,6 @@
   device loss; incompatible callback runtimes now fail safely before
   generation, and concrete macOS app, framework, and cache libraries take
   precedence over process-linked assets.
-
-* Updated the default llama.cpp native runtime to
-  `leehack/llamadart-native@b10255`, adding explicit bundled-MTP loading and
-  automatic model-specific token suppression alongside recent model,
-  multimodal, speculative-decoding, and backend improvements. Regenerated the
-  matching Dart FFI bindings, migrated model loading to llama.cpp's load-mode
-  ABI, and refreshed the Apple SwiftPM checksum and current runtime-pin docs.
 
 * Disabled automatic WebGPU fetch-backed model loading by default. Streamed
   loading remains the safe default; controlled range-capable deployments can

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,10 +7,11 @@
   the `llamadart_llama_cpp_flutter` Apple SwiftPM checksum. Speech generation
   is not yet exposed through the public Dart API.
 
-* Updated the default native LiteRT-LM runtime to
-  `leehack/litert-lm-native@v0.15.0-native.1`, with a corrected v0.15 streaming
-  callback bridge. Incompatible callback runtimes now fail safely before
-  generation, and explicit macOS library overrides take precedence over
+* Updated the default LiteRT-LM runtimes to
+  `leehack/litert-lm-native@v0.15.0-native.1` and
+  `@litert-lm/core@0.15.0`. The native artifact includes a corrected v0.15
+  streaming callback bridge; incompatible callback runtimes now fail safely
+  before generation, and explicit macOS library overrides take precedence over
   process-linked assets.
 
 * Updated the default llama.cpp native runtime to

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,11 +8,12 @@
   is not yet exposed through the public Dart API.
 
 * Updated the default LiteRT-LM runtimes to
-  `leehack/litert-lm-native@v0.15.0-native.2` and
+  `leehack/litert-lm-native@v0.15.0-native.3` and
   `@litert-lm/core@0.15.0`. The native artifact includes a corrected v0.15
-  streaming callback bridge; incompatible callback runtimes now fail safely
-  before generation, and concrete macOS app, framework, and cache libraries
-  take precedence over process-linked assets.
+  streaming callback bridge and an Android Dawn rollback for Mali-G715 GPU
+  device loss; incompatible callback runtimes now fail safely before
+  generation, and concrete macOS app, framework, and cache libraries take
+  precedence over process-linked assets.
 
 * Updated the default llama.cpp native runtime to
   `leehack/llamadart-native@b10255`, adding explicit bundled-MTP loading and

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@
   the `llamadart_llama_cpp_flutter` Apple SwiftPM checksum. Speech generation
   is not yet exposed through the public Dart API.
 
+* Updated the default native LiteRT-LM runtime to
+  `leehack/litert-lm-native@v0.15.0-native.1`, with a corrected v0.15 streaming
+  callback bridge. Incompatible callback runtimes now fail safely before
+  generation, and explicit macOS library overrides take precedence over
+  process-linked assets.
+
 * Updated the default llama.cpp native runtime to
   `leehack/llamadart-native@b10255`, adding explicit bundled-MTP loading and
   automatic model-specific token suppression alongside recent model,

--- a/README.md
+++ b/README.md
@@ -135,7 +135,7 @@ Current default runtime pins:
 | Runtime | Pin |
 | --- | --- |
 | Native llama.cpp / GGUF | `leehack/llamadart-native@b10276` |
-| Native LiteRT-LM / `.litertlm` | `leehack/litert-lm-native@v0.15.0-native.2` |
+| Native LiteRT-LM / `.litertlm` | `leehack/litert-lm-native@v0.15.0-native.3` |
 | Web llama.cpp / GGUF | `leehack/llama-web-bridge-assets@v0.1.26` |
 | Web LiteRT-LM / `.litertlm` | `@litert-lm/core@0.15.0` |
 

--- a/README.md
+++ b/README.md
@@ -135,7 +135,7 @@ Current default runtime pins:
 | Runtime | Pin |
 | --- | --- |
 | Native llama.cpp / GGUF | `leehack/llamadart-native@b10276` |
-| Native LiteRT-LM / `.litertlm` | `leehack/litert-lm-native@v0.14.0-native.2` |
+| Native LiteRT-LM / `.litertlm` | `leehack/litert-lm-native@v0.15.0-native.1` |
 | Web llama.cpp / GGUF | `leehack/llama-web-bridge-assets@v0.1.25` |
 | Web LiteRT-LM / `.litertlm` | `@litert-lm/core@0.14.0` |
 

--- a/README.md
+++ b/README.md
@@ -137,7 +137,7 @@ Current default runtime pins:
 | Native llama.cpp / GGUF | `leehack/llamadart-native@b10276` |
 | Native LiteRT-LM / `.litertlm` | `leehack/litert-lm-native@v0.15.0-native.1` |
 | Web llama.cpp / GGUF | `leehack/llama-web-bridge-assets@v0.1.25` |
-| Web LiteRT-LM / `.litertlm` | `@litert-lm/core@0.14.0` |
+| Web LiteRT-LM / `.litertlm` | `@litert-lm/core@0.15.0` |
 
 ## Common Tasks
 

--- a/README.md
+++ b/README.md
@@ -136,7 +136,7 @@ Current default runtime pins:
 | --- | --- |
 | Native llama.cpp / GGUF | `leehack/llamadart-native@b10276` |
 | Native LiteRT-LM / `.litertlm` | `leehack/litert-lm-native@v0.15.0-native.1` |
-| Web llama.cpp / GGUF | `leehack/llama-web-bridge-assets@v0.1.25` |
+| Web llama.cpp / GGUF | `leehack/llama-web-bridge-assets@v0.1.26` |
 | Web LiteRT-LM / `.litertlm` | `@litert-lm/core@0.15.0` |
 
 ## Common Tasks

--- a/README.md
+++ b/README.md
@@ -135,7 +135,7 @@ Current default runtime pins:
 | Runtime | Pin |
 | --- | --- |
 | Native llama.cpp / GGUF | `leehack/llamadart-native@b10276` |
-| Native LiteRT-LM / `.litertlm` | `leehack/litert-lm-native@v0.15.0-native.1` |
+| Native LiteRT-LM / `.litertlm` | `leehack/litert-lm-native@v0.15.0-native.2` |
 | Web llama.cpp / GGUF | `leehack/llama-web-bridge-assets@v0.1.26` |
 | Web LiteRT-LM / `.litertlm` | `@litert-lm/core@0.15.0` |
 

--- a/doc/webgpu_bridge.md
+++ b/doc/webgpu_bridge.md
@@ -19,7 +19,7 @@ pipelines.
    `https://cdn.jsdelivr.net/gh/leehack/llama-web-bridge-assets@<tag>/llama_webgpu_bridge.js`
 2. Local fallback: `./webgpu_bridge/llama_webgpu_bridge.js`
 
-Default pinned tag in the example is `v0.1.25`.
+Default pinned tag in the example is `v0.1.26`.
 
 For broader browser coverage in this repository, fetched/local assets are patched
 to a universal Safari-compatible gate by default (`MIN_SAFARI_VERSION=170400`).
@@ -32,7 +32,7 @@ model bytes.
 To vendor pinned assets into local app web files:
 
 ```bash
-WEBGPU_BRIDGE_ASSETS_TAG=v0.1.25 ./scripts/fetch_webgpu_bridge_assets.sh
+WEBGPU_BRIDGE_ASSETS_TAG=v0.1.26 ./scripts/fetch_webgpu_bridge_assets.sh
 ```
 
 Optional compatibility env vars:
@@ -113,7 +113,7 @@ You can override CDN source/version before the bridge loader runs:
 ```html
 <script>
   window.__llamadartBridgeAssetsRepo = 'leehack/llama-web-bridge-assets';
-  window.__llamadartBridgeAssetsTag = 'v0.1.25';
+  window.__llamadartBridgeAssetsTag = 'v0.1.26';
 </script>
 ```
 

--- a/example/chat_app/README.md
+++ b/example/chat_app/README.md
@@ -97,7 +97,7 @@ flutter test --run-skipped -t local-only \
    - LiteRT-LM `.litertlm` presets, when present, use the same model library
      flow. The example `pubspec.yaml` enables the `litert_lm` native runtime
      family for supported native targets, while Web builds load web-compatible
-     `.litertlm` URLs through `@litert-lm/core`; `web/index.html` sets a
+     `.litertlm` URLs through `@litert-lm/core@0.15.0`; `web/index.html` sets a
      default module URL that apps can override with
      `window.__llamadartLiteRtLmModuleUrl`.
    - LiteRT-LM Web is currently a single-turn text runtime. Because

--- a/example/chat_app/web/index.html
+++ b/example/chat_app/web/index.html
@@ -219,7 +219,7 @@
       typeof window.__llamadartLiteRtLmModuleUrl === 'string' &&
       window.__llamadartLiteRtLmModuleUrl.length > 0
         ? window.__llamadartLiteRtLmModuleUrl
-        : 'https://cdn.jsdelivr.net/npm/@litert-lm/core@0.14.0/+esm';
+        : 'https://cdn.jsdelivr.net/npm/@litert-lm/core@0.15.0/+esm';
     const localBridgeVersion = 'v0.1.25-local-b10255';
     window.__llamadartBridgeLocalVersion = localBridgeVersion;
 

--- a/example/chat_app/web/index.html
+++ b/example/chat_app/web/index.html
@@ -214,13 +214,13 @@
     const bridgeAssetsTag =
       typeof configuredTag === 'string' && configuredTag.length > 0
         ? configuredTag
-        : 'v0.1.25';
+        : 'v0.1.26';
     window.__llamadartLiteRtLmModuleUrl =
       typeof window.__llamadartLiteRtLmModuleUrl === 'string' &&
       window.__llamadartLiteRtLmModuleUrl.length > 0
         ? window.__llamadartLiteRtLmModuleUrl
         : 'https://cdn.jsdelivr.net/npm/@litert-lm/core@0.15.0/+esm';
-    const localBridgeVersion = 'v0.1.25-local-b10255';
+    const localBridgeVersion = 'v0.1.26-local-b10276';
     window.__llamadartBridgeLocalVersion = localBridgeVersion;
 
     const localBridgeUrl = `./webgpu_bridge/llama_webgpu_bridge.js?v=${localBridgeVersion}`;

--- a/hook/build.dart
+++ b/hook/build.dart
@@ -26,7 +26,7 @@ const _cacheBaseDir = 'llamadart';
 const _bundleCacheDir = 'native_bundles';
 const _reportDir = 'llamadart_bin';
 const _allowLegacyLocalBundleEnv = 'LLAMADART_ALLOW_LEGACY_LOCAL_BUNDLES';
-const _litertLmVersion = '0.15.0-native.1';
+const _litertLmVersion = '0.15.0-native.2';
 const _litertLmNativeReleaseBaseUrl =
     'https://github.com/leehack/litert-lm-native/releases/download/'
     'v$_litertLmVersion';
@@ -51,7 +51,7 @@ final _litertLmBundles = Map.unmodifiable({
 const _litertLmBundleSpecs = <_LiteRtLmBundleSpec>[
   _LiteRtLmBundleSpec(
     'android-arm64',
-    sha256: '6f249c5ff35a03cc4b474e2430747266750a282a738e5eeda6df4355418ccfa9',
+    sha256: '564d7492c80b8e69fd8c90a79cb5eafaa2a483e598d22fa50fba8e6810d7ad4d',
     requiredLibraries: {
       'libGemmaModelConstraintProvider.so',
       'libLiteRtGpuAccelerator.so',
@@ -65,7 +65,7 @@ const _litertLmBundleSpecs = <_LiteRtLmBundleSpec>[
   ),
   _LiteRtLmBundleSpec(
     'android-x64',
-    sha256: 'df7174591239edadddf950a748dcf5f13a66d4fba5cfd467547f815e6d6f0b90',
+    sha256: '47706da79866b56686738f229f8c22282eb3512e7205ccb2c3c55716315c4d65',
     requiredLibraries: {
       'libGemmaModelConstraintProvider.so',
       'libLiteRtGpuAccelerator.so',
@@ -79,27 +79,27 @@ const _litertLmBundleSpecs = <_LiteRtLmBundleSpec>[
   ),
   _LiteRtLmBundleSpec(
     'ios-arm64',
-    sha256: 'd77d80f163c2b49805ecebcaf8a677203cb934b1dc3a39eacc990e4eb9f26bcf',
+    sha256: 'eeb60f30c63a7cd5aed930da109bd6d747d5342789a7a7108955c4037666ac2b',
     requiredLibraries: {'LiteRtLm', 'CLiteRTLM'},
   ),
   _LiteRtLmBundleSpec(
     'ios-arm64-sim',
-    sha256: '12a835425fed122069a5b963ce2b09fe28683dc7f5e77637560d2a3f2f237c5c',
+    sha256: '1cc95975784b9cc77224d4c1960fa1e56e723e225f358747a3d35f035803c68c',
     requiredLibraries: {'LiteRtLm', 'CLiteRTLM'},
   ),
   _LiteRtLmBundleSpec(
     'macos-arm64',
-    sha256: '3fce309cce689d365f5d6378d329a0c435219deaf124f47c7e7147354ffc956c',
+    sha256: '4acfd518f6786bb95a45df3e28ee3a82b7defcc9fbe81d96b2426560c433277d',
     requiredLibraries: {'libLiteRtLm.dylib', 'libCLiteRTLM_mac.dylib'},
   ),
   _LiteRtLmBundleSpec(
     'macos-x64',
-    sha256: '8d0e9b90e5221ece5b77cd2284332e83f9179fe330611d7c51bc2b7d14dde8b6',
+    sha256: 'f33fec4dc2f4ddc7bc11a54a221809beee0d1ae55937957fb65e86b019f3b13a',
     requiredLibraries: {'libLiteRtLm.dylib', 'libCLiteRTLM_mac.dylib'},
   ),
   _LiteRtLmBundleSpec(
     'linux-arm64',
-    sha256: '1e17c71d7297c106dd23dd8a0a0638b16b024f5c6dce90000b45f43e71ea44af',
+    sha256: '6a525b4875bfd170d1a273af769d6cdbe5ecfca241ffaf169a1bc11b64e628cc',
     requiredLibraries: {
       'libGemmaModelConstraintProvider.so',
       'libLiteRt.so',
@@ -111,7 +111,7 @@ const _litertLmBundleSpecs = <_LiteRtLmBundleSpec>[
   ),
   _LiteRtLmBundleSpec(
     'linux-x64',
-    sha256: '84c5380baf8602ebb9167b8a603da3fe3242b47f31ea587a3b1df7177c7016dc',
+    sha256: 'b7b2501412bc8b37e7c40f81f552ecbd49090c60e2ab38bd0fa077a0a80afede',
     requiredLibraries: {
       'libGemmaModelConstraintProvider.so',
       'libLiteRt.so',
@@ -123,7 +123,7 @@ const _litertLmBundleSpecs = <_LiteRtLmBundleSpec>[
   ),
   _LiteRtLmBundleSpec(
     'windows-x64',
-    sha256: '4e1f7f6f38b2ca5580e4e8b9cc46a92b2d80649789156ff52f9d4c32e7726efd',
+    sha256: '5021ba4cd41abd41d9221e5aba20aeaf2c51947bc606d3d5a055c71e91b0b24f',
     requiredLibraries: {
       'LiteRtLm.dll',
       'libGemmaModelConstraintProvider.dll',

--- a/hook/build.dart
+++ b/hook/build.dart
@@ -26,7 +26,7 @@ const _cacheBaseDir = 'llamadart';
 const _bundleCacheDir = 'native_bundles';
 const _reportDir = 'llamadart_bin';
 const _allowLegacyLocalBundleEnv = 'LLAMADART_ALLOW_LEGACY_LOCAL_BUNDLES';
-const _litertLmVersion = '0.15.0-native.2';
+const _litertLmVersion = '0.15.0-native.3';
 const _litertLmNativeReleaseBaseUrl =
     'https://github.com/leehack/litert-lm-native/releases/download/'
     'v$_litertLmVersion';
@@ -51,7 +51,7 @@ final _litertLmBundles = Map.unmodifiable({
 const _litertLmBundleSpecs = <_LiteRtLmBundleSpec>[
   _LiteRtLmBundleSpec(
     'android-arm64',
-    sha256: '564d7492c80b8e69fd8c90a79cb5eafaa2a483e598d22fa50fba8e6810d7ad4d',
+    sha256: 'e362dab3941e3d7ac107d36d9dafe5f4bbdafeec0a2fa5978cab27c40ae6a281',
     requiredLibraries: {
       'libGemmaModelConstraintProvider.so',
       'libLiteRtGpuAccelerator.so',
@@ -65,7 +65,7 @@ const _litertLmBundleSpecs = <_LiteRtLmBundleSpec>[
   ),
   _LiteRtLmBundleSpec(
     'android-x64',
-    sha256: '47706da79866b56686738f229f8c22282eb3512e7205ccb2c3c55716315c4d65',
+    sha256: '5f62dd8bcbec83c3dbe5c32fa5956d8c65df283ee4eb118914f3218183c10eca',
     requiredLibraries: {
       'libGemmaModelConstraintProvider.so',
       'libLiteRtGpuAccelerator.so',
@@ -79,27 +79,27 @@ const _litertLmBundleSpecs = <_LiteRtLmBundleSpec>[
   ),
   _LiteRtLmBundleSpec(
     'ios-arm64',
-    sha256: 'eeb60f30c63a7cd5aed930da109bd6d747d5342789a7a7108955c4037666ac2b',
+    sha256: '1247ae3ed7f4b704be67412ebca234d11797d8f2317030f4d080bacde9311f0a',
     requiredLibraries: {'LiteRtLm', 'CLiteRTLM'},
   ),
   _LiteRtLmBundleSpec(
     'ios-arm64-sim',
-    sha256: '1cc95975784b9cc77224d4c1960fa1e56e723e225f358747a3d35f035803c68c',
+    sha256: 'b9ec4b4de9712bebf02998363ab58d727a9dcb48503f74432a50f1f8018ac20e',
     requiredLibraries: {'LiteRtLm', 'CLiteRTLM'},
   ),
   _LiteRtLmBundleSpec(
     'macos-arm64',
-    sha256: '4acfd518f6786bb95a45df3e28ee3a82b7defcc9fbe81d96b2426560c433277d',
+    sha256: '10ea956cfc9f67cd30daf211777cf95669a8c35a81f84ec204b6d9dfa9c95f11',
     requiredLibraries: {'libLiteRtLm.dylib', 'libCLiteRTLM_mac.dylib'},
   ),
   _LiteRtLmBundleSpec(
     'macos-x64',
-    sha256: 'f33fec4dc2f4ddc7bc11a54a221809beee0d1ae55937957fb65e86b019f3b13a',
+    sha256: '52fa4efb5fe038887a228d9f80f293d5d99edfc5bb8b9664be824a7a6c2319cc',
     requiredLibraries: {'libLiteRtLm.dylib', 'libCLiteRTLM_mac.dylib'},
   ),
   _LiteRtLmBundleSpec(
     'linux-arm64',
-    sha256: '6a525b4875bfd170d1a273af769d6cdbe5ecfca241ffaf169a1bc11b64e628cc',
+    sha256: '3d46faa300d7988688aff8d2961dfe6bd55c5312303aaf985269abba2752ea46',
     requiredLibraries: {
       'libGemmaModelConstraintProvider.so',
       'libLiteRt.so',
@@ -111,7 +111,7 @@ const _litertLmBundleSpecs = <_LiteRtLmBundleSpec>[
   ),
   _LiteRtLmBundleSpec(
     'linux-x64',
-    sha256: 'b7b2501412bc8b37e7c40f81f552ecbd49090c60e2ab38bd0fa077a0a80afede',
+    sha256: 'ebe4258be2778ab26d425f07e6880ed8ce44c04404544cb10924c51a9d15ad3d',
     requiredLibraries: {
       'libGemmaModelConstraintProvider.so',
       'libLiteRt.so',
@@ -123,7 +123,7 @@ const _litertLmBundleSpecs = <_LiteRtLmBundleSpec>[
   ),
   _LiteRtLmBundleSpec(
     'windows-x64',
-    sha256: '5021ba4cd41abd41d9221e5aba20aeaf2c51947bc606d3d5a055c71e91b0b24f',
+    sha256: 'b57155d048eecf274e30abea597deef4d3d557852975b06c8222adc9a0097f12',
     requiredLibraries: {
       'LiteRtLm.dll',
       'libGemmaModelConstraintProvider.dll',

--- a/hook/build.dart
+++ b/hook/build.dart
@@ -26,7 +26,7 @@ const _cacheBaseDir = 'llamadart';
 const _bundleCacheDir = 'native_bundles';
 const _reportDir = 'llamadart_bin';
 const _allowLegacyLocalBundleEnv = 'LLAMADART_ALLOW_LEGACY_LOCAL_BUNDLES';
-const _litertLmVersion = '0.14.0-native.2';
+const _litertLmVersion = '0.15.0-native.1';
 const _litertLmNativeReleaseBaseUrl =
     'https://github.com/leehack/litert-lm-native/releases/download/'
     'v$_litertLmVersion';
@@ -51,7 +51,7 @@ final _litertLmBundles = Map.unmodifiable({
 const _litertLmBundleSpecs = <_LiteRtLmBundleSpec>[
   _LiteRtLmBundleSpec(
     'android-arm64',
-    sha256: '0ea2d059ef4cb1c44181724cd6e96a4c5556c053649270c7384706359d4415e7',
+    sha256: '6f249c5ff35a03cc4b474e2430747266750a282a738e5eeda6df4355418ccfa9',
     requiredLibraries: {
       'libGemmaModelConstraintProvider.so',
       'libLiteRtGpuAccelerator.so',
@@ -65,7 +65,7 @@ const _litertLmBundleSpecs = <_LiteRtLmBundleSpec>[
   ),
   _LiteRtLmBundleSpec(
     'android-x64',
-    sha256: '07d1b875828361302791c40e58bcd6f634fdac0ce44a6dc18dc8cf526c33e686',
+    sha256: 'df7174591239edadddf950a748dcf5f13a66d4fba5cfd467547f815e6d6f0b90',
     requiredLibraries: {
       'libGemmaModelConstraintProvider.so',
       'libLiteRtGpuAccelerator.so',
@@ -79,27 +79,27 @@ const _litertLmBundleSpecs = <_LiteRtLmBundleSpec>[
   ),
   _LiteRtLmBundleSpec(
     'ios-arm64',
-    sha256: 'c542d2776b56a6f0f8e9f41474d04ebb64703761b08ed4172212641255cb8c2f',
+    sha256: 'd77d80f163c2b49805ecebcaf8a677203cb934b1dc3a39eacc990e4eb9f26bcf',
     requiredLibraries: {'LiteRtLm', 'CLiteRTLM'},
   ),
   _LiteRtLmBundleSpec(
     'ios-arm64-sim',
-    sha256: '9b96d44dbeeae922346125c656cd1acc9a854c6a035ac8182a0d3e66a79e0003',
+    sha256: '12a835425fed122069a5b963ce2b09fe28683dc7f5e77637560d2a3f2f237c5c',
     requiredLibraries: {'LiteRtLm', 'CLiteRTLM'},
   ),
   _LiteRtLmBundleSpec(
     'macos-arm64',
-    sha256: '7165bc8c9a7bb6fe3ea32b2cbc0ccc49e9b6c86d14c911bb7dc670fc1a254c2d',
+    sha256: '3fce309cce689d365f5d6378d329a0c435219deaf124f47c7e7147354ffc956c',
     requiredLibraries: {'libLiteRtLm.dylib', 'libCLiteRTLM_mac.dylib'},
   ),
   _LiteRtLmBundleSpec(
     'macos-x64',
-    sha256: 'ad2644d55e8b8577a9cd09263178bdadcad897c85e557d4be0ecd57da54588de',
+    sha256: '8d0e9b90e5221ece5b77cd2284332e83f9179fe330611d7c51bc2b7d14dde8b6',
     requiredLibraries: {'libLiteRtLm.dylib', 'libCLiteRTLM_mac.dylib'},
   ),
   _LiteRtLmBundleSpec(
     'linux-arm64',
-    sha256: '72da739c7f3b125c55f3357a923cdfde3d02a53ba6a5837a296c27c6b47137d4',
+    sha256: '1e17c71d7297c106dd23dd8a0a0638b16b024f5c6dce90000b45f43e71ea44af',
     requiredLibraries: {
       'libGemmaModelConstraintProvider.so',
       'libLiteRt.so',
@@ -111,7 +111,7 @@ const _litertLmBundleSpecs = <_LiteRtLmBundleSpec>[
   ),
   _LiteRtLmBundleSpec(
     'linux-x64',
-    sha256: '71b36a9f0ca0a64ee285f243a0a6562a603df10a2f5cd61ede31078d5c75b972',
+    sha256: '84c5380baf8602ebb9167b8a603da3fe3242b47f31ea587a3b1df7177c7016dc',
     requiredLibraries: {
       'libGemmaModelConstraintProvider.so',
       'libLiteRt.so',
@@ -123,7 +123,7 @@ const _litertLmBundleSpecs = <_LiteRtLmBundleSpec>[
   ),
   _LiteRtLmBundleSpec(
     'windows-x64',
-    sha256: '3139f3b8b3f35c7fadf6d3978c25e39a89b732e19b7b0f8be95c7b9dc4e341bc',
+    sha256: '4e1f7f6f38b2ca5580e4e8b9cc46a92b2d80649789156ff52f9d4c32e7726efd',
     requiredLibraries: {
       'LiteRtLm.dll',
       'libGemmaModelConstraintProvider.dll',

--- a/lib/src/backends/litert_lm/litert_lm_backend_web.dart
+++ b/lib/src/backends/litert_lm/litert_lm_backend_web.dart
@@ -24,7 +24,7 @@ import '../backend.dart';
 /// This backend wraps the official `@litert-lm/core` browser API. Apps can
 /// preload the package and expose `window.LiteRtLmEngine = module.Engine`, or
 /// set `window.__llamadartLiteRtLmModuleUrl` to a module URL such as
-/// `https://cdn.jsdelivr.net/npm/@litert-lm/core@0.14.0/+esm`.
+/// `https://cdn.jsdelivr.net/npm/@litert-lm/core@0.15.0/+esm`.
 class LiteRtLmBackend
     implements
         LlamaBackend,

--- a/lib/src/backends/litert_lm/litert_lm_runtime.dart
+++ b/lib/src/backends/litert_lm/litert_lm_runtime.dart
@@ -45,10 +45,14 @@ String? liteRtLmStreamProxyCompatibilityError({
   if (hasStreamProxy && callbackAbiVersion == _streamChunkCallbackAbiVersion) {
     return null;
   }
+  final detectedAbi = hasStreamProxy
+      ? callbackAbiVersion?.toString() ?? 'no ABI marker'
+      : 'missing StreamProxy';
   return 'LiteRT-LM exposes the 0.15+ stream-chunk callback API, but its '
-      'embedded StreamProxy is missing or not stream-chunk compatible. Install a '
-      'corrected litert-lm-native runtime before using asynchronous '
-      'generation.';
+      'embedded StreamProxy is missing or not stream-chunk compatible. '
+      'Expected callback ABI $_streamChunkCallbackAbiVersion from pinned '
+      'litert-lm-native v$_litertLmVersion; detected $detectedAbi. Install the '
+      'pinned runtime before using asynchronous generation.';
 }
 
 /// Builds a diagnostic for LiteRT-LM engine creation failures.

--- a/lib/src/backends/litert_lm/litert_lm_runtime.dart
+++ b/lib/src/backends/litert_lm/litert_lm_runtime.dart
@@ -7,12 +7,49 @@ import 'dart:isolate';
 import 'package:ffi/ffi.dart';
 import 'package:path/path.dart' as path;
 
+import '../../core/exceptions.dart';
 import '../../core/models/inference/model_params.dart';
 
-const _litertLmVersion = '0.14.0-native.2';
+const _litertLmVersion = '0.15.0-native.1';
 const _litertLmLibDirEnv = 'LLAMADART_LITERT_LM_LIB_DIR';
 const _liteRtLmIosNativeAsset = 'package:llamadart/litert_lm_LiteRtLm';
 const _processLibraryCandidate = '<process>';
+const _streamChunkCallbackAbiVersion = 2;
+
+/// Returns macOS LiteRT-LM candidates for a concrete runtime library path.
+///
+/// Concrete app/cache paths must win over process-linked native assets so
+/// validation and deployments do not silently use a different runtime version.
+/// Explicit overrides exclude process fallback entirely.
+List<String> liteRtLmMacOsLibraryCandidates(
+  String libraryPath, {
+  required bool explicitOverride,
+}) {
+  return explicitOverride
+      ? <String>[libraryPath]
+      : <String>[libraryPath, _processLibraryCandidate];
+}
+
+/// Describes an unsafe StreamProxy/upstream callback ABI combination.
+///
+/// This is public only for unit tests. A non-null result means registering the
+/// asynchronous callback would be unsafe and must fail before generation.
+String? liteRtLmStreamProxyCompatibilityError({
+  required bool hasStreamProxy,
+  required bool hasStreamChunkApi,
+  required int? callbackAbiVersion,
+}) {
+  if (!hasStreamChunkApi) {
+    return null;
+  }
+  if (hasStreamProxy && callbackAbiVersion == _streamChunkCallbackAbiVersion) {
+    return null;
+  }
+  return 'LiteRT-LM exposes the 0.15+ stream-chunk callback API, but its '
+      'embedded StreamProxy is missing or not stream-chunk compatible. Install a '
+      'corrected litert-lm-native runtime before using asynchronous '
+      'generation.';
+}
 
 /// Builds a diagnostic for LiteRT-LM engine creation failures.
 ///
@@ -287,6 +324,9 @@ typedef _ProxyFreeStringDart = void Function(Pointer<Char> value);
 
 typedef _ProxyDeleteNative = Void Function(Pointer<Void> callbackData);
 typedef _ProxyDeleteDart = void Function(Pointer<Void> callbackData);
+
+typedef _ProxyCallbackAbiVersionNative = Int32 Function();
+typedef _ProxyCallbackAbiVersionDart = int Function();
 
 typedef _LoadGlobalNative = Pointer<Void> Function(Pointer<Utf8> path);
 typedef _LoadGlobalDart = Pointer<Void> Function(Pointer<Utf8> path);
@@ -1321,10 +1361,10 @@ class LiteRtLmRuntimeClient {
       final appLibraryDir = _findMacOsAppLibraryDir();
       if (appLibraryDir != null) {
         return (
-          liteRtLmCandidates: [
-            _processLibraryCandidate,
+          liteRtLmCandidates: liteRtLmMacOsLibraryCandidates(
             '${appLibraryDir.path}/libLiteRtLm.dylib',
-          ],
+            explicitOverride: false,
+          ),
           companions: [
             for (final library in companions) '${appLibraryDir.path}/$library',
           ],
@@ -1333,11 +1373,14 @@ class LiteRtLmRuntimeClient {
       }
       final cacheDir = _findMacOsLiteRtLmCacheDir();
       if (cacheDir != null) {
+        final explicitOverride =
+            Platform.environment[_litertLmLibDirEnv]?.trim().isNotEmpty ??
+            false;
         return (
-          liteRtLmCandidates: [
-            _processLibraryCandidate,
+          liteRtLmCandidates: liteRtLmMacOsLibraryCandidates(
             '${cacheDir.path}/libLiteRtLm.dylib',
-          ],
+            explicitOverride: explicitOverride,
+          ),
           companions: [
             for (final library in companions) '${cacheDir.path}/$library',
           ],
@@ -1410,6 +1453,7 @@ class LiteRtLmRuntimeClient {
     String liteRtLmPath,
     bool directCallbackSupported,
   ) {
+    _validateEmbeddedStreamProxyCompatibility(liteRtLmLibrary);
     try {
       _loadRuntimeGloballyIfAvailable(liteRtLmLibrary, liteRtLmPath);
       final proxyCreate = liteRtLmLibrary
@@ -1440,6 +1484,40 @@ class LiteRtLmRuntimeClient {
           '$error',
         );
       }
+    }
+  }
+
+  void _validateEmbeddedStreamProxyCompatibility(
+    DynamicLibrary liteRtLmLibrary,
+  ) {
+    final hasStreamProxy = const [
+      'stream_proxy_create',
+      'stream_proxy_free_string',
+      'stream_proxy_delete',
+    ].every((symbol) => _hasNativeSymbol(liteRtLmLibrary, symbol));
+    final hasStreamChunkApi = _hasNativeSymbol(
+      liteRtLmLibrary,
+      'litert_lm_stream_chunk_get_text',
+    );
+    int? callbackAbiVersion;
+    if (hasStreamProxy) {
+      try {
+        callbackAbiVersion = liteRtLmLibrary
+            .lookupFunction<
+              _ProxyCallbackAbiVersionNative,
+              _ProxyCallbackAbiVersionDart
+            >('stream_proxy_callback_abi_version')();
+      } on ArgumentError {
+        callbackAbiVersion = null;
+      }
+    }
+    final compatibilityError = liteRtLmStreamProxyCompatibilityError(
+      hasStreamProxy: hasStreamProxy,
+      hasStreamChunkApi: hasStreamChunkApi,
+      callbackAbiVersion: callbackAbiVersion,
+    );
+    if (compatibilityError != null) {
+      throw LlamaUnsupportedException(compatibilityError);
     }
   }
 
@@ -1946,6 +2024,15 @@ DynamicLibrary _openLiteRtLmLibraryCandidate(String candidate) {
   return candidate == _processLibraryCandidate
       ? DynamicLibrary.process()
       : DynamicLibrary.open(candidate);
+}
+
+bool _hasNativeSymbol(DynamicLibrary library, String symbol) {
+  try {
+    library.lookup<NativeFunction<Void Function()>>(symbol);
+    return true;
+  } on ArgumentError {
+    return false;
+  }
 }
 
 List<DynamicLibrary> _openCompanionLibraries(Iterable<String> companions) {

--- a/lib/src/backends/litert_lm/litert_lm_runtime.dart
+++ b/lib/src/backends/litert_lm/litert_lm_runtime.dart
@@ -10,7 +10,7 @@ import 'package:path/path.dart' as path;
 import '../../core/exceptions.dart';
 import '../../core/models/inference/model_params.dart';
 
-const _litertLmVersion = '0.15.0-native.2';
+const _litertLmVersion = '0.15.0-native.3';
 const _litertLmLibDirEnv = 'LLAMADART_LITERT_LM_LIB_DIR';
 const _liteRtLmIosNativeAsset = 'package:llamadart/litert_lm_LiteRtLm';
 const _processLibraryCandidate = '<process>';

--- a/lib/src/backends/litert_lm/litert_lm_runtime.dart
+++ b/lib/src/backends/litert_lm/litert_lm_runtime.dart
@@ -10,7 +10,7 @@ import 'package:path/path.dart' as path;
 import '../../core/exceptions.dart';
 import '../../core/models/inference/model_params.dart';
 
-const _litertLmVersion = '0.15.0-native.1';
+const _litertLmVersion = '0.15.0-native.2';
 const _litertLmLibDirEnv = 'LLAMADART_LITERT_LM_LIB_DIR';
 const _liteRtLmIosNativeAsset = 'package:llamadart/litert_lm_LiteRtLm';
 const _processLibraryCandidate = '<process>';

--- a/lib/src/backends/litert_lm/litert_lm_runtime.dart
+++ b/lib/src/backends/litert_lm/litert_lm_runtime.dart
@@ -142,12 +142,11 @@ String liteRtLmIosFrameworkBinaryPath(String frameworksDirPath, String name) {
 ///
 /// `DynamicLibrary.open` does not resolve Dart native-asset ids (only `@Native`
 /// externals do), so the `package:llamadart/...` id is passed verbatim to
-/// dlopen and never loads. The process image is tried first so Flutter SPM apps
-/// can resolve the SPM-linked `CLiteRTLM` symbols exported by the companion
-/// plugin.
-/// When [frameworksDirPath] is known, absolute framework binary paths are tried
-/// next; the native-asset id and bare dylib names remain last-resort fallbacks
-/// for the error message.
+/// dlopen and never loads. When [frameworksDirPath] is known, the wrapper
+/// framework is tried first because it exports StreamProxy and reexports the
+/// upstream `CLiteRTLM` API. The process image and absolute upstream framework
+/// path remain fallbacks for older Flutter SPM packaging; native-asset ids and
+/// bare dylib names remain last-resort fallbacks for the error message.
 List<String> liteRtLmIosLibraryCandidates(
   Abi abi, {
   String? frameworksDirPath,
@@ -157,11 +156,11 @@ List<String> liteRtLmIosLibraryCandidates(
     return const <String>[];
   }
   return <String>[
+    if (frameworksDirPath != null)
+      liteRtLmIosFrameworkBinaryPath(frameworksDirPath, 'LiteRtLm'),
     _processLibraryCandidate,
     if (frameworksDirPath != null)
       liteRtLmIosFrameworkBinaryPath(frameworksDirPath, 'CLiteRTLM'),
-    if (frameworksDirPath != null)
-      liteRtLmIosFrameworkBinaryPath(frameworksDirPath, 'LiteRtLm'),
     ...fallbacks.where((candidate) => candidate != _processLibraryCandidate),
   ];
 }

--- a/lib/src/backends/litert_lm/litert_lm_runtime.dart
+++ b/lib/src/backends/litert_lm/litert_lm_runtime.dart
@@ -1345,10 +1345,10 @@ class LiteRtLmRuntimeClient {
           '${frameworksDir.path}/LiteRtLm.framework/Versions/A/LiteRtLm',
         ).existsSync();
         return (
-          liteRtLmCandidates: [
-            _processLibraryCandidate,
+          liteRtLmCandidates: liteRtLmMacOsLibraryCandidates(
             '${frameworksDir.path}/LiteRtLm.framework/Versions/A/LiteRtLm',
-          ],
+            explicitOverride: false,
+          ),
           companions: usesNativeSpmFramework
               ? const []
               : [

--- a/packages/llamadart_litert_lm_flutter/CHANGELOG.md
+++ b/packages/llamadart_litert_lm_flutter/CHANGELOG.md
@@ -1,6 +1,6 @@
 ## Unreleased
 
-* Updated Apple SwiftPM native pin to `leehack/litert-lm-native@v0.15.0-native.2`.
+* Updated Apple SwiftPM native pin to `leehack/litert-lm-native@v0.15.0-native.3`.
 
 ## 0.0.7
 

--- a/packages/llamadart_litert_lm_flutter/CHANGELOG.md
+++ b/packages/llamadart_litert_lm_flutter/CHANGELOG.md
@@ -1,6 +1,6 @@
 ## Unreleased
 
-* Updated Apple SwiftPM native pin to `leehack/litert-lm-native@v0.15.0-native.1`.
+* Updated Apple SwiftPM native pin to `leehack/litert-lm-native@v0.15.0-native.2`.
 
 ## 0.0.7
 

--- a/packages/llamadart_litert_lm_flutter/CHANGELOG.md
+++ b/packages/llamadart_litert_lm_flutter/CHANGELOG.md
@@ -1,3 +1,7 @@
+## Unreleased
+
+* Updated Apple SwiftPM native pin to `leehack/litert-lm-native@v0.15.0-native.1`.
+
 ## 0.0.7
 
 * Updated the install example for `llamadart` 0.8.17.

--- a/packages/llamadart_litert_lm_flutter/README.md
+++ b/packages/llamadart_litert_lm_flutter/README.md
@@ -19,7 +19,7 @@ dependencies:
 This package has no runtime Dart API of its own. Import `package:llamadart`
 normally from the core package and use `LlamaBackend()` / `LlamaEngine` there.
 
-The Apple SwiftPM manifest pins `leehack/litert-lm-native@v0.15.0-native.2`.
+The Apple SwiftPM manifest pins `leehack/litert-lm-native@v0.15.0-native.3`.
 
 Source for this package lives in
 `packages/llamadart_litert_lm_flutter` in the

--- a/packages/llamadart_litert_lm_flutter/README.md
+++ b/packages/llamadart_litert_lm_flutter/README.md
@@ -19,7 +19,7 @@ dependencies:
 This package has no runtime Dart API of its own. Import `package:llamadart`
 normally from the core package and use `LlamaBackend()` / `LlamaEngine` there.
 
-The Apple SwiftPM manifest pins `leehack/litert-lm-native@v0.15.0-native.1`.
+The Apple SwiftPM manifest pins `leehack/litert-lm-native@v0.15.0-native.2`.
 
 Source for this package lives in
 `packages/llamadart_litert_lm_flutter` in the

--- a/packages/llamadart_litert_lm_flutter/README.md
+++ b/packages/llamadart_litert_lm_flutter/README.md
@@ -19,7 +19,7 @@ dependencies:
 This package has no runtime Dart API of its own. Import `package:llamadart`
 normally from the core package and use `LlamaBackend()` / `LlamaEngine` there.
 
-The Apple SwiftPM manifest pins `leehack/litert-lm-native@v0.14.0-native.2`.
+The Apple SwiftPM manifest pins `leehack/litert-lm-native@v0.15.0-native.1`.
 
 Source for this package lives in
 `packages/llamadart_litert_lm_flutter` in the

--- a/packages/llamadart_litert_lm_flutter/darwin/llamadart_litert_lm_flutter/Package.swift
+++ b/packages/llamadart_litert_lm_flutter/darwin/llamadart_litert_lm_flutter/Package.swift
@@ -4,7 +4,7 @@ import PackageDescription
 
 let packageRoot = URL(fileURLWithPath: #filePath).deletingLastPathComponent()
 let artifactsRoot = packageRoot.appendingPathComponent("Artifacts")
-let liteRtLmTag = "v0.15.0-native.1"
+let liteRtLmTag = "v0.15.0-native.2"
 
 func localArtifactPath(_ name: String) -> String? {
     let path = artifactsRoot.appendingPathComponent(name).path
@@ -47,21 +47,21 @@ let package = Package(
             repository: "leehack/litert-lm-native",
             artifactName: "litert-lm-native-apple-LiteRtLm-xcframework-\(liteRtLmTag).zip",
             tag: liteRtLmTag,
-            checksum: "5180633604ef3ab1b9d50adc1d473374f13d637c9ddfbb69abb478fe69149ea1"
+            checksum: "5e5f82edb73fa7490c4ae673795c029620013205f4e3e27eb37e5860405ca075"
         ),
         nativeRepoBinaryTarget(
             name: "CLiteRTLM",
             repository: "leehack/litert-lm-native",
             artifactName: "litert-lm-native-apple-CLiteRTLM-xcframework-\(liteRtLmTag).zip",
             tag: liteRtLmTag,
-            checksum: "5d8ee69ccc01d3c250ff39a85ec4ddb09c5ddbe92d9761946dba71da3120be0f"
+            checksum: "aea8640e16259a3f3fe17c132685f85a0f626643fd6bfe2042437a495f87ee6b"
         ),
         nativeRepoBinaryTarget(
             name: "CLiteRTLMMac",
             repository: "leehack/litert-lm-native",
             artifactName: "litert-lm-native-apple-CLiteRTLMMac-xcframework-\(liteRtLmTag).zip",
             tag: liteRtLmTag,
-            checksum: "e07f6d7c58dc84ed694353f8bcccec86401c105cef546ca582443b58ef853b81"
+            checksum: "177ea6d66c50e7bbad01ffa4cc35fb1e3d142b9e77750f19d08c88b26c0aa95d"
         ),
         .target(
             name: "llamadart_litert_lm_flutter",

--- a/packages/llamadart_litert_lm_flutter/darwin/llamadart_litert_lm_flutter/Package.swift
+++ b/packages/llamadart_litert_lm_flutter/darwin/llamadart_litert_lm_flutter/Package.swift
@@ -4,7 +4,7 @@ import PackageDescription
 
 let packageRoot = URL(fileURLWithPath: #filePath).deletingLastPathComponent()
 let artifactsRoot = packageRoot.appendingPathComponent("Artifacts")
-let liteRtLmTag = "v0.14.0-native.2"
+let liteRtLmTag = "v0.15.0-native.1"
 
 func localArtifactPath(_ name: String) -> String? {
     let path = artifactsRoot.appendingPathComponent(name).path
@@ -47,21 +47,21 @@ let package = Package(
             repository: "leehack/litert-lm-native",
             artifactName: "litert-lm-native-apple-LiteRtLm-xcframework-\(liteRtLmTag).zip",
             tag: liteRtLmTag,
-            checksum: "3412410db1cf0d343371db9a4af711710db3ddfed14ec7f95d673dd16a1b0cbe"
+            checksum: "5180633604ef3ab1b9d50adc1d473374f13d637c9ddfbb69abb478fe69149ea1"
         ),
         nativeRepoBinaryTarget(
             name: "CLiteRTLM",
             repository: "leehack/litert-lm-native",
             artifactName: "litert-lm-native-apple-CLiteRTLM-xcframework-\(liteRtLmTag).zip",
             tag: liteRtLmTag,
-            checksum: "1d0663baa5df3d29ab845dfd034783289e7c4f9f5f27dbfcb9beb3c762dc6cdd"
+            checksum: "5d8ee69ccc01d3c250ff39a85ec4ddb09c5ddbe92d9761946dba71da3120be0f"
         ),
         nativeRepoBinaryTarget(
             name: "CLiteRTLMMac",
             repository: "leehack/litert-lm-native",
             artifactName: "litert-lm-native-apple-CLiteRTLMMac-xcframework-\(liteRtLmTag).zip",
             tag: liteRtLmTag,
-            checksum: "a889c3fea5b2fce522c84b429a6552ed3cb9e21a51ba00d04dceeae8c33143e5"
+            checksum: "e07f6d7c58dc84ed694353f8bcccec86401c105cef546ca582443b58ef853b81"
         ),
         .target(
             name: "llamadart_litert_lm_flutter",

--- a/packages/llamadart_litert_lm_flutter/darwin/llamadart_litert_lm_flutter/Package.swift
+++ b/packages/llamadart_litert_lm_flutter/darwin/llamadart_litert_lm_flutter/Package.swift
@@ -4,7 +4,7 @@ import PackageDescription
 
 let packageRoot = URL(fileURLWithPath: #filePath).deletingLastPathComponent()
 let artifactsRoot = packageRoot.appendingPathComponent("Artifacts")
-let liteRtLmTag = "v0.15.0-native.2"
+let liteRtLmTag = "v0.15.0-native.3"
 
 func localArtifactPath(_ name: String) -> String? {
     let path = artifactsRoot.appendingPathComponent(name).path
@@ -47,21 +47,21 @@ let package = Package(
             repository: "leehack/litert-lm-native",
             artifactName: "litert-lm-native-apple-LiteRtLm-xcframework-\(liteRtLmTag).zip",
             tag: liteRtLmTag,
-            checksum: "5e5f82edb73fa7490c4ae673795c029620013205f4e3e27eb37e5860405ca075"
+            checksum: "c4edfe0a20744f54508dd70cc643846a5802a2a3d23262a7af72b17ea5d4b3a4"
         ),
         nativeRepoBinaryTarget(
             name: "CLiteRTLM",
             repository: "leehack/litert-lm-native",
             artifactName: "litert-lm-native-apple-CLiteRTLM-xcframework-\(liteRtLmTag).zip",
             tag: liteRtLmTag,
-            checksum: "aea8640e16259a3f3fe17c132685f85a0f626643fd6bfe2042437a495f87ee6b"
+            checksum: "ba0e8db00d1dedacc6443afd582211f11c77d12d134c690be26c0ccb34c9b1c4"
         ),
         nativeRepoBinaryTarget(
             name: "CLiteRTLMMac",
             repository: "leehack/litert-lm-native",
             artifactName: "litert-lm-native-apple-CLiteRTLMMac-xcframework-\(liteRtLmTag).zip",
             tag: liteRtLmTag,
-            checksum: "177ea6d66c50e7bbad01ffa4cc35fb1e3d142b9e77750f19d08c88b26c0aa95d"
+            checksum: "687633c1e9567dcc6d82d0b742bf53d1c41f9af3024e381b160d82cf092489dc"
         ),
         .target(
             name: "llamadart_litert_lm_flutter",

--- a/scripts/fetch_webgpu_bridge_assets.sh
+++ b/scripts/fetch_webgpu_bridge_assets.sh
@@ -4,7 +4,7 @@ set -euo pipefail
 ROOT_DIR="$(git rev-parse --show-toplevel)"
 OUT_DIR="${WEBGPU_BRIDGE_OUT_DIR:-$ROOT_DIR/example/chat_app/web/webgpu_bridge}"
 ASSETS_REPO="${WEBGPU_BRIDGE_ASSETS_REPO:-leehack/llama-web-bridge-assets}"
-ASSETS_TAG="${WEBGPU_BRIDGE_ASSETS_TAG:-v0.1.25}"
+ASSETS_TAG="${WEBGPU_BRIDGE_ASSETS_TAG:-v0.1.26}"
 CDN_BASE="${WEBGPU_BRIDGE_CDN_BASE:-https://cdn.jsdelivr.net/gh/${ASSETS_REPO}@${ASSETS_TAG}}"
 PATCH_SAFARI_COMPAT="${WEBGPU_BRIDGE_PATCH_SAFARI_COMPAT:-1}"
 MIN_SAFARI_VERSION="${WEBGPU_BRIDGE_MIN_SAFARI_VERSION:-170400}"
@@ -14,7 +14,7 @@ if [[ "${1:-}" == "--help" || "${1:-}" == "-h" ]]; then
 Downloads prebuilt WebGPU bridge assets into the chat_app web directory.
 
 Default source:
-  https://cdn.jsdelivr.net/gh/leehack/llama-web-bridge-assets@v0.1.25
+  https://cdn.jsdelivr.net/gh/leehack/llama-web-bridge-assets@v0.1.26
 
 Environment variables:
   WEBGPU_BRIDGE_ASSETS_REPO   Asset repo in owner/repo format
@@ -28,7 +28,7 @@ Usage:
   ./scripts/fetch_webgpu_bridge_assets.sh
 
 Examples:
-  WEBGPU_BRIDGE_ASSETS_TAG=v0.1.25 ./scripts/fetch_webgpu_bridge_assets.sh
+  WEBGPU_BRIDGE_ASSETS_TAG=v0.1.26 ./scripts/fetch_webgpu_bridge_assets.sh
   WEBGPU_BRIDGE_ASSETS_REPO=acme/llama-web-bridge-assets WEBGPU_BRIDGE_ASSETS_TAG=v2 ./scripts/fetch_webgpu_bridge_assets.sh
 USAGE
   exit 0

--- a/test/unit/backends/litert_lm/litert_lm_runtime_test.dart
+++ b/test/unit/backends/litert_lm/litert_lm_runtime_test.dart
@@ -190,18 +190,19 @@ void main() {
     expect(liteRtLmIosLibraryCandidatesForAbi(Abi.macosArm64), isEmpty);
   });
 
-  test('LiteRT-LM iOS lookup prefers process then framework paths', () {
-    // With the app Frameworks dir known, process lookup is still tried first
-    // for SPM, then absolute upstream/wrapper framework paths.
+  test('LiteRT-LM iOS lookup prefers the wrapper framework path', () {
+    // The wrapper exports StreamProxy and reexports the upstream API, so it
+    // must precede process and CLiteRTLM handles that can expose only part of
+    // the required v0.15 callback ABI.
     expect(
       liteRtLmIosLibraryCandidates(
         Abi.iosArm64,
         frameworksDirPath: '/App.app/Frameworks',
       ),
       const <String>[
+        '/App.app/Frameworks/LiteRtLm.framework/LiteRtLm',
         '<process>',
         '/App.app/Frameworks/CLiteRTLM.framework/CLiteRTLM',
-        '/App.app/Frameworks/LiteRtLm.framework/LiteRtLm',
         'package:llamadart/litert_lm_LiteRtLm',
         'LiteRtLm',
         'CLiteRTLM',

--- a/test/unit/backends/litert_lm/litert_lm_runtime_test.dart
+++ b/test/unit/backends/litert_lm/litert_lm_runtime_test.dart
@@ -60,6 +60,69 @@ void main() {
     expect(liteRtLmMacOsCacheDirectoryCandidatesForAbi(Abi.linuxX64), isEmpty);
   });
 
+  test('macOS LiteRT-LM paths precede process-linked runtime fallback', () {
+    expect(
+      liteRtLmMacOsLibraryCandidates(
+        '/runtime/libLiteRtLm.dylib',
+        explicitOverride: true,
+      ),
+      const <String>['/runtime/libLiteRtLm.dylib'],
+    );
+    expect(
+      liteRtLmMacOsLibraryCandidates(
+        '/runtime/libLiteRtLm.dylib',
+        explicitOverride: false,
+      ),
+      const <String>['/runtime/libLiteRtLm.dylib', '<process>'],
+    );
+  });
+
+  test('rejects legacy StreamProxy with the v0.15 stream-chunk API', () {
+    expect(
+      liteRtLmStreamProxyCompatibilityError(
+        hasStreamProxy: true,
+        hasStreamChunkApi: true,
+        callbackAbiVersion: null,
+      ),
+      contains('not stream-chunk compatible'),
+    );
+    expect(
+      liteRtLmStreamProxyCompatibilityError(
+        hasStreamProxy: true,
+        hasStreamChunkApi: true,
+        callbackAbiVersion: 1,
+      ),
+      contains('not stream-chunk compatible'),
+    );
+  });
+
+  test('accepts legacy runtimes and stream-chunk-compatible proxies', () {
+    expect(
+      liteRtLmStreamProxyCompatibilityError(
+        hasStreamProxy: true,
+        hasStreamChunkApi: false,
+        callbackAbiVersion: 1,
+      ),
+      isNull,
+    );
+    expect(
+      liteRtLmStreamProxyCompatibilityError(
+        hasStreamProxy: true,
+        hasStreamChunkApi: true,
+        callbackAbiVersion: 2,
+      ),
+      isNull,
+    );
+    expect(
+      liteRtLmStreamProxyCompatibilityError(
+        hasStreamProxy: false,
+        hasStreamChunkApi: true,
+        callbackAbiVersion: null,
+      ),
+      contains('missing or not stream-chunk compatible'),
+    );
+  });
+
   test('LiteRT-LM cache lookup follows desktop runtime ABIs', () {
     expect(
       liteRtLmCacheDirectoryCandidatesForAbi(Abi.macosArm64),

--- a/test/unit/backends/litert_lm/litert_lm_runtime_test.dart
+++ b/test/unit/backends/litert_lm/litert_lm_runtime_test.dart
@@ -86,14 +86,15 @@ void main() {
       ),
       contains('not stream-chunk compatible'),
     );
-    expect(
-      liteRtLmStreamProxyCompatibilityError(
-        hasStreamProxy: true,
-        hasStreamChunkApi: true,
-        callbackAbiVersion: 1,
-      ),
-      contains('not stream-chunk compatible'),
+    final legacyAbiError = liteRtLmStreamProxyCompatibilityError(
+      hasStreamProxy: true,
+      hasStreamChunkApi: true,
+      callbackAbiVersion: 1,
     );
+    expect(legacyAbiError, contains('not stream-chunk compatible'));
+    expect(legacyAbiError, contains('Expected callback ABI 2'));
+    expect(legacyAbiError, contains('v0.15.0-native.3'));
+    expect(legacyAbiError, contains('detected 1'));
   });
 
   test('accepts legacy runtimes and stream-chunk-compatible proxies', () {

--- a/tool/macos_litert_lm_prepare_app.sh
+++ b/tool/macos_litert_lm_prepare_app.sh
@@ -84,8 +84,8 @@ resolve_litert_dir() {
   fi
 
   local candidates=(
-    "$ROOT_DIR/.dart_tool/llamadart/litert_lm/0.15.0-native.1/macos_$LITERT_ARCH"
-    "$ROOT_DIR/.dart_tool/llamadart/litert_lm/0.15.0-native.1/macos/$LITERT_ARCH"
+    "$ROOT_DIR/.dart_tool/llamadart/litert_lm/0.15.0-native.2/macos_$LITERT_ARCH"
+    "$ROOT_DIR/.dart_tool/llamadart/litert_lm/0.15.0-native.2/macos/$LITERT_ARCH"
   )
   local candidate
   for candidate in "${candidates[@]}"; do

--- a/tool/macos_litert_lm_prepare_app.sh
+++ b/tool/macos_litert_lm_prepare_app.sh
@@ -84,8 +84,8 @@ resolve_litert_dir() {
   fi
 
   local candidates=(
-    "$ROOT_DIR/.dart_tool/llamadart/litert_lm/0.15.0-native.2/macos_$LITERT_ARCH"
-    "$ROOT_DIR/.dart_tool/llamadart/litert_lm/0.15.0-native.2/macos/$LITERT_ARCH"
+    "$ROOT_DIR/.dart_tool/llamadart/litert_lm/0.15.0-native.3/macos_$LITERT_ARCH"
+    "$ROOT_DIR/.dart_tool/llamadart/litert_lm/0.15.0-native.3/macos/$LITERT_ARCH"
   )
   local candidate
   for candidate in "${candidates[@]}"; do

--- a/tool/macos_litert_lm_prepare_app.sh
+++ b/tool/macos_litert_lm_prepare_app.sh
@@ -84,8 +84,8 @@ resolve_litert_dir() {
   fi
 
   local candidates=(
-    "$ROOT_DIR/.dart_tool/llamadart/litert_lm/0.14.0-native.2/macos_$LITERT_ARCH"
-    "$ROOT_DIR/.dart_tool/llamadart/litert_lm/0.14.0-native.2/macos/$LITERT_ARCH"
+    "$ROOT_DIR/.dart_tool/llamadart/litert_lm/0.15.0-native.1/macos_$LITERT_ARCH"
+    "$ROOT_DIR/.dart_tool/llamadart/litert_lm/0.15.0-native.1/macos/$LITERT_ARCH"
   )
   local candidate
   for candidate in "${candidates[@]}"; do

--- a/tool/testing/playwright_chat_app_benchmark.py
+++ b/tool/testing/playwright_chat_app_benchmark.py
@@ -457,7 +457,7 @@ def main() -> int:
           typeof window.__llamadartLiteRtLmModuleUrl === 'string' &&
           window.__llamadartLiteRtLmModuleUrl.length > 0
             ? window.__llamadartLiteRtLmModuleUrl
-            : 'https://cdn.jsdelivr.net/npm/@litert-lm/core@0.14.0/+esm';
+            : 'https://cdn.jsdelivr.net/npm/@litert-lm/core@0.15.0/+esm';
         const moduleSource = [
           'import * as mod from ' + JSON.stringify(originalModuleUrl) + ';',
           'const summarizeSettings = (settings) => {{',

--- a/tool/testing/playwright_chat_app_real_model_smoke.py
+++ b/tool/testing/playwright_chat_app_real_model_smoke.py
@@ -316,7 +316,7 @@ def main() -> int:
             typeof window.__llamadartLiteRtLmModuleUrl === 'string' &&
             window.__llamadartLiteRtLmModuleUrl.length > 0
               ? window.__llamadartLiteRtLmModuleUrl
-              : 'https://cdn.jsdelivr.net/npm/@litert-lm/core@0.14.0/+esm';
+              : 'https://cdn.jsdelivr.net/npm/@litert-lm/core@0.15.0/+esm';
           window.__llamadartLiteRtLmOriginalModuleUrl = originalModuleUrl;
           const moduleSource = [
             'import * as mod from ' + JSON.stringify(originalModuleUrl) + ';',

--- a/website/docs/changelog/recent-releases.md
+++ b/website/docs/changelog/recent-releases.md
@@ -16,7 +16,8 @@ For canonical full release notes, use:
 - Updated the default LiteRT-LM runtimes to native `v0.15.0-native.1` and Web
   `@litert-lm/core@0.15.0`. The native artifact includes a corrected v0.15
   streaming callback bridge; incompatible callback runtimes now fail safely
-  before generation, and explicit macOS library overrides are honored.
+  before generation, and concrete macOS app, framework, and cache libraries
+  take precedence over process-linked assets.
 
 - Updated native llama.cpp to `b10255`, adding explicit bundled-MTP loading,
   automatic model-specific token suppression, and recent model, multimodal,

--- a/website/docs/changelog/recent-releases.md
+++ b/website/docs/changelog/recent-releases.md
@@ -10,8 +10,10 @@ For canonical full release notes, use:
 ## Unreleased
 
 - Updated native llama.cpp to `b10276`, including Qwen3-TTS model-loading
-  primitives, the matching penalty-sampler ABI migration, and refreshed Apple
-  artifacts. Speech generation is not yet exposed through the public Dart API.
+  primitives, explicit bundled-MTP loading, automatic model-specific token
+  suppression, recent model/runtime improvements, the matching load-mode and
+  penalty-sampler ABI migrations, and refreshed Apple artifacts. Speech
+  generation is not yet exposed through the public Dart API.
 
 - Updated the default LiteRT-LM runtimes to native `v0.15.0-native.3` and Web
   `@litert-lm/core@0.15.0`. The native artifact includes a corrected v0.15
@@ -19,11 +21,6 @@ For canonical full release notes, use:
   device loss; incompatible callback runtimes now fail safely before
   generation, and concrete macOS app, framework, and cache libraries take
   precedence over process-linked assets.
-
-- Updated native llama.cpp to `b10255`, adding explicit bundled-MTP loading,
-  automatic model-specific token suppression, and recent model, multimodal,
-  speculative-decoding, and backend improvements, with matching load-mode
-  bindings and Apple artifacts.
 
 - Updated WebGPU bridge assets to `v0.1.26` (llama.cpp `b10276`), refreshing
   both WebAssembly runtimes while preserving the existing bridge API.

--- a/website/docs/changelog/recent-releases.md
+++ b/website/docs/changelog/recent-releases.md
@@ -13,6 +13,11 @@ For canonical full release notes, use:
   primitives, the matching penalty-sampler ABI migration, and refreshed Apple
   artifacts. Speech generation is not yet exposed through the public Dart API.
 
+- Updated the default native LiteRT-LM runtime to `v0.15.0-native.1`, with a
+  corrected v0.15 streaming callback bridge. Incompatible callback runtimes
+  now fail safely before generation, and explicit macOS library overrides are
+  honored.
+
 - Updated native llama.cpp to `b10255`, adding explicit bundled-MTP loading,
   automatic model-specific token suppression, and recent model, multimodal,
   speculative-decoding, and backend improvements, with matching load-mode

--- a/website/docs/changelog/recent-releases.md
+++ b/website/docs/changelog/recent-releases.md
@@ -13,10 +13,10 @@ For canonical full release notes, use:
   primitives, the matching penalty-sampler ABI migration, and refreshed Apple
   artifacts. Speech generation is not yet exposed through the public Dart API.
 
-- Updated the default native LiteRT-LM runtime to `v0.15.0-native.1`, with a
-  corrected v0.15 streaming callback bridge. Incompatible callback runtimes
-  now fail safely before generation, and explicit macOS library overrides are
-  honored.
+- Updated the default LiteRT-LM runtimes to native `v0.15.0-native.1` and Web
+  `@litert-lm/core@0.15.0`. The native artifact includes a corrected v0.15
+  streaming callback bridge; incompatible callback runtimes now fail safely
+  before generation, and explicit macOS library overrides are honored.
 
 - Updated native llama.cpp to `b10255`, adding explicit bundled-MTP loading,
   automatic model-specific token suppression, and recent model, multimodal,

--- a/website/docs/changelog/recent-releases.md
+++ b/website/docs/changelog/recent-releases.md
@@ -13,7 +13,7 @@ For canonical full release notes, use:
   primitives, the matching penalty-sampler ABI migration, and refreshed Apple
   artifacts. Speech generation is not yet exposed through the public Dart API.
 
-- Updated the default LiteRT-LM runtimes to native `v0.15.0-native.1` and Web
+- Updated the default LiteRT-LM runtimes to native `v0.15.0-native.2` and Web
   `@litert-lm/core@0.15.0`. The native artifact includes a corrected v0.15
   streaming callback bridge; incompatible callback runtimes now fail safely
   before generation, and concrete macOS app, framework, and cache libraries

--- a/website/docs/changelog/recent-releases.md
+++ b/website/docs/changelog/recent-releases.md
@@ -24,7 +24,7 @@ For canonical full release notes, use:
   speculative-decoding, and backend improvements, with matching load-mode
   bindings and Apple artifacts.
 
-- Updated WebGPU bridge assets to `v0.1.25` (llama.cpp `b10255`), refreshing
+- Updated WebGPU bridge assets to `v0.1.26` (llama.cpp `b10276`), refreshing
   both WebAssembly runtimes while preserving the existing bridge API.
 
 - Disabled automatic WebGPU fetch-backed model loading by default. Streamed

--- a/website/docs/changelog/recent-releases.md
+++ b/website/docs/changelog/recent-releases.md
@@ -13,11 +13,12 @@ For canonical full release notes, use:
   primitives, the matching penalty-sampler ABI migration, and refreshed Apple
   artifacts. Speech generation is not yet exposed through the public Dart API.
 
-- Updated the default LiteRT-LM runtimes to native `v0.15.0-native.2` and Web
+- Updated the default LiteRT-LM runtimes to native `v0.15.0-native.3` and Web
   `@litert-lm/core@0.15.0`. The native artifact includes a corrected v0.15
-  streaming callback bridge; incompatible callback runtimes now fail safely
-  before generation, and concrete macOS app, framework, and cache libraries
-  take precedence over process-linked assets.
+  streaming callback bridge and an Android Dawn rollback for Mali-G715 GPU
+  device loss; incompatible callback runtimes now fail safely before
+  generation, and concrete macOS app, framework, and cache libraries take
+  precedence over process-linked assets.
 
 - Updated native llama.cpp to `b10255`, adding explicit bundled-MTP loading,
   automatic model-specific token suppression, and recent model, multimodal,

--- a/website/docs/platforms/support-matrix.md
+++ b/website/docs/platforms/support-matrix.md
@@ -8,7 +8,7 @@ backend-module configuration for
 `llamadart`.
 
 The native-assets hook currently pins `llamadart-native` tag `b10276` and
-`litert-lm-native` release `v0.15.0-native.1` (`hook/build.dart`). Apps can
+`litert-lm-native` release `v0.15.0-native.2` (`hook/build.dart`). Apps can
 override the llama.cpp native GitHub source with
 `hooks.user_defines.llamadart.llamadart_native_tag` and
 `hooks.user_defines.llamadart.llamadart_native_repository`, or use a local
@@ -120,7 +120,7 @@ Explicitly selecting `litert_lm` for a target without a pinned LiteRT-LM
 runtime fails during the build hook instead of producing an app that cannot
 load `.litertlm` models.
 
-## LiteRT-LM runtime coverage (`v0.15.0-native.1`)
+## LiteRT-LM runtime coverage (`v0.15.0-native.2`)
 
 | Platform target | LiteRT-LM bundle key | Selectable backends | Status |
 | --- | --- | --- | --- |
@@ -156,7 +156,7 @@ as a multi-turn `ChatSession` or tool-calling backend yet.
 instead of silently ignoring llama.cpp-only settings.
 
 Native LiteRT-LM exposes these load-time runtime controls through
-`ModelParams`. Nullable fields keep the pinned `v0.15.0-native.1` runtime
+`ModelParams`. Nullable fields keep the pinned `v0.15.0-native.2` runtime
 default.
 
 | Native C API | Dart field | Support decision |

--- a/website/docs/platforms/support-matrix.md
+++ b/website/docs/platforms/support-matrix.md
@@ -8,7 +8,7 @@ backend-module configuration for
 `llamadart`.
 
 The native-assets hook currently pins `llamadart-native` tag `b10276` and
-`litert-lm-native` release `v0.15.0-native.2` (`hook/build.dart`). Apps can
+`litert-lm-native` release `v0.15.0-native.3` (`hook/build.dart`). Apps can
 override the llama.cpp native GitHub source with
 `hooks.user_defines.llamadart.llamadart_native_tag` and
 `hooks.user_defines.llamadart.llamadart_native_repository`, or use a local
@@ -120,7 +120,7 @@ Explicitly selecting `litert_lm` for a target without a pinned LiteRT-LM
 runtime fails during the build hook instead of producing an app that cannot
 load `.litertlm` models.
 
-## LiteRT-LM runtime coverage (`v0.15.0-native.2`)
+## LiteRT-LM runtime coverage (`v0.15.0-native.3`)
 
 | Platform target | LiteRT-LM bundle key | Selectable backends | Status |
 | --- | --- | --- | --- |
@@ -156,7 +156,7 @@ as a multi-turn `ChatSession` or tool-calling backend yet.
 instead of silently ignoring llama.cpp-only settings.
 
 Native LiteRT-LM exposes these load-time runtime controls through
-`ModelParams`. Nullable fields keep the pinned `v0.15.0-native.2` runtime
+`ModelParams`. Nullable fields keep the pinned `v0.15.0-native.3` runtime
 default.
 
 | Native C API | Dart field | Support decision |

--- a/website/docs/platforms/support-matrix.md
+++ b/website/docs/platforms/support-matrix.md
@@ -8,7 +8,7 @@ backend-module configuration for
 `llamadart`.
 
 The native-assets hook currently pins `llamadart-native` tag `b10276` and
-`litert-lm-native` release `v0.14.0-native.2` (`hook/build.dart`). Apps can
+`litert-lm-native` release `v0.15.0-native.1` (`hook/build.dart`). Apps can
 override the llama.cpp native GitHub source with
 `hooks.user_defines.llamadart.llamadart_native_tag` and
 `hooks.user_defines.llamadart.llamadart_native_repository`, or use a local
@@ -120,7 +120,7 @@ Explicitly selecting `litert_lm` for a target without a pinned LiteRT-LM
 runtime fails during the build hook instead of producing an app that cannot
 load `.litertlm` models.
 
-## LiteRT-LM runtime coverage (`v0.14.0-native.2`)
+## LiteRT-LM runtime coverage (`v0.15.0-native.1`)
 
 | Platform target | LiteRT-LM bundle key | Selectable backends | Status |
 | --- | --- | --- | --- |
@@ -156,7 +156,7 @@ as a multi-turn `ChatSession` or tool-calling backend yet.
 instead of silently ignoring llama.cpp-only settings.
 
 Native LiteRT-LM exposes these load-time runtime controls through
-`ModelParams`. Nullable fields keep the pinned `v0.14.0-native.2` runtime
+`ModelParams`. Nullable fields keep the pinned `v0.15.0-native.1` runtime
 default.
 
 | Native C API | Dart field | Support decision |

--- a/website/docs/platforms/webgpu-bridge.md
+++ b/website/docs/platforms/webgpu-bridge.md
@@ -146,13 +146,13 @@ development validation, and CDN-first loading for normal hosted deployments:
 1. On localhost: local asset first, then CDN fallback.
 2. On hosted deployments: CDN asset first, then local fallback.
 
-The example currently pins bridge assets to `v0.1.25`, with local vendored assets
-identified as `v0.1.25-local-b10255`.
+The example currently pins bridge assets to `v0.1.26`, with local vendored assets
+identified as `v0.1.26-local-b10276`.
 
 Fetch pinned local assets with:
 
 ```bash
-WEBGPU_BRIDGE_ASSETS_TAG=v0.1.25 ./scripts/fetch_webgpu_bridge_assets.sh
+WEBGPU_BRIDGE_ASSETS_TAG=v0.1.26 ./scripts/fetch_webgpu_bridge_assets.sh
 ```
 
 To verify the loaded runtime in a browser console, inspect:
@@ -309,7 +309,7 @@ You can override bridge asset source/version before loader startup:
 ```html
 <script>
   window.__llamadartBridgeAssetsRepo = 'leehack/llama-web-bridge-assets';
-  window.__llamadartBridgeAssetsTag = 'v0.1.25';
+  window.__llamadartBridgeAssetsTag = 'v0.1.26';
   // Prefer local runtime even off localhost:
   // window.__llamadartPreferLocalBridgeRuntime = true;
   // Enable verbose bridge bootstrap console logs:


### PR DESCRIPTION
## Summary
- Update native LiteRT-LM from `0.14.0-native.2` to the corrected `0.15.0-native.3` companion release and Web LiteRT-LM from `@litert-lm/core@0.14.0` to `0.15.0`. Native `.3` preserves the v0.15 callback fix and rolls Android Dawn back to the last known-good revision after a Mali-G715 WebGPU device-loss regression.
- Guard the v0.15 stream-chunk callback boundary so incomplete or legacy StreamProxy adapters fail with the expected callback ABI and pinned runtime in the diagnostic instead of registering an ABI-incompatible callback.
- Prefer concrete macOS app, framework, and cache runtimes over process-linked fallback libraries, preventing old process-loaded wrappers from being mixed with the intended runtime.
- Update the WebGPU bridge assets from v0.1.25 to v0.1.26, consuming llama.cpp b10276 plus the bridge's upstream-aligned model/runtime fixes.
- Refresh native checksums, browser runtime URLs, runtime tests, user documentation, support matrices, and changelogs.

## Production-readiness scope
- **User-facing scope:** Native and Web `.litertlm` inference continue through the existing public `LlamaEngine` API while consuming LiteRT-LM 0.15 runtimes. Existing native streaming, thinking, tool calls, cancellation/regeneration, unload/reload, and multi-turn tool history remain supported; existing Web single-turn streaming remains supported. Existing Web GGUF inference automatically consumes the v0.1.26 bridge assets without a Dart API change.
- **Supported platforms/paths:** Native hook bundles for Android arm64/x64, iOS arm64/simulator, Linux arm64/x64, macOS arm64/x64, and Windows x64; Apple SwiftPM companion artifacts; Android arm64 and iOS arm64 GPU device validation; macOS arm64 CPU real-model validation; Chromium WebGPU real-model validation for both GGUF and LiteRT-LM paths.
- **Unsupported or intentionally unavailable paths:** Windows arm64 and iOS x86_64 simulator remain GGUF-only because the pinned LiteRT-LM release does not publish matching native bundles. The new upstream 0.15 AutoToolChat, cloning/state, embeddings, ASR, and TTS APIs are not exposed by this runtime-pin PR. LiteRT-LM Web remains single-turn and text-only in llamadart and continues to reject native-only controls. A native v0.15 library with a missing, incomplete, legacy, or unknown StreamProxy callback ABI is rejected with `LlamaUnsupportedException` before callback registration.
- **Out of scope / follow-ups:** LiteRT-LM GPU execution remains unavailable on this macOS host, but CPU real-model generation passed. Android Mali-G715 and iPad Metal GPU device paths passed against the exact `.3` artifacts. Windows arm64 and iOS x86_64 simulator remain unavailable as described above.

## Completeness checklist
- [x] Declared scope is fully implemented, or explicitly reduced above.
- [x] Unsupported platform/option combinations fail loudly with actionable diagnostics or are clearly documented as unavailable.
- [x] Public API docs, README/website docs, examples, support matrices, and changelog entries are updated where relevant.
- [x] Regression coverage covers the original issue plus key negative/version-skew paths where relevant.
- [x] Security/privacy review completed: no secrets, bearer tokens, signed URLs, or raw secret-bearing paths leak through logs, cache keys, metadata, errors, or snapshots.
- [x] Follow-up work that is useful but not required for this PR is tracked or explicitly identified above.

## Test Plan
- [x] `dart format --output=none --set-exit-if-changed .`
- [x] `dart analyze`
- [x] `dart test -p vm -j 1 --exclude-tags local-only` — 1,312 passed, 66 fixture-dependent skips.
- [x] `dart test -p chrome --exclude-tags local-only` — 738 passed, 1 skipped.
- [x] Other targeted/local validation:
  - 145 focused LiteRT-LM backend, hook, and release-pin tests passed during the v0.15 integration review; after repinning to `.3`, 54 targeted runtime/hook/pin-sync tests passed again.
  - Release-pin sync dry-run against the published `v0.15.0-native.3` GitHub release metadata passed.
  - The `v0.15.0-native.3` release workflow passed all nine runtime jobs plus packaging. Its 17-asset manifest contains 62 artifacts; all nine hook archive hashes and three SwiftPM checksums match the published release, and the tag resolves to the reviewed companion merge `7a70690481e0d4e76eefaa9cdc51b070c6f3861a`.
  - Exact published macOS arm64 `.3` artifacts passed public `LlamaEngine` CPU load/generate with Gemma 4 E2B and returned `4`. Broader streaming thinking, required `get_weather` tool calls, and native multi-turn tool history passed on `.2`; the `.3` source delta is Android Dawn-only.
  - Exact published Android arm64 `.3` artifacts passed Gemma 4 E2B GPU generation on a Pixel 9 Pro / Mali-G715: 58 decoded tokens, coherent output, 16.50 decode tok/s, and no `RegisterAccelerator` or WebGPU device-loss error.
  - Exact published Apple SwiftPM `.3` artifacts passed Gemma 4 E2B GPU generation on an iPad: 16/16 decoded tokens, coherent output, and 24.64 decode tok/s.
  - A deliberately incompatible v0.15 wrapper fails safely with `LlamaUnsupportedException` before callback registration.
  - `WEBGPU_BRIDGE_ASSETS_TAG=v0.1.26 ./scripts/fetch_webgpu_bridge_assets.sh` passed all manifest checksums.
  - The deployable Web chat build passed with staged v0.1.26 assets. A real local worker/WASM/GGUF smoke loaded Stories 15M and generated a non-empty response with no page errors or failed requests.
  - The deployable Web chat app loaded Gemma 4 E2B through `@litert-lm/core@0.15.0` on the WebGPU `GPU_ARTISAN` backend and generated the expected `4` with no page errors or request failures.
  - Chat-app unit tests (55 passed), Swift package manifest evaluation, docs-site build, link validation, and release-doc version validation passed.

## Matrix Evidence
| Matrix row | Scope covered | Platform / model / backend | Result | Evidence / notes |
| --- | --- | --- | --- | --- |
| `static-format-analyze` | format and analyzer | Repository and nested examples | PASS | Format unchanged; full analyzer clean. |
| `root-vm` | native-safe unit/integration coverage | Dart VM | PASS | 1,312 passed; 66 fixture-dependent skips. |
| `root-chrome` | browser regression coverage | Chrome | PASS | 738 passed; 1 skipped. |
| `docs-site` | website build and links | Docusaurus | PASS | Site build and link validation passed. |
| `release-doc-version-consistency` | version-sensitive documentation | Root/package/site docs | PASS | `llamadart 0.8.17`, llama.cpp Flutter `0.0.11`, LiteRT Flutter `0.0.7`. |
| `native-hook-bundles` | artifact selection, checksums, and release-pin synchronization | All published native targets | PASS | Nine hook SHA-256 values and three SwiftPM checksums match `v0.15.0-native.3`. |
| `litert-lm-engine-smoke` | public engine load/generate | macOS arm64 / Gemma 4 E2B `.litertlm` / CPU | PASS | Exact published `.3` artifact generated successfully. |
| `litert-lm-chat-features-smoke` | thinking, streaming tools, and history | macOS arm64 / Gemma 4 E2B `.litertlm` / CPU | PASS | Passed on `.2`; `.3` changes only the Android Dawn source revision. |
| `web-worker-real-model-smoke` | bridge worker/WASM/GGUF runtime | Chromium / Stories 15M GGUF / WebGPU | PASS | v0.1.26 assets loaded and generated non-empty output without browser errors. |
| `gemma4-litert-web` | real Web LiteRT-LM load and generation | Chromium / Gemma 4 E2B Web `.litertlm` / WebGPU | PASS | `@litert-lm/core@0.15.0` loaded on `GPU_ARTISAN` and generated `4`. |
| `device-native-gpu` | corrected Android Dawn runtime / native GPU | Pixel 9 Pro / Mali-G715 / Gemma 4 E2B | PASS | Exact `.3` artifact decoded 58 tokens at 16.50 tok/s with no accelerator-registration or device-loss error. |
| `ios-arm64-device-smoke` | Apple SwiftPM framework load and native GPU generation | iPad / Gemma 4 E2B / GPU | PASS | Exact `.3` artifact decoded 16/16 tokens at 24.64 tok/s with coherent output. |

## Review Notes
- The readiness review drove the v0.15 callback compatibility guard, concrete macOS runtime ordering, release-provenance verification, the Android Dawn regression isolation, and the physical Android/iPad GPU validation above.
- CI status / head SHA: All 14 exact-head checks passed for `8cdbddf902aea9442b624f154b5202e1fddac378`, including analysis, docs, Linux coverage, Chrome, the Web Chat Contract, macOS/Windows native tests, Ubuntu/Windows LiteRT-LM smokes, both companion packages, prompt-reuse parity, and the deploy preview.
