### PR TITLE
Prepare 0.8.18 release

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -249,6 +249,12 @@ make sure the PR template can honestly state:
   tokens, signed URLs, and raw secret-bearing paths.
 - Useful non-blocking follow-ups are tracked in GitHub Issues before merge.
 
+Before merging, reply to and resolve every review thread. For comments that are
+outdated, superseded, or intentionally non-actionable, record the concrete
+rationale in the thread before resolving it; classification alone is not a
+substitute for closing the thread. Do not merge while any review thread remains
+unresolved.
+
 For docs-only PRs, state that runtime behavior is unchanged and list docs
 validation. If implementation scope changed, reduce and state the scope rather
 than merging incomplete behavior.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-## Unreleased
+## 0.8.18
 
 * Updated the default llama.cpp native runtime pin to
   `leehack/llamadart-native@b10276`, picking up Qwen3-TTS model-loading

--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ For Dart or Flutter apps:
 
 ```yaml
 dependencies:
-  llamadart: ^0.8.17
+  llamadart: ^0.8.18
 ```
 
 Flutter iOS/macOS apps that should link Apple XCFrameworks through Swift
@@ -57,9 +57,9 @@ Package Manager should also add the runtime companion packages they need:
 
 ```yaml
 dependencies:
-  llamadart: ^0.8.17
-  llamadart_llama_cpp_flutter: ^0.0.11 # GGUF / llama.cpp
-  llamadart_litert_lm_flutter: ^0.0.7 # Apple .litertlm / LiteRT-LM targets
+  llamadart: ^0.8.18
+  llamadart_llama_cpp_flutter: ^0.0.12 # GGUF / llama.cpp
+  llamadart_litert_lm_flutter: ^0.0.8 # Apple .litertlm / LiteRT-LM targets
 ```
 
 The LiteRT-LM companion manifest includes consolidated iOS and macOS SwiftPM

--- a/example/chat_app/pubspec.lock
+++ b/example/chat_app/pubspec.lock
@@ -357,7 +357,7 @@ packages:
       path: "../.."
       relative: true
     source: path
-    version: "0.8.17"
+    version: "0.8.18"
   logging:
     dependency: transitive
     description:

--- a/packages/llamadart_litert_lm_flutter/CHANGELOG.md
+++ b/packages/llamadart_litert_lm_flutter/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 * Updated Apple SwiftPM native pin to `leehack/litert-lm-native@v0.15.0-native.3`.
 
+* Updated the install example for `llamadart` 0.8.18.
+
 ## 0.0.7
 
 * Updated the install example for `llamadart` 0.8.17.

--- a/packages/llamadart_litert_lm_flutter/CHANGELOG.md
+++ b/packages/llamadart_litert_lm_flutter/CHANGELOG.md
@@ -1,4 +1,4 @@
-## Unreleased
+## 0.0.8
 
 * Updated Apple SwiftPM native pin to `leehack/litert-lm-native@v0.15.0-native.3`.
 

--- a/packages/llamadart_litert_lm_flutter/README.md
+++ b/packages/llamadart_litert_lm_flutter/README.md
@@ -12,8 +12,8 @@ runtime fallback.
 
 ```yaml
 dependencies:
-  llamadart: ^0.8.17
-  llamadart_litert_lm_flutter: ^0.0.7
+  llamadart: ^0.8.18
+  llamadart_litert_lm_flutter: ^0.0.8
 ```
 
 This package has no runtime Dart API of its own. Import `package:llamadart`

--- a/packages/llamadart_litert_lm_flutter/pubspec.yaml
+++ b/packages/llamadart_litert_lm_flutter/pubspec.yaml
@@ -1,6 +1,6 @@
 name: llamadart_litert_lm_flutter
 description: Flutter Apple SwiftPM runtime companion package for llamadart LiteRT-LM support.
-version: 0.0.7
+version: 0.0.8
 repository: https://github.com/leehack/llamadart/tree/main/packages/llamadart_litert_lm_flutter
 homepage: https://github.com/leehack/llamadart
 issue_tracker: https://github.com/leehack/llamadart/issues

--- a/packages/llamadart_llama_cpp_flutter/CHANGELOG.md
+++ b/packages/llamadart_llama_cpp_flutter/CHANGELOG.md
@@ -1,4 +1,4 @@
-## Unreleased
+## 0.0.12
 
 * Updated Apple SwiftPM native pin to `leehack/llamadart-native@b10276`.
 

--- a/packages/llamadart_llama_cpp_flutter/README.md
+++ b/packages/llamadart_llama_cpp_flutter/README.md
@@ -9,8 +9,8 @@ core package's native-assets fallback.
 
 ```yaml
 dependencies:
-  llamadart: ^0.8.17
-  llamadart_llama_cpp_flutter: ^0.0.11
+  llamadart: ^0.8.18
+  llamadart_llama_cpp_flutter: ^0.0.12
 ```
 
 This package has no runtime Dart API of its own. Import `package:llamadart`

--- a/packages/llamadart_llama_cpp_flutter/pubspec.yaml
+++ b/packages/llamadart_llama_cpp_flutter/pubspec.yaml
@@ -1,6 +1,6 @@
 name: llamadart_llama_cpp_flutter
 description: Flutter Apple SwiftPM runtime companion package for llamadart llama.cpp and GGUF support.
-version: 0.0.11
+version: 0.0.12
 repository: https://github.com/leehack/llamadart/tree/main/packages/llamadart_llama_cpp_flutter
 homepage: https://github.com/leehack/llamadart
 issue_tracker: https://github.com/leehack/llamadart/issues

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: llamadart
 description: Dart and Flutter local LLM inference with llama.cpp GGUF and LiteRT-LM across native platforms and web.
-version: 0.8.17
+version: 0.8.18
 homepage: https://github.com/leehack/llamadart
 repository: https://github.com/leehack/llamadart
 issue_tracker: https://github.com/leehack/llamadart/issues

--- a/website/docs/changelog/recent-releases.md
+++ b/website/docs/changelog/recent-releases.md
@@ -7,7 +7,7 @@ For canonical full release notes, use:
 
 - [`CHANGELOG.md`](https://github.com/leehack/llamadart/blob/main/CHANGELOG.md)
 
-## Unreleased
+## 0.8.18
 
 - Updated native llama.cpp to `b10276`, including Qwen3-TTS model-loading
   primitives, explicit bundled-MTP loading, automatic model-specific token

--- a/website/docs/getting-started/installation.md
+++ b/website/docs/getting-started/installation.md
@@ -27,7 +27,7 @@ In Xcode, set `IPHONEOS_DEPLOYMENT_TARGET = 16.4` or
 
 ```yaml
 dependencies:
-  llamadart: ^0.8.17
+  llamadart: ^0.8.18
 ```
 
 For Flutter iOS/macOS apps that should link Apple XCFrameworks through Swift
@@ -35,9 +35,9 @@ Package Manager, also add the runtime companion packages you need:
 
 ```yaml
 dependencies:
-  llamadart: ^0.8.17
-  llamadart_llama_cpp_flutter: ^0.0.11 # GGUF / llama.cpp
-  llamadart_litert_lm_flutter: ^0.0.7 # Apple .litertlm / LiteRT-LM targets
+  llamadart: ^0.8.18
+  llamadart_llama_cpp_flutter: ^0.0.12 # GGUF / llama.cpp
+  llamadart_litert_lm_flutter: ^0.0.8 # Apple .litertlm / LiteRT-LM targets
 ```
 
 The companion packages are published independently from the `packages/`


### PR DESCRIPTION
## Summary
- prepare the `llamadart` 0.8.18 release
- publish `llamadart_llama_cpp_flutter` 0.0.12 for the b10276 Apple runtime pin
- publish `llamadart_litert_lm_flutter` 0.0.8 for the v0.15.0-native.3 Apple runtime pin
- finalize release notes and current install snippets
- require a written response and resolution for every review thread before merge

## Production-readiness scope
- **User-facing scope:** Publish the accumulated llama.cpp b10276, LiteRT-LM v0.15, WebGPU v0.1.26, runtime-safety, and ABI work already merged to `main`, and document the maintainer review-thread closure gate.
- **Supported platforms/paths:** Existing documented native, Flutter Apple companion, and Web paths. This PR changes release metadata only; it does not add runtime behavior.
- **Unsupported or intentionally unavailable paths:** Qwen3-TTS model loading primitives are present in the native runtime, but speech generation remains unavailable in the public Dart API as documented.
- **Out of scope / follow-ups:** None required for this release-prep diff. Android Vulkan remains outside the stable `auto` policy and is not claimed by the real-device CPU/auto smoke below.

## Completeness checklist
- [x] Declared scope is fully implemented, or explicitly reduced above.
- [x] Unsupported platform/option combinations fail loudly with actionable diagnostics or are clearly documented as unavailable.
- [x] Public API docs, README/website docs, examples, support matrices, and changelog entries are updated where relevant.
- [x] Regression coverage covers the original issue plus key negative/version-skew paths where relevant.
- [x] Security/privacy review completed: no secrets, bearer tokens, signed URLs, or raw secret-bearing paths leak through logs, cache keys, metadata, errors, or snapshots.
- [x] Follow-up work that is useful but not required for this PR is tracked in GitHub Issues, or explicitly marked "None" above.

## PR type guidance
- **Release-prep PR:** version, changelog, install snippet, companion-package, and lockfile updates only. Merging this PR is the explicit publishing approval boundary.

## Test Plan
- [x] `dart format --output=none --set-exit-if-changed .`
- [x] `dart analyze`
- [x] `dart test -p vm -j 1 --exclude-tags local-only` (1,312 passed, 66 fixture-dependent skips)
- [x] `dart test -p chrome --exclude-tags local-only` (738 passed, 1 skipped)
- [x] `dart run tool/testing/verify_release_docs_versions.dart`
- [x] `dart run tool/testing/check_platform_boundaries.dart`
- [x] `./tool/docs/validate_links.sh`
- [x] Core and both companion `pub publish --dry-run` checks: zero warnings
- [x] Both companion packages: format, analyze, tests, and SwiftPM manifest validation
- [ ] Exact-head PR CI on `1d98f638c` (rerun required after GitHub Actions action-download and runner-queue failures before repository steps)

## Matrix Evidence
| Matrix row | Scope covered | Platform / model / backend | Result | Evidence / notes |
| --- | --- | --- | --- | --- |
| `static-format-analyze` | Release metadata and boundaries | macOS arm64 host | PASS | Format, analyzer, and platform boundary checks green |
| `root-vm` | Core regression and native runtime | macOS arm64 / stories15M GGUF / Metal+CPU runtime | PASS | 1,312 tests; real load/generation and native-symbol coverage passed |
| `docs-site` | Release notes and install docs | Docusaurus production build | PASS | Strict build and broken-link validation passed |
| `release-doc-version-consistency` | Core and companion version alignment | 0.8.18 / 0.0.12 / 0.0.8 | PASS | Release verifier green |
| Companion packages | Apple artifact manifests and publishability | macOS host / SwiftPM | PASS | Both test suites and manifests green; zero-warning dry-runs |
| `android-arm64-device-smoke` | b10276 GGUF load/generation | Pixel 9 Pro, Android 17 / stories15M / CPU and stable `auto` | PASS | Both paths generated tokens; `auto` intentionally resolves to CPU on Android |
| `ios-arm64-device-smoke` | b10276 GGUF load/generation | iPad Pro 11-inch (M1), iPadOS 26.5.2 / stories15M / CPU and Metal | PASS | Both paths generated tokens; explicit Metal logged `MTL0 (Apple M1 GPU)` and completed in 27 seconds |

## Review Notes
- Independent review status: release-prep diff and review-thread closure rule manually reviewed; all review threads resolved.
- CI status / head SHA: `1d98f638c`; new exact-head CI is pending rerun after GitHub Actions action-download `Service Unavailable` failures and never-started jobs cancelled at the runner queue limit. No repository step has failed. The prior `dacb221ec` head had 14/14 green, and the Chrome suite also passed locally (738 passed, 1 skipped).
