### PR TITLE
Upgrade llama.cpp runtimes to b10333

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 ## Unreleased
 
+* Updated the default llama.cpp native runtime pin to
+  `leehack/llamadart-native@b10333`, regenerated matching Dart FFI bindings,
+  refreshed the `llamadart_llama_cpp_flutter` Apple SwiftPM checksum, and aligned
+  current README/website native override docs.
+
+* Updated WebGPU bridge assets to `v0.1.27` (llama.cpp `b10333`), keeping the
+  native and Web GGUF runtimes on the same upstream revision.
+
 * Fixed corrupt Qwen3.5 output on Android Vulkan by preserving the KQV
   offload required for correct hybrid model inference while retaining the
   remaining conservative Android context settings.

--- a/README.md
+++ b/README.md
@@ -134,9 +134,9 @@ Current default runtime pins:
 
 | Runtime | Pin |
 | --- | --- |
-| Native llama.cpp / GGUF | `leehack/llamadart-native@b10276` |
+| Native llama.cpp / GGUF | `leehack/llamadart-native@b10333` |
 | Native LiteRT-LM / `.litertlm` | `leehack/litert-lm-native@v0.15.0-native.3` |
-| Web llama.cpp / GGUF | `leehack/llama-web-bridge-assets@v0.1.26` |
+| Web llama.cpp / GGUF | `leehack/llama-web-bridge-assets@v0.1.27` |
 | Web LiteRT-LM / `.litertlm` | `@litert-lm/core@0.15.0` |
 
 ## Common Tasks

--- a/doc/webgpu_bridge.md
+++ b/doc/webgpu_bridge.md
@@ -19,7 +19,7 @@ pipelines.
    `https://cdn.jsdelivr.net/gh/leehack/llama-web-bridge-assets@<tag>/llama_webgpu_bridge.js`
 2. Local fallback: `./webgpu_bridge/llama_webgpu_bridge.js`
 
-Default pinned tag in the example is `v0.1.26`.
+Default pinned tag in the example is `v0.1.27`.
 
 For broader browser coverage in this repository, fetched/local assets are patched
 to a universal Safari-compatible gate by default (`MIN_SAFARI_VERSION=170400`).
@@ -32,7 +32,7 @@ model bytes.
 To vendor pinned assets into local app web files:
 
 ```bash
-WEBGPU_BRIDGE_ASSETS_TAG=v0.1.26 ./scripts/fetch_webgpu_bridge_assets.sh
+WEBGPU_BRIDGE_ASSETS_TAG=v0.1.27 ./scripts/fetch_webgpu_bridge_assets.sh
 ```
 
 Optional compatibility env vars:
@@ -113,7 +113,7 @@ You can override CDN source/version before the bridge loader runs:
 ```html
 <script>
   window.__llamadartBridgeAssetsRepo = 'leehack/llama-web-bridge-assets';
-  window.__llamadartBridgeAssetsTag = 'v0.1.26';
+  window.__llamadartBridgeAssetsTag = 'v0.1.27';
 </script>
 ```
 

--- a/example/chat_app/web/index.html
+++ b/example/chat_app/web/index.html
@@ -214,13 +214,13 @@
     const bridgeAssetsTag =
       typeof configuredTag === 'string' && configuredTag.length > 0
         ? configuredTag
-        : 'v0.1.26';
+        : 'v0.1.27';
     window.__llamadartLiteRtLmModuleUrl =
       typeof window.__llamadartLiteRtLmModuleUrl === 'string' &&
       window.__llamadartLiteRtLmModuleUrl.length > 0
         ? window.__llamadartLiteRtLmModuleUrl
         : 'https://cdn.jsdelivr.net/npm/@litert-lm/core@0.15.0/+esm';
-    const localBridgeVersion = 'v0.1.26-local-b10276';
+    const localBridgeVersion = 'v0.1.27-local-b10333';
     window.__llamadartBridgeLocalVersion = localBridgeVersion;
 
     const localBridgeUrl = `./webgpu_bridge/llama_webgpu_bridge.js?v=${localBridgeVersion}`;

--- a/hook/build.dart
+++ b/hook/build.dart
@@ -13,7 +13,7 @@ import 'package:path/path.dart' as path;
 
 import 'package:llamadart/src/hook/native_bundle_config.dart';
 
-const _llamaCppTag = 'b10276';
+const _llamaCppTag = 'b10333';
 const _nativeRepoSlug = 'leehack/llamadart-native';
 
 const _packageName = 'llamadart';

--- a/lib/src/backends/llama_cpp/bindings.dart
+++ b/lib/src/backends/llama_cpp/bindings.dart
@@ -6259,6 +6259,14 @@ external void ggml_build_forward_expand(
 );
 
 @ffi.Native<
+  ffi.Void Function(ffi.Pointer<ggml_cgraph>, ffi.Pointer<ggml_tensor>)
+>()
+external void ggml_build_forward_order(
+  ffi.Pointer<ggml_cgraph> cgraph,
+  ffi.Pointer<ggml_tensor> tensor,
+);
+
+@ffi.Native<
   ffi.Void Function(
     ffi.Pointer<ggml_context>,
     ffi.Pointer<ggml_cgraph>,
@@ -7540,6 +7548,29 @@ external ffi.Pointer<mtmd_input_chunk> mtmd_input_chunk_copy(
 
 @ffi.Native<ffi.Void Function(ffi.Pointer<mtmd_input_chunk>)>()
 external void mtmd_input_chunk_free(ffi.Pointer<mtmd_input_chunk> chunk);
+
+@ffi.Native<
+  ffi.Int32 Function(
+    ffi.Pointer<mtmd_input_chunk>,
+    ffi.Pointer<ffi.Char>,
+    ffi.Size,
+    ffi.Pointer<ffi.Size>,
+  )
+>()
+external int mtmd_input_chunk_save(
+  ffi.Pointer<mtmd_input_chunk> chunk,
+  ffi.Pointer<ffi.Char> out_buf,
+  int out_len,
+  ffi.Pointer<ffi.Size> expected_out_len,
+);
+
+@ffi.Native<
+  ffi.Pointer<mtmd_input_chunk> Function(ffi.Pointer<ffi.Char>, ffi.Size)
+>()
+external ffi.Pointer<mtmd_input_chunk> mtmd_input_chunk_load(
+  ffi.Pointer<ffi.Char> buf,
+  int len,
+);
 
 @ffi.Native<ffi.Size Function(ffi.Pointer<mtmd_image_tokens>)>()
 external int mtmd_image_tokens_get_n_tokens(
@@ -10534,7 +10565,8 @@ typedef ggml_backend_eval_callback =
 enum mtmd_input_chunk_type {
   MTMD_INPUT_CHUNK_TYPE_TEXT(0),
   MTMD_INPUT_CHUNK_TYPE_IMAGE(1),
-  MTMD_INPUT_CHUNK_TYPE_AUDIO(2);
+  MTMD_INPUT_CHUNK_TYPE_AUDIO(2),
+  MTMD_INPUT_CHUNK_TYPE_COUNT(3);
 
   final int value;
   const mtmd_input_chunk_type(this.value);
@@ -10543,6 +10575,7 @@ enum mtmd_input_chunk_type {
     0 => MTMD_INPUT_CHUNK_TYPE_TEXT,
     1 => MTMD_INPUT_CHUNK_TYPE_IMAGE,
     2 => MTMD_INPUT_CHUNK_TYPE_AUDIO,
+    3 => MTMD_INPUT_CHUNK_TYPE_COUNT,
     _ => throw ArgumentError('Unknown value for mtmd_input_chunk_type: $value'),
   };
 }

--- a/packages/llamadart_llama_cpp_flutter/CHANGELOG.md
+++ b/packages/llamadart_llama_cpp_flutter/CHANGELOG.md
@@ -1,3 +1,7 @@
+## Unreleased
+
+* Updated Apple SwiftPM native pin to `leehack/llamadart-native@b10333`.
+
 ## 0.0.12
 
 * Updated Apple SwiftPM native pin to `leehack/llamadart-native@b10276`.

--- a/packages/llamadart_llama_cpp_flutter/README.md
+++ b/packages/llamadart_llama_cpp_flutter/README.md
@@ -16,7 +16,7 @@ dependencies:
 This package has no runtime Dart API of its own. Import `package:llamadart`
 normally from the core package and use `LlamaBackend()` / `LlamaEngine` there.
 
-The Apple SwiftPM manifest pins `leehack/llamadart-native@b10276`.
+The Apple SwiftPM manifest pins `leehack/llamadart-native@b10333`.
 
 Source for this package lives in
 `packages/llamadart_llama_cpp_flutter` in the

--- a/packages/llamadart_llama_cpp_flutter/darwin/llamadart_llama_cpp_flutter/Package.swift
+++ b/packages/llamadart_llama_cpp_flutter/darwin/llamadart_llama_cpp_flutter/Package.swift
@@ -4,7 +4,7 @@ import PackageDescription
 
 let packageRoot = URL(fileURLWithPath: #filePath).deletingLastPathComponent()
 let artifactsRoot = packageRoot.appendingPathComponent("Artifacts")
-let llamaCppTag = "b10276"
+let llamaCppTag = "b10333"
 
 func localArtifactPath(_ name: String) -> String? {
     let path = artifactsRoot.appendingPathComponent(name).path
@@ -47,7 +47,7 @@ let package = Package(
             repository: "leehack/llamadart-native",
             artifactName: "llamadart-native-apple-xcframework-\(llamaCppTag).zip",
             tag: llamaCppTag,
-            checksum: "4df00fe6e17dc2d05b4dfe489b6fd603880e5f0bc9ce04dc28734b05f409b66d"
+            checksum: "ffd04ca1418f978e44b4b9f14436bc54a863d1791889c0ffad947419d519b1ea"
         ),
         .target(
             name: "llamadart_llama_cpp_flutter",

--- a/scripts/fetch_webgpu_bridge_assets.sh
+++ b/scripts/fetch_webgpu_bridge_assets.sh
@@ -4,7 +4,7 @@ set -euo pipefail
 ROOT_DIR="$(git rev-parse --show-toplevel)"
 OUT_DIR="${WEBGPU_BRIDGE_OUT_DIR:-$ROOT_DIR/example/chat_app/web/webgpu_bridge}"
 ASSETS_REPO="${WEBGPU_BRIDGE_ASSETS_REPO:-leehack/llama-web-bridge-assets}"
-ASSETS_TAG="${WEBGPU_BRIDGE_ASSETS_TAG:-v0.1.26}"
+ASSETS_TAG="${WEBGPU_BRIDGE_ASSETS_TAG:-v0.1.27}"
 CDN_BASE="${WEBGPU_BRIDGE_CDN_BASE:-https://cdn.jsdelivr.net/gh/${ASSETS_REPO}@${ASSETS_TAG}}"
 PATCH_SAFARI_COMPAT="${WEBGPU_BRIDGE_PATCH_SAFARI_COMPAT:-1}"
 MIN_SAFARI_VERSION="${WEBGPU_BRIDGE_MIN_SAFARI_VERSION:-170400}"
@@ -14,7 +14,7 @@ if [[ "${1:-}" == "--help" || "${1:-}" == "-h" ]]; then
 Downloads prebuilt WebGPU bridge assets into the chat_app web directory.
 
 Default source:
-  https://cdn.jsdelivr.net/gh/leehack/llama-web-bridge-assets@v0.1.26
+  https://cdn.jsdelivr.net/gh/leehack/llama-web-bridge-assets@v0.1.27
 
 Environment variables:
   WEBGPU_BRIDGE_ASSETS_REPO   Asset repo in owner/repo format
@@ -28,7 +28,7 @@ Usage:
   ./scripts/fetch_webgpu_bridge_assets.sh
 
 Examples:
-  WEBGPU_BRIDGE_ASSETS_TAG=v0.1.26 ./scripts/fetch_webgpu_bridge_assets.sh
+  WEBGPU_BRIDGE_ASSETS_TAG=v0.1.27 ./scripts/fetch_webgpu_bridge_assets.sh
   WEBGPU_BRIDGE_ASSETS_REPO=acme/llama-web-bridge-assets WEBGPU_BRIDGE_ASSETS_TAG=v2 ./scripts/fetch_webgpu_bridge_assets.sh
 USAGE
   exit 0

--- a/tool/testing/test_matrix.dart
+++ b/tool/testing/test_matrix.dart
@@ -260,7 +260,8 @@ const List<TestMatrixRow> testMatrixRows = <TestMatrixRow>[
         'built Flutter web chat app with real worker/WASM and GGUF model URL',
     command:
         'dart run tool/testing/run_local_e2e.dart --scenario '
-        'chat-app-web-real-model-smoke --model-url <model-url> --expect 4',
+        'chat-app-web-real-model-smoke --model-url <model-url> '
+        '--allow-any-response',
     useWhen:
         'Web chat app, web model loading, or WebGPU bridge runtime changes.',
   ),

--- a/website/docs/getting-started/installation.md
+++ b/website/docs/getting-started/installation.md
@@ -79,7 +79,7 @@ hooks:
     llamadart:
       # Optional. Defaults to llamadart's tested native runtime pin.
       # Use a leehack/llamadart-native release tag when testing another build.
-      llamadart_native_tag: b10276
+      llamadart_native_tag: b10333
 
       # Optional. GitHub repository slug or github.com URL.
       llamadart_native_repository: leehack/llamadart-native
@@ -105,7 +105,7 @@ per-target module list.
 
 Native source overrides are for compatibility testing. They do not regenerate
 Dart FFI bindings or symbol lookups, so the selected binary still must be ABI-
-and symbol-compatible with the default `leehack/llamadart-native@b10276` runtime.
+and symbol-compatible with the default `leehack/llamadart-native@b10333` runtime.
 
 Available native tags are published on the
 [`leehack/llamadart-native` releases page](https://github.com/leehack/llamadart-native/releases).
@@ -117,7 +117,7 @@ gh release list --repo leehack/llamadart-native --limit 20
 
 Before overriding, confirm the release includes the asset for your target. The
 hook downloads files named `llamadart-native-<bundle>-<tag>.tar.gz`, for example
-`llamadart-native-windows-x64-b10276.tar.gz`.
+`llamadart-native-windows-x64-b10333.tar.gz`.
 For local testing, `llamadart_native_path` may point directly at a bundle
 archive, at an extracted bundle directory, or at a directory containing
 `<tag>/<bundle>/`, `<bundle>/`, or the expected archive file.

--- a/website/docs/platforms/support-matrix.md
+++ b/website/docs/platforms/support-matrix.md
@@ -7,7 +7,7 @@ This page combines platform support, runtime-family selection, and
 backend-module configuration for
 `llamadart`.
 
-The native-assets hook currently pins `llamadart-native` tag `b10276` and
+The native-assets hook currently pins `llamadart-native` tag `b10333` and
 `litert-lm-native` release `v0.15.0-native.3` (`hook/build.dart`). Apps can
 override the llama.cpp native GitHub source with
 `hooks.user_defines.llamadart.llamadart_native_tag` and
@@ -196,7 +196,7 @@ device/model bundle, use `cpu` or `gpu` for that artifact.
   a web load failure as a package bug. The [WebGPU Bridge](./webgpu-bridge)
   page has the browser-console probe and Flutter Web smoke-test path.
 
-## Current llama.cpp module availability by bundle (`b10276`)
+## Current llama.cpp module availability by bundle (`b10333`)
 
 | Bundle key | Available backend modules in bundle |
 | --- | --- |
@@ -244,7 +244,7 @@ hooks:
   user_defines:
     llamadart:
       # Optional. Defaults to llamadart's tested native runtime pin.
-      llamadart_native_tag: b10276
+      llamadart_native_tag: b10333
 
       # Optional. GitHub repository slug or github.com URL.
       llamadart_native_repository: leehack/llamadart-native

--- a/website/docs/platforms/webgpu-bridge.md
+++ b/website/docs/platforms/webgpu-bridge.md
@@ -146,13 +146,13 @@ development validation, and CDN-first loading for normal hosted deployments:
 1. On localhost: local asset first, then CDN fallback.
 2. On hosted deployments: CDN asset first, then local fallback.
 
-The example currently pins bridge assets to `v0.1.26`, with local vendored assets
-identified as `v0.1.26-local-b10276`.
+The example currently pins bridge assets to `v0.1.27`, with local vendored assets
+identified as `v0.1.27-local-b10333`.
 
 Fetch pinned local assets with:
 
 ```bash
-WEBGPU_BRIDGE_ASSETS_TAG=v0.1.26 ./scripts/fetch_webgpu_bridge_assets.sh
+WEBGPU_BRIDGE_ASSETS_TAG=v0.1.27 ./scripts/fetch_webgpu_bridge_assets.sh
 ```
 
 To verify the loaded runtime in a browser console, inspect:
@@ -286,7 +286,7 @@ dart run tool/testing/run_local_e2e.dart --scenario chat-app-web-mock-smoke
 
 dart run tool/testing/run_local_e2e.dart --scenario chat-app-web-real-model-smoke \
   --model-url http://127.0.0.1:7358/example/llamadart_server/models/Qwen3.5-0.8B-Q4_K_M.gguf \
-  --expect 4
+  --allow-any-response
 ```
 
 The runner uses `scripts/build_chat_app_web.sh` to build Flutter web with the
@@ -309,7 +309,7 @@ You can override bridge asset source/version before loader startup:
 ```html
 <script>
   window.__llamadartBridgeAssetsRepo = 'leehack/llama-web-bridge-assets';
-  window.__llamadartBridgeAssetsTag = 'v0.1.26';
+  window.__llamadartBridgeAssetsTag = 'v0.1.27';
   // Prefer local runtime even off localhost:
   // window.__llamadartPreferLocalBridgeRuntime = true;
   // Enable verbose bridge bootstrap console logs:


### PR DESCRIPTION
## Summary

- update the default native llama.cpp runtime from `b10276` to published `leehack/llamadart-native@b10333`
- update Web GGUF assets from `v0.1.26` to published `llama-web-bridge-assets@v0.1.27`, aligning native and Web on llama.cpp `b10333`
- regenerate the matching FFI bindings and refresh the Apple SwiftPM artifact checksum
- align the README, support matrix, WebGPU docs, installation guidance, and changelogs with the new pins
- replace the stale real-Web-smoke `--expect 4` guidance with CI's supported `--allow-any-response` mode

## Why

The b10333 native release and v0.1.27 Web bridge assets are now both consumable, so llamadart can update the two GGUF runtimes together rather than leaving native and Web on different llama.cpp revisions. This follows the Qwen3.5 Android Vulkan correctness fix merged in #316.

Users receive the upstream b10276-to-b10333 runtime improvements automatically. This PR does not add a new public Dart API. The regenerated bindings add the upstream `ggml_build_forward_order`, `mtmd_input_chunk_save`, `mtmd_input_chunk_load`, and `MTMD_INPUT_CHUNK_TYPE_COUNT` declarations, but public multimodal chunk persistence remains out of scope.

## Validation

### Repository gates

- `dart format --output=none --set-exit-if-changed .`
- `dart analyze`
- `dart run tool/testing/check_platform_boundaries.dart`
- `dart run tool/testing/verify_release_docs_versions.dart`
- native pin sync dry-run for `b10333`
- docs build and broken-link validation
- `git diff --check`
- 77 hook tests
- 1,314 VM tests passed, 66 skipped
- 738 Chrome tests passed, 1 skipped
- 201 chat-app VM tests passed
- 4 chat-generation Chrome tests passed
- 30 E2E-runner/testing-matrix tests passed
- affected companion package analysis, 3 tests, and SwiftPM manifest validation passed

### Real runtime gates

- macOS arm64: published b10333 loaded and generated through Metal and CPU integration paths, including state/session and native-symbol coverage
- Pixel 9 Pro / Mali-G715: Qwen3.5 2B loaded with Vulkan, `resolvedGpuLayers=999`, and returned exact `PINEAPPLE` parity through raw generation and the public chat API
- Web: v0.1.27 asset checksums, deployable chat build, bridge bootstrap, deterministic mock chat, and real tiny-GGUF generation passed
- Gemma 4 12B on Metal: baseline, bundled MTP, and n-gram runs completed with identical output hashes; the short single-run performance sample is correctness evidence, not a performance claim

The published b10333 native workflow completed all platform/backend build jobs, including HIP, CUDA, Vulkan, Apple, Android, Windows, and packaging. The v0.1.27 bridge CI and asset publication workflows are green.

## Residual risk

No AMD GPU was available for a real HIP inference run. The b10333 HIP artifact builds successfully, but that packaging result is not behavioral hardware validation.

The old tiny-GGUF Web instruction expecting literal `4` fails identically on v0.1.26 and v0.1.27 while both produce the same valid non-empty response. This PR aligns the documentation and testing matrix with the required CI job's existing `--allow-any-response` gate.
