### PR TITLE
feat: add DSpark speculative decoding

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,15 @@
+## Unreleased
+
+* Added native llama.cpp DSpark speculative decoding through
+  `SpeculativeDecodingConfig.draftDspark(...)`, including exact
+  `draft-dspark` mapping, external draft-model validation, typed unsupported
+  failures, and benchmark coverage.
+
+* Updated the default llama.cpp native runtime pin to
+  `leehack/llamadart-native@b10356`, regenerated matching Dart FFI bindings,
+  refreshed the `llamadart_llama_cpp_flutter` Apple SwiftPM checksum, and
+  aligned current README/website native override docs.
+
 ## 0.8.19
 
 * Updated the default llama.cpp native runtime pin to

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 ## Unreleased
 
-* Added native llama.cpp DSpark speculative decoding through
-  `SpeculativeDecodingConfig.draftDspark(...)`, including exact
+* Added experimental, opt-in native llama.cpp DSpark speculative decoding
+  through `SpeculativeDecodingConfig.draftDspark(...)`, including exact
   `draft-dspark` mapping, external draft-model validation, typed unsupported
   failures, and benchmark coverage.
 

--- a/README.md
+++ b/README.md
@@ -134,7 +134,7 @@ Current default runtime pins:
 
 | Runtime | Pin |
 | --- | --- |
-| Native llama.cpp / GGUF | `leehack/llamadart-native@b10333` |
+| Native llama.cpp / GGUF | `leehack/llamadart-native@b10356` |
 | Native LiteRT-LM / `.litertlm` | `leehack/litert-lm-native@v0.15.0-native.3` |
 | Web llama.cpp / GGUF | `leehack/llama-web-bridge-assets@v0.1.27` |
 | Web LiteRT-LM / `.litertlm` | `@litert-lm/core@0.15.0` |

--- a/doc/testing_matrix.md
+++ b/doc/testing_matrix.md
@@ -169,7 +169,8 @@ dart run tool/testing/native_inference_benchmark.dart \
 dart run tool/testing/run_local_e2e.dart \
   --scenario llama-cpp-speculative-benchmark \
   --model-path models/Qwen3.5-0.8B-Q4_K_M.gguf \
-  --speculative-cases baseline,ngram-simple,ngram-map-k,ngram-map-k4v,ngram-mod,ngram-cache,mixed-ngram \
+  --draft-model-path path/to/dspark-draft.gguf \
+  --speculative-cases baseline,draft-dspark,ngram-simple,ngram-map-k,ngram-map-k4v,ngram-mod,ngram-cache,mixed-ngram \
   --backend cpu \
   --benchmark-gpu-layers 0 \
   --benchmark-max-tokens 128 \
@@ -181,9 +182,10 @@ dart run tool/testing/run_local_e2e.dart \
 ```
 
 In the local E2E scenario, external draft-model strategies require
-`--draft-model-path`. Bundled MTP uses `draft-mtp` without that option; the
-runner then loads the target with `ModelParams.loadMtp` automatically. The
-n-gram cache strategy can use existing cache paths or build a static cache with
+`--draft-model-path`; select `draft-dspark` to validate DSpark against the same
+target baseline. Bundled MTP uses `draft-mtp` without that option; the runner
+then loads the target with `ModelParams.loadMtp` automatically. The n-gram
+cache strategy can use existing cache paths or build a static cache with
 `--ngram-cache-build-static-path`.
 For `ngram-simple`, `ngram-map-k`, and `ngram-map-k4v`, `--ngram-size-m`
 sweeps the effective n-gram draft length; `--draft-token-max` is still useful

--- a/hook/build.dart
+++ b/hook/build.dart
@@ -13,7 +13,7 @@ import 'package:path/path.dart' as path;
 
 import 'package:llamadart/src/hook/native_bundle_config.dart';
 
-const _llamaCppTag = 'b10333';
+const _llamaCppTag = 'b10356';
 const _nativeRepoSlug = 'leehack/llamadart-native';
 
 const _packageName = 'llamadart';

--- a/lib/src/backends/llama_cpp/bindings.dart
+++ b/lib/src/backends/llama_cpp/bindings.dart
@@ -1317,6 +1317,14 @@ external ffi.Pointer<llama_sampler> llama_sampler_clone(
   ffi.Pointer<llama_sampler> smpl,
 );
 
+@ffi.Native<
+  ffi.Void Function(ffi.Pointer<llama_sampler>, ffi.Pointer<llama_sampler>)
+>()
+external void llama_sampler_copy(
+  ffi.Pointer<llama_sampler> src,
+  ffi.Pointer<llama_sampler> dst,
+);
+
 @ffi.Native<ffi.Void Function(ffi.Pointer<llama_sampler>)>()
 external void llama_sampler_free(ffi.Pointer<llama_sampler> smpl);
 
@@ -8722,6 +8730,7 @@ final class llama_sampler_i extends ffi.Struct {
       ffi.Bool Function(
         ffi.Pointer<llama_sampler> smpl,
         ggml_backend_buffer_type_t buft,
+        ffi.Uint32 n_outputs_max_per_seq,
       )
     >
   >
@@ -8755,6 +8764,21 @@ final class llama_sampler_i extends ffi.Struct {
     ffi.NativeFunction<ffi.Void Function(ffi.Pointer<llama_sampler> smpl)>
   >
   backend_set_input;
+
+  external ffi.Pointer<
+    ffi.NativeFunction<ffi.Void Function(ffi.Pointer<llama_sampler> smpl)>
+  >
+  backend_reset;
+
+  external ffi.Pointer<
+    ffi.NativeFunction<
+      ffi.Void Function(
+        ffi.Pointer<llama_sampler> src,
+        ffi.Pointer<llama_sampler> dst,
+      )
+    >
+  >
+  copy_state;
 }
 
 typedef llama_sampler_context_t = ffi.Pointer<ffi.Void>;
@@ -9307,6 +9331,9 @@ final class llama_context_params extends ffi.Struct {
 
   @ffi.Uint32()
   external int n_outputs_max;
+
+  @ffi.Uint32()
+  external int n_outputs_max_per_seq;
 
   @ffi.Int32()
   external int n_threads;

--- a/lib/src/backends/llama_cpp/llama_cpp_service.dart
+++ b/lib/src/backends/llama_cpp/llama_cpp_service.dart
@@ -666,6 +666,7 @@ final RegExp _linuxLlamadartProcMapsPattern = RegExp(
 );
 
 const int _maxLlamaCppReasoningBudgetTokens = 0x7fffffff;
+const String _minimumDsparkNativeTag = 'b10356';
 
 class _LlamaCppThinkingBudgetConfig {
   const _LlamaCppThinkingBudgetConfig({
@@ -721,23 +722,29 @@ class _LlamaCppSpeculativeConfig {
         strategy == SpeculativeDecodingStrategy.draftSimple ||
         strategy == SpeculativeDecodingStrategy.draftEagle3 ||
         strategy == SpeculativeDecodingStrategy.mtp ||
-        strategy == SpeculativeDecodingStrategy.draftDflash,
+        strategy == SpeculativeDecodingStrategy.draftDflash ||
+        strategy == SpeculativeDecodingStrategy.draftDspark,
   );
 
   bool get requiresExternalDraftModel => strategies.any(
     (strategy) =>
         strategy == SpeculativeDecodingStrategy.draftSimple ||
         strategy == SpeculativeDecodingStrategy.draftEagle3 ||
-        strategy == SpeculativeDecodingStrategy.draftDflash,
+        strategy == SpeculativeDecodingStrategy.draftDflash ||
+        strategy == SpeculativeDecodingStrategy.draftDspark,
   );
 
   bool get usesMtp => strategies.contains(SpeculativeDecodingStrategy.mtp);
+
+  bool get usesDspark =>
+      strategies.contains(SpeculativeDecodingStrategy.draftDspark);
 
   bool get suppressDraftProcessLogits => strategies.any(
     (strategy) =>
         strategy == SpeculativeDecodingStrategy.draftSimple ||
         strategy == SpeculativeDecodingStrategy.draftEagle3 ||
-        strategy == SpeculativeDecodingStrategy.draftDflash,
+        strategy == SpeculativeDecodingStrategy.draftDflash ||
+        strategy == SpeculativeDecodingStrategy.draftDspark,
   );
 }
 
@@ -800,6 +807,7 @@ class LlamaCppService {
     SpeculativeDecodingStrategy.draftEagle3: 'draft-eagle3',
     SpeculativeDecodingStrategy.mtp: 'draft-mtp',
     SpeculativeDecodingStrategy.draftDflash: 'draft-dflash',
+    SpeculativeDecodingStrategy.draftDspark: 'draft-dspark',
     SpeculativeDecodingStrategy.ngramSimple: 'ngram-simple',
     SpeculativeDecodingStrategy.ngramMapK: 'ngram-map-k',
     SpeculativeDecodingStrategy.ngramMapK4v: 'ngram-map-k4v',
@@ -812,6 +820,7 @@ class LlamaCppService {
         SpeculativeDecodingStrategy.draftEagle3,
         SpeculativeDecodingStrategy.mtp,
         SpeculativeDecodingStrategy.draftDflash,
+        SpeculativeDecodingStrategy.draftDspark,
       };
 
   int _nextHandle = 1;
@@ -3049,7 +3058,7 @@ class LlamaCppService {
     }
 
     if (_speculativeApiLookupAttempted) {
-      throw UnsupportedError(_speculativeUnavailableMessage());
+      throw LlamaUnsupportedException(_speculativeUnavailableMessage());
     }
     _speculativeApiLookupAttempted = true;
 
@@ -3082,12 +3091,13 @@ class LlamaCppService {
       }
     }
 
-    throw UnsupportedError(_speculativeUnavailableMessage());
+    throw LlamaUnsupportedException(_speculativeUnavailableMessage());
   }
 
   String _speculativeUnavailableMessage() {
     return 'llama.cpp speculative decoding is unavailable in this native '
-        'runtime bundle (missing llama_dart_speculative_* wrapper symbols).';
+        'runtime bundle (missing llama_dart_speculative_* wrapper symbols). '
+        'Use the package-pinned native runtime or an ABI-compatible build.';
   }
 
   // Legacy wrapper resolver retained for native bundles that still expose only
@@ -3952,7 +3962,7 @@ class LlamaCppService {
     }
 
     if (hasMediaParts) {
-      throw UnsupportedError(
+      throw LlamaUnsupportedException(
         'llama.cpp speculative decoding currently supports text-only '
         'generation in llamadart.',
       );
@@ -3964,7 +3974,7 @@ class LlamaCppService {
       );
     }
     if (params.grammar != null) {
-      throw UnsupportedError(
+      throw LlamaUnsupportedException(
         'llama.cpp speculative decoding does not yet support grammar '
         'sampling in llamadart.',
       );
@@ -3981,7 +3991,7 @@ class LlamaCppService {
     final uniqueStrategies = <SpeculativeDecodingStrategy>[];
     for (final strategy in strategies) {
       if (!_llamaCppSpeculativeTypeNames.containsKey(strategy)) {
-        throw UnsupportedError(
+        throw LlamaUnsupportedException(
           'llama.cpp does not support speculative strategy $strategy.',
         );
       }
@@ -3994,7 +4004,7 @@ class LlamaCppService {
         .where(_llamaCppDraftStrategies.contains)
         .length;
     if (draftStrategyCount > 1) {
-      throw UnsupportedError(
+      throw LlamaUnsupportedException(
         'llama.cpp speculative decoding can mix n-gram strategies with at '
         'most one draft-model strategy in llamadart.',
       );
@@ -4013,7 +4023,8 @@ class LlamaCppService {
       (strategy) =>
           strategy == SpeculativeDecodingStrategy.draftSimple ||
           strategy == SpeculativeDecodingStrategy.draftEagle3 ||
-          strategy == SpeculativeDecodingStrategy.draftDflash,
+          strategy == SpeculativeDecodingStrategy.draftDflash ||
+          strategy == SpeculativeDecodingStrategy.draftDspark,
     );
     if (requiresExternalDraft && draftModelPath == null) {
       throw ArgumentError(
@@ -4034,7 +4045,7 @@ class LlamaCppService {
             speculativeConfig.minProbability != null ||
             speculativeConfig.draftSplitProbability != null ||
             speculativeConfig.draftModelPath != null)) {
-      throw UnsupportedError(
+      throw LlamaUnsupportedException(
         'llama.cpp n-gram speculative decoding uses token history and does '
         'not support draftTokenMin, minProbability, draftSplitProbability, or '
         'draftModelPath unless a draft-model strategy is also enabled.',
@@ -4198,7 +4209,51 @@ class LlamaCppService {
       'ngramSizeN': config?.ngramSizeN,
       'ngramSizeM': config?.ngramSizeM,
       'ngramTokenMax': config?.ngramTokenMax,
+      'hasDraftContextStrategy': config?.hasDraftContextStrategy,
+      'requiresExternalDraftModel': config?.requiresExternalDraftModel,
+      'usesMtp': config?.usesMtp,
+      'suppressDraftProcessLogits': config?.suppressDraftProcessLogits,
     };
+  }
+
+  /// Throws the native speculative-session initialization error for tests.
+  Never debugThrowSpeculativeInitFailureForTesting(
+    GenerationParams params, {
+    bool hasMediaParts = false,
+  }) {
+    final config = _resolveLlamaCppSpeculativeConfig(
+      params,
+      hasMediaParts: hasMediaParts,
+    );
+    if (config == null) {
+      throw StateError('Speculative decoding must be enabled for this check.');
+    }
+    throw _speculativeInitFailure(config);
+  }
+
+  LlamaUnsupportedException _speculativeInitFailure(
+    _LlamaCppSpeculativeConfig config,
+  ) {
+    final strategyHint = config.usesDspark
+        ? 'DSpark requires leehack/llamadart-native@$_minimumDsparkNativeTag '
+              'or a newer ABI-compatible native build with DSpark '
+              'draft-context support. '
+        : '';
+    final draftHint = config.requiresExternalDraftModel
+        ? 'Verify that the external draft model is compatible with the target '
+              'model. '
+        : 'Verify that the selected strategy is compatible with this model. ';
+    return LlamaUnsupportedException(
+      'llama.cpp speculative decoding (${config.typeNames}) is not available '
+      'for this model/context. $strategyHint$draftHint'
+      'Use a native libllamadart build that includes the llama-common generic '
+      'speculative wrapper, and set ModelParams.speculativeRollbackTokenMax '
+      '>= the effective speculative draft length (draftTokenMax for '
+      'draft-model or ngram-cache strategies; ngramTokenMax when set for '
+      'ngram-mod, otherwise draftTokenMax/default; ngramSizeM for '
+      'ngram-simple, ngram-map-k, or ngram-map-k4v) when the target '
+      'architecture needs bounded rollback snapshots.',
+    );
   }
 
   ({int lastN, double repeat, double frequency, double presence})
@@ -4245,6 +4300,7 @@ class LlamaCppService {
         case SpeculativeDecodingStrategy.draftEagle3:
         case SpeculativeDecodingStrategy.mtp:
         case SpeculativeDecodingStrategy.draftDflash:
+        case SpeculativeDecodingStrategy.draftDspark:
           max = math.max(max, config.draftTokenMax ?? 3);
           break;
         case SpeculativeDecodingStrategy.ngramSimple:
@@ -4361,21 +4417,7 @@ class LlamaCppService {
           config: speculativeConfig,
         );
         if (speculativeSession == nullptr) {
-          final draftHint = speculativeConfig.requiresExternalDraftModel
-              ? 'Verify the draft model is compatible with the target model'
-              : 'Verify the selected strategy is compatible with this model';
-          throw UnsupportedError(
-            'llama.cpp speculative decoding (${speculativeConfig.typeNames}) '
-            'is not available for this model/context. $draftHint, use a '
-            'native libllamadart build that includes llama-common generic '
-            'speculative wrapper symbols, and set '
-            'ModelParams.speculativeRollbackTokenMax >= the effective '
-            'speculative draft length (draftTokenMax for draft-model or '
-            'ngram-cache strategies; ngramTokenMax when set for ngram-mod, '
-            'otherwise draftTokenMax/default; ngramSizeM for ngram-simple, '
-            'ngram-map-k, or ngram-map-k4v) when the target architecture '
-            'needs bounded rollback snapshots.',
-          );
+          throw _speculativeInitFailure(speculativeConfig);
         }
         if (speculativeApi.needEmbd(speculativeSession)) {
           llama_set_embeddings(ctx.pointer, true);

--- a/lib/src/core/models/inference/generation_params.dart
+++ b/lib/src/core/models/inference/generation_params.dart
@@ -69,6 +69,12 @@ enum SpeculativeDecodingStrategy {
 
   /// Self-speculative three-level n-gram cache.
   ngramCache,
+
+  /// DSpark draft-model speculative decoding.
+  ///
+  /// llama.cpp maps this to its `draft-dspark` path. It uses a separate draft
+  /// model and is distinct from MTP.
+  draftDspark,
 }
 
 /// Backend-neutral speculative decoding configuration.
@@ -117,7 +123,8 @@ class SpeculativeDecodingConfig {
 
   /// Optional draft model path for speculative decoding modes that use a
   /// separate drafter model, such as llama.cpp `--model-draft` with
-  /// `draft-simple`, `draft-eagle3`, `draft-mtp`, or `draft-dflash`.
+  /// `draft-simple`, `draft-eagle3`, `draft-mtp`, `draft-dflash`, or
+  /// `draft-dspark`.
   ///
   /// Leave null for models that carry their own MTP layers.
   final String? draftModelPath;
@@ -306,6 +313,39 @@ class SpeculativeDecodingConfig {
     required this.draftModelPath,
   }) : strategy = SpeculativeDecodingStrategy.draftDflash,
        strategies = const [SpeculativeDecodingStrategy.draftDflash],
+       ngramSize = null,
+       ngramSizeN = null,
+       ngramSizeM = null,
+       ngramMinHits = null,
+       ngramMatch = null,
+       ngramTokenMin = null,
+       ngramTokenMax = null,
+       ngramCacheStaticPath = null,
+       ngramCacheDynamicPath = null,
+       assert(draftTokenMax == null || draftTokenMax >= 0),
+       assert(draftTokenMin == null || draftTokenMin >= 0),
+       assert(
+         minProbability == null ||
+             (minProbability >= 0.0 && minProbability <= 1.0),
+       ),
+       assert(
+         draftSplitProbability == null ||
+             (draftSplitProbability >= 0.0 && draftSplitProbability <= 1.0),
+       );
+
+  /// Enables upstream llama.cpp `draft-dspark` speculative decoding.
+  ///
+  /// Native llama.cpp requires [draftModelPath] to identify a compatible
+  /// external DSpark draft GGUF. WebGPU and LiteRT-LM reject this strategy,
+  /// and native runtimes without DSpark draft-context support fail explicitly.
+  const SpeculativeDecodingConfig.draftDspark({
+    this.draftTokenMax,
+    this.draftTokenMin,
+    this.minProbability,
+    this.draftSplitProbability,
+    required this.draftModelPath,
+  }) : strategy = SpeculativeDecodingStrategy.draftDspark,
+       strategies = const [SpeculativeDecodingStrategy.draftDspark],
        ngramSize = null,
        ngramSizeN = null,
        ngramSizeM = null,

--- a/lib/src/core/models/inference/generation_params.dart
+++ b/lib/src/core/models/inference/generation_params.dart
@@ -70,10 +70,11 @@ enum SpeculativeDecodingStrategy {
   /// Self-speculative three-level n-gram cache.
   ngramCache,
 
-  /// DSpark draft-model speculative decoding.
+  /// Experimental, opt-in DSpark draft-model speculative decoding.
   ///
   /// llama.cpp maps this to its `draft-dspark` path. It uses a separate draft
-  /// model and is distinct from MTP.
+  /// model and is distinct from MTP. Callers must select this strategy
+  /// explicitly; it is never enabled by default.
   draftDspark,
 }
 
@@ -333,11 +334,14 @@ class SpeculativeDecodingConfig {
              (draftSplitProbability >= 0.0 && draftSplitProbability <= 1.0),
        );
 
-  /// Enables upstream llama.cpp `draft-dspark` speculative decoding.
+  /// Enables experimental upstream llama.cpp `draft-dspark` decoding.
   ///
-  /// Native llama.cpp requires [draftModelPath] to identify a compatible
-  /// external DSpark draft GGUF. WebGPU and LiteRT-LM reject this strategy,
-  /// and native runtimes without DSpark draft-context support fail explicitly.
+  /// This is an opt-in strategy and is never selected automatically. Native
+  /// llama.cpp requires [draftModelPath] to identify a compatible external
+  /// DSpark draft GGUF. Validate deterministic output, acceptance, and warmed
+  /// throughput for the exact target, draft, and backend before production
+  /// use. WebGPU and LiteRT-LM reject this strategy, and native runtimes without
+  /// DSpark draft-context support fail explicitly.
   const SpeculativeDecodingConfig.draftDspark({
     this.draftTokenMax,
     this.draftTokenMin,

--- a/packages/llamadart_llama_cpp_flutter/CHANGELOG.md
+++ b/packages/llamadart_llama_cpp_flutter/CHANGELOG.md
@@ -1,3 +1,7 @@
+## Unreleased
+
+* Updated Apple SwiftPM native pin to `leehack/llamadart-native@b10356`.
+
 ## 0.0.13
 
 * Updated Apple SwiftPM native pin to `leehack/llamadart-native@b10333`.

--- a/packages/llamadart_llama_cpp_flutter/README.md
+++ b/packages/llamadart_llama_cpp_flutter/README.md
@@ -16,7 +16,7 @@ dependencies:
 This package has no runtime Dart API of its own. Import `package:llamadart`
 normally from the core package and use `LlamaBackend()` / `LlamaEngine` there.
 
-The Apple SwiftPM manifest pins `leehack/llamadart-native@b10333`.
+The Apple SwiftPM manifest pins `leehack/llamadart-native@b10356`.
 
 Source for this package lives in
 `packages/llamadart_llama_cpp_flutter` in the

--- a/packages/llamadart_llama_cpp_flutter/darwin/llamadart_llama_cpp_flutter/Package.swift
+++ b/packages/llamadart_llama_cpp_flutter/darwin/llamadart_llama_cpp_flutter/Package.swift
@@ -4,7 +4,7 @@ import PackageDescription
 
 let packageRoot = URL(fileURLWithPath: #filePath).deletingLastPathComponent()
 let artifactsRoot = packageRoot.appendingPathComponent("Artifacts")
-let llamaCppTag = "b10333"
+let llamaCppTag = "b10356"
 
 func localArtifactPath(_ name: String) -> String? {
     let path = artifactsRoot.appendingPathComponent(name).path
@@ -47,7 +47,7 @@ let package = Package(
             repository: "leehack/llamadart-native",
             artifactName: "llamadart-native-apple-xcframework-\(llamaCppTag).zip",
             tag: llamaCppTag,
-            checksum: "ffd04ca1418f978e44b4b9f14436bc54a863d1791889c0ffad947419d519b1ea"
+            checksum: "d5a0dc77dfb406026a15a52b5b885c7ce24df626b83183e8e8d42135aa5683f8"
         ),
         .target(
             name: "llamadart_llama_cpp_flutter",

--- a/test/unit/backends/litert_lm/litert_lm_backend_web_test.dart
+++ b/test/unit/backends/litert_lm/litert_lm_backend_web_test.dart
@@ -459,22 +459,25 @@ void main() {
         const ModelParams(),
       );
 
-      await expectLater(
-        backend.generate(
-          contextHandle,
-          'hello',
-          const GenerationParams(
-            speculativeDecodingConfig: SpeculativeDecodingConfig.mtp(),
+      for (final config in const [
+        SpeculativeDecodingConfig.mtp(),
+        SpeculativeDecodingConfig.draftDspark(draftModelPath: 'draft.gguf'),
+      ]) {
+        await expectLater(
+          backend.generate(
+            contextHandle,
+            'hello',
+            GenerationParams(speculativeDecodingConfig: config),
           ),
-        ),
-        emitsError(
-          isA<UnsupportedError>().having(
-            (error) => error.message.toString(),
-            'message',
-            contains('speculativeDecodingConfig'),
+          emitsError(
+            isA<UnsupportedError>().having(
+              (error) => error.message.toString(),
+              'message',
+              contains('speculativeDecodingConfig'),
+            ),
           ),
-        ),
-      );
+        );
+      }
     } finally {
       await backend.dispose();
     }

--- a/test/unit/backends/litert_lm/litert_lm_service_test.dart
+++ b/test/unit/backends/litert_lm/litert_lm_service_test.dart
@@ -2163,6 +2163,28 @@ void main() {
         service.generate(
           contextHandle,
           'hello',
+          const GenerationParams(
+            speculativeDecodingConfig: SpeculativeDecodingConfig.draftDspark(
+              draftModelPath: 'draft.gguf',
+            ),
+          ),
+        ),
+        emitsError(
+          isA<UnsupportedError>().having(
+            (error) => error.message.toString(),
+            'message',
+            allOf(
+              contains('speculativeDecodingConfig.strategy'),
+              contains('speculativeDecodingConfig.draftModelPath'),
+            ),
+          ),
+        ),
+      );
+
+      await expectLater(
+        service.generate(
+          contextHandle,
+          'hello',
           const GenerationParams(thinkingBudget: ThinkingBudget(maxTokens: 16)),
         ),
         emitsError(

--- a/test/unit/backends/llama_cpp/llama_cpp_service_test.dart
+++ b/test/unit/backends/llama_cpp/llama_cpp_service_test.dart
@@ -170,6 +170,40 @@ void main() {
       expect(typeNames, 'ngram-mod,draft-mtp');
     });
 
+    test('maps DSpark exactly as an external non-MTP draft context', () {
+      final resolved = service.debugResolveSpeculativeNativeParamsForTesting(
+        const GenerationParams(
+          speculativeDecodingConfig: SpeculativeDecodingConfig.draftDspark(
+            draftModelPath: 'dspark.gguf',
+            draftTokenMax: 7,
+          ),
+        ),
+      );
+
+      expect(resolved['typeNames'], 'draft-dspark');
+      expect(resolved['draftTokenMax'], 7);
+      expect(resolved['hasDraftContextStrategy'], isTrue);
+      expect(resolved['requiresExternalDraftModel'], isTrue);
+      expect(resolved['usesMtp'], isFalse);
+      expect(resolved['suppressDraftProcessLogits'], isTrue);
+    });
+
+    test('mixes DSpark with draftless n-gram strategies in order', () {
+      final typeNames = service.debugResolveSpeculativeTypeNamesForTesting(
+        const GenerationParams(
+          speculativeDecodingConfig: SpeculativeDecodingConfig.mixed(
+            strategies: [
+              SpeculativeDecodingStrategy.ngramMod,
+              SpeculativeDecodingStrategy.draftDspark,
+            ],
+            draftModelPath: 'dspark.gguf',
+          ),
+        ),
+      );
+
+      expect(typeNames, 'ngram-mod,draft-dspark');
+    });
+
     test('rejects speculative decoding with a thinking budget', () {
       expect(
         () => service.debugResolveSpeculativeTypeNamesForTesting(
@@ -256,7 +290,30 @@ void main() {
           ),
         ),
         throwsA(
-          isA<UnsupportedError>().having(
+          isA<LlamaUnsupportedException>().having(
+            (error) => error.message,
+            'message',
+            contains('at most one draft-model strategy'),
+          ),
+        ),
+      );
+    });
+
+    test('rejects DSpark mixed with another draft-context strategy', () {
+      expect(
+        () => service.debugResolveSpeculativeTypeNamesForTesting(
+          const GenerationParams(
+            speculativeDecodingConfig: SpeculativeDecodingConfig.mixed(
+              strategies: [
+                SpeculativeDecodingStrategy.draftDspark,
+                SpeculativeDecodingStrategy.mtp,
+              ],
+              draftModelPath: 'dspark.gguf',
+            ),
+          ),
+        ),
+        throwsA(
+          isA<LlamaUnsupportedException>().having(
             (error) => error.message,
             'message',
             contains('at most one draft-model strategy'),
@@ -284,11 +341,56 @@ void main() {
       );
     });
 
+    test('requires a non-empty draftModelPath for DSpark', () {
+      expect(
+        () => service.debugResolveSpeculativeTypeNamesForTesting(
+          const GenerationParams(
+            speculativeDecodingConfig: SpeculativeDecodingConfig.mixed(
+              strategies: [SpeculativeDecodingStrategy.draftDspark],
+            ),
+          ),
+        ),
+        throwsA(
+          isA<ArgumentError>().having(
+            (error) => error.message,
+            'message',
+            contains('requires draftModelPath'),
+          ),
+        ),
+      );
+      expect(
+        () => service.debugResolveSpeculativeTypeNamesForTesting(
+          const GenerationParams(
+            speculativeDecodingConfig: SpeculativeDecodingConfig.draftDspark(
+              draftModelPath: ' ',
+            ),
+          ),
+        ),
+        throwsA(
+          isA<ArgumentError>().having(
+            (error) => error.message,
+            'message',
+            contains('must be null or a non-empty path'),
+          ),
+        ),
+      );
+    });
+
     test('suppresses process logits only for external draft strategies', () {
       expect(
         service.debugSuppressesDraftProcessLogitsForTesting(
           const GenerationParams(
             speculativeDecodingConfig: SpeculativeDecodingConfig.draftSimple(
+              draftModelPath: 'draft.gguf',
+            ),
+          ),
+        ),
+        isTrue,
+      );
+      expect(
+        service.debugSuppressesDraftProcessLogitsForTesting(
+          const GenerationParams(
+            speculativeDecodingConfig: SpeculativeDecodingConfig.draftDspark(
               draftModelPath: 'draft.gguf',
             ),
           ),
@@ -361,6 +463,55 @@ void main() {
           const ModelParams(),
         ),
         returnsNormally,
+      );
+    });
+
+    test('DSpark never requires target bundled MTP tensors', () {
+      expect(
+        () => service.debugValidateMtpModelLoadForTesting(
+          const GenerationParams(
+            speculativeDecodingConfig: SpeculativeDecodingConfig.draftDspark(
+              draftModelPath: 'draft.gguf',
+            ),
+          ),
+          const ModelParams(),
+        ),
+        returnsNormally,
+      );
+    });
+
+    test('reports DSpark native version skew as a typed failure', () {
+      expect(
+        () => service.debugThrowSpeculativeInitFailureForTesting(
+          const GenerationParams(
+            speculativeDecodingConfig: SpeculativeDecodingConfig.draftDspark(
+              draftModelPath: 'draft.gguf',
+            ),
+          ),
+        ),
+        throwsA(
+          isA<LlamaUnsupportedException>()
+              .having(
+                (error) => error.message,
+                'message',
+                contains('draft-dspark'),
+              )
+              .having(
+                (error) => error.message,
+                'message',
+                contains('llamadart-native@b10356'),
+              )
+              .having(
+                (error) => error.message,
+                'message',
+                contains('draft-context support'),
+              )
+              .having(
+                (error) => error.message,
+                'message',
+                contains('draftTokenMax'),
+              ),
+        ),
       );
     });
 

--- a/test/unit/backends/llama_cpp/load_param_helpers_test.dart
+++ b/test/unit/backends/llama_cpp/load_param_helpers_test.dart
@@ -242,6 +242,13 @@ void main() {
   });
 
   group('applyContextParams', () {
+    test('matches the native per-sequence output context ABI', () {
+      final defaults = llama_context_default_params();
+
+      expect(defaults.n_outputs_max, 0);
+      expect(defaults.n_outputs_max_per_seq, 1);
+    });
+
     test('writes type_k/type_v from cacheTypeK/V', () {
       final c = calloc<llama_context_params>();
       try {

--- a/test/unit/backends/webgpu/webgpu_backend_test.dart
+++ b/test/unit/backends/webgpu/webgpu_backend_test.dart
@@ -951,22 +951,25 @@ void main() {
     });
 
     test('rejects speculative decoding config', () {
-      expect(
-        () => backend.generate(
-          1,
-          'Hello',
-          const GenerationParams(
-            speculativeDecodingConfig: SpeculativeDecodingConfig.mtp(),
+      for (final config in const [
+        SpeculativeDecodingConfig.mtp(),
+        SpeculativeDecodingConfig.draftDspark(draftModelPath: 'draft.gguf'),
+      ]) {
+        expect(
+          () => backend.generate(
+            1,
+            'Hello',
+            GenerationParams(speculativeDecodingConfig: config),
           ),
-        ),
-        throwsA(
-          isA<UnsupportedError>().having(
-            (error) => error.message.toString(),
-            'message',
-            contains('speculative decoding'),
+          throwsA(
+            isA<UnsupportedError>().having(
+              (error) => error.message.toString(),
+              'message',
+              contains('speculative decoding'),
+            ),
           ),
-        ),
-      );
+        );
+      }
     });
 
     test(

--- a/test/unit/core/models/inference/generation_params_test.dart
+++ b/test/unit/core/models/inference/generation_params_test.dart
@@ -160,6 +160,13 @@ void main() {
     const dflash = SpeculativeDecodingConfig.draftDflash(
       draftModelPath: 'dflash.gguf',
     );
+    const dspark = SpeculativeDecodingConfig.draftDspark(
+      draftTokenMax: 7,
+      draftTokenMin: 2,
+      minProbability: 0.25,
+      draftSplitProbability: 0.1,
+      draftModelPath: 'dspark.gguf',
+    );
 
     expect(eagle.strategy, SpeculativeDecodingStrategy.draftEagle3);
     expect(eagle.strategies, [SpeculativeDecodingStrategy.draftEagle3]);
@@ -170,6 +177,13 @@ void main() {
     expect(eagle.draftModelPath, 'eagle.gguf');
     expect(dflash.strategy, SpeculativeDecodingStrategy.draftDflash);
     expect(dflash.draftModelPath, 'dflash.gguf');
+    expect(dspark.strategy, SpeculativeDecodingStrategy.draftDspark);
+    expect(dspark.strategies, [SpeculativeDecodingStrategy.draftDspark]);
+    expect(dspark.draftTokenMax, 7);
+    expect(dspark.draftTokenMin, 2);
+    expect(dspark.minProbability, 0.25);
+    expect(dspark.draftSplitProbability, 0.1);
+    expect(dspark.draftModelPath, 'dspark.gguf');
   });
 
   test('SpeculativeDecodingConfig stores ngram-mod and cache controls', () {

--- a/test/unit/tooling/llama_cpp_speculative_benchmark_test.dart
+++ b/test/unit/tooling/llama_cpp_speculative_benchmark_test.dart
@@ -27,6 +27,7 @@ void main() {
       expect(result.stdout, contains('--raw-prompt'));
       expect(result.stdout, contains('intentional raw-prompt comparisons'));
       expect(result.stdout, contains('--include-output'));
+      expect(result.stdout, contains('draft-dspark'));
     });
 
     test('builds llama.cpp static ngram cache bytes', () {
@@ -163,6 +164,41 @@ void main() {
           'baseline,draft-mtp',
         ]),
         isFalse,
+      );
+    });
+
+    test('maps DSpark aliases to the upstream benchmark case', () {
+      for (final alias in ['draft-dspark', 'dspark', 'draft_dspark']) {
+        final names = speculative_benchmark
+            .debugBuildBenchmarkCaseNamesForTesting([
+              '--model',
+              'target.gguf',
+              '--draft-model',
+              'draft.gguf',
+              '--cases',
+              alias,
+              '--draft-token-max',
+              '7',
+            ]);
+
+        expect(names, ['draft-dspark_draft_7'], reason: 'alias=$alias');
+      }
+    });
+
+    test('requires an external draft model for DSpark', () async {
+      final result = await Process.run(Platform.resolvedExecutable, [
+        '--disable-dart-dev',
+        'tool/testing/llama_cpp_speculative_benchmark.dart',
+        '--model',
+        'target.gguf',
+        '--cases',
+        'draft-dspark',
+      ]);
+
+      expect(result.exitCode, isNot(0));
+      expect(
+        result.stderr,
+        contains('draft-dspark requires --draft-model <draft.gguf>.'),
       );
     });
 

--- a/test/unit/tooling/llama_cpp_speculative_benchmark_test.dart
+++ b/test/unit/tooling/llama_cpp_speculative_benchmark_test.dart
@@ -28,6 +28,7 @@ void main() {
       expect(result.stdout, contains('intentional raw-prompt comparisons'));
       expect(result.stdout, contains('--include-output'));
       expect(result.stdout, contains('draft-dspark'));
+      expect(result.stdout, contains('DSpark is experimental and opt-in'));
     });
 
     test('builds llama.cpp static ngram cache bytes', () {

--- a/test/unit/tooling/test_matrix_test.dart
+++ b/test/unit/tooling/test_matrix_test.dart
@@ -83,8 +83,9 @@ void main() {
       expect(
         table,
         contains(
-          '--speculative-cases baseline,ngram-simple,ngram-map-k,ngram-map-k4v,'
-          'ngram-mod,ngram-cache,mixed-ngram',
+          '--draft-model-path <draft.gguf> --backend cpu '
+          '--speculative-cases baseline,draft-dspark,ngram-simple,ngram-map-k,'
+          'ngram-map-k4v,ngram-mod,ngram-cache,mixed-ngram',
         ),
       );
       expect(

--- a/tool/testing/llama_cpp_speculative_benchmark.dart
+++ b/tool/testing/llama_cpp_speculative_benchmark.dart
@@ -649,6 +649,19 @@ class _BenchmarkCase {
             draftSplitProbability: options.draftSplitProbability,
           ),
         );
+      case 'draft-dspark':
+        return _BenchmarkCase._(
+          name: 'draft-dspark_draft_$draftTokenMax',
+          caseType: requestedCase,
+          strategies: const <String>['draft-dspark'],
+          speculativeDecodingConfig: SpeculativeDecodingConfig.draftDspark(
+            draftModelPath: options.requiredDraftModelPath(requestedCase),
+            draftTokenMax: draftTokenMax,
+            draftTokenMin: options.draftTokenMin,
+            minProbability: options.minProbability,
+            draftSplitProbability: options.draftSplitProbability,
+          ),
+        );
       case 'ngram-simple':
         return _BenchmarkCase._(
           name: 'ngram-simple_m_$effectiveNgramSizeM',
@@ -1196,6 +1209,7 @@ const _allRequestedCases = <String>[
   'draft-eagle3',
   'draft-mtp',
   'draft-dflash',
+  'draft-dspark',
   'ngram-simple',
   'ngram-map-k',
   'ngram-map-k4v',
@@ -1221,6 +1235,7 @@ const _draftModelRequiredCases = <String>{
   'draft-simple',
   'draft-eagle3',
   'draft-dflash',
+  'draft-dspark',
   'mixed-ngram-draft-simple',
 };
 
@@ -1333,6 +1348,10 @@ String _canonicalCase(String value) {
     case 'dflash':
     case 'draft_dflash':
       return 'draft-dflash';
+    case 'draft-dspark':
+    case 'dspark':
+    case 'draft_dspark':
+      return 'draft-dspark';
     case 'mixed-ngram':
     case 'mixed_ngram':
       return 'mixed-ngram';
@@ -1541,7 +1560,7 @@ Case selection:
   --cases all                          Every supported case; draft-model cases
                                        require --draft-model.
   --draft-model <draft.gguf>           Draft model for draft-simple, eagle3,
-                                       dflash, external MTP, and mixed
+                                       dflash, dspark, external MTP, and mixed
                                        draft-model cases. Omit for bundled MTP.
   --draft-token-max <list>             Comma-separated draft-token depths for
                                        draft-model, ngram-mod, and ngram-cache

--- a/tool/testing/llama_cpp_speculative_benchmark.dart
+++ b/tool/testing/llama_cpp_speculative_benchmark.dart
@@ -1562,6 +1562,7 @@ Case selection:
   --draft-model <draft.gguf>           Draft model for draft-simple, eagle3,
                                        dflash, dspark, external MTP, and mixed
                                        draft-model cases. Omit for bundled MTP.
+                                       DSpark is experimental and opt-in.
   --draft-token-max <list>             Comma-separated draft-token depths for
                                        draft-model, ngram-mod, and ngram-cache
                                        cases. Default: 1,2.

--- a/tool/testing/test_matrix.dart
+++ b/tool/testing/test_matrix.dart
@@ -141,12 +141,13 @@ const List<TestMatrixRow> testMatrixRows = <TestMatrixRow>[
     tier: 'targeted',
     mode: 'local-only',
     covers:
-        'real GGUF llama.cpp speculative decoding baseline, bundled MTP, '
-        'n-gram, draft-model, and cache throughput/acceptance metrics',
+        'real GGUF llama.cpp speculative decoding baseline, n-gram, external '
+        'draft-model including DSpark, and cache throughput/acceptance metrics',
     command:
         'dart run tool/testing/run_local_e2e.dart --scenario '
         'llama-cpp-speculative-benchmark --model-path <model.gguf> '
-        '--backend cpu --speculative-cases baseline,ngram-simple,'
+        '--draft-model-path <draft.gguf> --backend cpu '
+        '--speculative-cases baseline,draft-dspark,ngram-simple,'
         'ngram-map-k,ngram-map-k4v,ngram-mod,ngram-cache,mixed-ngram '
         '--benchmark-gpu-layers 0 --benchmark-max-tokens 128 '
         '--benchmark-runs 3 --draft-token-max 1,2 '

--- a/website/docs/configuration/runtime-parameters.md
+++ b/website/docs/configuration/runtime-parameters.md
@@ -136,11 +136,12 @@ Important fields:
   `draftEagle3(...)`, `draftDflash(...)`, `draftDspark(...)`,
   `ngramSimple(...)`, `ngramMapK(...)`, `ngramMapK4v(...)`, `ngramMod(...)`,
   `ngramCache(...)`, and `mixed(...)` for draftless n-gram strategies plus one
-  draft-model strategy. `draftDspark(...)` maps exactly to llama.cpp
-  `draft-dspark`, requires a compatible external GGUF in `draftModelPath`, and
-  does not load target-model MTP tensors. Draftless n-gram strategies use token
-  history or n-gram caches without a draft model. WebGPU and LiteRT-LM web
-  reject speculative decoding until their speculative paths are implemented.
+  draft-model strategy. Experimental `draftDspark(...)` is opt-in, maps exactly
+  to llama.cpp `draft-dspark`, requires a compatible external GGUF in
+  `draftModelPath`, and does not load target-model MTP tensors. It is never
+  selected automatically. Draftless n-gram strategies use token history or
+  n-gram caches without a draft model. WebGPU and LiteRT-LM web reject
+  speculative decoding until their speculative paths are implemented.
 - `seed`: deterministic replay when set.
 - `grammar`: constrained decoding with GBNF.
 

--- a/website/docs/configuration/runtime-parameters.md
+++ b/website/docs/configuration/runtime-parameters.md
@@ -133,13 +133,14 @@ Important fields:
   speculative decoding. Native LiteRT-LM honors the legacy boolean flag.
   llama.cpp supports the upstream strategy surface:
   `SpeculativeDecodingConfig.mtp(...)`, `draftSimple(...)`,
-  `draftEagle3(...)`, `draftDflash(...)`, `ngramSimple(...)`,
-  `ngramMapK(...)`, `ngramMapK4v(...)`, `ngramMod(...)`,
+  `draftEagle3(...)`, `draftDflash(...)`, `draftDspark(...)`,
+  `ngramSimple(...)`, `ngramMapK(...)`, `ngramMapK4v(...)`, `ngramMod(...)`,
   `ngramCache(...)`, and `mixed(...)` for draftless n-gram strategies plus one
-  draft-model strategy. Draft-model strategies can load a separate GGUF through
-  `draftModelPath`; draftless n-gram strategies use token history or n-gram
-  caches without a draft model. WebGPU and LiteRT-LM web reject speculative
-  decoding until their speculative paths are implemented.
+  draft-model strategy. `draftDspark(...)` maps exactly to llama.cpp
+  `draft-dspark`, requires a compatible external GGUF in `draftModelPath`, and
+  does not load target-model MTP tensors. Draftless n-gram strategies use token
+  history or n-gram caches without a draft model. WebGPU and LiteRT-LM web
+  reject speculative decoding until their speculative paths are implemented.
 - `seed`: deterministic replay when set.
 - `grammar`: constrained decoding with GBNF.
 

--- a/website/docs/getting-started/installation.md
+++ b/website/docs/getting-started/installation.md
@@ -79,7 +79,7 @@ hooks:
     llamadart:
       # Optional. Defaults to llamadart's tested native runtime pin.
       # Use a leehack/llamadart-native release tag when testing another build.
-      llamadart_native_tag: b10333
+      llamadart_native_tag: b10356
 
       # Optional. GitHub repository slug or github.com URL.
       llamadart_native_repository: leehack/llamadart-native
@@ -105,7 +105,7 @@ per-target module list.
 
 Native source overrides are for compatibility testing. They do not regenerate
 Dart FFI bindings or symbol lookups, so the selected binary still must be ABI-
-and symbol-compatible with the default `leehack/llamadart-native@b10333` runtime.
+and symbol-compatible with the default `leehack/llamadart-native@b10356` runtime.
 
 Available native tags are published on the
 [`leehack/llamadart-native` releases page](https://github.com/leehack/llamadart-native/releases).
@@ -117,7 +117,7 @@ gh release list --repo leehack/llamadart-native --limit 20
 
 Before overriding, confirm the release includes the asset for your target. The
 hook downloads files named `llamadart-native-<bundle>-<tag>.tar.gz`, for example
-`llamadart-native-windows-x64-b10333.tar.gz`.
+`llamadart-native-windows-x64-b10356.tar.gz`.
 For local testing, `llamadart_native_path` may point directly at a bundle
 archive, at an extracted bundle directory, or at a directory containing
 `<tag>/<bundle>/`, `<bundle>/`, or the expected archive file.

--- a/website/docs/guides/performance-tuning.md
+++ b/website/docs/guides/performance-tuning.md
@@ -135,16 +135,23 @@ Guidelines:
   uses the legacy `speculativeDecoding` boolean. llama.cpp mirrors upstream
   `common_speculative`: `SpeculativeDecodingConfig.mtp(...)`,
   `draftSimple(...)`, `draftEagle3(...)`, `draftDflash(...)`,
-  `ngramSimple(...)`, `ngramMapK(...)`, `ngramMapK4v(...)`, `ngramMod(...)`,
-  `ngramCache(...)`, and `mixed(...)` for draftless n-gram strategies plus one
-  draft-model strategy. Draft-model strategies can load a separate GGUF through
-  `draftModelPath`; draftless n-gram strategies are workload-dependent and can
-  be slower than baseline on prompts with little repetition. For ngram-simple
-  and ngram-map strategies, `ngramSizeM` is the effective draft length and
-  mirrors upstream's draft m-gram window; `draftTokenMax` does not cap those
-  pure n-gram map strategies. For ngram-mod, `ngramTokenMax` is the effective
-  draft cap when set; otherwise it falls back to `draftTokenMax` or the
-  llama.cpp default.
+  `draftDspark(...)`, `ngramSimple(...)`, `ngramMapK(...)`,
+  `ngramMapK4v(...)`, `ngramMod(...)`, `ngramCache(...)`, and `mixed(...)` for
+  draftless n-gram strategies plus one draft-model strategy. Draft-model
+  strategies can load a separate GGUF through `draftModelPath`; draftless
+  n-gram strategies are workload-dependent and can be slower than baseline on
+  prompts with little repetition. For ngram-simple and ngram-map strategies,
+  `ngramSizeM` is the effective draft length and mirrors upstream's draft
+  m-gram window; `draftTokenMax` does not cap those pure n-gram map strategies.
+  For ngram-mod, `ngramTokenMax` is the effective draft cap when set; otherwise
+  it falls back to `draftTokenMax` or the llama.cpp default.
+- DSpark is a native llama.cpp external draft-model strategy. Use
+  `SpeculativeDecodingConfig.draftDspark(draftModelPath: ...)`; it maps to
+  upstream `draft-dspark`, requires the package-pinned `b10356` runtime or a
+  newer ABI-compatible build with DSpark draft-context support, and remains
+  subject to target/draft compatibility. Compare deterministic output,
+  acceptance, and warmed throughput against the same baseline before enabling
+  it in production.
 - DFlash draft models must use upstream-compatible GGUF metadata:
   `general.architecture=dflash` plus the `dflash.*` metadata block, including
   `dflash.target_layers`. A known-good public pair is target
@@ -271,6 +278,18 @@ dart run tool/testing/llama_cpp_speculative_benchmark.dart \
   --ngram-size-m 8,16 \
   --warmups 1
 
+# Benchmark an external DSpark draft model against the same target baseline
+dart run tool/testing/llama_cpp_speculative_benchmark.dart \
+  --model path/to/target.gguf \
+  --draft-model path/to/dspark-draft.gguf \
+  --cases baseline,draft-dspark \
+  --backend metal \
+  --gpu-layers 99 \
+  --max-tokens 256 \
+  --runs 3 \
+  --warmups 1 \
+  --include-output
+
 # Benchmark embeddings (sequential vs batch)
 dart run tool/testing/native_embedding_benchmark.dart \
   --model path/to/model.gguf \
@@ -288,8 +307,9 @@ dart run tool/testing/native_embedding_sweep.dart \
 ```
 
 For the speculative benchmark runner, external draft-model strategies require
-`--draft-model`; bundled MTP omits it and automatically loads the target's MTP
-tensors. The n-gram cache strategy requires cache paths. Current
+`--draft-model`; use the `draft-dspark` case for DSpark. Bundled MTP omits the
+draft path and automatically loads the target's MTP tensors. The n-gram cache
+strategy requires cache paths. Current
 measured llama.cpp n-gram parity results, including exact upstream comparison
 commands, are recorded in [Backend Benchmarks](./backend-benchmarks).
 

--- a/website/docs/guides/performance-tuning.md
+++ b/website/docs/guides/performance-tuning.md
@@ -145,13 +145,13 @@ Guidelines:
   m-gram window; `draftTokenMax` does not cap those pure n-gram map strategies.
   For ngram-mod, `ngramTokenMax` is the effective draft cap when set; otherwise
   it falls back to `draftTokenMax` or the llama.cpp default.
-- DSpark is a native llama.cpp external draft-model strategy. Use
-  `SpeculativeDecodingConfig.draftDspark(draftModelPath: ...)`; it maps to
-  upstream `draft-dspark`, requires the package-pinned `b10356` runtime or a
-  newer ABI-compatible build with DSpark draft-context support, and remains
-  subject to target/draft compatibility. Compare deterministic output,
-  acceptance, and warmed throughput against the same baseline before enabling
-  it in production.
+- DSpark is an experimental, opt-in native llama.cpp external draft-model
+  strategy. Use `SpeculativeDecodingConfig.draftDspark(draftModelPath: ...)`;
+  it is never selected automatically, maps to upstream `draft-dspark`, requires
+  the package-pinned `b10356` runtime or a newer ABI-compatible build with
+  DSpark draft-context support, and remains subject to target/draft/backend
+  compatibility. Compare deterministic output, acceptance, and warmed
+  throughput against the same baseline before enabling it in production.
 - DFlash draft models must use upstream-compatible GGUF metadata:
   `general.architecture=dflash` plus the `dflash.*` metadata block, including
   `dflash.target_layers`. A known-good public pair is target
@@ -278,7 +278,7 @@ dart run tool/testing/llama_cpp_speculative_benchmark.dart \
   --ngram-size-m 8,16 \
   --warmups 1
 
-# Benchmark an external DSpark draft model against the same target baseline
+# Benchmark the experimental DSpark path against the same target baseline
 dart run tool/testing/llama_cpp_speculative_benchmark.dart \
   --model path/to/target.gguf \
   --draft-model path/to/dspark-draft.gguf \

--- a/website/docs/platforms/support-matrix.md
+++ b/website/docs/platforms/support-matrix.md
@@ -183,12 +183,15 @@ device/model bundle, use `cpu` or `gpu` for that artifact.
   resolves known template delimiters automatically; raw generation requires
   explicit delimiters. LiteRT-LM and WebGPU reject the setting, as does the
   llama.cpp speculative-decoding path.
-- **DSpark speculative decoding** is supported on native llama.cpp/GGUF through
-  `SpeculativeDecodingConfig.draftDspark(...)`, which maps to upstream
-  `draft-dspark` and requires a compatible external draft GGUF. It is an
-  external non-MTP draft-context strategy and requires the default `b10356`
-  runtime or a newer ABI-compatible native build with the DSpark wrapper fix.
-  WebGPU and LiteRT-LM reject this llama.cpp-specific strategy explicitly.
+- **Experimental DSpark speculative decoding** is available as an explicit
+  opt-in on native llama.cpp/GGUF through
+  `SpeculativeDecodingConfig.draftDspark(...)`; it is never enabled by default.
+  It maps to upstream `draft-dspark`, requires a compatible external draft
+  GGUF, and remains subject to target/draft/backend parity, acceptance, and
+  throughput validation. It is an external non-MTP draft-context strategy and
+  requires the default `b10356` runtime or a newer ABI-compatible native build
+  with the DSpark wrapper fix. WebGPU and LiteRT-LM reject this llama.cpp-
+  specific strategy explicitly.
 - **State persistence** (`LlamaEngine.stateSaveFile(...)` /
   `stateLoadFile(...)`) is available on native backends and on WebGPU bridge
   assets `v0.1.15+` that expose `stateSaveFile` / `stateLoadFile` bridge APIs.

--- a/website/docs/platforms/support-matrix.md
+++ b/website/docs/platforms/support-matrix.md
@@ -7,7 +7,7 @@ This page combines platform support, runtime-family selection, and
 backend-module configuration for
 `llamadart`.
 
-The native-assets hook currently pins `llamadart-native` tag `b10333` and
+The native-assets hook currently pins `llamadart-native` tag `b10356` and
 `litert-lm-native` release `v0.15.0-native.3` (`hook/build.dart`). Apps can
 override the llama.cpp native GitHub source with
 `hooks.user_defines.llamadart.llamadart_native_tag` and
@@ -183,6 +183,12 @@ device/model bundle, use `cpu` or `gpu` for that artifact.
   resolves known template delimiters automatically; raw generation requires
   explicit delimiters. LiteRT-LM and WebGPU reject the setting, as does the
   llama.cpp speculative-decoding path.
+- **DSpark speculative decoding** is supported on native llama.cpp/GGUF through
+  `SpeculativeDecodingConfig.draftDspark(...)`, which maps to upstream
+  `draft-dspark` and requires a compatible external draft GGUF. It is an
+  external non-MTP draft-context strategy and requires the default `b10356`
+  runtime or a newer ABI-compatible native build with the DSpark wrapper fix.
+  WebGPU and LiteRT-LM reject this llama.cpp-specific strategy explicitly.
 - **State persistence** (`LlamaEngine.stateSaveFile(...)` /
   `stateLoadFile(...)`) is available on native backends and on WebGPU bridge
   assets `v0.1.15+` that expose `stateSaveFile` / `stateLoadFile` bridge APIs.
@@ -196,7 +202,7 @@ device/model bundle, use `cpu` or `gpu` for that artifact.
   a web load failure as a package bug. The [WebGPU Bridge](./webgpu-bridge)
   page has the browser-console probe and Flutter Web smoke-test path.
 
-## Current llama.cpp module availability by bundle (`b10333`)
+## Current llama.cpp module availability by bundle (`b10356`)
 
 | Bundle key | Available backend modules in bundle |
 | --- | --- |
@@ -244,7 +250,7 @@ hooks:
   user_defines:
     llamadart:
       # Optional. Defaults to llamadart's tested native runtime pin.
-      llamadart_native_tag: b10333
+      llamadart_native_tag: b10356
 
       # Optional. GitHub repository slug or github.com URL.
       llamadart_native_repository: leehack/llamadart-native


### PR DESCRIPTION
## Summary
- Add the experimental, opt-in `SpeculativeDecodingConfig.draftDspark(...)` API and map it exactly to upstream llama.cpp `draft-dspark`.
- Classify DSpark as an external, non-MTP draft-context strategy with explicit path, combination, unsupported-backend, and native version-skew failures.
- Atomically update the native runtime pin from b10333 to b10356, regenerate ABI-matched FFI bindings, and refresh the Apple SwiftPM checksum and companion references.
- Add API/service/negative tests, benchmark support, test-matrix coverage, documentation, and changelog entries.

## Production-readiness scope
- **User-facing scope:** Native llama.cpp users can explicitly opt into experimental DSpark with a compatible external draft GGUF through `SpeculativeDecodingConfig.draftDspark(draftModelPath: ...)`. It is never selected automatically.
- **Supported platforms/paths:** Experimental, opt-in availability on native llama.cpp/GGUF paths consuming the package-pinned b10356 artifacts. Exact behavioral validation was completed on macOS arm64 Metal.
- **Unsupported or intentionally unavailable paths:** WebGPU and LiteRT-LM reject the llama.cpp-specific strategy explicitly. Missing/older native capability and invalid or incompatible strategy/model combinations fail with typed, actionable diagnostics.
- **Out of scope / follow-ups:** Production parity and throughput clearance across compatible lossless targets and representative CUDA/HIP/Vulkan/multi-GPU hardware. Known upstream limitations remain open: [greedy divergence on quantized targets (#25618)](https://github.com/ggml-org/llama.cpp/issues/25618), [Metal small-batch performance (#25250)](https://github.com/ggml-org/llama.cpp/issues/25250), [no-vocab DSpark/DFlash mask-token failure (#26761)](https://github.com/ggml-org/llama.cpp/issues/26761), and [multi-GPU CUDA failure (#26554)](https://github.com/ggml-org/llama.cpp/issues/26554).

## Completeness checklist
- [x] Declared scope is fully implemented, or explicitly reduced above.
- [x] Unsupported platform/option combinations fail loudly with actionable diagnostics or are clearly documented as unavailable.
- [x] Public API docs, README/website docs, examples, support matrices, and changelog entries are updated where relevant.
- [x] Regression coverage covers the original issue plus key negative/version-skew paths where relevant.
- [x] Security/privacy review completed: no secrets, bearer tokens, signed URLs, or raw secret-bearing paths leak through logs, cache keys, metadata, errors, or snapshots.
- [x] Follow-up work that is useful but not required for this PR is tracked above.

## PR type guidance
- **Feature PR:** public API, documentation, platform matrix, unsupported-path behavior, and happy/negative-path tests are included.

## Test Plan
- [x] `dart format --output=none --set-exit-if-changed .`
- [x] `dart analyze`
- [x] `dart test -p vm -j 1 --exclude-tags local-only`
- [x] `dart test -p chrome --exclude-tags local-only`
- [x] Other targeted/local-only validation: coverage threshold, native hook/symbol and ABI tests, Apple companion analyze/tests/SwiftPM manifest, docs build/link validation, release-doc version checks, test-matrix catalog, and real Metal DSpark benchmark.
- [x] Experimental-framing follow-up: focused public API/benchmark tests, repository-wide analysis/format check, and docs build/link validation.

## Matrix Evidence
| Matrix row | Scope covered | Platform / model / backend | Result | Evidence / notes |
| --- | --- | --- | --- | --- |
| static-format-analyze | Format, analyzer, platform boundaries | macOS arm64 | PASS | 509 files unchanged; analyzer reported no issues |
| root-vm | Native-safe unit/integration suite | macOS arm64 VM | PASS | 1,323 passed; 66 fixture-dependent skips |
| root-chrome | Shared/public API browser suite | Chrome | PASS | 738 passed; 1 skip |
| coverage-lib | Maintained `lib/` coverage | VM | PASS | 74.83%, threshold 70% |
| native-hook-bundles | b10356 pin, ABI, symbols, bundle selection | macOS arm64 plus artifact metadata | PASS | Generated binding delta matches b10356 headers; release provenance/hash set verified |
| docs-site | Website build and links | Docusaurus | PASS | Optimized build and link validation passed, including the experimental-framing follow-up |
| release-doc-version-consistency | Current install/pin snippets | Local | PASS | Core and companion version checks passed |
| llama-cpp-speculative-benchmark | DSpark acceptance/parity/throughput | M4 Max Metal; Qwen3-8B Q4_K_M target; BF16 DSpark draft | PASS integration; FAIL parity/perf gate | DSpark completed all runs, 27.62% acceptance, 27.77 tok/s vs 75.02 baseline, 0/3 baseline hash matches |
| macos-arm64-runtime-smoke | Exact selected artifact runtime | macOS arm64 Metal | QUALIFIED | Exact upstream b10356 reproduced the same mode-specific output and comparable throughput, isolating the mismatch from Dart mapping |
| CUDA/HIP/Vulkan/multi-GPU and other OS/device smokes | Representative runtime clearance | Unavailable locally | N/A | Required hardware/platforms were unavailable |

## Review Notes
- Independent review status: local final-diff review found no blocking implementation, ABI, API, validation, documentation, or regression issues.
- CI status / head SHA: all 14 exact-head checks are green on `55c9b086a3664770686a7c1f909fb133483d2b2f`.
