### PR TITLE
Add experimental native speech-to-text support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 ## Unreleased
 
+* Added an experimental typed `SpeechToTextEngine` for whole-file native
+  llama.cpp transcription, including capability discovery, language-prefix
+  normalization, cancellation, audio metadata, typed failures, and a separate
+  **Transcribe Audio** flow in the Flutter chat example. Web and the current
+  LiteRT-LM artifacts fail explicitly as unsupported.
+
 * Added experimental, opt-in native llama.cpp DSpark speculative decoding
   through `SpeculativeDecodingConfig.draftDspark(...)`, including exact
   `draft-dspark` mapping, external draft-model validation, typed unsupported

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,10 +1,10 @@
 ## Unreleased
 
-* Added an experimental typed `SpeechToTextEngine` for whole-file native
-  llama.cpp transcription, including capability discovery, language-prefix
-  normalization, cancellation, audio metadata, typed failures, and a separate
-  **Transcribe Audio** flow in the Flutter chat example. Web and the current
-  LiteRT-LM artifacts fail explicitly as unsupported.
+* Added an experimental typed `SpeechToTextEngine` with an explicit Qwen3-ASR
+  adapter profile for whole-file native llama.cpp transcription, plus a
+  SHA-256-verified Qwen3-ASR 0.6B desktop preset and separate **Transcribe
+  Audio** flow in the Flutter chat example. Web and the current LiteRT-LM
+  artifacts fail explicitly as unsupported.
 
 * Added experimental, opt-in native llama.cpp DSpark speculative decoding
   through `SpeculativeDecodingConfig.draftDspark(...)`, including exact

--- a/README.md
+++ b/README.md
@@ -28,6 +28,8 @@ models through LiteRT-LM.
 - Streaming chat completions, llama.cpp thinking budgets, tool-call parsing,
   multimodal GGUF projectors, structured JSON output, embeddings, LoRA, state
   persistence, and runtime diagnostics where the active backend supports them.
+- Experimental typed whole-file speech recognition on native llama.cpp through
+  `SpeechToTextEngine`, with explicit capability and cancellation contracts.
 
 Unsupported runtime/option combinations are rejected explicitly instead of
 silently degrading. Check the support matrix before relying on a capability for
@@ -149,6 +151,7 @@ Current default runtime pins:
 | Generate typed JSON | [Structured output](https://llamadart.leehack.com/docs/guides/generation-and-streaming#structured-json-output) |
 | Use tool calling | [Tool calling](https://llamadart.leehack.com/docs/guides/tool-calling) |
 | Use images, audio, or projectors | [Multimodal](https://llamadart.leehack.com/docs/guides/multimodal) |
+| Transcribe speech on device | [Speech to text](https://llamadart.leehack.com/docs/guides/speech-to-text) |
 | Generate embeddings | [Embeddings](https://llamadart.leehack.com/docs/guides/embeddings) |
 | Load LoRA adapters | [LoRA adapters](https://llamadart.leehack.com/docs/guides/lora-adapters) |
 | Save and restore KV state | [API levels](https://llamadart.leehack.com/docs/guides/api-levels) |

--- a/doc/testing_matrix.md
+++ b/doc/testing_matrix.md
@@ -72,6 +72,7 @@ Pick targeted rows based on the touched surface:
 | Large WebGPU GGUF / wasm64 selection | `gemma4-webgpu-mem64` |
 | LiteRT-LM web / Gemma 4 web bundle | `gemma4-litert-web` |
 | Chat app model cache/download/projector | `chat-app-device-cache` |
+| Speech-to-text API, adapter, or chat flow | `speech-to-text-smoke` |
 | Example app, CLI, or server package | `examples-tests` |
 
 The required `Web Chat Contract` check runs the chat app tests on VM and
@@ -156,6 +157,12 @@ dart run tool/testing/run_local_e2e.dart --scenario gguf-chat-features-smoke \
 dart run tool/testing/run_local_e2e.dart --scenario litert-lm-chat-features-smoke \
   --model-path /path/to/gemma-4-E2B-it.litertlm \
   --backend auto
+
+dart run tool/testing/run_local_e2e.dart --scenario speech-to-text-smoke \
+  --model-path /path/to/Qwen3-ASR-0.6B-Q8_0.gguf \
+  --mmproj-path /path/to/mmproj-Qwen3-ASR-0.6B-Q8_0.gguf \
+  --audio-path /path/to/known-speech.wav \
+  --expect "Exact expected transcript."
 
 dart run tool/testing/run_local_e2e.dart --scenario chat-app-web-mock-smoke
 

--- a/example/chat_app/README.md
+++ b/example/chat_app/README.md
@@ -11,6 +11,8 @@ A Flutter chat application demonstrating real-world usage of llamadart with UI.
 - 📋 **Clipboard attachments**: Paste screenshots or copied image/audio files
   with `Cmd/Ctrl+V`, or use **Paste attachment** from the attachment menu on
   touch devices. Plain-text paste continues to work normally.
+- 🎙️ **Whole-file transcription**: Compatible native GGUF ASR models expose a
+  separate **Transcribe Audio** action backed by `SpeechToTextEngine`.
 - 📱 Material Design 3 UI
 - ⚙️ Model configuration (path, runtime-detected backend selection, GPU layers, context size)
 - 🧩 Capability badges per model (Tools / Thinking / Vision / Audio / Video)
@@ -89,6 +91,9 @@ flutter test --run-skipped -t local-only \
      a separate action, with an explicit combined option in the confirmation.
 3. Tap the **Download** icon. The app uses `Dio` to download the model directly to your device's app-specific cache directory. Additional model downloads enter a FIFO queue and start one at a time. A persistent progress pill remains in the app header when settings is closed; tap it to reopen download details.
 4. Once downloaded, tap **Select** to load the model.
+   - A custom native Qwen3-ASR GGUF + matching `mmproj` exposes both **Attach
+     Audio** and **Transcribe Audio**. The latter transcribes one selected file;
+     live microphone input, Web, LiteRT-LM STT, and TTS are not enabled yet.
    - Gemma 4 E2B is included as a GGUF + `mmproj` bundle. In the current
      native `llama.cpp` mtmd path used here, that projector exposes image,
      audio, and video input. Audio remains experimental upstream; start with

--- a/example/chat_app/README.md
+++ b/example/chat_app/README.md
@@ -70,12 +70,11 @@ flutter test --run-skipped -t local-only \
 2. Select one of the focused pre-configured models:
    - Cross-platform: FunctionGemma 270M, Qwen3.5 0.8B, Gemma 4 E2B
      GGUF, Gemma 4 E2B LiteRT-LM, and Gemma 4 E4B GGUF.
-   - Native desktop: Gemma 4 12B, Gemma 4 26B A4B, Gemma 4 31B,
-     and Qwen3.6 35B A3B.
-   - All built-in GGUF presets use [Unsloth distributions](https://huggingface.co/unsloth)
-     and show that source in the model card. The LiteRT-LM preset uses the
-     `litert-community` distribution because Unsloth does not publish the
-     required `.litertlm` bundle.
+   - Native desktop: Qwen3-ASR 0.6B, Gemma 4 12B, Gemma 4 26B A4B,
+     Gemma 4 31B, and Qwen3.6 35B A3B.
+   - Built-in GGUF chat presets use [Unsloth distributions](https://huggingface.co/unsloth).
+     The ASR preset uses llama.cpp's `ggml-org` Qwen3-ASR pair, and the
+     LiteRT-LM preset uses `litert-community`; every card identifies its source.
    - The library opens with the current platform selected. Use the Mobile, Web,
      and Desktop filters to compare compatible presets; unavailable models are
      clearly disabled when browsing another platform. Downloaded models appear
@@ -91,9 +90,10 @@ flutter test --run-skipped -t local-only \
      a separate action, with an explicit combined option in the confirmation.
 3. Tap the **Download** icon. The app uses `Dio` to download the model directly to your device's app-specific cache directory. Additional model downloads enter a FIFO queue and start one at a time. A persistent progress pill remains in the app header when settings is closed; tap it to reopen download details.
 4. Once downloaded, tap **Select** to load the model.
-   - A custom native Qwen3-ASR GGUF + matching `mmproj` exposes both **Attach
-     Audio** and **Transcribe Audio**. The latter transcribes one selected file;
-     live microphone input, Web, LiteRT-LM STT, and TTS are not enabled yet.
+   - The native-desktop Qwen3-ASR preset exposes both **Attach Audio** and
+     **Transcribe Audio**. The latter accepts WAV, MP3, or FLAC files and
+     requires the matching projector; live microphone input, Web, LiteRT-LM
+     STT, and TTS are not enabled yet. Its pinned downloads are SHA-256 verified.
    - Gemma 4 E2B is included as a GGUF + `mmproj` bundle. In the current
      native `llama.cpp` mtmd path used here, that projector exposes image,
      audio, and video input. Audio remains experimental upstream; start with

--- a/example/chat_app/lib/models/chat_message.dart
+++ b/example/chat_app/lib/models/chat_message.dart
@@ -42,6 +42,9 @@ class ChatMessage {
     return false;
   }
 
+  /// Whether this assistant message came from the speech-to-text workflow.
+  bool get isTranscription => debugBadges.contains('Transcription');
+
   /// Derived property to get thinking content if present.
   String? get thinkingText {
     final thinkingPart = parts?.whereType<LlamaThinkingContent>().firstOrNull;

--- a/example/chat_app/lib/models/chat_settings.dart
+++ b/example/chat_app/lib/models/chat_settings.dart
@@ -42,6 +42,7 @@ class ChatSettings {
   /// platform. Runtime projector probes can add to these capabilities.
   final bool modelSupportsVision;
   final bool modelSupportsAudio;
+  final bool modelSupportsSpeechToText;
 
   /// Whether media is consumed directly by the model backend instead of an
   /// external multimodal projector.
@@ -77,6 +78,7 @@ class ChatSettings {
     this.singleTurnMode = false,
     this.modelSupportsVision = false,
     this.modelSupportsAudio = false,
+    this.modelSupportsSpeechToText = false,
     this.directMediaInput = false,
     this.modelBytesHint,
   });
@@ -106,6 +108,7 @@ class ChatSettings {
     bool? singleTurnMode,
     bool? modelSupportsVision,
     bool? modelSupportsAudio,
+    bool? modelSupportsSpeechToText,
     bool? directMediaInput,
     int? modelBytesHint,
   }) {
@@ -135,6 +138,8 @@ class ChatSettings {
       singleTurnMode: singleTurnMode ?? this.singleTurnMode,
       modelSupportsVision: modelSupportsVision ?? this.modelSupportsVision,
       modelSupportsAudio: modelSupportsAudio ?? this.modelSupportsAudio,
+      modelSupportsSpeechToText:
+          modelSupportsSpeechToText ?? this.modelSupportsSpeechToText,
       directMediaInput: directMediaInput ?? this.directMediaInput,
       modelBytesHint: modelBytesHint ?? this.modelBytesHint,
     );

--- a/example/chat_app/lib/models/downloadable_model.dart
+++ b/example/chat_app/lib/models/downloadable_model.dart
@@ -104,6 +104,7 @@ class ResolvedModelAsset {
 class ModelCapabilities {
   final bool supportsVision;
   final bool supportsAudio;
+  final bool supportsSpeechToText;
   final bool supportsVideo;
   final bool supportsToolCalling;
   final bool supportsThinking;
@@ -111,6 +112,7 @@ class ModelCapabilities {
   const ModelCapabilities({
     this.supportsVision = false,
     this.supportsAudio = false,
+    this.supportsSpeechToText = false,
     this.supportsVideo = false,
     this.supportsToolCalling = false,
     this.supportsThinking = false,
@@ -189,9 +191,11 @@ class DownloadableModel {
   final int? webSizeBytes;
   final bool supportsVision;
   final bool supportsAudio;
+  final bool supportsSpeechToText;
   final bool supportsVideo;
   final bool? webSupportsVision;
   final bool? webSupportsAudio;
+  final bool? webSupportsSpeechToText;
   final bool? webSupportsVideo;
   final ModelMediaInputMode mediaInputMode;
   final ModelMediaInputMode? webMediaInputMode;
@@ -223,9 +227,11 @@ class DownloadableModel {
     this.mmprojFilename,
     this.supportsVision = false,
     this.supportsAudio = false,
+    this.supportsSpeechToText = false,
     this.supportsVideo = false,
     this.webSupportsVision,
     this.webSupportsAudio,
+    this.webSupportsSpeechToText,
     this.webSupportsVideo,
     this.mediaInputMode = ModelMediaInputMode.externalProjector,
     this.webMediaInputMode,
@@ -253,9 +259,11 @@ class DownloadableModel {
     this.webSizeBytes,
     this.supportsVision = false,
     this.supportsAudio = false,
+    this.supportsSpeechToText = false,
     this.supportsVideo = false,
     this.webSupportsVision,
     this.webSupportsAudio,
+    this.webSupportsSpeechToText,
     this.webSupportsVideo,
     this.mediaInputMode = ModelMediaInputMode.externalProjector,
     this.webMediaInputMode,
@@ -319,6 +327,9 @@ class DownloadableModel {
     if (web && webSizeBytes != null) {
       return webSizeBytes!;
     }
+    if (sizeBytes > 0) {
+      return sizeBytes;
+    }
     final source = modelSourceFor(web: web);
     if (source is RemoteModelAssetSource && source.sizeBytes != null) {
       return source.sizeBytes!;
@@ -333,6 +344,7 @@ class DownloadableModel {
   ModelCapabilities get capabilities => ModelCapabilities(
     supportsVision: supportsVision,
     supportsAudio: supportsAudio,
+    supportsSpeechToText: supportsSpeechToText,
     supportsVideo: supportsVideo,
     supportsToolCalling: supportsToolCalling,
     supportsThinking: supportsThinking,
@@ -343,6 +355,10 @@ class DownloadableModel {
 
   bool supportsAudioFor({required bool web}) =>
       web ? webSupportsAudio ?? supportsAudio : supportsAudio;
+
+  bool supportsSpeechToTextFor({required bool web}) => web
+      ? webSupportsSpeechToText ?? supportsSpeechToText
+      : supportsSpeechToText;
 
   bool supportsVideoFor({required bool web}) =>
       web ? webSupportsVideo ?? supportsVideo : supportsVideo;
@@ -373,7 +389,7 @@ class DownloadableModel {
   bool isAvailableFor({required bool web, required bool mobile}) =>
       availability == ModelAvailability.all || (!web && !mobile);
 
-  static const List<DownloadableModel> defaultModels = [
+  static final List<DownloadableModel> defaultModels = List.unmodifiable([
     DownloadableModel(
       name: 'FunctionGemma 270M',
       description: 'Tiny specialist for function calling and tool-use demos.',
@@ -412,6 +428,45 @@ class DownloadableModel {
         topK: 20,
         topP: 0.8,
         penalty: 1.0,
+        contextSize: 4096,
+        maxTokens: 1024,
+        thinkingEnabled: false,
+      ),
+    ),
+    DownloadableModel.fromSources(
+      id: 'qwen3-asr-0.6b-q8-0',
+      name: 'Qwen3-ASR 0.6B',
+      description:
+          'Experimental local whole-file speech transcription with Qwen3-ASR.',
+      modelSource: const RemoteModelAssetSource(
+        url:
+            'https://huggingface.co/ggml-org/Qwen3-ASR-0.6B-GGUF/resolve/928ab958557df9aa2ef1c93e0e83c7ad0933fae2/Qwen3-ASR-0.6B-Q8_0.gguf?download=true',
+        filename: 'Qwen3-ASR-0.6B-Q8_0.gguf',
+        sizeBytes: 804749248,
+        sha256:
+            'bca259818b50ca7c4c05e9bdb35a5dc04fa039653a6d6f3f0f331f96f6aa1971',
+      ),
+      multimodalProjectorSource: const RemoteModelAssetSource(
+        url:
+            'https://huggingface.co/ggml-org/Qwen3-ASR-0.6B-GGUF/resolve/928ab958557df9aa2ef1c93e0e83c7ad0933fae2/mmproj-Qwen3-ASR-0.6B-Q8_0.gguf?download=true',
+        filename: 'mmproj-Qwen3-ASR-0.6B-Q8_0.gguf',
+        sizeBytes: 214392480,
+        sha256:
+            '41a342b5e4c514e968cb756de6cd1b7be39eff43c44c57a2ef5fc6522e36603d',
+      ),
+      sizeBytes: 1019141728,
+      supportsAudio: true,
+      supportsSpeechToText: true,
+      webSupportsAudio: false,
+      webSupportsSpeechToText: false,
+      distribution: 'ggml-org',
+      availability: ModelAvailability.nativeDesktop,
+      minRamGb: 4,
+      preset: const ModelPreset(
+        temperature: 0,
+        topK: 1,
+        topP: 1,
+        penalty: 1,
         contextSize: 4096,
         maxTokens: 1024,
         thinkingEnabled: false,
@@ -618,5 +673,5 @@ class DownloadableModel {
         thinkingEnabled: false,
       ),
     ),
-  ];
+  ]);
 }

--- a/example/chat_app/lib/providers/chat_provider.dart
+++ b/example/chat_app/lib/providers/chat_provider.dart
@@ -82,6 +82,7 @@ class ChatProvider extends ChangeNotifier {
   double _loadingProgress = 0.0;
   bool _isLoaded = false;
   bool _isGenerating = false;
+  bool _isTranscribing = false;
   bool _isShuttingDown = false;
   bool _supportsVision = false;
   bool _supportsAudio = false;
@@ -91,6 +92,7 @@ class ChatProvider extends ChangeNotifier {
   String? _error;
   Timer? _settingsSaveDebounce;
   CancelToken? _activeModelPrefetchCancelToken;
+  SpeechToTextTask? _activeSpeechToTextTask;
   bool _isDisposed = false;
 
   // Telemetry
@@ -137,6 +139,7 @@ class ChatProvider extends ChangeNotifier {
   double get loadingProgress => _loadingProgress;
   bool get isLoaded => _isLoaded;
   bool get isGenerating => _isGenerating;
+  bool get isTranscribing => _isTranscribing;
 
   /// Whether the latest plain assistant response can be generated again.
   bool get canRegenerateLastResponse {
@@ -162,6 +165,19 @@ class ChatProvider extends ChangeNotifier {
 
   bool get supportsVision => _supportsVision;
   bool get supportsAudio => _supportsAudio;
+  bool get canTranscribeAudio =>
+      !kIsWeb &&
+      _isLoaded &&
+      !_isInitializing &&
+      !_isGenerating &&
+      _supportsAudio &&
+      !((_settings.modelPath ?? '')
+          .split('?')
+          .first
+          .split('#')
+          .first
+          .toLowerCase()
+          .endsWith('.litertlm'));
   bool get templateSupportsTools => _templateSupportsTools;
   bool get thinkingControlsSupported => _thinkingControlsSupported;
   String? get error => _error;
@@ -1046,11 +1062,14 @@ class ChatProvider extends ChangeNotifier {
   }
 
   void clearConversation() {
+    _activeSpeechToTextTask?.cancel();
+    _activeSpeechToTextTask = null;
     _messages.clear();
     _session?.reset();
     _currentTokens = 0;
     _isPruning = false;
     _isGenerating = false;
+    _isTranscribing = false;
     _stagedParts.clear();
     _clearGenerationMetrics();
     _messages.add(
@@ -1679,7 +1698,7 @@ class ChatProvider extends ChangeNotifier {
     if (!last.isUser &&
         !last.isInfo &&
         !hasContentParts &&
-        (text.isEmpty || text == '...')) {
+        (text.isEmpty || text == '...' || text == 'Transcribing…')) {
       _messages.removeLast();
     }
   }
@@ -1872,6 +1891,184 @@ class ChatProvider extends ChangeNotifier {
     );
   }
 
+  /// Picks one complete audio file and transcribes it with the loaded model.
+  Future<void> pickAudioForTranscription() async {
+    if (kIsWeb) {
+      _addInfoMessage(
+        'Dedicated speech-to-text is not available in the Web chat app yet.',
+      );
+      notifyListeners();
+      return;
+    }
+
+    try {
+      final result = await FilePicker.platform.pickFiles(
+        type: FileType.audio,
+        allowMultiple: false,
+      );
+      if (result == null || result.files.isEmpty) {
+        return;
+      }
+
+      final file = result.files.single;
+      final path = file.path;
+      if (path != null && path.isNotEmpty) {
+        await transcribeAudio(
+          SpeechAudioFileInput(path),
+          displayName: file.name,
+        );
+        return;
+      }
+
+      final bytes = file.bytes;
+      if (bytes != null && bytes.isNotEmpty) {
+        await transcribeAudio(
+          SpeechAudioBytesInput(bytes),
+          displayName: file.name,
+        );
+        return;
+      }
+
+      _addInfoMessage('Could not read the selected audio file.');
+      notifyListeners();
+    } catch (error) {
+      _logDart(
+        LlamaLogLevel.warn,
+        'Error picking audio for transcription: $error',
+      );
+      _addInfoMessage('Could not open the selected audio file.');
+      notifyListeners();
+    }
+  }
+
+  /// Transcribes one complete [audio] input and displays the result in chat.
+  ///
+  /// This is intentionally separate from attaching audio to a generic chat
+  /// turn. The current native backend emits only a final transcript.
+  Future<void> transcribeAudio(
+    SpeechAudioInput audio, {
+    String? displayName,
+  }) async {
+    if (_isGenerating || _session == null || !_chatService.engine.isReady) {
+      return;
+    }
+    if (kIsWeb) {
+      _addInfoMessage(
+        'Dedicated speech-to-text is not available in the Web chat app yet.',
+      );
+      notifyListeners();
+      return;
+    }
+
+    final llamaAudio = switch (audio) {
+      SpeechAudioFileInput(:final path) => LlamaAudioContent(path: path),
+      SpeechAudioBytesInput(:final bytes) => LlamaAudioContent(bytes: bytes),
+      SpeechPcmInput(:final samples) => LlamaAudioContent(samples: samples),
+    };
+    if (!await _ensureMultimodalProjectorForMedia(<LlamaContentPart>[
+      llamaAudio,
+    ])) {
+      return;
+    }
+
+    if (_settings.singleTurnMode) {
+      _session!.reset();
+    }
+
+    final sourceLabel = (displayName ?? '').trim().isEmpty
+        ? 'selected audio'
+        : displayName!.trim();
+    _messages.add(
+      ChatMessage(text: 'Transcribe audio: $sourceLabel', isUser: true),
+    );
+    _messages.add(ChatMessage(text: 'Transcribing…', isUser: false));
+    _isGenerating = true;
+    _isTranscribing = true;
+    _syncActiveConversationSnapshot();
+    notifyListeners();
+    await _yieldUiFrame();
+
+    try {
+      final recognizer = SpeechToTextEngine(_chatService.engine);
+      final task = await recognizer.transcribe(
+        SpeechToTextRequest(
+          audio: audio,
+          maxOutputTokens: math.min(1024, math.max(64, _settings.maxTokens)),
+        ),
+      );
+      _activeSpeechToTextTask = task;
+      if (!_isGenerating) {
+        task.cancel();
+      }
+
+      SpeechToTextResult? result;
+      await for (final event in task.events) {
+        if (event is SpeechToTextFinalEvent) {
+          result = event.result;
+        }
+      }
+      final completion = await task.done;
+
+      if (completion.state == SpeechToTextCompletionState.cancelled) {
+        _removeEmptyAssistantPlaceholder();
+        _addInfoMessage('Transcription cancelled.');
+        return;
+      }
+      if (completion.state == SpeechToTextCompletionState.failed) {
+        throw completion.error ?? LlamaSpeechException('Transcription failed.');
+      }
+
+      final transcript = (result ?? completion.result)?.text.trim() ?? '';
+      if (transcript.isEmpty) {
+        throw LlamaSpeechException(
+          'The model completed without returning transcript text.',
+        );
+      }
+
+      if (_messages.isNotEmpty && !_messages.last.isUser) {
+        _messages[_messages.length - 1] = _messages.last.copyWith(
+          text: transcript,
+          parts: <LlamaContentPart>[LlamaTextContent(transcript)],
+          debugBadges: const <String>['Transcription'],
+        );
+      }
+      _session!.addMessage(
+        LlamaChatMessage.fromText(
+          role: LlamaChatRole.user,
+          text: 'Transcribe audio: $sourceLabel',
+        ),
+      );
+      _session!.addMessage(
+        LlamaChatMessage.fromText(
+          role: LlamaChatRole.assistant,
+          text: transcript,
+        ),
+      );
+      try {
+        _messages.last.tokenCount = await _chatService.engine.getTokenCount(
+          transcript,
+        );
+      } on LlamaUnsupportedException {
+        // Token counting is optional for transcription display.
+      } on UnsupportedError {
+        // Token counting is optional for transcription display.
+      }
+    } catch (error) {
+      _removeEmptyAssistantPlaceholder();
+      _addInfoMessage(
+        error is LlamaUnsupportedException
+            ? error.message
+            : 'Transcription failed: ${_formatDisplayError(error)}',
+      );
+    } finally {
+      _activeSpeechToTextTask = null;
+      _isTranscribing = false;
+      _isGenerating = false;
+      _syncActiveConversationSnapshot();
+      notifyListeners();
+    }
+  }
+
   Future<void> _pickMediaPart({
     required FileType type,
     required Future<LlamaContentPart> Function(String path) fromPath,
@@ -1993,7 +2190,12 @@ class ChatProvider extends ChangeNotifier {
 
   void stopGeneration() {
     if (_isGenerating) {
-      _chatService.cancelGeneration();
+      final speechTask = _activeSpeechToTextTask;
+      if (speechTask != null) {
+        speechTask.cancel();
+      } else {
+        _chatService.cancelGeneration();
+      }
       _isGenerating = false;
       notifyListeners();
     }

--- a/example/chat_app/lib/providers/chat_provider.dart
+++ b/example/chat_app/lib/providers/chat_provider.dart
@@ -93,6 +93,8 @@ class ChatProvider extends ChangeNotifier {
   Timer? _settingsSaveDebounce;
   CancelToken? _activeModelPrefetchCancelToken;
   SpeechToTextTask? _activeSpeechToTextTask;
+  Completer<void>? _activeTranscriptionDone;
+  int _conversationRevision = 0;
   bool _isDisposed = false;
 
   // Telemetry
@@ -144,6 +146,7 @@ class ChatProvider extends ChangeNotifier {
   /// Whether the latest plain assistant response can be generated again.
   bool get canRegenerateLastResponse {
     if (_isGenerating ||
+        _isTranscribing ||
         _session == null ||
         !_chatService.engine.isReady ||
         _messages.length < 2) {
@@ -154,6 +157,7 @@ class ChatProvider extends ChangeNotifier {
     if (assistant.isUser ||
         assistant.isInfo ||
         assistant.isToolCall ||
+        assistant.isTranscription ||
         assistant.role == LlamaChatRole.tool) {
       return false;
     }
@@ -170,14 +174,9 @@ class ChatProvider extends ChangeNotifier {
       _isLoaded &&
       !_isInitializing &&
       !_isGenerating &&
+      !_isTranscribing &&
       _supportsAudio &&
-      !((_settings.modelPath ?? '')
-          .split('?')
-          .first
-          .split('#')
-          .first
-          .toLowerCase()
-          .endsWith('.litertlm'));
+      _settings.modelSupportsSpeechToText;
   bool get templateSupportsTools => _templateSupportsTools;
   bool get thinkingControlsSupported => _thinkingControlsSupported;
   String? get error => _error;
@@ -326,6 +325,7 @@ class ChatProvider extends ChangeNotifier {
   }
 
   void createConversation() {
+    _invalidateActiveTranscription();
     _syncActiveConversationSnapshot();
 
     final id = _conversationStateService.newConversationId();
@@ -372,6 +372,8 @@ class ChatProvider extends ChangeNotifier {
     if (index < 0) {
       return;
     }
+
+    await _cancelAndAwaitActiveTranscription();
 
     _syncActiveConversationSnapshot();
     final target = _conversations[index];
@@ -1062,14 +1064,13 @@ class ChatProvider extends ChangeNotifier {
   }
 
   void clearConversation() {
-    _activeSpeechToTextTask?.cancel();
-    _activeSpeechToTextTask = null;
+    final wasTranscribing = _isTranscribing;
+    _invalidateActiveTranscription();
     _messages.clear();
     _session?.reset();
     _currentTokens = 0;
     _isPruning = false;
-    _isGenerating = false;
-    _isTranscribing = false;
+    _isGenerating = wasTranscribing;
     _stagedParts.clear();
     _clearGenerationMetrics();
     _messages.add(
@@ -1084,7 +1085,7 @@ class ChatProvider extends ChangeNotifier {
   }
 
   Future<void> sendMessage(String text) async {
-    if (_isGenerating || _session == null) return;
+    if (_isGenerating || _isTranscribing || _session == null) return;
 
     if (_settings.singleTurnMode) {
       _session!.reset();
@@ -1903,7 +1904,8 @@ class ChatProvider extends ChangeNotifier {
 
     try {
       final result = await FilePicker.platform.pickFiles(
-        type: FileType.audio,
+        type: FileType.custom,
+        allowedExtensions: const <String>['wav', 'mp3', 'flac'],
         allowMultiple: false,
       );
       if (result == null || result.files.isEmpty) {
@@ -1949,7 +1951,10 @@ class ChatProvider extends ChangeNotifier {
     SpeechAudioInput audio, {
     String? displayName,
   }) async {
-    if (_isGenerating || _session == null || !_chatService.engine.isReady) {
+    if (_isGenerating ||
+        _isTranscribing ||
+        _session == null ||
+        !_chatService.engine.isReady) {
       return;
     }
     if (kIsWeb) {
@@ -1959,37 +1964,55 @@ class ChatProvider extends ChangeNotifier {
       notifyListeners();
       return;
     }
-
-    final llamaAudio = switch (audio) {
-      SpeechAudioFileInput(:final path) => LlamaAudioContent(path: path),
-      SpeechAudioBytesInput(:final bytes) => LlamaAudioContent(bytes: bytes),
-      SpeechPcmInput(:final samples) => LlamaAudioContent(samples: samples),
-    };
-    if (!await _ensureMultimodalProjectorForMedia(<LlamaContentPart>[
-      llamaAudio,
-    ])) {
+    if (!_settings.modelSupportsSpeechToText) {
+      _addInfoMessage(
+        'The selected model is audio-capable but is not declared as a '
+        'speech-to-text model.',
+      );
+      notifyListeners();
       return;
     }
 
-    if (_settings.singleTurnMode) {
-      _session!.reset();
-    }
-
-    final sourceLabel = (displayName ?? '').trim().isEmpty
-        ? 'selected audio'
-        : displayName!.trim();
-    _messages.add(
-      ChatMessage(text: 'Transcribe audio: $sourceLabel', isUser: true),
-    );
-    _messages.add(ChatMessage(text: 'Transcribing…', isUser: false));
+    final conversationRevision = _conversationRevision;
+    final operationDone = Completer<void>();
+    _activeTranscriptionDone = operationDone;
     _isGenerating = true;
     _isTranscribing = true;
-    _syncActiveConversationSnapshot();
     notifyListeners();
-    await _yieldUiFrame();
 
     try {
-      final recognizer = SpeechToTextEngine(_chatService.engine);
+      final llamaAudio = switch (audio) {
+        SpeechAudioFileInput(:final path) => LlamaAudioContent(path: path),
+        SpeechAudioBytesInput(:final bytes) => LlamaAudioContent(bytes: bytes),
+      };
+      if (!await _ensureMultimodalProjectorForMedia(<LlamaContentPart>[
+        llamaAudio,
+      ])) {
+        return;
+      }
+      if (conversationRevision != _conversationRevision) {
+        return;
+      }
+
+      if (_settings.singleTurnMode) {
+        _session!.reset();
+      }
+
+      final sourceLabel = (displayName ?? '').trim().isEmpty
+          ? 'selected audio'
+          : displayName!.trim();
+      _messages.add(
+        ChatMessage(text: 'Transcribe audio: $sourceLabel', isUser: true),
+      );
+      _messages.add(ChatMessage(text: 'Transcribing…', isUser: false));
+      _syncActiveConversationSnapshot();
+      notifyListeners();
+      await _yieldUiFrame();
+
+      final recognizer = SpeechToTextEngine(
+        _chatService.engine,
+        modelProfile: SpeechToTextModelProfile.qwen3Asr,
+      );
       final task = await recognizer.transcribe(
         SpeechToTextRequest(
           audio: audio,
@@ -1997,7 +2020,7 @@ class ChatProvider extends ChangeNotifier {
         ),
       );
       _activeSpeechToTextTask = task;
-      if (!_isGenerating) {
+      if (!_isGenerating || conversationRevision != _conversationRevision) {
         task.cancel();
       }
 
@@ -2008,6 +2031,10 @@ class ChatProvider extends ChangeNotifier {
         }
       }
       final completion = await task.done;
+
+      if (conversationRevision != _conversationRevision) {
+        return;
+      }
 
       if (completion.state == SpeechToTextCompletionState.cancelled) {
         _removeEmptyAssistantPlaceholder();
@@ -2023,6 +2050,18 @@ class ChatProvider extends ChangeNotifier {
         throw LlamaSpeechException(
           'The model completed without returning transcript text.',
         );
+      }
+
+      int? transcriptTokens;
+      try {
+        transcriptTokens = await _chatService.engine.getTokenCount(transcript);
+      } on LlamaUnsupportedException {
+        // Token counting is optional for transcription display.
+      } on UnsupportedError {
+        // Token counting is optional for transcription display.
+      }
+      if (conversationRevision != _conversationRevision) {
+        return;
       }
 
       if (_messages.isNotEmpty && !_messages.last.isUser) {
@@ -2044,16 +2083,15 @@ class ChatProvider extends ChangeNotifier {
           text: transcript,
         ),
       );
-      try {
-        _messages.last.tokenCount = await _chatService.engine.getTokenCount(
-          transcript,
-        );
-      } on LlamaUnsupportedException {
-        // Token counting is optional for transcription display.
-      } on UnsupportedError {
-        // Token counting is optional for transcription display.
+      if (transcriptTokens != null) {
+        _messages.last.tokenCount = transcriptTokens;
+        _messages.last.generatedTokenCount = transcriptTokens;
+        _currentTokens += transcriptTokens;
       }
     } catch (error) {
+      if (conversationRevision != _conversationRevision) {
+        return;
+      }
       _removeEmptyAssistantPlaceholder();
       _addInfoMessage(
         error is LlamaUnsupportedException
@@ -2062,10 +2100,18 @@ class ChatProvider extends ChangeNotifier {
       );
     } finally {
       _activeSpeechToTextTask = null;
+      if (identical(_activeTranscriptionDone, operationDone)) {
+        _activeTranscriptionDone = null;
+      }
+      if (!operationDone.isCompleted) {
+        operationDone.complete();
+      }
       _isTranscribing = false;
       _isGenerating = false;
       _syncActiveConversationSnapshot();
-      notifyListeners();
+      if (!_isDisposed) {
+        notifyListeners();
+      }
     }
   }
 
@@ -2189,13 +2235,13 @@ class ChatProvider extends ChangeNotifier {
   }
 
   void stopGeneration() {
+    if (_isTranscribing) {
+      _invalidateActiveTranscription();
+      notifyListeners();
+      return;
+    }
     if (_isGenerating) {
-      final speechTask = _activeSpeechToTextTask;
-      if (speechTask != null) {
-        speechTask.cancel();
-      } else {
-        _chatService.cancelGeneration();
-      }
+      _chatService.cancelGeneration();
       _isGenerating = false;
       notifyListeners();
     }
@@ -2338,6 +2384,7 @@ class ChatProvider extends ChangeNotifier {
   }
 
   Future<void> unloadModel() async {
+    await _cancelAndAwaitActiveTranscription();
     stopGeneration();
     _cancelActiveModelPrefetch();
     _session?.reset();
@@ -2358,6 +2405,7 @@ class ChatProvider extends ChangeNotifier {
         modelPath: path,
         modelSupportsVision: false,
         modelSupportsAudio: false,
+        modelSupportsSpeechToText: false,
         directMediaInput: false,
       ),
     );
@@ -2408,6 +2456,7 @@ class ChatProvider extends ChangeNotifier {
         singleTurnMode: false,
         modelSupportsVision: model.supportsVisionFor(web: kIsWeb),
         modelSupportsAudio: model.supportsAudioFor(web: kIsWeb),
+        modelSupportsSpeechToText: model.supportsSpeechToTextFor(web: kIsWeb),
         directMediaInput: mediaInputMode == ModelMediaInputMode.direct,
         // Auto uses the size for native memory planning; WebGPU also uses it
         // to select the mem64 core before loading large models.
@@ -2632,11 +2681,12 @@ class ChatProvider extends ChangeNotifier {
     _settingsSaveDebounce?.cancel();
     _settingsSaveDebounce = null;
     unawaited(_settingsService.saveSettings(_settings));
+    final transcriptionDone = _cancelAndAwaitActiveTranscription();
     stopGeneration();
     _cancelActiveModelPrefetch();
     _session?.reset();
     _session = null;
-    unawaited(_chatService.dispose());
+    unawaited(transcriptionDone.whenComplete(_chatService.dispose));
     super.dispose();
   }
 
@@ -2648,6 +2698,7 @@ class ChatProvider extends ChangeNotifier {
     _isShuttingDown = true;
     try {
       await _saveSettingsNow();
+      await _cancelAndAwaitActiveTranscription();
       stopGeneration();
       _cancelActiveModelPrefetch();
       _session?.reset();
@@ -2670,6 +2721,27 @@ class ChatProvider extends ChangeNotifier {
       await _chatService.dispose();
     } finally {
       _isShuttingDown = false;
+    }
+  }
+
+  void _invalidateActiveTranscription() {
+    _conversationRevision += 1;
+    _activeSpeechToTextTask?.cancel();
+  }
+
+  Future<void> _cancelAndAwaitActiveTranscription() async {
+    final task = _activeSpeechToTextTask;
+    final done = _activeTranscriptionDone;
+    if (!_isTranscribing && task == null && done == null) {
+      return;
+    }
+    _conversationRevision += 1;
+    task?.cancel();
+    if (task != null) {
+      await task.done;
+    }
+    if (done != null) {
+      await done.future;
     }
   }
 

--- a/example/chat_app/lib/screens/manage_models_screen.dart
+++ b/example/chat_app/lib/screens/manage_models_screen.dart
@@ -200,6 +200,8 @@ class _ManageModelsScreenState extends State<ManageModelsScreen>
       if (model.supportsThinking) 'thinking reasoning',
       if (model.supportsVisionFor(web: useWebCapabilities)) 'vision image',
       if (model.supportsAudioFor(web: useWebCapabilities)) 'audio voice',
+      if (model.supportsSpeechToTextFor(web: useWebCapabilities))
+        'speech-to-text speech to text transcription asr stt',
       if (model.supportsVideoFor(web: useWebCapabilities)) 'video',
     ].join(' ').toLowerCase();
     return query.split(RegExp(r'\s+')).every(searchable.contains);
@@ -302,6 +304,8 @@ class _ManageModelsScreenState extends State<ManageModelsScreen>
           sizeBytes: (decoded['sizeBytes'] as int?) ?? 0,
           supportsVision: (decoded['supportsVision'] as bool?) ?? false,
           supportsAudio: (decoded['supportsAudio'] as bool?) ?? false,
+          supportsSpeechToText:
+              (decoded['supportsSpeechToText'] as bool?) ?? false,
           supportsVideo: (decoded['supportsVideo'] as bool?) ?? false,
           supportsToolCalling:
               (decoded['supportsToolCalling'] as bool?) ?? false,
@@ -342,6 +346,7 @@ class _ManageModelsScreenState extends State<ManageModelsScreen>
             'sizeBytes': model.sizeBytes,
             'supportsVision': model.supportsVision,
             'supportsAudio': model.supportsAudio,
+            'supportsSpeechToText': model.supportsSpeechToText,
             'supportsVideo': model.supportsVideo,
             'supportsToolCalling': model.supportsToolCalling,
             'supportsThinking': model.supportsThinking,
@@ -671,6 +676,7 @@ class _ManageModelsScreenState extends State<ManageModelsScreen>
       sizeBytes: source.sizeBytes,
       supportsVision: source.supportsVision,
       supportsAudio: source.supportsAudio,
+      supportsSpeechToText: source.supportsSpeechToText,
       supportsVideo: source.supportsVideo,
       supportsToolCalling: source.supportsToolCalling,
       supportsThinking: source.supportsThinking,
@@ -737,7 +743,8 @@ class _ManageModelsScreenState extends State<ManageModelsScreen>
   }
 
   bool _includeProjectorFor(DownloadableModel model) {
-    return _includeProjectorByFile[model.filename] ?? true;
+    return model.supportsSpeechToTextFor(web: kIsWeb) ||
+        (_includeProjectorByFile[model.filename] ?? true);
   }
 
   void _setIncludeProjector(DownloadableModel model, bool value) {
@@ -2596,6 +2603,7 @@ class _PopularModelsDiscoverySheetState
         'sizeBytes': m.sizeBytes,
         'supportsVision': m.supportsVision,
         'supportsAudio': m.supportsAudio,
+        'supportsSpeechToText': m.supportsSpeechToText,
         'supportsVideo': m.supportsVideo,
         'supportsToolCalling': m.supportsToolCalling,
         'supportsThinking': m.supportsThinking,
@@ -2657,6 +2665,8 @@ class _PopularModelsDiscoverySheetState
       sizeBytes: (modelRaw['sizeBytes'] as num?)?.toInt() ?? 0,
       supportsVision: (modelRaw['supportsVision'] as bool?) ?? false,
       supportsAudio: (modelRaw['supportsAudio'] as bool?) ?? false,
+      supportsSpeechToText:
+          (modelRaw['supportsSpeechToText'] as bool?) ?? false,
       supportsVideo: (modelRaw['supportsVideo'] as bool?) ?? false,
       supportsToolCalling: (modelRaw['supportsToolCalling'] as bool?) ?? false,
       supportsThinking: (modelRaw['supportsThinking'] as bool?) ?? false,

--- a/example/chat_app/lib/services/model_download_controller_adapter.dart
+++ b/example/chat_app/lib/services/model_download_controller_adapter.dart
@@ -203,6 +203,10 @@ class ChatAppModelDownloadManager implements llama.ModelDownloadManager {
 
   llama.ModelCacheEntry _cacheEntry(llama.ModelSource source) {
     final now = DateTime.now().toUtc();
+    final boundAsset = model.modelSourceFor(web: useWebSources);
+    final remoteAsset = boundAsset is RemoteModelAssetSource
+        ? boundAsset
+        : null;
     return llama.ModelCacheEntry(
       sourceCanonicalKey: source.canonicalKey,
       cacheKey: source.cacheKey,
@@ -210,7 +214,10 @@ class ChatAppModelDownloadManager implements llama.ModelDownloadManager {
       filePath: source.isLocal
           ? source.path!
           : p.join(modelsDir, source.fileName),
-      bytes: model.sizeBytes > 0 ? model.sizeBytes : null,
+      bytes:
+          remoteAsset?.sizeBytes ??
+          (model.sizeBytes > 0 ? model.sizeBytes : null),
+      sha256: remoteAsset?.sha256,
       createdAt: now,
       updatedAt: now,
     );
@@ -228,6 +235,7 @@ DownloadableModel _modelWithoutProjector(DownloadableModel model) {
     webSizeBytes: model.webSizeBytes,
     supportsVision: false,
     supportsAudio: false,
+    supportsSpeechToText: false,
     supportsVideo: false,
     supportsToolCalling: model.supportsToolCalling,
     supportsThinking: model.supportsThinking,

--- a/example/chat_app/lib/services/model_service_io.dart
+++ b/example/chat_app/lib/services/model_service_io.dart
@@ -1,5 +1,6 @@
 import 'dart:io';
 
+import 'package:crypto/crypto.dart';
 import 'package:dio/dio.dart';
 import 'package:llamadart/llamadart.dart' as llama;
 import 'package:path/path.dart' as p;
@@ -18,6 +19,7 @@ class ModelServiceIO implements ModelService {
   static const int _parallelMaxParts = 4;
 
   final Dio _dio = Dio();
+  final Map<String, _VerifiedRemoteAsset> _verifiedRemoteAssets = {};
 
   Map<String, Object> _requestHeaders({int? rangeStart}) {
     final headers = <String, Object>{};
@@ -161,6 +163,7 @@ class ModelServiceIO implements ModelService {
             );
           },
         );
+        await _verifyDownloadedRemoteAsset(modelsDir, source);
       }
 
       if (mmprojNeedsDownload) {
@@ -184,6 +187,7 @@ class ModelServiceIO implements ModelService {
             );
           },
         );
+        await _verifyDownloadedRemoteAsset(modelsDir, source);
       }
 
       if (stageCount > 0) {
@@ -268,7 +272,71 @@ class ModelServiceIO implements ModelService {
       }
     }
 
+    if (source is RemoteModelAssetSource &&
+        !await _hasExpectedIntegrity(file, source)) {
+      return false;
+    }
+
     return true;
+  }
+
+  Future<bool> _hasExpectedIntegrity(
+    File file,
+    RemoteModelAssetSource source,
+  ) async {
+    final expectedSha256 = source.sha256?.trim().toLowerCase();
+    if (expectedSha256 == null || expectedSha256.isEmpty) {
+      return true;
+    }
+
+    final stat = await file.stat();
+    final expectedBytes = source.sizeBytes;
+    if (expectedBytes != null && stat.size != expectedBytes) {
+      _verifiedRemoteAssets.remove(file.path);
+      return false;
+    }
+
+    final cached = _verifiedRemoteAssets[file.path];
+    if (cached != null &&
+        cached.size == stat.size &&
+        cached.modified == stat.modified &&
+        cached.sha256 == expectedSha256) {
+      return true;
+    }
+
+    final actualSha256 = (await sha256.bind(file.openRead()).first).toString();
+    if (actualSha256 != expectedSha256) {
+      _verifiedRemoteAssets.remove(file.path);
+      return false;
+    }
+    _verifiedRemoteAssets[file.path] = _VerifiedRemoteAsset(
+      size: stat.size,
+      modified: stat.modified,
+      sha256: actualSha256,
+    );
+    return true;
+  }
+
+  Future<void> _verifyDownloadedRemoteAsset(
+    String modelsDir,
+    RemoteModelAssetSource source,
+  ) async {
+    final expectedSha256 = source.sha256?.trim();
+    if (expectedSha256 == null || expectedSha256.isEmpty) {
+      return;
+    }
+    final file = File(_assetPath(modelsDir, source));
+    if (await file.exists() && await _hasExpectedIntegrity(file, source)) {
+      return;
+    }
+    if (await file.exists()) {
+      await file.delete();
+    }
+    _verifiedRemoteAssets.remove(file.path);
+    throw StateError(
+      'SHA-256 verification failed for ${source.displayName}. '
+      'The incomplete download was discarded; retry the download.',
+    );
   }
 
   String _assetPath(String modelsDir, ModelAssetSource source) {
@@ -785,6 +853,7 @@ class ModelServiceIO implements ModelService {
     }
 
     final path = _assetPath(modelsDir, source);
+    _verifiedRemoteAssets.remove(path);
     final file = File(path);
     if (await file.exists()) {
       await file.delete();
@@ -835,6 +904,18 @@ class _ByteRange {
 
 class _ParallelRangeUnsupportedException implements Exception {
   const _ParallelRangeUnsupportedException();
+}
+
+class _VerifiedRemoteAsset {
+  final int size;
+  final DateTime modified;
+  final String sha256;
+
+  const _VerifiedRemoteAsset({
+    required this.size,
+    required this.modified,
+    required this.sha256,
+  });
 }
 
 class _ProgressDispatcher {

--- a/example/chat_app/lib/services/settings_service.dart
+++ b/example/chat_app/lib/services/settings_service.dart
@@ -31,6 +31,7 @@ class SettingsService {
   static const _keySingleTurnMode = 'single_turn_mode';
   static const _keyModelSupportsVision = 'model_supports_vision';
   static const _keyModelSupportsAudio = 'model_supports_audio';
+  static const _keyModelSupportsSpeechToText = 'model_supports_speech_to_text';
   static const _keyDirectMediaInput = 'direct_media_input';
   static const _keyModelBytesHint = 'model_bytes_hint';
 
@@ -64,6 +65,22 @@ class SettingsService {
         .toLowerCase();
     return normalized.endsWith('.litertlm') &&
         (normalized.contains('gemma-4') || normalized.contains('gemma4'));
+  }
+
+  bool _isQwen3AsrCatalogModel(String? modelPath) {
+    if (modelPath == null) {
+      return false;
+    }
+    final filename = modelPath
+        .split('?')
+        .first
+        .split('#')
+        .first
+        .replaceAll('\\', '/')
+        .split('/')
+        .last
+        .toLowerCase();
+    return filename == 'qwen3-asr-0.6b-q8_0.gguf';
   }
 
   Future<ChatSettings> loadSettings() async {
@@ -127,6 +144,9 @@ class SettingsService {
       modelSupportsVision: prefs.getBool(_keyModelSupportsVision) ?? false,
       modelSupportsAudio:
           prefs.getBool(_keyModelSupportsAudio) ?? migrateNativeGemma4Audio,
+      modelSupportsSpeechToText:
+          prefs.getBool(_keyModelSupportsSpeechToText) ??
+          _isQwen3AsrCatalogModel(migratedModelPath),
       directMediaInput:
           prefs.getBool(_keyDirectMediaInput) ?? migrateNativeGemma4Audio,
       modelBytesHint: prefs.getInt(_keyModelBytesHint),
@@ -173,6 +193,10 @@ class SettingsService {
     await prefs.setBool(_keySingleTurnMode, settings.singleTurnMode);
     await prefs.setBool(_keyModelSupportsVision, settings.modelSupportsVision);
     await prefs.setBool(_keyModelSupportsAudio, settings.modelSupportsAudio);
+    await prefs.setBool(
+      _keyModelSupportsSpeechToText,
+      settings.modelSupportsSpeechToText,
+    );
     await prefs.setBool(_keyDirectMediaInput, settings.directMediaInput);
     final modelBytesHint = settings.modelBytesHint;
     if (modelBytesHint != null && modelBytesHint > 0) {

--- a/example/chat_app/lib/widgets/chat_input.dart
+++ b/example/chat_app/lib/widgets/chat_input.dart
@@ -539,6 +539,8 @@ class _ChatInputState extends State<ChatInput> {
           provider.pickImage();
         } else if (value == 'audio') {
           provider.pickAudio();
+        } else if (value == 'transcribe_audio') {
+          unawaited(provider.pickAudioForTranscription());
         }
       },
       itemBuilder: (context) => [
@@ -571,6 +573,17 @@ class _ChatInputState extends State<ChatInput> {
                 Icon(Icons.audiotrack_outlined),
                 SizedBox(width: 12),
                 Expanded(child: Text('Attach Audio')),
+              ],
+            ),
+          ),
+        if (provider.canTranscribeAudio)
+          const PopupMenuItem(
+            value: 'transcribe_audio',
+            child: Row(
+              children: [
+                Icon(Icons.transcribe_outlined),
+                SizedBox(width: 12),
+                Expanded(child: Text('Transcribe Audio')),
               ],
             ),
           ),

--- a/example/chat_app/lib/widgets/model_card.dart
+++ b/example/chat_app/lib/widgets/model_card.dart
@@ -71,7 +71,10 @@ class ModelCard extends StatelessWidget {
     final isProjectorCached =
         cacheState?.multimodalProjector?.isAvailable ?? false;
     final isProjectorMissing = hasProjector && !isProjectorCached;
-    final canLoadModel = isModelCached || isWebLiteRtLmModel;
+    final requiresProjector = model.supportsSpeechToTextFor(web: isWeb);
+    final canLoadModel =
+        (isModelCached && (!requiresProjector || !isProjectorMissing)) ||
+        isWebLiteRtLmModel;
     final effectiveModelSizeBytes = model.sizeBytesFor(web: isWeb);
     final showWebLargeModelWarning =
         isWeb && effectiveModelSizeBytes >= webLargeModelWarningThresholdBytes;
@@ -89,6 +92,7 @@ class ModelCard extends StatelessWidget {
         isProjectorMissing &&
         !isDownloading &&
         onIncludeProjectorChanged != null &&
+        !requiresProjector &&
         !isWebLiteRtLmModel;
     final shouldShowProjectorDownloadAction =
         canLoadModel && isProjectorMissing && includeProjector;
@@ -255,6 +259,13 @@ class ModelCard extends StatelessWidget {
                             context,
                             icon: Icons.mic_none_rounded,
                             label: 'Audio',
+                            supported: true,
+                          ),
+                        if (model.supportsSpeechToTextFor(web: isWeb))
+                          _buildCapabilityChip(
+                            context,
+                            icon: Icons.transcribe_outlined,
+                            label: 'Speech-to-text',
                             supported: true,
                           ),
                         if (model.supportsVideoFor(web: isWeb))

--- a/example/chat_app/test/chat_input_test.dart
+++ b/example/chat_app/test/chat_input_test.dart
@@ -128,7 +128,82 @@ void main() {
 
     expect(find.text('Paste attachment'), findsOneWidget);
     expect(find.text('Attach Audio'), findsOneWidget);
+    expect(find.text('Transcribe Audio'), findsNothing);
     expect(find.text('Attach Image'), findsNothing);
+  });
+
+  testWidgets('shows dedicated transcription for native ASR models', (
+    tester,
+  ) async {
+    final engine = _SpeechMockLlamaEngine();
+    final provider = ChatProvider(
+      chatService: MockChatService(engine: engine),
+      settingsService: MockSettingsService(),
+      initialSettings: const ChatSettings(
+        modelPath: 'Qwen3-ASR-0.6B-Q8_0.gguf',
+        mmprojPath: 'mmproj-Qwen3-ASR-0.6B-Q8_0.gguf',
+      ),
+    );
+    addTearDown(provider.dispose);
+    await provider.loadModel();
+
+    final controller = TextEditingController();
+    final focusNode = FocusNode();
+    addTearDown(controller.dispose);
+    addTearDown(focusNode.dispose);
+
+    await tester.pumpWidget(
+      ChangeNotifierProvider<ChatProvider>.value(
+        value: provider,
+        child: MaterialApp(
+          home: Scaffold(
+            body: ChatInput(
+              controller: controller,
+              focusNode: focusNode,
+              onSend: () {},
+            ),
+          ),
+        ),
+      ),
+    );
+
+    await tester.tap(find.byTooltip('Add attachment'));
+    await tester.pumpAndSettle();
+
+    expect(find.text('Attach Audio'), findsOneWidget);
+    expect(find.text('Transcribe Audio'), findsOneWidget);
+  });
+
+  test('transcribes an in-memory audio file into chat', () async {
+    final engine = _SpeechMockLlamaEngine()
+      ..createChunkContents = const <String>[
+        'language English<asr_text>Recognized ',
+        'speech.',
+      ];
+    final provider = ChatProvider(
+      chatService: MockChatService(engine: engine),
+      settingsService: MockSettingsService(),
+      initialSettings: const ChatSettings(
+        modelPath: 'Qwen3-ASR-0.6B-Q8_0.gguf',
+        mmprojPath: 'mmproj-Qwen3-ASR-0.6B-Q8_0.gguf',
+      ),
+    );
+    addTearDown(provider.dispose);
+    await provider.loadModel();
+
+    await provider.transcribeAudio(
+      SpeechAudioBytesInput(Uint8List.fromList(const <int>[1, 2, 3])),
+      displayName: 'fixture.wav',
+    );
+
+    expect(provider.isTranscribing, isFalse);
+    expect(provider.isGenerating, isFalse);
+    expect(engine.createCalls, 1);
+    expect(
+      provider.messages.where((message) => !message.isInfo).map((m) => m.text),
+      <String>['Transcribe audio: fixture.wav', 'Recognized speech.'],
+    );
+    expect(provider.messages.last.debugBadges, contains('Transcription'));
   });
 
   test('stages clipboard media bytes for the next message', () async {
@@ -175,4 +250,9 @@ class _GeneratingReadyProvider extends ChatProvider {
 
   @override
   List<LlamaContentPart> get stagedParts => const <LlamaContentPart>[];
+}
+
+class _SpeechMockLlamaEngine extends MockLlamaEngine {
+  @override
+  Future<bool> get supportsAudio async => mmprojLoaded;
 }

--- a/example/chat_app/test/chat_input_test.dart
+++ b/example/chat_app/test/chat_input_test.dart
@@ -1,3 +1,4 @@
+import 'dart:async';
 import 'dart:typed_data';
 
 import 'package:flutter/material.dart';
@@ -142,6 +143,7 @@ void main() {
       initialSettings: const ChatSettings(
         modelPath: 'Qwen3-ASR-0.6B-Q8_0.gguf',
         mmprojPath: 'mmproj-Qwen3-ASR-0.6B-Q8_0.gguf',
+        modelSupportsSpeechToText: true,
       ),
     );
     addTearDown(provider.dispose);
@@ -186,6 +188,7 @@ void main() {
       initialSettings: const ChatSettings(
         modelPath: 'Qwen3-ASR-0.6B-Q8_0.gguf',
         mmprojPath: 'mmproj-Qwen3-ASR-0.6B-Q8_0.gguf',
+        modelSupportsSpeechToText: true,
       ),
     );
     addTearDown(provider.dispose);
@@ -204,6 +207,112 @@ void main() {
       <String>['Transcribe audio: fixture.wav', 'Recognized speech.'],
     );
     expect(provider.messages.last.debugBadges, contains('Transcription'));
+    expect(provider.messages.last.generatedTokenCount, 5);
+    expect(provider.currentTokens, 5);
+    expect(provider.canRegenerateLastResponse, isFalse);
+  });
+
+  test('does not overlap a stopped transcription while it settles', () async {
+    final engine = _BlockingSpeechMockLlamaEngine();
+    final provider = ChatProvider(
+      chatService: MockChatService(engine: engine),
+      settingsService: MockSettingsService(),
+      initialSettings: const ChatSettings(
+        modelPath: 'Qwen3-ASR-0.6B-Q8_0.gguf',
+        mmprojPath: 'mmproj-Qwen3-ASR-0.6B-Q8_0.gguf',
+        modelSupportsSpeechToText: true,
+      ),
+    );
+    addTearDown(provider.dispose);
+    await provider.loadModel();
+
+    final first = provider.transcribeAudio(
+      SpeechAudioBytesInput(Uint8List.fromList(const <int>[1, 2, 3])),
+      displayName: 'first.wav',
+    );
+    await engine.createStarted.future;
+
+    provider.stopGeneration();
+    expect(provider.isTranscribing, isTrue);
+    expect(provider.canTranscribeAudio, isFalse);
+    await provider.transcribeAudio(
+      SpeechAudioBytesInput(Uint8List.fromList(const <int>[4, 5, 6])),
+      displayName: 'second.wav',
+    );
+    expect(engine.createCalls, 1);
+
+    engine.releaseGeneration();
+    await first;
+    expect(provider.isTranscribing, isFalse);
+  });
+
+  test('reserves transcription before the projector probe completes', () async {
+    final engine = _BlockingAudioProbeSpeechMockLlamaEngine();
+    final provider = ChatProvider(
+      chatService: MockChatService(engine: engine),
+      settingsService: MockSettingsService(),
+      initialSettings: const ChatSettings(
+        modelPath: 'Qwen3-ASR-0.6B-Q8_0.gguf',
+        mmprojPath: 'mmproj-Qwen3-ASR-0.6B-Q8_0.gguf',
+        modelSupportsSpeechToText: true,
+      ),
+    );
+    addTearDown(provider.dispose);
+    await provider.loadModel();
+    engine.blockAudioProbe = true;
+
+    final first = provider.transcribeAudio(
+      SpeechAudioBytesInput(Uint8List.fromList(const <int>[1, 2, 3])),
+      displayName: 'first.wav',
+    );
+    await engine.audioProbeStarted.future;
+
+    expect(provider.isTranscribing, isTrue);
+    await provider.transcribeAudio(
+      SpeechAudioBytesInput(Uint8List.fromList(const <int>[4, 5, 6])),
+      displayName: 'second.wav',
+    );
+    expect(engine.createCalls, 0);
+
+    provider.stopGeneration();
+    engine.releaseAudioProbe();
+    await first;
+    expect(provider.isTranscribing, isFalse);
+    expect(engine.createCalls, 0);
+  });
+
+  test('clear suppresses stale transcription completion', () async {
+    final engine = _BlockingSpeechMockLlamaEngine();
+    final provider = ChatProvider(
+      chatService: MockChatService(engine: engine),
+      settingsService: MockSettingsService(),
+      initialSettings: const ChatSettings(
+        modelPath: 'Qwen3-ASR-0.6B-Q8_0.gguf',
+        mmprojPath: 'mmproj-Qwen3-ASR-0.6B-Q8_0.gguf',
+        modelSupportsSpeechToText: true,
+      ),
+    );
+    addTearDown(provider.dispose);
+    await provider.loadModel();
+
+    final transcription = provider.transcribeAudio(
+      SpeechAudioBytesInput(Uint8List.fromList(const <int>[1, 2, 3])),
+      displayName: 'fixture.wav',
+    );
+    await engine.createStarted.future;
+
+    provider.clearConversation();
+    final clearedMessages = provider.messages.map((message) => message.text);
+    expect(clearedMessages, <String>[
+      'Conversation cleared. Ready for a new topic!',
+    ]);
+
+    engine.releaseGeneration();
+    await transcription;
+    expect(provider.messages.map((message) => message.text), <String>[
+      'Conversation cleared. Ready for a new topic!',
+    ]);
+    expect(provider.currentTokens, 0);
   });
 
   test('stages clipboard media bytes for the next message', () async {
@@ -255,4 +364,74 @@ class _GeneratingReadyProvider extends ChatProvider {
 class _SpeechMockLlamaEngine extends MockLlamaEngine {
   @override
   Future<bool> get supportsAudio async => mmprojLoaded;
+}
+
+class _BlockingSpeechMockLlamaEngine extends _SpeechMockLlamaEngine {
+  final Completer<void> createStarted = Completer<void>();
+  final Completer<void> _release = Completer<void>();
+
+  void releaseGeneration() {
+    if (!_release.isCompleted) {
+      _release.complete();
+    }
+  }
+
+  @override
+  Stream<LlamaCompletionChunk> create(
+    List<LlamaChatMessage> messages, {
+    GenerationParams? params,
+    List<ToolDefinition>? tools,
+    ToolChoice? toolChoice,
+    bool parallelToolCalls = false,
+    bool enableThinking = true,
+    Map<String, dynamic>? responseFormat,
+    String? sourceLangCode,
+    String? targetLangCode,
+    Map<String, dynamic>? chatTemplateKwargs,
+    DateTime? templateNow,
+  }) async* {
+    createCalls += 1;
+    lastCreateParams = params;
+    if (!createStarted.isCompleted) {
+      createStarted.complete();
+    }
+    await _release.future;
+    for (final content in createChunkContents) {
+      yield LlamaCompletionChunk(
+        id: 'mock-id',
+        object: 'chat.completion.chunk',
+        created: 1234567890,
+        model: 'mock-model',
+        choices: <LlamaCompletionChunkChoice>[
+          LlamaCompletionChunkChoice(
+            index: 0,
+            delta: LlamaCompletionChunkDelta(content: content),
+          ),
+        ],
+      );
+    }
+  }
+}
+
+class _BlockingAudioProbeSpeechMockLlamaEngine extends _SpeechMockLlamaEngine {
+  final Completer<void> audioProbeStarted = Completer<void>();
+  final Completer<void> _releaseAudioProbe = Completer<void>();
+  bool blockAudioProbe = false;
+
+  void releaseAudioProbe() {
+    if (!_releaseAudioProbe.isCompleted) {
+      _releaseAudioProbe.complete();
+    }
+  }
+
+  @override
+  Future<bool> get supportsAudio async {
+    if (blockAudioProbe) {
+      if (!audioProbeStarted.isCompleted) {
+        audioProbeStarted.complete();
+      }
+      await _releaseAudioProbe.future;
+    }
+    return super.supportsAudio;
+  }
 }

--- a/example/chat_app/test/manage_models_screen_download_test.dart
+++ b/example/chat_app/test/manage_models_screen_download_test.dart
@@ -83,6 +83,42 @@ void main() {
       expect(prefs.getStringList('custom_hf_models_v1'), isEmpty);
     });
 
+    testWidgets('built-in ASR replaces a stale custom entry by filename', (
+      tester,
+    ) async {
+      debugDefaultTargetPlatformOverride = TargetPlatform.macOS;
+      try {
+        final asr = DownloadableModel.defaultModels.singleWhere(
+          (model) => model.name == 'Qwen3-ASR 0.6B',
+        );
+        SharedPreferences.setMockInitialValues({
+          'custom_hf_models_v1': <String>[
+            jsonEncode(<String, Object>{
+              'name': 'Old custom ASR',
+              'description': 'Temporary entry used before the built-in preset.',
+              'url': 'https://example.com/old-asr.gguf',
+              'filename': asr.filename,
+              'sizeBytes': asr.sizeBytes,
+            }),
+          ],
+        });
+
+        await _pumpScreen(
+          tester,
+          modelService: _HoldingModelService(
+            downloadedFiles: <String>{asr.filename},
+          ),
+          models: <DownloadableModel>[asr],
+        );
+
+        expect(find.text(asr.name), findsOneWidget);
+        expect(find.text('Old custom ASR'), findsNothing);
+        expect(find.text('Downloaded'), findsOneWidget);
+      } finally {
+        debugDefaultTargetPlatformOverride = null;
+      }
+    });
+
     testWidgets('selected multimodal model waits for models directory', (
       tester,
     ) async {
@@ -238,11 +274,21 @@ void main() {
         supportsAudio: true,
         webSupportsAudio: false,
       );
+      const desktopAsr = DownloadableModel(
+        name: 'Desktop ASR Model',
+        description: 'Desktop model with speech recognition.',
+        url: 'https://example.com/desktop-asr.gguf',
+        filename: 'desktop-asr.gguf',
+        sizeBytes: 20,
+        availability: ModelAvailability.nativeDesktop,
+        supportsAudio: true,
+        supportsSpeechToText: true,
+      );
 
       await _pumpScreen(
         tester,
         modelService: _HoldingModelService(),
-        models: const [desktopAudio],
+        models: const [desktopAudio, desktopAsr],
       );
 
       await tester.tap(find.widgetWithText(ChoiceChip, 'Desktop'));
@@ -250,6 +296,20 @@ void main() {
       await tester.pump();
 
       expect(find.text(desktopAudio.name), findsOneWidget);
+
+      await tester.enterText(find.byType(TextField).first, 'stt');
+      await tester.pump();
+
+      expect(find.text(desktopAsr.name), findsOneWidget);
+      expect(find.text(desktopAudio.name), findsNothing);
+
+      await tester.enterText(find.byType(TextField).first, 'speech-to-text');
+      await tester.pump();
+      expect(find.text(desktopAsr.name), findsOneWidget);
+
+      await tester.enterText(find.byType(TextField).first, 'speech to text');
+      await tester.pump();
+      expect(find.text(desktopAsr.name), findsOneWidget);
     });
 
     testWidgets('pause button cancels the active controller download', (

--- a/example/chat_app/test/model_card_test.dart
+++ b/example/chat_app/test/model_card_test.dart
@@ -77,6 +77,37 @@ void main() {
     expect(find.text('Audio'), findsNothing);
   });
 
+  testWidgets('ASR card distinguishes STT and requires its projector', (
+    tester,
+  ) async {
+    await _pumpCard(
+      tester,
+      model: _asrModel(),
+      isWeb: false,
+      isDownloaded: false,
+      cacheState: const ModelProfileCacheState(
+        model: ModelAssetCacheState(
+          role: ModelAssetRole.model,
+          label: 'asr.gguf',
+          isAvailable: true,
+        ),
+        multimodalProjector: ModelAssetCacheState(
+          role: ModelAssetRole.multimodalProjector,
+          label: 'asr-mmproj.gguf',
+          isAvailable: false,
+        ),
+      ),
+      onSelect: () {},
+      onDownload: () {},
+      onIncludeProjectorChanged: (_) {},
+    );
+
+    expect(find.text('Audio'), findsOneWidget);
+    expect(find.text('Speech-to-text'), findsOneWidget);
+    expect(find.text('Use Text Only'), findsNothing);
+    expect(find.text('Download Missing Assets'), findsOneWidget);
+  });
+
   testWidgets('shows distribution, desktop scope, and readable large size', (
     tester,
   ) async {
@@ -466,6 +497,20 @@ DownloadableModel _vlmModel() {
     mmprojFilename: 'mmproj.gguf',
     sizeBytes: 10,
     supportsVision: true,
+  );
+}
+
+DownloadableModel _asrModel() {
+  return const DownloadableModel(
+    name: 'ASR Test Model',
+    description: 'Fake ASR model for widget tests.',
+    url: 'https://example.com/asr.gguf',
+    filename: 'asr.gguf',
+    mmprojUrl: 'https://example.com/asr-mmproj.gguf',
+    mmprojFilename: 'asr-mmproj.gguf',
+    sizeBytes: 20,
+    supportsAudio: true,
+    supportsSpeechToText: true,
   );
 }
 

--- a/example/chat_app/test/model_download_controller_adapter_test.dart
+++ b/example/chat_app/test/model_download_controller_adapter_test.dart
@@ -30,6 +30,34 @@ void main() {
       },
     );
 
+    test('reports verified catalog metadata for the bound asset', () async {
+      const sha256 =
+          'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa';
+      final model = DownloadableModel.fromSources(
+        id: 'verified-model',
+        name: 'Verified Model',
+        description: 'Remote model with catalog integrity metadata.',
+        modelSource: const RemoteModelAssetSource(
+          url: 'https://example.com/verified.gguf?download=true',
+          filename: 'verified.gguf',
+          sizeBytes: 8,
+          sha256: sha256,
+        ),
+        sizeBytes: 12,
+      );
+      final service = _FakeModelService(downloadedFiles: {model.filename});
+      final manager = ChatAppModelDownloadManager(
+        modelService: service,
+        model: model,
+        modelsDir: '/models',
+      );
+
+      final entry = await manager.ensureModel(manager.source);
+
+      expect(entry.bytes, 8);
+      expect(entry.sha256, sha256);
+    });
+
     test(
       'rejects checksum options instead of reporting unverified ready',
       () async {

--- a/example/chat_app/test/model_service_test.dart
+++ b/example/chat_app/test/model_service_test.dart
@@ -1,9 +1,10 @@
 import 'dart:async';
 import 'dart:io';
+
 import 'package:crypto/crypto.dart';
+import 'package:dio/dio.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:llamadart_chat_example/models/downloadable_model.dart';
-import 'package:dio/dio.dart';
 import 'package:llamadart_chat_example/services/model_service_base.dart';
 import 'package:llamadart_chat_example/services/model_service_io.dart';
 import 'package:path/path.dart' as p;

--- a/example/chat_app/test/model_service_test.dart
+++ b/example/chat_app/test/model_service_test.dart
@@ -1,5 +1,6 @@
 import 'dart:async';
 import 'dart:io';
+import 'package:crypto/crypto.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:llamadart_chat_example/models/downloadable_model.dart';
 import 'package:dio/dio.dart';
@@ -124,6 +125,63 @@ void main() {
     expect(file.existsSync(), isTrue);
     expect(file.lengthSync(), testDataSize);
     expect(file.readAsBytesSync(), testData);
+  });
+
+  test('verified remote download enforces the catalog SHA-256', () async {
+    final model = DownloadableModel.fromSources(
+      name: 'Verified model',
+      description: 'Test',
+      modelSource: RemoteModelAssetSource(
+        url: '$baseUrl/model.gguf',
+        filename: 'verified-model.gguf',
+        sizeBytes: testDataSize,
+        sha256: sha256.convert(testData).toString(),
+      ),
+      sizeBytes: testDataSize,
+    );
+
+    Object? failure;
+    await service.downloadModel(
+      model: model,
+      modelsDir: tempDir.path,
+      cancelToken: CancelToken(),
+      onProgress: (_) {},
+      onSuccess: (_) {},
+      onError: (error) => failure = error,
+    );
+
+    expect(failure, isNull);
+    expect((await service.getModelCacheState(model)).isReady, isTrue);
+  });
+
+  test('failed catalog checksum discards the downloaded asset', () async {
+    final model = DownloadableModel.fromSources(
+      name: 'Invalid verified model',
+      description: 'Test',
+      modelSource: RemoteModelAssetSource(
+        url: '$baseUrl/model.gguf',
+        filename: 'invalid-verified-model.gguf',
+        sizeBytes: testDataSize,
+        sha256: List<String>.filled(64, '0').join(),
+      ),
+      sizeBytes: testDataSize,
+    );
+
+    Object? failure;
+    await service.downloadModel(
+      model: model,
+      modelsDir: tempDir.path,
+      cancelToken: CancelToken(),
+      onProgress: (_) {},
+      onSuccess: (_) {},
+      onError: (error) => failure = error,
+    );
+
+    expect(failure, isA<StateError>());
+    expect(
+      File(p.join(tempDir.path, 'invalid-verified-model.gguf')).existsSync(),
+      isFalse,
+    );
   });
 
   test('Multimodal download reports staged combined progress', () async {

--- a/example/chat_app/test/settings_service_test.dart
+++ b/example/chat_app/test/settings_service_test.dart
@@ -117,6 +117,7 @@ void main() {
       const settings = ChatSettings(
         modelSupportsVision: false,
         modelSupportsAudio: true,
+        modelSupportsSpeechToText: true,
         directMediaInput: true,
       );
 
@@ -125,6 +126,7 @@ void main() {
 
       expect(restored.modelSupportsVision, isFalse);
       expect(restored.modelSupportsAudio, isTrue);
+      expect(restored.modelSupportsSpeechToText, isTrue);
       expect(restored.directMediaInput, isTrue);
     });
 
@@ -142,6 +144,29 @@ void main() {
         expect(settings.directMediaInput, isTrue);
       },
     );
+
+    test('migrates the catalog Qwen3-ASR filename to typed STT', () async {
+      SharedPreferences.setMockInitialValues({
+        'model_path': '/models/Qwen3-ASR-0.6B-Q8_0.gguf',
+      });
+
+      final service = SettingsService();
+      final settings = await service.loadSettings();
+
+      expect(settings.modelSupportsSpeechToText, isTrue);
+    });
+
+    test('preserves an explicit disabled Qwen3-ASR STT setting', () async {
+      SharedPreferences.setMockInitialValues({
+        'model_path': '/models/Qwen3-ASR-0.6B-Q8_0.gguf',
+        'model_supports_speech_to_text': false,
+      });
+
+      final service = SettingsService();
+      final settings = await service.loadSettings();
+
+      expect(settings.modelSupportsSpeechToText, isFalse);
+    });
 
     test('migrates saved Unsloth UD Qwen model paths to Q4_K_M', () async {
       SharedPreferences.setMockInitialValues({

--- a/example/chat_app/test/unit_test.dart
+++ b/example/chat_app/test/unit_test.dart
@@ -1097,6 +1097,7 @@ void main() {
         orderedEquals(const [
           'FunctionGemma 270M',
           'Qwen3.5 0.8B Instruct',
+          'Qwen3-ASR 0.6B',
           'Gemma 4 E2B it',
           'Gemma 4 E2B LiteRT-LM',
           'Gemma 4 E4B it',
@@ -1111,9 +1112,54 @@ void main() {
         (model) => model.filename.endsWith('.gguf'),
       );
       for (final model in ggufModels) {
-        expect(model.distribution, 'Unsloth');
-        expect(model.url, contains('huggingface.co/unsloth/'));
+        if (model.supportsSpeechToText) {
+          expect(model.distribution, 'ggml-org');
+          expect(model.url, contains('huggingface.co/ggml-org/'));
+        } else {
+          expect(model.distribution, 'Unsloth');
+          expect(model.url, contains('huggingface.co/unsloth/'));
+        }
       }
+    });
+
+    test('Qwen3-ASR catalog entry pins its complete verified bundle', () {
+      final model = DownloadableModel.defaultModels.singleWhere(
+        (model) => model.name == 'Qwen3-ASR 0.6B',
+      );
+      final modelSource = model.modelSource as RemoteModelAssetSource;
+      final projectorSource =
+          model.multimodalProjectorSource as RemoteModelAssetSource;
+
+      expect(model.supportsAudio, isTrue);
+      expect(model.supportsSpeechToTextFor(web: false), isTrue);
+      expect(model.supportsSpeechToTextFor(web: true), isFalse);
+      expect(model.isNativeDesktopOnly, isTrue);
+      expect(model.sizeBytesFor(web: false), 1019141728);
+      expect(model.preset.temperature, 0);
+      expect(model.preset.topK, 1);
+      expect(model.preset.topP, 1);
+      expect(model.preset.penalty, 1);
+      expect(model.preset.contextSize, 4096);
+      expect(model.preset.maxTokens, 1024);
+      expect(model.preset.thinkingEnabled, isFalse);
+      expect(modelSource.sizeBytes, 804749248);
+      expect(
+        modelSource.sha256,
+        'bca259818b50ca7c4c05e9bdb35a5dc04fa039653a6d6f3f0f331f96f6aa1971',
+      );
+      expect(projectorSource.sizeBytes, 214392480);
+      expect(
+        projectorSource.sha256,
+        '41a342b5e4c514e968cb756de6cd1b7be39eff43c44c57a2ef5fc6522e36603d',
+      );
+      expect(
+        modelSource.url,
+        contains('928ab958557df9aa2ef1c93e0e83c7ad0933fae2'),
+      );
+      expect(
+        projectorSource.url,
+        contains('928ab958557df9aa2ef1c93e0e83c7ad0933fae2'),
+      );
     });
 
     test('Qwen3.5 0.8B uses Unsloth Q4_K_M non-thinking defaults', () {
@@ -1148,6 +1194,7 @@ void main() {
       expect(
         desktopModels.map((model) => model.name),
         orderedEquals(const [
+          'Qwen3-ASR 0.6B',
           'Gemma 4 12B it',
           'Gemma 4 26B A4B it',
           'Gemma 4 31B it',
@@ -1166,6 +1213,17 @@ void main() {
       expect(gemmaE4b.isNativeDesktopOnly, isFalse);
       expect(gemmaE4b.isAvailableFor(web: false, mobile: true), isTrue);
       expect(gemmaE4b.supportsAudioFor(web: false), isTrue);
+    });
+
+    test('Qwen3-ASR preset persists the dedicated STT declaration', () {
+      final model = DownloadableModel.defaultModels.singleWhere(
+        (model) => model.name == 'Qwen3-ASR 0.6B',
+      );
+
+      provider.applyModelPreset(model);
+
+      expect(provider.settings.modelSupportsAudio, isTrue);
+      expect(provider.settings.modelSupportsSpeechToText, isTrue);
     });
 
     test('Gemma 4 presets expose platform-specific audio capabilities', () {

--- a/lib/llamadart.dart
+++ b/lib/llamadart.dart
@@ -36,6 +36,9 @@ library;
 export 'src/core/engine/engine.dart' show LlamaEngine;
 export 'src/core/engine/chat_session.dart' show ChatSession;
 
+// Speech
+export 'src/core/speech/speech_to_text.dart';
+
 // Template APIs
 export 'src/core/template/chat_format.dart' show ChatFormat;
 export 'src/core/template/chat_parse_result.dart' show ChatParseResult;

--- a/lib/src/core/exceptions.dart
+++ b/lib/src/core/exceptions.dart
@@ -32,6 +32,18 @@ class LlamaInferenceException extends LlamaException {
   LlamaInferenceException(super.message, [super.details]);
 }
 
+/// Exception thrown when speech recognition fails.
+class LlamaSpeechException extends LlamaException {
+  /// Creates a new [LlamaSpeechException].
+  LlamaSpeechException(super.message, [super.details]);
+}
+
+/// Exception thrown when speech audio does not satisfy an input contract.
+class LlamaAudioFormatException extends LlamaSpeechException {
+  /// Creates a new [LlamaAudioFormatException].
+  LlamaAudioFormatException(super.message, [super.details]);
+}
+
 /// Exception thrown when an operation is not supported on the current platform.
 class LlamaUnsupportedException extends LlamaException {
   /// Creates a new [LlamaUnsupportedException].

--- a/lib/src/core/models/chat/content_part.dart
+++ b/lib/src/core/models/chat/content_part.dart
@@ -77,7 +77,10 @@ class LlamaImageContent extends LlamaContentPart {
   }
 }
 
-/// A part of a message containing audio data for speech-to-text models.
+/// A part of a message containing generic multimodal audio input.
+///
+/// This routes audio through normal generation. It does not by itself provide
+/// the typed transcript contract of `SpeechToTextEngine`.
 class LlamaAudioContent extends LlamaContentPart {
   /// Raw PCM Float32 audio samples.
   final Float32List? samples;

--- a/lib/src/core/speech/speech_platform_stub.dart
+++ b/lib/src/core/speech/speech_platform_stub.dart
@@ -1,4 +1,4 @@
-/// Whether the dedicated speech-to-text API is available on this platform.
+/// Whether the typed speech-to-text adapter is available on this platform.
 bool get isSpeechToTextPlatformSupported => true;
 
 /// Actionable explanation when speech-to-text is unavailable.

--- a/lib/src/core/speech/speech_platform_stub.dart
+++ b/lib/src/core/speech/speech_platform_stub.dart
@@ -1,0 +1,5 @@
+/// Whether the dedicated speech-to-text API is available on this platform.
+bool get isSpeechToTextPlatformSupported => true;
+
+/// Actionable explanation when speech-to-text is unavailable.
+String? get speechToTextPlatformUnsupportedReason => null;

--- a/lib/src/core/speech/speech_platform_web.dart
+++ b/lib/src/core/speech/speech_platform_web.dart
@@ -1,0 +1,7 @@
+/// Whether the dedicated speech-to-text API is available on Web.
+bool get isSpeechToTextPlatformSupported => false;
+
+/// Actionable explanation for the current Web limitation.
+String get speechToTextPlatformUnsupportedReason =>
+    'Dedicated speech-to-text is not available on Web yet. WebGPU audio '
+    'content remains model-dependent generic audio input.';

--- a/lib/src/core/speech/speech_platform_web.dart
+++ b/lib/src/core/speech/speech_platform_web.dart
@@ -1,7 +1,7 @@
-/// Whether the dedicated speech-to-text API is available on Web.
+/// Whether the typed speech-to-text adapter is available on Web.
 bool get isSpeechToTextPlatformSupported => false;
 
 /// Actionable explanation for the current Web limitation.
 String get speechToTextPlatformUnsupportedReason =>
-    'Dedicated speech-to-text is not available on Web yet. WebGPU audio '
+    'Typed speech-to-text is not available on Web yet. WebGPU audio '
     'content remains model-dependent generic audio input.';

--- a/lib/src/core/speech/speech_to_text.dart
+++ b/lib/src/core/speech/speech_to_text.dart
@@ -1,0 +1,656 @@
+import 'dart:async';
+import 'dart:typed_data';
+
+import '../engine/engine.dart';
+import '../exceptions.dart';
+import '../models/chat/chat_message.dart';
+import '../models/chat/chat_role.dart';
+import '../models/chat/content_part.dart';
+import '../models/inference/generation_params.dart';
+import 'speech_platform_stub.dart'
+    if (dart.library.js_interop) 'speech_platform_web.dart';
+
+/// The representation used by raw PCM speech input.
+enum SpeechAudioSampleFormat {
+  /// 32-bit IEEE floating-point samples in the range -1.0 to 1.0.
+  float32,
+
+  /// Signed 16-bit integer samples.
+  signedInt16,
+}
+
+/// The kind of audio input accepted by a speech recognizer.
+enum SpeechAudioInputKind {
+  /// A local encoded audio file.
+  file,
+
+  /// Encoded audio held in memory.
+  encodedBytes,
+
+  /// Raw PCM samples held in memory.
+  pcm,
+}
+
+/// Audio metadata supplied with speech input.
+class SpeechAudioFormat {
+  /// Sample rate in Hertz, when known.
+  final int? sampleRateHz;
+
+  /// Number of interleaved audio channels, when known.
+  final int? channelCount;
+
+  /// Raw sample representation, when the input is PCM.
+  final SpeechAudioSampleFormat? sampleFormat;
+
+  /// Container or codec hint such as `wav`, `mp3`, or `flac`.
+  final String? encoding;
+
+  /// MIME type supplied by the caller, when available.
+  final String? mimeType;
+
+  /// Creates audio metadata.
+  const SpeechAudioFormat({
+    this.sampleRateHz,
+    this.channelCount,
+    this.sampleFormat,
+    this.encoding,
+    this.mimeType,
+  });
+}
+
+/// Base class for audio accepted by [SpeechToTextEngine].
+sealed class SpeechAudioInput {
+  /// Optional source audio metadata.
+  final SpeechAudioFormat? format;
+
+  /// Creates a speech audio input.
+  const SpeechAudioInput({this.format});
+
+  /// The representation used by this input.
+  SpeechAudioInputKind get kind;
+}
+
+/// A local encoded audio file.
+class SpeechAudioFileInput extends SpeechAudioInput {
+  /// Local filesystem path.
+  final String path;
+
+  /// Creates a local-file input.
+  const SpeechAudioFileInput(this.path, {super.format});
+
+  @override
+  SpeechAudioInputKind get kind => SpeechAudioInputKind.file;
+}
+
+/// Encoded audio held in memory.
+class SpeechAudioBytesInput extends SpeechAudioInput {
+  /// Encoded audio bytes.
+  final Uint8List bytes;
+
+  /// Creates an encoded in-memory input.
+  const SpeechAudioBytesInput(this.bytes, {super.format});
+
+  @override
+  SpeechAudioInputKind get kind => SpeechAudioInputKind.encodedBytes;
+}
+
+/// Raw mono PCM input.
+class SpeechPcmInput extends SpeechAudioInput {
+  /// Interleaved floating-point PCM samples.
+  final Float32List samples;
+
+  /// Creates raw PCM input.
+  const SpeechPcmInput(this.samples, {required SpeechAudioFormat format})
+    : super(format: format);
+
+  @override
+  SpeechAudioInputKind get kind => SpeechAudioInputKind.pcm;
+}
+
+/// A request to recognize speech from one complete audio input.
+class SpeechToTextRequest {
+  /// Audio to transcribe.
+  final SpeechAudioInput audio;
+
+  /// Optional BCP-47 language hint, such as `en` or `fr-CA`.
+  ///
+  /// The first llama.cpp backend forwards this as prompt guidance. It is not a
+  /// guarantee that the model supports or obeys the requested language.
+  final String? languageHint;
+
+  /// Optional vocabulary or surrounding-text guidance for the recognizer.
+  final String? contextPrompt;
+
+  /// Maximum number of generated transcript tokens.
+  final int maxOutputTokens;
+
+  /// Creates a speech recognition request.
+  const SpeechToTextRequest({
+    required this.audio,
+    this.languageHint,
+    this.contextPrompt,
+    this.maxOutputTokens = 1024,
+  });
+}
+
+/// Runtime speech-to-text capabilities for the loaded engine.
+class SpeechToTextCapabilities {
+  /// Whether [SpeechToTextEngine.transcribe] can be used now.
+  final bool isSupported;
+
+  /// Actionable reason when [isSupported] is false.
+  final String? unsupportedReason;
+
+  /// Active runtime backend label.
+  final String? backendName;
+
+  /// Accepted audio input representations.
+  final Set<SpeechAudioInputKind> inputKinds;
+
+  /// File/byte encodings decoded by the first native backend.
+  final Set<String> encodedAudioFormats;
+
+  /// Raw PCM sample rates accepted by the first native backend.
+  final Set<int> pcmSampleRatesHz;
+
+  /// Whether text deltas can be emitted before the final transcript.
+  final bool supportsPartialResults;
+
+  /// Whether audio can be pushed incrementally while recognition is running.
+  final bool supportsStreamingInput;
+
+  /// Whether word or segment timestamps can be returned.
+  bool get supportsTimestamps =>
+      supportsSegmentTimestamps || supportsWordTimestamps;
+
+  /// Whether segment timestamps can be returned.
+  final bool supportsSegmentTimestamps;
+
+  /// Whether word timestamps can be returned.
+  final bool supportsWordTimestamps;
+
+  /// Whether confidence values can be returned.
+  final bool supportsConfidence;
+
+  /// Whether speaker labels can be returned.
+  final bool supportsSpeakerDiarization;
+
+  /// Whether the runtime can report the recognized language.
+  final bool supportsLanguageDetection;
+
+  /// Whether language hints can be passed to the model.
+  final bool supportsLanguageHints;
+
+  /// Whether an active task can be cancelled cooperatively.
+  final bool supportsCancellation;
+
+  /// Whether pausing the output subscription throttles native inference.
+  final bool supportsOutputBackpressure;
+
+  /// Maximum number of concurrent tasks owned by one engine wrapper.
+  final int maxConcurrentTasks;
+
+  /// Creates a capability snapshot.
+  const SpeechToTextCapabilities({
+    required this.isSupported,
+    this.unsupportedReason,
+    this.backendName,
+    this.inputKinds = const <SpeechAudioInputKind>{},
+    this.encodedAudioFormats = const <String>{},
+    this.pcmSampleRatesHz = const <int>{},
+    this.supportsPartialResults = false,
+    this.supportsStreamingInput = false,
+    this.supportsSegmentTimestamps = false,
+    this.supportsWordTimestamps = false,
+    this.supportsConfidence = false,
+    this.supportsSpeakerDiarization = false,
+    this.supportsLanguageDetection = false,
+    this.supportsLanguageHints = false,
+    this.supportsCancellation = false,
+    this.supportsOutputBackpressure = false,
+    this.maxConcurrentTasks = 0,
+  });
+}
+
+/// A recognized word with optional backend-provided metadata.
+class TranscriptWord {
+  /// Recognized word or token text.
+  final String text;
+
+  /// Start time relative to the beginning of the input, when available.
+  final Duration? start;
+
+  /// End time relative to the beginning of the input, when available.
+  final Duration? end;
+
+  /// Confidence in the range 0.0 to 1.0, when available.
+  final double? confidence;
+
+  /// Speaker label, when diarization is available.
+  final String? speaker;
+
+  /// Creates a recognized word.
+  const TranscriptWord({
+    required this.text,
+    this.start,
+    this.end,
+    this.confidence,
+    this.speaker,
+  });
+}
+
+/// A recognized transcript segment.
+class TranscriptSegment {
+  /// Segment text.
+  final String text;
+
+  /// Start time relative to the beginning of the input, when available.
+  final Duration? start;
+
+  /// End time relative to the beginning of the input, when available.
+  final Duration? end;
+
+  /// Confidence in the range 0.0 to 1.0, when available.
+  final double? confidence;
+
+  /// Speaker label, when diarization is available.
+  final String? speaker;
+
+  /// Word-level details, when available.
+  final List<TranscriptWord> words;
+
+  /// Creates a transcript segment.
+  const TranscriptSegment({
+    required this.text,
+    this.start,
+    this.end,
+    this.confidence,
+    this.speaker,
+    this.words = const <TranscriptWord>[],
+  });
+}
+
+/// Final speech recognition result.
+class SpeechToTextResult {
+  /// Complete normalized transcript text.
+  final String text;
+
+  /// Model-reported language, when available.
+  final String? language;
+
+  /// Structured transcript segments.
+  ///
+  /// The first backend returns one untimed segment for the complete transcript.
+  final List<TranscriptSegment> segments;
+
+  /// Metadata describing the supplied source audio, when available.
+  final SpeechAudioFormat? sourceFormat;
+
+  /// Creates a final recognition result.
+  const SpeechToTextResult({
+    required this.text,
+    this.language,
+    this.segments = const <TranscriptSegment>[],
+    this.sourceFormat,
+  });
+}
+
+/// Base class for streamed speech recognition events.
+sealed class SpeechToTextEvent {
+  /// Creates a speech recognition event.
+  const SpeechToTextEvent();
+}
+
+/// A replaceable, non-final transcript update.
+class SpeechToTextPartialEvent extends SpeechToTextEvent {
+  /// Current best transcript text.
+  final String text;
+
+  /// Creates a partial transcript event.
+  const SpeechToTextPartialEvent(this.text);
+}
+
+/// The final transcript event for a task.
+class SpeechToTextFinalEvent extends SpeechToTextEvent {
+  /// Final recognition result.
+  final SpeechToTextResult result;
+
+  /// Creates a final transcript event.
+  const SpeechToTextFinalEvent(this.result);
+}
+
+/// Terminal state of a speech recognition task.
+enum SpeechToTextCompletionState {
+  /// Recognition produced a final result.
+  completed,
+
+  /// Recognition was cancelled.
+  cancelled,
+
+  /// Recognition failed.
+  failed,
+}
+
+/// Terminal details for a speech recognition task.
+class SpeechToTextCompletion {
+  /// Terminal state.
+  final SpeechToTextCompletionState state;
+
+  /// Final result when [state] is [SpeechToTextCompletionState.completed].
+  final SpeechToTextResult? result;
+
+  /// Failure when [state] is [SpeechToTextCompletionState.failed].
+  final Object? error;
+
+  /// Creates terminal task details.
+  const SpeechToTextCompletion({required this.state, this.result, this.error});
+}
+
+/// A cancellable speech recognition operation.
+class SpeechToTextTask {
+  final StreamController<SpeechToTextEvent> _eventsController;
+  final Completer<SpeechToTextCompletion> _doneCompleter;
+  final void Function() _onCancel;
+  bool _cancelled = false;
+
+  SpeechToTextTask._({required void Function() onCancel})
+    : _onCancel = onCancel,
+      _eventsController = StreamController<SpeechToTextEvent>(),
+      _doneCompleter = Completer<SpeechToTextCompletion>();
+
+  /// Recognition events.
+  ///
+  /// The first backend emits one [SpeechToTextFinalEvent]. The event model is
+  /// intentionally future-compatible with backends that support partial text.
+  Stream<SpeechToTextEvent> get events => _eventsController.stream;
+
+  /// Completes once the task succeeds, is cancelled, or fails.
+  Future<SpeechToTextCompletion> get done => _doneCompleter.future;
+
+  /// Whether cancellation has been requested.
+  bool get isCancellationRequested => _cancelled;
+
+  /// Requests cooperative cancellation. Calling this more than once is safe.
+  void cancel() {
+    if (_cancelled || _doneCompleter.isCompleted) {
+      return;
+    }
+    _cancelled = true;
+    _onCancel();
+  }
+}
+
+/// Typed speech-to-text API backed by a loaded [LlamaEngine].
+///
+/// The first implementation supports complete audio inputs on native
+/// llama.cpp with an audio-capable multimodal projector, including Qwen3-ASR.
+/// It does not yet provide live microphone ingestion, partial transcripts,
+/// timestamps, confidence values, or diarization.
+class SpeechToTextEngine {
+  final LlamaEngine _engine;
+  bool _hasActiveTask = false;
+
+  /// Creates a speech recognizer over an existing loaded engine.
+  SpeechToTextEngine(this._engine);
+
+  /// Discovers speech recognition support for the current runtime and model.
+  Future<SpeechToTextCapabilities> get capabilities async {
+    if (!isSpeechToTextPlatformSupported) {
+      return SpeechToTextCapabilities(
+        isSupported: false,
+        unsupportedReason: speechToTextPlatformUnsupportedReason,
+      );
+    }
+    if (!_engine.isReady) {
+      return const SpeechToTextCapabilities(
+        isSupported: false,
+        unsupportedReason:
+            'Load a model and its audio-capable multimodal projector first.',
+      );
+    }
+
+    String? backendName;
+    try {
+      backendName = await _engine.getBackendName();
+    } catch (_) {
+      // Capability discovery can still use the explicit audio probe.
+    }
+    if (backendName?.toLowerCase().contains('litert-lm') ?? false) {
+      return SpeechToTextCapabilities(
+        isSupported: false,
+        unsupportedReason:
+            'Dedicated LiteRT-LM speech APIs are not exported by the current '
+            'native artifact.',
+        backendName: backendName,
+      );
+    }
+
+    bool supportsAudio;
+    try {
+      supportsAudio = await _engine.supportsAudio;
+    } catch (error) {
+      return SpeechToTextCapabilities(
+        isSupported: false,
+        unsupportedReason: 'The audio capability probe failed: $error',
+        backendName: backendName,
+      );
+    }
+    if (!supportsAudio) {
+      return SpeechToTextCapabilities(
+        isSupported: false,
+        unsupportedReason:
+            'The loaded multimodal projector does not report audio support.',
+        backendName: backendName,
+      );
+    }
+
+    return SpeechToTextCapabilities(
+      isSupported: true,
+      backendName: backendName,
+      inputKinds: const <SpeechAudioInputKind>{
+        SpeechAudioInputKind.file,
+        SpeechAudioInputKind.encodedBytes,
+        SpeechAudioInputKind.pcm,
+      },
+      encodedAudioFormats: const <String>{'wav', 'mp3', 'flac'},
+      pcmSampleRatesHz: const <int>{16000},
+      supportsLanguageHints: true,
+      supportsLanguageDetection: true,
+      supportsCancellation: true,
+      maxConcurrentTasks: 1,
+    );
+  }
+
+  /// Starts recognition for one complete audio input.
+  ///
+  /// The returned task exposes a future-compatible event stream and explicit
+  /// cancellation/completion state. Only one task may run per wrapper because
+  /// [LlamaEngine] owns one active generation context.
+  Future<SpeechToTextTask> transcribe(SpeechToTextRequest request) async {
+    if (_hasActiveTask) {
+      throw LlamaStateException(
+        'This SpeechToTextEngine already has an active task.',
+      );
+    }
+    _validateRequest(request);
+
+    final currentCapabilities = await capabilities;
+    if (!currentCapabilities.isSupported) {
+      throw LlamaUnsupportedException(
+        currentCapabilities.unsupportedReason ??
+            'Speech-to-text is not supported by the active runtime.',
+      );
+    }
+
+    _hasActiveTask = true;
+    late final SpeechToTextTask task;
+    task = SpeechToTextTask._(onCancel: _engine.cancelGeneration);
+    unawaited(_runTask(task, request));
+    return task;
+  }
+
+  void _validateRequest(SpeechToTextRequest request) {
+    if (request.maxOutputTokens <= 0) {
+      throw LlamaSpeechException('maxOutputTokens must be greater than 0.');
+    }
+
+    switch (request.audio) {
+      case SpeechAudioFileInput(:final path):
+        if (path.trim().isEmpty) {
+          throw LlamaAudioFormatException('Audio file path must not be empty.');
+        }
+      case SpeechAudioBytesInput(:final bytes):
+        if (bytes.isEmpty) {
+          throw LlamaAudioFormatException(
+            'Encoded audio bytes must not be empty.',
+          );
+        }
+      case SpeechPcmInput(:final samples, :final format):
+        if (samples.isEmpty) {
+          throw LlamaAudioFormatException(
+            'PCM audio samples must not be empty.',
+          );
+        }
+        if (format?.sampleFormat != SpeechAudioSampleFormat.float32 ||
+            format?.sampleRateHz != 16000 ||
+            format?.channelCount != 1) {
+          throw LlamaAudioFormatException(
+            'Raw PCM currently requires 16 kHz mono Float32 samples.',
+            format,
+          );
+        }
+    }
+  }
+
+  Future<void> _runTask(
+    SpeechToTextTask task,
+    SpeechToTextRequest request,
+  ) async {
+    try {
+      if (task.isCancellationRequested) {
+        await _completeCancelled(task);
+        return;
+      }
+
+      final output = StringBuffer();
+      await for (final chunk in _engine.create(
+        <LlamaChatMessage>[
+          LlamaChatMessage.withContent(
+            role: LlamaChatRole.user,
+            content: <LlamaContentPart>[
+              LlamaTextContent(_promptFor(request)),
+              _contentFor(request.audio),
+            ],
+          ),
+        ],
+        params: GenerationParams(
+          maxTokens: request.maxOutputTokens,
+          temp: 0,
+          topK: 1,
+          topP: 1,
+          penalty: 1,
+          seed: 1,
+          streamBatchTokenThreshold: 1,
+        ),
+        enableThinking: false,
+      )) {
+        if (task.isCancellationRequested) {
+          break;
+        }
+        final text = chunk.choices.first.delta.content;
+        if (text != null) {
+          output.write(text);
+        }
+      }
+
+      if (task.isCancellationRequested) {
+        await _completeCancelled(task);
+        return;
+      }
+
+      final normalized = _normalizeTranscript(output.toString());
+      final result = SpeechToTextResult(
+        text: normalized.text,
+        language: normalized.language,
+        segments: normalized.text.isEmpty
+            ? const <TranscriptSegment>[]
+            : <TranscriptSegment>[TranscriptSegment(text: normalized.text)],
+        sourceFormat: request.audio.format,
+      );
+      task._eventsController.add(SpeechToTextFinalEvent(result));
+      unawaited(task._eventsController.close());
+      task._doneCompleter.complete(
+        SpeechToTextCompletion(
+          state: SpeechToTextCompletionState.completed,
+          result: result,
+        ),
+      );
+    } catch (error, stackTrace) {
+      final speechError = error is LlamaSpeechException
+          ? error
+          : LlamaSpeechException('Speech recognition failed.', error);
+      task._eventsController.addError(speechError, stackTrace);
+      unawaited(task._eventsController.close());
+      task._doneCompleter.complete(
+        SpeechToTextCompletion(
+          state: SpeechToTextCompletionState.failed,
+          error: speechError,
+        ),
+      );
+    } finally {
+      _hasActiveTask = false;
+    }
+  }
+
+  Future<void> _completeCancelled(SpeechToTextTask task) async {
+    unawaited(task._eventsController.close());
+    task._doneCompleter.complete(
+      const SpeechToTextCompletion(
+        state: SpeechToTextCompletionState.cancelled,
+      ),
+    );
+  }
+
+  String _promptFor(SpeechToTextRequest request) {
+    final prompt = StringBuffer('Transcribe this audio accurately.');
+    final languageHint = request.languageHint?.trim();
+    if (languageHint != null && languageHint.isNotEmpty) {
+      prompt.write(' The requested language is $languageHint.');
+    }
+    final contextPrompt = request.contextPrompt?.trim();
+    if (contextPrompt != null && contextPrompt.isNotEmpty) {
+      prompt.write(' Context: $contextPrompt');
+    }
+    return prompt.toString();
+  }
+
+  LlamaAudioContent _contentFor(SpeechAudioInput audio) {
+    return switch (audio) {
+      SpeechAudioFileInput(:final path) => LlamaAudioContent(path: path),
+      SpeechAudioBytesInput(:final bytes) => LlamaAudioContent(bytes: bytes),
+      SpeechPcmInput(:final samples) => LlamaAudioContent(samples: samples),
+    };
+  }
+
+  ({String text, String? language}) _normalizeTranscript(String raw) {
+    final languagePrefix = RegExp(
+      r'^\s*language\s+([^<\r\n]+?)\s*<asr_text>\s*',
+      caseSensitive: false,
+    ).firstMatch(raw);
+    if (languagePrefix != null) {
+      return (
+        text: raw.substring(languagePrefix.end).trim(),
+        language: languagePrefix.group(1)?.trim(),
+      );
+    }
+
+    final marker = RegExp(
+      r'^\s*<asr_text>\s*',
+      caseSensitive: false,
+    ).firstMatch(raw);
+    return (
+      text: marker == null ? raw.trim() : raw.substring(marker.end).trim(),
+      language: null,
+    );
+  }
+}

--- a/lib/src/core/speech/speech_to_text.dart
+++ b/lib/src/core/speech/speech_to_text.dart
@@ -10,15 +10,6 @@ import '../models/inference/generation_params.dart';
 import 'speech_platform_stub.dart'
     if (dart.library.js_interop) 'speech_platform_web.dart';
 
-/// The representation used by raw PCM speech input.
-enum SpeechAudioSampleFormat {
-  /// 32-bit IEEE floating-point samples in the range -1.0 to 1.0.
-  float32,
-
-  /// Signed 16-bit integer samples.
-  signedInt16,
-}
-
 /// The kind of audio input accepted by a speech recognizer.
 enum SpeechAudioInputKind {
   /// A local encoded audio file.
@@ -26,9 +17,27 @@ enum SpeechAudioInputKind {
 
   /// Encoded audio held in memory.
   encodedBytes,
+}
 
-  /// Raw PCM samples held in memory.
-  pcm,
+/// Model-specific adapter used by [SpeechToTextEngine].
+///
+/// A profile is an explicit caller declaration. Generic multimodal audio
+/// support alone does not prove that a loaded model is an ASR model.
+enum SpeechToTextModelProfile {
+  /// Qwen3-ASR with its matching llama.cpp multimodal projector.
+  qwen3Asr,
+}
+
+/// How the active backend implements speech recognition.
+enum SpeechToTextImplementation {
+  /// No usable speech recognition path is available.
+  unavailable,
+
+  /// Audio is routed through multimodal chat with a model-specific adapter.
+  multimodalPromptAdapter,
+
+  /// A backend-native, dedicated speech recognition API.
+  dedicatedBackend,
 }
 
 /// Audio metadata supplied with speech input.
@@ -38,9 +47,6 @@ class SpeechAudioFormat {
 
   /// Number of interleaved audio channels, when known.
   final int? channelCount;
-
-  /// Raw sample representation, when the input is PCM.
-  final SpeechAudioSampleFormat? sampleFormat;
 
   /// Container or codec hint such as `wav`, `mp3`, or `flac`.
   final String? encoding;
@@ -52,7 +58,6 @@ class SpeechAudioFormat {
   const SpeechAudioFormat({
     this.sampleRateHz,
     this.channelCount,
-    this.sampleFormat,
     this.encoding,
     this.mimeType,
   });
@@ -94,19 +99,6 @@ class SpeechAudioBytesInput extends SpeechAudioInput {
   SpeechAudioInputKind get kind => SpeechAudioInputKind.encodedBytes;
 }
 
-/// Raw mono PCM input.
-class SpeechPcmInput extends SpeechAudioInput {
-  /// Interleaved floating-point PCM samples.
-  final Float32List samples;
-
-  /// Creates raw PCM input.
-  const SpeechPcmInput(this.samples, {required SpeechAudioFormat format})
-    : super(format: format);
-
-  @override
-  SpeechAudioInputKind get kind => SpeechAudioInputKind.pcm;
-}
-
 /// A request to recognize speech from one complete audio input.
 class SpeechToTextRequest {
   /// Audio to transcribe.
@@ -114,8 +106,8 @@ class SpeechToTextRequest {
 
   /// Optional BCP-47 language hint, such as `en` or `fr-CA`.
   ///
-  /// The first llama.cpp backend forwards this as prompt guidance. It is not a
-  /// guarantee that the model supports or obeys the requested language.
+  /// The field is reserved for recognizers with a validated language-hint
+  /// contract. The first Qwen3-ASR adapter rejects nonempty hints.
   final String? languageHint;
 
   /// Optional vocabulary or surrounding-text guidance for the recognizer.
@@ -144,14 +136,14 @@ class SpeechToTextCapabilities {
   /// Active runtime backend label.
   final String? backendName;
 
+  /// Whether recognition uses a prompt adapter or a dedicated backend API.
+  final SpeechToTextImplementation implementation;
+
   /// Accepted audio input representations.
   final Set<SpeechAudioInputKind> inputKinds;
 
   /// File/byte encodings decoded by the first native backend.
   final Set<String> encodedAudioFormats;
-
-  /// Raw PCM sample rates accepted by the first native backend.
-  final Set<int> pcmSampleRatesHz;
 
   /// Whether text deltas can be emitted before the final transcript.
   final bool supportsPartialResults;
@@ -187,7 +179,7 @@ class SpeechToTextCapabilities {
   /// Whether pausing the output subscription throttles native inference.
   final bool supportsOutputBackpressure;
 
-  /// Maximum number of concurrent tasks owned by one engine wrapper.
+  /// Maximum number of concurrent tasks owned by one underlying engine.
   final int maxConcurrentTasks;
 
   /// Creates a capability snapshot.
@@ -195,9 +187,9 @@ class SpeechToTextCapabilities {
     required this.isSupported,
     this.unsupportedReason,
     this.backendName,
+    this.implementation = SpeechToTextImplementation.unavailable,
     this.inputKinds = const <SpeechAudioInputKind>{},
     this.encodedAudioFormats = const <String>{},
-    this.pcmSampleRatesHz = const <int>{},
     this.supportsPartialResults = false,
     this.supportsStreamingInput = false,
     this.supportsSegmentTimestamps = false,
@@ -340,10 +332,36 @@ class SpeechToTextCompletion {
   final SpeechToTextResult? result;
 
   /// Failure when [state] is [SpeechToTextCompletionState.failed].
-  final Object? error;
+  final LlamaException? error;
 
-  /// Creates terminal task details.
-  const SpeechToTextCompletion({required this.state, this.result, this.error});
+  const SpeechToTextCompletion._({
+    required this.state,
+    this.result,
+    this.error,
+  });
+
+  /// Creates a successful completion.
+  factory SpeechToTextCompletion.completed(SpeechToTextResult result) =>
+      SpeechToTextCompletion._(
+        state: SpeechToTextCompletionState.completed,
+        result: result,
+      );
+
+  /// Creates a cancelled completion.
+  const factory SpeechToTextCompletion.cancelled() =
+      _CancelledSpeechToTextCompletion;
+
+  /// Creates a failed completion.
+  factory SpeechToTextCompletion.failed(LlamaException error) =>
+      SpeechToTextCompletion._(
+        state: SpeechToTextCompletionState.failed,
+        error: error,
+      );
+}
+
+class _CancelledSpeechToTextCompletion extends SpeechToTextCompletion {
+  const _CancelledSpeechToTextCompletion()
+    : super._(state: SpeechToTextCompletionState.cancelled);
 }
 
 /// A cancellable speech recognition operation.
@@ -360,6 +378,8 @@ class SpeechToTextTask {
 
   /// Recognition events.
   ///
+  /// This is a single-subscription stream. Runtime failures are emitted as a
+  /// stream error and are also reported by [done] as a failed completion.
   /// The first backend emits one [SpeechToTextFinalEvent]. The event model is
   /// intentionally future-compatible with backends that support partial text.
   Stream<SpeechToTextEvent> get events => _eventsController.stream;
@@ -382,16 +402,29 @@ class SpeechToTextTask {
 
 /// Typed speech-to-text API backed by a loaded [LlamaEngine].
 ///
-/// The first implementation supports complete audio inputs on native
-/// llama.cpp with an audio-capable multimodal projector, including Qwen3-ASR.
+/// The first implementation supports complete Qwen3-ASR audio inputs on native
+/// llama.cpp with a matching audio-capable multimodal projector.
 /// It does not yet provide live microphone ingestion, partial transcripts,
 /// timestamps, confidence values, or diarization.
 class SpeechToTextEngine {
+  static final Expando<_SpeechTaskState> _taskStates =
+      Expando<_SpeechTaskState>('llamadart.speechTaskState');
+
   final LlamaEngine _engine;
-  bool _hasActiveTask = false;
+  final _SpeechTaskState _taskState;
+
+  /// Model-specific adapter selected by the caller.
+  final SpeechToTextModelProfile modelProfile;
 
   /// Creates a speech recognizer over an existing loaded engine.
-  SpeechToTextEngine(this._engine);
+  ///
+  /// The engine must be used exclusively for this task until [SpeechToTextTask.done]
+  /// completes. The recognizer prevents two speech wrappers over the same
+  /// engine from running together, but direct [LlamaEngine.create] calls are
+  /// owned by the caller.
+  SpeechToTextEngine(LlamaEngine engine, {required this.modelProfile})
+    : _engine = engine,
+      _taskState = _taskStates[engine] ??= _SpeechTaskState();
 
   /// Discovers speech recognition support for the current runtime and model.
   Future<SpeechToTextCapabilities> get capabilities async {
@@ -447,15 +480,14 @@ class SpeechToTextEngine {
     return SpeechToTextCapabilities(
       isSupported: true,
       backendName: backendName,
+      implementation: SpeechToTextImplementation.multimodalPromptAdapter,
       inputKinds: const <SpeechAudioInputKind>{
         SpeechAudioInputKind.file,
         SpeechAudioInputKind.encodedBytes,
-        SpeechAudioInputKind.pcm,
       },
       encodedAudioFormats: const <String>{'wav', 'mp3', 'flac'},
-      pcmSampleRatesHz: const <int>{16000},
-      supportsLanguageHints: true,
-      supportsLanguageDetection: true,
+      supportsLanguageHints: false,
+      supportsLanguageDetection: false,
       supportsCancellation: true,
       maxConcurrentTasks: 1,
     );
@@ -464,34 +496,46 @@ class SpeechToTextEngine {
   /// Starts recognition for one complete audio input.
   ///
   /// The returned task exposes a future-compatible event stream and explicit
-  /// cancellation/completion state. Only one task may run per wrapper because
-  /// [LlamaEngine] owns one active generation context.
+  /// cancellation/completion state. Only one speech task may run per
+  /// [LlamaEngine], including through separate [SpeechToTextEngine] wrappers.
+  /// Invalid input and unsupported runtime/model preflight checks throw before
+  /// a task is returned; failures after startup are reported by the task.
   Future<SpeechToTextTask> transcribe(SpeechToTextRequest request) async {
-    if (_hasActiveTask) {
+    if (_taskState.isActive) {
       throw LlamaStateException(
-        'This SpeechToTextEngine already has an active task.',
+        'This LlamaEngine already has an active speech-to-text task.',
       );
     }
     _validateRequest(request);
+    _taskState.isActive = true;
 
-    final currentCapabilities = await capabilities;
-    if (!currentCapabilities.isSupported) {
-      throw LlamaUnsupportedException(
-        currentCapabilities.unsupportedReason ??
-            'Speech-to-text is not supported by the active runtime.',
-      );
+    try {
+      final currentCapabilities = await capabilities;
+      if (!currentCapabilities.isSupported) {
+        throw LlamaUnsupportedException(
+          currentCapabilities.unsupportedReason ??
+              'Speech-to-text is not supported by the active runtime.',
+        );
+      }
+
+      final task = SpeechToTextTask._(onCancel: _engine.cancelGeneration);
+      unawaited(_runTask(task, request));
+      return task;
+    } catch (_) {
+      _taskState.isActive = false;
+      rethrow;
     }
-
-    _hasActiveTask = true;
-    late final SpeechToTextTask task;
-    task = SpeechToTextTask._(onCancel: _engine.cancelGeneration);
-    unawaited(_runTask(task, request));
-    return task;
   }
 
   void _validateRequest(SpeechToTextRequest request) {
     if (request.maxOutputTokens <= 0) {
       throw LlamaSpeechException('maxOutputTokens must be greater than 0.');
+    }
+    final languageHint = request.languageHint?.trim();
+    if (languageHint != null && languageHint.isNotEmpty) {
+      throw LlamaUnsupportedException(
+        'The Qwen3-ASR prompt adapter does not expose validated language hints.',
+      );
     }
 
     switch (request.audio) {
@@ -499,24 +543,35 @@ class SpeechToTextEngine {
         if (path.trim().isEmpty) {
           throw LlamaAudioFormatException('Audio file path must not be empty.');
         }
+        final encoding = request.audio.format?.encoding?.trim().toLowerCase();
+        final extension = _fileExtension(path);
+        if (encoding != null && encoding.isNotEmpty) {
+          if (!const <String>{'wav', 'mp3', 'flac'}.contains(encoding)) {
+            throw LlamaAudioFormatException(
+              'Encoded audio files must use WAV, MP3, or FLAC.',
+              request.audio.format,
+            );
+          }
+        } else if (extension.isNotEmpty &&
+            !const <String>{'wav', 'mp3', 'flac'}.contains(extension)) {
+          throw LlamaAudioFormatException(
+            'Encoded audio files must use WAV, MP3, or FLAC.',
+            request.audio.format,
+          );
+        }
       case SpeechAudioBytesInput(:final bytes):
         if (bytes.isEmpty) {
           throw LlamaAudioFormatException(
             'Encoded audio bytes must not be empty.',
           );
         }
-      case SpeechPcmInput(:final samples, :final format):
-        if (samples.isEmpty) {
+        final encoding = request.audio.format?.encoding?.trim().toLowerCase();
+        if (encoding != null &&
+            encoding.isNotEmpty &&
+            !const <String>{'wav', 'mp3', 'flac'}.contains(encoding)) {
           throw LlamaAudioFormatException(
-            'PCM audio samples must not be empty.',
-          );
-        }
-        if (format?.sampleFormat != SpeechAudioSampleFormat.float32 ||
-            format?.sampleRateHz != 16000 ||
-            format?.channelCount != 1) {
-          throw LlamaAudioFormatException(
-            'Raw PCM currently requires 16 kHz mono Float32 samples.',
-            format,
+            'Encoded audio bytes must use WAV, MP3, or FLAC.',
+            request.audio.format,
           );
         }
     }
@@ -557,6 +612,9 @@ class SpeechToTextEngine {
         if (task.isCancellationRequested) {
           break;
         }
+        if (chunk.choices.isEmpty) {
+          continue;
+        }
         final text = chunk.choices.first.delta.content;
         if (text != null) {
           output.write(text);
@@ -579,44 +637,32 @@ class SpeechToTextEngine {
       );
       task._eventsController.add(SpeechToTextFinalEvent(result));
       unawaited(task._eventsController.close());
-      task._doneCompleter.complete(
-        SpeechToTextCompletion(
-          state: SpeechToTextCompletionState.completed,
-          result: result,
-        ),
-      );
+      task._doneCompleter.complete(SpeechToTextCompletion.completed(result));
     } catch (error, stackTrace) {
-      final speechError = error is LlamaSpeechException
+      if (task.isCancellationRequested) {
+        await _completeCancelled(task);
+        return;
+      }
+      final speechError = error is LlamaException
           ? error
           : LlamaSpeechException('Speech recognition failed.', error);
       task._eventsController.addError(speechError, stackTrace);
       unawaited(task._eventsController.close());
-      task._doneCompleter.complete(
-        SpeechToTextCompletion(
-          state: SpeechToTextCompletionState.failed,
-          error: speechError,
-        ),
-      );
+      task._doneCompleter.complete(SpeechToTextCompletion.failed(speechError));
     } finally {
-      _hasActiveTask = false;
+      _taskState.isActive = false;
     }
   }
 
   Future<void> _completeCancelled(SpeechToTextTask task) async {
     unawaited(task._eventsController.close());
-    task._doneCompleter.complete(
-      const SpeechToTextCompletion(
-        state: SpeechToTextCompletionState.cancelled,
-      ),
-    );
+    if (!task._doneCompleter.isCompleted) {
+      task._doneCompleter.complete(const SpeechToTextCompletion.cancelled());
+    }
   }
 
   String _promptFor(SpeechToTextRequest request) {
     final prompt = StringBuffer('Transcribe this audio accurately.');
-    final languageHint = request.languageHint?.trim();
-    if (languageHint != null && languageHint.isNotEmpty) {
-      prompt.write(' The requested language is $languageHint.');
-    }
     final contextPrompt = request.contextPrompt?.trim();
     if (contextPrompt != null && contextPrompt.isNotEmpty) {
       prompt.write(' Context: $contextPrompt');
@@ -628,8 +674,17 @@ class SpeechToTextEngine {
     return switch (audio) {
       SpeechAudioFileInput(:final path) => LlamaAudioContent(path: path),
       SpeechAudioBytesInput(:final bytes) => LlamaAudioContent(bytes: bytes),
-      SpeechPcmInput(:final samples) => LlamaAudioContent(samples: samples),
     };
+  }
+
+  String _fileExtension(String path) {
+    final cleanPath = path.split('?').first.split('#').first;
+    final filename = cleanPath.replaceAll('\\', '/').split('/').last;
+    final separator = filename.lastIndexOf('.');
+    if (separator < 0 || separator == filename.length - 1) {
+      return '';
+    }
+    return filename.substring(separator + 1).toLowerCase();
   }
 
   ({String text, String? language}) _normalizeTranscript(String raw) {
@@ -638,10 +693,7 @@ class SpeechToTextEngine {
       caseSensitive: false,
     ).firstMatch(raw);
     if (languagePrefix != null) {
-      return (
-        text: raw.substring(languagePrefix.end).trim(),
-        language: languagePrefix.group(1)?.trim(),
-      );
+      return (text: raw.substring(languagePrefix.end).trim(), language: null);
     }
 
     final marker = RegExp(
@@ -653,4 +705,8 @@ class SpeechToTextEngine {
       language: null,
     );
   }
+}
+
+class _SpeechTaskState {
+  bool isActive = false;
 }

--- a/lib/src/core/speech/speech_to_text.dart
+++ b/lib/src/core/speech/speech_to_text.dart
@@ -549,14 +549,14 @@ class SpeechToTextEngine {
           if (!const <String>{'wav', 'mp3', 'flac'}.contains(encoding)) {
             throw LlamaAudioFormatException(
               'Encoded audio files must use WAV, MP3, or FLAC.',
-              request.audio.format,
+              encoding,
             );
           }
         } else if (extension.isNotEmpty &&
             !const <String>{'wav', 'mp3', 'flac'}.contains(extension)) {
           throw LlamaAudioFormatException(
             'Encoded audio files must use WAV, MP3, or FLAC.',
-            request.audio.format,
+            extension,
           );
         }
       case SpeechAudioBytesInput(:final bytes):
@@ -571,7 +571,7 @@ class SpeechToTextEngine {
             !const <String>{'wav', 'mp3', 'flac'}.contains(encoding)) {
           throw LlamaAudioFormatException(
             'Encoded audio bytes must use WAV, MP3, or FLAC.',
-            request.audio.format,
+            encoding,
           );
         }
     }

--- a/test/e2e/backends/speech_to_text_e2e_test.dart
+++ b/test/e2e/backends/speech_to_text_e2e_test.dart
@@ -1,0 +1,84 @@
+@TestOn('vm')
+@Tags(<String>['local-only', 'e2e'])
+@Timeout(Duration(minutes: 10))
+library;
+
+import 'dart:io';
+
+import 'package:llamadart/llamadart.dart';
+import 'package:test/test.dart';
+
+const _modelPathKey = 'LLAMADART_STT_MODEL_PATH';
+const _mmprojPathKey = 'LLAMADART_STT_MMPROJ_PATH';
+const _audioPathKey = 'LLAMADART_STT_AUDIO_PATH';
+const _expectedTextKey = 'LLAMADART_STT_EXPECTED_TEXT';
+
+void main() {
+  test(
+    'transcribes a complete known audio fixture through the public API',
+    () async {
+      final modelPath = _requiredFile(_modelPathKey);
+      final mmprojPath = _requiredFile(_mmprojPathKey);
+      final audioPath = _requiredFile(_audioPathKey);
+      if (modelPath == null || mmprojPath == null || audioPath == null) {
+        return;
+      }
+
+      final engine = LlamaEngine(LlamaBackend());
+      try {
+        await engine.loadModel(
+          modelPath,
+          modelParams: const ModelParams(
+            contextSize: 4096,
+            preferredBackend: GpuBackend.cpu,
+            gpuLayers: 0,
+          ),
+        );
+        await engine.loadMultimodalProjector(mmprojPath);
+
+        final recognizer = SpeechToTextEngine(engine);
+        final capabilities = await recognizer.capabilities;
+        expect(
+          capabilities.isSupported,
+          isTrue,
+          reason: capabilities.unsupportedReason,
+        );
+
+        final task = await recognizer.transcribe(
+          SpeechToTextRequest(
+            audio: SpeechAudioFileInput(audioPath),
+            maxOutputTokens: 512,
+          ),
+        );
+        final events = await task.events.toList();
+        final completion = await task.done;
+
+        expect(completion.state, SpeechToTextCompletionState.completed);
+        expect(events.whereType<SpeechToTextFinalEvent>(), hasLength(1));
+        final result = completion.result!;
+        expect(result.text, isNotEmpty);
+        expect(result.text, isNot(contains('<asr_text>')));
+        expect(result.text, isNot(startsWith('language ')));
+
+        final expected = Platform.environment[_expectedTextKey]?.trim();
+        if (expected != null && expected.isNotEmpty) {
+          expect(result.text, expected);
+        }
+      } finally {
+        await engine.dispose();
+      }
+    },
+  );
+}
+
+String? _requiredFile(String environmentKey) {
+  final value = Platform.environment[environmentKey];
+  if (value == null || value.isEmpty) {
+    markTestSkipped('Set $environmentKey to run the speech-to-text E2E.');
+    return null;
+  }
+  if (!File(value).existsSync()) {
+    throw StateError('$environmentKey does not exist: $value');
+  }
+  return value;
+}

--- a/test/e2e/backends/speech_to_text_e2e_test.dart
+++ b/test/e2e/backends/speech_to_text_e2e_test.dart
@@ -20,7 +20,11 @@ void main() {
       final modelPath = _requiredFile(_modelPathKey);
       final mmprojPath = _requiredFile(_mmprojPathKey);
       final audioPath = _requiredFile(_audioPathKey);
-      if (modelPath == null || mmprojPath == null || audioPath == null) {
+      final expectedText = _requiredText(_expectedTextKey);
+      if (modelPath == null ||
+          mmprojPath == null ||
+          audioPath == null ||
+          expectedText == null) {
         return;
       }
 
@@ -36,7 +40,10 @@ void main() {
         );
         await engine.loadMultimodalProjector(mmprojPath);
 
-        final recognizer = SpeechToTextEngine(engine);
+        final recognizer = SpeechToTextEngine(
+          engine,
+          modelProfile: SpeechToTextModelProfile.qwen3Asr,
+        );
         final capabilities = await recognizer.capabilities;
         expect(
           capabilities.isSupported,
@@ -60,15 +67,21 @@ void main() {
         expect(result.text, isNot(contains('<asr_text>')));
         expect(result.text, isNot(startsWith('language ')));
 
-        final expected = Platform.environment[_expectedTextKey]?.trim();
-        if (expected != null && expected.isNotEmpty) {
-          expect(result.text, expected);
-        }
+        expect(result.text, expectedText);
       } finally {
         await engine.dispose();
       }
     },
   );
+}
+
+String? _requiredText(String environmentKey) {
+  final value = Platform.environment[environmentKey]?.trim();
+  if (value == null || value.isEmpty) {
+    markTestSkipped('Set $environmentKey to run the speech-to-text E2E.');
+    return null;
+  }
+  return value;
 }
 
 String? _requiredFile(String environmentKey) {

--- a/test/unit/core/exceptions_test.dart
+++ b/test/unit/core/exceptions_test.dart
@@ -26,6 +26,20 @@ void main() {
       expect(ex.toString(), contains('Gen failed'));
     });
 
+    test('LlamaSpeechException properties', () {
+      final ex = LlamaSpeechException('Recognition failed', 'decoder error');
+      expect(ex.message, 'Recognition failed');
+      expect(ex.details, 'decoder error');
+      expect(ex.toString(), contains('Recognition failed'));
+    });
+
+    test('LlamaAudioFormatException is a speech exception', () {
+      final ex = LlamaAudioFormatException('Unsupported audio', 'stereo');
+      expect(ex, isA<LlamaSpeechException>());
+      expect(ex.message, 'Unsupported audio');
+      expect(ex.details, 'stereo');
+    });
+
     test('LlamaUnsupportedException properties', () {
       final ex = LlamaUnsupportedException('No CUDA');
       expect(ex.message, 'No CUDA');

--- a/test/unit/core/speech/speech_platform_stub_test.dart
+++ b/test/unit/core/speech/speech_platform_stub_test.dart
@@ -1,0 +1,12 @@
+@TestOn('vm')
+library;
+
+import 'package:llamadart/src/core/speech/speech_platform_stub.dart';
+import 'package:test/test.dart';
+
+void main() {
+  test('native platform enables dedicated speech-to-text', () {
+    expect(isSpeechToTextPlatformSupported, isTrue);
+    expect(speechToTextPlatformUnsupportedReason, isNull);
+  });
+}

--- a/test/unit/core/speech/speech_platform_web_test.dart
+++ b/test/unit/core/speech/speech_platform_web_test.dart
@@ -1,0 +1,12 @@
+@TestOn('browser')
+library;
+
+import 'package:llamadart/src/core/speech/speech_platform_web.dart';
+import 'package:test/test.dart';
+
+void main() {
+  test('web platform reports dedicated speech-to-text as unsupported', () {
+    expect(isSpeechToTextPlatformSupported, isFalse);
+    expect(speechToTextPlatformUnsupportedReason, contains('not available'));
+  });
+}

--- a/test/unit/core/speech/speech_to_text_test.dart
+++ b/test/unit/core/speech/speech_to_text_test.dart
@@ -146,11 +146,57 @@ void main() {
           ),
         ),
         throwsA(
-          isA<LlamaAudioFormatException>().having(
-            (error) => error.message,
-            'message',
-            contains('WAV, MP3, or FLAC'),
+          isA<LlamaAudioFormatException>()
+              .having(
+                (error) => error.message,
+                'message',
+                contains('WAV, MP3, or FLAC'),
+              )
+              .having((error) => error.details, 'details', 'm4a'),
+        ),
+      );
+    });
+
+    test('reports an unsupported explicit encoding', () async {
+      await _loadSpeechModel(llamaEngine);
+
+      await expectLater(
+        speechEngine.transcribe(
+          const SpeechToTextRequest(
+            audio: SpeechAudioFileInput(
+              '/tmp/content-addressed-audio',
+              format: SpeechAudioFormat(encoding: 'AAC'),
+            ),
           ),
+        ),
+        throwsA(
+          isA<LlamaAudioFormatException>()
+              .having(
+                (error) => error.message,
+                'message',
+                contains('WAV, MP3, or FLAC'),
+              )
+              .having((error) => error.details, 'details', 'aac'),
+        ),
+      );
+
+      await expectLater(
+        speechEngine.transcribe(
+          SpeechToTextRequest(
+            audio: SpeechAudioBytesInput(
+              Uint8List.fromList(<int>[1, 2, 3]),
+              format: const SpeechAudioFormat(encoding: 'AAC'),
+            ),
+          ),
+        ),
+        throwsA(
+          isA<LlamaAudioFormatException>()
+              .having(
+                (error) => error.message,
+                'message',
+                contains('WAV, MP3, or FLAC'),
+              )
+              .having((error) => error.details, 'details', 'aac'),
         ),
       );
     });

--- a/test/unit/core/speech/speech_to_text_test.dart
+++ b/test/unit/core/speech/speech_to_text_test.dart
@@ -11,13 +11,16 @@ import 'package:test/test.dart';
 void main() {
   group('SpeechToTextEngine', () {
     late _SpeechBackend backend;
-    late LlamaEngine llamaEngine;
+    late _SpeechLlamaEngine llamaEngine;
     late SpeechToTextEngine speechEngine;
 
     setUp(() async {
       backend = _SpeechBackend();
-      llamaEngine = LlamaEngine(backend);
-      speechEngine = SpeechToTextEngine(llamaEngine);
+      llamaEngine = _SpeechLlamaEngine(backend);
+      speechEngine = SpeechToTextEngine(
+        llamaEngine,
+        modelProfile: SpeechToTextModelProfile.qwen3Asr,
+      );
     });
 
     tearDown(() => llamaEngine.dispose());
@@ -36,9 +39,12 @@ void main() {
 
       expect(capabilities.isSupported, isTrue);
       expect(capabilities.backendName, 'CPU');
+      expect(
+        capabilities.implementation,
+        SpeechToTextImplementation.multimodalPromptAdapter,
+      );
       expect(capabilities.inputKinds, containsAll(SpeechAudioInputKind.values));
       expect(capabilities.encodedAudioFormats, {'wav', 'mp3', 'flac'});
-      expect(capabilities.pcmSampleRatesHz, {16000});
       expect(capabilities.supportsPartialResults, isFalse);
       expect(capabilities.supportsStreamingInput, isFalse);
       expect(capabilities.supportsTimestamps, isFalse);
@@ -46,10 +52,32 @@ void main() {
       expect(capabilities.supportsWordTimestamps, isFalse);
       expect(capabilities.supportsConfidence, isFalse);
       expect(capabilities.supportsSpeakerDiarization, isFalse);
-      expect(capabilities.supportsLanguageDetection, isTrue);
+      expect(capabilities.supportsLanguageDetection, isFalse);
+      expect(capabilities.supportsLanguageHints, isFalse);
       expect(capabilities.supportsCancellation, isTrue);
       expect(capabilities.supportsOutputBackpressure, isFalse);
       expect(capabilities.maxConcurrentTasks, 1);
+    });
+
+    test('reports a projector without audio support as unsupported', () async {
+      backend.audioSupported = false;
+      await _loadSpeechModel(llamaEngine);
+
+      final capabilities = await speechEngine.capabilities;
+
+      expect(capabilities.isSupported, isFalse);
+      expect(capabilities.unsupportedReason, contains('does not report audio'));
+    });
+
+    test('turns an audio probe failure into capability diagnostics', () async {
+      backend.audioProbeError = StateError('old native symbols');
+      await _loadSpeechModel(llamaEngine);
+
+      final capabilities = await speechEngine.capabilities;
+
+      expect(capabilities.isSupported, isFalse);
+      expect(capabilities.unsupportedReason, contains('probe failed'));
+      expect(capabilities.unsupportedReason, contains('old native symbols'));
     });
 
     test(
@@ -64,7 +92,6 @@ void main() {
         final task = await speechEngine.transcribe(
           const SpeechToTextRequest(
             audio: SpeechAudioFileInput('/tmp/test.wav'),
-            languageHint: 'en',
             contextPrompt: 'llamadart',
             maxOutputTokens: 64,
           ),
@@ -75,7 +102,7 @@ void main() {
         expect(events, hasLength(1));
         final finalEvent = events.single as SpeechToTextFinalEvent;
         expect(finalEvent.result.text, 'Local speech recognition works.');
-        expect(finalEvent.result.language, 'English');
+        expect(finalEvent.result.language, isNull);
         expect(finalEvent.result.segments.single.text, finalEvent.result.text);
         expect(completion.state, SpeechToTextCompletionState.completed);
         expect(completion.result, same(finalEvent.result));
@@ -84,10 +111,6 @@ void main() {
         expect(
           (backend.lastParts![1] as LlamaAudioContent).path,
           '/tmp/test.wav',
-        );
-        expect(
-          backend.lastGenerationPrompt,
-          contains('requested language is en'),
         );
         expect(backend.lastGenerationPrompt, contains('Context: llamadart'));
         expect(backend.lastGenerationParams?.temp, 0);
@@ -113,51 +136,75 @@ void main() {
       expect(audio.bytes, <int>[1, 2, 3]);
     });
 
-    test('passes valid 16 kHz mono Float32 PCM', () async {
-      await _loadSpeechModel(llamaEngine);
-      final samples = Float32List.fromList(<double>[0, 0.25, -0.25]);
-
-      final task = await speechEngine.transcribe(
-        SpeechToTextRequest(
-          audio: SpeechPcmInput(
-            samples,
-            format: const SpeechAudioFormat(
-              sampleRateHz: 16000,
-              channelCount: 1,
-              sampleFormat: SpeechAudioSampleFormat.float32,
-            ),
-          ),
-        ),
-      );
-      await task.done;
-
-      final audio = backend.lastParts![1] as LlamaAudioContent;
-      expect(audio.samples, same(samples));
-    });
-
-    test('rejects PCM outside the first backend contract', () async {
+    test('rejects unsupported encoded file formats before inference', () async {
       await _loadSpeechModel(llamaEngine);
 
       expect(
         () => speechEngine.transcribe(
-          SpeechToTextRequest(
-            audio: SpeechPcmInput(
-              Float32List(4),
-              format: const SpeechAudioFormat(
-                sampleRateHz: 48000,
-                channelCount: 2,
-                sampleFormat: SpeechAudioSampleFormat.float32,
-              ),
-            ),
+          const SpeechToTextRequest(
+            audio: SpeechAudioFileInput('/tmp/recording.m4a'),
           ),
         ),
         throwsA(
           isA<LlamaAudioFormatException>().having(
             (error) => error.message,
             'message',
-            contains('16 kHz mono Float32'),
+            contains('WAV, MP3, or FLAC'),
           ),
         ),
+      );
+    });
+
+    test('accepts an extensionless file with an explicit encoding', () async {
+      await _loadSpeechModel(llamaEngine);
+      backend.generationText = 'Transcript.';
+
+      final task = await speechEngine.transcribe(
+        const SpeechToTextRequest(
+          audio: SpeechAudioFileInput(
+            '/tmp/content-addressed-audio',
+            format: SpeechAudioFormat(encoding: 'wav'),
+          ),
+        ),
+      );
+
+      expect((await task.done).result?.text, 'Transcript.');
+      final audio = backend.lastParts![1] as LlamaAudioContent;
+      expect(audio.path, '/tmp/content-addressed-audio');
+    });
+
+    test('validates empty inputs and token limits synchronously', () async {
+      await _loadSpeechModel(llamaEngine);
+
+      await expectLater(
+        speechEngine.transcribe(
+          const SpeechToTextRequest(audio: SpeechAudioFileInput('')),
+        ),
+        throwsA(isA<LlamaAudioFormatException>()),
+      );
+      await expectLater(
+        speechEngine.transcribe(
+          SpeechToTextRequest(audio: SpeechAudioBytesInput(Uint8List(0))),
+        ),
+        throwsA(isA<LlamaAudioFormatException>()),
+      );
+      await expectLater(
+        speechEngine.transcribe(
+          const SpeechToTextRequest(
+            audio: SpeechAudioFileInput('/tmp/test.wav'),
+            maxOutputTokens: 0,
+          ),
+        ),
+        throwsA(isA<LlamaSpeechException>()),
+      );
+      await expectLater(
+        speechEngine.transcribe(
+          const SpeechToTextRequest(
+            audio: SpeechAudioFileInput('/tmp/test.wav'),
+            languageHint: 'en',
+          ),
+        ),
+        throwsA(isA<LlamaUnsupportedException>()),
       );
     });
 
@@ -220,6 +267,125 @@ void main() {
       await first.done;
     });
 
+    test(
+      'reserves the engine before asynchronous capability discovery',
+      () async {
+        backend.blockAudioProbe = true;
+        await _loadSpeechModel(llamaEngine);
+
+        final firstFuture = speechEngine.transcribe(
+          const SpeechToTextRequest(
+            audio: SpeechAudioFileInput('/tmp/first.wav'),
+          ),
+        );
+        await backend.audioProbeStarted.future;
+
+        await expectLater(
+          speechEngine.transcribe(
+            const SpeechToTextRequest(
+              audio: SpeechAudioFileInput('/tmp/second.wav'),
+            ),
+          ),
+          throwsA(isA<LlamaStateException>()),
+        );
+
+        backend.releaseAudioProbe();
+        final first = await firstFuture;
+        await first.done;
+      },
+    );
+
+    test('shares the task reservation across wrappers', () async {
+      backend.blockGeneration = true;
+      await _loadSpeechModel(llamaEngine);
+      final otherWrapper = SpeechToTextEngine(
+        llamaEngine,
+        modelProfile: SpeechToTextModelProfile.qwen3Asr,
+      );
+      final first = await speechEngine.transcribe(
+        const SpeechToTextRequest(
+          audio: SpeechAudioFileInput('/tmp/first.wav'),
+        ),
+      );
+      await backend.generationStarted.future;
+
+      await expectLater(
+        otherWrapper.transcribe(
+          const SpeechToTextRequest(
+            audio: SpeechAudioFileInput('/tmp/second.wav'),
+          ),
+        ),
+        throwsA(isA<LlamaStateException>()),
+      );
+
+      first.cancel();
+      backend.releaseGeneration();
+      await first.done;
+    });
+
+    test('releases the task reservation after preflight failure', () async {
+      backend.audioSupported = false;
+      await _loadSpeechModel(llamaEngine);
+
+      await expectLater(
+        speechEngine.transcribe(
+          const SpeechToTextRequest(
+            audio: SpeechAudioFileInput('/tmp/first.wav'),
+          ),
+        ),
+        throwsA(isA<LlamaUnsupportedException>()),
+      );
+
+      backend.audioSupported = true;
+      final task = await speechEngine.transcribe(
+        const SpeechToTextRequest(
+          audio: SpeechAudioFileInput('/tmp/second.wav'),
+        ),
+      );
+      expect((await task.done).state, SpeechToTextCompletionState.completed);
+    });
+
+    test('ignores generation chunks without choices', () async {
+      llamaEngine.emitEmptyChoice = true;
+      await _loadSpeechModel(llamaEngine);
+
+      final task = await speechEngine.transcribe(
+        const SpeechToTextRequest(audio: SpeechAudioFileInput('/tmp/test.wav')),
+      );
+
+      expect((await task.done).result?.text, 'transcript');
+    });
+
+    test('preserves typed backend failures', () async {
+      backend.generationError = LlamaUnsupportedException('missing symbol');
+      await _loadSpeechModel(llamaEngine);
+      final task = await speechEngine.transcribe(
+        const SpeechToTextRequest(audio: SpeechAudioFileInput('/tmp/test.wav')),
+      );
+
+      task.events.listen((_) {}, onError: (_) {});
+      final completion = await task.done;
+
+      expect(completion.error, isA<LlamaUnsupportedException>());
+    });
+
+    test('cancellation wins over a simultaneous backend failure', () async {
+      backend
+        ..blockGeneration = true
+        ..generationError = StateError('late decoder error');
+      await _loadSpeechModel(llamaEngine);
+      final task = await speechEngine.transcribe(
+        const SpeechToTextRequest(audio: SpeechAudioFileInput('/tmp/test.wav')),
+      );
+      await backend.generationStarted.future;
+
+      task.cancel();
+      backend.releaseGeneration();
+
+      expect(await task.events.toList(), isEmpty);
+      expect((await task.done).state, SpeechToTextCompletionState.cancelled);
+    });
+
     test('returns typed failure completion and stream error', () async {
       backend.generationError = StateError('decoder failed');
       await _loadSpeechModel(llamaEngine);
@@ -234,9 +400,9 @@ void main() {
       );
       final completion = await task.done;
 
-      expect(await streamError.future, isA<LlamaSpeechException>());
+      expect(await streamError.future, isA<LlamaInferenceException>());
       expect(completion.state, SpeechToTextCompletionState.failed);
-      expect(completion.error, isA<LlamaSpeechException>());
+      expect(completion.error, isA<LlamaInferenceException>());
     });
   });
 }
@@ -249,11 +415,15 @@ Future<void> _loadSpeechModel(LlamaEngine engine) async {
 class _SpeechBackend implements LlamaBackend {
   bool _ready = false;
   bool audioSupported = true;
+  Object? audioProbeError;
   String backendName = 'CPU';
   String generationText = 'transcript';
   List<String>? generationChunks;
   Object? generationError;
   bool blockGeneration = false;
+  bool blockAudioProbe = false;
+  Completer<void> audioProbeStarted = Completer<void>();
+  final Completer<void> _audioProbeRelease = Completer<void>();
   Completer<void> generationStarted = Completer<void>();
   final Completer<void> _generationRelease = Completer<void>();
   int cancelGenerationCalls = 0;
@@ -283,7 +453,19 @@ class _SpeechBackend implements LlamaBackend {
   ) async => 3;
 
   @override
-  Future<bool> supportsAudio(int mmContextHandle) async => audioSupported;
+  Future<bool> supportsAudio(int mmContextHandle) async {
+    if (!audioProbeStarted.isCompleted) {
+      audioProbeStarted.complete();
+    }
+    if (blockAudioProbe) {
+      await _audioProbeRelease.future;
+    }
+    final error = audioProbeError;
+    if (error != null) {
+      throw error;
+    }
+    return audioSupported;
+  }
 
   @override
   Future<String> getBackendName() async => backendName;
@@ -342,6 +524,12 @@ class _SpeechBackend implements LlamaBackend {
     }
   }
 
+  void releaseAudioProbe() {
+    if (!_audioProbeRelease.isCompleted) {
+      _audioProbeRelease.complete();
+    }
+  }
+
   void releaseGeneration() {
     if (!_generationRelease.isCompleted) {
       _generationRelease.complete();
@@ -369,4 +557,48 @@ class _SpeechBackend implements LlamaBackend {
 
   @override
   dynamic noSuchMethod(Invocation invocation) => super.noSuchMethod(invocation);
+}
+
+class _SpeechLlamaEngine extends LlamaEngine {
+  bool emitEmptyChoice = false;
+
+  _SpeechLlamaEngine(super.backend);
+
+  @override
+  Stream<LlamaCompletionChunk> create(
+    List<LlamaChatMessage> messages, {
+    GenerationParams? params,
+    List<ToolDefinition>? tools,
+    ToolChoice? toolChoice,
+    bool parallelToolCalls = false,
+    bool enableThinking = true,
+    Map<String, dynamic>? responseFormat,
+    String? sourceLangCode,
+    String? targetLangCode,
+    Map<String, dynamic>? chatTemplateKwargs,
+    DateTime? templateNow,
+  }) async* {
+    if (emitEmptyChoice) {
+      yield LlamaCompletionChunk(
+        id: 'empty',
+        object: 'chat.completion.chunk',
+        created: 0,
+        model: 'test',
+        choices: const <LlamaCompletionChunkChoice>[],
+      );
+    }
+    yield* super.create(
+      messages,
+      params: params,
+      tools: tools,
+      toolChoice: toolChoice,
+      parallelToolCalls: parallelToolCalls,
+      enableThinking: enableThinking,
+      responseFormat: responseFormat,
+      sourceLangCode: sourceLangCode,
+      targetLangCode: targetLangCode,
+      chatTemplateKwargs: chatTemplateKwargs,
+      templateNow: templateNow,
+    );
+  }
 }

--- a/test/unit/core/speech/speech_to_text_test.dart
+++ b/test/unit/core/speech/speech_to_text_test.dart
@@ -1,0 +1,372 @@
+@TestOn('vm')
+library;
+
+import 'dart:async';
+import 'dart:convert';
+import 'dart:typed_data';
+
+import 'package:llamadart/llamadart.dart';
+import 'package:test/test.dart';
+
+void main() {
+  group('SpeechToTextEngine', () {
+    late _SpeechBackend backend;
+    late LlamaEngine llamaEngine;
+    late SpeechToTextEngine speechEngine;
+
+    setUp(() async {
+      backend = _SpeechBackend();
+      llamaEngine = LlamaEngine(backend);
+      speechEngine = SpeechToTextEngine(llamaEngine);
+    });
+
+    tearDown(() => llamaEngine.dispose());
+
+    test('reports the unloaded engine as unsupported', () async {
+      final capabilities = await speechEngine.capabilities;
+
+      expect(capabilities.isSupported, isFalse);
+      expect(capabilities.unsupportedReason, contains('Load a model'));
+    });
+
+    test('reports exact first-backend capabilities', () async {
+      await _loadSpeechModel(llamaEngine);
+
+      final capabilities = await speechEngine.capabilities;
+
+      expect(capabilities.isSupported, isTrue);
+      expect(capabilities.backendName, 'CPU');
+      expect(capabilities.inputKinds, containsAll(SpeechAudioInputKind.values));
+      expect(capabilities.encodedAudioFormats, {'wav', 'mp3', 'flac'});
+      expect(capabilities.pcmSampleRatesHz, {16000});
+      expect(capabilities.supportsPartialResults, isFalse);
+      expect(capabilities.supportsStreamingInput, isFalse);
+      expect(capabilities.supportsTimestamps, isFalse);
+      expect(capabilities.supportsSegmentTimestamps, isFalse);
+      expect(capabilities.supportsWordTimestamps, isFalse);
+      expect(capabilities.supportsConfidence, isFalse);
+      expect(capabilities.supportsSpeakerDiarization, isFalse);
+      expect(capabilities.supportsLanguageDetection, isTrue);
+      expect(capabilities.supportsCancellation, isTrue);
+      expect(capabilities.supportsOutputBackpressure, isFalse);
+      expect(capabilities.maxConcurrentTasks, 1);
+    });
+
+    test(
+      'normalizes Qwen3-ASR language prefix and emits one final event',
+      () async {
+        backend.generationChunks = const <String>[
+          'language English<asr_text>Local speech ',
+          'recognition works.',
+        ];
+        await _loadSpeechModel(llamaEngine);
+
+        final task = await speechEngine.transcribe(
+          const SpeechToTextRequest(
+            audio: SpeechAudioFileInput('/tmp/test.wav'),
+            languageHint: 'en',
+            contextPrompt: 'llamadart',
+            maxOutputTokens: 64,
+          ),
+        );
+        final events = await task.events.toList();
+        final completion = await task.done;
+
+        expect(events, hasLength(1));
+        final finalEvent = events.single as SpeechToTextFinalEvent;
+        expect(finalEvent.result.text, 'Local speech recognition works.');
+        expect(finalEvent.result.language, 'English');
+        expect(finalEvent.result.segments.single.text, finalEvent.result.text);
+        expect(completion.state, SpeechToTextCompletionState.completed);
+        expect(completion.result, same(finalEvent.result));
+        expect(backend.lastParts, hasLength(2));
+        expect(backend.lastParts![1], isA<LlamaAudioContent>());
+        expect(
+          (backend.lastParts![1] as LlamaAudioContent).path,
+          '/tmp/test.wav',
+        );
+        expect(
+          backend.lastGenerationPrompt,
+          contains('requested language is en'),
+        );
+        expect(backend.lastGenerationPrompt, contains('Context: llamadart'));
+        expect(backend.lastGenerationParams?.temp, 0);
+        expect(backend.lastGenerationParams?.topK, 1);
+        expect(backend.lastGenerationParams?.maxTokens, 64);
+      },
+    );
+
+    test('accepts encoded bytes and strips a bare transcript marker', () async {
+      backend.generationText = ' <asr_text> Byte-backed transcript. ';
+      await _loadSpeechModel(llamaEngine);
+
+      final task = await speechEngine.transcribe(
+        SpeechToTextRequest(
+          audio: SpeechAudioBytesInput(Uint8List.fromList(<int>[1, 2, 3])),
+        ),
+      );
+      final result = (await task.done).result!;
+
+      expect(result.text, 'Byte-backed transcript.');
+      expect(result.language, isNull);
+      final audio = backend.lastParts![1] as LlamaAudioContent;
+      expect(audio.bytes, <int>[1, 2, 3]);
+    });
+
+    test('passes valid 16 kHz mono Float32 PCM', () async {
+      await _loadSpeechModel(llamaEngine);
+      final samples = Float32List.fromList(<double>[0, 0.25, -0.25]);
+
+      final task = await speechEngine.transcribe(
+        SpeechToTextRequest(
+          audio: SpeechPcmInput(
+            samples,
+            format: const SpeechAudioFormat(
+              sampleRateHz: 16000,
+              channelCount: 1,
+              sampleFormat: SpeechAudioSampleFormat.float32,
+            ),
+          ),
+        ),
+      );
+      await task.done;
+
+      final audio = backend.lastParts![1] as LlamaAudioContent;
+      expect(audio.samples, same(samples));
+    });
+
+    test('rejects PCM outside the first backend contract', () async {
+      await _loadSpeechModel(llamaEngine);
+
+      expect(
+        () => speechEngine.transcribe(
+          SpeechToTextRequest(
+            audio: SpeechPcmInput(
+              Float32List(4),
+              format: const SpeechAudioFormat(
+                sampleRateHz: 48000,
+                channelCount: 2,
+                sampleFormat: SpeechAudioSampleFormat.float32,
+              ),
+            ),
+          ),
+        ),
+        throwsA(
+          isA<LlamaAudioFormatException>().having(
+            (error) => error.message,
+            'message',
+            contains('16 kHz mono Float32'),
+          ),
+        ),
+      );
+    });
+
+    test('rejects current LiteRT-LM runtimes explicitly', () async {
+      backend.backendName = 'LiteRT-LM CPU';
+      await _loadSpeechModel(llamaEngine);
+
+      final capabilities = await speechEngine.capabilities;
+
+      expect(capabilities.isSupported, isFalse);
+      expect(capabilities.unsupportedReason, contains('not exported'));
+      expect(
+        () => speechEngine.transcribe(
+          const SpeechToTextRequest(
+            audio: SpeechAudioFileInput('/tmp/test.wav'),
+          ),
+        ),
+        throwsA(isA<LlamaUnsupportedException>()),
+      );
+    });
+
+    test('cancels an active recognition task idempotently', () async {
+      backend.blockGeneration = true;
+      await _loadSpeechModel(llamaEngine);
+
+      final task = await speechEngine.transcribe(
+        const SpeechToTextRequest(audio: SpeechAudioFileInput('/tmp/test.wav')),
+      );
+      await backend.generationStarted.future;
+      task.cancel();
+      task.cancel();
+      backend.releaseGeneration();
+
+      expect(await task.events.toList(), isEmpty);
+      expect((await task.done).state, SpeechToTextCompletionState.cancelled);
+      expect(backend.cancelGenerationCalls, 1);
+    });
+
+    test('allows only one active task per wrapper', () async {
+      backend.blockGeneration = true;
+      await _loadSpeechModel(llamaEngine);
+      final first = await speechEngine.transcribe(
+        const SpeechToTextRequest(
+          audio: SpeechAudioFileInput('/tmp/first.wav'),
+        ),
+      );
+      await backend.generationStarted.future;
+
+      expect(
+        () => speechEngine.transcribe(
+          const SpeechToTextRequest(
+            audio: SpeechAudioFileInput('/tmp/second.wav'),
+          ),
+        ),
+        throwsA(isA<LlamaStateException>()),
+      );
+
+      first.cancel();
+      backend.releaseGeneration();
+      await first.done;
+    });
+
+    test('returns typed failure completion and stream error', () async {
+      backend.generationError = StateError('decoder failed');
+      await _loadSpeechModel(llamaEngine);
+      final task = await speechEngine.transcribe(
+        const SpeechToTextRequest(audio: SpeechAudioFileInput('/tmp/test.wav')),
+      );
+
+      final streamError = Completer<Object>();
+      task.events.listen(
+        (_) {},
+        onError: (Object error) => streamError.complete(error),
+      );
+      final completion = await task.done;
+
+      expect(await streamError.future, isA<LlamaSpeechException>());
+      expect(completion.state, SpeechToTextCompletionState.failed);
+      expect(completion.error, isA<LlamaSpeechException>());
+    });
+  });
+}
+
+Future<void> _loadSpeechModel(LlamaEngine engine) async {
+  await engine.loadModel('model.gguf');
+  await engine.loadMultimodalProjector('mmproj.gguf');
+}
+
+class _SpeechBackend implements LlamaBackend {
+  bool _ready = false;
+  bool audioSupported = true;
+  String backendName = 'CPU';
+  String generationText = 'transcript';
+  List<String>? generationChunks;
+  Object? generationError;
+  bool blockGeneration = false;
+  Completer<void> generationStarted = Completer<void>();
+  final Completer<void> _generationRelease = Completer<void>();
+  int cancelGenerationCalls = 0;
+  String? lastGenerationPrompt;
+  GenerationParams? lastGenerationParams;
+  List<LlamaContentPart>? lastParts;
+
+  @override
+  bool get isReady => _ready;
+
+  @override
+  bool get supportsUrlLoading => false;
+
+  @override
+  Future<int> modelLoad(String path, ModelParams params) async {
+    _ready = true;
+    return 1;
+  }
+
+  @override
+  Future<int> contextCreate(int modelHandle, ModelParams params) async => 2;
+
+  @override
+  Future<int?> multimodalContextCreate(
+    int modelHandle,
+    String mmProjPath,
+  ) async => 3;
+
+  @override
+  Future<bool> supportsAudio(int mmContextHandle) async => audioSupported;
+
+  @override
+  Future<String> getBackendName() async => backendName;
+
+  @override
+  Future<void> setLogLevel(LlamaLogLevel level) async {}
+
+  @override
+  Future<int> getContextSize(int contextHandle) async => 4096;
+
+  @override
+  Future<bool> supportsVision(int mmContextHandle) async => false;
+
+  @override
+  Future<Map<String, String>> modelMetadata(int modelHandle) async => const {
+    'llm.context_length': '4096',
+    'tokenizer.chat_template':
+        '{% for message in messages %}{{ message["role"] + ": " + '
+        'message["content"] }}{% endfor %}{% if add_generation_prompt %}'
+        '{{ "assistant: " }}{% endif %}',
+  };
+
+  @override
+  Future<String> applyChatTemplate(
+    int modelHandle,
+    List<Map<String, dynamic>> messages, {
+    String? customTemplate,
+    bool addAssistant = true,
+  }) async {
+    return messages.map((message) => message['content']).join('\n');
+  }
+
+  @override
+  Stream<List<int>> generate(
+    int contextHandle,
+    String prompt,
+    GenerationParams params, {
+    List<LlamaContentPart>? parts,
+  }) async* {
+    lastGenerationPrompt = prompt;
+    lastGenerationParams = params;
+    lastParts = parts;
+    if (!generationStarted.isCompleted) {
+      generationStarted.complete();
+    }
+    if (blockGeneration) {
+      await _generationRelease.future;
+    }
+    final error = generationError;
+    if (error != null) {
+      throw error;
+    }
+    final chunks = generationChunks ?? <String>[generationText];
+    for (final chunk in chunks) {
+      yield utf8.encode(chunk);
+    }
+  }
+
+  void releaseGeneration() {
+    if (!_generationRelease.isCompleted) {
+      _generationRelease.complete();
+    }
+  }
+
+  @override
+  void cancelGeneration() {
+    cancelGenerationCalls += 1;
+  }
+
+  @override
+  Future<void> modelFree(int modelHandle) async {}
+
+  @override
+  Future<void> contextFree(int contextHandle) async {}
+
+  @override
+  Future<void> multimodalContextFree(int mmContextHandle) async {}
+
+  @override
+  Future<void> dispose() async {
+    _ready = false;
+  }
+
+  @override
+  dynamic noSuchMethod(Invocation invocation) => super.noSuchMethod(invocation);
+}

--- a/test/unit/core/speech/speech_to_text_web_test.dart
+++ b/test/unit/core/speech/speech_to_text_web_test.dart
@@ -1,0 +1,28 @@
+@TestOn('browser')
+library;
+
+import 'package:llamadart/llamadart.dart';
+import 'package:test/test.dart';
+
+void main() {
+  test('dedicated speech-to-text is explicitly unsupported on Web', () async {
+    final engine = SpeechToTextEngine(LlamaEngine(_WebBackend()));
+
+    final capabilities = await engine.capabilities;
+
+    expect(capabilities.isSupported, isFalse);
+    expect(capabilities.unsupportedReason, contains('not available on Web'));
+    expect(capabilities.unsupportedReason, contains('generic audio input'));
+  });
+}
+
+class _WebBackend implements LlamaBackend {
+  @override
+  bool get isReady => false;
+
+  @override
+  bool get supportsUrlLoading => true;
+
+  @override
+  dynamic noSuchMethod(Invocation invocation) => super.noSuchMethod(invocation);
+}

--- a/test/unit/core/speech/speech_to_text_web_test.dart
+++ b/test/unit/core/speech/speech_to_text_web_test.dart
@@ -6,13 +6,24 @@ import 'package:test/test.dart';
 
 void main() {
   test('dedicated speech-to-text is explicitly unsupported on Web', () async {
-    final engine = SpeechToTextEngine(LlamaEngine(_WebBackend()));
+    final engine = SpeechToTextEngine(
+      LlamaEngine(_WebBackend()),
+      modelProfile: SpeechToTextModelProfile.qwen3Asr,
+    );
 
     final capabilities = await engine.capabilities;
 
     expect(capabilities.isSupported, isFalse);
     expect(capabilities.unsupportedReason, contains('not available on Web'));
     expect(capabilities.unsupportedReason, contains('generic audio input'));
+    await expectLater(
+      engine.transcribe(
+        const SpeechToTextRequest(
+          audio: SpeechAudioFileInput('/tmp/fixture.wav'),
+        ),
+      ),
+      throwsA(isA<LlamaUnsupportedException>()),
+    );
   });
 }
 

--- a/test/unit/tooling/run_local_e2e_test.dart
+++ b/test/unit/tooling/run_local_e2e_test.dart
@@ -271,6 +271,23 @@ void main() {
       );
     });
 
+    test('requires an exact expected speech transcript', () async {
+      final result = await runLocalE2e(const [
+        '--scenario',
+        'speech-to-text-smoke',
+        '--model-path',
+        'models/Qwen3-ASR-0.6B-Q8_0.gguf',
+        '--mmproj-path',
+        'models/mmproj-Qwen3-ASR-0.6B-Q8_0.gguf',
+        '--audio-path',
+        'test/fixtures/speech.wav',
+        '--dry-run',
+      ], projectRoot: '/repo');
+
+      expect(result.exitCode, 64);
+      expect(result.stderr, contains('a nonempty --expect'));
+    });
+
     test('requires mmproj path before GGUF image path', () async {
       final result = await runLocalE2e(const [
         '--scenario',

--- a/test/unit/tooling/run_local_e2e_test.dart
+++ b/test/unit/tooling/run_local_e2e_test.dart
@@ -29,6 +29,7 @@ void main() {
       expect(result.stdout, contains('root-template-e2e'));
       expect(result.stdout, contains('qwen35-multimodal-macos-repro'));
       expect(result.stdout, contains('gguf-chat-features-smoke'));
+      expect(result.stdout, contains('speech-to-text-smoke'));
       expect(result.stdout, contains('llama-cpp-speculative-benchmark'));
       expect(result.stdout, contains('llama-cpp-chat-template-smoke'));
       expect(result.stdout, contains('litert-lm-chat-features-smoke'));
@@ -226,6 +227,47 @@ void main() {
           'models/Qwen3.5-0.8B-Q4_K_M.gguf cpu '
           'models/Qwen3.5-0.8B-mmproj-F16.gguf test/fixtures/image.png',
         ),
+      );
+    });
+
+    test('dry-runs typed speech-to-text with exact fixture inputs', () async {
+      final result = await runLocalE2e(const [
+        '--scenario',
+        'speech-to-text-smoke',
+        '--model-path',
+        'models/Qwen3-ASR-0.6B-Q8_0.gguf',
+        '--mmproj-path',
+        'models/mmproj-Qwen3-ASR-0.6B-Q8_0.gguf',
+        '--audio-path',
+        'test/fixtures/speech.wav',
+        '--expect',
+        'Known transcript.',
+        '--dry-run',
+      ], projectRoot: '/repo');
+
+      expect(result.exitCode, 0);
+      expect(result.stdout, contains('speech-to-text-smoke'));
+      expect(
+        result.stdout,
+        contains('LLAMADART_STT_MODEL_PATH=models/Qwen3-ASR-0.6B-Q8_0.gguf'),
+      );
+      expect(
+        result.stdout,
+        contains(
+          'LLAMADART_STT_MMPROJ_PATH=models/mmproj-Qwen3-ASR-0.6B-Q8_0.gguf',
+        ),
+      );
+      expect(
+        result.stdout,
+        contains('LLAMADART_STT_AUDIO_PATH=test/fixtures/speech.wav'),
+      );
+      expect(
+        result.stdout,
+        contains("LLAMADART_STT_EXPECTED_TEXT='Known transcript.'"),
+      );
+      expect(
+        result.stdout,
+        contains('test/e2e/backends/speech_to_text_e2e_test.dart'),
       );
     });
 

--- a/tool/testing/run_local_e2e.dart
+++ b/tool/testing/run_local_e2e.dart
@@ -722,11 +722,14 @@ Future<LocalE2eResult> runLocalE2e(
   if (scenario.name == 'speech-to-text-smoke' &&
       (parsed.modelPath == null ||
           parsed.mmprojPath == null ||
-          parsed.audioPath == null)) {
+          parsed.audioPath == null ||
+          !parsed.expectProvided ||
+          parsed.expect.trim().isEmpty)) {
     return const LocalE2eResult(
       64,
       stderr:
-          '--model-path, --mmproj-path, and --audio-path are required for speech-to-text-smoke.\n',
+          '--model-path, --mmproj-path, --audio-path, and a nonempty --expect '
+          'are required for speech-to-text-smoke.\n',
     );
   }
   if ((scenario.name == 'llama-cpp-speculative-benchmark' ||

--- a/tool/testing/run_local_e2e.dart
+++ b/tool/testing/run_local_e2e.dart
@@ -74,6 +74,7 @@ class LocalE2eRunContext {
     required this.draftModelPath,
     required this.mmprojPath,
     required this.imagePath,
+    required this.audioPath,
     required this.modelUrl,
     required this.backend,
     required this.speculativeCases,
@@ -90,6 +91,7 @@ class LocalE2eRunContext {
     required this.ngramCacheBuildStaticPath,
     required this.ngramCacheBuildText,
     required this.expect,
+    required this.expectProvided,
     required this.allowAnyResponse,
     required this.skipBuild,
   });
@@ -102,6 +104,7 @@ class LocalE2eRunContext {
   final String? draftModelPath;
   final String? mmprojPath;
   final String? imagePath;
+  final String? audioPath;
   final String? modelUrl;
   final String backend;
   final String speculativeCases;
@@ -118,6 +121,7 @@ class LocalE2eRunContext {
   final String? ngramCacheBuildStaticPath;
   final String? ngramCacheBuildText;
   final String expect;
+  final bool expectProvided;
   final bool allowAnyResponse;
   final bool skipBuild;
 
@@ -240,6 +244,34 @@ List<LocalE2eScenario> buildLocalE2eScenarios({String? projectRoot}) {
           ),
         ];
       },
+    ),
+    LocalE2eScenario(
+      name: 'speech-to-text-smoke',
+      group: LocalE2eScenarioGroup.dartLocalOnly,
+      description:
+          'Run typed native Qwen3-ASR whole-file transcription against a known fixture.',
+      requiresDevice: false,
+      stepsBuilder: (context) => [
+        LocalE2eCommandStep(
+          workingDirectory: context.projectRoot,
+          executable: 'dart',
+          arguments: const [
+            'test',
+            '--run-skipped',
+            '-t',
+            'local-only',
+            'test/e2e/backends/speech_to_text_e2e_test.dart',
+          ],
+          environment: {
+            'LLAMADART_STT_MODEL_PATH': context.modelPath!,
+            'LLAMADART_STT_MMPROJ_PATH': context.mmprojPath!,
+            'LLAMADART_STT_AUDIO_PATH': context.audioPath!,
+            if (context.expectProvided)
+              'LLAMADART_STT_EXPECTED_TEXT': context.expect,
+          },
+          description: 'Typed speech-to-text real-model smoke',
+        ),
+      ],
     ),
     LocalE2eScenario(
       name: 'llama-cpp-speculative-benchmark',
@@ -684,6 +716,19 @@ Future<LocalE2eResult> runLocalE2e(
   if (parsed.imagePath != null && parsed.mmprojPath == null) {
     return LocalE2eResult(64, stderr: '--image-path requires --mmproj-path.\n');
   }
+  if (parsed.audioPath != null && parsed.mmprojPath == null) {
+    return LocalE2eResult(64, stderr: '--audio-path requires --mmproj-path.\n');
+  }
+  if (scenario.name == 'speech-to-text-smoke' &&
+      (parsed.modelPath == null ||
+          parsed.mmprojPath == null ||
+          parsed.audioPath == null)) {
+    return const LocalE2eResult(
+      64,
+      stderr:
+          '--model-path, --mmproj-path, and --audio-path are required for speech-to-text-smoke.\n',
+    );
+  }
   if ((scenario.name == 'llama-cpp-speculative-benchmark' ||
           scenario.name == 'llama-cpp-chat-template-smoke' ||
           scenario.name == 'litert-lm-chat-features-smoke') &&
@@ -703,6 +748,7 @@ Future<LocalE2eResult> runLocalE2e(
     draftModelPath: parsed.draftModelPath,
     mmprojPath: parsed.mmprojPath,
     imagePath: parsed.imagePath,
+    audioPath: parsed.audioPath,
     modelUrl: parsed.modelUrl,
     backend: parsed.backend,
     speculativeCases: parsed.speculativeCases,
@@ -719,6 +765,7 @@ Future<LocalE2eResult> runLocalE2e(
     ngramCacheBuildStaticPath: parsed.ngramCacheBuildStaticPath,
     ngramCacheBuildText: parsed.ngramCacheBuildText,
     expect: parsed.expect,
+    expectProvided: parsed.expectProvided,
     allowAnyResponse: parsed.allowAnyResponse,
     skipBuild: parsed.skipBuild,
   );
@@ -913,6 +960,7 @@ Options:
   --draft-model-path <path>      Optional draft GGUF model path for llama.cpp speculative benchmark.
   --mmproj-path <path>           Optional multimodal projector path for GGUF chat smoke.
   --image-path <path>            Optional image path for GGUF chat smoke multimodal variant.
+  --audio-path <path>            Complete audio fixture for speech-to-text smoke.
   --model-url <url>              Model URL for real-model web smoke.
   --backend <name>               Backend for local model scenarios (default: auto).
   --speculative-cases <list>     Benchmark cases for llama.cpp speculative benchmark.
@@ -965,6 +1013,7 @@ class _ParsedArgs {
     required this.benchmarkWarmups,
     required this.draftTokenMaxList,
     required this.expect,
+    required this.expectProvided,
     required this.allowAnyResponse,
     required this.skipBuild,
     this.scenario,
@@ -972,6 +1021,7 @@ class _ParsedArgs {
     this.draftModelPath,
     this.mmprojPath,
     this.imagePath,
+    this.audioPath,
     this.modelUrl,
     this.ngramSize,
     this.ngramSizeM,
@@ -994,6 +1044,7 @@ class _ParsedArgs {
   final String? draftModelPath;
   final String? mmprojPath;
   final String? imagePath;
+  final String? audioPath;
   final String? modelUrl;
   final String backend;
   final String speculativeCases;
@@ -1010,6 +1061,7 @@ class _ParsedArgs {
   final String? ngramCacheBuildStaticPath;
   final String? ngramCacheBuildText;
   final String expect;
+  final bool expectProvided;
   final bool allowAnyResponse;
   final bool skipBuild;
 
@@ -1030,6 +1082,7 @@ class _ParsedArgs {
     var benchmarkWarmups = '1';
     var draftTokenMaxList = '1,2';
     var expect = '4';
+    var expectProvided = false;
     var allowAnyResponse = false;
     var skipBuild = false;
     String? scenario;
@@ -1037,6 +1090,7 @@ class _ParsedArgs {
     String? draftModelPath;
     String? mmprojPath;
     String? imagePath;
+    String? audioPath;
     String? modelUrl;
     String? ngramSize;
     String? ngramSizeM;
@@ -1076,6 +1130,8 @@ class _ParsedArgs {
           mmprojPath = _readValue(args, ++index, arg);
         case '--image-path':
           imagePath = _readValue(args, ++index, arg);
+        case '--audio-path':
+          audioPath = _readValue(args, ++index, arg);
         case '--model-url':
           modelUrl = _readValue(args, ++index, arg);
         case '--backend':
@@ -1108,6 +1164,7 @@ class _ParsedArgs {
           ngramCacheBuildText = _readValue(args, ++index, arg);
         case '--expect':
           expect = _readValue(args, ++index, arg);
+          expectProvided = true;
         default:
           throw ArgumentError('Unknown option: $arg');
       }
@@ -1126,6 +1183,7 @@ class _ParsedArgs {
       draftModelPath: draftModelPath,
       mmprojPath: mmprojPath,
       imagePath: imagePath,
+      audioPath: audioPath,
       modelUrl: modelUrl,
       backend: backend,
       speculativeCases: speculativeCases,
@@ -1142,6 +1200,7 @@ class _ParsedArgs {
       ngramCacheBuildStaticPath: ngramCacheBuildStaticPath,
       ngramCacheBuildText: ngramCacheBuildText,
       expect: expect,
+      expectProvided: expectProvided,
       allowAnyResponse: allowAnyResponse,
       skipBuild: skipBuild,
     );

--- a/tool/testing/test_matrix.dart
+++ b/tool/testing/test_matrix.dart
@@ -176,6 +176,21 @@ const List<TestMatrixRow> testMatrixRows = <TestMatrixRow>[
         'Chat rendering, parser, tool calling, thinking, or GGUF feature work.',
   ),
   TestMatrixRow(
+    id: 'speech-to-text-smoke',
+    tier: 'targeted',
+    mode: 'local-only',
+    covers:
+        'real native Qwen3-ASR projector capability, whole-file transcription, '
+        'language-marker normalization, and exact known-fixture text',
+    command:
+        'dart run tool/testing/run_local_e2e.dart --scenario '
+        'speech-to-text-smoke --model-path <model.gguf> '
+        '--mmproj-path <mmproj.gguf> --audio-path <fixture.wav> '
+        '--expect "<expected transcript>"',
+    useWhen:
+        'Speech API, native audio routing, transcript normalization, or chat-app transcription changes.',
+  ),
+  TestMatrixRow(
     id: 'llama-cpp-chat-template-smoke',
     tier: 'targeted',
     mode: 'local-only',

--- a/website/docs/changelog/recent-releases.md
+++ b/website/docs/changelog/recent-releases.md
@@ -7,6 +7,12 @@ For canonical full release notes, use:
 
 - [`CHANGELOG.md`](https://github.com/leehack/llamadart/blob/main/CHANGELOG.md)
 
+## Unreleased
+
+- Added an experimental typed Qwen3-ASR whole-file transcription workflow and
+  a SHA-256-verified Qwen3-ASR 0.6B native-desktop chat-app preset. Web and the
+  current LiteRT-LM artifacts remain explicitly unsupported for typed STT.
+
 ## 0.8.19
 
 - Updated the native llama.cpp runtime to `b10333` and WebGPU bridge assets to

--- a/website/docs/examples/chat-app.md
+++ b/website/docs/examples/chat-app.md
@@ -61,6 +61,9 @@ flutter test
 - Runtime-verified multimodal capability gating after `mmproj` load, plus
   declared direct-media capabilities for native model bundles such as
   LiteRT-LM. The app hides unsupported attachment types for the active platform.
+- A separate **Transcribe Audio** action for compatible native GGUF models,
+  backed by the typed whole-file `SpeechToTextEngine`. This is distinct from
+  generic audio attachment and is not shown for Web or current LiteRT-LM.
 - Clipboard image/audio attachments through `Cmd/Ctrl+V` on desktop and web or
   **Paste attachment** on touch devices. Text-only clipboard content still
   follows the normal composer paste path, and media is capped at 64 MB.

--- a/website/docs/examples/chat-app.md
+++ b/website/docs/examples/chat-app.md
@@ -77,13 +77,14 @@ The built-in library is intentionally small and Unsloth-first:
 
 - Cross-platform: FunctionGemma 270M, Qwen3.5 0.8B, Gemma 4 E2B GGUF,
   Gemma 4 E2B LiteRT-LM, and Gemma 4 E4B GGUF.
-- Native desktop: Gemma 4 12B, Gemma 4 26B A4B, Gemma 4 31B, and
-  Qwen3.6 35B A3B.
+- Native desktop: Qwen3-ASR 0.6B, Gemma 4 12B, Gemma 4 26B A4B, Gemma 4 31B,
+  and Qwen3.6 35B A3B.
 
-Every GGUF preset uses an [Unsloth distribution](https://huggingface.co/unsloth)
-and identifies Unsloth in the model card. The LiteRT-LM preset is the only
-exception because the required `.litertlm` artifacts are published by
-`litert-community`. The library defaults to the current platform, promotes
+GGUF chat presets use [Unsloth distributions](https://huggingface.co/unsloth).
+The dedicated ASR preset uses llama.cpp's `ggml-org` Qwen3-ASR pair, while the
+`.litertlm` artifacts come from `litert-community`; cards identify each source.
+The Qwen3-ASR model and projector use immutable URLs and verified SHA-256
+digests. The library defaults to the current platform, promotes
 downloaded models, and supports name/capability search plus Mobile, Web, and
 Desktop filters. Browsing another platform keeps incompatible model actions
 disabled and explains why. Gemma 4 E4B remains cross-platform because it is

--- a/website/docs/guides/multimodal.md
+++ b/website/docs/guides/multimodal.md
@@ -95,6 +95,10 @@ Gemma 4 E2B GGUF projector path in native `llama.cpp` mtmd reports both vision
 and audio support; audio remains experimental upstream. Web continues to rely
 on the loaded bridge's runtime capability report.
 
+`LlamaAudioContent` is generic audio input routed through normal generation; it
+does not by itself provide a transcript contract. For typed whole-file native
+transcription, see [Speech to Text](./speech-to-text).
+
 For native LiteRT-LM `.litertlm` bundles, capability depends on the bundle's
 native template/model processors. `loadMultimodalProjector`,
 `loadMultimodalProjectorSource`, `supportsVision`, and `supportsAudio` are

--- a/website/docs/guides/speech-to-text.md
+++ b/website/docs/guides/speech-to-text.md
@@ -1,0 +1,139 @@
+---
+title: Speech to Text
+description: Transcribe complete audio files with the experimental typed native llama.cpp speech API.
+---
+
+`SpeechToTextEngine` is the typed API for speech recognition. It is separate
+from `LlamaEngine` because transcript events, timestamps, confidence, language,
+speaker labels, cancellation, and audio metadata have a different contract from
+chat-completion tokens.
+
+The first implementation is experimental and deliberately narrow: it adapts
+native llama.cpp audio input to whole-file transcription. It has been validated
+with Qwen3-ASR 0.6B, but recognition quality and language behavior remain model
+dependent. Generic `LlamaAudioContent` chat input still exists separately for
+audio-capable multimodal models.
+
+## Current support matrix
+
+| Runtime | Generic audio-input chat | Typed `SpeechToTextEngine` | Text to speech |
+| --- | --- | --- | --- |
+| Native llama.cpp / GGUF | Model + projector dependent | Experimental; complete file/bytes/PCM input, final transcript only | No public Dart API |
+| WebGPU / GGUF | Bridge + model dependent | Unsupported | Unsupported |
+| Native LiteRT-LM / `.litertlm` | Bundle dependent through normal generation | Unsupported by the pinned native artifact | Unsupported by the pinned native artifact |
+| LiteRT-LM Web | Unsupported | Unsupported | Unsupported |
+
+“Generic audio-input chat” means an audio content part is processed by normal
+generation. It does not imply a transcript schema, stable ASR behavior, or TTS.
+The typed STT API adds a stable Dart result/cancellation boundary, but the first
+backend still performs whole-audio llama.cpp generation internally.
+
+## Load a Qwen3-ASR model
+
+Use a matching model and multimodal projector pair. llama.cpp documents
+Qwen3-ASR in its
+[multimodal model list](https://github.com/ggml-org/llama.cpp/blob/b10356/docs/multimodal.md),
+and published GGUF pairs are available from
+[`ggml-org/Qwen3-ASR-0.6B-GGUF`](https://huggingface.co/ggml-org/Qwen3-ASR-0.6B-GGUF).
+
+```dart
+final engine = LlamaEngine(LlamaBackend());
+await engine.loadModel('/models/Qwen3-ASR-0.6B-Q8_0.gguf');
+await engine.loadMultimodalProjector(
+  '/models/mmproj-Qwen3-ASR-0.6B-Q8_0.gguf',
+);
+
+final recognizer = SpeechToTextEngine(engine);
+final capabilities = await recognizer.capabilities;
+if (!capabilities.isSupported) {
+  throw StateError(capabilities.unsupportedReason!);
+}
+```
+
+Always check `capabilities` after both artifacts are loaded. Projector load
+success alone does not prove audio support.
+
+## Transcribe a complete file
+
+```dart
+final task = await recognizer.transcribe(
+  const SpeechToTextRequest(
+    audio: SpeechAudioFileInput('/recordings/meeting.wav'),
+    languageHint: 'en',
+    contextPrompt: 'llamadart, Qwen3-ASR',
+  ),
+);
+
+await for (final event in task.events) {
+  if (event is SpeechToTextFinalEvent) {
+    print(event.result.text);
+    print(event.result.language);
+  }
+}
+
+final completion = await task.done;
+print(completion.state);
+```
+
+Native llama.cpp currently decodes WAV, MP3, and FLAC file or byte inputs. Raw
+PCM uses `SpeechPcmInput` and currently requires mono 16 kHz `Float32` samples:
+
+```dart
+final input = SpeechPcmInput(
+  samples,
+  format: const SpeechAudioFormat(
+    sampleRateHz: 16000,
+    channelCount: 1,
+    sampleFormat: SpeechAudioSampleFormat.float32,
+  ),
+);
+```
+
+`SpeechAudioFormat` also carries optional encoding and MIME metadata. Final
+results reserve segment and word timing, confidence, and speaker fields so a
+future backend can add them without changing the top-level API. The current
+llama.cpp adapter returns one untimed segment and no confidence or diarization.
+
+## Streaming, cancellation, and concurrency
+
+The event stream is future-compatible with partial transcripts, but the first
+backend consumes the complete input before inference and emits only one final
+event. It does not accept live microphone frames, and pausing the Dart event
+subscription does not throttle native inference.
+
+Call `task.cancel()` to request cooperative cancellation:
+
+```dart
+final task = await recognizer.transcribe(request);
+// Later:
+task.cancel();
+final completion = await task.done;
+assert(completion.state == SpeechToTextCompletionState.cancelled);
+```
+
+Cancelling a stream subscription does not cancel the native task. One
+`SpeechToTextEngine` wrapper allows one active task because its `LlamaEngine`
+owns a single generation context.
+
+## Chat app
+
+The Flutter chat example exposes two different audio actions on compatible
+native GGUF models:
+
+- **Attach Audio** sends audio through normal multimodal chat.
+- **Transcribe Audio** selects one file and uses `SpeechToTextEngine`.
+
+The transcription action is hidden on Web and for current LiteRT-LM bundles.
+It is a file workflow, not live microphone capture.
+
+## Known limits
+
+- Qwen3-ASR may emit a leading `language English<asr_text>` marker. llamadart
+  normalizes that leading marker and exposes the language separately.
+- There are no word/segment timestamps, confidence scores, speaker
+  diarization, or incremental audio frames in the current backend.
+- Native inference backend correctness and performance remain device dependent;
+  establish a CPU baseline before claiming GPU support for a deployment.
+- TTS is not exposed. llama.cpp's current Qwen3-TTS helper is experimental and
+  requires a stable downstream native wrapper before it can support a public
+  Dart `TextToSpeechEngine`.

--- a/website/docs/guides/speech-to-text.md
+++ b/website/docs/guides/speech-to-text.md
@@ -18,7 +18,7 @@ audio-capable multimodal models.
 
 | Runtime | Generic audio-input chat | Typed `SpeechToTextEngine` | Text to speech |
 | --- | --- | --- | --- |
-| Native llama.cpp / GGUF | Model + projector dependent | Experimental; complete file/bytes/PCM input, final transcript only | No public Dart API |
+| Native llama.cpp / GGUF | Model + projector dependent | Experimental Qwen3-ASR adapter; complete WAV/MP3/FLAC file or bytes, final transcript only | No public Dart API |
 | WebGPU / GGUF | Bridge + model dependent | Unsupported | Unsupported |
 | Native LiteRT-LM / `.litertlm` | Bundle dependent through normal generation | Unsupported by the pinned native artifact | Unsupported by the pinned native artifact |
 | LiteRT-LM Web | Unsupported | Unsupported | Unsupported |
@@ -26,7 +26,9 @@ audio-capable multimodal models.
 “Generic audio-input chat” means an audio content part is processed by normal
 generation. It does not imply a transcript schema, stable ASR behavior, or TTS.
 The typed STT API adds a stable Dart result/cancellation boundary, but the first
-backend still performs whole-audio llama.cpp generation internally.
+backend still performs whole-audio llama.cpp generation internally. Its
+`SpeechToTextImplementation.multimodalPromptAdapter` capability makes that
+distinction inspectable; it is not a dedicated native ASR engine.
 
 ## Load a Qwen3-ASR model
 
@@ -43,7 +45,10 @@ await engine.loadMultimodalProjector(
   '/models/mmproj-Qwen3-ASR-0.6B-Q8_0.gguf',
 );
 
-final recognizer = SpeechToTextEngine(engine);
+final recognizer = SpeechToTextEngine(
+  engine,
+  modelProfile: SpeechToTextModelProfile.qwen3Asr,
+);
 final capabilities = await recognizer.capabilities;
 if (!capabilities.isSupported) {
   throw StateError(capabilities.unsupportedReason!);
@@ -51,7 +56,9 @@ if (!capabilities.isSupported) {
 ```
 
 Always check `capabilities` after both artifacts are loaded. Projector load
-success alone does not prove audio support.
+success alone does not prove audio support. The required `modelProfile` is an
+explicit declaration that prevents an ordinary audio-understanding model from
+being advertised as ASR merely because it accepts audio.
 
 ## Transcribe a complete file
 
@@ -59,35 +66,33 @@ success alone does not prove audio support.
 final task = await recognizer.transcribe(
   const SpeechToTextRequest(
     audio: SpeechAudioFileInput('/recordings/meeting.wav'),
-    languageHint: 'en',
     contextPrompt: 'llamadart, Qwen3-ASR',
   ),
 );
 
-await for (final event in task.events) {
-  if (event is SpeechToTextFinalEvent) {
-    print(event.result.text);
-    print(event.result.language);
+try {
+  await for (final event in task.events) {
+    if (event is SpeechToTextFinalEvent) {
+      print(event.result.text);
+    }
   }
+} on LlamaException catch (error) {
+  print('Recognition failed: $error');
 }
 
 final completion = await task.done;
 print(completion.state);
 ```
 
-Native llama.cpp currently decodes WAV, MP3, and FLAC file or byte inputs. Raw
-PCM uses `SpeechPcmInput` and currently requires mono 16 kHz `Float32` samples:
+`transcribe` itself throws typed input, state, or unsupported errors when
+preflight fails before a task can start. After startup, `events` is a
+single-subscription stream: runtime failure is emitted as a stream error and
+the same terminal condition is available through `task.done`.
 
-```dart
-final input = SpeechPcmInput(
-  samples,
-  format: const SpeechAudioFormat(
-    sampleRateHz: 16000,
-    channelCount: 1,
-    sampleFormat: SpeechAudioSampleFormat.float32,
-  ),
-);
-```
+Native llama.cpp currently decodes WAV, MP3, and FLAC file or byte inputs. Raw
+PCM is intentionally not exposed by the typed API yet: projector sample rates
+are model-specific, and the current public engine capability does not report
+the loaded projector's required rate.
 
 `SpeechAudioFormat` also carries optional encoding and MIME metadata. Final
 results reserve segment and word timing, confidence, and speaker fields so a
@@ -111,9 +116,9 @@ final completion = await task.done;
 assert(completion.state == SpeechToTextCompletionState.cancelled);
 ```
 
-Cancelling a stream subscription does not cancel the native task. One
-`SpeechToTextEngine` wrapper allows one active task because its `LlamaEngine`
-owns a single generation context.
+Cancelling a stream subscription does not cancel the native task. All
+`SpeechToTextEngine` wrappers over one `LlamaEngine` share a one-task lease.
+Do not call `LlamaEngine.create` on that engine until the speech task completes.
 
 ## Chat app
 
@@ -126,14 +131,24 @@ native GGUF models:
 The transcription action is hidden on Web and for current LiteRT-LM bundles.
 It is a file workflow, not live microphone capture.
 
+The chat app's desktop catalog includes the validated Qwen3-ASR 0.6B Q8_0
+model/projector pair. Its immutable artifact revision, byte sizes, and SHA-256
+digests are pinned, and the native downloader verifies both files before the
+model can be selected.
+
 ## Known limits
 
 - Qwen3-ASR may emit a leading `language English<asr_text>` marker. llamadart
-  normalizes that leading marker and exposes the language separately.
+  strips that marker, but does not expose it as reliable detected-language
+  metadata until language behavior has a dedicated validation contract.
 - There are no word/segment timestamps, confidence scores, speaker
   diarization, or incremental audio frames in the current backend.
 - Native inference backend correctness and performance remain device dependent;
   establish a CPU baseline before claiming GPU support for a deployment.
+- The local real-model smoke has passed on macOS arm64 CPU. A separate
+  chat-app/manual smoke has passed on Metal. The redistributable fixture and
+  Linux, Windows, Android, and iOS validation remain tracked in
+  [issue #325](https://github.com/leehack/llamadart/issues/325).
 - TTS is not exposed. llama.cpp's current Qwen3-TTS helper is experimental and
   requires a stable downstream native wrapper before it can support a public
   Dart `TextToSpeechEngine`.

--- a/website/docs/platforms/support-matrix.md
+++ b/website/docs/platforms/support-matrix.md
@@ -16,10 +16,12 @@ bundle source with `hooks.user_defines.llamadart.llamadart_native_path`. Module
 availability below is for the pinned/default artifacts.
 
 Speech support is narrower than general runtime availability. Native
-llama.cpp/GGUF has experimental whole-file `SpeechToTextEngine` support when a
-loaded projector reports audio capability. WebGPU, native LiteRT-LM, and
-LiteRT-LM Web do not currently expose the typed STT API, and no runtime exposes
-public Dart TTS. See the
+llama.cpp/GGUF has an experimental whole-file `SpeechToTextEngine` adapter when
+the caller explicitly selects the Qwen3-ASR profile and the loaded projector
+reports audio capability. This path is real-model validated on macOS arm64;
+other native targets still need representative validation. WebGPU, native
+LiteRT-LM, and LiteRT-LM Web do not currently expose the typed STT API, and no
+runtime exposes public Dart TTS. See the
 [speech support matrix](../guides/speech-to-text#current-support-matrix).
 
 Available override tags are published on the

--- a/website/docs/platforms/support-matrix.md
+++ b/website/docs/platforms/support-matrix.md
@@ -15,6 +15,13 @@ override the llama.cpp native GitHub source with
 bundle source with `hooks.user_defines.llamadart.llamadart_native_path`. Module
 availability below is for the pinned/default artifacts.
 
+Speech support is narrower than general runtime availability. Native
+llama.cpp/GGUF has experimental whole-file `SpeechToTextEngine` support when a
+loaded projector reports audio capability. WebGPU, native LiteRT-LM, and
+LiteRT-LM Web do not currently expose the typed STT API, and no runtime exposes
+public Dart TTS. See the
+[speech support matrix](../guides/speech-to-text#current-support-matrix).
+
 Available override tags are published on the
 [`leehack/llamadart-native` releases page](https://github.com/leehack/llamadart-native/releases)
 or via `gh release list --repo leehack/llamadart-native --limit 20`.

--- a/website/sidebars.ts
+++ b/website/sidebars.ts
@@ -33,6 +33,7 @@ const sidebars: SidebarsConfig = {
         'guides/embeddings',
         'guides/tool-calling',
         'guides/multimodal',
+        'guides/speech-to-text',
         'guides/lora-adapters'
       ]
     },


### PR DESCRIPTION
## Summary
- add an experimental typed `SpeechToTextEngine` for whole-file Qwen3-ASR transcription over native llama.cpp
- add task-scoped events, completion state, cancellation, explicit model capability discovery, typed failures, and transcript metadata placeholders
- add a native-desktop Qwen3-ASR 0.6B chat-app preset with separate speech-to-text UX, mandatory projector handling, immutable artifact URLs, and SHA-256 verification
- harden concurrent startup, Stop/Clear/conversation-switch/unload lifecycle behavior, catalog migration, and exact-transcript test routing

The root problem is that generic `LlamaAudioContent` generation had no stable transcription contract and could not distinguish audio-understanding chat from an ASR workflow.

Related to #325. This PR intentionally does not close the issue.

## Production-readiness scope
- **User-facing scope:** Native users can transcribe one complete WAV, MP3, or FLAC input through a typed API and the Flutter chat example using the Qwen3-ASR profile.
- **Supported platforms/paths:** Native llama.cpp with an explicitly selected Qwen3-ASR profile and an audio-capable matching projector. Real-model validation currently covers macOS arm64 CPU; a separate chat-app/manual smoke covered Metal.
- **Unsupported or intentionally unavailable paths:** Typed STT on WebGPU, native LiteRT-LM, and LiteRT-LM Web fails or is disabled explicitly. Live microphone/streaming audio, partial transcripts, timestamps, confidence, language claims, diarization, raw PCM, and TTS are unavailable.
- **Out of scope / follow-ups:** Keep #325 open for a redistributable fixture, Linux x64 CPU validation, malformed/silence/stereo/resampling/30-second boundary cases, and real cancellation/cleanup/memory gates. TTS remains tracked by #322.

## Completeness checklist
- [x] Declared scope is fully implemented, or explicitly reduced above.
- [x] Unsupported platform/option combinations fail loudly with actionable diagnostics or are clearly documented as unavailable.
- [x] Public API docs, README/website docs, examples, support matrices, and changelog entries are updated where relevant.
- [ ] Full model-backed acceptance coverage from #325 is pending as listed above.
- [x] Security/privacy review completed: no secrets, bearer tokens, signed URLs, or raw secret-bearing paths leak through logs, cache keys, metadata, errors, or snapshots.
- [x] Follow-up work that is useful but not required for this PR is tracked in GitHub Issues.

## PR type guidance
- **Feature PR:** includes API/docs/example updates, exact platform scope, unsupported-path behavior, and happy/negative-path tests.

## Test Plan
- [x] `dart format --output=none --set-exit-if-changed lib test tool example/chat_app/lib example/chat_app/test`
- [x] `dart analyze lib test tool`
- [x] `flutter analyze` in `example/chat_app`
- [x] `dart test -p vm -j 1 --exclude-tags local-only` — 1,347 passed
- [x] `dart test -p chrome --exclude-tags local-only` — 742 passed
- [x] `flutter test` in `example/chat_app` — 215 passed
- [x] `./tool/docs/validate_links.sh`
- [x] `./tool/docs/build_site.sh`
- [x] Coverage gate — 75.02% line coverage, above the 70% threshold
- [x] macOS arm64 Qwen3-ASR 0.6B CPU real-model smoke; separate chat-app/manual Metal smoke

## Matrix Evidence
| Matrix row | Scope covered | Platform / model / backend | Result | Evidence / notes |
| --- | --- | --- | --- | --- |
| `speech-to-text-smoke` | typed API, projector capability, marker normalization, exact transcript | macOS arm64 / Qwen3-ASR 0.6B Q8_0 / llama.cpp CPU | PASS | Local real-model run; checked-in redistributable fixture remains #325 follow-up |
| `examples-tests` | chat transcription UX, lifecycle, catalog, download integrity | Flutter VM / mock engine and filesystem | PASS | 215 chat-app tests |
| Web unsupported contract | typed Web STT rejection | Chrome / Web platform stub | PASS | Included in 742 Chrome tests |
| docs validation | guide, example, matrix, changelog | Docusaurus | PASS | Links and production build green |

## Review Notes
- Independent review status: three focused read-only reviews covered the public API, chat/catalog/download lifecycle, and docs/test claims; all concrete findings were addressed. No external human approval yet.
- CI status / head SHA: all 12 required PR checks passed on `6d837317b411071732e383acdb5b6f12876d9585`; the separate Copilot reviewer check also passed.