### PR TITLE
Fix Qwen3.5 Android Vulkan KQV offload

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## Unreleased
+
+* Fixed corrupt Qwen3.5 output on Android Vulkan by preserving the KQV
+  offload required for correct hybrid model inference while retaining the
+  remaining conservative Android context settings.
+
 ## 0.8.18
 
 * Updated the default llama.cpp native runtime pin to

--- a/lib/src/backends/llama_cpp/llama_cpp_service.dart
+++ b/lib/src/backends/llama_cpp/llama_cpp_service.dart
@@ -3828,15 +3828,14 @@ class LlamaCppService {
       resolvedGpuLayers: resolvedModelGpuLayers,
       isAndroid: Platform.isAndroid,
     )) {
-      final modelArchitecture = _getModelMetadataValue(
-        modelHandle,
-        'general.architecture',
-      );
-      final keepKqvOffload = shouldKeepAndroidVulkanKqvOffloadEnabled(
-        modelArchitecture,
-      );
-      if (!_androidVulkanAllowKqvOffload && !keepKqvOffload) {
-        ctxParams.offload_kqv = false;
+      if (!_androidVulkanAllowKqvOffload) {
+        final modelArchitecture = _getModelMetadataValue(
+          modelHandle,
+          'general.architecture',
+        );
+        if (!shouldKeepAndroidVulkanKqvOffloadEnabled(modelArchitecture)) {
+          ctxParams.offload_kqv = false;
+        }
       }
       if (!_androidVulkanAllowOpOffload) {
         ctxParams.op_offload = false;

--- a/lib/src/backends/llama_cpp/llama_cpp_service.dart
+++ b/lib/src/backends/llama_cpp/llama_cpp_service.dart
@@ -961,6 +961,27 @@ class LlamaCppService {
         effectiveGpuLayers > 0;
   }
 
+  /// Returns whether Android Vulkan must keep KQV offload enabled for the
+  /// model architecture to preserve inference correctness.
+  ///
+  /// Qwen3.5 produces incorrect logits when its model layers are offloaded to
+  /// Vulkan while KQV remains on the CPU. Keep the other conservative Android
+  /// Vulkan settings independent so this correctness exception does not also
+  /// enable op offload or Flash Attention.
+  static bool shouldKeepAndroidVulkanKqvOffloadEnabled(
+    String? modelArchitecture,
+  ) {
+    if (modelArchitecture == null || modelArchitecture.isEmpty) {
+      return false;
+    }
+
+    final normalized = modelArchitecture.toLowerCase().replaceAll(
+      RegExp('[^a-z0-9]'),
+      '',
+    );
+    return normalized == 'qwen35';
+  }
+
   /// Resolves effective context batch parameters.
   ///
   /// Uses the shared non-FFI helper for consistent default resolution and
@@ -3807,7 +3828,13 @@ class LlamaCppService {
       resolvedGpuLayers: resolvedModelGpuLayers,
       isAndroid: Platform.isAndroid,
     )) {
-      if (!_androidVulkanAllowKqvOffload) {
+      final modelArchitecture = getMetadata(
+        modelHandle,
+      )['general.architecture'];
+      final keepKqvOffload = shouldKeepAndroidVulkanKqvOffloadEnabled(
+        modelArchitecture,
+      );
+      if (!_androidVulkanAllowKqvOffload && !keepKqvOffload) {
         ctxParams.offload_kqv = false;
       }
       if (!_androidVulkanAllowOpOffload) {

--- a/lib/src/backends/llama_cpp/llama_cpp_service.dart
+++ b/lib/src/backends/llama_cpp/llama_cpp_service.dart
@@ -3828,9 +3828,10 @@ class LlamaCppService {
       resolvedGpuLayers: resolvedModelGpuLayers,
       isAndroid: Platform.isAndroid,
     )) {
-      final modelArchitecture = getMetadata(
+      final modelArchitecture = _getModelMetadataValue(
         modelHandle,
-      )['general.architecture'];
+        'general.architecture',
+      );
       final keepKqvOffload = shouldKeepAndroidVulkanKqvOffloadEnabled(
         modelArchitecture,
       );
@@ -7102,6 +7103,39 @@ class LlamaCppService {
       malloc.free(pathPtr);
       malloc.free(tokensPtr);
       malloc.free(countPtr);
+    }
+  }
+
+  /// Returns one metadata value without enumerating the full model metadata.
+  String? _getModelMetadataValue(int modelHandle, String key) {
+    final model = _models[modelHandle];
+    if (model == null || key.isEmpty) return null;
+
+    final keyPtr = key.toNativeUtf8();
+    try {
+      final length = llama_model_meta_val_str(
+        model.pointer,
+        keyPtr.cast(),
+        nullptr,
+        0,
+      );
+      if (length < 0) return null;
+
+      final valueBuf = malloc<Int8>(length + 1);
+      try {
+        final written = llama_model_meta_val_str(
+          model.pointer,
+          keyPtr.cast(),
+          valueBuf.cast(),
+          length + 1,
+        );
+        if (written != length) return null;
+        return valueBuf.cast<Utf8>().toDartString(length: written);
+      } finally {
+        malloc.free(valueBuf);
+      }
+    } finally {
+      malloc.free(keyPtr);
     }
   }
 

--- a/test/unit/backends/llama_cpp/llama_cpp_service_test.dart
+++ b/test/unit/backends/llama_cpp/llama_cpp_service_test.dart
@@ -953,6 +953,30 @@ void main() {
     });
   });
 
+  group('shouldKeepAndroidVulkanKqvOffloadEnabled', () {
+    test('keeps KQV offload enabled for Qwen3.5 architecture metadata', () {
+      expect(
+        LlamaCppService.shouldKeepAndroidVulkanKqvOffloadEnabled('qwen35'),
+        isTrue,
+      );
+      expect(
+        LlamaCppService.shouldKeepAndroidVulkanKqvOffloadEnabled('Qwen3.5'),
+        isTrue,
+      );
+    });
+
+    test('keeps conservative KQV policy for other architectures', () {
+      expect(
+        LlamaCppService.shouldKeepAndroidVulkanKqvOffloadEnabled('llama'),
+        isFalse,
+      );
+      expect(
+        LlamaCppService.shouldKeepAndroidVulkanKqvOffloadEnabled(null),
+        isFalse,
+      );
+    });
+  });
+
   group('resolveMtmdUseGpuForLoad', () {
     test('forces CPU mode to disable projector GPU offload', () {
       const params = ModelParams(


### PR DESCRIPTION
## Summary
- Preserve KQV offload for Qwen3.5 when Android Vulkan model layers are GPU-offloaded.
- Keep the remaining conservative Android Vulkan settings for op offload and Flash Attention unchanged.
- Add architecture-policy regression coverage and an Unreleased changelog entry.
- Read the architecture through llama.cpp's single-key metadata API instead of enumerating and allocating buffers for all GGUF metadata during every context creation.

## Production-readiness scope
- **User-facing scope:** Qwen3.5 generation on Android Vulkan no longer produces corrupt logits solely because llamadart moved KQV computation back to CPU.
- **Supported platforms/paths:** Native Android Vulkan with GPU-offloaded Qwen3.5 models identified by `general.architecture=qwen35`.
- **Unsupported or intentionally unavailable paths:** No new unsupported path. CPU, non-Android, non-Vulkan, and other model architectures retain their existing behavior.
- **Out of scope / follow-ups:** Native/Web runtime pin upgrades, Qwen3.6, AMD/HIP, MTP, multimodal, and broader upstream correctness work remain separate.

## Completeness checklist
- [x] Declared scope is fully implemented, or explicitly reduced above.
- [x] Unsupported platform/option combinations fail loudly with actionable diagnostics or are clearly documented as unavailable.
- [x] Public API docs, README/website docs, examples, support matrices, and changelog entries are updated where relevant.
- [x] Regression coverage covers the original issue plus key negative/version-skew paths where relevant.
- [x] Security/privacy review completed: no secrets, bearer tokens, signed URLs, or raw secret-bearing paths leak through logs, cache keys, metadata, errors, or snapshots.
- [x] Follow-up work that is useful but not required for this PR is tracked in GitHub Issues, or explicitly marked "None" above.

## Root cause
llamadart's conservative Android Vulkan context policy disabled KQV offload for every architecture. Published b10333 runtime A/B tests isolated `--no-kv-offload` as the corruption trigger for Qwen3.5 2B and 4B on Mali-G715; disabling op offload or Flash Attention independently did not reproduce it. The fix uses runtime architecture metadata so other models retain the conservative policy.

## PR type guidance
- **Bugfix PR:** includes the regression root cause, focused policy tests, negative architecture coverage, and physical-device validation.

## Test Plan
- [x] `dart format --output=none --set-exit-if-changed lib/src/backends/llama_cpp/llama_cpp_service.dart test/unit/backends/llama_cpp/llama_cpp_service_test.dart`
- [x] `dart analyze lib/src/backends/llama_cpp/llama_cpp_service.dart test/unit/backends/llama_cpp/llama_cpp_service_test.dart`
- [x] `dart test -p vm -j 1 test/unit/backends/llama_cpp/llama_cpp_service_test.dart` — 91 passed
- [x] Full VM suite — passed exact-head CI
- [ ] Chrome suite — N/A; native Android context policy only
- [x] Other targeted/local-only validation: published b10333 shared-runtime A/B plus patched Flutter/Dart probes on a physical Pixel 9 Pro.

## Matrix Evidence
| Matrix row | Scope covered | Platform / model / backend | Result | Evidence / notes |
| --- | --- | --- | --- | --- |
| Native Android Vulkan | Original corruption and fixed public path | Pixel 9 Pro / Mali-G715 / Qwen3.5 2B Q4_K_M / Vulkan | PASS | Default KQV returned exact text and parsed tool call; patched `generate` and `create` matched; prompt-prefix reuse parity passed; 999 GPU layers |
| Native Android Vulkan | Same-architecture size control | Pixel 9 Pro / Mali-G715 / Qwen3.5 4B Q4_K_M / Vulkan | PASS | Default KQV returned exact deterministic text; KQV-disabled control reproduced corruption |
| Native Android Vulkan | Negative architecture control | Pixel 9 Pro / Mali-G715 / Gemma 3 1B Q4_K_M / Vulkan | PASS | Default and KQV-disabled paths were coherent; patched Dart path passed |
| Native Android Vulkan | Negative hybrid/MoE control | Pixel 9 Pro / Mali-G715 / Gemma 4 E2B Q4_0 / Vulkan | PASS | CPU/default-KQV/KQV-disabled parity; patched `generate` and `create` returned exact text |
| Native macOS | Unchanged non-Android paths | M4 Max / Qwen3.5 2B / Metal and CPU | PASS | Exact text, parsed tool call, and prompt-reuse parity before the Android-only change |

## Review Notes
- Independent review status: local llama PR-readiness review found no blocking findings.
- CI status / head SHA: all 12 populated exact-head checks passed on `57ed9761f`; review threads resolved.