### PR TITLE
Upgrade native llama.cpp runtime to b10276

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 ## Unreleased
 
+* Updated the default llama.cpp native runtime pin to
+  `leehack/llamadart-native@b10276`, picking up Qwen3-TTS model-loading
+  primitives and recent runtime fixes. Regenerated matching Dart FFI bindings,
+  migrated the penalty sampler to the new vocabulary-sized ABI, and refreshed
+  the `llamadart_llama_cpp_flutter` Apple SwiftPM checksum. Speech generation
+  is not yet exposed through the public Dart API.
+
 * Updated the default llama.cpp native runtime to
   `leehack/llamadart-native@b10255`, adding explicit bundled-MTP loading and
   automatic model-specific token suppression alongside recent model,

--- a/README.md
+++ b/README.md
@@ -134,7 +134,7 @@ Current default runtime pins:
 
 | Runtime | Pin |
 | --- | --- |
-| Native llama.cpp / GGUF | `leehack/llamadart-native@b10255` |
+| Native llama.cpp / GGUF | `leehack/llamadart-native@b10276` |
 | Native LiteRT-LM / `.litertlm` | `leehack/litert-lm-native@v0.14.0-native.2` |
 | Web llama.cpp / GGUF | `leehack/llama-web-bridge-assets@v0.1.25` |
 | Web LiteRT-LM / `.litertlm` | `@litert-lm/core@0.14.0` |

--- a/hook/build.dart
+++ b/hook/build.dart
@@ -13,7 +13,7 @@ import 'package:path/path.dart' as path;
 
 import 'package:llamadart/src/hook/native_bundle_config.dart';
 
-const _llamaCppTag = 'b10255';
+const _llamaCppTag = 'b10276';
 const _nativeRepoSlug = 'leehack/llamadart-native';
 
 const _packageName = 'llamadart';

--- a/lib/src/backends/llama_cpp/bindings.dart
+++ b/lib/src/backends/llama_cpp/bindings.dart
@@ -1522,12 +1522,14 @@ external ffi.Pointer<llama_sampler> llama_sampler_init_grammar_lazy_patterns(
 @ffi.Native<
   ffi.Pointer<llama_sampler> Function(
     ffi.Int32,
+    ffi.Int32,
     ffi.Float,
     ffi.Float,
     ffi.Float,
   )
 >()
 external ffi.Pointer<llama_sampler> llama_sampler_init_penalties(
+  int n_vocab,
   int penalty_last_n,
   double penalty_repeat,
   double penalty_freq,
@@ -1538,7 +1540,6 @@ external ffi.Pointer<llama_sampler> llama_sampler_init_penalties(
 @ffi.Native<
   ffi.Pointer<llama_sampler> Function(
     ffi.Pointer<llama_vocab>,
-    ffi.Int32,
     ffi.Float,
     ffi.Float,
     ffi.Int32,
@@ -1549,7 +1550,6 @@ external ffi.Pointer<llama_sampler> llama_sampler_init_penalties(
 >()
 external ffi.Pointer<llama_sampler> llama_sampler_init_dry(
   ffi.Pointer<llama_vocab> vocab,
-  int n_ctx_train,
   double dry_multiplier,
   double dry_base,
   int dry_allowed_length,
@@ -7650,6 +7650,24 @@ external void mtmd_log_set(
 @ffi.Native<mtmd_caps Function(ffi.Pointer<ffi.Char>)>()
 external mtmd_caps mtmd_get_cap_from_file(ffi.Pointer<ffi.Char> mmproj_fname);
 
+@ffi.Native<mtmd_gen_audio_info Function(ffi.Pointer<mtmd_context>)>()
+external mtmd_gen_audio_info mtmd_gen_audio_get_info(
+  ffi.Pointer<mtmd_context> ctx,
+);
+
+@ffi.Native<
+  ffi.Int32 Function(
+    ffi.Pointer<mtmd_context>,
+    ffi.Pointer<mtmd_gen_inp>,
+    ffi.Pointer<mtmd_gen_out>,
+  )
+>()
+external int mtmd_gen_audio_process(
+  ffi.Pointer<mtmd_context> ctx,
+  ffi.Pointer<mtmd_gen_inp> inp,
+  ffi.Pointer<mtmd_gen_out> out,
+);
+
 /// //////////////////////////////////////
 @ffi.Native<ffi.Pointer<mtmd_input_chunks> Function()>()
 external ffi.Pointer<mtmd_input_chunks> mtmd_test_create_input_chunks();
@@ -7833,6 +7851,84 @@ external int mtmd_helper_video_read_next(
   ffi.Pointer<mtmd_helper_video> ctx,
   ffi.Pointer<ffi.Pointer<mtmd_bitmap>> out_bitmap,
   ffi.Pointer<ffi.Pointer<ffi.Char>> out_text,
+);
+
+@ffi.Native<
+  ffi.Bool Function(ffi.Pointer<llama_context>, ffi.Pointer<mtmd_context>)
+>()
+external bool mtmd_helper_model_can_chat(
+  ffi.Pointer<llama_context> lctx,
+  ffi.Pointer<mtmd_context> mctx,
+);
+
+@ffi.Native<
+  ffi.Pointer<mtmd_helper_gen_audio> Function(
+    ffi.Pointer<llama_context>,
+    ffi.Pointer<mtmd_context>,
+  )
+>()
+external ffi.Pointer<mtmd_helper_gen_audio> mtmd_helper_gen_audio_init(
+  ffi.Pointer<llama_context> lctx,
+  ffi.Pointer<mtmd_context> mctx,
+);
+
+@ffi.Native<ffi.Void Function(ffi.Pointer<mtmd_helper_gen_audio>)>()
+external void mtmd_helper_gen_audio_free(
+  ffi.Pointer<mtmd_helper_gen_audio> ctx,
+);
+
+@ffi.Native<ffi.Void Function(ffi.Pointer<mtmd_helper_gen_audio>)>()
+external void mtmd_helper_gen_audio_reset(
+  ffi.Pointer<mtmd_helper_gen_audio> ctx,
+);
+
+@ffi.Native<
+  ffi.Int32 Function(
+    ffi.Pointer<mtmd_helper_gen_audio>,
+    ffi.Pointer<mtmd_helper_gen_audio_inp>,
+  )
+>()
+external int mtmd_helper_gen_audio_set_input(
+  ffi.Pointer<mtmd_helper_gen_audio> ctx,
+  ffi.Pointer<mtmd_helper_gen_audio_inp> inp,
+);
+
+@ffi.Native<ffi.Int32 Function(ffi.Pointer<mtmd_helper_gen_audio>, ffi.Int32)>()
+external int mtmd_helper_gen_audio_step_prompt(
+  ffi.Pointer<mtmd_helper_gen_audio> ctx,
+  int n_batch,
+);
+
+@ffi.Native<
+  ffi.Int32 Function(
+    ffi.Pointer<mtmd_helper_gen_audio>,
+    llama_token,
+    ffi.Pointer<ffi.Float>,
+    ffi.Pointer<ffi.Pointer<ffi.Float>>,
+  )
+>()
+external int mtmd_helper_gen_audio_step_gen(
+  ffi.Pointer<mtmd_helper_gen_audio> ctx,
+  int sampled,
+  ffi.Pointer<ffi.Float> h_state_in,
+  ffi.Pointer<ffi.Pointer<ffi.Float>> h_state_out,
+);
+
+@ffi.Native<
+  ffi.Int32 Function(
+    ffi.Pointer<mtmd_helper_gen_audio>,
+    ffi.Pointer<ffi.Int32>,
+    ffi.Pointer<ffi.Pointer<ffi.Char>>,
+    ffi.Pointer<ffi.Size>,
+    ffi.Pointer<ffi.Int64>,
+  )
+>()
+external int mtmd_helper_gen_audio_get_output(
+  ffi.Pointer<mtmd_helper_gen_audio> ctx,
+  ffi.Pointer<ffi.Int32> out_sample_rate,
+  ffi.Pointer<ffi.Pointer<ffi.Char>> out_data,
+  ffi.Pointer<ffi.Size> out_data_len,
+  ffi.Pointer<ffi.Int64> out_n_samples,
 );
 
 @ffi.Native<ffi.Void Function(ffi.Int)>()
@@ -8546,9 +8642,6 @@ final class llama_sampler_data extends ffi.Struct {
   external ffi.Pointer<ggml_tensor> sampled;
 
   external ffi.Pointer<ggml_tensor> candidates;
-
-  @ffi.Int64()
-  external int n_vocab;
 }
 
 final class llama_sampler_i extends ffi.Struct {
@@ -10566,6 +10659,92 @@ final class mtmd_caps extends ffi.Struct {
   external bool inp_audio;
 }
 
+/// //////////////////////////////////////
+enum mtmd_gen_audio_type {
+  MTMD_GEN_AUDIO_TYPE_NONE(0),
+  MTMD_GEN_AUDIO_TYPE_QWEN3TTS(1);
+
+  final int value;
+  const mtmd_gen_audio_type(this.value);
+
+  static mtmd_gen_audio_type fromValue(int value) => switch (value) {
+    0 => MTMD_GEN_AUDIO_TYPE_NONE,
+    1 => MTMD_GEN_AUDIO_TYPE_QWEN3TTS,
+    _ => throw ArgumentError('Unknown value for mtmd_gen_audio_type: $value'),
+  };
+}
+
+final class mtmd_gen_audio_info extends ffi.Struct {
+  @ffi.UnsignedInt()
+  external int typeAsInt;
+
+  mtmd_gen_audio_type get type => mtmd_gen_audio_type.fromValue(typeAsInt);
+
+  @ffi.Int32()
+  external int sample_rate;
+}
+
+enum mtmd_gen_process_type {
+  MTMD_GEN_PROCESS_TYPE_GEN_CODE(0),
+  MTMD_GEN_PROCESS_TYPE_GEN_WAV(1);
+
+  final int value;
+  const mtmd_gen_process_type(this.value);
+
+  static mtmd_gen_process_type fromValue(int value) => switch (value) {
+    0 => MTMD_GEN_PROCESS_TYPE_GEN_CODE,
+    1 => MTMD_GEN_PROCESS_TYPE_GEN_WAV,
+    _ => throw ArgumentError('Unknown value for mtmd_gen_process_type: $value'),
+  };
+}
+
+final class mtmd_gen_inp extends ffi.Struct {
+  @ffi.UnsignedInt()
+  external int typeAsInt;
+
+  mtmd_gen_process_type get type => mtmd_gen_process_type.fromValue(typeAsInt);
+
+  @ffi.Int32()
+  external int code0;
+
+  external ffi.Pointer<ffi.Float> embd;
+
+  @ffi.Int32()
+  external int top_k;
+
+  @ffi.Float()
+  external double top_p;
+
+  external ffi.Pointer<ffi.Int32> codes;
+
+  @ffi.Size()
+  external int n_codes;
+
+  external ffi.Pointer<ffi.Char> state_data;
+
+  @ffi.Size()
+  external int state_size;
+}
+
+final class mtmd_gen_out extends ffi.Struct {
+  external ffi.Pointer<ffi.Int32> codes;
+
+  @ffi.Size()
+  external int n_codes;
+
+  external ffi.Pointer<ffi.Float> embd;
+
+  external ffi.Pointer<ffi.Float> audio;
+
+  @ffi.Size()
+  external int n_samples;
+
+  external ffi.Pointer<ffi.Char> state_data;
+
+  @ffi.Size()
+  external int state_size;
+}
+
 final class mtmd_helper_video extends ffi.Opaque {}
 
 final class mtmd_helper_bitmap_wrapper extends ffi.Struct {
@@ -10603,6 +10782,50 @@ final class mtmd_helper_video_init_params extends ffi.Struct {
 
   @ffi.Int64()
   external int timestamp_interval_ms;
+}
+
+final class mtmd_helper_gen_audio extends ffi.Opaque {}
+
+enum mtmd_helper_gen_audio_outtype {
+  MTMD_HELPER_GEN_AUDIO_OUTTYPE_PCM(0),
+  MTMD_HELPER_GEN_AUDIO_OUTTYPE_WAV(1);
+
+  final int value;
+  const mtmd_helper_gen_audio_outtype(this.value);
+
+  static mtmd_helper_gen_audio_outtype fromValue(int value) => switch (value) {
+    0 => MTMD_HELPER_GEN_AUDIO_OUTTYPE_PCM,
+    1 => MTMD_HELPER_GEN_AUDIO_OUTTYPE_WAV,
+    _ => throw ArgumentError(
+      'Unknown value for mtmd_helper_gen_audio_outtype: $value',
+    ),
+  };
+}
+
+final class mtmd_helper_gen_audio_inp extends ffi.Struct {
+  @llama_seq_id()
+  external int seq_id;
+
+  external ffi.Pointer<ffi.Char> prompt;
+
+  @ffi.Size()
+  external int prompt_len;
+
+  external ffi.Pointer<mtmd_bitmap> speaker_ref;
+
+  external ffi.Pointer<ffi.Char> lang;
+
+  @ffi.Int32()
+  external int top_k;
+
+  @ffi.Float()
+  external double top_p;
+
+  @ffi.UnsignedInt()
+  external int out_typeAsInt;
+
+  mtmd_helper_gen_audio_outtype get out_type =>
+      mtmd_helper_gen_audio_outtype.fromValue(out_typeAsInt);
 }
 
 final class llama_dart_mtp extends ffi.Opaque {}

--- a/lib/src/backends/llama_cpp/llama_cpp_service.dart
+++ b/lib/src/backends/llama_cpp/llama_cpp_service.dart
@@ -5445,6 +5445,7 @@ class LlamaCppService {
 
     final penaltyConfig = _resolvePenaltySamplerConfig(params);
     final penaltiesSampler = llama_sampler_init_penalties(
+      vocabSize,
       penaltyConfig.lastN,
       penaltyConfig.repeat,
       penaltyConfig.frequency,

--- a/packages/llamadart_llama_cpp_flutter/CHANGELOG.md
+++ b/packages/llamadart_llama_cpp_flutter/CHANGELOG.md
@@ -1,6 +1,6 @@
 ## Unreleased
 
-* Updated Apple SwiftPM native pin to `leehack/llamadart-native@b10255`.
+* Updated Apple SwiftPM native pin to `leehack/llamadart-native@b10276`.
 
 ## 0.0.11
 

--- a/packages/llamadart_llama_cpp_flutter/README.md
+++ b/packages/llamadart_llama_cpp_flutter/README.md
@@ -16,7 +16,7 @@ dependencies:
 This package has no runtime Dart API of its own. Import `package:llamadart`
 normally from the core package and use `LlamaBackend()` / `LlamaEngine` there.
 
-The Apple SwiftPM manifest pins `leehack/llamadart-native@b10255`.
+The Apple SwiftPM manifest pins `leehack/llamadart-native@b10276`.
 
 Source for this package lives in
 `packages/llamadart_llama_cpp_flutter` in the

--- a/packages/llamadart_llama_cpp_flutter/darwin/llamadart_llama_cpp_flutter/Package.swift
+++ b/packages/llamadart_llama_cpp_flutter/darwin/llamadart_llama_cpp_flutter/Package.swift
@@ -4,7 +4,7 @@ import PackageDescription
 
 let packageRoot = URL(fileURLWithPath: #filePath).deletingLastPathComponent()
 let artifactsRoot = packageRoot.appendingPathComponent("Artifacts")
-let llamaCppTag = "b10255"
+let llamaCppTag = "b10276"
 
 func localArtifactPath(_ name: String) -> String? {
     let path = artifactsRoot.appendingPathComponent(name).path
@@ -47,7 +47,7 @@ let package = Package(
             repository: "leehack/llamadart-native",
             artifactName: "llamadart-native-apple-xcframework-\(llamaCppTag).zip",
             tag: llamaCppTag,
-            checksum: "3167cf79774ae057c305698ee8402ecc506654dc901dfba94a49490330727b7a"
+            checksum: "4df00fe6e17dc2d05b4dfe489b6fd603880e5f0bc9ce04dc28734b05f409b66d"
         ),
         .target(
             name: "llamadart_llama_cpp_flutter",

--- a/website/docs/changelog/recent-releases.md
+++ b/website/docs/changelog/recent-releases.md
@@ -9,6 +9,10 @@ For canonical full release notes, use:
 
 ## Unreleased
 
+- Updated native llama.cpp to `b10276`, including Qwen3-TTS model-loading
+  primitives, the matching penalty-sampler ABI migration, and refreshed Apple
+  artifacts. Speech generation is not yet exposed through the public Dart API.
+
 - Updated native llama.cpp to `b10255`, adding explicit bundled-MTP loading,
   automatic model-specific token suppression, and recent model, multimodal,
   speculative-decoding, and backend improvements, with matching load-mode

--- a/website/docs/getting-started/installation.md
+++ b/website/docs/getting-started/installation.md
@@ -79,7 +79,7 @@ hooks:
     llamadart:
       # Optional. Defaults to llamadart's tested native runtime pin.
       # Use a leehack/llamadart-native release tag when testing another build.
-      llamadart_native_tag: b10255
+      llamadart_native_tag: b10276
 
       # Optional. GitHub repository slug or github.com URL.
       llamadart_native_repository: leehack/llamadart-native
@@ -105,7 +105,7 @@ per-target module list.
 
 Native source overrides are for compatibility testing. They do not regenerate
 Dart FFI bindings or symbol lookups, so the selected binary still must be ABI-
-and symbol-compatible with the default `leehack/llamadart-native@b10255` runtime.
+and symbol-compatible with the default `leehack/llamadart-native@b10276` runtime.
 
 Available native tags are published on the
 [`leehack/llamadart-native` releases page](https://github.com/leehack/llamadart-native/releases).
@@ -117,7 +117,7 @@ gh release list --repo leehack/llamadart-native --limit 20
 
 Before overriding, confirm the release includes the asset for your target. The
 hook downloads files named `llamadart-native-<bundle>-<tag>.tar.gz`, for example
-`llamadart-native-windows-x64-b10255.tar.gz`.
+`llamadart-native-windows-x64-b10276.tar.gz`.
 For local testing, `llamadart_native_path` may point directly at a bundle
 archive, at an extracted bundle directory, or at a directory containing
 `<tag>/<bundle>/`, `<bundle>/`, or the expected archive file.

--- a/website/docs/platforms/support-matrix.md
+++ b/website/docs/platforms/support-matrix.md
@@ -7,7 +7,7 @@ This page combines platform support, runtime-family selection, and
 backend-module configuration for
 `llamadart`.
 
-The native-assets hook currently pins `llamadart-native` tag `b10255` and
+The native-assets hook currently pins `llamadart-native` tag `b10276` and
 `litert-lm-native` release `v0.14.0-native.2` (`hook/build.dart`). Apps can
 override the llama.cpp native GitHub source with
 `hooks.user_defines.llamadart.llamadart_native_tag` and
@@ -196,7 +196,7 @@ device/model bundle, use `cpu` or `gpu` for that artifact.
   a web load failure as a package bug. The [WebGPU Bridge](./webgpu-bridge)
   page has the browser-console probe and Flutter Web smoke-test path.
 
-## Current llama.cpp module availability by bundle (`b10255`)
+## Current llama.cpp module availability by bundle (`b10276`)
 
 | Bundle key | Available backend modules in bundle |
 | --- | --- |
@@ -244,7 +244,7 @@ hooks:
   user_defines:
     llamadart:
       # Optional. Defaults to llamadart's tested native runtime pin.
-      llamadart_native_tag: b10255
+      llamadart_native_tag: b10276
 
       # Optional. GitHub repository slug or github.com URL.
       llamadart_native_repository: leehack/llamadart-native


### PR DESCRIPTION
## Summary
- Update the default native llama.cpp runtime from `leehack/llamadart-native@b10255` to published `b10276`.
- Regenerate Dart FFI bindings from the exact b10276 header bundle.
- Migrate penalty-sampler initialization to the new vocabulary-sized ABI and refresh the Apple SwiftPM checksum and current pin documentation.

## Production-readiness scope
- **User-facing scope:** Native GGUF users receive the published b10276 model/backend/correctness updates through the existing Dart API.
- **Supported platforms/paths:** Existing native-assets llama.cpp bundles and Apple SwiftPM paths published by `llamadart-native@b10276`.
- **Unsupported or intentionally unavailable paths:** Web remains on bridge-assets v0.1.25 / llama.cpp b10255. Generated Qwen3-TTS audio bindings remain internal; speech generation is not exposed through the public Dart API.
- **Out of scope / follow-ups:** Publish and consume the repaired b10276 Web bridge separately. Design and validate a backend-neutral speech-output API before exposing Qwen3-TTS.

## Completeness checklist
- [x] Declared scope is fully implemented, or explicitly reduced above.
- [x] Unsupported platform/option combinations fail loudly with actionable diagnostics or are clearly documented as unavailable.
- [x] Public API docs, README/website docs, examples, support matrices, and changelog entries are updated where relevant.
- [x] Regression coverage covers the original issue plus key negative/version-skew paths where relevant.
- [x] Security/privacy review completed: no secrets, bearer tokens, signed URLs, or raw secret-bearing paths leak through logs, cache keys, metadata, errors, or snapshots.
- [x] Follow-up work that is useful but not required for this PR is explicitly marked above.

## PR type guidance
- **Feature PR:** N/A; no new public Dart API.
- **Bugfix PR:** The generated b10276 ABI adds `n_vocab` to `llama_sampler_init_penalties`; the Dart call now passes the active model vocabulary size.
- **Docs-only PR:** N/A.

## Test Plan
- [x] `dart format` on changed Dart files
- [x] `dart analyze lib hook tool test`
- [x] `dart test -p vm -j 1 --exclude-tags local-only` — 1,309 passed, 66 fixture skips
- [ ] `dart test -p chrome --exclude-tags local-only` — N/A; Web runtime and Dart Web API are unchanged
- [x] Published-artifact native inference and state/session round-trips
- [x] `dart run tool/testing/verify_release_docs_versions.dart`
- [x] `./tool/docs/validate_links.sh`
- [x] SwiftPM `dump-package`

The broad monorepo analyzer still reports pre-existing unbootstrapped example-package dependency errors; scoped core analysis is clean.

## Matrix Evidence
| Matrix row | Scope covered | Platform / model / backend | Result | Evidence / notes |
| --- | --- | --- | --- | --- |
| VM suite | Core, hook, bindings, native integration | macOS arm64 / b10276 / native | PASS | 1,309 passed; 66 fixture skips |
| Native inference | Model load, generation, penalty sampler | macOS arm64 / stories15M / native | PASS | Model loaded and generated successfully |
| State persistence | KV state save/load and resume | macOS arm64 / stories15M / native | PASS | Seven state/session cases passed |
| Apple package | SwiftPM manifest and checksum wiring | macOS arm64 / b10276 XCFramework | PASS | Manifest parsed successfully |
| Docs | Current pin docs and changelog | Docusaurus | PASS | Build and broken-link validation passed |

## Review Notes
- Independent review status: Pending.
- CI status / head SHA: Pending at `cc46dfc76`.
