### PR TITLE
Prepare 0.8.19 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-## Unreleased
+## 0.8.19
 
 * Updated the default llama.cpp native runtime pin to
   `leehack/llamadart-native@b10333`, regenerated matching Dart FFI bindings,

--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ For Dart or Flutter apps:
 
 ```yaml
 dependencies:
-  llamadart: ^0.8.18
+  llamadart: ^0.8.19
 ```
 
 Flutter iOS/macOS apps that should link Apple XCFrameworks through Swift
@@ -57,9 +57,9 @@ Package Manager should also add the runtime companion packages they need:
 
 ```yaml
 dependencies:
-  llamadart: ^0.8.18
-  llamadart_llama_cpp_flutter: ^0.0.12 # GGUF / llama.cpp
-  llamadart_litert_lm_flutter: ^0.0.8 # Apple .litertlm / LiteRT-LM targets
+  llamadart: ^0.8.19
+  llamadart_llama_cpp_flutter: ^0.0.13 # GGUF / llama.cpp
+  llamadart_litert_lm_flutter: ^0.0.9 # Apple .litertlm / LiteRT-LM targets
 ```
 
 The LiteRT-LM companion manifest includes consolidated iOS and macOS SwiftPM

--- a/example/chat_app/pubspec.lock
+++ b/example/chat_app/pubspec.lock
@@ -357,7 +357,7 @@ packages:
       path: "../.."
       relative: true
     source: path
-    version: "0.8.18"
+    version: "0.8.19"
   logging:
     dependency: transitive
     description:

--- a/packages/llamadart_litert_lm_flutter/CHANGELOG.md
+++ b/packages/llamadart_litert_lm_flutter/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.0.9
+
+* Updated the install example for `llamadart` 0.8.19.
+
 ## 0.0.8
 
 * Updated Apple SwiftPM native pin to `leehack/litert-lm-native@v0.15.0-native.3`.

--- a/packages/llamadart_litert_lm_flutter/README.md
+++ b/packages/llamadart_litert_lm_flutter/README.md
@@ -12,8 +12,8 @@ runtime fallback.
 
 ```yaml
 dependencies:
-  llamadart: ^0.8.18
-  llamadart_litert_lm_flutter: ^0.0.8
+  llamadart: ^0.8.19
+  llamadart_litert_lm_flutter: ^0.0.9
 ```
 
 This package has no runtime Dart API of its own. Import `package:llamadart`

--- a/packages/llamadart_litert_lm_flutter/pubspec.yaml
+++ b/packages/llamadart_litert_lm_flutter/pubspec.yaml
@@ -1,6 +1,6 @@
 name: llamadart_litert_lm_flutter
 description: Flutter Apple SwiftPM runtime companion package for llamadart LiteRT-LM support.
-version: 0.0.8
+version: 0.0.9
 repository: https://github.com/leehack/llamadart/tree/main/packages/llamadart_litert_lm_flutter
 homepage: https://github.com/leehack/llamadart
 issue_tracker: https://github.com/leehack/llamadart/issues

--- a/packages/llamadart_llama_cpp_flutter/CHANGELOG.md
+++ b/packages/llamadart_llama_cpp_flutter/CHANGELOG.md
@@ -1,4 +1,4 @@
-## Unreleased
+## 0.0.13
 
 * Updated Apple SwiftPM native pin to `leehack/llamadart-native@b10333`.
 

--- a/packages/llamadart_llama_cpp_flutter/README.md
+++ b/packages/llamadart_llama_cpp_flutter/README.md
@@ -9,8 +9,8 @@ core package's native-assets fallback.
 
 ```yaml
 dependencies:
-  llamadart: ^0.8.18
-  llamadart_llama_cpp_flutter: ^0.0.12
+  llamadart: ^0.8.19
+  llamadart_llama_cpp_flutter: ^0.0.13
 ```
 
 This package has no runtime Dart API of its own. Import `package:llamadart`

--- a/packages/llamadart_llama_cpp_flutter/pubspec.yaml
+++ b/packages/llamadart_llama_cpp_flutter/pubspec.yaml
@@ -1,6 +1,6 @@
 name: llamadart_llama_cpp_flutter
 description: Flutter Apple SwiftPM runtime companion package for llamadart llama.cpp and GGUF support.
-version: 0.0.12
+version: 0.0.13
 repository: https://github.com/leehack/llamadart/tree/main/packages/llamadart_llama_cpp_flutter
 homepage: https://github.com/leehack/llamadart
 issue_tracker: https://github.com/leehack/llamadart/issues

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: llamadart
 description: Dart and Flutter local LLM inference with llama.cpp GGUF and LiteRT-LM across native platforms and web.
-version: 0.8.18
+version: 0.8.19
 homepage: https://github.com/leehack/llamadart
 repository: https://github.com/leehack/llamadart
 issue_tracker: https://github.com/leehack/llamadart/issues

--- a/website/docs/changelog/recent-releases.md
+++ b/website/docs/changelog/recent-releases.md
@@ -7,6 +7,15 @@ For canonical full release notes, use:
 
 - [`CHANGELOG.md`](https://github.com/leehack/llamadart/blob/main/CHANGELOG.md)
 
+## 0.8.19
+
+- Updated the native llama.cpp runtime and WebGPU bridge assets to `b10333`,
+  including matching Dart FFI bindings and refreshed Apple SwiftPM artifacts.
+
+- Fixed corrupt Qwen3.5 output on Android Vulkan by preserving the KQV
+  offload required for correct hybrid model inference while retaining the
+  remaining conservative Android context settings.
+
 ## 0.8.18
 
 - Updated native llama.cpp to `b10276`, including Qwen3-TTS model-loading

--- a/website/docs/changelog/recent-releases.md
+++ b/website/docs/changelog/recent-releases.md
@@ -9,8 +9,9 @@ For canonical full release notes, use:
 
 ## 0.8.19
 
-- Updated the native llama.cpp runtime and WebGPU bridge assets to `b10333`,
-  including matching Dart FFI bindings and refreshed Apple SwiftPM artifacts.
+- Updated the native llama.cpp runtime to `b10333` and WebGPU bridge assets to
+  `v0.1.27` (llama.cpp `b10333`), including matching Dart FFI bindings and
+  refreshed Apple SwiftPM artifacts.
 
 - Fixed corrupt Qwen3.5 output on Android Vulkan by preserving the KQV
   offload required for correct hybrid model inference while retaining the

--- a/website/docs/getting-started/installation.md
+++ b/website/docs/getting-started/installation.md
@@ -27,7 +27,7 @@ In Xcode, set `IPHONEOS_DEPLOYMENT_TARGET = 16.4` or
 
 ```yaml
 dependencies:
-  llamadart: ^0.8.18
+  llamadart: ^0.8.19
 ```
 
 For Flutter iOS/macOS apps that should link Apple XCFrameworks through Swift
@@ -35,9 +35,9 @@ Package Manager, also add the runtime companion packages you need:
 
 ```yaml
 dependencies:
-  llamadart: ^0.8.18
-  llamadart_llama_cpp_flutter: ^0.0.12 # GGUF / llama.cpp
-  llamadart_litert_lm_flutter: ^0.0.8 # Apple .litertlm / LiteRT-LM targets
+  llamadart: ^0.8.19
+  llamadart_llama_cpp_flutter: ^0.0.13 # GGUF / llama.cpp
+  llamadart_litert_lm_flutter: ^0.0.9 # Apple .litertlm / LiteRT-LM targets
 ```
 
 The companion packages are published independently from the `packages/`


### PR DESCRIPTION
## Summary

- Prepare `llamadart` 0.8.19 from the runtime and correctness changes already on `main`.
- Publish `llamadart_llama_cpp_flutter` 0.0.13 for the b10333 Apple SwiftPM runtime.
- Publish `llamadart_litert_lm_flutter` 0.0.9 so its public install example stays aligned.

## Scope

This PR changes release metadata, changelogs, and current install snippets only. Runtime behavior is unchanged from current `main`.

Merging this versioned release-prep branch is the publication approval boundary and will trigger release automation.

## Validation

- `dart format --output=none --set-exit-if-changed .`
- `dart analyze`
- `dart test -p vm -j 1 --exclude-tags local-only` — 1,314 passed, 66 skipped
- `dart test -p chrome --exclude-tags local-only` — 738 passed, 1 skipped
- `dart run tool/testing/verify_release_docs_versions.dart`
- `dart run tool/testing/test_matrix.dart --tier release`
- Companion package analysis, tests, SwiftPM manifest validation, and publish dry-runs
- Docusaurus production build and strict link validation
- Publish dry-runs for all three packages with zero warnings
- All 14 exact-head PR checks passed at `df43a191c55c3b28d7bc7f588e16a029ba9ff660`

The runtime and device-backed changes were validated before landing on `main`; this release-only diff does not alter runtime code.
