### PR TITLE
Add native microphone transcription and Ask with voice

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,8 +3,9 @@
 * Added an experimental typed `SpeechToTextEngine` with an explicit Qwen3-ASR
   adapter profile for whole-file native llama.cpp transcription, plus a
   SHA-256-verified Qwen3-ASR 0.6B desktop preset and separate **Transcribe
-  Audio** flow in the Flutter chat example. Web and the current LiteRT-LM
-  artifacts fail explicitly as unsupported.
+  Audio** and foreground microphone recording flows in the Flutter chat
+  example. Web and the current LiteRT-LM artifacts fail explicitly as
+  unsupported.
 
 * Added experimental, opt-in native llama.cpp DSpark speculative decoding
   through `SpeculativeDecodingConfig.draftDspark(...)`, including exact

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,10 +2,11 @@
 
 * Added an experimental typed `SpeechToTextEngine` with an explicit Qwen3-ASR
   adapter profile for whole-file native llama.cpp transcription, plus a
-  SHA-256-verified Qwen3-ASR 0.6B desktop preset and separate **Transcribe
-  Audio** and foreground microphone recording flows in the Flutter chat
-  example. Web and the current LiteRT-LM artifacts fail explicitly as
-  unsupported.
+  SHA-256-verified Qwen3-ASR 0.6B native mobile-and-desktop preset and separate
+  **Transcribe Audio** and foreground microphone recording flows in the Flutter
+  chat example. The flow has been exercised on a physical Pixel with CPU
+  inference and in the iOS Simulator; Web and the current LiteRT-LM artifacts
+  fail explicitly as unsupported.
 
 * Added experimental, opt-in native llama.cpp DSpark speculative decoding
   through `SpeculativeDecodingConfig.draftDspark(...)`, including exact

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,11 +8,13 @@
   inference and in the iOS Simulator; Web and the current LiteRT-LM artifacts
   fail explicitly as unsupported.
 
-* Added **Ask with voice** to the native Flutter chat example for direct-media
-  models such as Gemma 4 E2B LiteRT-LM. The app sends a microphone recording
-  through normal multimodal chat so the model can answer the spoken request;
-  it remains separate from typed speech-to-text and is available on Android,
-  iOS, macOS, and Windows, with Linux recording and Web excluded.
+* Added **Ask with voice** to the native Flutter chat example for Gemma 4 E2B
+  through both the LiteRT-LM direct-media bundle and the audio-capable GGUF +
+  projector path. The app sends a microphone recording through normal
+  multimodal chat so the model can answer the spoken request; it remains
+  separate from typed speech-to-text and is available on Android, iOS, macOS,
+  and Windows, with Linux recording and Web excluded. llama.cpp audio input is
+  experimental, and the GGUF path does not yet have mobile device validation.
 
 * Added experimental, opt-in native llama.cpp DSpark speculative decoding
   through `SpeculativeDecodingConfig.draftDspark(...)`, including exact

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,12 @@
   inference and in the iOS Simulator; Web and the current LiteRT-LM artifacts
   fail explicitly as unsupported.
 
+* Added **Ask with voice** to the native Flutter chat example for direct-media
+  models such as Gemma 4 E2B LiteRT-LM. The app sends a microphone recording
+  through normal multimodal chat so the model can answer the spoken request;
+  it remains separate from typed speech-to-text and is available on Android,
+  iOS, macOS, and Windows, with Linux recording and Web excluded.
+
 * Added experimental, opt-in native llama.cpp DSpark speculative decoding
   through `SpeculativeDecodingConfig.draftDspark(...)`, including exact
   `draft-dspark` mapping, external draft-model validation, typed unsupported

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,9 +12,11 @@
   through both the LiteRT-LM direct-media bundle and the audio-capable GGUF +
   projector path. The app sends a microphone recording through normal
   multimodal chat so the model can answer the spoken request; it remains
-  separate from typed speech-to-text and is available on Android, iOS, macOS,
-  and Windows, with Linux recording and Web excluded. llama.cpp audio input is
-  experimental, and the GGUF path does not yet have mobile device validation.
+  separate from typed speech-to-text and is code-supported on Android, iOS,
+  macOS, and Windows, with Linux recording and Web excluded. Current packaged
+  microphone validation covers LiteRT-LM on macOS; llama.cpp audio input is
+  experimental and has engine-level Metal evidence only. Android, iOS, and
+  Windows device validation remains outstanding.
 
 * Added experimental, opt-in native llama.cpp DSpark speculative decoding
   through `SpeculativeDecodingConfig.draftDspark(...)`, including exact

--- a/analysis_options.yaml
+++ b/analysis_options.yaml
@@ -3,6 +3,13 @@ include: package:lints/recommended.yaml
 analyzer:
   exclude:
     - packages/**
+    - build/**
+    - android/**
+    - ios/**
+    - web/**
+    - windows/**
+    - macos/**
+    - linux/**
 
 linter:
   rules:

--- a/doc/litert_lm_templates.md
+++ b/doc/litert_lm_templates.md
@@ -107,23 +107,24 @@ dart run tool/litert_lm_chat_features_smoke.dart \
 dart run tool/litert_lm_chat_features_smoke.dart \
   /path/to/gemma-4-E2B-it.litertlm gpu
 
-LITERT_LM_AUDIO_PATH=/path/to/known-question.wav \
-LITERT_LM_AUDIO_EXPECTED_TEXT=4 \
 dart run tool/testing/run_local_e2e.dart --scenario \
   litert-lm-chat-features-smoke \
   --model-path /path/to/gemma-4-E2B-it.litertlm \
-  --backend gpu
+  --backend gpu \
+  --audio-path /path/to/known-question.wav \
+  --expect 4
 ```
 
 The optional audio variant reads the encoded file into bytes, asks the model
 to answer the spoken question rather than transcribe it, and requires the
-normalized final answer to match `LITERT_LM_AUDIO_EXPECTED_TEXT`. The local E2E
-runner inherits both environment variables; it does not include the audio path
-or raw audio bytes in result metadata. For the verified Gemma 4 E2B bundle,
-`--backend gpu` or `--backend npu` selects the text executor (and GPU vision
-where applicable); its bundle-constrained audio executor still runs on CPU.
-LiteRT-LM supports independent executor selection, so this is the current
-bundle compatibility policy rather than a universal CPU-audio limitation.
+normalized final answer to match `--expect`. The local E2E runner forwards the
+shared audio flags without including the audio path or raw bytes in result
+metadata; results include the encoded byte length and a stable SHA-256 fixture
+ID. Native audio preprocessing first uses the selected executor, then retries
+on CPU if that executor is incompatible and remembers the working choice for
+the loaded model. With the verified Gemma 4 E2B bundle, `--backend gpu` resolves
+to GPU text/vision and CPU audio. That transparent fallback is bundle/runtime
+compatibility behavior, not a universal LiteRT-LM CPU-audio limitation.
 
 The smoke scripts are not a universal model certification suite. Passing them
 means the representative Qwen/Gemma chat-template family can load on the chosen

--- a/doc/litert_lm_templates.md
+++ b/doc/litert_lm_templates.md
@@ -106,7 +106,24 @@ dart run tool/litert_lm_chat_features_smoke.dart \
 
 dart run tool/litert_lm_chat_features_smoke.dart \
   /path/to/gemma-4-E2B-it.litertlm gpu
+
+LITERT_LM_AUDIO_PATH=/path/to/known-question.wav \
+LITERT_LM_AUDIO_EXPECTED_TEXT=4 \
+dart run tool/testing/run_local_e2e.dart --scenario \
+  litert-lm-chat-features-smoke \
+  --model-path /path/to/gemma-4-E2B-it.litertlm \
+  --backend gpu
 ```
+
+The optional audio variant reads the encoded file into bytes, asks the model
+to answer the spoken question rather than transcribe it, and requires the
+normalized final answer to match `LITERT_LM_AUDIO_EXPECTED_TEXT`. The local E2E
+runner inherits both environment variables; it does not include the audio path
+or raw audio bytes in result metadata. For the verified Gemma 4 E2B bundle,
+`--backend gpu` or `--backend npu` selects the text executor (and GPU vision
+where applicable); its bundle-constrained audio executor still runs on CPU.
+LiteRT-LM supports independent executor selection, so this is the current
+bundle compatibility policy rather than a universal CPU-audio limitation.
 
 The smoke scripts are not a universal model certification suite. Passing them
 means the representative Qwen/Gemma chat-template family can load on the chosen

--- a/doc/testing_matrix.md
+++ b/doc/testing_matrix.md
@@ -74,6 +74,7 @@ Pick targeted rows based on the touched surface:
 | Chat app model cache/download/projector | `chat-app-device-cache` |
 | Speech-to-text API or adapter | `speech-to-text-smoke` |
 | Chat-app microphone transcription flow | `chat-app-microphone-transcription-smoke` |
+| Chat-app Ask with voice | `gguf-chat-features-smoke`, `litert-lm-chat-features-smoke`, `chat-app-voice-question-smoke` |
 | Example app, CLI, or server package | `examples-tests` |
 
 The required `Web Chat Contract` check runs the chat app tests on VM and
@@ -92,8 +93,8 @@ The matrix is designed to cover these essential axes:
 | llama.cpp WebGPU GGUF | `web-bridge-smoke`, `web-mock-chat-smoke`, `web-real-model-smoke`, `webgpu-multimodal-regression`, `gemma4-webgpu-mem64` |
 | LiteRT-LM native `.litertlm` | `litert-lm-engine-smoke`, `litert-lm-chat-features-smoke`, `native-hook-bundles` |
 | LiteRT-LM web `.litertlm` | `gemma4-litert-web` |
-| Model families | Qwen 2.5 prompt reuse, Qwen 3/3.5 chat/multimodal, Gemma 4 tool/thinking/mem64/LiteRT-LM |
-| Feature paths | load/generate, prompt reuse, chat templates, streaming, tool calls, thinking, multimodal, model cache, native hook packaging |
+| Model families | Qwen 2.5 prompt reuse, Qwen 3/3.5 chat/multimodal, Gemma 4 tool/thinking/mem64/LiteRT-LM/audio |
+| Feature paths | load/generate, prompt reuse, chat templates, streaming, tool calls, thinking, multimodal image/audio, model cache, native hook packaging |
 | Platforms | See `dart run tool/testing/test_matrix.dart --tier platform`; each supported family/architecture is marked as CI, local, manual/device, or hook-only. |
 
 ## Platform Rows
@@ -155,6 +156,13 @@ dart run tool/testing/run_local_e2e.dart --scenario gguf-chat-features-smoke \
   --mmproj-path models/Qwen3.5-0.8B-mmproj-F16.gguf \
   --image-path test/fixtures/image.png
 
+dart run tool/testing/run_local_e2e.dart --scenario gguf-chat-features-smoke \
+  --model-path /path/to/gemma-4-E2B-it-Q4_K_S.gguf \
+  --backend metal \
+  --mmproj-path /path/to/gemma-4-E2B-it-mmproj-F16.gguf \
+  --audio-path /path/to/known-question.wav \
+  --expect 4
+
 LITERT_LM_AUDIO_PATH=/path/to/known-question.wav \
 LITERT_LM_AUDIO_EXPECTED_TEXT=4 \
 dart run tool/testing/run_local_e2e.dart --scenario litert-lm-chat-features-smoke \
@@ -190,6 +198,12 @@ dart run tool/testing/run_local_e2e.dart \
   --benchmark-warmups 1 \
   --ngram-cache-build-static-path /tmp/llamadart-ngram-cache.bin
 ```
+
+Supplying `--audio-path` selects the GGUF smoke's audio-only variant after
+model and projector initialization. It validates byte-backed audio question
+answering against `--expect`; run the no-audio invocation separately for the
+chat, tool-call, thinking, and optional image checks. The JSON result reports
+the encoded byte length but not the fixture path.
 
 In the local E2E scenario, external draft-model strategies require
 `--draft-model-path`; select `draft-dspark` to validate DSpark against the same
@@ -237,7 +251,8 @@ Example filled row:
 
 | Matrix row | Scope covered | Platform / model / backend | Result | Evidence / notes |
 | --- | --- | --- | --- | --- |
-| `gguf-chat-features-smoke` | real GGUF chat/tool/thinking/multimodal smoke | macOS arm64, Qwen3.5-0.8B-Q4_K_M.gguf, llama.cpp auto/cpu | PASS | `RESULT gguf_chat_features ...`, no thinking marker leak, one `get_weather` tool call, optional image output |
+| `gguf-chat-features-smoke` | base GGUF chat/tool/thinking | macOS arm64, Qwen3.5-0.8B-Q4_K_M.gguf, llama.cpp auto/cpu | PASS | Base `RESULT gguf_chat_features ...`, no thinking marker leak, and one `get_weather` tool call. |
+| `gguf-chat-features-smoke` | separate byte-backed audio-answer variant | macOS arm64, Gemma 4 E2B GGUF + projector, llama.cpp Metal | PASS | Audio-only result with `variant: audioAnswer` and exact expected text. Experimental audio result is not mobile validation. |
 
 ## Agentic Workflow
 

--- a/doc/testing_matrix.md
+++ b/doc/testing_matrix.md
@@ -155,6 +155,8 @@ dart run tool/testing/run_local_e2e.dart --scenario gguf-chat-features-smoke \
   --mmproj-path models/Qwen3.5-0.8B-mmproj-F16.gguf \
   --image-path test/fixtures/image.png
 
+LITERT_LM_AUDIO_PATH=/path/to/known-question.wav \
+LITERT_LM_AUDIO_EXPECTED_TEXT=4 \
 dart run tool/testing/run_local_e2e.dart --scenario litert-lm-chat-features-smoke \
   --model-path /path/to/gemma-4-E2B-it.litertlm \
   --backend auto

--- a/doc/testing_matrix.md
+++ b/doc/testing_matrix.md
@@ -74,7 +74,7 @@ Pick targeted rows based on the touched surface:
 | Chat app model cache/download/projector | `chat-app-device-cache` |
 | Speech-to-text API or adapter | `speech-to-text-smoke` |
 | Chat-app microphone transcription flow | `chat-app-microphone-transcription-smoke` |
-| Chat-app Ask with voice | `gguf-chat-features-smoke`, `litert-lm-chat-features-smoke`, `chat-app-voice-question-smoke` |
+| Chat-app Ask with voice | `gguf-audio-chat-smoke`, `litert-lm-chat-features-smoke`, `chat-app-voice-question-smoke` |
 | Example app, CLI, or server package | `examples-tests` |
 
 The required `Web Chat Contract` check runs the chat app tests on VM and
@@ -89,7 +89,7 @@ The matrix is designed to cover these essential axes:
 
 | Axis | Covered by |
 | --- | --- |
-| llama.cpp native GGUF | `root-vm`, `native-prompt-reuse-parity`, `native-inference-benchmark`, `gguf-chat-features-smoke` |
+| llama.cpp native GGUF | `root-vm`, `native-prompt-reuse-parity`, `native-inference-benchmark`, `gguf-chat-features-smoke`, `gguf-audio-chat-smoke` |
 | llama.cpp WebGPU GGUF | `web-bridge-smoke`, `web-mock-chat-smoke`, `web-real-model-smoke`, `webgpu-multimodal-regression`, `gemma4-webgpu-mem64` |
 | LiteRT-LM native `.litertlm` | `litert-lm-engine-smoke`, `litert-lm-chat-features-smoke`, `native-hook-bundles` |
 | LiteRT-LM web `.litertlm` | `gemma4-litert-web` |
@@ -156,18 +156,18 @@ dart run tool/testing/run_local_e2e.dart --scenario gguf-chat-features-smoke \
   --mmproj-path models/Qwen3.5-0.8B-mmproj-F16.gguf \
   --image-path test/fixtures/image.png
 
-dart run tool/testing/run_local_e2e.dart --scenario gguf-chat-features-smoke \
+dart run tool/testing/run_local_e2e.dart --scenario gguf-audio-chat-smoke \
   --model-path /path/to/gemma-4-E2B-it-Q4_K_S.gguf \
   --backend metal \
   --mmproj-path /path/to/gemma-4-E2B-it-mmproj-F16.gguf \
   --audio-path /path/to/known-question.wav \
   --expect 4
 
-LITERT_LM_AUDIO_PATH=/path/to/known-question.wav \
-LITERT_LM_AUDIO_EXPECTED_TEXT=4 \
 dart run tool/testing/run_local_e2e.dart --scenario litert-lm-chat-features-smoke \
   --model-path /path/to/gemma-4-E2B-it.litertlm \
-  --backend auto
+  --backend auto \
+  --audio-path /path/to/known-question.wav \
+  --expect 4
 
 dart run tool/testing/run_local_e2e.dart --scenario speech-to-text-smoke \
   --model-path /path/to/Qwen3-ASR-0.6B-Q8_0.gguf \
@@ -199,11 +199,12 @@ dart run tool/testing/run_local_e2e.dart \
   --ngram-cache-build-static-path /tmp/llamadart-ngram-cache.bin
 ```
 
-Supplying `--audio-path` selects the GGUF smoke's audio-only variant after
-model and projector initialization. It validates byte-backed audio question
-answering against `--expect`; run the no-audio invocation separately for the
-chat, tool-call, thinking, and optional image checks. The JSON result reports
-the encoded byte length but not the fixture path.
+The dedicated `gguf-audio-chat-smoke` scenario validates byte-backed audio
+question answering against `--expect` after model and projector initialization.
+Run `gguf-chat-features-smoke` separately for chat, tool-call, thinking, and
+optional image checks. Both GGUF and LiteRT-LM audio results report the encoded
+byte length and a stable SHA-256 fixture ID, but not the fixture path or raw
+audio bytes.
 
 In the local E2E scenario, external draft-model strategies require
 `--draft-model-path`; select `draft-dspark` to validate DSpark against the same
@@ -252,7 +253,7 @@ Example filled row:
 | Matrix row | Scope covered | Platform / model / backend | Result | Evidence / notes |
 | --- | --- | --- | --- | --- |
 | `gguf-chat-features-smoke` | base GGUF chat/tool/thinking | macOS arm64, Qwen3.5-0.8B-Q4_K_M.gguf, llama.cpp auto/cpu | PASS | Base `RESULT gguf_chat_features ...`, no thinking marker leak, and one `get_weather` tool call. |
-| `gguf-chat-features-smoke` | separate byte-backed audio-answer variant | macOS arm64, Gemma 4 E2B GGUF + projector, llama.cpp Metal | PASS | Audio-only result with `variant: audioAnswer` and exact expected text. Experimental audio result is not mobile validation. |
+| `gguf-audio-chat-smoke` | byte-backed exact audio answer | macOS arm64, Gemma 4 E2B GGUF + projector, llama.cpp Metal | PASS | Audio-only result with `variant: audioAnswer`, exact expected text, and fixture SHA-256. Experimental engine evidence is not microphone UI or mobile validation. |
 
 ## Agentic Workflow
 

--- a/doc/testing_matrix.md
+++ b/doc/testing_matrix.md
@@ -72,7 +72,8 @@ Pick targeted rows based on the touched surface:
 | Large WebGPU GGUF / wasm64 selection | `gemma4-webgpu-mem64` |
 | LiteRT-LM web / Gemma 4 web bundle | `gemma4-litert-web` |
 | Chat app model cache/download/projector | `chat-app-device-cache` |
-| Speech-to-text API, adapter, or chat flow | `speech-to-text-smoke` |
+| Speech-to-text API or adapter | `speech-to-text-smoke` |
+| Chat-app microphone transcription flow | `chat-app-microphone-transcription-smoke` |
 | Example app, CLI, or server package | `examples-tests` |
 
 The required `Web Chat Contract` check runs the chat app tests on VM and

--- a/example/basic_app/analysis_options.yaml
+++ b/example/basic_app/analysis_options.yaml
@@ -1,1 +1,11 @@
 include: package:lints/recommended.yaml
+
+analyzer:
+  exclude:
+    - build/**
+    - android/**
+    - ios/**
+    - web/**
+    - windows/**
+    - macos/**
+    - linux/**

--- a/example/chat_app/README.md
+++ b/example/chat_app/README.md
@@ -114,20 +114,21 @@ flutter test --run-skipped -t local-only \
    - The complete Qwen3-ASR model/projector, microphone, and final-transcript
      flow has passed on a physical Pixel using CPU inference and in the iOS
      Simulator. This is not yet physical-iPhone or Windows validation.
-   - The native Gemma 4 E2B LiteRT-LM preset exposes **Ask with voice** when its
-     selected platform profile declares direct audio input. It records for at
-     most 30 seconds;
-     **Stop & ask** sends the encoded WAV bytes through normal multimodal chat
-     and asks the model to answer the spoken request. This is not
+   - The native Gemma 4 E2B presets expose **Ask with voice** when either the
+     LiteRT-LM platform profile declares direct audio input or the matching
+     GGUF projector is loaded and reports audio support. It records for at most
+     30 seconds; **Stop & ask** sends the encoded WAV bytes through normal
+     multimodal chat and asks the model to answer the spoken request. This is not
      `SpeechToTextEngine`: it has no transcript, timestamp, confidence, or live
      partial-text contract. Qwen3-ASR continues to use the separate five-minute
      **Stop & transcribe** flow, and takes precedence for models declared as
      ASR profiles.
    - The voice-question UI is code-supported on Android, iOS, macOS, and
-     Windows when the native direct-media bundle and microphone recorder are
-     available. Linux recording and Web are excluded. Automated tests cover
-     capability gating and lifecycle behavior, but each native platform still
-     requires real-model/device evidence before being described as validated.
+     Windows when a native direct-media bundle or audio-capable projector and
+     microphone recorder are available. Linux recording and Web are excluded.
+     Automated tests cover capability gating and lifecycle behavior, but each
+     native platform still requires real-model/device evidence before being
+     described as validated.
      See the `chat-app-voice-question-smoke` row in
      `tool/testing/test_matrix.dart`.
    - After **Stop & ask**, the app makes a best-effort attempt to delete the
@@ -139,11 +140,14 @@ flutter test --run-skipped -t local-only \
      runs text (and vision, when used), while its bundle-constrained audio
      executor runs on CPU. This is not a claim that LiteRT-LM audio is
      universally CPU-only.
-   - Gemma 4 E2B is included as a GGUF + `mmproj` bundle. In the current
-     native `llama.cpp` mtmd path used here, that projector exposes image,
-     audio, and video input. Audio remains experimental upstream; start with
-     short mono clips for the most reliable results. Web keeps audio
-     runtime-gated until the loaded bridge reports support.
+   - Gemma 4 E2B is included as a GGUF + `mmproj` bundle. In the current native
+     `llama.cpp` mtmd path used here, that projector exposes image, audio, and
+     video input, so it uses the same **Ask with voice** interaction. Audio
+     remains experimental upstream; start with short mono clips for the most
+     reliable results. The GGUF audio-answer path has current engine-level
+     real-model evidence on macOS; microphone UI/device validation on Android
+     and iOS remains outstanding. Web keeps audio runtime-gated until the
+     loaded bridge reports support.
    - LiteRT-LM `.litertlm` presets, when present, use the same model library
      flow. The example `pubspec.yaml` enables the `litert_lm` native runtime
      family for supported native targets, while Web builds load web-compatible

--- a/example/chat_app/README.md
+++ b/example/chat_app/README.md
@@ -14,6 +14,9 @@ A Flutter chat application demonstrating real-world usage of llamadart with UI.
 - 🎙️ **Whole-file transcription**: Compatible native GGUF ASR models can
   transcribe a selected file or capture a foreground microphone recording,
   then transcribe it after **Stop & transcribe**.
+- 🗣️ **Ask with voice**: Compatible native direct-media models can receive a
+  short microphone recording as ordinary multimodal chat and answer the spoken
+  request after **Stop & ask**.
 - 📱 Material Design 3 UI
 - ⚙️ Model configuration (path, runtime-detected backend selection, GPU layers, context size)
 - 🧩 Capability badges per model (Tools / Thinking / Vision / Audio / Video)
@@ -111,6 +114,31 @@ flutter test --run-skipped -t local-only \
    - The complete Qwen3-ASR model/projector, microphone, and final-transcript
      flow has passed on a physical Pixel using CPU inference and in the iOS
      Simulator. This is not yet physical-iPhone or Windows validation.
+   - The native Gemma 4 E2B LiteRT-LM preset exposes **Ask with voice** when its
+     selected platform profile declares direct audio input. It records for at
+     most 30 seconds;
+     **Stop & ask** sends the encoded WAV bytes through normal multimodal chat
+     and asks the model to answer the spoken request. This is not
+     `SpeechToTextEngine`: it has no transcript, timestamp, confidence, or live
+     partial-text contract. Qwen3-ASR continues to use the separate five-minute
+     **Stop & transcribe** flow, and takes precedence for models declared as
+     ASR profiles.
+   - The voice-question UI is code-supported on Android, iOS, macOS, and
+     Windows when the native direct-media bundle and microphone recorder are
+     available. Linux recording and Web are excluded. Automated tests cover
+     capability gating and lifecycle behavior, but each native platform still
+     requires real-model/device evidence before being described as validated.
+     See the `chat-app-voice-question-smoke` row in
+     `tool/testing/test_matrix.dart`.
+   - After **Stop & ask**, the app makes a best-effort attempt to delete the
+     temporary WAV file. Its encoded bytes remain in the in-memory conversation
+     history so later turns and response regeneration can retain the audio
+     context; those turns can therefore reprocess the recording and use
+     additional memory.
+   - For the built-in Gemma 4 E2B LiteRT-LM bundle, the selected backend still
+     runs text (and vision, when used), while its bundle-constrained audio
+     executor runs on CPU. This is not a claim that LiteRT-LM audio is
+     universally CPU-only.
    - Gemma 4 E2B is included as a GGUF + `mmproj` bundle. In the current
      native `llama.cpp` mtmd path used here, that projector exposes image,
      audio, and video input. Audio remains experimental upstream; start with

--- a/example/chat_app/README.md
+++ b/example/chat_app/README.md
@@ -71,8 +71,9 @@ flutter test --run-skipped -t local-only \
 2. Select one of the focused pre-configured models:
    - Cross-platform: FunctionGemma 270M, Qwen3.5 0.8B, Gemma 4 E2B
      GGUF, Gemma 4 E2B LiteRT-LM, and Gemma 4 E4B GGUF.
-   - Native desktop: Qwen3-ASR 0.6B, Gemma 4 12B, Gemma 4 26B A4B,
-     Gemma 4 31B, and Qwen3.6 35B A3B.
+   - Native mobile and desktop: Qwen3-ASR 0.6B.
+   - Native desktop: Gemma 4 12B, Gemma 4 26B A4B, Gemma 4 31B, and
+     Qwen3.6 35B A3B.
    - Built-in GGUF chat presets use [Unsloth distributions](https://huggingface.co/unsloth).
      The ASR preset uses llama.cpp's `ggml-org` Qwen3-ASR pair, and the
      LiteRT-LM preset uses `litert-community`; every card identifies its source.
@@ -91,20 +92,25 @@ flutter test --run-skipped -t local-only \
      a separate action, with an explicit combined option in the confirmation.
 3. Tap the **Download** icon. The app uses `Dio` to download the model directly to your device's app-specific cache directory. Additional model downloads enter a FIFO queue and start one at a time. A persistent progress pill remains in the app header when settings is closed; tap it to reopen download details.
 4. Once downloaded, tap **Select** to load the model.
-   - The native-desktop Qwen3-ASR preset exposes **Attach Audio** and
-     **Transcribe Audio**. On macOS and Windows it also shows a microphone
-     button; compatible custom mobile ASR configurations can use the same
-     control. File transcription accepts WAV, MP3, or FLAC. The microphone
-     records a temporary mono WAV for up to five minutes; **Stop & transcribe**
-     finalizes it, runs whole-file STT, and deletes it.
+   - The native Qwen3-ASR preset exposes **Attach Audio** and **Transcribe
+     Audio** on mobile and desktop builds. On Android, iOS, macOS, and Windows
+     it also shows a microphone button. File transcription accepts WAV, MP3,
+     or FLAC. The microphone records a temporary mono WAV for up to five
+     minutes; **Stop & transcribe** finalizes it, runs whole-file STT, and
+     deletes it.
      Capture is foreground-only and cancelling discards the temporary file.
      Live partial transcription, Web, LiteRT-LM STT, and TTS are not enabled
-     yet. All STT actions require the matching projector, and the preset's
-     pinned downloads are SHA-256 verified.
+     yet. Web support is tracked in
+     [issue #329](https://github.com/leehack/llamadart/issues/329). All STT
+     actions require the matching projector, and the preset's pinned downloads
+     are SHA-256 verified.
    - Microphone capture is enabled on Android, iOS, macOS, and Windows when a
      compatible ASR model is active. It remains hidden on Linux because the
      recorder plugin can report startup before its required external tools are
      ready; selected-file transcription still works there.
+   - The complete Qwen3-ASR model/projector, microphone, and final-transcript
+     flow has passed on a physical Pixel using CPU inference and in the iOS
+     Simulator. This is not yet physical-iPhone or Windows validation.
    - Gemma 4 E2B is included as a GGUF + `mmproj` bundle. In the current
      native `llama.cpp` mtmd path used here, that projector exposes image,
      audio, and video input. Audio remains experimental upstream; start with

--- a/example/chat_app/README.md
+++ b/example/chat_app/README.md
@@ -14,9 +14,9 @@ A Flutter chat application demonstrating real-world usage of llamadart with UI.
 - 🎙️ **Whole-file transcription**: Compatible native GGUF ASR models can
   transcribe a selected file or capture a foreground microphone recording,
   then transcribe it after **Stop & transcribe**.
-- 🗣️ **Ask with voice**: Compatible native direct-media models can receive a
-  short microphone recording as ordinary multimodal chat and answer the spoken
-  request after **Stop & ask**.
+- 🗣️ **Ask with voice**: Compatible native direct-media models or GGUF models
+  with an audio-capable projector can receive a short microphone recording as
+  ordinary multimodal chat and answer the request after **Stop & ask**.
 - 📱 Material Design 3 UI
 - ⚙️ Model configuration (path, runtime-detected backend selection, GPU layers, context size)
 - 🧩 Capability badges per model (Tools / Thinking / Vision / Audio / Video)
@@ -126,9 +126,10 @@ flutter test --run-skipped -t local-only \
    - The voice-question UI is code-supported on Android, iOS, macOS, and
      Windows when a native direct-media bundle or audio-capable projector and
      microphone recorder are available. Linux recording and Web are excluded.
-     Automated tests cover capability gating and lifecycle behavior, but each
-     native platform still requires real-model/device evidence before being
-     described as validated.
+     Automated tests cover capability gating and lifecycle behavior. Current
+     packaged microphone UI evidence is LiteRT-LM on macOS; the GGUF path has
+     engine-level Metal evidence only. Android, iOS, and Windows still require
+     real-model/device evidence before being described as validated.
      See the `chat-app-voice-question-smoke` row in
      `tool/testing/test_matrix.dart`.
    - After **Stop & ask**, the app makes a best-effort attempt to delete the
@@ -136,18 +137,19 @@ flutter test --run-skipped -t local-only \
      history so later turns and response regeneration can retain the audio
      context; those turns can therefore reprocess the recording and use
      additional memory.
-   - For the built-in Gemma 4 E2B LiteRT-LM bundle, the selected backend still
-     runs text (and vision, when used), while its bundle-constrained audio
-     executor runs on CPU. This is not a claim that LiteRT-LM audio is
-     universally CPU-only.
+   - LiteRT-LM first initializes audio preprocessing on the selected backend,
+     then transparently retries CPU if that executor is incompatible and
+     remembers the working choice for the loaded model. For the validated
+     Gemma 4 E2B bundle, GPU text/vision with CPU audio is the resolved path;
+     this is not a universal LiteRT-LM CPU-audio limitation.
    - Gemma 4 E2B is included as a GGUF + `mmproj` bundle. In the current native
      `llama.cpp` mtmd path used here, that projector exposes image, audio, and
      video input, so it uses the same **Ask with voice** interaction. Audio
      remains experimental upstream; start with short mono clips for the most
      reliable results. The GGUF audio-answer path has current engine-level
-     real-model evidence on macOS; microphone UI/device validation on Android
-     and iOS remains outstanding. Web keeps audio runtime-gated until the
-     loaded bridge reports support.
+     real-model evidence on macOS; microphone UI/device validation on Android,
+     iOS, and Windows remains outstanding. Web keeps audio runtime-gated until
+     the loaded bridge reports support.
    - LiteRT-LM `.litertlm` presets, when present, use the same model library
      flow. The example `pubspec.yaml` enables the `litert_lm` native runtime
      family for supported native targets, while Web builds load web-compatible

--- a/example/chat_app/README.md
+++ b/example/chat_app/README.md
@@ -11,8 +11,9 @@ A Flutter chat application demonstrating real-world usage of llamadart with UI.
 - 📋 **Clipboard attachments**: Paste screenshots or copied image/audio files
   with `Cmd/Ctrl+V`, or use **Paste attachment** from the attachment menu on
   touch devices. Plain-text paste continues to work normally.
-- 🎙️ **Whole-file transcription**: Compatible native GGUF ASR models expose a
-  separate **Transcribe Audio** action backed by `SpeechToTextEngine`.
+- 🎙️ **Whole-file transcription**: Compatible native GGUF ASR models can
+  transcribe a selected file or capture a foreground microphone recording,
+  then transcribe it after **Stop & transcribe**.
 - 📱 Material Design 3 UI
 - ⚙️ Model configuration (path, runtime-detected backend selection, GPU layers, context size)
 - 🧩 Capability badges per model (Tools / Thinking / Vision / Audio / Video)
@@ -90,10 +91,20 @@ flutter test --run-skipped -t local-only \
      a separate action, with an explicit combined option in the confirmation.
 3. Tap the **Download** icon. The app uses `Dio` to download the model directly to your device's app-specific cache directory. Additional model downloads enter a FIFO queue and start one at a time. A persistent progress pill remains in the app header when settings is closed; tap it to reopen download details.
 4. Once downloaded, tap **Select** to load the model.
-   - The native-desktop Qwen3-ASR preset exposes both **Attach Audio** and
-     **Transcribe Audio**. The latter accepts WAV, MP3, or FLAC files and
-     requires the matching projector; live microphone input, Web, LiteRT-LM
-     STT, and TTS are not enabled yet. Its pinned downloads are SHA-256 verified.
+   - The native-desktop Qwen3-ASR preset exposes **Attach Audio** and
+     **Transcribe Audio**. On macOS and Windows it also shows a microphone
+     button; compatible custom mobile ASR configurations can use the same
+     control. File transcription accepts WAV, MP3, or FLAC. The microphone
+     records a temporary mono WAV for up to five minutes; **Stop & transcribe**
+     finalizes it, runs whole-file STT, and deletes it.
+     Capture is foreground-only and cancelling discards the temporary file.
+     Live partial transcription, Web, LiteRT-LM STT, and TTS are not enabled
+     yet. All STT actions require the matching projector, and the preset's
+     pinned downloads are SHA-256 verified.
+   - Microphone capture is enabled on Android, iOS, macOS, and Windows when a
+     compatible ASR model is active. It remains hidden on Linux because the
+     recorder plugin can report startup before its required external tools are
+     ready; selected-file transcription still works there.
    - Gemma 4 E2B is included as a GGUF + `mmproj` bundle. In the current
      native `llama.cpp` mtmd path used here, that projector exposes image,
      audio, and video input. Audio remains experimental upstream; start with

--- a/example/chat_app/analysis_options.yaml
+++ b/example/chat_app/analysis_options.yaml
@@ -1,1 +1,11 @@
 include: package:flutter_lints/flutter.yaml
+
+analyzer:
+  exclude:
+    - build/**
+    - android/**
+    - ios/**
+    - web/**
+    - windows/**
+    - macos/**
+    - linux/**

--- a/example/chat_app/android/app/src/main/AndroidManifest.xml
+++ b/example/chat_app/android/app/src/main/AndroidManifest.xml
@@ -1,5 +1,6 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android">
     <uses-permission android:name="android.permission.INTERNET"/>
+    <uses-permission android:name="android.permission.RECORD_AUDIO"/>
 
     <application
         android:label="llamadart_chat_example"

--- a/example/chat_app/integration_test/model_cache_mmproj_e2e_test.dart
+++ b/example/chat_app/integration_test/model_cache_mmproj_e2e_test.dart
@@ -27,89 +27,87 @@ import 'package:llamadart_chat_example/services/model_service_base.dart';
 void main() {
   IntegrationTestWidgetsFlutterBinding.ensureInitialized();
 
-  testWidgets(
-    'downloads, caches, and loads tiny multimodal model + mmproj',
-    (tester) async {
-      final model = DownloadableModel.defaultModels.firstWhere(
-        (candidate) => candidate.name == 'LFM2-VL 450M',
-      );
-      expect(model.multimodalProjectorSource, isNotNull);
+  testWidgets('downloads, caches, and loads tiny multimodal model + mmproj', (
+    tester,
+  ) async {
+    final model = DownloadableModel.defaultModels.firstWhere(
+      (candidate) => candidate.name == 'LFM2-VL 450M',
+    );
+    expect(model.multimodalProjectorSource, isNotNull);
 
-      final service = ModelService();
-      final modelsDir = await service.getModelsDirectory();
+    final service = ModelService();
+    final modelsDir = await service.getModelsDirectory();
 
-      await service.deleteModel(modelsDir, model);
-      var downloaded = await service.getDownloadedModels([model]);
-      expect(downloaded.contains(model.filename), isFalse);
+    await service.deleteModel(modelsDir, model);
+    var downloaded = await service.getDownloadedModels([model]);
+    expect(downloaded.contains(model.filename), isFalse);
 
-      final stages = <ModelDownloadStage>{};
-      final progressEvents = <ModelDownloadProgress>[];
-      Object? downloadError;
-      String? successFilename;
+    final stages = <ModelDownloadStage>{};
+    final progressEvents = <ModelDownloadProgress>[];
+    Object? downloadError;
+    String? successFilename;
 
-      await service.downloadModel(
-        model: model,
-        modelsDir: modelsDir,
-        cancelToken: CancelToken(),
-        onProgress: (_) {},
-        onProgressDetail: (detail) {
-          stages.add(detail.stage);
-          progressEvents.add(detail);
-          debugPrint(
-            'E2E download ${detail.stage.name} '
-            '${(detail.overallProgress * 100).toStringAsFixed(1)}% '
-            '${detail.stageDownloadedBytes}/${detail.stageTotalBytes ?? -1}',
-          );
-        },
-        onSuccess: (filename) {
-          successFilename = filename;
-        },
-        onError: (error) {
-          downloadError = error;
-        },
-      );
-
-      expect(downloadError, isNull);
-      expect(successFilename, model.filename);
-      expect(stages, contains(ModelDownloadStage.model));
-      expect(stages, contains(ModelDownloadStage.multimodalProjector));
-      expect(progressEvents.last.overallProgress, 1.0);
-
-      downloaded = await service.getDownloadedModels([model]);
-      expect(downloaded, contains(model.filename));
-
-      final modelSource = model.modelSource;
-      final mmprojSource = model.multimodalProjectorSource!;
-      final modelLoadRef = kIsWeb || modelSource is LocalModelAssetSource
-          ? modelSource.loadReference
-          : p.join(modelsDir, model.filename);
-      final mmprojLoadRef = kIsWeb || mmprojSource is LocalModelAssetSource
-          ? mmprojSource.loadReference
-          : p.join(modelsDir, mmprojSource.displayName);
-
-      final chatService = ChatService();
-      try {
-        await chatService.init(
-          ChatSettings(
-            modelPath: modelLoadRef,
-            mmprojPath: mmprojLoadRef,
-            preferredBackend: GpuBackend.cpu,
-            gpuLayers: 0,
-            contextSize: 512,
-            maxTokens: 32,
-            nativeLogLevel: LlamaLogLevel.warn,
-          ),
-          eagerLoadMultimodalProjector: true,
-          onProgress: (progress) =>
-              debugPrint('E2E load ${(progress * 100).toStringAsFixed(1)}%'),
+    await service.downloadModel(
+      model: model,
+      modelsDir: modelsDir,
+      cancelToken: CancelToken(),
+      onProgress: (_) {},
+      onProgressDetail: (detail) {
+        stages.add(detail.stage);
+        progressEvents.add(detail);
+        debugPrint(
+          'E2E download ${detail.stage.name} '
+          '${(detail.overallProgress * 100).toStringAsFixed(1)}% '
+          '${detail.stageDownloadedBytes}/${detail.stageTotalBytes ?? -1}',
         );
+      },
+      onSuccess: (filename) {
+        successFilename = filename;
+      },
+      onError: (error) {
+        downloadError = error;
+      },
+    );
 
-        expect(chatService.engine.isReady, isTrue);
-        expect(await chatService.engine.supportsVision, isTrue);
-      } finally {
-        await chatService.dispose();
-      }
-    },
-    timeout: const Timeout(Duration(minutes: 30)),
-  );
+    expect(downloadError, isNull);
+    expect(successFilename, model.filename);
+    expect(stages, contains(ModelDownloadStage.model));
+    expect(stages, contains(ModelDownloadStage.multimodalProjector));
+    expect(progressEvents.last.overallProgress, 1.0);
+
+    downloaded = await service.getDownloadedModels([model]);
+    expect(downloaded, contains(model.filename));
+
+    final modelSource = model.modelSource;
+    final mmprojSource = model.multimodalProjectorSource!;
+    final modelLoadRef = kIsWeb || modelSource is LocalModelAssetSource
+        ? modelSource.loadReference
+        : p.join(modelsDir, model.filename);
+    final mmprojLoadRef = kIsWeb || mmprojSource is LocalModelAssetSource
+        ? mmprojSource.loadReference
+        : p.join(modelsDir, mmprojSource.displayName);
+
+    final chatService = ChatService();
+    try {
+      await chatService.init(
+        ChatSettings(
+          modelPath: modelLoadRef,
+          mmprojPath: mmprojLoadRef,
+          preferredBackend: GpuBackend.cpu,
+          gpuLayers: 0,
+          contextSize: 512,
+          maxTokens: 32,
+          nativeLogLevel: LlamaLogLevel.warn,
+        ),
+        eagerLoadMultimodalProjector: true,
+        onProgress: (progress) =>
+            debugPrint('E2E load ${(progress * 100).toStringAsFixed(1)}%'),
+      );
+
+      expect(chatService.engine.isReady, isTrue);
+      expect(await chatService.engine.supportsVision, isTrue);
+    } finally {
+      await chatService.dispose();
+    }
+  }, timeout: const Timeout(Duration(minutes: 30)));
 }

--- a/example/chat_app/ios/Runner/Info.plist
+++ b/example/chat_app/ios/Runner/Info.plist
@@ -26,6 +26,8 @@
 	<string>$(FLUTTER_BUILD_NUMBER)</string>
 	<key>LSRequiresIPhoneOS</key>
 	<true/>
+	<key>NSMicrophoneUsageDescription</key>
+	<string>Record speech locally so the selected on-device model can transcribe it.</string>
 	<key>UIApplicationSceneManifest</key>
 	<dict>
 		<key>UIApplicationSupportsMultipleScenes</key>

--- a/example/chat_app/ios/Runner/Info.plist
+++ b/example/chat_app/ios/Runner/Info.plist
@@ -27,7 +27,7 @@
 	<key>LSRequiresIPhoneOS</key>
 	<true/>
 	<key>NSMicrophoneUsageDescription</key>
-	<string>Record speech locally so the selected on-device model can transcribe it.</string>
+	<string>Record speech locally so the selected on-device model can transcribe it or answer the spoken request.</string>
 	<key>UIApplicationSceneManifest</key>
 	<dict>
 		<key>UIApplicationSupportsMultipleScenes</key>

--- a/example/chat_app/lib/main.dart
+++ b/example/chat_app/lib/main.dart
@@ -35,6 +35,12 @@ class _MyAppState extends State<MyApp> {
   void initState() {
     super.initState();
     _listener = AppLifecycleListener(
+      onHide: () {
+        unawaited(_chatProvider.cancelAudioRecording());
+      },
+      onPause: () {
+        unawaited(_chatProvider.cancelAudioRecording());
+      },
       onDetach: () {
         unawaited(_chatProvider.shutdown());
       },

--- a/example/chat_app/lib/models/downloadable_model.dart
+++ b/example/chat_app/lib/models/downloadable_model.dart
@@ -507,16 +507,21 @@ class DownloadableModel {
         thinkingEnabled: false,
       ),
     ),
-    DownloadableModel(
+    DownloadableModel.fromSources(
       name: 'Gemma 4 E2B LiteRT-LM',
       description:
           'Optimized LiteRT-LM variant with native audio and text-only Web support.',
-      url:
-          'https://huggingface.co/litert-community/gemma-4-E2B-it-litert-lm/resolve/main/gemma-4-E2B-it.litertlm?download=true',
-      filename: 'gemma-4-E2B-it.litertlm',
+      modelSource: const RemoteModelAssetSource(
+        url:
+            'https://huggingface.co/litert-community/gemma-4-E2B-it-litert-lm/resolve/6b78abd019e61a1ca4cbe3b212d2c9ce8ff38a94/gemma-4-E2B-it.litertlm?download=true',
+        filename: 'gemma-4-E2B-it.litertlm',
+        sizeBytes: 2588147712,
+        sha256:
+            '181938105e0eefd105961417e8da75903eacda102c4fce9ce90f50b97139a63c',
+      ),
       sizeBytes: 2588147712,
       webSizeBytes: 2008432640,
-      webModelSource: RemoteModelAssetSource(
+      webModelSource: const RemoteModelAssetSource(
         url:
             'https://huggingface.co/litert-community/gemma-4-E2B-it-litert-lm/resolve/main/gemma-4-E2B-it-web.litertlm?download=true',
         filename: 'gemma-4-E2B-it-web.litertlm',

--- a/example/chat_app/lib/models/downloadable_model.dart
+++ b/example/chat_app/lib/models/downloadable_model.dart
@@ -499,17 +499,18 @@ class DownloadableModel {
             '140be8d7849741f88c50757d529b84373ee8e27052cc2236855b537f4a8215fa',
       ),
       sizeBytes: 4029586368,
-      webSizeBytes: 3043927168,
+      webSizeBytes: 4029588384,
       webModelSource: const RemoteModelAssetSource(
         url:
             'https://huggingface.co/unsloth/gemma-4-E2B-it-GGUF/resolve/main/gemma-4-E2B-it-Q4_K_S.gguf?download=true',
         filename: 'gemma-4-E2B-it-Q4_K_S.gguf',
-        sizeBytes: 3043927168,
+        sizeBytes: 3043934304,
       ),
       webMultimodalProjectorSource: const RemoteModelAssetSource(
         url:
             'https://huggingface.co/unsloth/gemma-4-E2B-it-GGUF/resolve/main/mmproj-F16.gguf?download=true',
         filename: 'gemma-4-E2B-it-mmproj-F16.gguf',
+        sizeBytes: 985654080,
       ),
       distribution: 'Unsloth',
       minRamGb: 8,

--- a/example/chat_app/lib/models/downloadable_model.dart
+++ b/example/chat_app/lib/models/downloadable_model.dart
@@ -23,7 +23,7 @@ enum ModelAssetRole { model, multimodalProjector }
 
 enum ModelMediaInputMode { externalProjector, direct, none }
 
-enum ModelAvailability { all, nativeDesktop }
+enum ModelAvailability { all, native, nativeDesktop }
 
 abstract class ModelAssetSource {
   const ModelAssetSource();
@@ -386,8 +386,14 @@ class DownloadableModel {
   bool get isNativeDesktopOnly =>
       availability == ModelAvailability.nativeDesktop;
 
+  bool get isNativeOnly => availability == ModelAvailability.native;
+
   bool isAvailableFor({required bool web, required bool mobile}) =>
-      availability == ModelAvailability.all || (!web && !mobile);
+      switch (availability) {
+        ModelAvailability.all => true,
+        ModelAvailability.native => !web,
+        ModelAvailability.nativeDesktop => !web && !mobile,
+      };
 
   static final List<DownloadableModel> defaultModels = List.unmodifiable([
     DownloadableModel(
@@ -460,7 +466,7 @@ class DownloadableModel {
       webSupportsAudio: false,
       webSupportsSpeechToText: false,
       distribution: 'ggml-org',
-      availability: ModelAvailability.nativeDesktop,
+      availability: ModelAvailability.native,
       minRamGb: 4,
       preset: const ModelPreset(
         temperature: 0,

--- a/example/chat_app/lib/models/downloadable_model.dart
+++ b/example/chat_app/lib/models/downloadable_model.dart
@@ -478,17 +478,39 @@ class DownloadableModel {
         thinkingEnabled: false,
       ),
     ),
-    DownloadableModel(
+    DownloadableModel.fromSources(
       name: 'Gemma 4 E2B it',
       description:
           'Compact multimodal assistant for image, audio, and video input.',
-      url:
-          'https://huggingface.co/unsloth/gemma-4-E2B-it-GGUF/resolve/main/gemma-4-E2B-it-Q4_K_S.gguf?download=true',
-      filename: 'gemma-4-E2B-it-Q4_K_S.gguf',
-      mmprojUrl:
-          'https://huggingface.co/unsloth/gemma-4-E2B-it-GGUF/resolve/main/mmproj-F16.gguf?download=true',
-      mmprojFilename: 'gemma-4-E2B-it-mmproj-F16.gguf',
-      sizeBytes: 3043927168,
+      modelSource: const RemoteModelAssetSource(
+        url:
+            'https://huggingface.co/unsloth/gemma-4-E2B-it-GGUF/resolve/90f9618340396838ee7ff5b0ba2da27da62953d3/gemma-4-E2B-it-Q4_K_S.gguf?download=true',
+        filename: 'gemma-4-E2B-it-Q4_K_S.gguf',
+        sizeBytes: 3043932288,
+        sha256:
+            '0a2fac16f388b4839f075dedb681357aec3e73a96bd66b413e462b6853550c99',
+      ),
+      multimodalProjectorSource: const RemoteModelAssetSource(
+        url:
+            'https://huggingface.co/unsloth/gemma-4-E2B-it-GGUF/resolve/90f9618340396838ee7ff5b0ba2da27da62953d3/mmproj-F16.gguf?download=true',
+        filename: 'gemma-4-E2B-it-mmproj-F16.gguf',
+        sizeBytes: 985654080,
+        sha256:
+            '140be8d7849741f88c50757d529b84373ee8e27052cc2236855b537f4a8215fa',
+      ),
+      sizeBytes: 4029586368,
+      webSizeBytes: 3043927168,
+      webModelSource: const RemoteModelAssetSource(
+        url:
+            'https://huggingface.co/unsloth/gemma-4-E2B-it-GGUF/resolve/main/gemma-4-E2B-it-Q4_K_S.gguf?download=true',
+        filename: 'gemma-4-E2B-it-Q4_K_S.gguf',
+        sizeBytes: 3043927168,
+      ),
+      webMultimodalProjectorSource: const RemoteModelAssetSource(
+        url:
+            'https://huggingface.co/unsloth/gemma-4-E2B-it-GGUF/resolve/main/mmproj-F16.gguf?download=true',
+        filename: 'gemma-4-E2B-it-mmproj-F16.gguf',
+      ),
       distribution: 'Unsloth',
       minRamGb: 8,
       supportsVision: true,

--- a/example/chat_app/lib/models/downloadable_model.dart
+++ b/example/chat_app/lib/models/downloadable_model.dart
@@ -521,7 +521,7 @@ class DownloadableModel {
       supportsToolCalling: true,
       supportsThinking: true,
       preset: ModelPreset(
-        temperature: 0.7,
+        temperature: 1.0,
         topK: 64,
         topP: 0.95,
         penalty: 1.0,
@@ -558,9 +558,10 @@ class DownloadableModel {
       webMediaInputMode: ModelMediaInputMode.none,
       supportsThinking: true,
       preset: ModelPreset(
-        temperature: 0.7,
+        temperature: 1.0,
         topK: 64,
         topP: 0.95,
+        penalty: 1.0,
         contextSize: 8192,
         maxTokens: 1024,
         thinkingEnabled: false,
@@ -586,7 +587,7 @@ class DownloadableModel {
       supportsToolCalling: true,
       supportsThinking: true,
       preset: ModelPreset(
-        temperature: 0.7,
+        temperature: 1.0,
         topK: 64,
         topP: 0.95,
         penalty: 1.0,
@@ -615,7 +616,7 @@ class DownloadableModel {
       supportsToolCalling: true,
       supportsThinking: true,
       preset: ModelPreset(
-        temperature: 0.7,
+        temperature: 1.0,
         topK: 64,
         topP: 0.95,
         penalty: 1.0,
@@ -643,7 +644,7 @@ class DownloadableModel {
       supportsToolCalling: true,
       supportsThinking: true,
       preset: ModelPreset(
-        temperature: 0.7,
+        temperature: 1.0,
         topK: 64,
         topP: 0.95,
         penalty: 1.0,
@@ -671,7 +672,7 @@ class DownloadableModel {
       supportsToolCalling: true,
       supportsThinking: true,
       preset: ModelPreset(
-        temperature: 0.7,
+        temperature: 1.0,
         topK: 64,
         topP: 0.95,
         penalty: 1.0,

--- a/example/chat_app/lib/providers/chat_provider.dart
+++ b/example/chat_app/lib/providers/chat_provider.dart
@@ -100,10 +100,9 @@ class ChatProvider extends ChangeNotifier {
   );
 
   static const String _voiceQuestionPrompt =
-      'Listen to the attached recording and answer the spoken request '
-      'directly. Do not provide a transcript or describe the audio unless the '
-      'speaker asks for that. If there is no clear spoken request, briefly ask '
-      'the user to record it again.';
+      'Listen carefully to every spoken word. Determine what the speaker is '
+      'asking, solve that request, and return only the final answer. Do not '
+      'merely repeat a word from the recording.';
   static const String _androidDebugImagePath = String.fromEnvironment(
     'LLAMADART_CHAT_APP_DEBUG_IMAGE_PATH',
     defaultValue: '',
@@ -272,10 +271,27 @@ class ChatProvider extends ChangeNotifier {
       _supportsAudio &&
       _settings.modelSupportsSpeechToText;
 
-  /// Whether the active direct-media model can answer a recorded question.
+  bool get _supportsVoiceQuestionInput {
+    if (!_settings.modelSupportsAudio || _settings.modelSupportsSpeechToText) {
+      return false;
+    }
+    if (_settings.directMediaInput) {
+      return true;
+    }
+
+    final configuredMmproj = (_settings.mmprojPath ?? '').trim();
+    final loadedMmproj = (_loadedMmprojPath ?? '').trim();
+    return configuredMmproj.isNotEmpty &&
+        _mmprojLoaded &&
+        loadedMmproj == configuredMmproj &&
+        _supportsAudio;
+  }
+
+  /// Whether the active audio-chat model can answer a recorded question.
   ///
-  /// This intentionally excludes dedicated ASR profiles. The initial product
-  /// path is native Gemma 4 through LiteRT-LM, whose Web bundle is text-only.
+  /// Direct-media models use their declared audio capability. External-media
+  /// models additionally require a configured, loaded projector and a positive
+  /// runtime audio capability probe. Dedicated ASR profiles remain separate.
   bool get canAskWithVoice =>
       !kIsWeb &&
       _isLoaded &&
@@ -284,9 +300,7 @@ class ChatProvider extends ChangeNotifier {
       !_isTranscribing &&
       !hasActiveAudioRecording &&
       _supportsAudio &&
-      _settings.modelSupportsAudio &&
-      _settings.directMediaInput &&
-      !_settings.modelSupportsSpeechToText;
+      _supportsVoiceQuestionInput;
 
   /// Whether the selected model/platform exposes a microphone action.
   ///
@@ -295,10 +309,7 @@ class ChatProvider extends ChangeNotifier {
   bool get supportsMicrophoneRecording =>
       !kIsWeb &&
       _audioRecordingService.isSupported &&
-      (_settings.modelSupportsSpeechToText ||
-          (_settings.modelSupportsAudio &&
-              _settings.directMediaInput &&
-              !_settings.modelSupportsSpeechToText));
+      (_settings.modelSupportsSpeechToText || _supportsVoiceQuestionInput);
 
   /// Whether the active model can start a supported microphone workflow.
   bool get canStartAudioRecording =>

--- a/example/chat_app/lib/providers/chat_provider.dart
+++ b/example/chat_app/lib/providers/chat_provider.dart
@@ -7,6 +7,7 @@ import 'package:dio/dio.dart';
 import 'package:file_picker/file_picker.dart';
 import 'package:flutter/foundation.dart';
 import 'package:llamadart/llamadart.dart';
+import 'package:path/path.dart' as p;
 
 import '../models/chat_conversation.dart';
 import '../models/chat_message.dart';
@@ -723,6 +724,89 @@ class ChatProvider extends ChangeNotifier {
     );
   }
 
+  bool _sameLocalPath(String first, String second) {
+    return p.equals(
+      p.normalize(p.absolute(first)),
+      p.normalize(p.absolute(second)),
+    );
+  }
+
+  Future<void> _preflightManagedCatalogModel() async {
+    final configuredModelPath = _settings.modelPath?.trim();
+    if (kIsWeb ||
+        configuredModelPath == null ||
+        configuredModelPath.isEmpty ||
+        !p.isAbsolute(configuredModelPath) ||
+        _isRemoteUrl(configuredModelPath)) {
+      return;
+    }
+
+    final configuredFilename = p.basename(configuredModelPath);
+    final matchingCatalogModels = <DownloadableModel>[];
+    for (final candidate in DownloadableModel.defaultModels) {
+      final source = candidate.modelSource;
+      if (source is RemoteModelAssetSource &&
+          p.equals(source.filename, configuredFilename)) {
+        matchingCatalogModels.add(candidate);
+      }
+    }
+    if (matchingCatalogModels.isEmpty) {
+      return;
+    }
+
+    final modelsDir = await _modelService.getModelsDirectory();
+    DownloadableModel? catalogModel;
+    for (final candidate in matchingCatalogModels) {
+      final source = candidate.modelSource as RemoteModelAssetSource;
+      final managedPath = p.join(modelsDir, source.filename);
+      if (_sameLocalPath(configuredModelPath, managedPath)) {
+        catalogModel = candidate;
+        break;
+      }
+    }
+    if (catalogModel == null) {
+      return;
+    }
+
+    final cacheState = await _modelService.getModelCacheState(catalogModel);
+    if (!cacheState.model.isAvailable) {
+      throw LlamaModelException(
+        'The cached ${catalogModel.name} model is incomplete or does not '
+        'match the pinned catalog artifact. Open Manage models, remove its '
+        'cached assets, and download it again.',
+      );
+    }
+
+    final projectorSource = catalogModel.multimodalProjectorSource;
+    final configuredProjectorPath = _settings.mmprojPath?.trim();
+    final usesManagedCatalogProjector =
+        projectorSource is RemoteModelAssetSource &&
+        configuredProjectorPath != null &&
+        configuredProjectorPath.isNotEmpty &&
+        _sameLocalPath(
+          configuredProjectorPath,
+          p.join(modelsDir, projectorSource.filename),
+        );
+    if (usesManagedCatalogProjector &&
+        !(cacheState.multimodalProjector?.isAvailable ?? false)) {
+      throw LlamaModelException(
+        'The cached ${catalogModel.name} multimodal projector is incomplete '
+        'or does not match the pinned catalog artifact. Open Manage models, '
+        'remove its cached assets, and download it again.',
+      );
+    }
+
+    final catalogSizeBytes = catalogModel.sizeBytesFor(web: false);
+    final usesCompleteManagedCatalogProfile =
+        projectorSource == null || usesManagedCatalogProjector;
+    if (usesCompleteManagedCatalogProfile &&
+        catalogSizeBytes > 0 &&
+        _settings.modelBytesHint != catalogSizeBytes) {
+      _settings = _settings.copyWith(modelBytesHint: catalogSizeBytes);
+      await _saveSettingsNow();
+    }
+  }
+
   void _cancelActiveModelPrefetch() {
     final cancelToken = _activeModelPrefetchCancelToken;
     if (cancelToken != null && !cancelToken.isCancelled) {
@@ -962,6 +1046,7 @@ class ChatProvider extends ChangeNotifier {
     updateLoadingUi(0.1);
 
     try {
+      await _preflightManagedCatalogModel();
       final eagerLoadMmproj =
           (_settings.mmprojPath?.trim().isNotEmpty ?? false);
 

--- a/example/chat_app/lib/providers/chat_provider.dart
+++ b/example/chat_app/lib/providers/chat_provider.dart
@@ -13,6 +13,7 @@ import '../models/chat_message.dart';
 import '../models/chat_settings.dart';
 import '../models/downloadable_model.dart';
 import '../services/assistant_output_service.dart';
+import '../services/audio_recording_service.dart';
 import '../services/chat_service.dart';
 import '../services/chat_generation_service.dart';
 import '../services/chat_session_service.dart';
@@ -22,6 +23,24 @@ import '../services/settings_service.dart';
 import '../services/model_service_base.dart' as model_service;
 import '../services/tool_declaration_service.dart';
 import '../utils/backend_utils.dart';
+
+/// The chat app's microphone capture lifecycle.
+enum ChatAudioRecordingState {
+  /// No microphone operation is active.
+  idle,
+
+  /// Permission and recorder startup are pending.
+  starting,
+
+  /// Audio is being captured.
+  recording,
+
+  /// The WAV file is being finalized before transcription.
+  stopping,
+
+  /// An active or pending capture is being discarded.
+  cancelling,
+}
 
 class ChatProvider extends ChangeNotifier {
   static const String _defaultToolDeclarationsJson = '''
@@ -45,12 +64,16 @@ class ChatProvider extends ChangeNotifier {
     milliseconds: 220,
   );
   static const int _multimodalMaxImageEdge = 384;
+
+  /// The maximum microphone recording length before automatic transcription.
+  static const Duration maxAudioRecordingDuration = Duration(minutes: 5);
   static const String _androidDebugImagePath = String.fromEnvironment(
     'LLAMADART_CHAT_APP_DEBUG_IMAGE_PATH',
     defaultValue: '',
   );
 
   final ChatService _chatService;
+  final AudioRecordingService _audioRecordingService;
   final ChatGenerationService _chatGenerationService;
   final ChatSessionService _chatSessionService;
   final ConversationStateService _conversationStateService;
@@ -83,6 +106,7 @@ class ChatProvider extends ChangeNotifier {
   bool _isLoaded = false;
   bool _isGenerating = false;
   bool _isTranscribing = false;
+  ChatAudioRecordingState _audioRecordingState = ChatAudioRecordingState.idle;
   bool _isShuttingDown = false;
   bool _supportsVision = false;
   bool _supportsAudio = false;
@@ -94,6 +118,14 @@ class ChatProvider extends ChangeNotifier {
   CancelToken? _activeModelPrefetchCancelToken;
   SpeechToTextTask? _activeSpeechToTextTask;
   Completer<void>? _activeTranscriptionDone;
+  Completer<void>? _activeRecordingTransitionDone;
+  Completer<void>? _activeRecordingCancellationDone;
+  Timer? _audioRecordingTimer;
+  Duration _audioRecordingElapsed = Duration.zero;
+  String? _audioRecordingModelPath;
+  String? _audioRecordingMmprojPath;
+  String? _audioRecordingConversationId;
+  int _audioRecordingRevision = 0;
   int _conversationRevision = 0;
   bool _isDisposed = false;
 
@@ -143,10 +175,25 @@ class ChatProvider extends ChangeNotifier {
   bool get isGenerating => _isGenerating;
   bool get isTranscribing => _isTranscribing;
 
+  /// The current microphone capture phase.
+  ChatAudioRecordingState get audioRecordingState => _audioRecordingState;
+
+  /// Whether the microphone is actively capturing audio frames.
+  bool get isRecordingAudio =>
+      _audioRecordingState == ChatAudioRecordingState.recording;
+
+  /// Whether microphone startup, capture, stop, or cancellation is active.
+  bool get hasActiveAudioRecording =>
+      _audioRecordingState != ChatAudioRecordingState.idle;
+
+  /// The elapsed duration of the active microphone recording.
+  Duration get audioRecordingElapsed => _audioRecordingElapsed;
+
   /// Whether the latest plain assistant response can be generated again.
   bool get canRegenerateLastResponse {
     if (_isGenerating ||
         _isTranscribing ||
+        hasActiveAudioRecording ||
         _session == null ||
         !_chatService.engine.isReady ||
         _messages.length < 2) {
@@ -175,8 +222,13 @@ class ChatProvider extends ChangeNotifier {
       !_isInitializing &&
       !_isGenerating &&
       !_isTranscribing &&
+      !hasActiveAudioRecording &&
       _supportsAudio &&
       _settings.modelSupportsSpeechToText;
+
+  /// Whether the active model can start a microphone transcription capture.
+  bool get canStartAudioRecording =>
+      _audioRecordingService.isSupported && canTranscribeAudio;
   bool get templateSupportsTools => _templateSupportsTools;
   bool get thinkingControlsSupported => _thinkingControlsSupported;
   String? get error => _error;
@@ -245,6 +297,7 @@ class ChatProvider extends ChangeNotifier {
 
   ChatProvider({
     ChatService? chatService,
+    AudioRecordingService? audioRecordingService,
     ChatGenerationService? chatGenerationService,
     ChatSessionService? chatSessionService,
     ConversationStateService? conversationStateService,
@@ -256,6 +309,8 @@ class ChatProvider extends ChangeNotifier {
     ChatSettings? initialSettings,
     bool? enableWebModelPrefetch,
   }) : _chatService = chatService ?? ChatService(),
+       _audioRecordingService =
+           audioRecordingService ?? AudioRecordingService(),
        _chatGenerationService =
            chatGenerationService ?? const ChatGenerationService(),
        _chatSessionService = chatSessionService ?? const ChatSessionService(),
@@ -325,6 +380,7 @@ class ChatProvider extends ChangeNotifier {
   }
 
   void createConversation() {
+    unawaited(_cancelAndAwaitAudioRecording());
     _invalidateActiveTranscription();
     _syncActiveConversationSnapshot();
 
@@ -373,6 +429,7 @@ class ChatProvider extends ChangeNotifier {
       return;
     }
 
+    await _cancelAndAwaitAudioRecording();
     await _cancelAndAwaitActiveTranscription();
 
     _syncActiveConversationSnapshot();
@@ -745,6 +802,8 @@ class ChatProvider extends ChangeNotifier {
       return;
     }
 
+    await _cancelAndAwaitAudioRecording();
+
     _isInitializing = true;
     _isLoaded = false;
     _error = null;
@@ -1064,6 +1123,7 @@ class ChatProvider extends ChangeNotifier {
   }
 
   void clearConversation() {
+    unawaited(_cancelAndAwaitAudioRecording());
     final wasTranscribing = _isTranscribing;
     _invalidateActiveTranscription();
     _messages.clear();
@@ -1085,7 +1145,12 @@ class ChatProvider extends ChangeNotifier {
   }
 
   Future<void> sendMessage(String text) async {
-    if (_isGenerating || _isTranscribing || _session == null) return;
+    if (_isGenerating ||
+        _isTranscribing ||
+        hasActiveAudioRecording ||
+        _session == null) {
+      return;
+    }
 
     if (_settings.singleTurnMode) {
       _session!.reset();
@@ -1892,6 +1957,177 @@ class ChatProvider extends ChangeNotifier {
     );
   }
 
+  /// Starts foreground microphone capture for a later whole-file transcript.
+  Future<void> startAudioRecording() async {
+    if (!_audioRecordingService.isSupported) {
+      _addInfoMessage('Microphone recording is unavailable on this platform.');
+      notifyListeners();
+      return;
+    }
+    if (!canTranscribeAudio || hasActiveAudioRecording) {
+      return;
+    }
+
+    final revision = ++_audioRecordingRevision;
+    final transitionDone = Completer<void>();
+    _activeRecordingTransitionDone = transitionDone;
+    _audioRecordingState = ChatAudioRecordingState.starting;
+    _audioRecordingElapsed = Duration.zero;
+    _audioRecordingModelPath = _settings.modelPath;
+    _audioRecordingMmprojPath = _settings.mmprojPath;
+    _audioRecordingConversationId = _activeConversationId;
+    notifyListeners();
+
+    try {
+      await _audioRecordingService.start();
+      if (revision != _audioRecordingRevision || _isDisposed) {
+        return;
+      }
+
+      _audioRecordingState = ChatAudioRecordingState.recording;
+      _startAudioRecordingTimer(revision);
+    } catch (error) {
+      if (revision != _audioRecordingRevision || _isDisposed) {
+        return;
+      }
+      _addInfoMessage(
+        error is AudioRecordingException
+            ? error.message
+            : 'Could not start microphone recording.',
+      );
+      _resetAudioRecordingState();
+    } finally {
+      if (identical(_activeRecordingTransitionDone, transitionDone)) {
+        _activeRecordingTransitionDone = null;
+      }
+      if (!transitionDone.isCompleted) {
+        transitionDone.complete();
+      }
+      if (revision == _audioRecordingRevision &&
+          _audioRecordingState == ChatAudioRecordingState.starting) {
+        _resetAudioRecordingState();
+      }
+      if (!_isDisposed) {
+        notifyListeners();
+      }
+    }
+  }
+
+  /// Stops microphone capture, transcribes the finalized WAV, then deletes it.
+  Future<void> stopAudioRecordingAndTranscribe() async {
+    if (_audioRecordingState != ChatAudioRecordingState.recording) {
+      return;
+    }
+
+    final revision = _audioRecordingRevision;
+    final transitionDone = Completer<void>();
+    _activeRecordingTransitionDone = transitionDone;
+    _audioRecordingTimer?.cancel();
+    _audioRecordingTimer = null;
+    _audioRecordingState = ChatAudioRecordingState.stopping;
+    notifyListeners();
+
+    String? path;
+    try {
+      path = await _audioRecordingService.stop();
+      if (revision != _audioRecordingRevision || _isDisposed) {
+        await _audioRecordingService.deleteRecording(path);
+        return;
+      }
+    } catch (error) {
+      await _audioRecordingService.cancel();
+      if (revision == _audioRecordingRevision && !_isDisposed) {
+        _addInfoMessage(
+          error is AudioRecordingException
+              ? error.message
+              : 'Could not finish the microphone recording.',
+        );
+      }
+    } finally {
+      if (identical(_activeRecordingTransitionDone, transitionDone)) {
+        _activeRecordingTransitionDone = null;
+      }
+      if (!transitionDone.isCompleted) {
+        transitionDone.complete();
+      }
+    }
+
+    if (revision != _audioRecordingRevision || _isDisposed || path == null) {
+      if (revision == _audioRecordingRevision) {
+        _resetAudioRecordingState();
+        if (!_isDisposed) {
+          notifyListeners();
+        }
+      }
+      return;
+    }
+
+    final contextMatches =
+        _audioRecordingModelPath == _settings.modelPath &&
+        _audioRecordingMmprojPath == _settings.mmprojPath &&
+        _audioRecordingConversationId == _activeConversationId;
+    _resetAudioRecordingState();
+    notifyListeners();
+
+    if (!contextMatches) {
+      await _audioRecordingService.deleteRecording(path);
+      _addInfoMessage(
+        'Recording discarded because the active model or conversation changed.',
+      );
+      notifyListeners();
+      return;
+    }
+
+    try {
+      await transcribeAudio(
+        SpeechAudioFileInput(path),
+        displayName: 'Microphone recording',
+      );
+    } finally {
+      await _audioRecordingService.deleteRecording(path);
+    }
+  }
+
+  /// Discards an active microphone recording without transcribing it.
+  Future<void> cancelAudioRecording({bool showMessage = true}) async {
+    await _cancelAndAwaitAudioRecording(showMessage: showMessage);
+  }
+
+  void _startAudioRecordingTimer(int revision) {
+    _audioRecordingTimer?.cancel();
+    _audioRecordingTimer = Timer.periodic(const Duration(seconds: 1), (timer) {
+      if (revision != _audioRecordingRevision ||
+          _audioRecordingState != ChatAudioRecordingState.recording) {
+        _audioRecordingTimer?.cancel();
+        _audioRecordingTimer = null;
+        return;
+      }
+
+      _audioRecordingElapsed = Duration(seconds: timer.tick);
+      if (_audioRecordingElapsed >= maxAudioRecordingDuration) {
+        _audioRecordingElapsed = maxAudioRecordingDuration;
+        _addInfoMessage(
+          'Maximum recording length reached. Transcribing the recording now.',
+        );
+        unawaited(stopAudioRecordingAndTranscribe());
+        return;
+      }
+      if (!_isDisposed) {
+        notifyListeners();
+      }
+    });
+  }
+
+  void _resetAudioRecordingState() {
+    _audioRecordingTimer?.cancel();
+    _audioRecordingTimer = null;
+    _audioRecordingState = ChatAudioRecordingState.idle;
+    _audioRecordingElapsed = Duration.zero;
+    _audioRecordingModelPath = null;
+    _audioRecordingMmprojPath = null;
+    _audioRecordingConversationId = null;
+  }
+
   /// Picks one complete audio file and transcribes it with the loaded model.
   Future<void> pickAudioForTranscription() async {
     if (kIsWeb) {
@@ -2384,6 +2620,7 @@ class ChatProvider extends ChangeNotifier {
   }
 
   Future<void> unloadModel() async {
+    await _cancelAndAwaitAudioRecording();
     await _cancelAndAwaitActiveTranscription();
     stopGeneration();
     _cancelActiveModelPrefetch();
@@ -2400,6 +2637,7 @@ class ChatProvider extends ChangeNotifier {
   }
 
   void updateModelPath(String path) {
+    unawaited(_cancelAndAwaitAudioRecording());
     _updateSettings(
       _settings.copyWith(
         modelPath: path,
@@ -2413,6 +2651,7 @@ class ChatProvider extends ChangeNotifier {
 
   /// Apply model-specific recommended generation and runtime parameters.
   void applyModelPreset(DownloadableModel model) {
+    unawaited(_cancelAndAwaitAudioRecording());
     final shouldKeepToolsEnabled =
         model.supportsToolCalling && _settings.toolsEnabled;
     final shouldUseReducedAndroidContext =
@@ -2572,12 +2811,14 @@ class ChatProvider extends ChangeNotifier {
   }
 
   void updateMmprojPath(String path) {
+    unawaited(_cancelAndAwaitAudioRecording());
     _updateSettings(_settings.copyWith(mmprojPath: path));
   }
 
   Future<bool> loadConfiguredMmproj({
     String successMessage = 'Multimodal projector loaded.',
   }) async {
+    await _cancelAndAwaitAudioRecording();
     final mmprojPath = (_settings.mmprojPath ?? '').trim();
     if (mmprojPath.isEmpty) {
       _addInfoMessage(
@@ -2620,6 +2861,7 @@ class ChatProvider extends ChangeNotifier {
   }
 
   Future<void> clearMmprojPath() async {
+    await _cancelAndAwaitAudioRecording();
     if ((_settings.mmprojPath ?? '').isEmpty && !_mmprojLoaded) {
       return;
     }
@@ -2681,12 +2923,18 @@ class ChatProvider extends ChangeNotifier {
     _settingsSaveDebounce?.cancel();
     _settingsSaveDebounce = null;
     unawaited(_settingsService.saveSettings(_settings));
+    final recordingDone = _cancelAndAwaitAudioRecording();
     final transcriptionDone = _cancelAndAwaitActiveTranscription();
     stopGeneration();
     _cancelActiveModelPrefetch();
     _session?.reset();
     _session = null;
-    unawaited(transcriptionDone.whenComplete(_chatService.dispose));
+    unawaited(() async {
+      await recordingDone;
+      await transcriptionDone;
+      await _audioRecordingService.dispose();
+      await _chatService.dispose();
+    }());
     super.dispose();
   }
 
@@ -2698,6 +2946,7 @@ class ChatProvider extends ChangeNotifier {
     _isShuttingDown = true;
     try {
       await _saveSettingsNow();
+      await _cancelAndAwaitAudioRecording();
       await _cancelAndAwaitActiveTranscription();
       stopGeneration();
       _cancelActiveModelPrefetch();
@@ -2718,6 +2967,7 @@ class ChatProvider extends ChangeNotifier {
       _runtimeNotes = null;
       _runtimeModelSource = null;
       _runtimeModelCacheState = null;
+      await _audioRecordingService.dispose();
       await _chatService.dispose();
     } finally {
       _isShuttingDown = false;
@@ -2742,6 +2992,56 @@ class ChatProvider extends ChangeNotifier {
     }
     if (done != null) {
       await done.future;
+    }
+  }
+
+  Future<void> _cancelAndAwaitAudioRecording({bool showMessage = false}) async {
+    final activeCancellation = _activeRecordingCancellationDone;
+    if (activeCancellation != null) {
+      await activeCancellation.future;
+      return;
+    }
+
+    final transition = _activeRecordingTransitionDone;
+    if (_audioRecordingState == ChatAudioRecordingState.idle &&
+        transition == null) {
+      return;
+    }
+
+    final cancellationDone = Completer<void>();
+    _activeRecordingCancellationDone = cancellationDone;
+    final conversationRevision = _conversationRevision;
+    final revision = ++_audioRecordingRevision;
+    _audioRecordingTimer?.cancel();
+    _audioRecordingTimer = null;
+    _audioRecordingState = ChatAudioRecordingState.cancelling;
+    if (!_isDisposed) {
+      notifyListeners();
+    }
+
+    try {
+      if (transition != null) {
+        await transition.future;
+      }
+      await _audioRecordingService.cancel();
+    } finally {
+      if (revision == _audioRecordingRevision) {
+        _resetAudioRecordingState();
+        if (showMessage &&
+            !_isDisposed &&
+            conversationRevision == _conversationRevision) {
+          _addInfoMessage('Microphone recording cancelled.');
+        }
+      }
+      if (identical(_activeRecordingCancellationDone, cancellationDone)) {
+        _activeRecordingCancellationDone = null;
+      }
+      if (!cancellationDone.isCompleted) {
+        cancellationDone.complete();
+      }
+      if (!_isDisposed) {
+        notifyListeners();
+      }
     }
   }
 

--- a/example/chat_app/lib/providers/chat_provider.dart
+++ b/example/chat_app/lib/providers/chat_provider.dart
@@ -731,6 +731,39 @@ class ChatProvider extends ChangeNotifier {
     );
   }
 
+  Future<bool> _isRelocatableIosCatalogPath(
+    String configuredPath, {
+    required String expectedFilename,
+  }) async {
+    if (kIsWeb ||
+        defaultTargetPlatform != TargetPlatform.iOS ||
+        !p.isAbsolute(configuredPath) ||
+        !p.equals(p.basename(configuredPath), expectedFilename) ||
+        await File(configuredPath).exists()) {
+      return false;
+    }
+
+    final components = p
+        .normalize(configuredPath)
+        .split(p.separator)
+        .where((component) => component.isNotEmpty)
+        .toList(growable: false);
+    if (components.length < 10) {
+      return false;
+    }
+    final tail = components.sublist(components.length - 10);
+    return p.equals(tail[0], 'var') &&
+        p.equals(tail[1], 'mobile') &&
+        p.equals(tail[2], 'Containers') &&
+        p.equals(tail[3], 'Data') &&
+        p.equals(tail[4], 'Application') &&
+        tail[5].isNotEmpty &&
+        p.equals(tail[6], 'Library') &&
+        p.equals(tail[7], 'Caches') &&
+        p.equals(tail[8], 'models') &&
+        p.equals(tail[9], expectedFilename);
+  }
+
   Future<void> _preflightManagedCatalogModel() async {
     final configuredModelPath = _settings.modelPath?.trim();
     if (kIsWeb ||
@@ -756,11 +789,20 @@ class ChatProvider extends ChangeNotifier {
 
     final modelsDir = await _modelService.getModelsDirectory();
     DownloadableModel? catalogModel;
+    var shouldRelocateModelPath = false;
     for (final candidate in matchingCatalogModels) {
       final source = candidate.modelSource as RemoteModelAssetSource;
       final managedPath = p.join(modelsDir, source.filename);
       if (_sameLocalPath(configuredModelPath, managedPath)) {
         catalogModel = candidate;
+        break;
+      }
+      if (await _isRelocatableIosCatalogPath(
+        configuredModelPath,
+        expectedFilename: source.filename,
+      )) {
+        catalogModel = candidate;
+        shouldRelocateModelPath = true;
         break;
       }
     }
@@ -779,14 +821,25 @@ class ChatProvider extends ChangeNotifier {
 
     final projectorSource = catalogModel.multimodalProjectorSource;
     final configuredProjectorPath = _settings.mmprojPath?.trim();
-    final usesManagedCatalogProjector =
-        projectorSource is RemoteModelAssetSource &&
+    var shouldRelocateProjectorPath = false;
+    var usesManagedCatalogProjector = false;
+    String? managedProjectorPath;
+    if (projectorSource is RemoteModelAssetSource &&
         configuredProjectorPath != null &&
-        configuredProjectorPath.isNotEmpty &&
-        _sameLocalPath(
+        configuredProjectorPath.isNotEmpty) {
+      managedProjectorPath = p.join(modelsDir, projectorSource.filename);
+      usesManagedCatalogProjector = _sameLocalPath(
+        configuredProjectorPath,
+        managedProjectorPath,
+      );
+      if (!usesManagedCatalogProjector) {
+        shouldRelocateProjectorPath = await _isRelocatableIosCatalogPath(
           configuredProjectorPath,
-          p.join(modelsDir, projectorSource.filename),
+          expectedFilename: projectorSource.filename,
         );
+        usesManagedCatalogProjector = shouldRelocateProjectorPath;
+      }
+    }
     if (usesManagedCatalogProjector &&
         !(cacheState.multimodalProjector?.isAvailable ?? false)) {
       throw LlamaModelException(
@@ -799,10 +852,28 @@ class ChatProvider extends ChangeNotifier {
     final catalogSizeBytes = catalogModel.sizeBytesFor(web: false);
     final usesCompleteManagedCatalogProfile =
         projectorSource == null || usesManagedCatalogProjector;
-    if (usesCompleteManagedCatalogProfile &&
+    final shouldUpdateSizeHint =
+        usesCompleteManagedCatalogProfile &&
         catalogSizeBytes > 0 &&
-        _settings.modelBytesHint != catalogSizeBytes) {
-      _settings = _settings.copyWith(modelBytesHint: catalogSizeBytes);
+        _settings.modelBytesHint != catalogSizeBytes;
+    if (shouldRelocateModelPath ||
+        shouldRelocateProjectorPath ||
+        shouldUpdateSizeHint) {
+      _settings = _settings.copyWith(
+        modelPath: shouldRelocateModelPath
+            ? p.join(
+                modelsDir,
+                (catalogModel.modelSource as RemoteModelAssetSource).filename,
+              )
+            : _settings.modelPath,
+        mmprojPath: shouldRelocateProjectorPath
+            ? managedProjectorPath
+            : _settings.mmprojPath,
+        modelBytesHint: shouldUpdateSizeHint
+            ? catalogSizeBytes
+            : _settings.modelBytesHint,
+      );
+      _syncActiveConversationSnapshot(touchUpdatedAt: false);
       await _saveSettingsNow();
     }
   }

--- a/example/chat_app/lib/providers/chat_provider.dart
+++ b/example/chat_app/lib/providers/chat_provider.dart
@@ -3025,7 +3025,7 @@ class ChatProvider extends ChangeNotifier {
   Future<LlamaImageContent?> _prepareImagePartFromPath(String path) async {
     try {
       final bytes = await File(path).readAsBytes();
-      return _prepareImagePartFromBytes(bytes);
+      return await _prepareImagePartFromBytes(bytes);
     } catch (error) {
       _logDart(
         LlamaLogLevel.warn,

--- a/example/chat_app/lib/providers/chat_provider.dart
+++ b/example/chat_app/lib/providers/chat_provider.dart
@@ -35,12 +35,38 @@ enum ChatAudioRecordingState {
   /// Audio is being captured.
   recording,
 
-  /// The WAV file is being finalized before transcription.
+  /// The WAV file is being finalized before transcription or chat input.
   stopping,
 
   /// An active or pending capture is being discarded.
   cancelling,
 }
+
+/// The action performed after a microphone recording is finalized.
+enum ChatAudioRecordingPurpose {
+  /// Run the dedicated whole-file speech-to-text workflow.
+  transcription,
+
+  /// Send the recording to a general audio-capable chat model for an answer.
+  voiceQuestion,
+}
+
+typedef _VoiceQuestionContext = ({
+  int operationId,
+  int conversationRevision,
+  String? modelPath,
+  String? mmprojPath,
+  String conversationId,
+});
+
+typedef _GenerationContext = ({
+  int operationId,
+  int conversationRevision,
+  String? modelPath,
+  String? mmprojPath,
+  String conversationId,
+  ChatSession session,
+});
 
 class ChatProvider extends ChangeNotifier {
   static const String _defaultToolDeclarationsJson = '''
@@ -67,6 +93,17 @@ class ChatProvider extends ChangeNotifier {
 
   /// The maximum microphone recording length before automatic transcription.
   static const Duration maxAudioRecordingDuration = Duration(minutes: 5);
+
+  /// The maximum voice-question recording accepted by Gemma 4 audio input.
+  static const Duration maxVoiceQuestionRecordingDuration = Duration(
+    seconds: 30,
+  );
+
+  static const String _voiceQuestionPrompt =
+      'Listen to the attached recording and answer the spoken request '
+      'directly. Do not provide a transcript or describe the audio unless the '
+      'speaker asks for that. If there is no clear spoken request, briefly ask '
+      'the user to record it again.';
   static const String _androidDebugImagePath = String.fromEnvironment(
     'LLAMADART_CHAT_APP_DEBUG_IMAGE_PATH',
     defaultValue: '',
@@ -122,6 +159,11 @@ class ChatProvider extends ChangeNotifier {
   Completer<void>? _activeRecordingCancellationDone;
   Timer? _audioRecordingTimer;
   Duration _audioRecordingElapsed = Duration.zero;
+  ChatAudioRecordingPurpose? _audioRecordingPurpose;
+  int _voiceQuestionOperationSequence = 0;
+  int? _activeVoiceQuestionOperationId;
+  int _generationOperationSequence = 0;
+  int? _activeGenerationOperationId;
   String? _audioRecordingModelPath;
   String? _audioRecordingMmprojPath;
   String? _audioRecordingConversationId;
@@ -189,6 +231,10 @@ class ChatProvider extends ChangeNotifier {
   /// The elapsed duration of the active microphone recording.
   Duration get audioRecordingElapsed => _audioRecordingElapsed;
 
+  /// The action frozen when the current microphone recording began.
+  ChatAudioRecordingPurpose? get audioRecordingPurpose =>
+      _audioRecordingPurpose;
+
   /// Whether the latest plain assistant response can be generated again.
   bool get canRegenerateLastResponse {
     if (_isGenerating ||
@@ -226,9 +272,38 @@ class ChatProvider extends ChangeNotifier {
       _supportsAudio &&
       _settings.modelSupportsSpeechToText;
 
-  /// Whether the active model can start a microphone transcription capture.
+  /// Whether the active direct-media model can answer a recorded question.
+  ///
+  /// This intentionally excludes dedicated ASR profiles. The initial product
+  /// path is native Gemma 4 through LiteRT-LM, whose Web bundle is text-only.
+  bool get canAskWithVoice =>
+      !kIsWeb &&
+      _isLoaded &&
+      !_isInitializing &&
+      !_isGenerating &&
+      !_isTranscribing &&
+      !hasActiveAudioRecording &&
+      _supportsAudio &&
+      _settings.modelSupportsAudio &&
+      _settings.directMediaInput &&
+      !_settings.modelSupportsSpeechToText;
+
+  /// Whether the selected model/platform exposes a microphone action.
+  ///
+  /// This remains true while the model is busy so the composer can keep the
+  /// control visible but disabled instead of shifting its layout.
+  bool get supportsMicrophoneRecording =>
+      !kIsWeb &&
+      _audioRecordingService.isSupported &&
+      (_settings.modelSupportsSpeechToText ||
+          (_settings.modelSupportsAudio &&
+              _settings.directMediaInput &&
+              !_settings.modelSupportsSpeechToText));
+
+  /// Whether the active model can start a supported microphone workflow.
   bool get canStartAudioRecording =>
-      _audioRecordingService.isSupported && canTranscribeAudio;
+      _audioRecordingService.isSupported &&
+      (canTranscribeAudio || canAskWithVoice);
   bool get templateSupportsTools => _templateSupportsTools;
   bool get thinkingControlsSupported => _thinkingControlsSupported;
   String? get error => _error;
@@ -381,6 +456,12 @@ class ChatProvider extends ChangeNotifier {
 
   void createConversation() {
     unawaited(_cancelAndAwaitAudioRecording());
+    final hadActiveGeneration = _activeGenerationOperationId != null;
+    _invalidateActiveVoiceQuestion(releaseGeneration: true);
+    _invalidateActiveGeneration(cancelNative: true);
+    if (hadActiveGeneration) {
+      _removeEmptyAssistantPlaceholder();
+    }
     _invalidateActiveTranscription();
     _syncActiveConversationSnapshot();
 
@@ -429,6 +510,13 @@ class ChatProvider extends ChangeNotifier {
       return;
     }
 
+    final hadActiveGeneration = _activeGenerationOperationId != null;
+    _invalidateActiveVoiceQuestion(releaseGeneration: true);
+    _invalidateActiveGeneration(cancelNative: true);
+    if (hadActiveGeneration) {
+      _removeEmptyAssistantPlaceholder();
+      _restoreSessionFromMessages();
+    }
     await _cancelAndAwaitAudioRecording();
     await _cancelAndAwaitActiveTranscription();
 
@@ -1124,10 +1212,19 @@ class ChatProvider extends ChangeNotifier {
 
   void clearConversation() {
     unawaited(_cancelAndAwaitAudioRecording());
+    _invalidateActiveVoiceQuestion(releaseGeneration: true);
+    _invalidateActiveGeneration(cancelNative: true);
     final wasTranscribing = _isTranscribing;
     _invalidateActiveTranscription();
     _messages.clear();
     _session?.reset();
+    _session = _chatService.engine.isReady && _isLoaded
+        ? _chatSessionService.createSession(
+            engine: _chatService.engine,
+            contextSize: _settings.contextSize,
+            systemPrompt: _sessionSystemPrompt(),
+          )
+        : null;
     _currentTokens = 0;
     _isPruning = false;
     _isGenerating = wasTranscribing;
@@ -1152,10 +1249,6 @@ class ChatProvider extends ChangeNotifier {
       return;
     }
 
-    if (_settings.singleTurnMode) {
-      _session!.reset();
-    }
-
     if (!_chatService.engine.isReady) {
       _messages.add(
         ChatMessage(
@@ -1173,25 +1266,52 @@ class ChatProvider extends ChangeNotifier {
 
     if (parts.isEmpty && text.isEmpty) return;
 
-    if (!await _ensureMultimodalProjectorForMedia(parts)) {
+    final generationContext = _beginGeneration();
+    if (generationContext == null) {
       return;
     }
+    var generationStarted = false;
+    try {
+      if (_settings.singleTurnMode) {
+        generationContext.session.reset();
+      }
 
-    // For UI display, include text in parts
-    final displayParts = [
-      ...parts,
-      if (text.isNotEmpty) LlamaTextContent(text),
-    ];
-    final userMsg = ChatMessage(text: text, isUser: true, parts: displayParts);
-    _messages.add(userMsg);
-    _stagedParts.clear();
-    _isGenerating = true;
-    _syncActiveConversationSnapshot();
-    notifyListeners();
+      if (!await _ensureMultimodalProjectorForMedia(parts) ||
+          !_generationContextMatches(generationContext)) {
+        return;
+      }
 
-    await _yieldUiFrame();
+      // For UI display, include text in parts
+      final displayParts = [
+        ...parts,
+        if (text.isNotEmpty) LlamaTextContent(text),
+      ];
+      final userMsg = ChatMessage(
+        text: text,
+        isUser: true,
+        parts: displayParts,
+      );
+      _messages.add(userMsg);
+      _stagedParts.clear();
+      _syncActiveConversationSnapshot();
+      notifyListeners();
 
-    await _generateResponse(text, parts: parts.isEmpty ? null : parts);
+      await _yieldUiFrame();
+      if (!_generationContextMatches(generationContext)) {
+        return;
+      }
+
+      generationStarted = true;
+      await _generateResponse(
+        text,
+        context: generationContext,
+        parts: parts.isEmpty ? null : parts,
+      );
+    } finally {
+      if (!generationStarted) {
+        _releaseGeneration(generationContext);
+      }
+    }
   }
 
   /// Removes the latest plain assistant response and generates a replacement.
@@ -1210,12 +1330,29 @@ class ChatProvider extends ChangeNotifier {
     if (userIndex < 0) return;
 
     final userMessage = _messages[userIndex];
+    final requestText = userMessage.parts
+        ?.whereType<LlamaTextContent>()
+        .map((part) => part.text)
+        .where((text) => text.trim().isNotEmpty)
+        .join('\n');
     final mediaParts = userMessage.parts
         ?.where((part) => part is! LlamaTextContent)
         .toList(growable: false);
+    final expectedConversationRevision = _conversationRevision;
+    final expectedModelPath = _settings.modelPath;
+    final expectedMmprojPath = _settings.mmprojPath;
+    final expectedConversationId = _activeConversationId;
+    final expectedSession = _session;
     if (mediaParts != null &&
         mediaParts.isNotEmpty &&
         !await _ensureMultimodalProjectorForMedia(mediaParts)) {
+      return;
+    }
+    if (expectedConversationRevision != _conversationRevision ||
+        expectedModelPath != _settings.modelPath ||
+        expectedMmprojPath != _settings.mmprojPath ||
+        expectedConversationId != _activeConversationId ||
+        !identical(expectedSession, _session)) {
       return;
     }
 
@@ -1234,15 +1371,32 @@ class ChatProvider extends ChangeNotifier {
       systemPrompt: _sessionSystemPrompt(),
       messages: history,
     );
-    _isGenerating = true;
+    final generationContext = _beginGeneration();
+    if (generationContext == null) {
+      return;
+    }
     _syncActiveConversationSnapshot();
     notifyListeners();
 
-    await _yieldUiFrame();
-    await _generateResponse(
-      userMessage.text,
-      parts: mediaParts == null || mediaParts.isEmpty ? null : mediaParts,
-    );
+    var generationStarted = false;
+    try {
+      await _yieldUiFrame();
+      if (!_generationContextMatches(generationContext)) {
+        return;
+      }
+      generationStarted = true;
+      await _generateResponse(
+        requestText == null || requestText.isEmpty
+            ? userMessage.text
+            : requestText,
+        context: generationContext,
+        parts: mediaParts == null || mediaParts.isEmpty ? null : mediaParts,
+      );
+    } finally {
+      if (!generationStarted) {
+        _releaseGeneration(generationContext);
+      }
+    }
   }
 
   Map<String, dynamic>? _thinkingTemplateKwargs() {
@@ -1403,10 +1557,79 @@ class ChatProvider extends ChangeNotifier {
     }
   }
 
+  _GenerationContext? _beginGeneration() {
+    final session = _session;
+    if (session == null || !_chatService.engine.isReady) {
+      return null;
+    }
+
+    final operationId = ++_generationOperationSequence;
+    final context = (
+      operationId: operationId,
+      conversationRevision: _conversationRevision,
+      modelPath: _settings.modelPath,
+      mmprojPath: _settings.mmprojPath,
+      conversationId: _activeConversationId,
+      session: session,
+    );
+    _activeGenerationOperationId = operationId;
+    _isGenerating = true;
+    return context;
+  }
+
+  bool _generationContextMatches(_GenerationContext context) =>
+      _activeGenerationOperationId == context.operationId &&
+      _isGenerating &&
+      context.conversationRevision == _conversationRevision &&
+      context.modelPath == _settings.modelPath &&
+      context.mmprojPath == _settings.mmprojPath &&
+      context.conversationId == _activeConversationId &&
+      identical(context.session, _session);
+
+  void _releaseGeneration(_GenerationContext context) {
+    if (_activeGenerationOperationId != context.operationId) {
+      return;
+    }
+    _activeGenerationOperationId = null;
+    if (!_isTranscribing) {
+      _isGenerating = false;
+    }
+    if (_generationIdentityMatches(context)) {
+      _syncActiveConversationSnapshot();
+    }
+    if (!_isDisposed) {
+      notifyListeners();
+    }
+  }
+
+  bool _generationIdentityMatches(_GenerationContext context) =>
+      context.conversationRevision == _conversationRevision &&
+      context.modelPath == _settings.modelPath &&
+      context.mmprojPath == _settings.mmprojPath &&
+      context.conversationId == _activeConversationId &&
+      identical(context.session, _session);
+
+  void _invalidateActiveGeneration({bool cancelNative = false}) {
+    final hadActiveGeneration = _activeGenerationOperationId != null;
+    _activeGenerationOperationId = null;
+    if (cancelNative && hadActiveGeneration) {
+      _chatService.cancelGeneration();
+    }
+    if (!_isTranscribing) {
+      _isGenerating = false;
+    }
+  }
+
   Future<void> _generateResponse(
     String text, {
+    required _GenerationContext context,
     List<LlamaContentPart>? parts,
   }) async {
+    if (!_generationContextMatches(context)) {
+      _releaseGeneration(context);
+      return;
+    }
+
     var generationResult = const GenerationStreamResult(
       fullResponse: '',
       fullThinking: '',
@@ -1423,10 +1646,16 @@ class ChatProvider extends ChangeNotifier {
     var isCpuMultimodalTurn = false;
 
     try {
+      if (!_generationContextMatches(context)) {
+        return;
+      }
       _messages.add(ChatMessage(text: "...", isUser: false));
       notifyListeners();
 
       await _yieldUiFrame();
+      if (!_generationContextMatches(context)) {
+        return;
+      }
 
       final params = _chatGenerationService.buildParams(_settings);
       final chatParts = _chatGenerationService.buildChatParts(
@@ -1465,11 +1694,11 @@ class ChatProvider extends ChangeNotifier {
           : const Duration(seconds: 240);
 
       final templateKwargs = _thinkingTemplateKwargs();
-      _session!.systemPrompt = _sessionSystemPrompt();
+      context.session.systemPrompt = _sessionSystemPrompt();
 
       generationResult = await _chatGenerationService
           .consumeStream(
-            stream: _session!.create(
+            stream: context.session.create(
               chatParts,
               params: effectiveParams,
               tools: toolsForTurn,
@@ -1480,9 +1709,12 @@ class ChatProvider extends ChangeNotifier {
             thinkingEnabled: _settings.thinkingEnabled,
             uiNotifyIntervalMs: 16,
             cleanResponse: (response) => response,
-            shouldContinue: () => _isGenerating,
+            shouldContinue: () => _generationContextMatches(context),
             stallTimeout: streamStallTimeout,
             onUpdate: (update) {
+              if (!_generationContextMatches(context)) {
+                return;
+              }
               _currentTokens += update.generatedTokenDelta;
               appliedGeneratedTokenDeltas += update.generatedTokenDelta;
 
@@ -1507,7 +1739,9 @@ class ChatProvider extends ChangeNotifier {
           .timeout(
             streamWallTimeout,
             onTimeout: () {
-              _chatService.cancelGeneration();
+              if (_generationContextMatches(context)) {
+                _chatService.cancelGeneration();
+              }
               throw TimeoutException(
                 'Generation exceeded wall timeout.',
                 streamWallTimeout,
@@ -1515,14 +1749,18 @@ class ChatProvider extends ChangeNotifier {
             },
           );
 
+      if (!_generationContextMatches(context)) {
+        return;
+      }
+
       final fullResponse = generationResult.fullResponse;
       final fullThinking = generationResult.fullThinking;
       _lastFirstTokenLatencyMs = generationResult.firstTokenLatencyMs;
 
       // Final update
       if (_messages.isNotEmpty && !_messages.last.isUser) {
-        final lastSessionMessage = _session!.history.isNotEmpty
-            ? _session!.history.last
+        final lastSessionMessage = context.session.history.isNotEmpty
+            ? context.session.history.last
             : null;
         var toolCalls = lastSessionMessage == null
             ? const <LlamaToolCallContent>[]
@@ -1585,23 +1823,33 @@ class ChatProvider extends ChangeNotifier {
           // Some backends (e.g. LiteRT-LM on web) don't expose tokenizer
           // operations, so retain the generated-token count as the cache hint
           // instead of failing the turn.
+          var tokenCount = generationResult.generatedTokens;
           try {
-            _messages.last.tokenCount = await _chatService.engine.getTokenCount(
-              finalText,
-            );
+            tokenCount = await _chatService.engine.getTokenCount(finalText);
           } on LlamaUnsupportedException {
-            _messages.last.tokenCount = generationResult.generatedTokens;
+            // Keep the generated-token fallback.
           } on UnsupportedError {
-            _messages.last.tokenCount = generationResult.generatedTokens;
+            // Keep the generated-token fallback.
+          }
+          if (!_generationContextMatches(context)) {
+            return;
+          }
+          if (_messages.isNotEmpty && !_messages.last.isUser) {
+            _messages.last.tokenCount = tokenCount;
           }
         }
       }
       _removeEmptyAssistantPlaceholder();
     } catch (e) {
+      if (!_generationContextMatches(context)) {
+        return;
+      }
       _removeEmptyAssistantPlaceholder();
       final errorText = e.toString();
       if (e is TimeoutException) {
-        _chatService.cancelGeneration();
+        if (_generationContextMatches(context)) {
+          _chatService.cancelGeneration();
+        }
         _messages.add(
           ChatMessage(
             text: hasMediaPartsInTurn && isCpuMultimodalTurn
@@ -1678,78 +1926,68 @@ class ChatProvider extends ChangeNotifier {
         );
       }
     } finally {
-      final generatedTokens = generationResult.generatedTokens;
-      final elapsedMs = generationResult.elapsedMs;
-      final decodeElapsedMs = generationResult.decodeElapsedMs;
+      if (_generationContextMatches(context)) {
+        final generatedTokens = generationResult.generatedTokens;
+        final elapsedMs = generationResult.elapsedMs;
+        final decodeElapsedMs = generationResult.decodeElapsedMs;
 
-      int? nativeEvalTokens;
-      double? nativeEvalMs;
-      try {
-        final perf = await _chatService.engine.getPerformanceContext();
-        if (perf != null) {
-          _lastNativePromptEvalMs = perf.promptEvalMs.round();
-          _lastNativeEvalMs = perf.evalMs.round();
-          _lastNativeSampleMs = perf.sampleMs.round();
-          _lastNativePromptEvalTokens = perf.promptEvalTokens;
-          _lastNativeEvalTokens = perf.evalTokens;
-          _lastNativeReusedGraphs = perf.reusedGraphs;
-          nativeEvalTokens = perf.evalTokens;
-          nativeEvalMs = perf.evalMs;
-        } else {
-          _lastNativePromptEvalMs = null;
-          _lastNativeEvalMs = null;
-          _lastNativeSampleMs = null;
-          _lastNativePromptEvalTokens = null;
-          _lastNativeEvalTokens = null;
-          _lastNativeReusedGraphs = null;
+        BackendPerfContextData? performance;
+        try {
+          performance = await _chatService.engine.getPerformanceContext();
+        } catch (_) {
+          performance = null;
         }
-      } catch (_) {
-        _lastNativePromptEvalMs = null;
-        _lastNativeEvalMs = null;
-        _lastNativeSampleMs = null;
-        _lastNativePromptEvalTokens = null;
-        _lastNativeEvalTokens = null;
-        _lastNativeReusedGraphs = null;
-      }
 
-      final effectiveGeneratedTokens = nativeEvalTokens ?? generatedTokens;
-      if (_messages.isNotEmpty &&
-          !_messages.last.isUser &&
-          !_messages.last.isInfo) {
-        _messages.last.generatedTokenCount = effectiveGeneratedTokens;
-      }
-      if (nativeEvalTokens != null &&
-          nativeEvalTokens != appliedGeneratedTokenDeltas) {
-        _currentTokens = math.max(
-          0,
-          _currentTokens + nativeEvalTokens - appliedGeneratedTokenDeltas,
-        );
-      }
+        if (_generationContextMatches(context)) {
+          final nativeEvalTokens = performance?.evalTokens;
+          final nativeEvalMs = performance?.evalMs;
+          _lastNativePromptEvalMs = performance?.promptEvalMs.round();
+          _lastNativeEvalMs = performance?.evalMs.round();
+          _lastNativeSampleMs = performance?.sampleMs.round();
+          _lastNativePromptEvalTokens = performance?.promptEvalTokens;
+          _lastNativeEvalTokens = nativeEvalTokens;
+          _lastNativeReusedGraphs = performance?.reusedGraphs;
 
-      if (effectiveGeneratedTokens > 0 && elapsedMs > 0) {
-        _lastTokensPerSecond = effectiveGeneratedTokens / (elapsedMs / 1000);
-      } else {
-        _lastTokensPerSecond = null;
-      }
+          final effectiveGeneratedTokens = nativeEvalTokens ?? generatedTokens;
+          if (_messages.isNotEmpty &&
+              !_messages.last.isUser &&
+              !_messages.last.isInfo) {
+            _messages.last.generatedTokenCount = effectiveGeneratedTokens;
+          }
+          if (nativeEvalTokens != null &&
+              nativeEvalTokens != appliedGeneratedTokenDeltas) {
+            _currentTokens = math.max(
+              0,
+              _currentTokens + nativeEvalTokens - appliedGeneratedTokenDeltas,
+            );
+          }
 
-      final effectiveDecodeElapsedMs = nativeEvalMs != null && nativeEvalMs > 0
-          ? nativeEvalMs
-          : decodeElapsedMs.toDouble();
-      if (effectiveGeneratedTokens > 0 && effectiveDecodeElapsedMs > 0) {
-        _lastDecodeTokensPerSecond =
-            effectiveGeneratedTokens / (effectiveDecodeElapsedMs / 1000);
-      } else {
-        _lastDecodeTokensPerSecond = null;
-      }
+          if (effectiveGeneratedTokens > 0 && elapsedMs > 0) {
+            _lastTokensPerSecond =
+                effectiveGeneratedTokens / (elapsedMs / 1000);
+          } else {
+            _lastTokensPerSecond = null;
+          }
 
-      if (generationResult.firstTokenLatencyMs != null ||
-          generationResult.fullResponse.isNotEmpty ||
-          generationResult.fullThinking.isNotEmpty) {
-        _lastGenerationLatencyMs = elapsedMs;
+          final effectiveDecodeElapsedMs =
+              nativeEvalMs != null && nativeEvalMs > 0
+              ? nativeEvalMs
+              : decodeElapsedMs.toDouble();
+          if (effectiveGeneratedTokens > 0 && effectiveDecodeElapsedMs > 0) {
+            _lastDecodeTokensPerSecond =
+                effectiveGeneratedTokens / (effectiveDecodeElapsedMs / 1000);
+          } else {
+            _lastDecodeTokensPerSecond = null;
+          }
+
+          if (generationResult.firstTokenLatencyMs != null ||
+              generationResult.fullResponse.isNotEmpty ||
+              generationResult.fullThinking.isNotEmpty) {
+            _lastGenerationLatencyMs = elapsedMs;
+          }
+        }
       }
-      _isGenerating = false;
-      _syncActiveConversationSnapshot();
-      notifyListeners();
+      _releaseGeneration(context);
     }
   }
 
@@ -1957,14 +2195,24 @@ class ChatProvider extends ChangeNotifier {
     );
   }
 
-  /// Starts foreground microphone capture for a later whole-file transcript.
-  Future<void> startAudioRecording() async {
+  /// Starts foreground microphone capture for the active model's voice flow.
+  Future<void> startAudioRecording({ChatAudioRecordingPurpose? purpose}) async {
     if (!_audioRecordingService.isSupported) {
       _addInfoMessage('Microphone recording is unavailable on this platform.');
       notifyListeners();
       return;
     }
-    if (!canTranscribeAudio || hasActiveAudioRecording) {
+
+    final selectedPurpose =
+        purpose ??
+        (canTranscribeAudio
+            ? ChatAudioRecordingPurpose.transcription
+            : ChatAudioRecordingPurpose.voiceQuestion);
+    final canStartSelectedPurpose = switch (selectedPurpose) {
+      ChatAudioRecordingPurpose.transcription => canTranscribeAudio,
+      ChatAudioRecordingPurpose.voiceQuestion => canAskWithVoice,
+    };
+    if (!canStartSelectedPurpose || hasActiveAudioRecording) {
       return;
     }
 
@@ -1973,6 +2221,7 @@ class ChatProvider extends ChangeNotifier {
     _activeRecordingTransitionDone = transitionDone;
     _audioRecordingState = ChatAudioRecordingState.starting;
     _audioRecordingElapsed = Duration.zero;
+    _audioRecordingPurpose = selectedPurpose;
     _audioRecordingModelPath = _settings.modelPath;
     _audioRecordingMmprojPath = _settings.mmprojPath;
     _audioRecordingConversationId = _activeConversationId;
@@ -2013,10 +2262,12 @@ class ChatProvider extends ChangeNotifier {
     }
   }
 
-  /// Stops microphone capture, transcribes the finalized WAV, then deletes it.
-  Future<void> stopAudioRecordingAndTranscribe() async {
-    if (_audioRecordingState != ChatAudioRecordingState.recording) {
-      return;
+  Future<String?> _finishAudioRecording(
+    ChatAudioRecordingPurpose purpose,
+  ) async {
+    if (_audioRecordingState != ChatAudioRecordingState.recording ||
+        _audioRecordingPurpose != purpose) {
+      return null;
     }
 
     final revision = _audioRecordingRevision;
@@ -2032,7 +2283,7 @@ class ChatProvider extends ChangeNotifier {
       path = await _audioRecordingService.stop();
       if (revision != _audioRecordingRevision || _isDisposed) {
         await _audioRecordingService.deleteRecording(path);
-        return;
+        return null;
       }
     } catch (error) {
       await _audioRecordingService.cancel();
@@ -2059,7 +2310,7 @@ class ChatProvider extends ChangeNotifier {
           notifyListeners();
         }
       }
-      return;
+      return null;
     }
 
     final contextMatches =
@@ -2075,6 +2326,18 @@ class ChatProvider extends ChangeNotifier {
         'Recording discarded because the active model or conversation changed.',
       );
       notifyListeners();
+      return null;
+    }
+
+    return path;
+  }
+
+  /// Stops microphone capture and runs dedicated whole-file transcription.
+  Future<void> stopAudioRecordingAndTranscribe() async {
+    final path = await _finishAudioRecording(
+      ChatAudioRecordingPurpose.transcription,
+    );
+    if (path == null) {
       return;
     }
 
@@ -2088,7 +2351,188 @@ class ChatProvider extends ChangeNotifier {
     }
   }
 
-  /// Discards an active microphone recording without transcribing it.
+  /// Stops microphone capture and asks the active audio-chat model to answer.
+  Future<void> stopAudioRecordingAndAsk() async {
+    final path = await _finishAudioRecording(
+      ChatAudioRecordingPurpose.voiceQuestion,
+    );
+    if (path == null) {
+      return;
+    }
+
+    final context = _reserveVoiceQuestion();
+    if (context == null) {
+      await _audioRecordingService.deleteRecording(path);
+      if (!_isDisposed) {
+        _addInfoMessage(
+          'The active model can no longer accept a recorded voice question.',
+        );
+        notifyListeners();
+      }
+      return;
+    }
+
+    Uint8List? audioBytes;
+    try {
+      audioBytes = await _audioRecordingService.readRecording(path);
+    } catch (error) {
+      if (_voiceQuestionContextMatches(context) && !_isDisposed) {
+        _addInfoMessage(
+          error is AudioRecordingException
+              ? error.message
+              : 'The microphone recording could not be read.',
+        );
+      }
+    } finally {
+      await _audioRecordingService.deleteRecording(path);
+    }
+
+    if (audioBytes == null) {
+      _releaseVoiceQuestionReservation(context);
+      return;
+    }
+    await _submitVoiceQuestion(audioBytes, context);
+  }
+
+  /// Sends encoded [audioBytes] as a spoken question to the active chat model.
+  ///
+  /// Existing staged composer attachments are intentionally left untouched.
+  Future<void> askWithVoice(Uint8List audioBytes) async {
+    final context = _reserveVoiceQuestion();
+    if (context == null) {
+      return;
+    }
+    await _submitVoiceQuestion(audioBytes, context);
+  }
+
+  _VoiceQuestionContext? _reserveVoiceQuestion() {
+    if (!canAskWithVoice || _session == null || !_chatService.engine.isReady) {
+      return null;
+    }
+    final operationId = ++_voiceQuestionOperationSequence;
+    final context = (
+      operationId: operationId,
+      conversationRevision: _conversationRevision,
+      modelPath: _settings.modelPath,
+      mmprojPath: _settings.mmprojPath,
+      conversationId: _activeConversationId,
+    );
+    _activeVoiceQuestionOperationId = operationId;
+    _isGenerating = true;
+    notifyListeners();
+    return context;
+  }
+
+  bool _voiceQuestionContextMatches(_VoiceQuestionContext context) =>
+      _activeVoiceQuestionOperationId == context.operationId &&
+      _isGenerating &&
+      context.conversationRevision == _conversationRevision &&
+      context.modelPath == _settings.modelPath &&
+      context.mmprojPath == _settings.mmprojPath &&
+      context.conversationId == _activeConversationId;
+
+  Future<void> _submitVoiceQuestion(
+    Uint8List audioBytes,
+    _VoiceQuestionContext context,
+  ) async {
+    _GenerationContext? generationContext;
+    var generationStarted = false;
+    try {
+      if (!_voiceQuestionContextMatches(context)) {
+        return;
+      }
+      if (audioBytes.isEmpty) {
+        _addInfoMessage('The microphone recording did not contain any audio.');
+        return;
+      }
+
+      final audio = LlamaAudioContent(bytes: audioBytes);
+      if (!await _ensureMultimodalProjectorForMedia(<LlamaContentPart>[
+            audio,
+          ]) ||
+          !_voiceQuestionContextMatches(context)) {
+        return;
+      }
+
+      generationContext = _beginGeneration();
+      if (generationContext == null) {
+        return;
+      }
+
+      if (_settings.singleTurnMode) {
+        generationContext.session.reset();
+      }
+
+      _messages.add(
+        ChatMessage(
+          text: 'Voice question',
+          isUser: true,
+          parts: <LlamaContentPart>[
+            audio,
+            const LlamaTextContent(_voiceQuestionPrompt),
+          ],
+        ),
+      );
+      _syncActiveConversationSnapshot();
+      notifyListeners();
+      await _yieldUiFrame();
+
+      if (!_voiceQuestionContextMatches(context)) {
+        return;
+      }
+      generationStarted = true;
+      await _generateResponse(
+        _voiceQuestionPrompt,
+        context: generationContext,
+        parts: <LlamaContentPart>[audio],
+      );
+    } catch (error) {
+      if (_voiceQuestionContextMatches(context) && !_isDisposed) {
+        _addInfoMessage('Voice question failed: ${_formatDisplayError(error)}');
+      }
+    } finally {
+      final reservedGeneration = generationContext;
+      if (!generationStarted && reservedGeneration != null) {
+        _releaseGeneration(reservedGeneration);
+      }
+      _releaseVoiceQuestionReservation(
+        context,
+        releaseGeneration: generationContext == null,
+      );
+    }
+  }
+
+  void _releaseVoiceQuestionReservation(
+    _VoiceQuestionContext context, {
+    bool releaseGeneration = true,
+  }) {
+    if (_activeVoiceQuestionOperationId != context.operationId) {
+      return;
+    }
+    _activeVoiceQuestionOperationId = null;
+    if (releaseGeneration &&
+        _activeGenerationOperationId == null &&
+        !_isTranscribing) {
+      _isGenerating = false;
+      _syncActiveConversationSnapshot();
+      if (!_isDisposed) {
+        notifyListeners();
+      }
+    }
+  }
+
+  void _invalidateActiveVoiceQuestion({bool releaseGeneration = false}) {
+    final hadActiveVoiceQuestion = _activeVoiceQuestionOperationId != null;
+    _activeVoiceQuestionOperationId = null;
+    if (releaseGeneration &&
+        hadActiveVoiceQuestion &&
+        _activeGenerationOperationId == null &&
+        !_isTranscribing) {
+      _isGenerating = false;
+    }
+  }
+
+  /// Discards an active microphone recording without processing it.
   Future<void> cancelAudioRecording({bool showMessage = true}) async {
     await _cancelAndAwaitAudioRecording(showMessage: showMessage);
   }
@@ -2104,12 +2548,21 @@ class ChatProvider extends ChangeNotifier {
       }
 
       _audioRecordingElapsed = Duration(seconds: timer.tick);
-      if (_audioRecordingElapsed >= maxAudioRecordingDuration) {
-        _audioRecordingElapsed = maxAudioRecordingDuration;
-        _addInfoMessage(
-          'Maximum recording length reached. Transcribing the recording now.',
-        );
-        unawaited(stopAudioRecordingAndTranscribe());
+      final purpose = _audioRecordingPurpose;
+      final maximumDuration = purpose == ChatAudioRecordingPurpose.voiceQuestion
+          ? maxVoiceQuestionRecordingDuration
+          : maxAudioRecordingDuration;
+      if (_audioRecordingElapsed >= maximumDuration) {
+        _audioRecordingElapsed = maximumDuration;
+        if (purpose == ChatAudioRecordingPurpose.voiceQuestion) {
+          _addInfoMessage('30-second limit reached. Asking the model now.');
+          unawaited(stopAudioRecordingAndAsk());
+        } else {
+          _addInfoMessage(
+            'Maximum recording length reached. Transcribing the recording now.',
+          );
+          unawaited(stopAudioRecordingAndTranscribe());
+        }
         return;
       }
       if (!_isDisposed) {
@@ -2123,6 +2576,7 @@ class ChatProvider extends ChangeNotifier {
     _audioRecordingTimer = null;
     _audioRecordingState = ChatAudioRecordingState.idle;
     _audioRecordingElapsed = Duration.zero;
+    _audioRecordingPurpose = null;
     _audioRecordingModelPath = null;
     _audioRecordingMmprojPath = null;
     _audioRecordingConversationId = null;
@@ -2477,8 +2931,13 @@ class ChatProvider extends ChangeNotifier {
       return;
     }
     if (_isGenerating) {
-      _chatService.cancelGeneration();
-      _isGenerating = false;
+      final hadActiveGeneration = _activeGenerationOperationId != null;
+      _invalidateActiveVoiceQuestion(releaseGeneration: true);
+      _invalidateActiveGeneration(cancelNative: true);
+      if (hadActiveGeneration) {
+        _removeEmptyAssistantPlaceholder();
+        _restoreSessionFromMessages();
+      }
       notifyListeners();
     }
   }
@@ -2486,7 +2945,23 @@ class ChatProvider extends ChangeNotifier {
   void _updateSettings(ChatSettings newSettings) {
     final declarationsChanged =
         _settings.toolDeclarations != newSettings.toolDeclarations;
+    final modelContextChanged =
+        _settings.modelPath != newSettings.modelPath ||
+        _settings.mmprojPath != newSettings.mmprojPath ||
+        _settings.directMediaInput != newSettings.directMediaInput ||
+        _settings.modelSupportsAudio != newSettings.modelSupportsAudio ||
+        _settings.modelSupportsSpeechToText !=
+            newSettings.modelSupportsSpeechToText;
+    final hadActiveGeneration = _activeGenerationOperationId != null;
+    if (modelContextChanged) {
+      _invalidateActiveVoiceQuestion(releaseGeneration: true);
+      _invalidateActiveGeneration(cancelNative: true);
+    }
     _settings = newSettings;
+    if (modelContextChanged && hadActiveGeneration) {
+      _removeEmptyAssistantPlaceholder();
+      _restoreSessionFromMessages();
+    }
     if (declarationsChanged) {
       _rebuildDeclaredToolsFromSettings();
     }

--- a/example/chat_app/lib/screens/manage_models_screen.dart
+++ b/example/chat_app/lib/screens/manage_models_screen.dart
@@ -21,7 +21,7 @@ import '../widgets/tool_declarations_dialog.dart';
 
 enum _CustomModelRemoval { entryOnly, entryAndFiles }
 
-enum _ModelPlatformFilter { all, mobileAndWeb, desktop }
+enum _ModelPlatformFilter { all, mobile, web, desktop }
 
 enum _ModelLibraryMenuAction { removeAll }
 
@@ -157,8 +157,11 @@ class _ManageModelsScreenState extends State<ManageModelsScreen>
           defaultTargetPlatform == TargetPlatform.iOS);
 
   _ModelPlatformFilter get _currentPlatformFilter {
-    if (kIsWeb || _isMobilePlatform) {
-      return _ModelPlatformFilter.mobileAndWeb;
+    if (kIsWeb) {
+      return _ModelPlatformFilter.web;
+    }
+    if (_isMobilePlatform) {
+      return _ModelPlatformFilter.mobile;
     }
     return _ModelPlatformFilter.desktop;
   }
@@ -170,7 +173,11 @@ class _ManageModelsScreenState extends State<ManageModelsScreen>
   bool _matchesPlatformFilter(DownloadableModel model) {
     return switch (_modelPlatformFilter) {
       _ModelPlatformFilter.all => true,
-      _ModelPlatformFilter.mobileAndWeb => model.isAvailableFor(
+      _ModelPlatformFilter.mobile => model.isAvailableFor(
+        web: false,
+        mobile: true,
+      ),
+      _ModelPlatformFilter.web => model.isAvailableFor(
         web: true,
         mobile: false,
       ),
@@ -186,11 +193,11 @@ class _ManageModelsScreenState extends State<ManageModelsScreen>
     if (query.isEmpty) {
       return true;
     }
-    // A Web user can browse the Desktop catalog. In that scope, search the
-    // native capability profile rather than hiding features unavailable only
-    // in the browser runtime.
+    // A Web user can browse the All, Mobile, and Desktop catalogs. Outside the
+    // Web filter, search the native capability profile rather than hiding
+    // features unavailable only in the browser runtime.
     final useWebCapabilities =
-        kIsWeb && _modelPlatformFilter != _ModelPlatformFilter.desktop;
+        kIsWeb && _modelPlatformFilter == _ModelPlatformFilter.web;
     final searchable = <String>[
       model.name,
       model.description,
@@ -1647,9 +1654,13 @@ class _ManageModelsScreenState extends State<ManageModelsScreen>
                                   'All',
                                   Icons.apps_rounded,
                                 ),
-                                _ModelPlatformFilter.mobileAndWeb => (
-                                  'Mobile & Web',
+                                _ModelPlatformFilter.mobile => (
+                                  'Mobile',
                                   Icons.smartphone_rounded,
+                                ),
+                                _ModelPlatformFilter.web => (
+                                  'Web',
+                                  Icons.language_rounded,
                                 ),
                                 _ModelPlatformFilter.desktop => (
                                   'Desktop',

--- a/example/chat_app/lib/services/audio_recording_service.dart
+++ b/example/chat_app/lib/services/audio_recording_service.dart
@@ -1,0 +1,56 @@
+import 'audio_recording_service_stub.dart'
+    if (dart.library.io) 'audio_recording_service_io.dart';
+
+/// The reason a microphone recording operation could not be completed.
+enum AudioRecordingFailure {
+  /// Recording is unavailable on the current platform or runtime.
+  unsupported,
+
+  /// The user did not grant microphone access.
+  permissionDenied,
+
+  /// The recorder could not begin capturing audio.
+  startFailed,
+
+  /// The recorder could not finalize captured audio.
+  stopFailed,
+}
+
+/// A user-actionable microphone recording failure.
+class AudioRecordingException implements Exception {
+  /// The failure category.
+  final AudioRecordingFailure failure;
+
+  /// A message suitable for display in the chat UI.
+  final String message;
+
+  /// Creates a recording failure.
+  const AudioRecordingException(this.failure, this.message);
+
+  @override
+  String toString() => message;
+}
+
+/// Captures temporary audio files for the chat app's transcription flow.
+abstract class AudioRecordingService {
+  /// Creates the platform recording service.
+  factory AudioRecordingService() => createAudioRecordingService();
+
+  /// Whether this runtime has a microphone recorder implementation.
+  bool get isSupported;
+
+  /// Starts a new temporary recording.
+  Future<void> start();
+
+  /// Stops the active recording and returns its temporary WAV path.
+  Future<String> stop();
+
+  /// Cancels the active recording and removes any partial file.
+  Future<void> cancel();
+
+  /// Removes a completed temporary recording.
+  Future<void> deleteRecording(String path);
+
+  /// Releases recorder resources and removes any active recording.
+  Future<void> dispose();
+}

--- a/example/chat_app/lib/services/audio_recording_service.dart
+++ b/example/chat_app/lib/services/audio_recording_service.dart
@@ -1,3 +1,5 @@
+import 'dart:typed_data';
+
 import 'audio_recording_service_stub.dart'
     if (dart.library.io) 'audio_recording_service_io.dart';
 
@@ -14,6 +16,9 @@ enum AudioRecordingFailure {
 
   /// The recorder could not finalize captured audio.
   stopFailed,
+
+  /// A finalized recording could not be read for model input.
+  readFailed,
 }
 
 /// A user-actionable microphone recording failure.
@@ -44,6 +49,9 @@ abstract class AudioRecordingService {
 
   /// Stops the active recording and returns its temporary WAV path.
   Future<String> stop();
+
+  /// Reads a finalized temporary recording as encoded WAV bytes.
+  Future<Uint8List> readRecording(String path);
 
   /// Cancels the active recording and removes any partial file.
   Future<void> cancel();

--- a/example/chat_app/lib/services/audio_recording_service_io.dart
+++ b/example/chat_app/lib/services/audio_recording_service_io.dart
@@ -1,4 +1,5 @@
 import 'dart:io';
+import 'dart:typed_data';
 
 import 'package:path/path.dart' as p;
 import 'package:path_provider/path_provider.dart';
@@ -130,6 +131,27 @@ class _IoAudioRecordingService implements AudioRecordingService {
       throw const AudioRecordingException(
         AudioRecordingFailure.stopFailed,
         'Could not finish the microphone recording.',
+      );
+    }
+  }
+
+  @override
+  Future<Uint8List> readRecording(String path) async {
+    try {
+      final bytes = await File(path).readAsBytes();
+      if (bytes.isEmpty) {
+        throw const AudioRecordingException(
+          AudioRecordingFailure.readFailed,
+          'The microphone recording could not be read.',
+        );
+      }
+      return bytes;
+    } on AudioRecordingException {
+      rethrow;
+    } catch (_) {
+      throw const AudioRecordingException(
+        AudioRecordingFailure.readFailed,
+        'The microphone recording could not be read.',
       );
     }
   }

--- a/example/chat_app/lib/services/audio_recording_service_io.dart
+++ b/example/chat_app/lib/services/audio_recording_service_io.dart
@@ -1,0 +1,194 @@
+import 'dart:io';
+
+import 'package:path/path.dart' as p;
+import 'package:path_provider/path_provider.dart';
+import 'package:record/record.dart';
+
+import 'audio_recording_service.dart';
+import 'wav_audio_validator.dart';
+
+class _IoAudioRecordingService implements AudioRecordingService {
+  AudioRecorder? _recorder;
+  String? _activePath;
+  bool _isRecording = false;
+  bool _isDisposed = false;
+
+  @override
+  bool get isSupported =>
+      Platform.isAndroid ||
+      Platform.isIOS ||
+      Platform.isMacOS ||
+      Platform.isWindows;
+
+  @override
+  Future<void> start() async {
+    if (_isDisposed || !isSupported) {
+      throw const AudioRecordingException(
+        AudioRecordingFailure.unsupported,
+        'Microphone recording is unavailable on this platform.',
+      );
+    }
+    if (_isRecording) {
+      throw const AudioRecordingException(
+        AudioRecordingFailure.startFailed,
+        'A microphone recording is already in progress.',
+      );
+    }
+
+    final recorder = _recorder ??= AudioRecorder();
+    String? path;
+    try {
+      final hasPermission = await recorder.hasPermission();
+      if (!hasPermission) {
+        throw const AudioRecordingException(
+          AudioRecordingFailure.permissionDenied,
+          'Microphone permission was denied. Enable microphone access in '
+          'system settings and try again.',
+        );
+      }
+      if (!await recorder.isEncoderSupported(AudioEncoder.wav)) {
+        throw const AudioRecordingException(
+          AudioRecordingFailure.unsupported,
+          'WAV microphone recording is unavailable on this device.',
+        );
+      }
+
+      final temporaryDirectory = await getTemporaryDirectory();
+      path = p.join(
+        temporaryDirectory.path,
+        'llamadart_recording_${DateTime.now().microsecondsSinceEpoch}.wav',
+      );
+      _activePath = path;
+      await recorder.start(
+        const RecordConfig(
+          encoder: AudioEncoder.wav,
+          sampleRate: 16000,
+          numChannels: 1,
+          androidConfig: AndroidRecordConfig(manageBluetooth: false),
+        ),
+        path: path,
+      );
+      _isRecording = true;
+    } on AudioRecordingException {
+      rethrow;
+    } catch (_) {
+      _isRecording = false;
+      _activePath = null;
+      if (path != null) {
+        try {
+          await recorder.cancel();
+        } catch (_) {
+          // Best-effort recorder cleanup continues with the file below.
+        }
+        await _deleteFile(path);
+      }
+      throw AudioRecordingException(
+        AudioRecordingFailure.startFailed,
+        _startFailureMessage,
+      );
+    }
+  }
+
+  @override
+  Future<String> stop() async {
+    final recorder = _recorder;
+    final fallbackPath = _activePath;
+    if (!_isRecording || recorder == null || fallbackPath == null) {
+      throw const AudioRecordingException(
+        AudioRecordingFailure.stopFailed,
+        'No microphone recording is in progress.',
+      );
+    }
+
+    try {
+      final stoppedPath = await recorder.stop();
+      _isRecording = false;
+      _activePath = null;
+      final path = stoppedPath ?? fallbackPath;
+      if (!await wavHasAudioData(path)) {
+        await _deleteFile(path);
+        if (path != fallbackPath) {
+          await _deleteFile(fallbackPath);
+        }
+        throw const AudioRecordingException(
+          AudioRecordingFailure.stopFailed,
+          'The microphone recording did not contain any audio.',
+        );
+      }
+      return path;
+    } on AudioRecordingException {
+      rethrow;
+    } catch (_) {
+      try {
+        await recorder.cancel();
+      } catch (_) {
+        // Best-effort native recorder cleanup continues with the file below.
+      }
+      _isRecording = false;
+      _activePath = null;
+      await _deleteFile(fallbackPath);
+      throw const AudioRecordingException(
+        AudioRecordingFailure.stopFailed,
+        'Could not finish the microphone recording.',
+      );
+    }
+  }
+
+  @override
+  Future<void> cancel() async {
+    final recorder = _recorder;
+    final path = _activePath;
+    final shouldCancelRecorder = _isRecording || path != null;
+    _isRecording = false;
+    _activePath = null;
+    if (recorder != null && shouldCancelRecorder) {
+      try {
+        await recorder.cancel();
+      } catch (_) {
+        // Best-effort cleanup continues with the temporary file below.
+      }
+    }
+    if (path != null) {
+      await _deleteFile(path);
+    }
+  }
+
+  @override
+  Future<void> deleteRecording(String path) => _deleteFile(path);
+
+  @override
+  Future<void> dispose() async {
+    if (_isDisposed) {
+      return;
+    }
+    _isDisposed = true;
+    await cancel();
+    final recorder = _recorder;
+    _recorder = null;
+    await recorder?.dispose();
+  }
+
+  Future<void> _deleteFile(String path) async {
+    try {
+      final file = File(path);
+      if (await file.exists()) {
+        await file.delete();
+      }
+    } catch (_) {
+      // Temporary recording cleanup is best effort.
+    }
+  }
+
+  String get _startFailureMessage {
+    if (Platform.isWindows) {
+      return 'Could not start microphone recording. Check the input device '
+          'and allow desktop apps to access the microphone in system settings.';
+    }
+    return 'Could not start microphone recording. Check that an input device '
+        'is available and not in use.';
+  }
+}
+
+/// Creates the native microphone recorder implementation.
+AudioRecordingService createAudioRecordingService() =>
+    _IoAudioRecordingService();

--- a/example/chat_app/lib/services/audio_recording_service_stub.dart
+++ b/example/chat_app/lib/services/audio_recording_service_stub.dart
@@ -1,0 +1,35 @@
+import 'audio_recording_service.dart';
+
+class _UnsupportedAudioRecordingService implements AudioRecordingService {
+  @override
+  bool get isSupported => false;
+
+  @override
+  Future<void> start() async {
+    throw const AudioRecordingException(
+      AudioRecordingFailure.unsupported,
+      'Microphone recording is unavailable on this platform.',
+    );
+  }
+
+  @override
+  Future<String> stop() async {
+    throw const AudioRecordingException(
+      AudioRecordingFailure.unsupported,
+      'Microphone recording is unavailable on this platform.',
+    );
+  }
+
+  @override
+  Future<void> cancel() async {}
+
+  @override
+  Future<void> deleteRecording(String path) async {}
+
+  @override
+  Future<void> dispose() async {}
+}
+
+/// Creates the unsupported-platform recorder implementation.
+AudioRecordingService createAudioRecordingService() =>
+    _UnsupportedAudioRecordingService();

--- a/example/chat_app/lib/services/audio_recording_service_stub.dart
+++ b/example/chat_app/lib/services/audio_recording_service_stub.dart
@@ -1,3 +1,5 @@
+import 'dart:typed_data';
+
 import 'audio_recording_service.dart';
 
 class _UnsupportedAudioRecordingService implements AudioRecordingService {
@@ -14,6 +16,14 @@ class _UnsupportedAudioRecordingService implements AudioRecordingService {
 
   @override
   Future<String> stop() async {
+    throw const AudioRecordingException(
+      AudioRecordingFailure.unsupported,
+      'Microphone recording is unavailable on this platform.',
+    );
+  }
+
+  @override
+  Future<Uint8List> readRecording(String path) async {
     throw const AudioRecordingException(
       AudioRecordingFailure.unsupported,
       'Microphone recording is unavailable on this platform.',

--- a/example/chat_app/lib/services/chat_service.dart
+++ b/example/chat_app/lib/services/chat_service.dart
@@ -86,7 +86,14 @@ class ChatService {
         await _engine.loadModel(settings.modelPath!, modelParams: modelParams);
       }
 
-      if (eagerWarmUpLiteRtLmRuntime && _isLiteRtLmModel(settings.modelPath)) {
+      final isLiteRtLmModel = _isLiteRtLmModel(settings.modelPath);
+      final directAudioLiteRtLm =
+          isLiteRtLmModel &&
+          settings.directMediaInput &&
+          settings.modelSupportsAudio;
+      if (eagerWarmUpLiteRtLmRuntime &&
+          isLiteRtLmModel &&
+          !directAudioLiteRtLm) {
         emitProgress(0.92);
         await _warmUpLiteRtLmRuntime(settings);
       }

--- a/example/chat_app/lib/services/model_service_io.dart
+++ b/example/chat_app/lib/services/model_service_io.dart
@@ -1,3 +1,4 @@
+import 'dart:convert';
 import 'dart:io';
 
 import 'package:crypto/crypto.dart';
@@ -10,6 +11,8 @@ import '../models/downloadable_model.dart';
 import 'model_service_base.dart';
 
 class ModelServiceIO implements ModelService {
+  static const int _integrityStampVersion = 1;
+  static const int _downloadProvenanceVersion = 2;
   static const String _hfToken = String.fromEnvironment('HF_TOKEN');
   static const bool _enableParallelRangeDownloads = bool.fromEnvironment(
     'LLAMADART_CHAT_PARALLEL_DOWNLOAD',
@@ -19,9 +22,17 @@ class ModelServiceIO implements ModelService {
   static const int _parallelMaxParts = 4;
 
   final Dio _dio = Dio();
+  final Future<String> Function(File file) _fileSha256;
   final Map<String, _VerifiedRemoteAsset> _verifiedRemoteAssets = {};
 
-  Map<String, Object> _requestHeaders({int? rangeStart}) {
+  ModelServiceIO({Future<String> Function(File file)? fileSha256})
+    : _fileSha256 = fileSha256 ?? _computeFileSha256;
+
+  static Future<String> _computeFileSha256(File file) async {
+    return (await sha256.bind(file.openRead()).first).toString();
+  }
+
+  Map<String, Object> _requestHeaders({int? rangeStart, String? ifRange}) {
     final headers = <String, Object>{};
     final token = _hfToken.trim();
     if (token.isNotEmpty) {
@@ -29,6 +40,9 @@ class ModelServiceIO implements ModelService {
     }
     if (rangeStart != null && rangeStart > 0) {
       headers['range'] = 'bytes=$rangeStart-';
+      if (ifRange != null && ifRange.isNotEmpty) {
+        headers['if-range'] = ifRange;
+      }
     }
     return headers;
   }
@@ -146,7 +160,7 @@ class ModelServiceIO implements ModelService {
         final source = modelRemoteSource;
         final modelSavePath = _assetPath(modelsDir, source);
         await _downloadFileWithResume(
-          url: source.url,
+          source: source,
           savePath: modelSavePath,
           cancelToken: cancelToken,
           onProgress: (downloadedBytes, totalBytes, resumed) {
@@ -170,7 +184,7 @@ class ModelServiceIO implements ModelService {
         final source = mmprojRemoteSource;
         final mmprojSavePath = _assetPath(modelsDir, source);
         await _downloadFileWithResume(
-          url: source.url,
+          source: source,
           savePath: mmprojSavePath,
           cancelToken: cancelToken,
           onProgress: (downloadedBytes, totalBytes, resumed) {
@@ -259,9 +273,18 @@ class ModelServiceIO implements ModelService {
     required ModelAssetRole role,
   }) async {
     final path = _assetPath(modelsDir, source);
+    if (source is RemoteModelAssetSource) {
+      await _discardStalePartial(path, source);
+    }
     final file = File(path);
     final partialFile = File('$path.download');
-    if (!await file.exists() || await partialFile.exists()) {
+    if (!await file.exists()) {
+      if (source is RemoteModelAssetSource) {
+        await _clearVerifiedRemoteAsset(path);
+      }
+      return false;
+    }
+    if (await partialFile.exists()) {
       return false;
     }
 
@@ -292,29 +315,90 @@ class ModelServiceIO implements ModelService {
     final stat = await file.stat();
     final expectedBytes = source.sizeBytes;
     if (expectedBytes != null && stat.size != expectedBytes) {
-      _verifiedRemoteAssets.remove(file.path);
+      await _clearVerifiedRemoteAsset(file.path);
       return false;
     }
 
     final cached = _verifiedRemoteAssets[file.path];
-    if (cached != null &&
-        cached.size == stat.size &&
-        cached.modified == stat.modified &&
-        cached.sha256 == expectedSha256) {
+    if (cached != null && cached.matches(stat, source, expectedSha256)) {
       return true;
     }
 
-    final actualSha256 = (await sha256.bind(file.openRead()).first).toString();
-    if (actualSha256 != expectedSha256) {
-      _verifiedRemoteAssets.remove(file.path);
+    final persisted = await _readVerifiedRemoteAsset(file.path);
+    if (persisted != null && persisted.matches(stat, source, expectedSha256)) {
+      _verifiedRemoteAssets[file.path] = persisted;
+      return true;
+    }
+
+    final String actualSha256;
+    final FileStat verifiedStat;
+    try {
+      actualSha256 = (await _fileSha256(file)).toLowerCase();
+      verifiedStat = await file.stat();
+    } on FileSystemException {
+      await _clearVerifiedRemoteAsset(file.path);
       return false;
     }
-    _verifiedRemoteAssets[file.path] = _VerifiedRemoteAsset(
-      size: stat.size,
-      modified: stat.modified,
+    if (!_sameFileState(stat, verifiedStat)) {
+      await _clearVerifiedRemoteAsset(file.path);
+      return false;
+    }
+    if (actualSha256 != expectedSha256) {
+      await _clearVerifiedRemoteAsset(file.path);
+      return false;
+    }
+    final verified = _VerifiedRemoteAsset(
+      sourceCacheKey: source.cacheKey,
+      size: verifiedStat.size,
+      modifiedMicros: verifiedStat.modified.microsecondsSinceEpoch,
+      changedMicros: verifiedStat.changed.microsecondsSinceEpoch,
       sha256: actualSha256,
     );
+    _verifiedRemoteAssets[file.path] = verified;
+    await _persistVerifiedRemoteAsset(file.path, verified);
     return true;
+  }
+
+  bool _sameFileState(FileStat first, FileStat second) {
+    return first.size == second.size &&
+        first.modified == second.modified &&
+        first.changed == second.changed;
+  }
+
+  File _integrityStampFile(String path) {
+    return File('$path.llamadart-integrity.json');
+  }
+
+  Future<_VerifiedRemoteAsset?> _readVerifiedRemoteAsset(String path) async {
+    final stamp = await _readJsonMap(_integrityStampFile(path));
+    if (stamp == null || stamp['version'] != _integrityStampVersion) {
+      return null;
+    }
+    try {
+      return _VerifiedRemoteAsset.fromJson(stamp);
+    } on Object {
+      return null;
+    }
+  }
+
+  Future<void> _persistVerifiedRemoteAsset(
+    String path,
+    _VerifiedRemoteAsset verified,
+  ) async {
+    try {
+      await _writeJsonAtomically(_integrityStampFile(path), {
+        'version': _integrityStampVersion,
+        ...verified.toJson(),
+      });
+    } catch (_) {
+      // The stamp is an optimization only. A future process can safely hash
+      // the artifact again if metadata cannot be persisted.
+    }
+  }
+
+  Future<void> _clearVerifiedRemoteAsset(String path) async {
+    _verifiedRemoteAssets.remove(path);
+    await _deleteIfExists(_integrityStampFile(path));
   }
 
   Future<void> _verifyDownloadedRemoteAsset(
@@ -332,7 +416,7 @@ class ModelServiceIO implements ModelService {
     if (await file.exists()) {
       await file.delete();
     }
-    _verifiedRemoteAssets.remove(file.path);
+    await _clearVerifiedRemoteAsset(file.path);
     throw StateError(
       'SHA-256 verification failed for ${source.displayName}. '
       'The incomplete download was discarded; retry the download.',
@@ -358,8 +442,133 @@ class ModelServiceIO implements ModelService {
     }
   }
 
+  File _downloadProvenanceFile(String path) {
+    return File('$path.download.source.json');
+  }
+
+  Future<_DownloadProvenance?> _discardStalePartial(
+    String savePath,
+    RemoteModelAssetSource source,
+  ) async {
+    final tempFile = File('$savePath.download');
+    final provenanceFile = _downloadProvenanceFile(savePath);
+    if (!await tempFile.exists()) {
+      await _deleteIfExists(provenanceFile);
+      return null;
+    }
+
+    final provenance = await _readDownloadProvenance(provenanceFile);
+    final partialLength = await tempFile.length();
+    if (provenance == null ||
+        !provenance.matchesSource(source) ||
+        provenance.partialIsInvalid(partialLength)) {
+      await tempFile.delete();
+      await _deleteIfExists(provenanceFile);
+      return null;
+    }
+    return provenance;
+  }
+
+  Future<_DownloadProvenance?> _readDownloadProvenance(File file) async {
+    final data = await _readJsonMap(file);
+    if (data == null || data['version'] != _downloadProvenanceVersion) {
+      return null;
+    }
+    try {
+      return _DownloadProvenance.fromJson(data);
+    } on Object {
+      return null;
+    }
+  }
+
+  Future<void> _writeDownloadProvenance(
+    String savePath,
+    _DownloadProvenance provenance,
+  ) async {
+    await _writeJsonAtomically(_downloadProvenanceFile(savePath), {
+      'version': _downloadProvenanceVersion,
+      ...provenance.toJson(),
+    });
+  }
+
+  Future<Map<String, Object?>?> _readJsonMap(File file) async {
+    try {
+      if (!await file.exists()) {
+        return null;
+      }
+      final decoded = jsonDecode(await file.readAsString());
+      if (decoded is! Map) {
+        return null;
+      }
+      return decoded.map(
+        (key, value) => MapEntry(key.toString(), value as Object?),
+      );
+    } catch (_) {
+      return null;
+    }
+  }
+
+  Future<void> _writeJsonAtomically(
+    File destination,
+    Map<String, Object?> data,
+  ) async {
+    await destination.parent.create(recursive: true);
+    final temporary = File(
+      '${destination.path}.tmp.$pid.${DateTime.now().microsecondsSinceEpoch}',
+    );
+    try {
+      await temporary.writeAsString(jsonEncode(data), flush: true);
+      if (await destination.exists()) {
+        await destination.delete();
+      }
+      await temporary.rename(destination.path);
+    } finally {
+      await _deleteIfExists(temporary);
+    }
+  }
+
+  Future<void> _deleteIfExists(File file) async {
+    try {
+      if (await file.exists()) {
+        await file.delete();
+      }
+    } on FileSystemException {
+      // Cleanup is best effort. Callers still validate metadata before reuse.
+    }
+  }
+
   Future<void> _downloadFileWithResume({
-    required String url,
+    required RemoteModelAssetSource source,
+    required String savePath,
+    required CancelToken cancelToken,
+    required void Function(int downloadedBytes, int? totalBytes, bool resumed)
+    onProgress,
+  }) async {
+    final existingProvenance = await _discardStalePartial(savePath, source);
+    if (existingProvenance == null) {
+      await _writeDownloadProvenance(
+        savePath,
+        _DownloadProvenance.fromSource(source),
+      );
+    }
+    var completed = false;
+    try {
+      await _downloadFile(
+        source: source,
+        savePath: savePath,
+        cancelToken: cancelToken,
+        onProgress: onProgress,
+      );
+      completed = true;
+    } finally {
+      if (completed) {
+        await _deleteIfExists(_downloadProvenanceFile(savePath));
+      }
+    }
+  }
+
+  Future<void> _downloadFile({
+    required RemoteModelAssetSource source,
     required String savePath,
     required CancelToken cancelToken,
     required void Function(int downloadedBytes, int? totalBytes, bool resumed)
@@ -371,14 +580,30 @@ class ModelServiceIO implements ModelService {
     final canTryParallel =
         _enableParallelRangeDownloads && !await tempFile.exists();
     if (canTryParallel) {
-      final probe = await _probeRemoteFile(url: url, cancelToken: cancelToken);
+      final probe = await _probeRemoteFile(
+        url: source.url,
+        cancelToken: cancelToken,
+      );
       if (probe != null && probe.supportsRanges) {
         final totalBytes = probe.contentLength;
-        if (totalBytes != null && totalBytes >= _parallelThresholdBytes) {
+        final canBindRepresentation =
+            probe.validator != null ||
+            _hasCryptographicOrImmutableSafety(source);
+        if (totalBytes != null &&
+            totalBytes >= _parallelThresholdBytes &&
+            canBindRepresentation) {
+          await _writeDownloadProvenance(
+            savePath,
+            _DownloadProvenance.fromSource(source).withRepresentation(
+              validator: probe.validator,
+              totalBytes: totalBytes,
+            ),
+          );
           final completed = await _downloadFileInParallel(
-            url: url,
+            url: source.url,
             savePath: savePath,
             totalBytes: totalBytes,
+            validator: probe.validator,
             cancelToken: cancelToken,
             onProgress: onProgress,
           );
@@ -390,15 +615,30 @@ class ModelServiceIO implements ModelService {
     }
 
     while (true) {
-      final startByte = allowResume && await tempFile.exists()
+      final provenance = await _readDownloadProvenance(
+        _downloadProvenanceFile(savePath),
+      );
+      final candidateStartByte = allowResume && await tempFile.exists()
           ? await tempFile.length()
           : 0;
+      final canResume =
+          candidateStartByte > 0 &&
+          provenance != null &&
+          provenance.canAttemptResume(
+            source,
+            partialLength: candidateStartByte,
+          );
+      final startByte = canResume ? candidateStartByte : 0;
+      if (candidateStartByte > 0 && !canResume) {
+        await tempFile.delete();
+      }
       final headers = _requestHeaders(
         rangeStart: startByte > 0 ? startByte : null,
+        ifRange: startByte > 0 ? provenance?.validator?.value : null,
       );
 
       final response = await _dio.get<ResponseBody>(
-        url,
+        source.url,
         cancelToken: cancelToken,
         options: Options(
           responseType: ResponseType.stream,
@@ -412,13 +652,46 @@ class ModelServiceIO implements ModelService {
       if (statusCode == HttpStatus.requestedRangeNotSatisfiable &&
           startByte > 0 &&
           await tempFile.exists()) {
-        final finalFile = File(savePath);
-        if (await finalFile.exists()) {
-          await finalFile.delete();
+        final unsatisfiedTotal = _parseUnsatisfiedContentRangeTotal(
+          response.headers.value('content-range'),
+        );
+        final validatorMatches = _responseValidatorMatches(
+          response.headers,
+          provenance?.validator,
+        );
+        final hasIndependentCompletionProof =
+            provenance?.validator != null ||
+            (provenance?.expectedSha256?.isNotEmpty ?? false);
+        var canTrustCompletePartial =
+            unsatisfiedTotal == startByte &&
+            provenance != null &&
+            provenance.totalBytes == startByte &&
+            hasIndependentCompletionProof &&
+            provenance.canAttemptResume(source, partialLength: startByte) &&
+            validatorMatches;
+        final expectedSha256 = provenance?.expectedSha256;
+        if (canTrustCompletePartial &&
+            expectedSha256 != null &&
+            expectedSha256.isNotEmpty) {
+          canTrustCompletePartial =
+              (await _fileSha256(tempFile)).toLowerCase() == expectedSha256;
         }
-        await tempFile.rename(savePath);
-        onProgress(startByte, startByte, true);
-        return;
+        if (canTrustCompletePartial) {
+          final finalFile = File(savePath);
+          if (await finalFile.exists()) {
+            await finalFile.delete();
+          }
+          await tempFile.rename(savePath);
+          onProgress(startByte, startByte, true);
+          return;
+        }
+        await tempFile.delete();
+        await _writeDownloadProvenance(
+          savePath,
+          _DownloadProvenance.fromSource(source),
+        );
+        allowResume = false;
+        continue;
       }
 
       if (statusCode >= HttpStatus.badRequest) {
@@ -436,7 +709,25 @@ class ModelServiceIO implements ModelService {
           startByte > 0 &&
           statusCode == HttpStatus.partialContent &&
           contentRange != null &&
-          contentRange.start == startByte;
+          contentRange.start == startByte &&
+          _responseValidatorMatches(response.headers, provenance?.validator) &&
+          _responseTotalMatches(contentRange.total, provenance?.knownTotal);
+
+      if (startByte == 0) {
+        final responseTotal = _resolveTotalBytes(
+          headers: response.headers,
+          statusCode: statusCode,
+          startByte: 0,
+        );
+        final responseValidator = _preferredResponseValidator(response.headers);
+        await _writeDownloadProvenance(
+          savePath,
+          _DownloadProvenance.fromSource(source).withRepresentation(
+            validator: responseValidator,
+            totalBytes: responseTotal,
+          ),
+        );
+      }
 
       if (startByte > 0 && !canAppend) {
         if (await tempFile.exists()) {
@@ -444,6 +735,17 @@ class ModelServiceIO implements ModelService {
         }
 
         if (statusCode == HttpStatus.ok) {
+          await _writeDownloadProvenance(
+            savePath,
+            _DownloadProvenance.fromSource(source).withRepresentation(
+              validator: _preferredResponseValidator(response.headers),
+              totalBytes: _resolveTotalBytes(
+                headers: response.headers,
+                statusCode: statusCode,
+                startByte: 0,
+              ),
+            ),
+          );
           await _consumeResponseBody(
             tempFile: tempFile,
             finalPath: savePath,
@@ -457,6 +759,10 @@ class ModelServiceIO implements ModelService {
         }
 
         allowResume = false;
+        await _writeDownloadProvenance(
+          savePath,
+          _DownloadProvenance.fromSource(source),
+        );
         continue;
       }
 
@@ -550,6 +856,7 @@ class ModelServiceIO implements ModelService {
       return _RemoteFileProbe(
         contentLength: contentLength,
         supportsRanges: acceptRanges.contains('bytes'),
+        validator: _preferredResponseValidator(response.headers),
       );
     } catch (_) {
       return null;
@@ -560,6 +867,7 @@ class ModelServiceIO implements ModelService {
     required String url,
     required String savePath,
     required int totalBytes,
+    required _HttpRepresentationValidator? validator,
     required CancelToken cancelToken,
     required void Function(int downloadedBytes, int? totalBytes, bool resumed)
     onProgress,
@@ -585,6 +893,8 @@ class ModelServiceIO implements ModelService {
           _downloadRangePart(
             url: url,
             range: ranges[i],
+            totalBytes: totalBytes,
+            validator: validator,
             output: partFiles[i],
             cancelToken: cancelToken,
             onProgress: (received) {
@@ -637,12 +947,17 @@ class ModelServiceIO implements ModelService {
   Future<void> _downloadRangePart({
     required String url,
     required _ByteRange range,
+    required int totalBytes,
+    required _HttpRepresentationValidator? validator,
     required File output,
     required CancelToken cancelToken,
     required void Function(int receivedBytes) onProgress,
   }) async {
     final headers = _requestHeaders();
     headers['range'] = 'bytes=${range.start}-${range.end}';
+    if (validator != null) {
+      headers['if-range'] = validator.value;
+    }
 
     final response = await _dio.get<ResponseBody>(
       url,
@@ -673,7 +988,9 @@ class ModelServiceIO implements ModelService {
     );
     if (contentRange == null ||
         contentRange.start != range.start ||
-        contentRange.end > range.end) {
+        contentRange.end > range.end ||
+        contentRange.total != totalBytes ||
+        !_responseValidatorMatches(response.headers, validator)) {
       throw const _ParallelRangeUnsupportedException();
     }
 
@@ -812,6 +1129,72 @@ class ModelServiceIO implements ModelService {
     return contentLength;
   }
 
+  bool _hasCryptographicOrImmutableSafety(RemoteModelAssetSource source) {
+    final expectedSha256 = source.sha256?.trim();
+    if (expectedSha256 != null && expectedSha256.isNotEmpty) {
+      return true;
+    }
+    final uri = Uri.tryParse(source.url);
+    if (uri == null) {
+      return false;
+    }
+    final segments = uri.pathSegments;
+    final resolveIndex = segments.indexOf('resolve');
+    if (resolveIndex < 0 || resolveIndex + 1 >= segments.length) {
+      return false;
+    }
+    final revision = segments[resolveIndex + 1];
+    return RegExp(r'^[0-9a-fA-F]{40,64}$').hasMatch(revision);
+  }
+
+  _HttpRepresentationValidator? _preferredResponseValidator(Headers headers) {
+    final etag = headers.value(HttpHeaders.etagHeader)?.trim();
+    if (etag != null &&
+        etag.isNotEmpty &&
+        !etag.toUpperCase().startsWith('W/')) {
+      return _HttpRepresentationValidator(
+        kind: _HttpValidatorKind.strongEtag,
+        value: etag,
+      );
+    }
+    final lastModified = headers.value(HttpHeaders.lastModifiedHeader)?.trim();
+    if (lastModified != null && lastModified.isNotEmpty) {
+      return _HttpRepresentationValidator(
+        kind: _HttpValidatorKind.lastModified,
+        value: lastModified,
+      );
+    }
+    return null;
+  }
+
+  bool _responseValidatorMatches(
+    Headers headers,
+    _HttpRepresentationValidator? expected,
+  ) {
+    if (expected == null) {
+      return true;
+    }
+    final actual = switch (expected.kind) {
+      _HttpValidatorKind.strongEtag =>
+        headers.value(HttpHeaders.etagHeader)?.trim(),
+      _HttpValidatorKind.lastModified =>
+        headers.value(HttpHeaders.lastModifiedHeader)?.trim(),
+    };
+    return actual == expected.value;
+  }
+
+  bool _responseTotalMatches(int? actual, int? expected) {
+    return expected == null || actual == expected;
+  }
+
+  int? _parseUnsatisfiedContentRangeTotal(String? raw) {
+    if (raw == null || raw.isEmpty) {
+      return null;
+    }
+    final match = RegExp(r'^bytes\s+\*/(\d+)$').firstMatch(raw);
+    return match == null ? null : int.tryParse(match.group(1)!);
+  }
+
   _ContentRange? _parseContentRange(String? raw) {
     if (raw == null || raw.isEmpty) {
       return null;
@@ -853,7 +1236,7 @@ class ModelServiceIO implements ModelService {
     }
 
     final path = _assetPath(modelsDir, source);
-    _verifiedRemoteAssets.remove(path);
+    await _clearVerifiedRemoteAsset(path);
     final file = File(path);
     if (await file.exists()) {
       await file.delete();
@@ -863,6 +1246,8 @@ class ModelServiceIO implements ModelService {
     if (await tempFile.exists()) {
       await tempFile.delete();
     }
+
+    await _deleteIfExists(_downloadProvenanceFile(path));
 
     final legacyMeta = File('$path.meta');
     if (await legacyMeta.exists()) {
@@ -886,11 +1271,31 @@ class _ContentRange {
 class _RemoteFileProbe {
   final int? contentLength;
   final bool supportsRanges;
+  final _HttpRepresentationValidator? validator;
 
   const _RemoteFileProbe({
     required this.contentLength,
     required this.supportsRanges,
+    required this.validator,
   });
+}
+
+enum _HttpValidatorKind { strongEtag, lastModified }
+
+class _HttpRepresentationValidator {
+  final _HttpValidatorKind kind;
+  final String value;
+
+  const _HttpRepresentationValidator({required this.kind, required this.value});
+
+  factory _HttpRepresentationValidator.fromJson(Map<String, Object?> data) {
+    return _HttpRepresentationValidator(
+      kind: _HttpValidatorKind.values.byName(data['kind'] as String),
+      value: data['value'] as String,
+    );
+  }
+
+  Map<String, Object?> toJson() => {'kind': kind.name, 'value': value};
 }
 
 class _ByteRange {
@@ -907,15 +1312,154 @@ class _ParallelRangeUnsupportedException implements Exception {
 }
 
 class _VerifiedRemoteAsset {
+  final String sourceCacheKey;
   final int size;
-  final DateTime modified;
+  final int modifiedMicros;
+  final int changedMicros;
   final String sha256;
 
   const _VerifiedRemoteAsset({
+    required this.sourceCacheKey,
     required this.size,
-    required this.modified,
+    required this.modifiedMicros,
+    required this.changedMicros,
     required this.sha256,
   });
+
+  factory _VerifiedRemoteAsset.fromJson(Map<String, Object?> data) {
+    return _VerifiedRemoteAsset(
+      sourceCacheKey: data['sourceCacheKey'] as String,
+      size: data['size'] as int,
+      modifiedMicros: data['modifiedMicros'] as int,
+      changedMicros: data['changedMicros'] as int,
+      sha256: data['sha256'] as String,
+    );
+  }
+
+  bool matches(
+    FileStat stat,
+    RemoteModelAssetSource source,
+    String expectedSha256,
+  ) {
+    return sourceCacheKey == source.cacheKey &&
+        size == stat.size &&
+        modifiedMicros == stat.modified.microsecondsSinceEpoch &&
+        changedMicros == stat.changed.microsecondsSinceEpoch &&
+        sha256 == expectedSha256;
+  }
+
+  Map<String, Object?> toJson() => {
+    'sourceCacheKey': sourceCacheKey,
+    'size': size,
+    'modifiedMicros': modifiedMicros,
+    'changedMicros': changedMicros,
+    'sha256': sha256,
+  };
+}
+
+class _DownloadProvenance {
+  final String sourceCacheKey;
+  final String? expectedSha256;
+  final int? expectedSizeBytes;
+  final _HttpRepresentationValidator? validator;
+  final int? totalBytes;
+
+  const _DownloadProvenance({
+    required this.sourceCacheKey,
+    required this.expectedSha256,
+    required this.expectedSizeBytes,
+    required this.validator,
+    required this.totalBytes,
+  });
+
+  factory _DownloadProvenance.fromSource(RemoteModelAssetSource source) {
+    return _DownloadProvenance(
+      sourceCacheKey: source.cacheKey,
+      expectedSha256: source.sha256?.trim().toLowerCase(),
+      expectedSizeBytes: source.sizeBytes,
+      validator: null,
+      totalBytes: null,
+    );
+  }
+
+  factory _DownloadProvenance.fromJson(Map<String, Object?> data) {
+    return _DownloadProvenance(
+      sourceCacheKey: data['sourceCacheKey'] as String,
+      expectedSha256: data['expectedSha256'] as String?,
+      expectedSizeBytes: data['expectedSizeBytes'] as int?,
+      validator: data['validator'] is Map
+          ? _HttpRepresentationValidator.fromJson(
+              (data['validator'] as Map).map(
+                (key, value) => MapEntry(key.toString(), value as Object?),
+              ),
+            )
+          : null,
+      totalBytes: data['totalBytes'] as int?,
+    );
+  }
+
+  bool matchesSource(RemoteModelAssetSource source) {
+    final expected = _DownloadProvenance.fromSource(source);
+    return sourceCacheKey == expected.sourceCacheKey &&
+        expectedSha256 == expected.expectedSha256 &&
+        expectedSizeBytes == expected.expectedSizeBytes;
+  }
+
+  bool partialIsInvalid(int partialLength) {
+    final total = knownTotal;
+    return partialLength <= 0 || (total != null && partialLength > total);
+  }
+
+  bool canAttemptResume(
+    RemoteModelAssetSource source, {
+    required int partialLength,
+  }) {
+    if (!matchesSource(source) || partialIsInvalid(partialLength)) {
+      return false;
+    }
+    if (knownTotal == null) {
+      return false;
+    }
+    return validator != null ||
+        (expectedSha256?.isNotEmpty ?? false) ||
+        _isImmutableRevision(source.url);
+  }
+
+  int? get knownTotal => totalBytes ?? expectedSizeBytes;
+
+  _DownloadProvenance withRepresentation({
+    required _HttpRepresentationValidator? validator,
+    required int? totalBytes,
+  }) {
+    return _DownloadProvenance(
+      sourceCacheKey: sourceCacheKey,
+      expectedSha256: expectedSha256,
+      expectedSizeBytes: expectedSizeBytes,
+      validator: validator,
+      totalBytes: totalBytes,
+    );
+  }
+
+  static bool _isImmutableRevision(String url) {
+    final uri = Uri.tryParse(url);
+    if (uri == null) {
+      return false;
+    }
+    final segments = uri.pathSegments;
+    final resolveIndex = segments.indexOf('resolve');
+    if (resolveIndex < 0 || resolveIndex + 1 >= segments.length) {
+      return false;
+    }
+    return RegExp(r'^[0-9a-fA-F]{40,64}$').hasMatch(segments[resolveIndex + 1]);
+  }
+
+  Map<String, Object?> toJson() => {
+    'sourceCacheKey': sourceCacheKey,
+    'expectedSha256': expectedSha256,
+    'expectedSizeBytes': expectedSizeBytes,
+    'validator': validator?.toJson(),
+    'totalBytes': totalBytes,
+  };
 }
 
 class _ProgressDispatcher {

--- a/example/chat_app/lib/services/wav_audio_validator.dart
+++ b/example/chat_app/lib/services/wav_audio_validator.dart
@@ -1,0 +1,60 @@
+import 'dart:io';
+import 'dart:typed_data';
+
+/// Returns whether [path] is a RIFF/WAVE file with a nonempty data chunk.
+Future<bool> wavHasAudioData(String path) async {
+  RandomAccessFile? input;
+  try {
+    final file = File(path);
+    final fileLength = await file.length();
+    if (fileLength < 20) {
+      return false;
+    }
+    input = await file.open();
+    final riffHeader = await input.read(12);
+    if (riffHeader.length != 12 ||
+        riffHeader[0] != 0x52 ||
+        riffHeader[1] != 0x49 ||
+        riffHeader[2] != 0x46 ||
+        riffHeader[3] != 0x46 ||
+        riffHeader[8] != 0x57 ||
+        riffHeader[9] != 0x41 ||
+        riffHeader[10] != 0x56 ||
+        riffHeader[11] != 0x45) {
+      return false;
+    }
+
+    var offset = 12;
+    while (offset + 8 <= fileLength) {
+      await input.setPosition(offset);
+      final chunkHeader = await input.read(8);
+      if (chunkHeader.length != 8) {
+        return false;
+      }
+      final chunkSize = ByteData.sublistView(
+        chunkHeader,
+      ).getUint32(4, Endian.little);
+      final payloadOffset = offset + 8;
+      final isDataChunk =
+          chunkHeader[0] == 0x64 &&
+          chunkHeader[1] == 0x61 &&
+          chunkHeader[2] == 0x74 &&
+          chunkHeader[3] == 0x61;
+      if (isDataChunk) {
+        return chunkSize > 0 && fileLength - payloadOffset >= chunkSize;
+      }
+
+      final paddedChunkSize = chunkSize + (chunkSize.isOdd ? 1 : 0);
+      final nextOffset = payloadOffset + paddedChunkSize;
+      if (nextOffset <= offset || nextOffset > fileLength) {
+        return false;
+      }
+      offset = nextOffset;
+    }
+    return false;
+  } catch (_) {
+    return false;
+  } finally {
+    await input?.close();
+  }
+}

--- a/example/chat_app/lib/widgets/chat_input.dart
+++ b/example/chat_app/lib/widgets/chat_input.dart
@@ -205,11 +205,15 @@ class _ChatInputState extends State<ChatInput> {
     return Consumer<ChatProvider>(
       builder: (context, provider, _) {
         final isGenerating = provider.isGenerating;
+        final hasActiveAudioRecording = provider.hasActiveAudioRecording;
         final isReady = provider.isReady;
         final stagedParts = provider.stagedParts;
         final hasAttachments = stagedParts.isNotEmpty;
         final canSubmit =
-            !isGenerating && isReady && (_hasDraftText || hasAttachments);
+            !isGenerating &&
+            !hasActiveAudioRecording &&
+            isReady &&
+            (_hasDraftText || hasAttachments);
         final sendActionLabel = isGenerating
             ? 'Stop generation'
             : 'Send message';
@@ -296,20 +300,36 @@ class _ChatInputState extends State<ChatInput> {
                       _buildFunctionCallingRow(context, provider),
                       const SizedBox(height: 10),
                     ],
+                    if (hasActiveAudioRecording) ...[
+                      _buildAudioRecordingRow(context, provider),
+                      const SizedBox(height: 8),
+                    ],
                     if (hasAttachments)
                       _buildStagedPartsStrip(context, provider, stagedParts),
                     Row(
                       crossAxisAlignment: CrossAxisAlignment.end,
                       children: [
-                        if (provider.canAttachMedia)
+                        if (provider.canAttachMedia && !hasActiveAudioRecording)
                           _buildAttachmentMenu(context, provider),
+                        if (provider.canStartAudioRecording)
+                          IconButton(
+                            key: const ValueKey<String>('record_audio_button'),
+                            tooltip: 'Record audio',
+                            onPressed: () =>
+                                unawaited(provider.startAudioRecording()),
+                            icon: Icon(
+                              Icons.mic_none_rounded,
+                              color: colorScheme.primary,
+                              semanticLabel: kIsWeb ? null : 'Record audio',
+                            ),
+                          ),
                         Expanded(
                           child: CallbackShortcuts(
                             bindings: shortcutBindings,
                             child: TextField(
                               controller: widget.controller,
                               focusNode: widget.focusNode,
-                              enabled: isReady,
+                              enabled: isReady && !hasActiveAudioRecording,
                               maxLines: 6,
                               minLines: 1,
                               textCapitalization: TextCapitalization.sentences,
@@ -589,6 +609,123 @@ class _ChatInputState extends State<ChatInput> {
           ),
       ],
     );
+  }
+
+  Widget _buildAudioRecordingRow(BuildContext context, ChatProvider provider) {
+    final colorScheme = Theme.of(context).colorScheme;
+    final state = provider.audioRecordingState;
+    final isRecording = state == ChatAudioRecordingState.recording;
+    final isStarting = state == ChatAudioRecordingState.starting;
+    final status = switch (state) {
+      ChatAudioRecordingState.starting => 'Requesting microphone access…',
+      ChatAudioRecordingState.recording =>
+        'Recording ${_formatRecordingDuration(provider.audioRecordingElapsed)}',
+      ChatAudioRecordingState.stopping => 'Finishing recording…',
+      ChatAudioRecordingState.cancelling => 'Discarding recording…',
+      ChatAudioRecordingState.idle => '',
+    };
+    final semanticStatus = switch (state) {
+      ChatAudioRecordingState.starting => 'Requesting microphone access',
+      ChatAudioRecordingState.recording => 'Microphone recording in progress',
+      ChatAudioRecordingState.stopping => 'Finishing microphone recording',
+      ChatAudioRecordingState.cancelling => 'Discarding microphone recording',
+      ChatAudioRecordingState.idle => '',
+    };
+
+    return Semantics(
+      liveRegion: true,
+      label: semanticStatus,
+      child: Container(
+        key: const ValueKey<String>('audio_recording_status'),
+        padding: const EdgeInsets.symmetric(horizontal: 12, vertical: 8),
+        decoration: BoxDecoration(
+          color: colorScheme.errorContainer.withValues(alpha: 0.55),
+          borderRadius: BorderRadius.circular(12),
+        ),
+        child: LayoutBuilder(
+          builder: (context, constraints) {
+            Widget statusIndicator() => isRecording
+                ? Icon(
+                    Icons.fiber_manual_record_rounded,
+                    size: 16,
+                    color: colorScheme.error,
+                  )
+                : SizedBox.square(
+                    dimension: 16,
+                    child: CircularProgressIndicator(
+                      strokeWidth: 2,
+                      color: colorScheme.error,
+                    ),
+                  );
+
+            Widget statusText() => Text(
+              status,
+              style: TextStyle(
+                color: colorScheme.onErrorContainer,
+                fontWeight: FontWeight.w600,
+              ),
+            );
+
+            final actions = <Widget>[
+              if (isStarting || isRecording)
+                TextButton(
+                  key: const ValueKey<String>('discard_audio_recording_button'),
+                  onPressed: () => unawaited(provider.cancelAudioRecording()),
+                  child: const Text('Discard'),
+                ),
+              if (isRecording)
+                FilledButton.tonalIcon(
+                  key: const ValueKey<String>(
+                    'stop_and_transcribe_audio_button',
+                  ),
+                  onPressed: () =>
+                      unawaited(provider.stopAudioRecordingAndTranscribe()),
+                  icon: const Icon(Icons.stop_rounded, size: 18),
+                  label: const Text('Stop & transcribe'),
+                ),
+            ];
+
+            if (constraints.maxWidth < 520) {
+              return Column(
+                crossAxisAlignment: CrossAxisAlignment.stretch,
+                children: [
+                  Row(
+                    children: [
+                      statusIndicator(),
+                      const SizedBox(width: 8),
+                      Expanded(child: statusText()),
+                    ],
+                  ),
+                  if (actions.isNotEmpty) ...[
+                    const SizedBox(height: 4),
+                    Align(
+                      alignment: Alignment.centerRight,
+                      child: Wrap(spacing: 4, children: actions),
+                    ),
+                  ],
+                ],
+              );
+            }
+
+            return Row(
+              children: [
+                statusIndicator(),
+                const SizedBox(width: 8),
+                Expanded(child: statusText()),
+                if (actions.isNotEmpty) Wrap(spacing: 4, children: actions),
+              ],
+            );
+          },
+        ),
+      ),
+    );
+  }
+
+  String _formatRecordingDuration(Duration duration) {
+    final totalSeconds = duration.inSeconds;
+    final minutes = totalSeconds ~/ 60;
+    final seconds = totalSeconds % 60;
+    return '$minutes:${seconds.toString().padLeft(2, '0')}';
   }
 
   Widget _buildPartPreview(LlamaContentPart part) {

--- a/example/chat_app/lib/widgets/chat_input.dart
+++ b/example/chat_app/lib/widgets/chat_input.dart
@@ -226,6 +226,14 @@ class _ChatInputState extends State<ChatInput> {
         final usesMetaPaste =
             platform == TargetPlatform.macOS || platform == TargetPlatform.iOS;
         final safeBottom = MediaQuery.paddingOf(context).bottom;
+        final microphoneActionLabel =
+            provider.settings.modelSupportsSpeechToText
+            ? 'Record for transcription.'
+            : 'Ask with voice. Records up to 30 seconds.';
+        final VoidCallback? startAudioRecordingAction =
+            provider.canStartAudioRecording
+            ? () => unawaited(provider.startAudioRecording())
+            : null;
         final shortcutBindings = <ShortcutActivator, VoidCallback>{
           const SingleActivator(
             LogicalKeyboardKey.enter,
@@ -311,16 +319,28 @@ class _ChatInputState extends State<ChatInput> {
                       children: [
                         if (provider.canAttachMedia && !hasActiveAudioRecording)
                           _buildAttachmentMenu(context, provider),
-                        if (provider.canStartAudioRecording)
-                          IconButton(
-                            key: const ValueKey<String>('record_audio_button'),
-                            tooltip: 'Record audio',
-                            onPressed: () =>
-                                unawaited(provider.startAudioRecording()),
-                            icon: Icon(
-                              Icons.mic_none_rounded,
-                              color: colorScheme.primary,
-                              semanticLabel: kIsWeb ? null : 'Record audio',
+                        if (provider.supportsMicrophoneRecording)
+                          Semantics(
+                            label: microphoneActionLabel,
+                            button: true,
+                            enabled: provider.canStartAudioRecording,
+                            onTap: startAudioRecordingAction,
+                            excludeSemantics: true,
+                            child: IconButton(
+                              key: const ValueKey<String>(
+                                'record_audio_button',
+                              ),
+                              tooltip:
+                                  provider.settings.modelSupportsSpeechToText
+                                  ? 'Record for transcription'
+                                  : 'Ask with voice',
+                              onPressed: startAudioRecordingAction,
+                              icon: Icon(
+                                Icons.mic_none_rounded,
+                                color: provider.canStartAudioRecording
+                                    ? colorScheme.primary
+                                    : null,
+                              ),
                             ),
                           ),
                         Expanded(
@@ -616,18 +636,40 @@ class _ChatInputState extends State<ChatInput> {
     final state = provider.audioRecordingState;
     final isRecording = state == ChatAudioRecordingState.recording;
     final isStarting = state == ChatAudioRecordingState.starting;
+    final isVoiceQuestion =
+        provider.audioRecordingPurpose ==
+        ChatAudioRecordingPurpose.voiceQuestion;
+    final maximumDuration = isVoiceQuestion
+        ? ChatProvider.maxVoiceQuestionRecordingDuration
+        : ChatProvider.maxAudioRecordingDuration;
     final status = switch (state) {
       ChatAudioRecordingState.starting => 'Requesting microphone access…',
       ChatAudioRecordingState.recording =>
-        'Recording ${_formatRecordingDuration(provider.audioRecordingElapsed)}',
-      ChatAudioRecordingState.stopping => 'Finishing recording…',
+        isVoiceQuestion
+            ? 'Recording voice question '
+                  '${_formatRecordingDuration(provider.audioRecordingElapsed)} / '
+                  '${_formatRecordingDuration(maximumDuration)}'
+            : 'Recording for transcription '
+                  '${_formatRecordingDuration(provider.audioRecordingElapsed)} / '
+                  '${_formatRecordingDuration(maximumDuration)}',
+      ChatAudioRecordingState.stopping =>
+        isVoiceQuestion ? 'Preparing voice question…' : 'Finishing recording…',
       ChatAudioRecordingState.cancelling => 'Discarding recording…',
       ChatAudioRecordingState.idle => '',
     };
     final semanticStatus = switch (state) {
-      ChatAudioRecordingState.starting => 'Requesting microphone access',
-      ChatAudioRecordingState.recording => 'Microphone recording in progress',
-      ChatAudioRecordingState.stopping => 'Finishing microphone recording',
+      ChatAudioRecordingState.starting =>
+        isVoiceQuestion
+            ? 'Requesting microphone access for a voice question'
+            : 'Requesting microphone access for transcription',
+      ChatAudioRecordingState.recording =>
+        isVoiceQuestion
+            ? 'Recording voice question. Maximum 30 seconds.'
+            : 'Microphone recording for transcription in progress',
+      ChatAudioRecordingState.stopping =>
+        isVoiceQuestion
+            ? 'Preparing recorded voice question'
+            : 'Finishing microphone recording',
       ChatAudioRecordingState.cancelling => 'Discarding microphone recording',
       ChatAudioRecordingState.idle => '',
     };
@@ -675,13 +717,20 @@ class _ChatInputState extends State<ChatInput> {
                 ),
               if (isRecording)
                 FilledButton.tonalIcon(
-                  key: const ValueKey<String>(
-                    'stop_and_transcribe_audio_button',
+                  key: ValueKey<String>(
+                    isVoiceQuestion
+                        ? 'stop_and_ask_audio_button'
+                        : 'stop_and_transcribe_audio_button',
                   ),
-                  onPressed: () =>
-                      unawaited(provider.stopAudioRecordingAndTranscribe()),
+                  onPressed: () => unawaited(
+                    isVoiceQuestion
+                        ? provider.stopAudioRecordingAndAsk()
+                        : provider.stopAudioRecordingAndTranscribe(),
+                  ),
                   icon: const Icon(Icons.stop_rounded, size: 18),
-                  label: const Text('Stop & transcribe'),
+                  label: Text(
+                    isVoiceQuestion ? 'Stop & ask' : 'Stop & transcribe',
+                  ),
                 ),
             ];
 

--- a/example/chat_app/lib/widgets/model_card.dart
+++ b/example/chat_app/lib/widgets/model_card.dart
@@ -108,12 +108,16 @@ class ModelCard extends StatelessWidget {
     final downloadToggleLabel = isDownloading
         ? 'Pause Download'
         : 'Resume Download';
-    final platformLabel = model.isNativeDesktopOnly
-        ? 'Desktop'
-        : 'All platforms';
-    final unavailableLabel = model.isNativeDesktopOnly
-        ? 'Available on desktop'
-        : 'Unavailable on this platform';
+    final platformLabel = switch (model.availability) {
+      ModelAvailability.all => 'All platforms',
+      ModelAvailability.native => 'Native platforms',
+      ModelAvailability.nativeDesktop => 'Desktop',
+    };
+    final unavailableLabel = switch (model.availability) {
+      ModelAvailability.all => 'Unavailable on this platform',
+      ModelAvailability.native => 'Available on native platforms',
+      ModelAvailability.nativeDesktop => 'Available on desktop',
+    };
 
     return Container(
       decoration: BoxDecoration(
@@ -193,9 +197,13 @@ class ModelCard extends StatelessWidget {
                         ),
                         _buildMetaChip(
                           context,
-                          icon: model.isNativeDesktopOnly
-                              ? Icons.desktop_mac_outlined
-                              : Icons.devices_rounded,
+                          icon: switch (model.availability) {
+                            ModelAvailability.all => Icons.devices_rounded,
+                            ModelAvailability.native =>
+                              Icons.phone_android_rounded,
+                            ModelAvailability.nativeDesktop =>
+                              Icons.desktop_mac_outlined,
+                          },
                           label: platformLabel,
                         ),
                       ],

--- a/example/chat_app/lib/widgets/model_card.dart
+++ b/example/chat_app/lib/widgets/model_card.dart
@@ -200,7 +200,7 @@ class ModelCard extends StatelessWidget {
                           icon: switch (model.availability) {
                             ModelAvailability.all => Icons.devices_rounded,
                             ModelAvailability.native =>
-                              Icons.phone_android_rounded,
+                              Icons.devices_other_rounded,
                             ModelAvailability.nativeDesktop =>
                               Icons.desktop_mac_outlined,
                           },

--- a/example/chat_app/linux/flutter/generated_plugin_registrant.cc
+++ b/example/chat_app/linux/flutter/generated_plugin_registrant.cc
@@ -7,12 +7,16 @@
 #include "generated_plugin_registrant.h"
 
 #include <pasteboard/pasteboard_plugin.h>
+#include <record_linux/record_linux_plugin.h>
 #include <url_launcher_linux/url_launcher_plugin.h>
 
 void fl_register_plugins(FlPluginRegistry* registry) {
   g_autoptr(FlPluginRegistrar) pasteboard_registrar =
       fl_plugin_registry_get_registrar_for_plugin(registry, "PasteboardPlugin");
   pasteboard_plugin_register_with_registrar(pasteboard_registrar);
+  g_autoptr(FlPluginRegistrar) record_linux_registrar =
+      fl_plugin_registry_get_registrar_for_plugin(registry, "RecordLinuxPlugin");
+  record_linux_plugin_register_with_registrar(record_linux_registrar);
   g_autoptr(FlPluginRegistrar) url_launcher_linux_registrar =
       fl_plugin_registry_get_registrar_for_plugin(registry, "UrlLauncherPlugin");
   url_launcher_plugin_register_with_registrar(url_launcher_linux_registrar);

--- a/example/chat_app/linux/flutter/generated_plugins.cmake
+++ b/example/chat_app/linux/flutter/generated_plugins.cmake
@@ -4,6 +4,7 @@
 
 list(APPEND FLUTTER_PLUGIN_LIST
   pasteboard
+  record_linux
   url_launcher_linux
 )
 

--- a/example/chat_app/macos/Flutter/GeneratedPluginRegistrant.swift
+++ b/example/chat_app/macos/Flutter/GeneratedPluginRegistrant.swift
@@ -7,12 +7,14 @@ import Foundation
 
 import file_picker
 import pasteboard
+import record_macos
 import shared_preferences_foundation
 import url_launcher_macos
 
 func RegisterGeneratedPlugins(registry: FlutterPluginRegistry) {
   FilePickerPlugin.register(with: registry.registrar(forPlugin: "FilePickerPlugin"))
   PasteboardPlugin.register(with: registry.registrar(forPlugin: "PasteboardPlugin"))
+  RecordMacOsPlugin.register(with: registry.registrar(forPlugin: "RecordMacOsPlugin"))
   SharedPreferencesPlugin.register(with: registry.registrar(forPlugin: "SharedPreferencesPlugin"))
   UrlLauncherPlugin.register(with: registry.registrar(forPlugin: "UrlLauncherPlugin"))
 }

--- a/example/chat_app/macos/Runner/DebugProfile.entitlements
+++ b/example/chat_app/macos/Runner/DebugProfile.entitlements
@@ -12,5 +12,7 @@
 	<true/>
 	<key>com.apple.security.files.user-selected.read-only</key>
 	<true/>
+	<key>com.apple.security.device.audio-input</key>
+	<true/>
 </dict>
 </plist>

--- a/example/chat_app/macos/Runner/Info.plist
+++ b/example/chat_app/macos/Runner/Info.plist
@@ -25,7 +25,7 @@
 	<key>NSHumanReadableCopyright</key>
 	<string>$(PRODUCT_COPYRIGHT)</string>
 	<key>NSMicrophoneUsageDescription</key>
-	<string>Record speech locally so the selected on-device model can transcribe it.</string>
+	<string>Record speech locally so the selected on-device model can transcribe it or answer the spoken request.</string>
 	<key>NSMainNibFile</key>
 	<string>MainMenu</string>
 	<key>NSPrincipalClass</key>

--- a/example/chat_app/macos/Runner/Info.plist
+++ b/example/chat_app/macos/Runner/Info.plist
@@ -24,6 +24,8 @@
 	<string>$(MACOSX_DEPLOYMENT_TARGET)</string>
 	<key>NSHumanReadableCopyright</key>
 	<string>$(PRODUCT_COPYRIGHT)</string>
+	<key>NSMicrophoneUsageDescription</key>
+	<string>Record speech locally so the selected on-device model can transcribe it.</string>
 	<key>NSMainNibFile</key>
 	<string>MainMenu</string>
 	<key>NSPrincipalClass</key>

--- a/example/chat_app/macos/Runner/Release.entitlements
+++ b/example/chat_app/macos/Runner/Release.entitlements
@@ -8,5 +8,7 @@
 	<true/>
 	<key>com.apple.security.files.user-selected.read-only</key>
 	<true/>
+	<key>com.apple.security.device.audio-input</key>
+	<true/>
 </dict>
 </plist>

--- a/example/chat_app/pubspec.lock
+++ b/example/chat_app/pubspec.lock
@@ -574,6 +574,70 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "2.2.0"
+  record:
+    dependency: "direct main"
+    description:
+      name: record
+      sha256: "10911465138fafacef459a780564e883e01bd48eabf87ab20543684884492870"
+      url: "https://pub.dev"
+    source: hosted
+    version: "6.2.1"
+  record_android:
+    dependency: transitive
+    description:
+      name: record_android
+      sha256: eb1732e42d0d2a1895b8db86e4fc917287e6d8491b6ed59918aea8bed6c69de4
+      url: "https://pub.dev"
+    source: hosted
+    version: "1.5.2"
+  record_ios:
+    dependency: transitive
+    description:
+      name: record_ios
+      sha256: c051fb48edd7a0e265daafb9108730dc827c27b551728a3fdfb3ef69efd89c73
+      url: "https://pub.dev"
+    source: hosted
+    version: "1.2.1"
+  record_linux:
+    dependency: transitive
+    description:
+      name: record_linux
+      sha256: "31181787bf7eccb0e298835836b69b3cd0a903863b75d70e937de3dec71cd8f3"
+      url: "https://pub.dev"
+    source: hosted
+    version: "1.3.1"
+  record_macos:
+    dependency: transitive
+    description:
+      name: record_macos
+      sha256: cfe1b61435e27db418bf513dc36820d10c9f7eb1843786c2c9a52e07e2f4f627
+      url: "https://pub.dev"
+    source: hosted
+    version: "1.2.2"
+  record_platform_interface:
+    dependency: transitive
+    description:
+      name: record_platform_interface
+      sha256: "8e56cbe06c6984137fb86132ff03459f29938d927496d9b2d0962e2d6345d488"
+      url: "https://pub.dev"
+    source: hosted
+    version: "1.6.0"
+  record_web:
+    dependency: transitive
+    description:
+      name: record_web
+      sha256: "7e9846981c1f2d111d86f0ae3309071f5bba8b624d1c977316706f08fc31d16d"
+      url: "https://pub.dev"
+    source: hosted
+    version: "1.3.0"
+  record_windows:
+    dependency: transitive
+    description:
+      name: record_windows
+      sha256: "223258060a1d25c62bae18282c16783f28581ec19401d17e56b5205b9f039d78"
+      url: "https://pub.dev"
+    source: hosted
+    version: "1.0.7"
   shared_preferences:
     dependency: "direct main"
     description:

--- a/example/chat_app/pubspec.yaml
+++ b/example/chat_app/pubspec.yaml
@@ -21,6 +21,7 @@ dependencies:
   dio: ^5.9.0
   crypto: ^3.0.6
   path_provider: ^2.1.5
+  record: ^6.2.1
   google_fonts: ^8.0.0
   flutter_markdown: ^0.7.7+1
   url_launcher: ^6.3.2

--- a/example/chat_app/test/audio_recording_service_test.dart
+++ b/example/chat_app/test/audio_recording_service_test.dart
@@ -1,0 +1,21 @@
+import 'dart:io';
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:llamadart_chat_example/services/audio_recording_service.dart';
+
+void main() {
+  test(
+    'default recorder exposes only the safe native platform matrix',
+    () async {
+      final recorder = AudioRecordingService();
+      addTearDown(recorder.dispose);
+
+      final expected =
+          Platform.isAndroid ||
+          Platform.isIOS ||
+          Platform.isMacOS ||
+          Platform.isWindows;
+      expect(recorder.isSupported, expected);
+    },
+  );
+}

--- a/example/chat_app/test/audio_recording_service_test.dart
+++ b/example/chat_app/test/audio_recording_service_test.dart
@@ -18,4 +18,40 @@ void main() {
       expect(recorder.isSupported, expected);
     },
   );
+
+  test('reads a finalized recording as encoded bytes', () async {
+    final recorder = AudioRecordingService();
+    addTearDown(recorder.dispose);
+    final directory = await Directory.systemTemp.createTemp(
+      'llamadart_recording_read_test_',
+    );
+    addTearDown(() => directory.delete(recursive: true));
+    final file = File('${directory.path}/recording.wav');
+    const expected = <int>[0x52, 0x49, 0x46, 0x46];
+    await file.writeAsBytes(expected);
+
+    expect(await recorder.readRecording(file.path), expected);
+  });
+
+  test('reports an actionable finalized-recording read failure', () async {
+    final recorder = AudioRecordingService();
+    addTearDown(recorder.dispose);
+
+    await expectLater(
+      recorder.readRecording('/path/that/does/not/exist/recording.wav'),
+      throwsA(
+        isA<AudioRecordingException>()
+            .having(
+              (error) => error.failure,
+              'failure',
+              AudioRecordingFailure.readFailed,
+            )
+            .having(
+              (error) => error.message,
+              'message',
+              'The microphone recording could not be read.',
+            ),
+      ),
+    );
+  });
 }

--- a/example/chat_app/test/chat_input_test.dart
+++ b/example/chat_app/test/chat_input_test.dart
@@ -428,6 +428,10 @@ void main() {
           modelPath: 'gemma-4-E2B-it.litertlm',
           modelSupportsAudio: true,
           directMediaInput: true,
+          temperature: 1.0,
+          topK: 64,
+          topP: 0.95,
+          thinkingEnabled: false,
         ),
       );
       addTearDown(provider.dispose);
@@ -446,6 +450,16 @@ void main() {
       expect(recorder.readCalls, 1);
       expect(recorder.deletedPaths, <String>[recorder.recordedPath]);
       expect(engine.createCalls, 1);
+      expect(engine.lastCreateParams?.temp, 1.0);
+      expect(engine.lastCreateParams?.topK, 64);
+      expect(engine.lastCreateParams?.topP, 0.95);
+      expect(engine.lastCreateParams?.seed, isNull);
+      expect(engine.lastCreateEnableThinking, isFalse);
+      expect(engine.lastCreateChatTemplateKwargs, <String, dynamic>{
+        'enable_thinking': false,
+        'thinking': false,
+        'reasoning': false,
+      });
       expect(provider.stagedParts, hasLength(1));
       expect(
         (provider.stagedParts.single as LlamaAudioContent).bytes,
@@ -490,6 +504,11 @@ void main() {
           modelPath: 'gemma-4-E2B-it.litertlm',
           modelSupportsAudio: true,
           directMediaInput: true,
+          temperature: 0.42,
+          topK: 17,
+          topP: 0.83,
+          thinkingEnabled: true,
+          thinkingBudgetTokens: 64,
         ),
       );
       addTearDown(provider.dispose);
@@ -497,11 +516,29 @@ void main() {
 
       await provider.askWithVoice(Uint8List.fromList(const <int>[1, 2, 3]));
       expect(provider.canRegenerateLastResponse, isTrue);
+      expect(engine.lastCreateParams?.temp, 0.42);
+      expect(engine.lastCreateParams?.topK, 17);
+      expect(engine.lastCreateParams?.topP, 0.83);
+      expect(engine.lastCreateParams?.seed, isNull);
+      expect(engine.lastCreateEnableThinking, isTrue);
 
       engine.createChunkContents = const <String>['Second answer.'];
       await provider.regenerateLastResponse();
 
       expect(engine.createCalls, 2);
+      expect(engine.lastCreateParams?.temp, 0.42);
+      expect(engine.lastCreateParams?.topK, 17);
+      expect(engine.lastCreateParams?.topP, 0.83);
+      expect(engine.lastCreateParams?.seed, isNull);
+      expect(engine.lastCreateEnableThinking, isTrue);
+      expect(engine.lastCreateChatTemplateKwargs, <String, dynamic>{
+        'enable_thinking': true,
+        'thinking': true,
+        'reasoning': true,
+        'thinking_budget': 64,
+        'reasoning_budget': 64,
+        'max_thinking_tokens': 64,
+      });
       final regeneratedUserTurn = engine.lastCreateMessages!.last;
       expect(
         regeneratedUserTurn.parts.whereType<LlamaTextContent>().single.text,
@@ -511,6 +548,24 @@ void main() {
         regeneratedUserTurn.parts.whereType<LlamaAudioContent>().single.bytes,
         <int>[1, 2, 3],
       );
+
+      engine.createChunkContents = const <String>['Follow-up answer.'];
+      await provider.sendMessage('Follow-up question');
+
+      expect(engine.createCalls, 3);
+      expect(engine.lastCreateParams?.temp, 0.42);
+      expect(engine.lastCreateParams?.topK, 17);
+      expect(engine.lastCreateParams?.topP, 0.83);
+      expect(engine.lastCreateParams?.seed, isNull);
+      expect(engine.lastCreateEnableThinking, isTrue);
+      expect(engine.lastCreateChatTemplateKwargs, <String, dynamic>{
+        'enable_thinking': true,
+        'thinking': true,
+        'reasoning': true,
+        'thinking_budget': 64,
+        'reasoning_budget': 64,
+        'max_thinking_tokens': 64,
+      });
     },
   );
 

--- a/example/chat_app/test/chat_input_test.dart
+++ b/example/chat_app/test/chat_input_test.dart
@@ -129,6 +129,7 @@ void main() {
     final provider = ChatProvider(
       chatService: MockChatService(),
       settingsService: MockSettingsService(),
+      audioRecordingService: _FakeAudioRecordingService(),
       initialSettings: const ChatSettings(
         modelPath: 'gemma-4-E2B-it.litertlm',
         modelSupportsAudio: true,

--- a/example/chat_app/test/chat_input_test.dart
+++ b/example/chat_app/test/chat_input_test.dart
@@ -135,9 +135,7 @@ void main() {
     expect(find.byTooltip('Record audio'), findsNothing);
   });
 
-  testWidgets('shows transcription and recording for supported native ASR models', (
-    tester,
-  ) async {
+  testWidgets('shows supported ASR recording controls', (tester) async {
     final engine = _SpeechMockLlamaEngine();
     final provider = ChatProvider(
       chatService: MockChatService(engine: engine),

--- a/example/chat_app/test/chat_input_test.dart
+++ b/example/chat_app/test/chat_input_test.dart
@@ -461,7 +461,7 @@ void main() {
       expect(storedAudio.bytes, recorder.recordedBytes);
       expect(
         userMessage.parts!.whereType<LlamaTextContent>().single.text,
-        contains('answer the spoken request'),
+        contains('solve that request'),
       );
 
       final generatedUserTurn = engine.lastCreateMessages!.last;
@@ -472,7 +472,7 @@ void main() {
       );
       expect(
         generatedUserTurn.parts.whereType<LlamaTextContent>().single.text,
-        contains('answer the spoken request'),
+        contains('solve that request'),
       );
     },
   );
@@ -504,7 +504,7 @@ void main() {
       final regeneratedUserTurn = engine.lastCreateMessages!.last;
       expect(
         regeneratedUserTurn.parts.whereType<LlamaTextContent>().single.text,
-        contains('answer the spoken request'),
+        contains('solve that request'),
       );
       expect(
         regeneratedUserTurn.parts.whereType<LlamaAudioContent>().single.bytes,
@@ -513,27 +513,90 @@ void main() {
     },
   );
 
-  test(
-    'external-projector audio is excluded from the first voice path',
-    () async {
-      final provider = ChatProvider(
-        chatService: MockChatService(),
-        audioRecordingService: _FakeAudioRecordingService(),
-        settingsService: MockSettingsService(),
-        initialSettings: const ChatSettings(
-          modelPath: 'audio-chat.gguf',
-          mmprojPath: 'audio-mmproj.gguf',
-          modelSupportsAudio: true,
-        ),
-      );
-      addTearDown(provider.dispose);
-      await provider.loadModel();
+  test('external-projector audio can answer a recorded question', () async {
+    final engine = _SpeechMockLlamaEngine()
+      ..createChunkContents = const <String>['4'];
+    final recorder = _FakeAudioRecordingService();
+    final provider = ChatProvider(
+      chatService: MockChatService(engine: engine),
+      audioRecordingService: recorder,
+      settingsService: MockSettingsService(),
+      initialSettings: const ChatSettings(
+        modelPath: 'gemma-4-E2B-it-Q4_K_S.gguf',
+        mmprojPath: 'gemma-4-E2B-it-mmproj-F16.gguf',
+        modelSupportsAudio: true,
+      ),
+    );
+    addTearDown(provider.dispose);
+    await provider.loadModel();
 
-      expect(provider.settings.modelSupportsAudio, isTrue);
-      expect(provider.canAskWithVoice, isFalse);
-      expect(provider.supportsMicrophoneRecording, isFalse);
-    },
-  );
+    expect(provider.supportsAudio, isTrue);
+    expect(provider.canAskWithVoice, isTrue);
+    expect(provider.supportsMicrophoneRecording, isTrue);
+
+    await provider.startAudioRecording();
+    expect(
+      provider.audioRecordingPurpose,
+      ChatAudioRecordingPurpose.voiceQuestion,
+    );
+    await provider.stopAudioRecordingAndAsk();
+
+    expect(engine.createCalls, 1);
+    expect(recorder.deletedPaths, <String>[recorder.recordedPath]);
+    final generatedUserTurn = engine.lastCreateMessages!.last;
+    expect(
+      generatedUserTurn.parts.whereType<LlamaAudioContent>().single.bytes,
+      recorder.recordedBytes,
+    );
+    expect(
+      generatedUserTurn.parts.whereType<LlamaTextContent>().single.text,
+      'Listen carefully to every spoken word. Determine what the speaker is '
+      'asking, solve that request, and return only the final answer. Do not '
+      'merely repeat a word from the recording.',
+    );
+
+    provider.updateMmprojPath('replacement-mmproj.gguf');
+    expect(provider.canAskWithVoice, isFalse);
+    expect(provider.supportsMicrophoneRecording, isFalse);
+  });
+
+  test('external-projector voice requires a configured projector', () async {
+    final provider = ChatProvider(
+      chatService: MockChatService(engine: _AlwaysAudioMockLlamaEngine()),
+      audioRecordingService: _FakeAudioRecordingService(),
+      settingsService: MockSettingsService(),
+      initialSettings: const ChatSettings(
+        modelPath: 'audio-chat.gguf',
+        modelSupportsAudio: true,
+      ),
+    );
+    addTearDown(provider.dispose);
+    await provider.loadModel();
+
+    expect(provider.supportsAudio, isTrue);
+    expect(provider.canAskWithVoice, isFalse);
+    expect(provider.supportsMicrophoneRecording, isFalse);
+  });
+
+  test('external-projector voice requires runtime audio support', () async {
+    final provider = ChatProvider(
+      chatService: MockChatService(),
+      audioRecordingService: _FakeAudioRecordingService(),
+      settingsService: MockSettingsService(),
+      initialSettings: const ChatSettings(
+        modelPath: 'audio-chat.gguf',
+        mmprojPath: 'audio-mmproj.gguf',
+        modelSupportsAudio: true,
+      ),
+    );
+    addTearDown(provider.dispose);
+    await provider.loadModel();
+
+    expect(provider.settings.modelSupportsAudio, isTrue);
+    expect(provider.supportsAudio, isFalse);
+    expect(provider.canAskWithVoice, isFalse);
+    expect(provider.supportsMicrophoneRecording, isFalse);
+  });
 
   test('dedicated STT takes precedence over direct audio chat', () async {
     final recorder = _FakeAudioRecordingService();
@@ -546,7 +609,6 @@ void main() {
         mmprojPath: 'mmproj-Qwen3-ASR-0.6B-Q8_0.gguf',
         modelSupportsAudio: true,
         modelSupportsSpeechToText: true,
-        directMediaInput: true,
       ),
     );
     addTearDown(provider.dispose);
@@ -1380,6 +1442,11 @@ class _BusyVoiceProvider extends _GeneratingReadyProvider {
 class _SpeechMockLlamaEngine extends MockLlamaEngine {
   @override
   Future<bool> get supportsAudio async => mmprojLoaded;
+}
+
+class _AlwaysAudioMockLlamaEngine extends MockLlamaEngine {
+  @override
+  Future<bool> get supportsAudio async => true;
 }
 
 class _BlockingSpeechMockLlamaEngine extends _SpeechMockLlamaEngine {

--- a/example/chat_app/test/chat_input_test.dart
+++ b/example/chat_app/test/chat_input_test.dart
@@ -135,12 +135,13 @@ void main() {
     expect(find.byTooltip('Record audio'), findsNothing);
   });
 
-  testWidgets('shows dedicated transcription for native ASR models', (
+  testWidgets('shows transcription and recording for supported native ASR models', (
     tester,
   ) async {
     final engine = _SpeechMockLlamaEngine();
     final provider = ChatProvider(
       chatService: MockChatService(engine: engine),
+      audioRecordingService: _FakeAudioRecordingService(),
       settingsService: MockSettingsService(),
       initialSettings: const ChatSettings(
         modelPath: 'Qwen3-ASR-0.6B-Q8_0.gguf',

--- a/example/chat_app/test/chat_input_test.dart
+++ b/example/chat_app/test/chat_input_test.dart
@@ -6,6 +6,7 @@ import 'package:flutter_test/flutter_test.dart';
 import 'package:llamadart/llamadart.dart';
 import 'package:llamadart_chat_example/models/chat_settings.dart';
 import 'package:llamadart_chat_example/providers/chat_provider.dart';
+import 'package:llamadart_chat_example/services/audio_recording_service.dart';
 import 'package:llamadart_chat_example/widgets/chat_input.dart';
 import 'package:provider/provider.dart';
 
@@ -131,6 +132,7 @@ void main() {
     expect(find.text('Attach Audio'), findsOneWidget);
     expect(find.text('Transcribe Audio'), findsNothing);
     expect(find.text('Attach Image'), findsNothing);
+    expect(find.byTooltip('Record audio'), findsNothing);
   });
 
   testWidgets('shows dedicated transcription for native ASR models', (
@@ -174,6 +176,410 @@ void main() {
 
     expect(find.text('Attach Audio'), findsOneWidget);
     expect(find.text('Transcribe Audio'), findsOneWidget);
+    expect(find.byTooltip('Record audio'), findsOneWidget);
+  });
+
+  testWidgets('microphone controls stop and transcribe from the composer', (
+    tester,
+  ) async {
+    final oldSize = tester.view.physicalSize;
+    final oldRatio = tester.view.devicePixelRatio;
+    tester.view
+      ..physicalSize = const Size(390, 844)
+      ..devicePixelRatio = 1.0;
+    addTearDown(() {
+      tester.view
+        ..physicalSize = oldSize
+        ..devicePixelRatio = oldRatio;
+    });
+
+    final engine = _SpeechMockLlamaEngine()
+      ..createChunkContents = const <String>[
+        'language English<asr_text>Composer recording.',
+      ];
+    final recorder = _FakeAudioRecordingService();
+    final provider = ChatProvider(
+      chatService: MockChatService(engine: engine),
+      audioRecordingService: recorder,
+      settingsService: MockSettingsService(),
+      initialSettings: const ChatSettings(
+        modelPath: 'Qwen3-ASR-0.6B-Q8_0.gguf',
+        mmprojPath: 'mmproj-Qwen3-ASR-0.6B-Q8_0.gguf',
+        modelSupportsSpeechToText: true,
+      ),
+    );
+    addTearDown(provider.dispose);
+    await provider.loadModel();
+
+    final controller = TextEditingController();
+    final focusNode = FocusNode();
+    addTearDown(controller.dispose);
+    addTearDown(focusNode.dispose);
+
+    await tester.pumpWidget(
+      ChangeNotifierProvider<ChatProvider>.value(
+        value: provider,
+        child: MaterialApp(
+          home: Scaffold(
+            body: ChatInput(
+              controller: controller,
+              focusNode: focusNode,
+              onSend: () {},
+            ),
+          ),
+        ),
+      ),
+    );
+
+    await tester.tap(find.byTooltip('Record audio'));
+    await tester.pumpAndSettle();
+
+    expect(find.text('Recording 0:00'), findsOneWidget);
+    expect(find.text('Discard'), findsOneWidget);
+    expect(find.text('Stop & transcribe'), findsOneWidget);
+    expect(tester.widget<TextField>(find.byType(TextField)).enabled, isFalse);
+
+    await tester.tap(find.text('Stop & transcribe'));
+    await tester.pumpAndSettle();
+
+    expect(find.byKey(const ValueKey('audio_recording_status')), findsNothing);
+    expect(find.byTooltip('Record audio'), findsOneWidget);
+    expect(engine.createCalls, 1);
+    expect(recorder.deletedPaths, <String>[recorder.recordedPath]);
+  });
+
+  test('records, transcribes, and deletes the temporary WAV', () async {
+    final engine = _SpeechMockLlamaEngine()
+      ..createChunkContents = const <String>[
+        'language English<asr_text>Recorded speech.',
+      ];
+    final recorder = _FakeAudioRecordingService();
+    final provider = ChatProvider(
+      chatService: MockChatService(engine: engine),
+      audioRecordingService: recorder,
+      settingsService: MockSettingsService(),
+      initialSettings: const ChatSettings(
+        modelPath: 'Qwen3-ASR-0.6B-Q8_0.gguf',
+        mmprojPath: 'mmproj-Qwen3-ASR-0.6B-Q8_0.gguf',
+        modelSupportsSpeechToText: true,
+      ),
+    );
+    addTearDown(provider.dispose);
+    await provider.loadModel();
+
+    await provider.startAudioRecording();
+    expect(provider.audioRecordingState, ChatAudioRecordingState.recording);
+    expect(provider.canTranscribeAudio, isFalse);
+    expect(recorder.startCalls, 1);
+
+    await provider.stopAudioRecordingAndTranscribe();
+
+    expect(recorder.stopCalls, 1);
+    expect(recorder.deletedPaths, <String>[recorder.recordedPath]);
+    expect(provider.audioRecordingState, ChatAudioRecordingState.idle);
+    expect(engine.createCalls, 1);
+    expect(
+      provider.messages.where((message) => !message.isInfo).map((m) => m.text),
+      <String>['Transcribe audio: Microphone recording', 'Recorded speech.'],
+    );
+  });
+
+  test('reports microphone permission denial without starting STT', () async {
+    final engine = _SpeechMockLlamaEngine();
+    final recorder = _FakeAudioRecordingService(
+      startError: const AudioRecordingException(
+        AudioRecordingFailure.permissionDenied,
+        'Microphone permission was denied for this test.',
+      ),
+    );
+    final provider = ChatProvider(
+      chatService: MockChatService(engine: engine),
+      audioRecordingService: recorder,
+      settingsService: MockSettingsService(),
+      initialSettings: const ChatSettings(
+        modelPath: 'Qwen3-ASR-0.6B-Q8_0.gguf',
+        mmprojPath: 'mmproj-Qwen3-ASR-0.6B-Q8_0.gguf',
+        modelSupportsSpeechToText: true,
+      ),
+    );
+    addTearDown(provider.dispose);
+    await provider.loadModel();
+
+    await provider.startAudioRecording();
+
+    expect(provider.audioRecordingState, ChatAudioRecordingState.idle);
+    expect(engine.createCalls, 0);
+    expect(
+      provider.messages.last.text,
+      'Microphone permission was denied for this test.',
+    );
+  });
+
+  test('does not advertise an unsupported platform recorder', () async {
+    final engine = _SpeechMockLlamaEngine();
+    final recorder = _FakeAudioRecordingService(supported: false);
+    final provider = ChatProvider(
+      chatService: MockChatService(engine: engine),
+      audioRecordingService: recorder,
+      settingsService: MockSettingsService(),
+      initialSettings: const ChatSettings(
+        modelPath: 'Qwen3-ASR-0.6B-Q8_0.gguf',
+        mmprojPath: 'mmproj-Qwen3-ASR-0.6B-Q8_0.gguf',
+        modelSupportsSpeechToText: true,
+      ),
+    );
+    addTearDown(provider.dispose);
+    await provider.loadModel();
+
+    expect(provider.canStartAudioRecording, isFalse);
+    await provider.startAudioRecording();
+
+    expect(recorder.startCalls, 0);
+    expect(
+      provider.messages.last.text,
+      'Microphone recording is unavailable on this platform.',
+    );
+  });
+
+  test('reserves microphone startup before awaiting permission', () async {
+    final engine = _SpeechMockLlamaEngine();
+    final startGate = Completer<void>();
+    final recorder = _FakeAudioRecordingService(startGate: startGate);
+    final provider = ChatProvider(
+      chatService: MockChatService(engine: engine),
+      audioRecordingService: recorder,
+      settingsService: MockSettingsService(),
+      initialSettings: const ChatSettings(
+        modelPath: 'Qwen3-ASR-0.6B-Q8_0.gguf',
+        mmprojPath: 'mmproj-Qwen3-ASR-0.6B-Q8_0.gguf',
+        modelSupportsSpeechToText: true,
+      ),
+    );
+    addTearDown(provider.dispose);
+    await provider.loadModel();
+
+    final first = provider.startAudioRecording();
+    expect(provider.audioRecordingState, ChatAudioRecordingState.starting);
+    await provider.startAudioRecording();
+    expect(recorder.startCalls, 1);
+
+    startGate.complete();
+    await first;
+    expect(provider.audioRecordingState, ChatAudioRecordingState.recording);
+    await provider.cancelAudioRecording(showMessage: false);
+  });
+
+  test('cancellation wins while microphone startup is pending', () async {
+    final engine = _SpeechMockLlamaEngine();
+    final startGate = Completer<void>();
+    final recorder = _FakeAudioRecordingService(startGate: startGate);
+    final provider = ChatProvider(
+      chatService: MockChatService(engine: engine),
+      audioRecordingService: recorder,
+      settingsService: MockSettingsService(),
+      initialSettings: const ChatSettings(
+        modelPath: 'Qwen3-ASR-0.6B-Q8_0.gguf',
+        mmprojPath: 'mmproj-Qwen3-ASR-0.6B-Q8_0.gguf',
+        modelSupportsSpeechToText: true,
+      ),
+    );
+    addTearDown(provider.dispose);
+    await provider.loadModel();
+
+    final start = provider.startAudioRecording();
+    final cancel = provider.cancelAudioRecording(showMessage: false);
+    expect(provider.audioRecordingState, ChatAudioRecordingState.cancelling);
+
+    startGate.complete();
+    await Future.wait(<Future<void>>[start, cancel]);
+
+    expect(recorder.startCalls, 1);
+    expect(recorder.cancelCalls, 1);
+    expect(engine.createCalls, 0);
+    expect(provider.audioRecordingState, ChatAudioRecordingState.idle);
+  });
+
+  test('discard cancels capture without transcribing', () async {
+    final engine = _SpeechMockLlamaEngine();
+    final recorder = _FakeAudioRecordingService();
+    final provider = ChatProvider(
+      chatService: MockChatService(engine: engine),
+      audioRecordingService: recorder,
+      settingsService: MockSettingsService(),
+      initialSettings: const ChatSettings(
+        modelPath: 'Qwen3-ASR-0.6B-Q8_0.gguf',
+        mmprojPath: 'mmproj-Qwen3-ASR-0.6B-Q8_0.gguf',
+        modelSupportsSpeechToText: true,
+      ),
+    );
+    addTearDown(provider.dispose);
+    await provider.loadModel();
+
+    await provider.startAudioRecording();
+    await provider.cancelAudioRecording();
+
+    expect(recorder.cancelCalls, 1);
+    expect(recorder.stopCalls, 0);
+    expect(engine.createCalls, 0);
+    expect(provider.audioRecordingState, ChatAudioRecordingState.idle);
+    expect(provider.messages.last.text, 'Microphone recording cancelled.');
+  });
+
+  testWidgets('recording limit automatically stops and transcribes', (
+    tester,
+  ) async {
+    final engine = _SpeechMockLlamaEngine()
+      ..createChunkContents = const <String>[
+        'language English<asr_text>Limited recording.',
+      ];
+    final recorder = _FakeAudioRecordingService();
+    final provider = ChatProvider(
+      chatService: MockChatService(engine: engine),
+      audioRecordingService: recorder,
+      settingsService: MockSettingsService(),
+      initialSettings: const ChatSettings(
+        modelPath: 'Qwen3-ASR-0.6B-Q8_0.gguf',
+        mmprojPath: 'mmproj-Qwen3-ASR-0.6B-Q8_0.gguf',
+        modelSupportsSpeechToText: true,
+      ),
+    );
+    addTearDown(provider.dispose);
+    await provider.loadModel();
+    await provider.startAudioRecording();
+
+    await tester.pump(ChatProvider.maxAudioRecordingDuration);
+    await tester.pumpAndSettle();
+
+    expect(recorder.stopCalls, 1);
+    expect(engine.createCalls, 1);
+    expect(provider.audioRecordingState, ChatAudioRecordingState.idle);
+    expect(
+      provider.messages.map((message) => message.text),
+      contains(
+        'Maximum recording length reached. Transcribing the recording now.',
+      ),
+    );
+  });
+
+  test('stop failure resets capture and reports an actionable error', () async {
+    final engine = _SpeechMockLlamaEngine();
+    final recorder = _FakeAudioRecordingService(
+      stopError: const AudioRecordingException(
+        AudioRecordingFailure.stopFailed,
+        'The test recorder could not finalize audio.',
+      ),
+    );
+    final provider = ChatProvider(
+      chatService: MockChatService(engine: engine),
+      audioRecordingService: recorder,
+      settingsService: MockSettingsService(),
+      initialSettings: const ChatSettings(
+        modelPath: 'Qwen3-ASR-0.6B-Q8_0.gguf',
+        mmprojPath: 'mmproj-Qwen3-ASR-0.6B-Q8_0.gguf',
+        modelSupportsSpeechToText: true,
+      ),
+    );
+    addTearDown(provider.dispose);
+    await provider.loadModel();
+    await provider.startAudioRecording();
+
+    await provider.stopAudioRecordingAndTranscribe();
+
+    expect(recorder.cancelCalls, 1);
+    expect(engine.createCalls, 0);
+    expect(provider.audioRecordingState, ChatAudioRecordingState.idle);
+    expect(
+      provider.messages.last.text,
+      'The test recorder could not finalize audio.',
+    );
+  });
+
+  test('unloading the model cancels an active recording first', () async {
+    final engine = _SpeechMockLlamaEngine();
+    final recorder = _FakeAudioRecordingService();
+    final provider = ChatProvider(
+      chatService: MockChatService(engine: engine),
+      audioRecordingService: recorder,
+      settingsService: MockSettingsService(),
+      initialSettings: const ChatSettings(
+        modelPath: 'Qwen3-ASR-0.6B-Q8_0.gguf',
+        mmprojPath: 'mmproj-Qwen3-ASR-0.6B-Q8_0.gguf',
+        modelSupportsSpeechToText: true,
+      ),
+    );
+    addTearDown(provider.dispose);
+    await provider.loadModel();
+    await provider.startAudioRecording();
+
+    await provider.unloadModel();
+
+    expect(recorder.cancelCalls, 1);
+    expect(provider.audioRecordingState, ChatAudioRecordingState.idle);
+    expect(provider.isLoaded, isFalse);
+  });
+
+  test('clear wins a pending stop and deletes its stale WAV', () async {
+    final engine = _SpeechMockLlamaEngine();
+    final stopGate = Completer<void>();
+    final recorder = _FakeAudioRecordingService(stopGate: stopGate);
+    final provider = ChatProvider(
+      chatService: MockChatService(engine: engine),
+      audioRecordingService: recorder,
+      settingsService: MockSettingsService(),
+      initialSettings: const ChatSettings(
+        modelPath: 'Qwen3-ASR-0.6B-Q8_0.gguf',
+        mmprojPath: 'mmproj-Qwen3-ASR-0.6B-Q8_0.gguf',
+        modelSupportsSpeechToText: true,
+      ),
+    );
+    addTearDown(provider.dispose);
+    await provider.loadModel();
+    await provider.startAudioRecording();
+
+    final stop = provider.stopAudioRecordingAndTranscribe();
+    expect(provider.audioRecordingState, ChatAudioRecordingState.stopping);
+    provider.clearConversation();
+    expect(provider.audioRecordingState, ChatAudioRecordingState.cancelling);
+
+    stopGate.complete();
+    await stop;
+    await provider.cancelAudioRecording(showMessage: false);
+
+    expect(engine.createCalls, 0);
+    expect(recorder.deletedPaths, <String>[recorder.recordedPath]);
+    expect(provider.audioRecordingState, ChatAudioRecordingState.idle);
+    expect(provider.messages.map((message) => message.text), <String>[
+      'Conversation cleared. Ready for a new topic!',
+    ]);
+  });
+
+  test('clear suppresses a late recording-cancelled message', () async {
+    final engine = _SpeechMockLlamaEngine();
+    final cancelGate = Completer<void>();
+    final recorder = _FakeAudioRecordingService(cancelGate: cancelGate);
+    final provider = ChatProvider(
+      chatService: MockChatService(engine: engine),
+      audioRecordingService: recorder,
+      settingsService: MockSettingsService(),
+      initialSettings: const ChatSettings(
+        modelPath: 'Qwen3-ASR-0.6B-Q8_0.gguf',
+        mmprojPath: 'mmproj-Qwen3-ASR-0.6B-Q8_0.gguf',
+        modelSupportsSpeechToText: true,
+      ),
+    );
+    addTearDown(provider.dispose);
+    await provider.loadModel();
+    await provider.startAudioRecording();
+
+    final discard = provider.cancelAudioRecording();
+    provider.clearConversation();
+    cancelGate.complete();
+    await discard;
+    await provider.cancelAudioRecording(showMessage: false);
+
+    expect(provider.messages.map((message) => message.text), <String>[
+      'Conversation cleared. Ready for a new topic!',
+    ]);
   });
 
   test('transcribes an in-memory audio file into chat', () async {
@@ -433,5 +839,79 @@ class _BlockingAudioProbeSpeechMockLlamaEngine extends _SpeechMockLlamaEngine {
       await _releaseAudioProbe.future;
     }
     return super.supportsAudio;
+  }
+}
+
+class _FakeAudioRecordingService implements AudioRecordingService {
+  final bool supported;
+  final Object? startError;
+  final Object? stopError;
+  final Completer<void>? startGate;
+  final Completer<void>? stopGate;
+  final Completer<void>? cancelGate;
+  final String recordedPath = '/tmp/llamadart_test_recording.wav';
+
+  int startCalls = 0;
+  int stopCalls = 0;
+  int cancelCalls = 0;
+  int disposeCalls = 0;
+  final List<String> deletedPaths = <String>[];
+
+  _FakeAudioRecordingService({
+    this.supported = true,
+    this.startError,
+    this.stopError,
+    this.startGate,
+    this.stopGate,
+    this.cancelGate,
+  });
+
+  @override
+  bool get isSupported => supported;
+
+  @override
+  Future<void> start() async {
+    startCalls += 1;
+    final gate = startGate;
+    if (gate != null) {
+      await gate.future;
+    }
+    final error = startError;
+    if (error != null) {
+      throw error;
+    }
+  }
+
+  @override
+  Future<String> stop() async {
+    stopCalls += 1;
+    final gate = stopGate;
+    if (gate != null) {
+      await gate.future;
+    }
+    final error = stopError;
+    if (error != null) {
+      throw error;
+    }
+    return recordedPath;
+  }
+
+  @override
+  Future<void> cancel() async {
+    cancelCalls += 1;
+    final gate = cancelGate;
+    if (gate != null) {
+      await gate.future;
+    }
+  }
+
+  @override
+  Future<void> deleteRecording(String path) async {
+    deletedPaths.add(path);
+  }
+
+  @override
+  Future<void> dispose() async {
+    disposeCalls += 1;
   }
 }

--- a/example/chat_app/test/chat_input_test.dart
+++ b/example/chat_app/test/chat_input_test.dart
@@ -7,6 +7,7 @@ import 'package:llamadart/llamadart.dart';
 import 'package:llamadart_chat_example/models/chat_settings.dart';
 import 'package:llamadart_chat_example/providers/chat_provider.dart';
 import 'package:llamadart_chat_example/services/audio_recording_service.dart';
+import 'package:llamadart_chat_example/services/chat_generation_service.dart';
 import 'package:llamadart_chat_example/widgets/chat_input.dart';
 import 'package:provider/provider.dart';
 
@@ -45,6 +46,38 @@ void main() {
 
     await tester.enterText(find.byType(TextField), 'draft next prompt');
     expect(controller.text, 'draft next prompt');
+  });
+
+  testWidgets('keeps a supported microphone action visible while busy', (
+    tester,
+  ) async {
+    final provider = _BusyVoiceProvider();
+    addTearDown(provider.dispose);
+    final controller = TextEditingController();
+    final focusNode = FocusNode();
+    addTearDown(controller.dispose);
+    addTearDown(focusNode.dispose);
+
+    await tester.pumpWidget(
+      ChangeNotifierProvider<ChatProvider>.value(
+        value: provider,
+        child: MaterialApp(
+          home: Scaffold(
+            body: ChatInput(
+              controller: controller,
+              focusNode: focusNode,
+              onSend: () {},
+            ),
+          ),
+        ),
+      ),
+    );
+
+    expect(find.byTooltip('Ask with voice'), findsOneWidget);
+    final button = tester.widget<IconButton>(
+      find.byKey(const ValueKey<String>('record_audio_button')),
+    );
+    expect(button.onPressed, isNull);
   });
 
   testWidgets('uses mobile submit behavior without desktop shortcut copy', (
@@ -90,7 +123,7 @@ void main() {
     expect(find.text('Ask anything…'), findsOneWidget);
   });
 
-  testWidgets('shows audio attachment for direct-media native models', (
+  testWidgets('shows Ask with voice for direct-media native models', (
     tester,
   ) async {
     final provider = ChatProvider(
@@ -132,7 +165,100 @@ void main() {
     expect(find.text('Attach Audio'), findsOneWidget);
     expect(find.text('Transcribe Audio'), findsNothing);
     expect(find.text('Attach Image'), findsNothing);
-    expect(find.byTooltip('Record audio'), findsNothing);
+    expect(find.byTooltip('Ask with voice'), findsOneWidget);
+    expect(
+      find.bySemanticsLabel('Ask with voice. Records up to 30 seconds.'),
+      findsOneWidget,
+    );
+  });
+
+  testWidgets('microphone controls stop and ask from the composer', (
+    tester,
+  ) async {
+    final oldSize = tester.view.physicalSize;
+    final oldRatio = tester.view.devicePixelRatio;
+    tester.view
+      ..physicalSize = const Size(320, 700)
+      ..devicePixelRatio = 1.0;
+    addTearDown(() {
+      tester.view
+        ..physicalSize = oldSize
+        ..devicePixelRatio = oldRatio;
+    });
+
+    final engine = MockLlamaEngine()..createChunkContents = const <String>[];
+    final recorder = _FakeAudioRecordingService();
+    final provider = ChatProvider(
+      chatService: MockChatService(engine: engine),
+      audioRecordingService: recorder,
+      chatGenerationService: const _ImmediateChatGenerationService(),
+      settingsService: MockSettingsService(),
+      initialSettings: const ChatSettings(
+        modelPath: 'gemma-4-E2B-it.litertlm',
+        modelSupportsAudio: true,
+        directMediaInput: true,
+      ),
+    );
+    addTearDown(provider.dispose);
+    await provider.loadModel();
+
+    final controller = TextEditingController(text: 'keep this draft');
+    final focusNode = FocusNode();
+    addTearDown(controller.dispose);
+    addTearDown(focusNode.dispose);
+
+    await tester.pumpWidget(
+      ChangeNotifierProvider<ChatProvider>.value(
+        value: provider,
+        child: MaterialApp(
+          home: Scaffold(
+            body: ChatInput(
+              controller: controller,
+              focusNode: focusNode,
+              onSend: () {},
+            ),
+          ),
+        ),
+      ),
+    );
+
+    await tester.tap(find.byTooltip('Ask with voice'));
+    await tester.pumpAndSettle();
+
+    expect(find.text('Recording voice question 0:00 / 0:30'), findsOneWidget);
+    expect(find.text('Discard'), findsOneWidget);
+    expect(find.text('Stop & ask'), findsOneWidget);
+    expect(find.text('Stop & transcribe'), findsNothing);
+    expect(tester.widget<TextField>(find.byType(TextField)).enabled, isFalse);
+
+    await tester.tap(find.text('Stop & ask'));
+    var sawVoiceGeneration = false;
+    for (var index = 0; index < 120; index++) {
+      await tester.pump(const Duration(milliseconds: 16));
+      sawVoiceGeneration = sawVoiceGeneration || provider.isGenerating;
+      if (sawVoiceGeneration &&
+          engine.createCalls > 0 &&
+          !provider.isGenerating) {
+        break;
+      }
+    }
+
+    expect(find.byKey(const ValueKey('audio_recording_status')), findsNothing);
+    expect(find.byTooltip('Ask with voice'), findsOneWidget);
+    expect(controller.text, 'keep this draft');
+    expect(engine.createCalls, 1);
+    expect(recorder.deletedPaths, <String>[recorder.recordedPath]);
+    final conversationMessages = provider.messages
+        .where((message) => !message.isInfo)
+        .toList(growable: false);
+    expect(conversationMessages[0].text, 'Voice question');
+    final audio = conversationMessages[0].parts!
+        .whereType<LlamaAudioContent>()
+        .single;
+    expect(audio.path, isNull);
+    expect(audio.bytes, recorder.recordedBytes);
+    provider.stopGeneration();
+    await tester.pumpAndSettle();
   });
 
   testWidgets('shows supported ASR recording controls', (tester) async {
@@ -175,7 +301,8 @@ void main() {
 
     expect(find.text('Attach Audio'), findsOneWidget);
     expect(find.text('Transcribe Audio'), findsOneWidget);
-    expect(find.byTooltip('Record audio'), findsOneWidget);
+    expect(find.byTooltip('Record for transcription'), findsOneWidget);
+    expect(find.bySemanticsLabel('Record for transcription.'), findsOneWidget);
   });
 
   testWidgets('microphone controls stop and transcribe from the composer', (
@@ -230,10 +357,13 @@ void main() {
       ),
     );
 
-    await tester.tap(find.byTooltip('Record audio'));
+    await tester.tap(find.byTooltip('Record for transcription'));
     await tester.pumpAndSettle();
 
-    expect(find.text('Recording 0:00'), findsOneWidget);
+    expect(
+      find.text('Recording for transcription 0:00 / 5:00'),
+      findsOneWidget,
+    );
     expect(find.text('Discard'), findsOneWidget);
     expect(find.text('Stop & transcribe'), findsOneWidget);
     expect(tester.widget<TextField>(find.byType(TextField)).enabled, isFalse);
@@ -242,7 +372,7 @@ void main() {
     await tester.pumpAndSettle();
 
     expect(find.byKey(const ValueKey('audio_recording_status')), findsNothing);
-    expect(find.byTooltip('Record audio'), findsOneWidget);
+    expect(find.byTooltip('Record for transcription'), findsOneWidget);
     expect(engine.createCalls, 1);
     expect(recorder.deletedPaths, <String>[recorder.recordedPath]);
   });
@@ -280,6 +410,189 @@ void main() {
     expect(
       provider.messages.where((message) => !message.isInfo).map((m) => m.text),
       <String>['Transcribe audio: Microphone recording', 'Recorded speech.'],
+    );
+  });
+
+  test(
+    'records a byte-backed voice turn without consuming staged attachments',
+    () async {
+      final engine = MockLlamaEngine()
+        ..createChunkContents = const <String>['A direct answer.'];
+      final recorder = _FakeAudioRecordingService();
+      final provider = ChatProvider(
+        chatService: MockChatService(engine: engine),
+        audioRecordingService: recorder,
+        settingsService: MockSettingsService(),
+        initialSettings: const ChatSettings(
+          modelPath: 'gemma-4-E2B-it.litertlm',
+          modelSupportsAudio: true,
+          directMediaInput: true,
+        ),
+      );
+      addTearDown(provider.dispose);
+      await provider.loadModel();
+      final stagedBytes = Uint8List.fromList(const <int>[9, 8, 7]);
+      expect(provider.stageAudioAttachment(stagedBytes), isTrue);
+
+      expect(provider.canAskWithVoice, isTrue);
+      await provider.startAudioRecording();
+      expect(
+        provider.audioRecordingPurpose,
+        ChatAudioRecordingPurpose.voiceQuestion,
+      );
+      await provider.stopAudioRecordingAndAsk();
+
+      expect(recorder.readCalls, 1);
+      expect(recorder.deletedPaths, <String>[recorder.recordedPath]);
+      expect(engine.createCalls, 1);
+      expect(provider.stagedParts, hasLength(1));
+      expect(
+        (provider.stagedParts.single as LlamaAudioContent).bytes,
+        stagedBytes,
+      );
+      final userMessage = provider.messages.firstWhere(
+        (message) => message.isUser && !message.isInfo,
+      );
+      expect(userMessage.text, 'Voice question');
+      final storedAudio = userMessage.parts!
+          .whereType<LlamaAudioContent>()
+          .single;
+      expect(storedAudio.path, isNull);
+      expect(storedAudio.bytes, recorder.recordedBytes);
+      expect(
+        userMessage.parts!.whereType<LlamaTextContent>().single.text,
+        contains('answer the spoken request'),
+      );
+
+      final generatedUserTurn = engine.lastCreateMessages!.last;
+      expect(generatedUserTurn.role, LlamaChatRole.user);
+      expect(
+        generatedUserTurn.parts.whereType<LlamaAudioContent>().single.bytes,
+        recorder.recordedBytes,
+      );
+      expect(
+        generatedUserTurn.parts.whereType<LlamaTextContent>().single.text,
+        contains('answer the spoken request'),
+      );
+    },
+  );
+
+  test(
+    'regenerating a voice answer keeps the hidden model instruction',
+    () async {
+      final engine = MockLlamaEngine()
+        ..createChunkContents = const <String>['First answer.'];
+      final provider = ChatProvider(
+        chatService: MockChatService(engine: engine),
+        settingsService: MockSettingsService(),
+        initialSettings: const ChatSettings(
+          modelPath: 'gemma-4-E2B-it.litertlm',
+          modelSupportsAudio: true,
+          directMediaInput: true,
+        ),
+      );
+      addTearDown(provider.dispose);
+      await provider.loadModel();
+
+      await provider.askWithVoice(Uint8List.fromList(const <int>[1, 2, 3]));
+      expect(provider.canRegenerateLastResponse, isTrue);
+
+      engine.createChunkContents = const <String>['Second answer.'];
+      await provider.regenerateLastResponse();
+
+      expect(engine.createCalls, 2);
+      final regeneratedUserTurn = engine.lastCreateMessages!.last;
+      expect(
+        regeneratedUserTurn.parts.whereType<LlamaTextContent>().single.text,
+        contains('answer the spoken request'),
+      );
+      expect(
+        regeneratedUserTurn.parts.whereType<LlamaAudioContent>().single.bytes,
+        <int>[1, 2, 3],
+      );
+    },
+  );
+
+  test(
+    'external-projector audio is excluded from the first voice path',
+    () async {
+      final provider = ChatProvider(
+        chatService: MockChatService(),
+        audioRecordingService: _FakeAudioRecordingService(),
+        settingsService: MockSettingsService(),
+        initialSettings: const ChatSettings(
+          modelPath: 'audio-chat.gguf',
+          mmprojPath: 'audio-mmproj.gguf',
+          modelSupportsAudio: true,
+        ),
+      );
+      addTearDown(provider.dispose);
+      await provider.loadModel();
+
+      expect(provider.settings.modelSupportsAudio, isTrue);
+      expect(provider.canAskWithVoice, isFalse);
+      expect(provider.supportsMicrophoneRecording, isFalse);
+    },
+  );
+
+  test('dedicated STT takes precedence over direct audio chat', () async {
+    final recorder = _FakeAudioRecordingService();
+    final provider = ChatProvider(
+      chatService: MockChatService(engine: _SpeechMockLlamaEngine()),
+      audioRecordingService: recorder,
+      settingsService: MockSettingsService(),
+      initialSettings: const ChatSettings(
+        modelPath: 'Qwen3-ASR-0.6B-Q8_0.gguf',
+        mmprojPath: 'mmproj-Qwen3-ASR-0.6B-Q8_0.gguf',
+        modelSupportsAudio: true,
+        modelSupportsSpeechToText: true,
+        directMediaInput: true,
+      ),
+    );
+    addTearDown(provider.dispose);
+    await provider.loadModel();
+
+    expect(provider.canTranscribeAudio, isTrue);
+    expect(provider.canAskWithVoice, isFalse);
+    await provider.startAudioRecording();
+    expect(
+      provider.audioRecordingPurpose,
+      ChatAudioRecordingPurpose.transcription,
+    );
+    await provider.cancelAudioRecording(showMessage: false);
+  });
+
+  test('voice WAV read failure deletes the file without generation', () async {
+    final engine = MockLlamaEngine();
+    final recorder = _FakeAudioRecordingService(
+      readError: const AudioRecordingException(
+        AudioRecordingFailure.readFailed,
+        'The test recording could not be read.',
+      ),
+    );
+    final provider = ChatProvider(
+      chatService: MockChatService(engine: engine),
+      audioRecordingService: recorder,
+      settingsService: MockSettingsService(),
+      initialSettings: const ChatSettings(
+        modelPath: 'gemma-4-E2B-it.litertlm',
+        modelSupportsAudio: true,
+        directMediaInput: true,
+      ),
+    );
+    addTearDown(provider.dispose);
+    await provider.loadModel();
+    await provider.startAudioRecording();
+
+    await provider.stopAudioRecordingAndAsk();
+
+    expect(engine.createCalls, 0);
+    expect(provider.isGenerating, isFalse);
+    expect(provider.audioRecordingState, ChatAudioRecordingState.idle);
+    expect(recorder.deletedPaths, <String>[recorder.recordedPath]);
+    expect(
+      provider.messages.last.text,
+      'The test recording could not be read.',
     );
   });
 
@@ -460,6 +773,54 @@ void main() {
     );
   });
 
+  testWidgets('voice recording automatically asks at 30 seconds', (
+    tester,
+  ) async {
+    final engine = MockLlamaEngine()..createChunkContents = const <String>[];
+    final recorder = _FakeAudioRecordingService();
+    final provider = ChatProvider(
+      chatService: MockChatService(engine: engine),
+      audioRecordingService: recorder,
+      chatGenerationService: const _ImmediateChatGenerationService(),
+      settingsService: MockSettingsService(),
+      initialSettings: const ChatSettings(
+        modelPath: 'gemma-4-E2B-it.litertlm',
+        modelSupportsAudio: true,
+        directMediaInput: true,
+      ),
+    );
+    addTearDown(provider.dispose);
+    await provider.loadModel();
+    await provider.startAudioRecording();
+
+    await tester.pump(ChatProvider.maxVoiceQuestionRecordingDuration);
+    var sawAutomaticGeneration = false;
+    for (var index = 0; index < 120; index++) {
+      await tester.pump(const Duration(milliseconds: 16));
+      sawAutomaticGeneration = sawAutomaticGeneration || provider.isGenerating;
+      if (sawAutomaticGeneration &&
+          engine.createCalls > 0 &&
+          !provider.isGenerating) {
+        break;
+      }
+    }
+
+    expect(recorder.stopCalls, 1);
+    expect(recorder.readCalls, 1);
+    expect(engine.createCalls, 1);
+    expect(provider.audioRecordingState, ChatAudioRecordingState.idle);
+    expect(
+      provider.messages.map((message) => message.text),
+      contains('30-second limit reached. Asking the model now.'),
+    );
+    expect(
+      provider.messages.map((message) => message.text),
+      contains('Voice question'),
+    );
+    provider.stopGeneration();
+    await tester.pumpAndSettle();
+  });
+
   test('stop failure resets capture and reports an actionable error', () async {
     final engine = _SpeechMockLlamaEngine();
     final recorder = _FakeAudioRecordingService(
@@ -580,6 +941,194 @@ void main() {
       'Conversation cleared. Ready for a new topic!',
     ]);
   });
+
+  test('clear wins while finalized voice audio is being read', () async {
+    final engine = MockLlamaEngine();
+    final readGate = Completer<void>();
+    final recorder = _FakeAudioRecordingService(readGate: readGate);
+    final provider = ChatProvider(
+      chatService: MockChatService(engine: engine),
+      audioRecordingService: recorder,
+      settingsService: MockSettingsService(),
+      initialSettings: const ChatSettings(
+        modelPath: 'gemma-4-E2B-it.litertlm',
+        modelSupportsAudio: true,
+        directMediaInput: true,
+      ),
+    );
+    addTearDown(provider.dispose);
+    await provider.loadModel();
+    await provider.startAudioRecording();
+
+    final ask = provider.stopAudioRecordingAndAsk();
+    await Future<void>.delayed(Duration.zero);
+    expect(recorder.readCalls, 1);
+    expect(provider.isGenerating, isTrue);
+
+    provider.clearConversation();
+    readGate.complete();
+    await ask;
+
+    expect(engine.createCalls, 0);
+    expect(recorder.deletedPaths, <String>[recorder.recordedPath]);
+    expect(provider.isGenerating, isFalse);
+    expect(provider.messages.map((message) => message.text), <String>[
+      'Conversation cleared. Ready for a new topic!',
+    ]);
+  });
+
+  for (final contextChange
+      in <({String name, void Function(ChatProvider) run})>[
+        (
+          name: 'model path',
+          run: (provider) => provider.updateModelPath('replacement.gguf'),
+        ),
+        (
+          name: 'mmproj path',
+          run: (provider) =>
+              provider.updateMmprojPath('replacement-mmproj.gguf'),
+        ),
+      ]) {
+    test(
+      '${contextChange.name} change releases a pending voice read',
+      () async {
+        final engine = MockLlamaEngine();
+        final readGate = Completer<void>();
+        final recorder = _FakeAudioRecordingService(readGate: readGate);
+        final provider = ChatProvider(
+          chatService: MockChatService(engine: engine),
+          audioRecordingService: recorder,
+          settingsService: MockSettingsService(),
+          initialSettings: const ChatSettings(
+            modelPath: 'gemma-4-E2B-it.litertlm',
+            modelSupportsAudio: true,
+            directMediaInput: true,
+          ),
+        );
+        addTearDown(provider.dispose);
+        await provider.loadModel();
+        await provider.startAudioRecording();
+
+        final ask = provider.stopAudioRecordingAndAsk();
+        await Future<void>.delayed(Duration.zero);
+        expect(recorder.readCalls, 1);
+        expect(provider.isGenerating, isTrue);
+
+        contextChange.run(provider);
+        expect(provider.isGenerating, isFalse);
+
+        readGate.complete();
+        await ask;
+
+        expect(engine.createCalls, 0);
+        expect(recorder.deletedPaths, <String>[recorder.recordedPath]);
+        expect(provider.isGenerating, isFalse);
+      },
+    );
+  }
+
+  test('stale voice read cannot take ownership from a new text turn', () async {
+    final engine = _BlockingSpeechMockLlamaEngine();
+    final readGate = Completer<void>();
+    final recorder = _FakeAudioRecordingService(readGate: readGate);
+    final provider = ChatProvider(
+      chatService: MockChatService(engine: engine),
+      audioRecordingService: recorder,
+      settingsService: MockSettingsService(),
+      initialSettings: const ChatSettings(
+        modelPath: 'gemma-4-E2B-it.litertlm',
+        modelSupportsAudio: true,
+        directMediaInput: true,
+      ),
+    );
+    addTearDown(provider.dispose);
+    await provider.loadModel();
+    await provider.startAudioRecording();
+
+    final ask = provider.stopAudioRecordingAndAsk();
+    await Future<void>.delayed(Duration.zero);
+    expect(recorder.readCalls, 1);
+
+    provider.clearConversation();
+    final freshTurn = provider.sendMessage('Fresh question');
+    await engine.createStarted.future;
+    expect(provider.isGenerating, isTrue);
+
+    readGate.complete();
+    await ask;
+
+    expect(engine.createCalls, 1);
+    expect(provider.isGenerating, isTrue);
+    expect(
+      provider.messages.where((message) => message.isUser).map((m) => m.text),
+      <String>['Fresh question'],
+    );
+
+    engine.releaseGeneration();
+    await freshTurn;
+    expect(provider.isGenerating, isFalse);
+  });
+
+  for (final transition in <String>['clear', 'switch']) {
+    test(
+      'started voice generation cannot mutate or finish a fresh turn after $transition',
+      () async {
+        final engine = _SequencedBlockingLlamaEngine();
+        final provider = ChatProvider(
+          chatService: MockChatService(engine: engine),
+          settingsService: MockSettingsService(),
+          initialSettings: const ChatSettings(
+            modelPath: 'gemma-4-E2B-it.litertlm',
+            modelSupportsAudio: true,
+            directMediaInput: true,
+          ),
+        );
+        addTearDown(provider.dispose);
+        await provider.loadModel();
+
+        String? switchTarget;
+        if (transition == 'switch') {
+          switchTarget = provider.activeConversationId;
+          provider.createConversation();
+        }
+
+        final voiceTurn = provider.askWithVoice(
+          Uint8List.fromList(const <int>[1, 2, 3]),
+        );
+        await engine.started(0);
+
+        if (switchTarget == null) {
+          provider.clearConversation();
+        } else {
+          await provider.switchConversation(switchTarget);
+        }
+        final freshTurn = provider.sendMessage('Fresh question');
+        await engine.started(1);
+        expect(provider.isGenerating, isTrue);
+
+        engine.release(0);
+        await voiceTurn;
+
+        expect(provider.isGenerating, isTrue);
+        expect(
+          provider.messages
+              .where((message) => message.isUser)
+              .map((message) => message.text),
+          <String>['Fresh question'],
+        );
+        expect(
+          provider.messages.map((message) => message.text),
+          isNot(contains('Stale voice answer')),
+        );
+
+        engine.release(1);
+        await freshTurn;
+
+        expect(provider.isGenerating, isFalse);
+        expect(provider.messages.last.text, 'Fresh answer');
+      },
+    );
+  }
 
   test('transcribes an in-memory audio file into chat', () async {
     final engine = _SpeechMockLlamaEngine()
@@ -742,6 +1291,53 @@ void main() {
   });
 }
 
+class _ImmediateChatGenerationService extends ChatGenerationService {
+  const _ImmediateChatGenerationService();
+
+  @override
+  Future<GenerationStreamResult> consumeStream({
+    required Stream<LlamaCompletionChunk> stream,
+    required bool thinkingEnabled,
+    required int uiNotifyIntervalMs,
+    required String Function(String) cleanResponse,
+    required bool Function() shouldContinue,
+    required void Function(GenerationStreamUpdate update) onUpdate,
+    Duration? stallTimeout,
+  }) async {
+    final text = StringBuffer();
+    final thinking = StringBuffer();
+    var generatedTokens = 0;
+    await for (final chunk in stream) {
+      if (!shouldContinue() || chunk.choices.isEmpty) {
+        continue;
+      }
+      final delta = chunk.choices.first.delta;
+      text.write(delta.content ?? '');
+      if (thinkingEnabled) {
+        thinking.write(delta.thinking ?? '');
+      }
+      generatedTokens += 1;
+    }
+    final cleanText = cleanResponse(text.toString());
+    onUpdate(
+      GenerationStreamUpdate(
+        cleanText: cleanText,
+        fullThinking: thinking.toString(),
+        shouldNotify: true,
+        generatedTokenDelta: generatedTokens,
+      ),
+    );
+    return GenerationStreamResult(
+      fullResponse: text.toString(),
+      fullThinking: thinking.toString(),
+      generatedTokens: generatedTokens,
+      firstTokenLatencyMs: generatedTokens == 0 ? null : 0,
+      elapsedMs: 1,
+      decodeElapsedMs: 1,
+    );
+  }
+}
+
 class _GeneratingReadyProvider extends ChatProvider {
   _GeneratingReadyProvider()
     : super(
@@ -764,6 +1360,21 @@ class _GeneratingReadyProvider extends ChatProvider {
 
   @override
   List<LlamaContentPart> get stagedParts => const <LlamaContentPart>[];
+}
+
+class _BusyVoiceProvider extends _GeneratingReadyProvider {
+  @override
+  ChatSettings get settings => const ChatSettings(
+    modelPath: 'gemma-4-E2B-it.litertlm',
+    modelSupportsAudio: true,
+    directMediaInput: true,
+  );
+
+  @override
+  bool get supportsMicrophoneRecording => true;
+
+  @override
+  bool get canStartAudioRecording => false;
 }
 
 class _SpeechMockLlamaEngine extends MockLlamaEngine {
@@ -818,6 +1429,66 @@ class _BlockingSpeechMockLlamaEngine extends _SpeechMockLlamaEngine {
   }
 }
 
+class _SequencedBlockingLlamaEngine extends MockLlamaEngine {
+  final List<Completer<void>> _started = <Completer<void>>[];
+  final List<Completer<void>> _release = <Completer<void>>[];
+
+  Future<void> started(int index) async {
+    while (_started.length <= index) {
+      await Future<void>.delayed(Duration.zero);
+    }
+    await _started[index].future;
+  }
+
+  void release(int index) {
+    final gate = _release[index];
+    if (!gate.isCompleted) {
+      gate.complete();
+    }
+  }
+
+  @override
+  Stream<LlamaCompletionChunk> create(
+    List<LlamaChatMessage> messages, {
+    GenerationParams? params,
+    List<ToolDefinition>? tools,
+    ToolChoice? toolChoice,
+    bool parallelToolCalls = false,
+    bool enableThinking = true,
+    Map<String, dynamic>? responseFormat,
+    String? sourceLangCode,
+    String? targetLangCode,
+    Map<String, dynamic>? chatTemplateKwargs,
+    DateTime? templateNow,
+  }) async* {
+    final index = createCalls;
+    createCalls += 1;
+    lastCreateParams = params;
+    lastCreateMessages = List<LlamaChatMessage>.from(messages);
+    final startedGate = Completer<void>();
+    final releaseGate = Completer<void>();
+    _started.add(startedGate);
+    _release.add(releaseGate);
+    startedGate.complete();
+    await releaseGate.future;
+
+    yield LlamaCompletionChunk(
+      id: 'mock-id-$index',
+      object: 'chat.completion.chunk',
+      created: 1234567890,
+      model: 'mock-model',
+      choices: <LlamaCompletionChunkChoice>[
+        LlamaCompletionChunkChoice(
+          index: 0,
+          delta: LlamaCompletionChunkDelta(
+            content: index == 0 ? 'Stale voice answer' : 'Fresh answer',
+          ),
+        ),
+      ],
+    );
+  }
+}
+
 class _BlockingAudioProbeSpeechMockLlamaEngine extends _SpeechMockLlamaEngine {
   final Completer<void> audioProbeStarted = Completer<void>();
   final Completer<void> _releaseAudioProbe = Completer<void>();
@@ -845,13 +1516,22 @@ class _FakeAudioRecordingService implements AudioRecordingService {
   final bool supported;
   final Object? startError;
   final Object? stopError;
+  final Object? readError;
   final Completer<void>? startGate;
   final Completer<void>? stopGate;
+  final Completer<void>? readGate;
   final Completer<void>? cancelGate;
   final String recordedPath = '/tmp/llamadart_test_recording.wav';
+  final Uint8List recordedBytes = Uint8List.fromList(const <int>[
+    0x52,
+    0x49,
+    0x46,
+    0x46,
+  ]);
 
   int startCalls = 0;
   int stopCalls = 0;
+  int readCalls = 0;
   int cancelCalls = 0;
   int disposeCalls = 0;
   final List<String> deletedPaths = <String>[];
@@ -860,8 +1540,10 @@ class _FakeAudioRecordingService implements AudioRecordingService {
     this.supported = true,
     this.startError,
     this.stopError,
+    this.readError,
     this.startGate,
     this.stopGate,
+    this.readGate,
     this.cancelGate,
   });
 
@@ -893,6 +1575,20 @@ class _FakeAudioRecordingService implements AudioRecordingService {
       throw error;
     }
     return recordedPath;
+  }
+
+  @override
+  Future<Uint8List> readRecording(String path) async {
+    readCalls += 1;
+    final gate = readGate;
+    if (gate != null) {
+      await gate.future;
+    }
+    final error = readError;
+    if (error != null) {
+      throw error;
+    }
+    return recordedBytes;
   }
 
   @override

--- a/example/chat_app/test/chat_service_test.dart
+++ b/example/chat_app/test/chat_service_test.dart
@@ -239,6 +239,27 @@ void main() {
       expect(engine.createCalls, 0);
     });
 
+    test('skips text-only warmup for direct-audio LiteRT-LM models', () async {
+      final engine = MockLlamaEngine();
+      final service = ChatService(engine: engine);
+
+      await service.init(
+        const ChatSettings(
+          modelPath: 'gemma-4-E2B-it.litertlm',
+          preferredBackend: GpuBackend.auto,
+          contextSize: 8192,
+          maxTokens: 32,
+          gpuLayers: 0,
+          modelSupportsAudio: true,
+          directMediaInput: true,
+        ),
+        eagerLoadMultimodalProjector: false,
+      );
+
+      expect(engine.lastModelParams, isNotNull);
+      expect(engine.createCalls, 0);
+    });
+
     test('keeps explicit CPU loads on LiteRT-LM models', () async {
       debugDefaultTargetPlatformOverride = TargetPlatform.android;
       final engine = MockLlamaEngine();

--- a/example/chat_app/test/manage_models_screen_download_test.dart
+++ b/example/chat_app/test/manage_models_screen_download_test.dart
@@ -119,6 +119,36 @@ void main() {
       }
     });
 
+    for (final platform in <TargetPlatform>[
+      TargetPlatform.android,
+      TargetPlatform.iOS,
+      TargetPlatform.linux,
+    ]) {
+      testWidgets('Qwen3-ASR is available on native ${platform.name}', (
+        tester,
+      ) async {
+        debugDefaultTargetPlatformOverride = platform;
+        try {
+          final asr = DownloadableModel.defaultModels.singleWhere(
+            (model) => model.name == 'Qwen3-ASR 0.6B',
+          );
+          SharedPreferences.setMockInitialValues({});
+
+          await _pumpScreen(
+            tester,
+            modelService: _HoldingModelService(),
+            models: <DownloadableModel>[asr],
+          );
+
+          expect(find.text(asr.name), findsOneWidget);
+          expect(find.text('Native platforms'), findsOneWidget);
+          expect(find.text('Download Model + Projector'), findsOneWidget);
+        } finally {
+          debugDefaultTargetPlatformOverride = null;
+        }
+      });
+    }
+
     testWidgets('selected multimodal model waits for models directory', (
       tester,
     ) async {
@@ -221,43 +251,70 @@ void main() {
     testWidgets('platform and capability search narrow the model library', (
       tester,
     ) async {
-      SharedPreferences.setMockInitialValues({});
-      final general = _remoteModel();
-      final vision = _remoteVisionModel();
-      const desktop = DownloadableModel(
-        name: 'Desktop Specialist',
-        description: 'Large desktop-only model.',
-        url: 'https://example.com/desktop.gguf',
-        filename: 'desktop.gguf',
-        sizeBytes: 20,
-        availability: ModelAvailability.nativeDesktop,
-      );
+      debugDefaultTargetPlatformOverride = TargetPlatform.macOS;
+      try {
+        SharedPreferences.setMockInitialValues({});
+        final general = _remoteModel();
+        final vision = _remoteVisionModel();
+        const native = DownloadableModel(
+          name: 'Native Specialist',
+          description: 'Native-only model.',
+          url: 'https://example.com/native.gguf',
+          filename: 'native.gguf',
+          sizeBytes: 20,
+          availability: ModelAvailability.native,
+        );
+        const desktop = DownloadableModel(
+          name: 'Desktop Specialist',
+          description: 'Large desktop-only model.',
+          url: 'https://example.com/desktop.gguf',
+          filename: 'desktop.gguf',
+          sizeBytes: 20,
+          availability: ModelAvailability.nativeDesktop,
+        );
 
-      await _pumpScreen(
-        tester,
-        modelService: _HoldingModelService(),
-        models: [general, vision, desktop],
-      );
+        await _pumpScreen(
+          tester,
+          modelService: _HoldingModelService(),
+          models: [general, vision, native, desktop],
+        );
 
-      expect(find.widgetWithText(ChoiceChip, 'Mobile & Web'), findsOneWidget);
-      expect(find.widgetWithText(ChoiceChip, 'Mobile'), findsNothing);
-      expect(find.widgetWithText(ChoiceChip, 'Web'), findsNothing);
+        expect(find.widgetWithText(ChoiceChip, 'All'), findsOneWidget);
+        expect(find.widgetWithText(ChoiceChip, 'Mobile'), findsOneWidget);
+        expect(find.widgetWithText(ChoiceChip, 'Web'), findsOneWidget);
+        expect(find.widgetWithText(ChoiceChip, 'Desktop'), findsOneWidget);
+        expect(find.text(native.name), findsOneWidget);
+        expect(find.text(desktop.name), findsOneWidget);
 
-      await tester.tap(find.widgetWithText(ChoiceChip, 'Desktop'));
-      await tester.pumpAndSettle();
-      expect(find.text(desktop.name), findsOneWidget);
-      await tester.tap(find.widgetWithText(ChoiceChip, 'Mobile & Web'));
-      await tester.pumpAndSettle();
-      expect(find.text(desktop.name), findsNothing);
+        await tester.tap(find.widgetWithText(ChoiceChip, 'Web'));
+        await tester.pumpAndSettle();
+        expect(find.text(general.name), findsOneWidget);
+        expect(find.text(native.name), findsNothing);
+        expect(find.text(desktop.name), findsNothing);
 
-      await tester.enterText(find.byType(TextField).first, 'vision');
-      await tester.pump();
-      expect(find.text(vision.name), findsOneWidget);
-      expect(find.text(general.name), findsNothing);
+        await tester.tap(find.widgetWithText(ChoiceChip, 'Mobile'));
+        await tester.pumpAndSettle();
+        expect(find.text(native.name), findsOneWidget);
+        expect(find.text(desktop.name), findsNothing);
 
-      await tester.tap(find.byTooltip('Clear model search'));
-      await tester.pump();
-      expect(find.text(general.name), findsOneWidget);
+        await tester.tap(find.widgetWithText(ChoiceChip, 'Desktop'));
+        await tester.pumpAndSettle();
+        expect(find.text(native.name), findsOneWidget);
+        expect(find.text(desktop.name), findsOneWidget);
+
+        await tester.tap(find.widgetWithText(ChoiceChip, 'Mobile'));
+        await tester.pumpAndSettle();
+        await tester.enterText(find.byType(TextField).first, 'vision');
+        await tester.pump();
+        expect(find.text(vision.name), findsOneWidget);
+        expect(find.text(general.name), findsNothing);
+
+        await tester.tap(find.byTooltip('Clear model search'));
+        await tester.pump();
+        expect(find.text(general.name), findsOneWidget);
+      } finally {
+        debugDefaultTargetPlatformOverride = null;
+      }
     });
 
     testWidgets('desktop search uses native capability profile', (

--- a/example/chat_app/test/mocks.dart
+++ b/example/chat_app/test/mocks.dart
@@ -113,6 +113,8 @@ class MockLlamaEngine extends LlamaEngine {
   int createCalls = 0;
   ModelParams? lastModelParams;
   GenerationParams? lastCreateParams;
+  bool? lastCreateEnableThinking;
+  Map<String, dynamic>? lastCreateChatTemplateKwargs;
   List<LlamaChatMessage>? lastCreateMessages;
   BackendPerfContextData? performanceContext;
   List<String> createChunkContents = const ['Hi there'];
@@ -203,6 +205,10 @@ class MockLlamaEngine extends LlamaEngine {
   }) async* {
     createCalls += 1;
     lastCreateParams = params;
+    lastCreateEnableThinking = enableThinking;
+    lastCreateChatTemplateKwargs = chatTemplateKwargs == null
+        ? null
+        : Map<String, dynamic>.from(chatTemplateKwargs);
     lastCreateMessages = List<LlamaChatMessage>.from(messages);
     for (final content in createChunkContents) {
       yield LlamaCompletionChunk(

--- a/example/chat_app/test/mocks.dart
+++ b/example/chat_app/test/mocks.dart
@@ -113,6 +113,7 @@ class MockLlamaEngine extends LlamaEngine {
   int createCalls = 0;
   ModelParams? lastModelParams;
   GenerationParams? lastCreateParams;
+  List<LlamaChatMessage>? lastCreateMessages;
   BackendPerfContextData? performanceContext;
   List<String> createChunkContents = const ['Hi there'];
   String? lastLoadedModelPath;
@@ -202,6 +203,7 @@ class MockLlamaEngine extends LlamaEngine {
   }) async* {
     createCalls += 1;
     lastCreateParams = params;
+    lastCreateMessages = List<LlamaChatMessage>.from(messages);
     for (final content in createChunkContents) {
       yield LlamaCompletionChunk(
         id: "mock-id",

--- a/example/chat_app/test/mocks.dart
+++ b/example/chat_app/test/mocks.dart
@@ -119,6 +119,7 @@ class MockLlamaEngine extends LlamaEngine {
   BackendPerfContextData? performanceContext;
   List<String> createChunkContents = const ['Hi there'];
   String? lastLoadedModelPath;
+  String? lastLoadedMmprojPath;
   String? lastLoadedModelUrl;
 
   MockLlamaEngine() : super(MockLlamaBackend());
@@ -150,6 +151,7 @@ class MockLlamaEngine extends LlamaEngine {
   @override
   Future<void> loadMultimodalProjector(String mmProjPath) async {
     loadMultimodalProjectorCalls += 1;
+    lastLoadedMmprojPath = mmProjPath;
     mmprojLoaded = true;
   }
 

--- a/example/chat_app/test/model_card_test.dart
+++ b/example/chat_app/test/model_card_test.dart
@@ -104,6 +104,7 @@ void main() {
 
     expect(find.text('Audio'), findsOneWidget);
     expect(find.text('Speech-to-text'), findsOneWidget);
+    expect(find.text('Native platforms'), findsOneWidget);
     expect(find.text('Use Text Only'), findsNothing);
     expect(find.text('Download Missing Assets'), findsOneWidget);
   });
@@ -418,6 +419,25 @@ void main() {
     );
     expect(button.onPressed, isNull);
   });
+
+  testWidgets('native-only cards explain Web unavailability', (tester) async {
+    await _pumpCard(
+      tester,
+      model: _asrModel(),
+      isWeb: true,
+      isDownloaded: false,
+      isAvailableOnCurrentPlatform: false,
+      onSelect: () {},
+      onDownload: () {},
+    );
+
+    expect(find.text('Native platforms'), findsOneWidget);
+    expect(find.text('Available on native platforms'), findsOneWidget);
+    final button = tester.widget<OutlinedButton>(
+      find.widgetWithText(OutlinedButton, 'Available on native platforms'),
+    );
+    expect(button.onPressed, isNull);
+  });
 }
 
 Future<void> _pumpCard(
@@ -509,6 +529,7 @@ DownloadableModel _asrModel() {
     mmprojUrl: 'https://example.com/asr-mmproj.gguf',
     mmprojFilename: 'asr-mmproj.gguf',
     sizeBytes: 20,
+    availability: ModelAvailability.native,
     supportsAudio: true,
     supportsSpeechToText: true,
   );

--- a/example/chat_app/test/model_card_test.dart
+++ b/example/chat_app/test/model_card_test.dart
@@ -105,6 +105,7 @@ void main() {
     expect(find.text('Audio'), findsOneWidget);
     expect(find.text('Speech-to-text'), findsOneWidget);
     expect(find.text('Native platforms'), findsOneWidget);
+    expect(find.byIcon(Icons.devices_other_rounded), findsOneWidget);
     expect(find.text('Use Text Only'), findsNothing);
     expect(find.text('Download Missing Assets'), findsOneWidget);
   });

--- a/example/chat_app/test/model_service_test.dart
+++ b/example/chat_app/test/model_service_test.dart
@@ -1,4 +1,5 @@
 import 'dart:async';
+import 'dart:convert';
 import 'dart:io';
 
 import 'package:crypto/crypto.dart';
@@ -17,6 +18,10 @@ void main() {
   late List<int> testData;
   late List<int> mmprojData;
   late Map<String, int> getRequestCountByPath;
+  late List<String?> modelRangeHeaders;
+  late List<String?> modelIfRangeHeaders;
+
+  const stableEtag = '"model-v1"';
 
   const int testDataSize = 1024 * 1024 * 5; // 5 MB
   const int mmprojDataSize = 1024 * 1024 * 2; // 2 MB
@@ -26,6 +31,8 @@ void main() {
     testData = List.generate(testDataSize, (i) => i % 256);
     mmprojData = List.generate(mmprojDataSize, (i) => (i * 7) % 256);
     getRequestCountByPath = <String, int>{};
+    modelRangeHeaders = <String?>[];
+    modelIfRangeHeaders = <String?>[];
     tempDir = await Directory.systemTemp.createTemp('model_service_test');
     service = TestModelService(tempDir);
 
@@ -38,6 +45,7 @@ void main() {
       if (path == '/model.gguf' || path == '/mmproj.gguf') {
         final payload = path == '/model.gguf' ? testData : mmprojData;
         final payloadSize = payload.length;
+        request.response.headers.set(HttpHeaders.etagHeader, stableEtag);
 
         if (request.method == 'HEAD') {
           request.response.headers.contentLength = payloadSize;
@@ -46,6 +54,10 @@ void main() {
         } else if (request.method == 'GET') {
           getRequestCountByPath[path] = (getRequestCountByPath[path] ?? 0) + 1;
           final rangeHeader = request.headers.value('range');
+          if (path == '/model.gguf') {
+            modelRangeHeaders.add(rangeHeader);
+            modelIfRangeHeaders.add(request.headers.value('if-range'));
+          }
           int start = 0;
           int end = payloadSize - 1;
           var isPartial = false;
@@ -154,6 +166,71 @@ void main() {
     expect(failure, isNull);
     expect((await service.getModelCacheState(model)).isReady, isTrue);
   });
+
+  test(
+    'persisted integrity stamp avoids rehashing unchanged catalog assets',
+    () async {
+      final source = RemoteModelAssetSource(
+        url: '$baseUrl/model.gguf?revision=one',
+        filename: 'persisted-verification.gguf',
+        sizeBytes: testDataSize,
+        sha256: sha256.convert(testData).toString(),
+      );
+      final model = DownloadableModel.fromSources(
+        name: 'Persisted verification',
+        description: 'Test',
+        modelSource: source,
+        sizeBytes: testDataSize,
+      );
+      final file = File(p.join(tempDir.path, source.filename));
+      await file.writeAsBytes(testData);
+
+      var digestCalls = 0;
+      Future<String> countDigest(File input) async {
+        digestCalls += 1;
+        return (await sha256.bind(input.openRead()).first).toString();
+      }
+
+      final first = TestModelService(tempDir, fileSha256: countDigest);
+      expect((await first.getModelCacheState(model)).isReady, isTrue);
+      expect(digestCalls, 1);
+
+      final restarted = TestModelService(tempDir, fileSha256: countDigest);
+      expect((await restarted.getModelCacheState(model)).isReady, isTrue);
+      expect(digestCalls, 1);
+
+      final revisedSource = RemoteModelAssetSource(
+        url: '$baseUrl/model.gguf?revision=two',
+        filename: source.filename,
+        sizeBytes: source.sizeBytes,
+        sha256: source.sha256,
+      );
+      final revisedModel = DownloadableModel.fromSources(
+        name: model.name,
+        description: model.description,
+        modelSource: revisedSource,
+        sizeBytes: model.sizeBytes,
+      );
+      final revisedService = TestModelService(tempDir, fileSha256: countDigest);
+      expect(
+        (await revisedService.getModelCacheState(revisedModel)).isReady,
+        isTrue,
+      );
+      expect(digestCalls, 2);
+
+      final corrupted = List<int>.from(testData)..[0] ^= 0xff;
+      await file.writeAsBytes(corrupted);
+      await file.setLastModified(
+        DateTime.now().add(const Duration(seconds: 2)),
+      );
+      final changedService = TestModelService(tempDir, fileSha256: countDigest);
+      expect(
+        (await changedService.getModelCacheState(revisedModel)).isReady,
+        isFalse,
+      );
+      expect(digestCalls, 3);
+    },
+  );
 
   test('failed catalog checksum discards the downloaded asset', () async {
     final model = DownloadableModel.fromSources(
@@ -365,9 +442,13 @@ void main() {
     // Verify partial state uses the temp file.
     final file = File(p.join(tempDir.path, 'model.gguf'));
     final tempFile = File(p.join(tempDir.path, 'model.gguf.download'));
+    final provenanceFile = File(
+      p.join(tempDir.path, 'model.gguf.download.source.json'),
+    );
 
     expect(tempFile.existsSync(), isTrue);
     expect(tempFile.lengthSync(), greaterThan(0));
+    expect(provenanceFile.existsSync(), isTrue);
     expect(simulatedCrash, isTrue);
 
     // 2. Resume download
@@ -385,6 +466,285 @@ void main() {
     expect(file.lengthSync(), testDataSize);
     expect(file.readAsBytesSync(), testData);
     expect(tempFile.existsSync(), isFalse); // Should be cleaned up
+    expect(provenanceFile.existsSync(), isFalse);
+    expect(modelRangeHeaders.whereType<String>(), isNotEmpty);
+    expect(modelIfRangeHeaders.whereType<String>(), contains(stableEtag));
+  });
+
+  test('resume rejects a partial created for a different source', () async {
+    final oldModel = DownloadableModel(
+      name: 'Old source',
+      description: 'Test',
+      url: '$baseUrl/model.gguf?revision=old',
+      filename: 'revision-bound.gguf',
+      sizeBytes: testDataSize,
+    );
+
+    var simulatedCrash = false;
+    await service.downloadModel(
+      model: oldModel,
+      modelsDir: tempDir.path,
+      cancelToken: CancelToken(),
+      onProgress: (progress) {
+        if (progress > 0.3 && !simulatedCrash) {
+          simulatedCrash = true;
+          throw Exception('Simulated crash');
+        }
+      },
+      onSuccess: (_) {},
+      onError: (_) {},
+    );
+
+    final tempFile = File(p.join(tempDir.path, 'revision-bound.gguf.download'));
+    final provenanceFile = File(
+      p.join(tempDir.path, 'revision-bound.gguf.download.source.json'),
+    );
+    expect(simulatedCrash, isTrue);
+    expect(tempFile.existsSync(), isTrue);
+    expect(provenanceFile.existsSync(), isTrue);
+
+    final newModel = DownloadableModel(
+      name: 'New source',
+      description: 'Test',
+      url: '$baseUrl/model.gguf?revision=new',
+      filename: oldModel.filename,
+      sizeBytes: testDataSize,
+    );
+    await service.downloadModel(
+      model: newModel,
+      modelsDir: tempDir.path,
+      cancelToken: CancelToken(),
+      onProgress: (_) {},
+      onSuccess: (_) {},
+      onError: (error) => fail('Fresh download failed: $error'),
+    );
+
+    expect(modelRangeHeaders.last, isNull);
+    expect(
+      File(p.join(tempDir.path, newModel.filename)).readAsBytesSync(),
+      testData,
+    );
+    expect(tempFile.existsSync(), isFalse);
+    expect(provenanceFile.existsSync(), isFalse);
+  });
+
+  test(
+    'same URL changed ETag restarts instead of mixing representations',
+    () async {
+      final mutableData = List<int>.generate(64 * 1024, (i) => i % 251);
+      final replacementData = List<int>.generate(
+        mutableData.length,
+        (i) => (i * 17) % 251,
+      );
+      var currentData = mutableData;
+      var currentEtag = '"mutable-v1"';
+      final rangeHeaders = <String?>[];
+      final ifRangeHeaders = <String?>[];
+      final mutableServer = await HttpServer.bind(
+        InternetAddress.loopbackIPv4,
+        0,
+      );
+      addTearDown(() => mutableServer.close(force: true));
+      mutableServer.listen((request) async {
+        final range = request.headers.value(HttpHeaders.rangeHeader);
+        final ifRange = request.headers.value('if-range');
+        rangeHeaders.add(range);
+        ifRangeHeaders.add(ifRange);
+        request.response.headers.set(HttpHeaders.etagHeader, currentEtag);
+
+        var start = 0;
+        final validatorMatches = ifRange == null || ifRange == currentEtag;
+        if (range != null && validatorMatches) {
+          start = int.parse(
+            RegExp(r'bytes=(\d+)-').firstMatch(range)!.group(1)!,
+          );
+          request.response.statusCode = HttpStatus.partialContent;
+          request.response.headers.set(
+            HttpHeaders.contentRangeHeader,
+            'bytes $start-${currentData.length - 1}/${currentData.length}',
+          );
+        } else {
+          request.response.statusCode = HttpStatus.ok;
+        }
+        request.response.headers.contentLength = currentData.length - start;
+        await request.response.addStream(
+          Stream<List<int>>.fromIterable([currentData.sublist(start)]),
+        );
+        await request.response.close();
+      });
+      final mutableUrl =
+          'http://${mutableServer.address.address}:${mutableServer.port}/model.gguf';
+      final model = DownloadableModel(
+        name: 'Mutable model',
+        description: 'Test',
+        url: mutableUrl,
+        filename: 'same-url-changed-etag.gguf',
+        sizeBytes: mutableData.length,
+      );
+
+      var crashed = false;
+      await service.downloadModel(
+        model: model,
+        modelsDir: tempDir.path,
+        cancelToken: CancelToken(),
+        onProgress: (progress) {
+          if (progress > 0.25 && !crashed) {
+            crashed = true;
+            throw Exception('Simulated crash');
+          }
+        },
+        onSuccess: (_) {},
+        onError: (_) {},
+      );
+      expect(crashed, isTrue);
+
+      currentData = replacementData;
+      currentEtag = '"mutable-v2"';
+      await service.downloadModel(
+        model: model,
+        modelsDir: tempDir.path,
+        cancelToken: CancelToken(),
+        onProgress: (_) {},
+        onSuccess: (_) {},
+        onError: (error) => fail('Replacement download failed: $error'),
+      );
+
+      expect(rangeHeaders.whereType<String>(), isNotEmpty);
+      expect(ifRangeHeaders.whereType<String>(), contains('"mutable-v1"'));
+      expect(
+        File(p.join(tempDir.path, model.filename)).readAsBytesSync(),
+        replacementData,
+      );
+    },
+  );
+
+  test(
+    'mutable source without validator restarts without a Range request',
+    () async {
+      final unsafeData = List<int>.generate(32 * 1024, (i) => i % 239);
+      final rangeHeaders = <String?>[];
+      final unsafeServer = await HttpServer.bind(
+        InternetAddress.loopbackIPv4,
+        0,
+      );
+      addTearDown(() => unsafeServer.close(force: true));
+      unsafeServer.listen((request) async {
+        rangeHeaders.add(request.headers.value(HttpHeaders.rangeHeader));
+        request.response.statusCode = HttpStatus.ok;
+        request.response.headers.contentLength = unsafeData.length;
+        await request.response.addStream(
+          Stream<List<int>>.fromIterable([unsafeData]),
+        );
+        await request.response.close();
+      });
+      final unsafeUrl =
+          'http://${unsafeServer.address.address}:${unsafeServer.port}/model.gguf';
+      final model = DownloadableModel(
+        name: 'Unsafe mutable model',
+        description: 'Test',
+        url: unsafeUrl,
+        filename: 'unsafe-mutable.gguf',
+        sizeBytes: unsafeData.length,
+      );
+
+      var crashed = false;
+      await service.downloadModel(
+        model: model,
+        modelsDir: tempDir.path,
+        cancelToken: CancelToken(),
+        onProgress: (progress) {
+          if (progress > 0.25 && !crashed) {
+            crashed = true;
+            throw Exception('Simulated crash');
+          }
+        },
+        onSuccess: (_) {},
+        onError: (_) {},
+      );
+      await service.downloadModel(
+        model: model,
+        modelsDir: tempDir.path,
+        cancelToken: CancelToken(),
+        onProgress: (_) {},
+        onSuccess: (_) {},
+        onError: (error) => fail('Restart failed: $error'),
+      );
+
+      expect(rangeHeaders.whereType<String>(), isEmpty);
+      expect(
+        File(p.join(tempDir.path, model.filename)).readAsBytesSync(),
+        unsafeData,
+      );
+    },
+  );
+
+  test('unsafe 416 never promotes an arbitrary partial', () async {
+    final fullData = List<int>.generate(16 * 1024, (i) => i % 227);
+    var requestCount = 0;
+    final rangeHeaders = <String?>[];
+    final rangeServer = await HttpServer.bind(InternetAddress.loopbackIPv4, 0);
+    addTearDown(() => rangeServer.close(force: true));
+    rangeServer.listen((request) async {
+      requestCount += 1;
+      final range = request.headers.value(HttpHeaders.rangeHeader);
+      rangeHeaders.add(range);
+      if (range != null && requestCount == 1) {
+        request.response.statusCode = HttpStatus.requestedRangeNotSatisfiable;
+        request.response.headers.set(
+          HttpHeaders.contentRangeHeader,
+          'bytes */${fullData.length}',
+        );
+        await request.response.close();
+        return;
+      }
+      request.response.statusCode = HttpStatus.ok;
+      request.response.headers.contentLength = fullData.length;
+      await request.response.addStream(
+        Stream<List<int>>.fromIterable([fullData]),
+      );
+      await request.response.close();
+    });
+    final revision = List<String>.filled(40, 'a').join();
+    final rangeUrl =
+        'http://${rangeServer.address.address}:${rangeServer.port}/resolve/$revision/model.gguf';
+    final model = DownloadableModel(
+      name: 'Unsafe 416 model',
+      description: 'Test',
+      url: rangeUrl,
+      filename: 'unsafe-416.gguf',
+      sizeBytes: fullData.length,
+    );
+    final partial = File(p.join(tempDir.path, '${model.filename}.download'));
+    await partial.writeAsBytes(List<int>.filled(fullData.length, 0x7f));
+    final source = model.modelSource as RemoteModelAssetSource;
+    await File(
+      p.join(tempDir.path, '${model.filename}.download.source.json'),
+    ).writeAsString(
+      jsonEncode({
+        'version': 2,
+        'sourceCacheKey': source.cacheKey,
+        'expectedSha256': null,
+        'expectedSizeBytes': fullData.length,
+        'validator': null,
+        'totalBytes': fullData.length,
+      }),
+    );
+
+    await service.downloadModel(
+      model: model,
+      modelsDir: tempDir.path,
+      cancelToken: CancelToken(),
+      onProgress: (_) {},
+      onSuccess: (_) {},
+      onError: (error) => fail('416 recovery failed: $error'),
+    );
+
+    expect(rangeHeaders.first, isNotNull);
+    expect(rangeHeaders.last, isNull);
+    expect(
+      File(p.join(tempDir.path, model.filename)).readAsBytesSync(),
+      fullData,
+    );
   });
 
   test('Remote model can depend on local mmproj availability', () async {
@@ -442,13 +802,9 @@ void main() {
     var downloaded = await service.getDownloadedModels([model]);
     expect(downloaded, isNot(contains(model.filename)));
 
-    // Still incomplete while .download exists.
+    // An unbound legacy partial is discarded rather than resumed.
+    expect(tempFile.existsSync(), isFalse);
     await meta.delete();
-    downloaded = await service.getDownloadedModels([model]);
-    expect(downloaded, isNot(contains(model.filename)));
-
-    // Valid once partial marker is removed.
-    await tempFile.delete();
     downloaded = await service.getDownloadedModels([model]);
     expect(downloaded, contains(model.filename));
   });
@@ -456,7 +812,7 @@ void main() {
 
 class TestModelService extends ModelServiceIO {
   final Directory testDir;
-  TestModelService(this.testDir);
+  TestModelService(this.testDir, {super.fileSha256});
 
   @override
   Future<String> getModelsDirectory() async {

--- a/example/chat_app/test/unit_test.dart
+++ b/example/chat_app/test/unit_test.dart
@@ -1263,6 +1263,59 @@ void main() {
       );
     });
 
+    test('Gemma 4 E2B GGUF pins its verified native bundle', () {
+      final model = DownloadableModel.defaultModels.singleWhere(
+        (model) => model.name == 'Gemma 4 E2B it',
+      );
+      final nativeModelSource = model.modelSource as RemoteModelAssetSource;
+      final nativeProjectorSource =
+          model.multimodalProjectorSource as RemoteModelAssetSource;
+      final webModelSource = model.webModelSource as RemoteModelAssetSource;
+      final webProjectorSource =
+          model.webMultimodalProjectorSource as RemoteModelAssetSource;
+
+      expect(
+        nativeModelSource.url,
+        'https://huggingface.co/unsloth/gemma-4-E2B-it-GGUF/resolve/90f9618340396838ee7ff5b0ba2da27da62953d3/gemma-4-E2B-it-Q4_K_S.gguf?download=true',
+      );
+      expect(nativeModelSource.filename, 'gemma-4-E2B-it-Q4_K_S.gguf');
+      expect(nativeModelSource.sizeBytes, 3043932288);
+      expect(
+        nativeModelSource.sha256,
+        '0a2fac16f388b4839f075dedb681357aec3e73a96bd66b413e462b6853550c99',
+      );
+      expect(
+        nativeProjectorSource.url,
+        'https://huggingface.co/unsloth/gemma-4-E2B-it-GGUF/resolve/90f9618340396838ee7ff5b0ba2da27da62953d3/mmproj-F16.gguf?download=true',
+      );
+      expect(nativeProjectorSource.filename, 'gemma-4-E2B-it-mmproj-F16.gguf');
+      expect(nativeProjectorSource.sizeBytes, 985654080);
+      expect(
+        nativeProjectorSource.sha256,
+        '140be8d7849741f88c50757d529b84373ee8e27052cc2236855b537f4a8215fa',
+      );
+      expect(
+        model.sizeBytesFor(web: false),
+        nativeModelSource.sizeBytes! + nativeProjectorSource.sizeBytes!,
+      );
+
+      expect(
+        webModelSource.url,
+        'https://huggingface.co/unsloth/gemma-4-E2B-it-GGUF/resolve/main/gemma-4-E2B-it-Q4_K_S.gguf?download=true',
+      );
+      expect(webModelSource.filename, nativeModelSource.filename);
+      expect(webModelSource.sizeBytes, 3043927168);
+      expect(webModelSource.sha256, isNull);
+      expect(
+        webProjectorSource.url,
+        'https://huggingface.co/unsloth/gemma-4-E2B-it-GGUF/resolve/main/mmproj-F16.gguf?download=true',
+      );
+      expect(webProjectorSource.filename, nativeProjectorSource.filename);
+      expect(webProjectorSource.sizeBytes, isNull);
+      expect(webProjectorSource.sha256, isNull);
+      expect(model.sizeBytesFor(web: true), 3043927168);
+    });
+
     test('Gemma 4 E2B LiteRT-LM pins its verified native bundle', () {
       final model = DownloadableModel.defaultModels.singleWhere(
         (model) => model.name == 'Gemma 4 E2B LiteRT-LM',

--- a/example/chat_app/test/unit_test.dart
+++ b/example/chat_app/test/unit_test.dart
@@ -1133,7 +1133,11 @@ void main() {
       expect(model.supportsAudio, isTrue);
       expect(model.supportsSpeechToTextFor(web: false), isTrue);
       expect(model.supportsSpeechToTextFor(web: true), isFalse);
-      expect(model.isNativeDesktopOnly, isTrue);
+      expect(model.isNativeOnly, isTrue);
+      expect(model.isNativeDesktopOnly, isFalse);
+      expect(model.isAvailableFor(web: false, mobile: true), isTrue);
+      expect(model.isAvailableFor(web: false, mobile: false), isTrue);
+      expect(model.isAvailableFor(web: true, mobile: false), isFalse);
       expect(model.sizeBytesFor(web: false), 1019141728);
       expect(model.preset.temperature, 0);
       expect(model.preset.topK, 1);
@@ -1186,7 +1190,7 @@ void main() {
       expect(small.preset.contextSize, 4096);
     });
 
-    test('large models are native-desktop-only while Gemma E4B is not', () {
+    test('large models remain desktop-only while Qwen3-ASR is native', () {
       final desktopModels = DownloadableModel.defaultModels
           .where((model) => model.isNativeDesktopOnly)
           .toList(growable: false);
@@ -1194,7 +1198,6 @@ void main() {
       expect(
         desktopModels.map((model) => model.name),
         orderedEquals(const [
-          'Qwen3-ASR 0.6B',
           'Gemma 4 12B it',
           'Gemma 4 26B A4B it',
           'Gemma 4 31B it',
@@ -1206,6 +1209,14 @@ void main() {
         expect(model.isAvailableFor(web: false, mobile: true), isFalse);
         expect(model.isAvailableFor(web: true, mobile: false), isFalse);
       }
+
+      final qwenAsr = DownloadableModel.defaultModels.singleWhere(
+        (model) => model.name == 'Qwen3-ASR 0.6B',
+      );
+      expect(qwenAsr.isNativeOnly, isTrue);
+      expect(qwenAsr.isAvailableFor(web: false, mobile: true), isTrue);
+      expect(qwenAsr.isAvailableFor(web: false, mobile: false), isTrue);
+      expect(qwenAsr.isAvailableFor(web: true, mobile: false), isFalse);
 
       final gemmaE4b = DownloadableModel.defaultModels.singleWhere(
         (model) => model.name == 'Gemma 4 E4B it',

--- a/example/chat_app/test/unit_test.dart
+++ b/example/chat_app/test/unit_test.dart
@@ -1263,6 +1263,41 @@ void main() {
       );
     });
 
+    test('Gemma 4 E2B LiteRT-LM pins its verified native bundle', () {
+      final model = DownloadableModel.defaultModels.singleWhere(
+        (model) => model.name == 'Gemma 4 E2B LiteRT-LM',
+      );
+      final nativeSource = model.modelSource as RemoteModelAssetSource;
+      final webSource = model.webModelSource as RemoteModelAssetSource;
+
+      expect(
+        nativeSource.url,
+        'https://huggingface.co/litert-community/gemma-4-E2B-it-litert-lm/resolve/6b78abd019e61a1ca4cbe3b212d2c9ce8ff38a94/gemma-4-E2B-it.litertlm?download=true',
+      );
+      expect(nativeSource.filename, 'gemma-4-E2B-it.litertlm');
+      expect(nativeSource.sizeBytes, 2588147712);
+      expect(
+        nativeSource.sha256,
+        '181938105e0eefd105961417e8da75903eacda102c4fce9ce90f50b97139a63c',
+      );
+      expect(model.sizeBytesFor(web: false), 2588147712);
+      expect(model.supportsAudioFor(web: false), isTrue);
+      expect(model.supportsSpeechToTextFor(web: false), isFalse);
+      expect(model.mediaInputModeFor(web: false), ModelMediaInputMode.direct);
+
+      expect(
+        webSource.url,
+        'https://huggingface.co/litert-community/gemma-4-E2B-it-litert-lm/resolve/main/gemma-4-E2B-it-web.litertlm?download=true',
+      );
+      expect(webSource.filename, 'gemma-4-E2B-it-web.litertlm');
+      expect(webSource.sizeBytes, 2008432640);
+      expect(webSource.sha256, isNull);
+      expect(model.sizeBytesFor(web: true), 2008432640);
+      expect(model.supportsAudioFor(web: true), isFalse);
+      expect(model.supportsSpeechToTextFor(web: true), isFalse);
+      expect(model.mediaInputModeFor(web: true), ModelMediaInputMode.none);
+    });
+
     test(
       'native LiteRT-LM preset enables direct audio after model load',
       () async {

--- a/example/chat_app/test/unit_test.dart
+++ b/example/chat_app/test/unit_test.dart
@@ -200,17 +200,213 @@ void main() {
     );
 
     test(
+      'stale iOS managed paths relocate to the validated current cache',
+      () async {
+        if (kIsWeb) {
+          return;
+        }
+        debugDefaultTargetPlatformOverride = TargetPlatform.iOS;
+        final model = DownloadableModel.defaultModels.singleWhere(
+          (candidate) => candidate.name == 'Gemma 4 E2B it',
+        );
+        final modelSource = model.modelSource as RemoteModelAssetSource;
+        final projectorSource =
+            model.multimodalProjectorSource as RemoteModelAssetSource;
+        final staleModelsDir = p.join(
+          p.separator,
+          'var',
+          'mobile',
+          'Containers',
+          'Data',
+          'Application',
+          'OLD',
+          'Library',
+          'Caches',
+          'models',
+        );
+        final currentModelsDir = p.join(
+          p.separator,
+          'var',
+          'mobile',
+          'Containers',
+          'Data',
+          'Application',
+          'NEW',
+          'Library',
+          'Caches',
+          'models',
+        );
+        final staleSettings = ChatSettings(
+          modelPath: p.join(staleModelsDir, modelSource.filename),
+          mmprojPath: p.join(staleModelsDir, projectorSource.filename),
+          preferredBackend: GpuBackend.cpu,
+          modelBytesHint: 3043927168,
+        );
+        final settingsService = MockSettingsService()..settings = staleSettings;
+        final engine = MockLlamaEngine();
+        final modelService = _RecordingModelService(
+          modelsDir: currentModelsDir,
+          cacheState: app_model_service.ModelProfileCacheState(
+            model: app_model_service.ModelAssetCacheState(
+              role: ModelAssetRole.model,
+              label: modelSource.filename,
+              isAvailable: true,
+            ),
+            multimodalProjector: app_model_service.ModelAssetCacheState(
+              role: ModelAssetRole.multimodalProjector,
+              label: projectorSource.filename,
+              isAvailable: true,
+            ),
+          ),
+        );
+        final relocatedProvider = ChatProvider(
+          chatService: MockChatService(engine: engine),
+          settingsService: settingsService,
+          modelService: modelService,
+          initialSettings: staleSettings,
+        );
+        addTearDown(relocatedProvider.dispose);
+
+        await relocatedProvider.loadModel();
+
+        final expectedModelPath = p.join(
+          currentModelsDir,
+          modelSource.filename,
+        );
+        final expectedProjectorPath = p.join(
+          currentModelsDir,
+          projectorSource.filename,
+        );
+        expect(relocatedProvider.isLoaded, isTrue);
+        expect(engine.lastLoadedModelPath, expectedModelPath);
+        expect(engine.lastLoadedMmprojPath, expectedProjectorPath);
+        expect(relocatedProvider.settings.modelPath, expectedModelPath);
+        expect(relocatedProvider.settings.mmprojPath, expectedProjectorPath);
+        expect(settingsService.settings.modelPath, expectedModelPath);
+        expect(settingsService.settings.mmprojPath, expectedProjectorPath);
+        expect(
+          settingsService.settings.modelBytesHint,
+          model.sizeBytesFor(web: false),
+        );
+        expect(modelService.cacheStateCalls, 1);
+      },
+    );
+
+    test(
+      'stale iOS managed paths do not relocate from an invalid current cache',
+      () async {
+        if (kIsWeb) {
+          return;
+        }
+        debugDefaultTargetPlatformOverride = TargetPlatform.iOS;
+        final model = DownloadableModel.defaultModels.singleWhere(
+          (candidate) => candidate.name == 'Gemma 4 E2B it',
+        );
+        final modelSource = model.modelSource as RemoteModelAssetSource;
+        final projectorSource =
+            model.multimodalProjectorSource as RemoteModelAssetSource;
+        final staleSettings = ChatSettings(
+          modelPath: p.join(
+            p.separator,
+            'var',
+            'mobile',
+            'Containers',
+            'Data',
+            'Application',
+            'OLD',
+            'Library',
+            'Caches',
+            'models',
+            modelSource.filename,
+          ),
+          mmprojPath: p.join(
+            p.separator,
+            'var',
+            'mobile',
+            'Containers',
+            'Data',
+            'Application',
+            'OLD',
+            'Library',
+            'Caches',
+            'models',
+            projectorSource.filename,
+          ),
+          preferredBackend: GpuBackend.cpu,
+        );
+        for (final entry in <({bool model, bool projector, String error})>[
+          (model: false, projector: true, error: 'model is incomplete'),
+          (
+            model: true,
+            projector: false,
+            error: 'multimodal projector is incomplete',
+          ),
+        ]) {
+          final settingsService = MockSettingsService()
+            ..settings = staleSettings;
+          final engine = MockLlamaEngine();
+          final modelService = _RecordingModelService(
+            modelsDir: p.join(
+              p.separator,
+              'var',
+              'mobile',
+              'Containers',
+              'Data',
+              'Application',
+              'NEW',
+              'Library',
+              'Caches',
+              'models',
+            ),
+            cacheState: app_model_service.ModelProfileCacheState(
+              model: app_model_service.ModelAssetCacheState(
+                role: ModelAssetRole.model,
+                label: modelSource.filename,
+                isAvailable: entry.model,
+              ),
+              multimodalProjector: app_model_service.ModelAssetCacheState(
+                role: ModelAssetRole.multimodalProjector,
+                label: projectorSource.filename,
+                isAvailable: entry.projector,
+              ),
+            ),
+          );
+          final invalidProvider = ChatProvider(
+            chatService: MockChatService(engine: engine),
+            settingsService: settingsService,
+            modelService: modelService,
+            initialSettings: staleSettings,
+          );
+          addTearDown(invalidProvider.dispose);
+
+          await invalidProvider.loadModel();
+
+          expect(invalidProvider.isLoaded, isFalse);
+          expect(invalidProvider.error, contains(entry.error));
+          expect(engine.lastLoadedModelPath, isNull);
+          expect(settingsService.settings.modelPath, staleSettings.modelPath);
+          expect(settingsService.settings.mmprojPath, staleSettings.mmprojPath);
+        }
+      },
+    );
+
+    test(
       'manual model and projector paths bypass catalog-only assumptions',
       () async {
         if (kIsWeb) {
           return;
         }
+        debugDefaultTargetPlatformOverride = TargetPlatform.iOS;
         final model = DownloadableModel.defaultModels.singleWhere(
           (candidate) => candidate.name == 'Gemma 4 E2B it',
         );
         final source = model.modelSource as RemoteModelAssetSource;
         final modelsDir = p.absolute('managed-catalog-cache');
-        final manualPath = p.join('custom-models', source.filename);
+        final manualPath = p.join(
+          p.separator,
+          'custom-models',
+          source.filename,
+        );
         final modelService = _RecordingModelService(modelsDir: modelsDir);
         final engine = MockLlamaEngine();
         final manualProvider = ChatProvider(

--- a/example/chat_app/test/unit_test.dart
+++ b/example/chat_app/test/unit_test.dart
@@ -1383,6 +1383,22 @@ void main() {
       expect(small.preset.contextSize, 4096);
     });
 
+    test('Gemma 4 presets use the recommended sampling configuration', () {
+      final gemmaModels = DownloadableModel.defaultModels
+          .where((model) => model.name.startsWith('Gemma 4 '))
+          .toList(growable: false);
+
+      expect(gemmaModels, isNotEmpty);
+      for (final model in gemmaModels) {
+        expect(model.preset.temperature, 1.0, reason: model.name);
+        expect(model.preset.topK, 64, reason: model.name);
+        expect(model.preset.topP, 0.95, reason: model.name);
+        expect(model.preset.minP, 0.0, reason: model.name);
+        expect(model.preset.penalty, 1.0, reason: model.name);
+        expect(model.preset.thinkingEnabled, isFalse, reason: model.name);
+      }
+    });
+
     test('large models remain desktop-only while Qwen3-ASR is native', () {
       final desktopModels = DownloadableModel.defaultModels
           .where((model) => model.isNativeDesktopOnly)

--- a/example/chat_app/test/unit_test.dart
+++ b/example/chat_app/test/unit_test.dart
@@ -289,6 +289,7 @@ void main() {
             }),
           ),
           settingsService: settingsService,
+          enableWebModelPrefetch: false,
           initialSettings: initialSettings,
         );
         addTearDown(liteRtWebProvider.dispose);

--- a/example/chat_app/test/unit_test.dart
+++ b/example/chat_app/test/unit_test.dart
@@ -4,12 +4,13 @@ import 'package:dio/dio.dart';
 import 'package:flutter/foundation.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:llamadart/llamadart.dart';
-import 'package:llamadart_chat_example/providers/chat_provider.dart';
 import 'package:llamadart_chat_example/models/chat_settings.dart';
 import 'package:llamadart_chat_example/models/downloadable_model.dart';
+import 'package:llamadart_chat_example/providers/chat_provider.dart';
 import 'package:llamadart_chat_example/services/chat_service.dart';
 import 'package:llamadart_chat_example/services/model_service_base.dart'
     as app_model_service;
+import 'package:path/path.dart' as p;
 
 import 'mocks.dart';
 
@@ -75,6 +76,197 @@ void main() {
       expect(mockEngine.initialized, isTrue);
       expect(provider.maxGenerationTokens, greaterThan(0));
     });
+
+    test(
+      'managed catalog direct load rejects invalid cached artifacts',
+      () async {
+        if (kIsWeb) {
+          return;
+        }
+        final model = DownloadableModel.defaultModels.singleWhere(
+          (candidate) => candidate.name == 'Gemma 4 E2B it',
+        );
+        final modelSource = model.modelSource as RemoteModelAssetSource;
+        final projectorSource =
+            model.multimodalProjectorSource as RemoteModelAssetSource;
+        final modelsDir = p.absolute('managed-catalog-cache');
+        final settings = ChatSettings(
+          modelPath: p.join(modelsDir, modelSource.filename),
+          mmprojPath: p.join(modelsDir, projectorSource.filename),
+          preferredBackend: GpuBackend.cpu,
+        );
+
+        for (final entry in <({bool model, bool projector, String error})>[
+          (
+            model: false,
+            projector: true,
+            error: 'model is incomplete or does not match',
+          ),
+          (
+            model: true,
+            projector: false,
+            error: 'multimodal projector is incomplete or does not match',
+          ),
+        ]) {
+          final engine = MockLlamaEngine();
+          final modelService = _RecordingModelService(
+            modelsDir: modelsDir,
+            cacheState: app_model_service.ModelProfileCacheState(
+              model: app_model_service.ModelAssetCacheState(
+                role: ModelAssetRole.model,
+                label: modelSource.filename,
+                isAvailable: entry.model,
+              ),
+              multimodalProjector: app_model_service.ModelAssetCacheState(
+                role: ModelAssetRole.multimodalProjector,
+                label: projectorSource.filename,
+                isAvailable: entry.projector,
+              ),
+            ),
+          );
+          final invalidProvider = ChatProvider(
+            chatService: MockChatService(engine: engine),
+            settingsService: MockSettingsService()..settings = settings,
+            modelService: modelService,
+            initialSettings: settings,
+          );
+          addTearDown(invalidProvider.dispose);
+
+          await invalidProvider.loadModel();
+
+          expect(invalidProvider.isLoaded, isFalse);
+          expect(invalidProvider.error, contains(entry.error));
+          expect(engine.lastLoadedModelPath, isNull);
+          expect(modelService.cacheStateCalls, 1);
+        }
+      },
+    );
+
+    test(
+      'managed Gemma cache migrates the persisted aggregate size hint',
+      () async {
+        if (kIsWeb) {
+          return;
+        }
+        final model = DownloadableModel.defaultModels.singleWhere(
+          (candidate) => candidate.name == 'Gemma 4 E2B it',
+        );
+        final modelSource = model.modelSource as RemoteModelAssetSource;
+        final projectorSource =
+            model.multimodalProjectorSource as RemoteModelAssetSource;
+        final modelsDir = p.absolute('managed-catalog-cache');
+        final settings = ChatSettings(
+          modelPath: p.join(modelsDir, modelSource.filename),
+          mmprojPath: p.join(modelsDir, projectorSource.filename),
+          preferredBackend: GpuBackend.cpu,
+          modelBytesHint: 3043927168,
+        );
+        final settingsService = MockSettingsService()..settings = settings;
+        final modelService = _RecordingModelService(
+          modelsDir: modelsDir,
+          cacheState: app_model_service.ModelProfileCacheState(
+            model: app_model_service.ModelAssetCacheState(
+              role: ModelAssetRole.model,
+              label: modelSource.filename,
+              isAvailable: true,
+            ),
+            multimodalProjector: app_model_service.ModelAssetCacheState(
+              role: ModelAssetRole.multimodalProjector,
+              label: projectorSource.filename,
+              isAvailable: true,
+            ),
+          ),
+        );
+        final managedProvider = ChatProvider(
+          chatService: MockChatService(engine: MockLlamaEngine()),
+          settingsService: settingsService,
+          modelService: modelService,
+          initialSettings: settings,
+        );
+        addTearDown(managedProvider.dispose);
+
+        await managedProvider.loadModel();
+
+        expect(managedProvider.isLoaded, isTrue);
+        expect(
+          managedProvider.settings.modelBytesHint,
+          model.sizeBytesFor(web: false),
+        );
+        expect(
+          settingsService.settings.modelBytesHint,
+          model.sizeBytesFor(web: false),
+        );
+      },
+    );
+
+    test(
+      'manual model and projector paths bypass catalog-only assumptions',
+      () async {
+        if (kIsWeb) {
+          return;
+        }
+        final model = DownloadableModel.defaultModels.singleWhere(
+          (candidate) => candidate.name == 'Gemma 4 E2B it',
+        );
+        final source = model.modelSource as RemoteModelAssetSource;
+        final modelsDir = p.absolute('managed-catalog-cache');
+        final manualPath = p.join('custom-models', source.filename);
+        final modelService = _RecordingModelService(modelsDir: modelsDir);
+        final engine = MockLlamaEngine();
+        final manualProvider = ChatProvider(
+          chatService: MockChatService(engine: engine),
+          settingsService: MockSettingsService(),
+          modelService: modelService,
+          initialSettings: ChatSettings(
+            modelPath: manualPath,
+            preferredBackend: GpuBackend.cpu,
+          ),
+        );
+        addTearDown(manualProvider.dispose);
+
+        await manualProvider.loadModel();
+
+        expect(manualProvider.isLoaded, isTrue);
+        expect(engine.lastLoadedModelPath, manualPath);
+        expect(modelService.cacheStateCalls, 0);
+
+        const customHint = 123456789;
+        final customProjectorSettings = ChatSettings(
+          modelPath: p.join(modelsDir, source.filename),
+          mmprojPath: p.join('custom-models', 'custom-mmproj.gguf'),
+          preferredBackend: GpuBackend.cpu,
+          modelBytesHint: customHint,
+        );
+        final customProjectorService = _RecordingModelService(
+          modelsDir: modelsDir,
+          cacheState: app_model_service.ModelProfileCacheState(
+            model: app_model_service.ModelAssetCacheState(
+              role: ModelAssetRole.model,
+              label: source.filename,
+              isAvailable: true,
+            ),
+            multimodalProjector: app_model_service.ModelAssetCacheState(
+              role: ModelAssetRole.multimodalProjector,
+              label: 'catalog-mmproj.gguf',
+              isAvailable: false,
+            ),
+          ),
+        );
+        final customProjectorProvider = ChatProvider(
+          chatService: MockChatService(engine: MockLlamaEngine()),
+          settingsService: MockSettingsService(),
+          modelService: customProjectorService,
+          initialSettings: customProjectorSettings,
+        );
+        addTearDown(customProjectorProvider.dispose);
+
+        await customProjectorProvider.loadModel();
+
+        expect(customProjectorProvider.isLoaded, isTrue);
+        expect(customProjectorProvider.settings.modelBytesHint, customHint);
+        expect(customProjectorService.cacheStateCalls, 1);
+      },
+    );
 
     test(
       'loadModel disables structured controls for LiteRT-LM web metadata',
@@ -1304,16 +1496,35 @@ void main() {
         'https://huggingface.co/unsloth/gemma-4-E2B-it-GGUF/resolve/main/gemma-4-E2B-it-Q4_K_S.gguf?download=true',
       );
       expect(webModelSource.filename, nativeModelSource.filename);
-      expect(webModelSource.sizeBytes, 3043927168);
+      expect(webModelSource.sizeBytes, 3043934304);
       expect(webModelSource.sha256, isNull);
+      expect(
+        webModelSource.cacheKey,
+        // Asset identity deliberately excludes size metadata, so existing
+        // browser cache entries keep the same key after the corrected size.
+        const RemoteModelAssetSource(
+          url:
+              'https://huggingface.co/unsloth/gemma-4-E2B-it-GGUF/resolve/main/gemma-4-E2B-it-Q4_K_S.gguf?download=true',
+          filename: 'gemma-4-E2B-it-Q4_K_S.gguf',
+          sizeBytes: 3043927168,
+        ).cacheKey,
+      );
       expect(
         webProjectorSource.url,
         'https://huggingface.co/unsloth/gemma-4-E2B-it-GGUF/resolve/main/mmproj-F16.gguf?download=true',
       );
       expect(webProjectorSource.filename, nativeProjectorSource.filename);
-      expect(webProjectorSource.sizeBytes, isNull);
+      expect(webProjectorSource.sizeBytes, 985654080);
       expect(webProjectorSource.sha256, isNull);
-      expect(model.sizeBytesFor(web: true), 3043927168);
+      expect(
+        webProjectorSource.cacheKey,
+        const RemoteModelAssetSource(
+          url:
+              'https://huggingface.co/unsloth/gemma-4-E2B-it-GGUF/resolve/main/mmproj-F16.gguf?download=true',
+          filename: 'gemma-4-E2B-it-mmproj-F16.gguf',
+        ).cacheKey,
+      );
+      expect(model.sizeBytesFor(web: true), 4029588384);
     });
 
     test('Gemma 4 E2B LiteRT-LM pins its verified native bundle', () {
@@ -1710,18 +1921,26 @@ class _RecordingModelService
     implements
         app_model_service.ModelService,
         app_model_service.WebCachePrefetchModelService {
-  _RecordingModelService({this.supportsPrefetch = true, this.downloadError});
+  _RecordingModelService({
+    this.supportsPrefetch = true,
+    this.downloadError,
+    this.modelsDir = 'browser-cache',
+    this.cacheState,
+  });
 
   final bool supportsPrefetch;
   final Object? downloadError;
+  final String modelsDir;
+  final app_model_service.ModelProfileCacheState? cacheState;
   int downloadCalls = 0;
+  int cacheStateCalls = 0;
   DownloadableModel? lastModel;
 
   @override
   Future<bool> supportsWebCachePrefetch() async => supportsPrefetch;
 
   @override
-  Future<String> getModelsDirectory() async => 'browser-cache';
+  Future<String> getModelsDirectory() async => modelsDir;
 
   @override
   Future<Set<String>> getDownloadedModels(
@@ -1734,6 +1953,11 @@ class _RecordingModelService
   Future<app_model_service.ModelProfileCacheState> getModelCacheState(
     DownloadableModel model,
   ) async {
+    cacheStateCalls += 1;
+    final configured = cacheState;
+    if (configured != null) {
+      return configured;
+    }
     final mmprojSource = model.multimodalProjectorSource;
     return app_model_service.ModelProfileCacheState(
       model: app_model_service.ModelAssetCacheState(

--- a/example/chat_app/test/wav_audio_validator_test.dart
+++ b/example/chat_app/test/wav_audio_validator_test.dart
@@ -1,0 +1,78 @@
+import 'dart:io';
+import 'dart:typed_data';
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:llamadart_chat_example/services/wav_audio_validator.dart';
+
+void main() {
+  late Directory temporaryDirectory;
+
+  setUp(() async {
+    temporaryDirectory = await Directory.systemTemp.createTemp(
+      'llamadart_wav_validator_',
+    );
+  });
+
+  tearDown(() async {
+    if (await temporaryDirectory.exists()) {
+      await temporaryDirectory.delete(recursive: true);
+    }
+  });
+
+  test('accepts a WAV with PCM bytes in its data chunk', () async {
+    final file = File('${temporaryDirectory.path}/speech.wav');
+    await file.writeAsBytes(_wavBytes(const <int>[1, 2, 3, 4]));
+
+    expect(await wavHasAudioData(file.path), isTrue);
+  });
+
+  test('rejects a header-only WAV', () async {
+    final file = File('${temporaryDirectory.path}/silent.wav');
+    await file.writeAsBytes(_wavBytes(const <int>[]));
+
+    expect(await wavHasAudioData(file.path), isFalse);
+  });
+
+  test('rejects a truncated data chunk and a non-WAV file', () async {
+    final truncated = File('${temporaryDirectory.path}/truncated.wav');
+    final truncatedBytes = _wavBytes(const <int>[1, 2]);
+    ByteData.sublistView(truncatedBytes).setUint32(40, 64, Endian.little);
+    await truncated.writeAsBytes(truncatedBytes);
+    final invalid = File('${temporaryDirectory.path}/invalid.wav');
+    await invalid.writeAsString('not audio');
+
+    expect(await wavHasAudioData(truncated.path), isFalse);
+    expect(await wavHasAudioData(invalid.path), isFalse);
+    expect(
+      await wavHasAudioData('${temporaryDirectory.path}/missing.wav'),
+      isFalse,
+    );
+  });
+}
+
+Uint8List _wavBytes(List<int> audioBytes) {
+  final bytes = Uint8List(44 + audioBytes.length);
+  final data = ByteData.sublistView(bytes);
+
+  void writeAscii(int offset, String value) {
+    for (var index = 0; index < value.length; index += 1) {
+      bytes[offset + index] = value.codeUnitAt(index);
+    }
+  }
+
+  writeAscii(0, 'RIFF');
+  data.setUint32(4, bytes.length - 8, Endian.little);
+  writeAscii(8, 'WAVE');
+  writeAscii(12, 'fmt ');
+  data.setUint32(16, 16, Endian.little);
+  data.setUint16(20, 1, Endian.little);
+  data.setUint16(22, 1, Endian.little);
+  data.setUint32(24, 16000, Endian.little);
+  data.setUint32(28, 32000, Endian.little);
+  data.setUint16(32, 2, Endian.little);
+  data.setUint16(34, 16, Endian.little);
+  writeAscii(36, 'data');
+  data.setUint32(40, audioBytes.length, Endian.little);
+  bytes.setRange(44, bytes.length, audioBytes);
+  return bytes;
+}

--- a/example/chat_app/windows/flutter/generated_plugin_registrant.cc
+++ b/example/chat_app/windows/flutter/generated_plugin_registrant.cc
@@ -7,11 +7,14 @@
 #include "generated_plugin_registrant.h"
 
 #include <pasteboard/pasteboard_plugin.h>
+#include <record_windows/record_windows_plugin_c_api.h>
 #include <url_launcher_windows/url_launcher_windows.h>
 
 void RegisterPlugins(flutter::PluginRegistry* registry) {
   PasteboardPluginRegisterWithRegistrar(
       registry->GetRegistrarForPlugin("PasteboardPlugin"));
+  RecordWindowsPluginCApiRegisterWithRegistrar(
+      registry->GetRegistrarForPlugin("RecordWindowsPluginCApi"));
   UrlLauncherWindowsRegisterWithRegistrar(
       registry->GetRegistrarForPlugin("UrlLauncherWindows"));
 }

--- a/example/chat_app/windows/flutter/generated_plugins.cmake
+++ b/example/chat_app/windows/flutter/generated_plugins.cmake
@@ -4,6 +4,7 @@
 
 list(APPEND FLUTTER_PLUGIN_LIST
   pasteboard
+  record_windows
   url_launcher_windows
 )
 

--- a/example/llamadart_server/lib/src/features/openai_api/presentation/http/handlers/chat_completions_handler.dart
+++ b/example/llamadart_server/lib/src/features/openai_api/presentation/http/handlers/chat_completions_handler.dart
@@ -51,7 +51,7 @@ class ChatCompletionsHandler {
         return _streamWriter.create(request);
       }
 
-      return _nonStreamingResponse(request);
+      return await _nonStreamingResponse(request);
     } on OpenAiHttpException catch (error) {
       return errorJsonResponse(error);
     } catch (error) {

--- a/lib/src/backends/litert_lm/litert_lm_service.dart
+++ b/lib/src/backends/litert_lm/litert_lm_service.dart
@@ -20,7 +20,6 @@ import 'litert_lm_platform.dart';
 import 'litert_lm_runtime.dart';
 
 const int _gemma4DefaultVisualTokenBudget = 280;
-const String _verifiedGemma4E2bAudioBundle = 'gemma-4-e2b-it.litertlm';
 
 /// Worker-owned service for the LiteRT-LM backend.
 ///
@@ -41,6 +40,7 @@ class LiteRtLmService {
   int? _activeMaxNumImages;
   bool? _activeVisionEnabled;
   bool? _activeAudioEnabled;
+  String? _workingAudioBackend;
   int _nextModelHandle = 1;
   int _nextContextHandle = 1;
   int? _modelHandle;
@@ -84,6 +84,7 @@ class LiteRtLmService {
     _modelParams = params;
     _activeBackend = resolvedBackend;
     _activeSpeculativeDecoding = null;
+    _workingAudioBackend = null;
     _modelHandle = _nextModelHandle++;
     _contextHandle = null;
     _lastMetrics = null;
@@ -102,6 +103,7 @@ class LiteRtLmService {
     _modelParams = null;
     _activeBackend = null;
     _activeSpeculativeDecoding = null;
+    _workingAudioBackend = null;
     _modelHandle = null;
     _contextHandle = null;
     _lastMetrics = null;
@@ -518,6 +520,7 @@ class LiteRtLmService {
     _modelPath = null;
     _modelParams = null;
     _activeBackend = null;
+    _workingAudioBackend = null;
     _modelHandle = null;
     _contextHandle = null;
     _modelLoaded = false;
@@ -584,49 +587,75 @@ class LiteRtLmService {
     _activeMaxNumImages = null;
     _activeVisionEnabled = null;
     _activeAudioEnabled = null;
-    final client = _clientFactory();
     final responseThinkingTags = _responseThinkingTagsForModel(modelPath);
-    client.configureResponseThinkingTags(
-      startTag: responseThinkingTags.startTag,
-      endTag: responseThinkingTags.endTag,
-    );
-    try {
-      await client.initialize(
-        modelPath: modelPath,
-        backend: backend,
-        visionBackend: resolvedVisionEnabled
-            ? _visionBackendName(backend)
-            : null,
-        // LiteRT-LM bundles constrain the audio executor independently from
-        // text. Only the verified Gemma 4 E2B catalog bundle is known to
-        // require CPU audio; preserve the selected media backend for custom
-        // bundles.
-        audioBackend: resolvedAudioEnabled
-            ? _audioBackendName(modelPath, backend)
-            : null,
-        maxTokens: modelParams.contextSize,
-        maxNumImages: resolvedMaxNumImages,
-        cacheDir: _defaultCacheDir(),
-        speculativeDecoding: resolvedSpeculativeDecoding,
-        minLogLevel: _liteRtLmMinLogLevel(_logLevel),
-        activationDataType: modelParams.liteRtLmActivationDataType,
-        prefillChunkSize: modelParams.liteRtLmPrefillChunkSize,
-        parallelFileSectionLoading:
-            modelParams.liteRtLmParallelFileSectionLoading,
-        dispatchLibDir: modelParams.liteRtLmDispatchLibDir,
-        numberOfThreads: modelParams.numberOfThreads == 0
-            ? null
-            : modelParams.numberOfThreads,
+    final visionBackend = resolvedVisionEnabled
+        ? _visionBackendName(backend)
+        : null;
+    final requestedAudioBackend = resolvedAudioEnabled
+        ? (_workingAudioBackend ?? _visionBackendName(backend))
+        : null;
+
+    Future<LiteRtLmRuntimeClient> initializeClient(String? audioBackend) async {
+      final client = _clientFactory();
+      client.configureResponseThinkingTags(
+        startTag: responseThinkingTags.startTag,
+        endTag: responseThinkingTags.endTag,
       );
-    } catch (_) {
       try {
-        client.dispose();
+        await client.initialize(
+          modelPath: modelPath,
+          backend: backend,
+          visionBackend: visionBackend,
+          audioBackend: audioBackend,
+          maxTokens: modelParams.contextSize,
+          maxNumImages: resolvedMaxNumImages,
+          cacheDir: _defaultCacheDir(),
+          speculativeDecoding: resolvedSpeculativeDecoding,
+          minLogLevel: _liteRtLmMinLogLevel(_logLevel),
+          activationDataType: modelParams.liteRtLmActivationDataType,
+          prefillChunkSize: modelParams.liteRtLmPrefillChunkSize,
+          parallelFileSectionLoading:
+              modelParams.liteRtLmParallelFileSectionLoading,
+          dispatchLibDir: modelParams.liteRtLmDispatchLibDir,
+          numberOfThreads: modelParams.numberOfThreads == 0
+              ? null
+              : modelParams.numberOfThreads,
+        );
+        return client;
       } catch (_) {
-        // Preserve the initialization error reported by the runtime.
+        try {
+          client.dispose();
+        } catch (_) {
+          // Preserve the initialization error reported by the runtime.
+        }
+        rethrow;
       }
-      rethrow;
+    }
+
+    late LiteRtLmRuntimeClient client;
+    var resolvedAudioBackend = requestedAudioBackend;
+    try {
+      client = await initializeClient(requestedAudioBackend);
+    } catch (initialError, initialStackTrace) {
+      final canRetryWithCpuAudio =
+          resolvedAudioEnabled &&
+          requestedAudioBackend != null &&
+          requestedAudioBackend != liteRtLmCpuBackend;
+      if (!canRetryWithCpuAudio) {
+        rethrow;
+      }
+
+      try {
+        resolvedAudioBackend = liteRtLmCpuBackend;
+        client = await initializeClient(resolvedAudioBackend);
+      } catch (_) {
+        Error.throwWithStackTrace(initialError, initialStackTrace);
+      }
     }
     _client = client;
+    if (resolvedAudioEnabled) {
+      _workingAudioBackend = resolvedAudioBackend;
+    }
     _activeSpeculativeDecoding = resolvedSpeculativeDecoding;
     _activeMaxNumImages = resolvedMaxNumImages;
     _activeVisionEnabled = resolvedVisionEnabled;
@@ -729,15 +758,6 @@ class LiteRtLmService {
       return liteRtLmCpuBackend;
     }
     return backend;
-  }
-
-  String _audioBackendName(String modelPath, String backend) {
-    final modelName = File(modelPath).uri.pathSegments.last;
-    final normalized = modelName.toLowerCase().replaceAll('_', '-');
-    if (normalized == _verifiedGemma4E2bAudioBundle) {
-      return liteRtLmCpuBackend;
-    }
-    return _visionBackendName(backend);
   }
 
   Map<String, dynamic> _nativeImageContent(LlamaImageContent part) {

--- a/lib/src/backends/litert_lm/litert_lm_service.dart
+++ b/lib/src/backends/litert_lm/litert_lm_service.dart
@@ -20,6 +20,7 @@ import 'litert_lm_platform.dart';
 import 'litert_lm_runtime.dart';
 
 const int _gemma4DefaultVisualTokenBudget = 280;
+const String _verifiedGemma4E2bAudioBundle = 'gemma-4-e2b-it.litertlm';
 
 /// Worker-owned service for the LiteRT-LM backend.
 ///
@@ -594,9 +595,15 @@ class LiteRtLmService {
         modelPath: modelPath,
         backend: backend,
         visionBackend: resolvedVisionEnabled
-            ? _mediaBackendName(backend)
+            ? _visionBackendName(backend)
             : null,
-        audioBackend: resolvedAudioEnabled ? _mediaBackendName(backend) : null,
+        // LiteRT-LM bundles constrain the audio executor independently from
+        // text. Only the verified Gemma 4 E2B catalog bundle is known to
+        // require CPU audio; preserve the selected media backend for custom
+        // bundles.
+        audioBackend: resolvedAudioEnabled
+            ? _audioBackendName(modelPath, backend)
+            : null,
         maxTokens: modelParams.contextSize,
         maxNumImages: resolvedMaxNumImages,
         cacheDir: _defaultCacheDir(),
@@ -717,11 +724,20 @@ class LiteRtLmService {
         .isNotEmpty;
   }
 
-  String _mediaBackendName(String backend) {
+  String _visionBackendName(String backend) {
     if (backend == liteRtLmNpuBackend) {
       return liteRtLmCpuBackend;
     }
     return backend;
+  }
+
+  String _audioBackendName(String modelPath, String backend) {
+    final modelName = File(modelPath).uri.pathSegments.last;
+    final normalized = modelName.toLowerCase().replaceAll('_', '-');
+    if (normalized == _verifiedGemma4E2bAudioBundle) {
+      return liteRtLmCpuBackend;
+    }
+    return _visionBackendName(backend);
   }
 
   Map<String, dynamic> _nativeImageContent(LlamaImageContent part) {

--- a/lib/src/core/models/chat/chat_message.dart
+++ b/lib/src/core/models/chat/chat_message.dart
@@ -224,8 +224,8 @@ class LlamaChatMessage {
   ///
   /// Some templates (e.g. SmolVLM) require `content` to be a list of
   /// `{type: 'text', text: '...'}` or `{type: 'image'}` objects.
-  /// This method also normalizes OpenAI's `image_url` type to `image`
-  /// for HuggingFace Jinja template compatibility.
+  /// This method also normalizes OpenAI's `image_url` and `input_audio` types
+  /// to the `image` and `audio` shapes used by HuggingFace Jinja templates.
   Map<String, dynamic> toJsonMultimodal() {
     final json = toJson();
     final content = json['content'];
@@ -236,10 +236,15 @@ class LlamaChatMessage {
         {'type': 'text', 'text': content},
       ];
     } else if (content is List) {
-      // Normalize image_url → image for template compatibility
+      // Normalize OpenAI media types for HuggingFace template compatibility.
       json['content'] = content.map((part) {
-        if (part is Map<String, dynamic> && part['type'] == 'image_url') {
-          return {'type': 'image'};
+        if (part is Map<String, dynamic>) {
+          switch (part['type']) {
+            case 'image_url':
+              return {'type': 'image'};
+            case 'input_audio':
+              return {'type': 'audio'};
+          }
         }
         return part;
       }).toList();

--- a/lib/src/platform/io/model_download_manager_io.dart
+++ b/lib/src/platform/io/model_download_manager_io.dart
@@ -564,7 +564,12 @@ class DefaultModelDownloadManager implements ModelDownloadManager {
         return null;
       }
       if (!await metadataFile.exists()) {
-        return _recoverMetadataEntry(source, metadataFile, finalFile, options);
+        return await _recoverMetadataEntry(
+          source,
+          metadataFile,
+          finalFile,
+          options,
+        );
       }
     } on FileSystemException {
       return _recoverMetadataEntry(source, metadataFile, finalFile, options);
@@ -889,7 +894,7 @@ class DefaultModelDownloadManager implements ModelDownloadManager {
           if (partMetadataFile != null) {
             await _deleteIfExists(partMetadataFile);
           }
-          return _downloadOnce(
+          return await _downloadOnce(
             source,
             options,
             uri,
@@ -912,7 +917,7 @@ class DefaultModelDownloadManager implements ModelDownloadManager {
         if (partMetadataFile != null) {
           await _deleteIfExists(partMetadataFile);
         }
-        return _downloadOnce(
+        return await _downloadOnce(
           source,
           options,
           uri,

--- a/test/e2e/backends/llama_cpp_chat_template_backend_e2e_test.dart
+++ b/test/e2e/backends/llama_cpp_chat_template_backend_e2e_test.dart
@@ -55,13 +55,9 @@ void main() {
           expect(rendered, contains('Say hello.'));
           expect(rendered, isNot(equals('Say hello.')));
 
-          final custom = await backend.applyChatTemplate(
-            modelHandle,
-            const [
-              {'role': 'user', 'content': 'Say hello.'},
-            ],
-            customTemplate: '{{ "CUSTOM:" ~ messages[0]["content"] }}',
-          );
+          final custom = await backend.applyChatTemplate(modelHandle, const [
+            {'role': 'user', 'content': 'Say hello.'},
+          ], customTemplate: '{{ "CUSTOM:" ~ messages[0]["content"] }}');
           expect(custom, contains('CUSTOM:Say hello.'));
 
           await backend.modelFree(modelHandle);

--- a/test/integration/engine_reloading_test.dart
+++ b/test/integration/engine_reloading_test.dart
@@ -20,56 +20,52 @@ void main() {
       await engine.dispose();
     });
 
-    test(
-      'should be able to unload and reload a model',
-      () async {
-        // First load
-        await engine.loadModel(
-          modelPath,
-          modelParams: const ModelParams(
-            contextSize: 128,
-            gpuLayers: 0,
-            numberOfThreads: 1,
-            numberOfThreadsBatch: 1,
-          ),
-        );
-        expect(engine.isReady, isTrue);
+    test('should be able to unload and reload a model', () async {
+      // First load
+      await engine.loadModel(
+        modelPath,
+        modelParams: const ModelParams(
+          contextSize: 128,
+          gpuLayers: 0,
+          numberOfThreads: 1,
+          numberOfThreadsBatch: 1,
+        ),
+      );
+      expect(engine.isReady, isTrue);
 
-        // Simple generation to ensure it works
-        var response1 = await engine.create([
-          LlamaChatMessage.fromText(
-            role: LlamaChatRole.user,
-            text: 'Hello, say hi!',
-          ),
-        ]).join();
-        expect(response1, isNotEmpty);
+      // Simple generation to ensure it works
+      var response1 = await engine.create([
+        LlamaChatMessage.fromText(
+          role: LlamaChatRole.user,
+          text: 'Hello, say hi!',
+        ),
+      ]).join();
+      expect(response1, isNotEmpty);
 
-        // Unload
-        await engine.unloadModel();
-        expect(engine.isReady, isFalse);
+      // Unload
+      await engine.unloadModel();
+      expect(engine.isReady, isFalse);
 
-        // Second load
-        await engine.loadModel(
-          modelPath,
-          modelParams: const ModelParams(
-            contextSize: 128,
-            gpuLayers: 0,
-            numberOfThreads: 1,
-            numberOfThreadsBatch: 1,
-          ),
-        );
-        expect(engine.isReady, isTrue);
+      // Second load
+      await engine.loadModel(
+        modelPath,
+        modelParams: const ModelParams(
+          contextSize: 128,
+          gpuLayers: 0,
+          numberOfThreads: 1,
+          numberOfThreadsBatch: 1,
+        ),
+      );
+      expect(engine.isReady, isTrue);
 
-        // Verify inference works again
-        var response2 = await engine.create([
-          LlamaChatMessage.fromText(
-            role: LlamaChatRole.user,
-            text: 'Say hello again!',
-          ),
-        ]).join();
-        expect(response2, isNotEmpty);
-      },
-      timeout: const Timeout(Duration(minutes: 2)),
-    );
+      // Verify inference works again
+      var response2 = await engine.create([
+        LlamaChatMessage.fromText(
+          role: LlamaChatRole.user,
+          text: 'Say hello again!',
+        ),
+      ]).join();
+      expect(response2, isNotEmpty);
+    }, timeout: const Timeout(Duration(minutes: 2)));
   });
 }

--- a/test/unit/backends/litert_lm/litert_lm_service_test.dart
+++ b/test/unit/backends/litert_lm/litert_lm_service_test.dart
@@ -831,6 +831,104 @@ void main() {
     },
   );
 
+  test('keeps GPU text and vision while using a CPU audio executor', () async {
+    final fakeClient = _FakeLiteRtLmRuntimeClient();
+    final service = LiteRtLmService(clientFactory: () => fakeClient);
+    final gemmaModelFile = File('${tempDir.path}/gemma-4-E2B-it.litertlm');
+    await gemmaModelFile.writeAsString('fake model');
+    final imageFile = File('${tempDir.path}/gpu-media-image.png');
+    await imageFile.writeAsBytes(const <int>[
+      0x89,
+      0x50,
+      0x4e,
+      0x47,
+      0x0d,
+      0x0a,
+      0x1a,
+      0x0a,
+    ]);
+
+    if (!service.getAvailableBackendInfo().contains('gpu')) {
+      service.dispose();
+      return;
+    }
+
+    try {
+      final modelHandle = await service.loadModel(
+        gemmaModelFile.path,
+        const ModelParams(liteRtLmBackend: LiteRtLmBackendPreference.gpu),
+      );
+      final contextHandle = service.createContext(
+        modelHandle,
+        const ModelParams(liteRtLmBackend: LiteRtLmBackendPreference.gpu),
+      );
+
+      final chunksFuture = service.generateChat(contextHandle, [
+        LlamaChatMessage.withContent(
+          role: LlamaChatRole.user,
+          content: [
+            const LlamaTextContent('Answer the spoken request.'),
+            LlamaImageContent(path: imageFile.path),
+            LlamaAudioContent(bytes: Uint8List.fromList(const <int>[1, 2, 3])),
+          ],
+        ),
+      ], const GenerationParams(maxTokens: 8)).toList();
+
+      await fakeClient.generateStarted.future;
+      fakeClient.generated.add('ok');
+      await fakeClient.generated.close();
+
+      expect(await chunksFuture, [utf8.encode('ok')]);
+      expect(fakeClient.lastBackend, 'gpu');
+      expect(fakeClient.lastVisionBackend, 'gpu');
+      expect(fakeClient.lastAudioBackend, 'cpu');
+    } finally {
+      service.dispose();
+    }
+  });
+
+  test('preserves GPU audio for custom LiteRT-LM bundles', () async {
+    final fakeClient = _FakeLiteRtLmRuntimeClient();
+    final service = LiteRtLmService(clientFactory: () => fakeClient);
+
+    if (!service.getAvailableBackendInfo().contains('gpu')) {
+      service.dispose();
+      return;
+    }
+
+    try {
+      final modelHandle = await service.loadModel(
+        modelFile.path,
+        const ModelParams(liteRtLmBackend: LiteRtLmBackendPreference.gpu),
+      );
+      final contextHandle = service.createContext(
+        modelHandle,
+        const ModelParams(liteRtLmBackend: LiteRtLmBackendPreference.gpu),
+      );
+
+      final chunksFuture = service.generateChat(contextHandle, [
+        LlamaChatMessage.withContent(
+          role: LlamaChatRole.user,
+          content: [
+            const LlamaTextContent('Answer the spoken request.'),
+            LlamaAudioContent(bytes: Uint8List.fromList(const <int>[1, 2, 3])),
+          ],
+        ),
+      ], const GenerationParams(maxTokens: 8)).toList();
+
+      await fakeClient.generateStarted.future;
+      fakeClient.generated.add('ok');
+      await fakeClient.generated.close();
+
+      expect(await chunksFuture, [utf8.encode('ok')]);
+      expect(fakeClient.lastBackend, 'gpu');
+      expect(fakeClient.lastVisionBackend, isNull);
+      expect(fakeClient.lastAudioBackend, 'gpu');
+    } finally {
+      service.dispose();
+    }
+  });
+
   test(
     'rejects unsupported native chat media shapes before runtime init',
     () async {

--- a/test/unit/backends/litert_lm/litert_lm_service_test.dart
+++ b/test/unit/backends/litert_lm/litert_lm_service_test.dart
@@ -831,22 +831,124 @@ void main() {
     },
   );
 
-  test('keeps GPU text and vision while using a CPU audio executor', () async {
-    final fakeClient = _FakeLiteRtLmRuntimeClient();
-    final service = LiteRtLmService(clientFactory: () => fakeClient);
-    final gemmaModelFile = File('${tempDir.path}/gemma-4-E2B-it.litertlm');
-    await gemmaModelFile.writeAsString('fake model');
-    final imageFile = File('${tempDir.path}/gpu-media-image.png');
-    await imageFile.writeAsBytes(const <int>[
-      0x89,
-      0x50,
-      0x4e,
-      0x47,
-      0x0d,
-      0x0a,
-      0x1a,
-      0x0a,
-    ]);
+  test(
+    'retries renamed audio bundles with only the audio executor on CPU',
+    () async {
+      final gpuAudioClient = _FakeLiteRtLmRuntimeClient(
+        initializeError: StateError('GPU audio executor is incompatible'),
+      );
+      final cpuAudioClient = _FakeLiteRtLmRuntimeClient();
+      final recreatedCpuAudioClient = _FakeLiteRtLmRuntimeClient();
+      final clients = <_FakeLiteRtLmRuntimeClient>[
+        gpuAudioClient,
+        cpuAudioClient,
+        recreatedCpuAudioClient,
+      ];
+      var nextClient = 0;
+      final service = LiteRtLmService(
+        clientFactory: () => clients[nextClient++],
+      );
+      final renamedModelFile = File('${tempDir.path}/renamed-bundle.litertlm');
+      await renamedModelFile.writeAsString('fake model');
+      final imageFile = File('${tempDir.path}/gpu-media-image.png');
+      await imageFile.writeAsBytes(const <int>[
+        0x89,
+        0x50,
+        0x4e,
+        0x47,
+        0x0d,
+        0x0a,
+        0x1a,
+        0x0a,
+      ]);
+
+      if (!service.getAvailableBackendInfo().contains('gpu')) {
+        service.dispose();
+        return;
+      }
+
+      try {
+        final modelHandle = await service.loadModel(
+          renamedModelFile.path,
+          const ModelParams(liteRtLmBackend: LiteRtLmBackendPreference.gpu),
+        );
+        final contextHandle = service.createContext(
+          modelHandle,
+          const ModelParams(liteRtLmBackend: LiteRtLmBackendPreference.gpu),
+        );
+
+        final chunksFuture = service.generateChat(contextHandle, [
+          LlamaChatMessage.withContent(
+            role: LlamaChatRole.user,
+            content: [
+              const LlamaTextContent('Answer the spoken request.'),
+              LlamaImageContent(path: imageFile.path),
+              LlamaAudioContent(
+                bytes: Uint8List.fromList(const <int>[1, 2, 3]),
+              ),
+            ],
+          ),
+        ], const GenerationParams(maxTokens: 8)).toList();
+
+        await cpuAudioClient.generateStarted.future;
+        cpuAudioClient.generated.add('ok');
+        await cpuAudioClient.generated.close();
+
+        expect(await chunksFuture, [utf8.encode('ok')]);
+        expect(gpuAudioClient.lastBackend, 'gpu');
+        expect(gpuAudioClient.lastVisionBackend, 'gpu');
+        expect(gpuAudioClient.lastAudioBackend, 'gpu');
+        expect(gpuAudioClient.disposeCount, 1);
+        expect(cpuAudioClient.lastBackend, 'gpu');
+        expect(cpuAudioClient.lastVisionBackend, 'gpu');
+        expect(cpuAudioClient.lastAudioBackend, 'cpu');
+
+        final recreatedChunksFuture = service.generateChat(contextHandle, [
+          LlamaChatMessage.withContent(
+            role: LlamaChatRole.user,
+            content: [
+              const LlamaTextContent('Compare the images and audio.'),
+              LlamaImageContent(path: imageFile.path),
+              LlamaImageContent(path: imageFile.path),
+              LlamaAudioContent(
+                bytes: Uint8List.fromList(const <int>[1, 2, 3]),
+              ),
+            ],
+          ),
+        ], const GenerationParams(maxTokens: 8)).toList();
+
+        await recreatedCpuAudioClient.generateStarted.future;
+        recreatedCpuAudioClient.generated.add('again');
+        await recreatedCpuAudioClient.generated.close();
+
+        expect(await recreatedChunksFuture, [utf8.encode('again')]);
+        expect(cpuAudioClient.disposeCount, 1);
+        expect(recreatedCpuAudioClient.lastBackend, 'gpu');
+        expect(recreatedCpuAudioClient.lastVisionBackend, 'gpu');
+        expect(recreatedCpuAudioClient.lastAudioBackend, 'cpu');
+        expect(recreatedCpuAudioClient.lastMaxNumImages, 2);
+        expect(nextClient, 3);
+      } finally {
+        service.dispose();
+      }
+    },
+  );
+
+  test('forgets learned CPU audio fallback when another model loads', () async {
+    final gpuAudioClient = _FakeLiteRtLmRuntimeClient(
+      initializeError: StateError('GPU audio executor is incompatible'),
+    );
+    final cpuAudioClient = _FakeLiteRtLmRuntimeClient();
+    final nextModelGpuAudioClient = _FakeLiteRtLmRuntimeClient();
+    final clients = <_FakeLiteRtLmRuntimeClient>[
+      gpuAudioClient,
+      cpuAudioClient,
+      nextModelGpuAudioClient,
+    ];
+    var nextClient = 0;
+    final service = LiteRtLmService(clientFactory: () => clients[nextClient++]);
+    final nextModelFile = File('${tempDir.path}/next-model.litertlm');
+    await nextModelFile.writeAsString('different fake model');
 
     if (!service.getAvailableBackendInfo().contains('gpu')) {
       service.dispose();
@@ -854,42 +956,66 @@ void main() {
     }
 
     try {
-      final modelHandle = await service.loadModel(
-        gemmaModelFile.path,
+      final firstModelHandle = await service.loadModel(
+        modelFile.path,
         const ModelParams(liteRtLmBackend: LiteRtLmBackendPreference.gpu),
       );
-      final contextHandle = service.createContext(
-        modelHandle,
+      final firstContextHandle = service.createContext(
+        firstModelHandle,
         const ModelParams(liteRtLmBackend: LiteRtLmBackendPreference.gpu),
       );
 
-      final chunksFuture = service.generateChat(contextHandle, [
+      final firstChunksFuture = service.generateChat(firstContextHandle, [
         LlamaChatMessage.withContent(
           role: LlamaChatRole.user,
           content: [
-            const LlamaTextContent('Answer the spoken request.'),
-            LlamaImageContent(path: imageFile.path),
+            const LlamaTextContent('Transcribe this.'),
             LlamaAudioContent(bytes: Uint8List.fromList(const <int>[1, 2, 3])),
           ],
         ),
       ], const GenerationParams(maxTokens: 8)).toList();
 
-      await fakeClient.generateStarted.future;
-      fakeClient.generated.add('ok');
-      await fakeClient.generated.close();
+      await cpuAudioClient.generateStarted.future;
+      cpuAudioClient.generated.add('first');
+      await cpuAudioClient.generated.close();
+      expect(await firstChunksFuture, [utf8.encode('first')]);
+      expect(cpuAudioClient.lastAudioBackend, 'cpu');
 
-      expect(await chunksFuture, [utf8.encode('ok')]);
-      expect(fakeClient.lastBackend, 'gpu');
-      expect(fakeClient.lastVisionBackend, 'gpu');
-      expect(fakeClient.lastAudioBackend, 'cpu');
+      final nextModelHandle = await service.loadModel(
+        nextModelFile.path,
+        const ModelParams(liteRtLmBackend: LiteRtLmBackendPreference.gpu),
+      );
+      final nextContextHandle = service.createContext(
+        nextModelHandle,
+        const ModelParams(liteRtLmBackend: LiteRtLmBackendPreference.gpu),
+      );
+      final nextChunksFuture = service.generateChat(nextContextHandle, [
+        LlamaChatMessage.withContent(
+          role: LlamaChatRole.user,
+          content: [
+            const LlamaTextContent('Transcribe this too.'),
+            LlamaAudioContent(bytes: Uint8List.fromList(const <int>[4, 5, 6])),
+          ],
+        ),
+      ], const GenerationParams(maxTokens: 8)).toList();
+
+      await nextModelGpuAudioClient.generateStarted.future;
+      nextModelGpuAudioClient.generated.add('second');
+      await nextModelGpuAudioClient.generated.close();
+
+      expect(await nextChunksFuture, [utf8.encode('second')]);
+      expect(nextModelGpuAudioClient.lastAudioBackend, 'gpu');
+      expect(nextClient, 3);
     } finally {
       service.dispose();
     }
   });
 
-  test('preserves GPU audio for custom LiteRT-LM bundles', () async {
+  test('does not force unrelated same-name bundles to CPU audio', () async {
     final fakeClient = _FakeLiteRtLmRuntimeClient();
     final service = LiteRtLmService(clientFactory: () => fakeClient);
+    final sameNameModelFile = File('${tempDir.path}/gemma-4-E2B-it.litertlm');
+    await sameNameModelFile.writeAsString('unrelated fake model');
 
     if (!service.getAvailableBackendInfo().contains('gpu')) {
       service.dispose();
@@ -898,7 +1024,7 @@ void main() {
 
     try {
       final modelHandle = await service.loadModel(
-        modelFile.path,
+        sameNameModelFile.path,
         const ModelParams(liteRtLmBackend: LiteRtLmBackendPreference.gpu),
       );
       final contextHandle = service.createContext(
@@ -924,6 +1050,61 @@ void main() {
       expect(fakeClient.lastBackend, 'gpu');
       expect(fakeClient.lastVisionBackend, isNull);
       expect(fakeClient.lastAudioBackend, 'gpu');
+    } finally {
+      service.dispose();
+    }
+  });
+
+  test('preserves the primary error when CPU audio fallback fails', () async {
+    final primaryError = StateError('primary GPU audio failure');
+    final gpuAudioClient = _FakeLiteRtLmRuntimeClient(
+      initializeError: primaryError,
+    );
+    final cpuAudioClient = _FakeLiteRtLmRuntimeClient(
+      initializeError: StateError('CPU audio fallback failure'),
+    );
+    final clients = <_FakeLiteRtLmRuntimeClient>[
+      gpuAudioClient,
+      cpuAudioClient,
+    ];
+    var nextClient = 0;
+    final service = LiteRtLmService(clientFactory: () => clients[nextClient++]);
+
+    if (!service.getAvailableBackendInfo().contains('gpu')) {
+      service.dispose();
+      return;
+    }
+
+    try {
+      final modelHandle = await service.loadModel(
+        modelFile.path,
+        const ModelParams(liteRtLmBackend: LiteRtLmBackendPreference.gpu),
+      );
+      final contextHandle = service.createContext(
+        modelHandle,
+        const ModelParams(liteRtLmBackend: LiteRtLmBackendPreference.gpu),
+      );
+
+      await expectLater(
+        service.generateChat(contextHandle, [
+          LlamaChatMessage.withContent(
+            role: LlamaChatRole.user,
+            content: [
+              const LlamaTextContent('Answer the spoken request.'),
+              LlamaAudioContent(
+                bytes: Uint8List.fromList(const <int>[1, 2, 3]),
+              ),
+            ],
+          ),
+        ], const GenerationParams(maxTokens: 8)).drain<void>(),
+        throwsA(same(primaryError)),
+      );
+
+      expect(gpuAudioClient.lastAudioBackend, 'gpu');
+      expect(gpuAudioClient.disposeCount, 1);
+      expect(cpuAudioClient.lastAudioBackend, 'cpu');
+      expect(cpuAudioClient.disposeCount, 1);
+      expect(nextClient, 2);
     } finally {
       service.dispose();
     }

--- a/test/unit/core/engine/engine_test.dart
+++ b/test/unit/core/engine/engine_test.dart
@@ -1004,11 +1004,10 @@ void main() {
             reason: testCase.label,
           );
           expect(downloadManager.ensureModelCalls, 2, reason: testCase.label);
-          expect(
-            downloadManager.sources.map((source) => source.cacheKey),
-            [testCase.modelSource.cacheKey, testCase.projectorSource.cacheKey],
-            reason: testCase.label,
-          );
+          expect(downloadManager.sources.map((source) => source.cacheKey), [
+            testCase.modelSource.cacheKey,
+            testCase.projectorSource.cacheKey,
+          ], reason: testCase.label);
         }
       },
     );

--- a/test/unit/core/models/chat/chat_message_test.dart
+++ b/test/unit/core/models/chat/chat_message_test.dart
@@ -1,3 +1,5 @@
+import 'dart:typed_data';
+
 import 'package:test/test.dart';
 import 'package:llamadart/src/core/models/chat/chat_message.dart';
 import 'package:llamadart/src/core/models/chat/chat_role.dart';
@@ -51,6 +53,37 @@ void main() {
         'role': 'user',
         'content': [
           {'type': 'text', 'text': 'Part 1Part 2'},
+        ],
+      });
+    });
+
+    test('normalizes template-facing audio without changing wire JSON', () {
+      final message = LlamaChatMessage.withContent(
+        role: LlamaChatRole.user,
+        content: <LlamaContentPart>[
+          LlamaAudioContent(bytes: Uint8List.fromList(<int>[82, 73, 70, 70])),
+          const LlamaTextContent('answer the recording'),
+        ],
+      );
+
+      expect(message.toJson(), <String, dynamic>{
+        'role': 'user',
+        'content': <Map<String, dynamic>>[
+          <String, dynamic>{
+            'type': 'input_audio',
+            'input_audio': <String, dynamic>{
+              'data': 'UklGRg==',
+              'format': 'audio',
+            },
+          },
+          <String, dynamic>{'type': 'text', 'text': 'answer the recording'},
+        ],
+      });
+      expect(message.toJsonMultimodal(), <String, dynamic>{
+        'role': 'user',
+        'content': <Map<String, dynamic>>[
+          <String, dynamic>{'type': 'audio'},
+          <String, dynamic>{'type': 'text', 'text': 'answer the recording'},
         ],
       });
     });

--- a/test/unit/core/template/handlers/gemma4_handler_test.dart
+++ b/test/unit/core/template/handlers/gemma4_handler_test.dart
@@ -2,6 +2,7 @@
 library;
 
 import 'dart:convert';
+import 'dart:typed_data';
 
 import 'package:llamadart/src/core/models/chat/chat_message.dart';
 import 'package:llamadart/src/core/models/chat/chat_role.dart';
@@ -12,6 +13,46 @@ import 'package:test/test.dart';
 
 void main() {
   group('Gemma4Handler', () {
+    test('renders audio inside the user turn for audio-only templates', () {
+      const template = '''
+<|begin_of_text|>
+{% for message in messages %}
+<|turn>{{ message['role'] }}
+{% for item in message['content'] %}
+{% if item['type'] == 'audio' %}<|audio|>{% elif item['type'] == 'text' %}{{ item['text'] }}{% endif %}
+{% endfor %}<turn|>
+{% endfor %}
+{% if add_generation_prompt %}<|turn>model
+{% endif %}
+''';
+      final audioBytes = Uint8List.fromList(<int>[82, 73, 70, 70]);
+
+      final result = ChatTemplateEngine.render(
+        templateSource: template,
+        messages: <LlamaChatMessage>[
+          LlamaChatMessage.withContent(
+            role: LlamaChatRole.user,
+            content: <LlamaContentPart>[
+              LlamaAudioContent(bytes: audioBytes),
+              const LlamaTextContent('answer the recording'),
+            ],
+          ),
+        ],
+        metadata: const <String, String>{},
+      );
+
+      final userTurn = result.prompt.indexOf('<|turn>user');
+      final audioMarker = result.prompt.indexOf('<|audio|>');
+      final instruction = result.prompt.indexOf('answer the recording');
+      final assistantTurn = result.prompt.indexOf('<|turn>model');
+      expect(userTurn, greaterThanOrEqualTo(0));
+      expect(audioMarker, greaterThan(userTurn));
+      expect(instruction, greaterThan(audioMarker));
+      expect(assistantTurn, greaterThan(instruction));
+      expect(result.prompt.indexOf('<|audio|>'), audioMarker);
+      expect(result.prompt.lastIndexOf('<|audio|>'), audioMarker);
+    });
+
     test('renders thinking flag into Gemma 4 template context', () {
       const template =
           '{% if enable_thinking %}<|turn>system\n<|think|><turn|>\n{% endif %}'

--- a/test/unit/core/template/template_render_context_test.dart
+++ b/test/unit/core/template/template_render_context_test.dart
@@ -354,7 +354,7 @@ void main() {
         final content = renderedMessages.single['content'];
         expect(content, isA<List>());
         expect(content, hasLength(3));
-        expect(content.first['type'], equals('input_audio'));
+        expect(content.first, equals({'type': 'audio'}));
         expect(content[1], equals({'type': 'text', 'text': 'prefix:'}));
         expect(content.last['type'], equals('text'));
         expect(content.last['text'], contains('"tool_calls"'));

--- a/test/unit/tooling/macos_litert_lm_prepare_app_script_test.dart
+++ b/test/unit/tooling/macos_litert_lm_prepare_app_script_test.dart
@@ -51,70 +51,62 @@ void main() {
       expect(project, contains(r'bash \"$SCRIPT\"'));
     });
 
-    test(
-      'rejects incomplete explicit arm64 runtime directories',
-      () async {
-        final root = await Directory.systemTemp.createTemp(
-          'litert_prepare_partial_',
-        );
-        addTearDown(() => root.delete(recursive: true));
+    test('rejects incomplete explicit arm64 runtime directories', () async {
+      final root = await Directory.systemTemp.createTemp(
+        'litert_prepare_partial_',
+      );
+      addTearDown(() => root.delete(recursive: true));
 
-        final libDir = Directory(path.join(root.path, 'litert'))..createSync();
-        await File(path.join(libDir.path, 'libLiteRtLm.dylib')).create();
+      final libDir = Directory(path.join(root.path, 'litert'))..createSync();
+      await File(path.join(libDir.path, 'libLiteRtLm.dylib')).create();
 
-        final appDir = Directory(path.join(root.path, 'Test.app'));
-        final result = await _runPrepareApp(appDir, libDir, arch: 'arm64');
+      final appDir = Directory(path.join(root.path, 'Test.app'));
+      final result = await _runPrepareApp(appDir, libDir, arch: 'arm64');
 
-        expect(result.exitCode, 2);
-        expect(result.stderr, contains('library directory is incomplete'));
-        expect(result.stderr, contains('libCLiteRTLM_mac.dylib'));
+      expect(result.exitCode, 2);
+      expect(result.stderr, contains('library directory is incomplete'));
+      expect(result.stderr, contains('libCLiteRTLM_mac.dylib'));
+      expect(
+        Directory(
+          path.join(appDir.path, 'Contents', 'Frameworks'),
+        ).existsSync(),
+        isFalse,
+      );
+    }, skip: Platform.isWindows ? 'requires bash and POSIX symlinks' : false);
+
+    test('installs the full arm64 companion library set', () async {
+      final root = await Directory.systemTemp.createTemp(
+        'litert_prepare_full_',
+      );
+      addTearDown(() => root.delete(recursive: true));
+
+      final libDir = Directory(path.join(root.path, 'litert'))..createSync();
+      for (final library in _arm64Libraries) {
+        await File(path.join(libDir.path, library)).create();
+      }
+
+      final appDir = Directory(path.join(root.path, 'Test.app'));
+      final result = await _runPrepareApp(appDir, libDir, arch: 'arm64');
+
+      expect(result.exitCode, 0, reason: result.stderr.toString());
+      expect(result.stdout, contains('Prepared LiteRT-LM macOS'));
+
+      final frameworksDir = path.join(appDir.path, 'Contents', 'Frameworks');
+      final runtimeDir = path.join(frameworksDir, 'LiteRtLmRuntime');
+      for (final library in _arm64Libraries) {
+        final libraryPath = path.join(runtimeDir, library);
+        expect(File(libraryPath).existsSync(), isTrue, reason: library);
+      }
+      for (final framework in _oldFrameworks) {
         expect(
           Directory(
-            path.join(appDir.path, 'Contents', 'Frameworks'),
+            path.join(frameworksDir, '$framework.framework'),
           ).existsSync(),
           isFalse,
+          reason: framework,
         );
-      },
-      skip: Platform.isWindows ? 'requires bash and POSIX symlinks' : false,
-    );
-
-    test(
-      'installs the full arm64 companion library set',
-      () async {
-        final root = await Directory.systemTemp.createTemp(
-          'litert_prepare_full_',
-        );
-        addTearDown(() => root.delete(recursive: true));
-
-        final libDir = Directory(path.join(root.path, 'litert'))..createSync();
-        for (final library in _arm64Libraries) {
-          await File(path.join(libDir.path, library)).create();
-        }
-
-        final appDir = Directory(path.join(root.path, 'Test.app'));
-        final result = await _runPrepareApp(appDir, libDir, arch: 'arm64');
-
-        expect(result.exitCode, 0, reason: result.stderr.toString());
-        expect(result.stdout, contains('Prepared LiteRT-LM macOS'));
-
-        final frameworksDir = path.join(appDir.path, 'Contents', 'Frameworks');
-        final runtimeDir = path.join(frameworksDir, 'LiteRtLmRuntime');
-        for (final library in _arm64Libraries) {
-          final libraryPath = path.join(runtimeDir, library);
-          expect(File(libraryPath).existsSync(), isTrue, reason: library);
-        }
-        for (final framework in _oldFrameworks) {
-          expect(
-            Directory(
-              path.join(frameworksDir, '$framework.framework'),
-            ).existsSync(),
-            isFalse,
-            reason: framework,
-          );
-        }
-      },
-      skip: Platform.isWindows ? 'requires bash and POSIX symlinks' : false,
-    );
+      }
+    }, skip: Platform.isWindows ? 'requires bash and POSIX symlinks' : false);
 
     test(
       'does not treat unrelated Flutter frameworks as LiteRT-LM runtime',
@@ -159,34 +151,30 @@ void main() {
       skip: Platform.isWindows ? 'requires bash and POSIX symlinks' : false,
     );
 
-    test(
-      'skips when a complete fallback runtime is already bundled',
-      () async {
-        final root = await Directory.systemTemp.createTemp(
-          'litert_prepare_skip_bundled_',
-        );
-        addTearDown(() => root.delete(recursive: true));
+    test('skips when a complete fallback runtime is already bundled', () async {
+      final root = await Directory.systemTemp.createTemp(
+        'litert_prepare_skip_bundled_',
+      );
+      addTearDown(() => root.delete(recursive: true));
 
-        final libDir = Directory(path.join(root.path, 'litert'))..createSync();
-        for (final library in _arm64Libraries) {
-          await File(path.join(libDir.path, library)).create();
-        }
+      final libDir = Directory(path.join(root.path, 'litert'))..createSync();
+      for (final library in _arm64Libraries) {
+        await File(path.join(libDir.path, library)).create();
+      }
 
-        final appDir = Directory(path.join(root.path, 'Test.app'));
-        final runtimeDir = Directory(
-          path.join(appDir.path, 'Contents', 'Frameworks', 'LiteRtLmRuntime'),
-        )..createSync(recursive: true);
-        for (final library in _arm64Libraries) {
-          await File(path.join(runtimeDir.path, library)).create();
-        }
+      final appDir = Directory(path.join(root.path, 'Test.app'));
+      final runtimeDir = Directory(
+        path.join(appDir.path, 'Contents', 'Frameworks', 'LiteRtLmRuntime'),
+      )..createSync(recursive: true);
+      for (final library in _arm64Libraries) {
+        await File(path.join(runtimeDir.path, library)).create();
+      }
 
-        final result = await _runPrepareApp(appDir, libDir, arch: 'arm64');
+      final result = await _runPrepareApp(appDir, libDir, arch: 'arm64');
 
-        expect(result.exitCode, 0, reason: result.stderr.toString());
-        expect(result.stdout, contains('Complete LiteRT-LM runtime detected'));
-      },
-      skip: Platform.isWindows ? 'requires bash and POSIX symlinks' : false,
-    );
+      expect(result.exitCode, 0, reason: result.stderr.toString());
+      expect(result.stdout, contains('Complete LiteRT-LM runtime detected'));
+    }, skip: Platform.isWindows ? 'requires bash and POSIX symlinks' : false);
 
     test(
       'does not treat partial arm64 native SPM runtime as complete',
@@ -228,52 +216,46 @@ void main() {
       skip: Platform.isWindows ? 'requires bash and POSIX symlinks' : false,
     );
 
-    test(
-      'installs the x64 runtime library set',
-      () async {
-        final root = await Directory.systemTemp.createTemp(
-          'litert_prepare_x64_',
-        );
-        addTearDown(() => root.delete(recursive: true));
+    test('installs the x64 runtime library set', () async {
+      final root = await Directory.systemTemp.createTemp('litert_prepare_x64_');
+      addTearDown(() => root.delete(recursive: true));
 
-        final libDir = Directory(path.join(root.path, 'litert'))..createSync();
-        for (final library in _x64Libraries) {
-          await File(path.join(libDir.path, library)).create();
-        }
+      final libDir = Directory(path.join(root.path, 'litert'))..createSync();
+      for (final library in _x64Libraries) {
+        await File(path.join(libDir.path, library)).create();
+      }
 
-        final appDir = Directory(path.join(root.path, 'Test.app'));
-        final result = await _runPrepareApp(appDir, libDir, arch: 'x64');
+      final appDir = Directory(path.join(root.path, 'Test.app'));
+      final result = await _runPrepareApp(appDir, libDir, arch: 'x64');
 
-        expect(result.exitCode, 0, reason: result.stderr.toString());
+      expect(result.exitCode, 0, reason: result.stderr.toString());
 
-        final frameworksDir = path.join(appDir.path, 'Contents', 'Frameworks');
-        final runtimeDir = path.join(frameworksDir, 'LiteRtLmRuntime');
-        for (final library in _x64Libraries) {
-          final libraryPath = path.join(runtimeDir, library);
-          expect(File(libraryPath).existsSync(), isTrue, reason: library);
-        }
+      final frameworksDir = path.join(appDir.path, 'Contents', 'Frameworks');
+      final runtimeDir = path.join(frameworksDir, 'LiteRtLmRuntime');
+      for (final library in _x64Libraries) {
+        final libraryPath = path.join(runtimeDir, library);
+        expect(File(libraryPath).existsSync(), isTrue, reason: library);
+      }
+      expect(
+        File(
+          path.join(
+            frameworksDir,
+            'LiteRtLmRuntime',
+            'libLiteRtMetalAccelerator.dylib',
+          ),
+        ).existsSync(),
+        isFalse,
+      );
+      for (final framework in _oldFrameworks) {
         expect(
-          File(
-            path.join(
-              frameworksDir,
-              'LiteRtLmRuntime',
-              'libLiteRtMetalAccelerator.dylib',
-            ),
+          Directory(
+            path.join(frameworksDir, '$framework.framework'),
           ).existsSync(),
           isFalse,
+          reason: framework,
         );
-        for (final framework in _oldFrameworks) {
-          expect(
-            Directory(
-              path.join(frameworksDir, '$framework.framework'),
-            ).existsSync(),
-            isFalse,
-            reason: framework,
-          );
-        }
-      },
-      skip: Platform.isWindows ? 'requires bash and POSIX symlinks' : false,
-    );
+      }
+    }, skip: Platform.isWindows ? 'requires bash and POSIX symlinks' : false);
   });
 }
 

--- a/test/unit/tooling/run_local_e2e_test.dart
+++ b/test/unit/tooling/run_local_e2e_test.dart
@@ -16,6 +16,7 @@ void main() {
       expect(result.stdout, contains('--ngram-cache-build-text <txt>'));
       expect(result.stdout, contains('--ngram-token-max <n>'));
       expect(result.stdout, contains('--allow-any-response'));
+      expect(result.stdout, contains('GGUF_AUDIO_EXPECTED_TEXT'));
       expect(
         result.stdout,
         contains('defaults to the resolved benchmark prompt'),
@@ -228,6 +229,78 @@ void main() {
           'models/Qwen3.5-0.8B-mmproj-F16.gguf test/fixtures/image.png',
         ),
       );
+    });
+
+    test('dry-runs GGUF audio chat with an exact expected answer', () async {
+      final result = await runLocalE2e(const [
+        '--scenario',
+        'gguf-chat-features-smoke',
+        '--model-path',
+        'models/gemma-4-E2B-it-Q4_K_S.gguf',
+        '--backend',
+        'metal',
+        '--mmproj-path',
+        'models/gemma-4-E2B-it-mmproj-F16.gguf',
+        '--audio-path',
+        'test/fixtures/question.wav',
+        '--expect',
+        '4',
+        '--dry-run',
+      ], projectRoot: '/repo');
+
+      expect(result.exitCode, 0);
+      expect(
+        result.stdout,
+        contains('GGUF_AUDIO_PATH=test/fixtures/question.wav'),
+      );
+      expect(result.stdout, contains('GGUF_AUDIO_EXPECTED_TEXT=4'));
+      expect(
+        result.stdout,
+        contains(
+          'dart run tool/gguf_chat_features_smoke.dart '
+          'models/gemma-4-E2B-it-Q4_K_S.gguf metal '
+          'models/gemma-4-E2B-it-mmproj-F16.gguf',
+        ),
+      );
+    });
+
+    test('requires an exact expected GGUF audio answer', () async {
+      final result = await runLocalE2e(const [
+        '--scenario',
+        'gguf-chat-features-smoke',
+        '--model-path',
+        'models/gemma-4-E2B-it-Q4_K_S.gguf',
+        '--mmproj-path',
+        'models/gemma-4-E2B-it-mmproj-F16.gguf',
+        '--audio-path',
+        'test/fixtures/question.wav',
+        '--dry-run',
+      ], projectRoot: '/repo');
+
+      expect(result.exitCode, 64);
+      expect(result.stderr, contains('A nonempty --expect is required'));
+      expect(result.stderr, contains('gguf-chat-features-smoke'));
+    });
+
+    test('keeps GGUF image and audio variants separate', () async {
+      final result = await runLocalE2e(const [
+        '--scenario',
+        'gguf-chat-features-smoke',
+        '--model-path',
+        'models/gemma-4-E2B-it-Q4_K_S.gguf',
+        '--mmproj-path',
+        'models/gemma-4-E2B-it-mmproj-F16.gguf',
+        '--image-path',
+        'test/fixtures/image.png',
+        '--audio-path',
+        'test/fixtures/question.wav',
+        '--expect',
+        '4',
+        '--dry-run',
+      ], projectRoot: '/repo');
+
+      expect(result.exitCode, 64);
+      expect(result.stderr, contains('select separate'));
     });
 
     test('dry-runs typed speech-to-text with exact fixture inputs', () async {

--- a/test/unit/tooling/run_local_e2e_test.dart
+++ b/test/unit/tooling/run_local_e2e_test.dart
@@ -5,11 +5,12 @@ import 'dart:io';
 
 import 'package:test/test.dart';
 
+import '../../../tool/audio_chat_smoke_support.dart';
 import '../../../tool/testing/run_local_e2e.dart';
 
 void main() {
   group('run_local_e2e', () {
-    test('documents generated ngram cache text default', () async {
+    test('documents shared runner options and defaults', () async {
       final result = await runLocalE2e(const ['--help'], projectRoot: '/repo');
 
       expect(result.exitCode, 0);
@@ -30,6 +31,7 @@ void main() {
       expect(result.stdout, contains('root-template-e2e'));
       expect(result.stdout, contains('qwen35-multimodal-macos-repro'));
       expect(result.stdout, contains('gguf-chat-features-smoke'));
+      expect(result.stdout, contains('gguf-audio-chat-smoke'));
       expect(result.stdout, contains('speech-to-text-smoke'));
       expect(result.stdout, contains('llama-cpp-speculative-benchmark'));
       expect(result.stdout, contains('llama-cpp-chat-template-smoke'));
@@ -198,7 +200,9 @@ void main() {
         expect(
           result.stdout,
           contains(
-            'cd /repo && dart run tool/gguf_chat_features_smoke.dart '
+            "cd /repo && GGUF_AUDIO_PATH='' "
+            "GGUF_AUDIO_EXPECTED_TEXT='' dart run "
+            'tool/gguf_chat_features_smoke.dart '
             'models/Qwen3.5-0.8B-Q4_K_M.gguf cpu',
           ),
         );
@@ -224,7 +228,9 @@ void main() {
       expect(
         result.stdout,
         contains(
-          'cd /repo && dart run tool/gguf_chat_features_smoke.dart '
+          "cd /repo && GGUF_AUDIO_PATH='' "
+          "GGUF_AUDIO_EXPECTED_TEXT='' dart run "
+          'tool/gguf_chat_features_smoke.dart '
           'models/Qwen3.5-0.8B-Q4_K_M.gguf cpu '
           'models/Qwen3.5-0.8B-mmproj-F16.gguf test/fixtures/image.png',
         ),
@@ -234,7 +240,7 @@ void main() {
     test('dry-runs GGUF audio chat with an exact expected answer', () async {
       final result = await runLocalE2e(const [
         '--scenario',
-        'gguf-chat-features-smoke',
+        'gguf-audio-chat-smoke',
         '--model-path',
         'models/gemma-4-E2B-it-Q4_K_S.gguf',
         '--backend',
@@ -267,7 +273,7 @@ void main() {
     test('requires an exact expected GGUF audio answer', () async {
       final result = await runLocalE2e(const [
         '--scenario',
-        'gguf-chat-features-smoke',
+        'gguf-audio-chat-smoke',
         '--model-path',
         'models/gemma-4-E2B-it-Q4_K_S.gguf',
         '--mmproj-path',
@@ -278,14 +284,14 @@ void main() {
       ], projectRoot: '/repo');
 
       expect(result.exitCode, 64);
-      expect(result.stderr, contains('A nonempty --expect is required'));
-      expect(result.stderr, contains('gguf-chat-features-smoke'));
+      expect(result.stderr, contains('a nonempty --expect'));
+      expect(result.stderr, contains('gguf-audio-chat-smoke'));
     });
 
-    test('keeps GGUF image and audio variants separate', () async {
+    test('rejects image input for the dedicated GGUF audio smoke', () async {
       final result = await runLocalE2e(const [
         '--scenario',
-        'gguf-chat-features-smoke',
+        'gguf-audio-chat-smoke',
         '--model-path',
         'models/gemma-4-E2B-it-Q4_K_S.gguf',
         '--mmproj-path',
@@ -300,7 +306,7 @@ void main() {
       ], projectRoot: '/repo');
 
       expect(result.exitCode, 64);
-      expect(result.stderr, contains('select separate'));
+      expect(result.stderr, contains('--image-path is not supported'));
     });
 
     test('dry-runs typed speech-to-text with exact fixture inputs', () async {
@@ -570,10 +576,58 @@ void main() {
       expect(
         result.stdout,
         contains(
-          'cd /repo && dart run tool/litert_lm_chat_features_smoke.dart '
+          "cd /repo && LITERT_LM_AUDIO_PATH='' "
+          "LITERT_LM_AUDIO_EXPECTED_TEXT='' dart run "
+          'tool/litert_lm_chat_features_smoke.dart '
           'models/gemma-4-E2B-it.litertlm auto',
         ),
       );
+    });
+
+    test('dry-runs LiteRT-LM audio chat with shared CLI flags', () async {
+      final result = await runLocalE2e(const [
+        '--scenario',
+        'litert-lm-chat-features-smoke',
+        '--model-path',
+        'models/gemma-4-E2B-it.litertlm',
+        '--backend',
+        'gpu',
+        '--audio-path',
+        'test/fixtures/question.wav',
+        '--expect',
+        '4',
+        '--dry-run',
+      ], projectRoot: '/repo');
+
+      expect(result.exitCode, 0);
+      expect(
+        result.stdout,
+        contains('LITERT_LM_AUDIO_PATH=test/fixtures/question.wav'),
+      );
+      expect(result.stdout, contains('LITERT_LM_AUDIO_EXPECTED_TEXT=4'));
+      expect(
+        result.stdout,
+        contains(
+          'dart run tool/litert_lm_chat_features_smoke.dart '
+          'models/gemma-4-E2B-it.litertlm gpu',
+        ),
+      );
+    });
+
+    test('requires an exact expected LiteRT-LM audio answer', () async {
+      final result = await runLocalE2e(const [
+        '--scenario',
+        'litert-lm-chat-features-smoke',
+        '--model-path',
+        'models/gemma-4-E2B-it.litertlm',
+        '--audio-path',
+        'test/fixtures/question.wav',
+        '--dry-run',
+      ], projectRoot: '/repo');
+
+      expect(result.exitCode, 64);
+      expect(result.stderr, contains('A nonempty --expect is required'));
+      expect(result.stderr, contains('litert-lm-chat-features-smoke'));
     });
 
     test(
@@ -682,6 +736,41 @@ void main() {
 
       expect(result.exitCode, isNot(0));
       expect(result.stderr, contains('Background server exited'));
+    });
+  });
+
+  group('audio chat smoke support', () {
+    test('normalizes presentation-only answer differences', () {
+      expect(normalizeAudioChatAnswer('  **4.**\n'), '4');
+      expect(
+        () => verifyExactAudioChatAnswer(
+          scenarioName: 'fixture',
+          actualText: 'five',
+          expectedText: '4',
+        ),
+        throwsA(isA<StateError>()),
+      );
+    });
+
+    test('reports a stable path-free fixture identity', () async {
+      final tempDir = await Directory.systemTemp.createTemp(
+        'audio_chat_smoke_support_test_',
+      );
+      addTearDown(() => tempDir.delete(recursive: true));
+      final audioPath = '${tempDir.path}/private-recording.wav';
+      await File(audioPath).writeAsBytes(const <int>[1, 2, 3]);
+
+      final first = await readAudioChatSmokeFixture(audioPath);
+      final second = await readAudioChatSmokeFixture(audioPath);
+      final metadata = first.toJson();
+
+      expect(first.fixtureId, second.fixtureId);
+      expect(first.fixtureId, startsWith('sha256:'));
+      expect(first.fixtureId.length, 71);
+      expect(metadata, hasLength(2));
+      expect(metadata['encodedByteLength'], 3);
+      expect(metadata['fixtureId'], first.fixtureId);
+      expect(metadata.toString(), isNot(contains(audioPath)));
     });
   });
 }

--- a/tool/audio_chat_smoke_support.dart
+++ b/tool/audio_chat_smoke_support.dart
@@ -1,0 +1,95 @@
+import 'dart:io';
+import 'dart:typed_data';
+
+import 'package:crypto/crypto.dart';
+
+/// Deterministic instruction shared by the audio-chat real-model smokes.
+const String audioChatQuestionPrompt =
+    'Listen carefully to every spoken word. Determine what the speaker is '
+    'asking, solve that request, and return only the final answer. Do not '
+    'merely repeat a word from the recording.';
+
+/// Encoded audio bytes and path-free identity used by a smoke result.
+class AudioChatSmokeFixture {
+  const AudioChatSmokeFixture({required this.bytes, required this.fixtureId});
+
+  /// Complete encoded audio file bytes.
+  final Uint8List bytes;
+
+  /// Stable SHA-256 identity that does not expose the source path.
+  final String fixtureId;
+
+  /// Path-free result metadata suitable for logs and PR evidence.
+  Map<String, Object> toJson() => <String, Object>{
+    'encodedByteLength': bytes.length,
+    'fixtureId': fixtureId,
+  };
+}
+
+/// Resolves an optional encoded-audio path from [environmentName].
+String? optionalAudioChatSmokePath({
+  required String environmentName,
+  required String smokeName,
+}) {
+  final value = Platform.environment[environmentName]?.trim();
+  if (value == null || value.isEmpty) {
+    return null;
+  }
+  if (!File(value).existsSync()) {
+    throw ArgumentError('$smokeName audio fixture does not exist.');
+  }
+  return value;
+}
+
+/// Resolves and validates the exact expected answer for an audio variant.
+String? optionalAudioChatExpectedText({
+  required String? audioPath,
+  required String environmentName,
+  required String audioEnvironmentName,
+}) {
+  if (audioPath == null) {
+    return null;
+  }
+  final value = Platform.environment[environmentName]?.trim();
+  if (value == null || value.isEmpty) {
+    throw ArgumentError(
+      '$environmentName is required when $audioEnvironmentName is set.',
+    );
+  }
+  if (normalizeAudioChatAnswer(value).isEmpty) {
+    throw ArgumentError('$environmentName must contain a verifiable answer.');
+  }
+  return value;
+}
+
+/// Reads an encoded fixture and computes its stable, path-free identity.
+Future<AudioChatSmokeFixture> readAudioChatSmokeFixture(String path) async {
+  final bytes = await File(path).readAsBytes();
+  if (bytes.isEmpty) {
+    throw ArgumentError('Audio-chat smoke fixture must not be empty.');
+  }
+  final digest = sha256.convert(bytes);
+  return AudioChatSmokeFixture(bytes: bytes, fixtureId: 'sha256:$digest');
+}
+
+/// Normalizes insignificant presentation around a short exact answer.
+String normalizeAudioChatAnswer(String value) {
+  final collapsed = value.trim().toLowerCase().replaceAll(RegExp(r'\s+'), ' ');
+  return collapsed.replaceAll(RegExp(r'^[`*_]+|[`*_.!,;:?]+$'), '').trim();
+}
+
+/// Requires [actualText] to equal [expectedText] after normalization.
+void verifyExactAudioChatAnswer({
+  required String scenarioName,
+  required String actualText,
+  required String expectedText,
+}) {
+  final expected = normalizeAudioChatAnswer(expectedText);
+  final actual = normalizeAudioChatAnswer(actualText);
+  if (actual != expected) {
+    throw StateError(
+      '$scenarioName answer mismatch: expected "$expected", received '
+      '"$actual".',
+    );
+  }
+}

--- a/tool/gguf_chat_features_smoke.dart
+++ b/tool/gguf_chat_features_smoke.dart
@@ -1,8 +1,9 @@
 import 'dart:convert';
 import 'dart:io';
-import 'dart:typed_data';
 
 import 'package:llamadart/llamadart.dart';
+
+import 'audio_chat_smoke_support.dart';
 
 Future<void> main(List<String> args) async {
   final modelPath = args.isNotEmpty
@@ -33,7 +34,10 @@ Future<void> main(List<String> args) async {
     exitCode = 64;
     return;
   }
-  final audioPath = _optionalAudioPath();
+  final audioPath = optionalAudioChatSmokePath(
+    environmentName: 'GGUF_AUDIO_PATH',
+    smokeName: 'GGUF smoke',
+  );
   if (audioPath != null && mmprojPath == null) {
     stderr.writeln('GGUF_AUDIO_PATH requires GGUF_MMPROJ/mmproj path.');
     exitCode = 64;
@@ -46,8 +50,14 @@ Future<void> main(List<String> args) async {
     exitCode = 64;
     return;
   }
-  final audioExpectedText = _audioExpectedText(audioPath);
-  final audioBytes = audioPath == null ? null : await _readAudio(audioPath);
+  final audioExpectedText = optionalAudioChatExpectedText(
+    audioPath: audioPath,
+    environmentName: 'GGUF_AUDIO_EXPECTED_TEXT',
+    audioEnvironmentName: 'GGUF_AUDIO_PATH',
+  );
+  final audioFixture = audioPath == null
+      ? null
+      : await readAudioChatSmokeFixture(audioPath);
 
   final engine = LlamaEngine(LlamaBackend());
   try {
@@ -66,7 +76,7 @@ Future<void> main(List<String> args) async {
       await engine.loadMultimodalProjector(mmprojPath);
     }
 
-    if (audioBytes != null) {
+    if (audioFixture != null) {
       final audioChat = await _runScenario(
         engine: engine,
         name: 'audioChat',
@@ -74,8 +84,8 @@ Future<void> main(List<String> args) async {
           LlamaChatMessage.withContent(
             role: LlamaChatRole.user,
             content: [
-              LlamaAudioContent(bytes: audioBytes),
-              const LlamaTextContent(_audioQuestionPrompt),
+              LlamaAudioContent(bytes: audioFixture.bytes),
+              const LlamaTextContent(audioChatQuestionPrompt),
             ],
           ),
         ],
@@ -83,14 +93,18 @@ Future<void> main(List<String> args) async {
         enableThinking: false,
         maxTokens: 64,
       );
-      _verifyExactAnswer(audioChat, audioExpectedText!);
+      verifyExactAudioChatAnswer(
+        scenarioName: audioChat.name,
+        actualText: audioChat.content,
+        expectedText: audioExpectedText!,
+      );
       _verifyNoThinking(audioChat);
 
       final result = {
         'backendName': await engine.getBackendName(),
         'requestedBackend': backend.name,
         'variant': 'audioAnswer',
-        'audioInput': {'encodedByteLength': audioBytes.length},
+        'audioInput': audioFixture.toJson(),
         'audioChat': audioChat.toJson(),
       };
       print('RESULT gguf_chat_features ${jsonEncode(result)}');
@@ -277,54 +291,9 @@ Future<void> main(List<String> args) async {
   }
 }
 
-const String _audioQuestionPrompt =
-    'Listen carefully to every spoken word. Determine what the speaker is '
-    'asking, solve that request, and return only the final answer. Do not '
-    'merely repeat a word from the recording.';
-
 String? _nonEmptyTrimmed(String? value) {
   final trimmed = value?.trim();
   return trimmed == null || trimmed.isEmpty ? null : trimmed;
-}
-
-String? _optionalAudioPath() {
-  final value = _nonEmptyTrimmed(Platform.environment['GGUF_AUDIO_PATH']);
-  if (value == null) {
-    return null;
-  }
-  final audio = File(value);
-  if (!audio.existsSync()) {
-    throw ArgumentError('GGUF smoke audio does not exist.');
-  }
-  return audio.path;
-}
-
-String? _audioExpectedText(String? audioPath) {
-  if (audioPath == null) {
-    return null;
-  }
-  final value = _nonEmptyTrimmed(
-    Platform.environment['GGUF_AUDIO_EXPECTED_TEXT'],
-  );
-  if (value == null) {
-    throw ArgumentError(
-      'GGUF_AUDIO_EXPECTED_TEXT is required when GGUF_AUDIO_PATH is set.',
-    );
-  }
-  if (_normalizeAnswer(value).isEmpty) {
-    throw ArgumentError(
-      'GGUF_AUDIO_EXPECTED_TEXT must contain a verifiable answer.',
-    );
-  }
-  return value;
-}
-
-Future<Uint8List> _readAudio(String path) async {
-  final bytes = await File(path).readAsBytes();
-  if (bytes.isEmpty) {
-    throw ArgumentError('GGUF smoke audio must not be empty.');
-  }
-  return bytes;
 }
 
 Future<_ScenarioResult> _runScenario({
@@ -419,22 +388,6 @@ void _verifyThinkingSuppressedByZeroBudget(_ScenarioResult result) {
 void _verifyThinkingSeparation(_ScenarioResult result) {
   _verifyHasOutput(result);
   _verifyNoThinkingMarkers(result);
-}
-
-void _verifyExactAnswer(_ScenarioResult result, String expectedText) {
-  final expected = _normalizeAnswer(expectedText);
-  final actual = _normalizeAnswer(result.content);
-  if (actual != expected) {
-    throw StateError(
-      '${result.name} answer mismatch: expected "$expected", received '
-      '"$actual".',
-    );
-  }
-}
-
-String _normalizeAnswer(String value) {
-  final collapsed = value.trim().toLowerCase().replaceAll(RegExp(r'\s+'), ' ');
-  return collapsed.replaceAll(RegExp(r'^[`*_]+|[`*_.!,;:?]+$'), '').trim();
 }
 
 void _verifyNoThinkingMarkers(_ScenarioResult result) {

--- a/tool/gguf_chat_features_smoke.dart
+++ b/tool/gguf_chat_features_smoke.dart
@@ -1,5 +1,6 @@
 import 'dart:convert';
 import 'dart:io';
+import 'dart:typed_data';
 
 import 'package:llamadart/llamadart.dart';
 
@@ -11,7 +12,10 @@ Future<void> main(List<String> args) async {
     stderr.writeln(
       'Usage: dart run tool/gguf_chat_features_smoke.dart '
       '<model.gguf> [auto|cpu|metal|vulkan|cuda|opencl|hip|blas] '
-      '[mmproj.gguf] [image-path]',
+      '[mmproj.gguf] [image-path]\n'
+      'Optional env:\n'
+      '  GGUF_AUDIO_PATH=<local encoded WAV file>\n'
+      '  GGUF_AUDIO_EXPECTED_TEXT=<expected answer; required with audio>',
     );
     exitCode = 64;
     return;
@@ -29,6 +33,21 @@ Future<void> main(List<String> args) async {
     exitCode = 64;
     return;
   }
+  final audioPath = _optionalAudioPath();
+  if (audioPath != null && mmprojPath == null) {
+    stderr.writeln('GGUF_AUDIO_PATH requires GGUF_MMPROJ/mmproj path.');
+    exitCode = 64;
+    return;
+  }
+  if (audioPath != null && imagePath != null) {
+    stderr.writeln(
+      'GGUF audio-answer and image variants must be run separately.',
+    );
+    exitCode = 64;
+    return;
+  }
+  final audioExpectedText = _audioExpectedText(audioPath);
+  final audioBytes = audioPath == null ? null : await _readAudio(audioPath);
 
   final engine = LlamaEngine(LlamaBackend());
   try {
@@ -45,6 +64,37 @@ Future<void> main(List<String> args) async {
     );
     if (mmprojPath != null) {
       await engine.loadMultimodalProjector(mmprojPath);
+    }
+
+    if (audioBytes != null) {
+      final audioChat = await _runScenario(
+        engine: engine,
+        name: 'audioChat',
+        messages: [
+          LlamaChatMessage.withContent(
+            role: LlamaChatRole.user,
+            content: [
+              LlamaAudioContent(bytes: audioBytes),
+              const LlamaTextContent(_audioQuestionPrompt),
+            ],
+          ),
+        ],
+        tools: const [],
+        enableThinking: false,
+        maxTokens: 64,
+      );
+      _verifyExactAnswer(audioChat, audioExpectedText!);
+      _verifyNoThinking(audioChat);
+
+      final result = {
+        'backendName': await engine.getBackendName(),
+        'requestedBackend': backend.name,
+        'variant': 'audioAnswer',
+        'audioInput': {'encodedByteLength': audioBytes.length},
+        'audioChat': audioChat.toJson(),
+      };
+      print('RESULT gguf_chat_features ${jsonEncode(result)}');
+      return;
     }
 
     final template = await engine.chatTemplate(
@@ -195,7 +245,6 @@ Future<void> main(List<String> args) async {
             maxTokens: 120,
           )
         : null;
-
     _verifyNoThinking(noThinking);
     _verifyThinkingSeparation(thinking);
     _verifyNoThinking(toolCallNoThinking);
@@ -210,7 +259,6 @@ Future<void> main(List<String> args) async {
       _verifyHasOutput(multimodal);
       _verifyNoThinking(multimodal);
     }
-
     final result = {
       'backendName': await engine.getBackendName(),
       'requestedBackend': backend.name,
@@ -229,9 +277,54 @@ Future<void> main(List<String> args) async {
   }
 }
 
+const String _audioQuestionPrompt =
+    'Listen carefully to every spoken word. Determine what the speaker is '
+    'asking, solve that request, and return only the final answer. Do not '
+    'merely repeat a word from the recording.';
+
 String? _nonEmptyTrimmed(String? value) {
   final trimmed = value?.trim();
   return trimmed == null || trimmed.isEmpty ? null : trimmed;
+}
+
+String? _optionalAudioPath() {
+  final value = _nonEmptyTrimmed(Platform.environment['GGUF_AUDIO_PATH']);
+  if (value == null) {
+    return null;
+  }
+  final audio = File(value);
+  if (!audio.existsSync()) {
+    throw ArgumentError('GGUF smoke audio does not exist.');
+  }
+  return audio.path;
+}
+
+String? _audioExpectedText(String? audioPath) {
+  if (audioPath == null) {
+    return null;
+  }
+  final value = _nonEmptyTrimmed(
+    Platform.environment['GGUF_AUDIO_EXPECTED_TEXT'],
+  );
+  if (value == null) {
+    throw ArgumentError(
+      'GGUF_AUDIO_EXPECTED_TEXT is required when GGUF_AUDIO_PATH is set.',
+    );
+  }
+  if (_normalizeAnswer(value).isEmpty) {
+    throw ArgumentError(
+      'GGUF_AUDIO_EXPECTED_TEXT must contain a verifiable answer.',
+    );
+  }
+  return value;
+}
+
+Future<Uint8List> _readAudio(String path) async {
+  final bytes = await File(path).readAsBytes();
+  if (bytes.isEmpty) {
+    throw ArgumentError('GGUF smoke audio must not be empty.');
+  }
+  return bytes;
 }
 
 Future<_ScenarioResult> _runScenario({
@@ -326,6 +419,22 @@ void _verifyThinkingSuppressedByZeroBudget(_ScenarioResult result) {
 void _verifyThinkingSeparation(_ScenarioResult result) {
   _verifyHasOutput(result);
   _verifyNoThinkingMarkers(result);
+}
+
+void _verifyExactAnswer(_ScenarioResult result, String expectedText) {
+  final expected = _normalizeAnswer(expectedText);
+  final actual = _normalizeAnswer(result.content);
+  if (actual != expected) {
+    throw StateError(
+      '${result.name} answer mismatch: expected "$expected", received '
+      '"$actual".',
+    );
+  }
+}
+
+String _normalizeAnswer(String value) {
+  final collapsed = value.trim().toLowerCase().replaceAll(RegExp(r'\s+'), ' ');
+  return collapsed.replaceAll(RegExp(r'^[`*_]+|[`*_.!,;:?]+$'), '').trim();
 }
 
 void _verifyNoThinkingMarkers(_ScenarioResult result) {

--- a/tool/litert_lm_chat_features_smoke.dart
+++ b/tool/litert_lm_chat_features_smoke.dart
@@ -144,9 +144,10 @@ Future<void> main(List<String> args) async {
                 content: [
                   LlamaAudioContent(bytes: audioBytes),
                   const LlamaTextContent(
-                    'Answer the spoken question directly. Return only the '
-                    'final answer, with no transcript, explanation, or '
-                    'description of the recording.',
+                    'Listen carefully to every spoken word. Determine what '
+                    'the speaker is asking, solve that request, and return '
+                    'only the final answer. Do not merely repeat a word from '
+                    'the recording.',
                   ),
                 ],
               ),

--- a/tool/litert_lm_chat_features_smoke.dart
+++ b/tool/litert_lm_chat_features_smoke.dart
@@ -1,8 +1,9 @@
 import 'dart:convert';
 import 'dart:io';
-import 'dart:typed_data';
 
 import 'package:llamadart/llamadart.dart';
+
+import 'audio_chat_smoke_support.dart';
 
 Future<void> main(List<String> args) async {
   final modelPath = args.isNotEmpty
@@ -23,9 +24,18 @@ Future<void> main(List<String> args) async {
 
   final backend = args.length > 1 ? _parseBackend(args[1]) : _defaultBackend();
   final imagePath = _optionalImagePath(args.length > 2 ? args[2] : null);
-  final audioPath = _optionalAudioPath();
-  final audioExpectedText = _audioExpectedText(audioPath);
-  final audioBytes = audioPath == null ? null : await _readAudio(audioPath);
+  final audioPath = optionalAudioChatSmokePath(
+    environmentName: 'LITERT_LM_AUDIO_PATH',
+    smokeName: 'LiteRT-LM smoke',
+  );
+  final audioExpectedText = optionalAudioChatExpectedText(
+    audioPath: audioPath,
+    environmentName: 'LITERT_LM_AUDIO_EXPECTED_TEXT',
+    audioEnvironmentName: 'LITERT_LM_AUDIO_PATH',
+  );
+  final audioFixture = audioPath == null
+      ? null
+      : await readAudioChatSmokeFixture(audioPath);
   final engine = LlamaEngine(LlamaBackend());
   try {
     await engine.loadModel(
@@ -134,7 +144,7 @@ Future<void> main(List<String> args) async {
             enableThinking: false,
             maxTokens: 96,
           );
-    final audioChat = audioBytes == null
+    final audioChat = audioFixture == null
         ? null
         : await _runScenario(
             engine: engine,
@@ -142,13 +152,8 @@ Future<void> main(List<String> args) async {
               LlamaChatMessage.withContent(
                 role: LlamaChatRole.user,
                 content: [
-                  LlamaAudioContent(bytes: audioBytes),
-                  const LlamaTextContent(
-                    'Listen carefully to every spoken word. Determine what '
-                    'the speaker is asking, solve that request, and return '
-                    'only the final answer. Do not merely repeat a word from '
-                    'the recording.',
-                  ),
+                  LlamaAudioContent(bytes: audioFixture.bytes),
+                  const LlamaTextContent(audioChatQuestionPrompt),
                 ],
               ),
             ],
@@ -167,7 +172,7 @@ Future<void> main(List<String> args) async {
         'nativeMediaRender': nativeMediaRender.toJson(),
       if (multimodal != null) 'multimodal': multimodal.toJson(),
       if (audioChat != null) ...{
-        'audioInput': {'encodedByteLength': audioBytes!.length},
+        'audioInput': audioFixture!.toJson(),
         'audioChat': audioChat.toJson(),
       },
     };
@@ -214,14 +219,11 @@ void _verifyResult({
     throw StateError('Gemma 4 multimodal scenario produced no content.');
   }
   if (audioChat != null) {
-    final expected = _normalizeAnswer(audioExpectedText!);
-    final actual = _normalizeAnswer(audioChat.content);
-    if (actual != expected) {
-      throw StateError(
-        'Gemma 4 audio chat answer mismatch: expected "$expected", '
-        'received "$actual".',
-      );
-    }
+    verifyExactAudioChatAnswer(
+      scenarioName: 'Gemma 4 audio chat',
+      actualText: audioChat.content,
+      expectedText: audioExpectedText!,
+    );
   }
 }
 
@@ -371,50 +373,6 @@ String? _optionalImagePath(String? argValue) {
     throw ArgumentError('LiteRT-LM smoke image does not exist: $value');
   }
   return image.path;
-}
-
-String? _optionalAudioPath() {
-  final value = Platform.environment['LITERT_LM_AUDIO_PATH'];
-  if (value == null || value.trim().isEmpty) {
-    return null;
-  }
-  final audio = File(value);
-  if (!audio.existsSync()) {
-    throw ArgumentError('LiteRT-LM smoke audio does not exist: $value');
-  }
-  return audio.path;
-}
-
-String? _audioExpectedText(String? audioPath) {
-  if (audioPath == null) {
-    return null;
-  }
-  final value = Platform.environment['LITERT_LM_AUDIO_EXPECTED_TEXT'];
-  if (value == null || value.trim().isEmpty) {
-    throw ArgumentError(
-      'LITERT_LM_AUDIO_EXPECTED_TEXT is required when '
-      'LITERT_LM_AUDIO_PATH is set.',
-    );
-  }
-  if (_normalizeAnswer(value).isEmpty) {
-    throw ArgumentError(
-      'LITERT_LM_AUDIO_EXPECTED_TEXT must contain a verifiable answer.',
-    );
-  }
-  return value;
-}
-
-Future<Uint8List> _readAudio(String path) async {
-  final bytes = await File(path).readAsBytes();
-  if (bytes.isEmpty) {
-    throw ArgumentError('LiteRT-LM smoke audio must not be empty.');
-  }
-  return bytes;
-}
-
-String _normalizeAnswer(String value) {
-  final collapsed = value.trim().toLowerCase().replaceAll(RegExp(r'\s+'), ' ');
-  return collapsed.replaceAll(RegExp(r'^[`*_]+|[`*_.!,;:?]+$'), '').trim();
 }
 
 LiteRtLmBackendPreference _parseBackend(String value) {

--- a/tool/litert_lm_chat_features_smoke.dart
+++ b/tool/litert_lm_chat_features_smoke.dart
@@ -1,5 +1,6 @@
 import 'dart:convert';
 import 'dart:io';
+import 'dart:typed_data';
 
 import 'package:llamadart/llamadart.dart';
 
@@ -11,7 +12,10 @@ Future<void> main(List<String> args) async {
     stderr.writeln(
       'Usage: dart run tool/litert_lm_chat_features_smoke.dart '
       '<model.litertlm> [cpu|gpu|npu|auto] [image-path]\n'
-      'Optional env: LITERT_LM_IMAGE_PATH=<local image file>',
+      'Optional env:\n'
+      '  LITERT_LM_IMAGE_PATH=<local image file>\n'
+      '  LITERT_LM_AUDIO_PATH=<local encoded audio file>\n'
+      '  LITERT_LM_AUDIO_EXPECTED_TEXT=<expected answer; required with audio>',
     );
     exitCode = 64;
     return;
@@ -19,6 +23,9 @@ Future<void> main(List<String> args) async {
 
   final backend = args.length > 1 ? _parseBackend(args[1]) : _defaultBackend();
   final imagePath = _optionalImagePath(args.length > 2 ? args[2] : null);
+  final audioPath = _optionalAudioPath();
+  final audioExpectedText = _audioExpectedText(audioPath);
+  final audioBytes = audioPath == null ? null : await _readAudio(audioPath);
   final engine = LlamaEngine(LlamaBackend());
   try {
     await engine.loadModel(
@@ -127,6 +134,27 @@ Future<void> main(List<String> args) async {
             enableThinking: false,
             maxTokens: 96,
           );
+    final audioChat = audioBytes == null
+        ? null
+        : await _runScenario(
+            engine: engine,
+            messages: [
+              LlamaChatMessage.withContent(
+                role: LlamaChatRole.user,
+                content: [
+                  LlamaAudioContent(bytes: audioBytes),
+                  const LlamaTextContent(
+                    'Answer the spoken question directly. Return only the '
+                    'final answer, with no transcript, explanation, or '
+                    'description of the recording.',
+                  ),
+                ],
+              ),
+            ],
+            tools: const [],
+            enableThinking: false,
+            maxTokens: 64,
+          );
 
     final result = {
       'backendName': await engine.getBackendName(),
@@ -137,12 +165,18 @@ Future<void> main(List<String> args) async {
       if (nativeMediaRender != null)
         'nativeMediaRender': nativeMediaRender.toJson(),
       if (multimodal != null) 'multimodal': multimodal.toJson(),
+      if (audioChat != null) ...{
+        'audioInput': {'encodedByteLength': audioBytes!.length},
+        'audioChat': audioChat.toJson(),
+      },
     };
     _verifyResult(
       thinking: thinking,
       toolCall: toolCall,
       nativeToolHistory: nativeToolHistory,
       multimodal: multimodal,
+      audioChat: audioChat,
+      audioExpectedText: audioExpectedText,
     );
     print('RESULT litert_lm_chat_features ${jsonEncode(result)}');
   } finally {
@@ -155,6 +189,8 @@ void _verifyResult({
   required _ScenarioResult toolCall,
   required _ScenarioResult nativeToolHistory,
   _ScenarioResult? multimodal,
+  _ScenarioResult? audioChat,
+  String? audioExpectedText,
 }) {
   if (thinking.thinking.trim().isEmpty) {
     throw StateError('Gemma 4 thinking scenario produced no thinking delta.');
@@ -175,6 +211,16 @@ void _verifyResult({
   );
   if (multimodal != null && multimodal.content.trim().isEmpty) {
     throw StateError('Gemma 4 multimodal scenario produced no content.');
+  }
+  if (audioChat != null) {
+    final expected = _normalizeAnswer(audioExpectedText!);
+    final actual = _normalizeAnswer(audioChat.content);
+    if (actual != expected) {
+      throw StateError(
+        'Gemma 4 audio chat answer mismatch: expected "$expected", '
+        'received "$actual".',
+      );
+    }
   }
 }
 
@@ -324,6 +370,50 @@ String? _optionalImagePath(String? argValue) {
     throw ArgumentError('LiteRT-LM smoke image does not exist: $value');
   }
   return image.path;
+}
+
+String? _optionalAudioPath() {
+  final value = Platform.environment['LITERT_LM_AUDIO_PATH'];
+  if (value == null || value.trim().isEmpty) {
+    return null;
+  }
+  final audio = File(value);
+  if (!audio.existsSync()) {
+    throw ArgumentError('LiteRT-LM smoke audio does not exist: $value');
+  }
+  return audio.path;
+}
+
+String? _audioExpectedText(String? audioPath) {
+  if (audioPath == null) {
+    return null;
+  }
+  final value = Platform.environment['LITERT_LM_AUDIO_EXPECTED_TEXT'];
+  if (value == null || value.trim().isEmpty) {
+    throw ArgumentError(
+      'LITERT_LM_AUDIO_EXPECTED_TEXT is required when '
+      'LITERT_LM_AUDIO_PATH is set.',
+    );
+  }
+  if (_normalizeAnswer(value).isEmpty) {
+    throw ArgumentError(
+      'LITERT_LM_AUDIO_EXPECTED_TEXT must contain a verifiable answer.',
+    );
+  }
+  return value;
+}
+
+Future<Uint8List> _readAudio(String path) async {
+  final bytes = await File(path).readAsBytes();
+  if (bytes.isEmpty) {
+    throw ArgumentError('LiteRT-LM smoke audio must not be empty.');
+  }
+  return bytes;
+}
+
+String _normalizeAnswer(String value) {
+  final collapsed = value.trim().toLowerCase().replaceAll(RegExp(r'\s+'), ' ');
+  return collapsed.replaceAll(RegExp(r'^[`*_]+|[`*_.!,;:?]+$'), '').trim();
 }
 
 LiteRtLmBackendPreference _parseBackend(String value) {

--- a/tool/testing/run_local_e2e.dart
+++ b/tool/testing/run_local_e2e.dart
@@ -380,7 +380,8 @@ List<LocalE2eScenario> buildLocalE2eScenarios({String? projectRoot}) {
     LocalE2eScenario(
       name: 'litert-lm-chat-features-smoke',
       group: LocalE2eScenarioGroup.dartLocalOnly,
-      description: 'Run real LiteRT-LM chat, thinking, and tool-call smoke.',
+      description:
+          'Run real LiteRT-LM chat, thinking, tool-call, and optional media smoke.',
       requiresDevice: false,
       stepsBuilder: (context) {
         final arguments = <String>[
@@ -985,6 +986,11 @@ Options:
   --allow-any-response           Accept any non-empty real-model Web response.
   --skip-build                   Reuse an existing Flutter web build where supported.
   -h, --help                     Show this help.
+
+Inherited environment for litert-lm-chat-features-smoke:
+  LITERT_LM_IMAGE_PATH           Optional local image fixture.
+  LITERT_LM_AUDIO_PATH           Optional local encoded audio fixture.
+  LITERT_LM_AUDIO_EXPECTED_TEXT  Required exact expected answer when audio is set.
 ''';
 }
 

--- a/tool/testing/run_local_e2e.dart
+++ b/tool/testing/run_local_e2e.dart
@@ -221,7 +221,7 @@ List<LocalE2eScenario> buildLocalE2eScenarios({String? projectRoot}) {
       name: 'gguf-chat-features-smoke',
       group: LocalE2eScenarioGroup.dartLocalOnly,
       description:
-          'Run real GGUF chat, thinking-budget/suppression, and tool-call smoke.',
+          'Run real GGUF chat/tool/thinking smoke or a separate optional exact audio-answer variant.',
       requiresDevice: false,
       stepsBuilder: (context) {
         final arguments = <String>['run', 'tool/gguf_chat_features_smoke.dart'];
@@ -240,6 +240,12 @@ List<LocalE2eScenario> buildLocalE2eScenarios({String? projectRoot}) {
             workingDirectory: context.projectRoot,
             executable: 'dart',
             arguments: arguments,
+            environment: {
+              if (context.audioPath != null)
+                'GGUF_AUDIO_PATH': context.audioPath!,
+              if (context.audioPath != null && context.expectProvided)
+                'GGUF_AUDIO_EXPECTED_TEXT': context.expect,
+            },
             description: 'GGUF chat feature smoke',
           ),
         ];
@@ -720,6 +726,16 @@ Future<LocalE2eResult> runLocalE2e(
   if (parsed.audioPath != null && parsed.mmprojPath == null) {
     return LocalE2eResult(64, stderr: '--audio-path requires --mmproj-path.\n');
   }
+  if (scenario.name == 'gguf-chat-features-smoke' &&
+      parsed.audioPath != null &&
+      parsed.imagePath != null) {
+    return const LocalE2eResult(
+      64,
+      stderr:
+          '--audio-path and --image-path select separate '
+          'gguf-chat-features-smoke variants.\n',
+    );
+  }
   if (scenario.name == 'speech-to-text-smoke' &&
       (parsed.modelPath == null ||
           parsed.mmprojPath == null ||
@@ -731,6 +747,16 @@ Future<LocalE2eResult> runLocalE2e(
       stderr:
           '--model-path, --mmproj-path, --audio-path, and a nonempty --expect '
           'are required for speech-to-text-smoke.\n',
+    );
+  }
+  if (scenario.name == 'gguf-chat-features-smoke' &&
+      parsed.audioPath != null &&
+      (!parsed.expectProvided || parsed.expect.trim().isEmpty)) {
+    return const LocalE2eResult(
+      64,
+      stderr:
+          'A nonempty --expect is required when --audio-path is set for '
+          'gguf-chat-features-smoke.\n',
     );
   }
   if ((scenario.name == 'llama-cpp-speculative-benchmark' ||
@@ -964,7 +990,7 @@ Options:
   --draft-model-path <path>      Optional draft GGUF model path for llama.cpp speculative benchmark.
   --mmproj-path <path>           Optional multimodal projector path for GGUF chat smoke.
   --image-path <path>            Optional image path for GGUF chat smoke multimodal variant.
-  --audio-path <path>            Complete audio fixture for speech-to-text smoke.
+  --audio-path <path>            Complete audio fixture for speech-to-text or GGUF audio-chat smoke.
   --model-url <url>              Model URL for real-model web smoke.
   --backend <name>               Backend for local model scenarios (default: auto).
   --speculative-cases <list>     Benchmark cases for llama.cpp speculative benchmark.
@@ -982,7 +1008,7 @@ Options:
                                  Build a static ngram-cache file before speculative benchmark.
   --ngram-cache-build-text <txt> Optional source text for generated ngram-cache static file
                                  (defaults to the resolved benchmark prompt).
-  --expect <text>                Expected response text for real-model web smoke.
+  --expect <text>                Exact expected transcript/answer, or expected real-model Web response.
   --allow-any-response           Accept any non-empty real-model Web response.
   --skip-build                   Reuse an existing Flutter web build where supported.
   -h, --help                     Show this help.
@@ -991,6 +1017,10 @@ Inherited environment for litert-lm-chat-features-smoke:
   LITERT_LM_IMAGE_PATH           Optional local image fixture.
   LITERT_LM_AUDIO_PATH           Optional local encoded audio fixture.
   LITERT_LM_AUDIO_EXPECTED_TEXT  Required exact expected answer when audio is set.
+
+Direct environment for tool/gguf_chat_features_smoke.dart:
+  GGUF_AUDIO_PATH                Optional local encoded WAV fixture.
+  GGUF_AUDIO_EXPECTED_TEXT       Required exact expected answer when audio is set.
 ''';
 }
 

--- a/tool/testing/run_local_e2e.dart
+++ b/tool/testing/run_local_e2e.dart
@@ -221,7 +221,7 @@ List<LocalE2eScenario> buildLocalE2eScenarios({String? projectRoot}) {
       name: 'gguf-chat-features-smoke',
       group: LocalE2eScenarioGroup.dartLocalOnly,
       description:
-          'Run real GGUF chat/tool/thinking smoke or a separate optional exact audio-answer variant.',
+          'Run real GGUF chat, thinking-budget/suppression, tool-call, and optional image smoke.',
       requiresDevice: false,
       stepsBuilder: (context) {
         final arguments = <String>['run', 'tool/gguf_chat_features_smoke.dart'];
@@ -240,16 +240,39 @@ List<LocalE2eScenario> buildLocalE2eScenarios({String? projectRoot}) {
             workingDirectory: context.projectRoot,
             executable: 'dart',
             arguments: arguments,
-            environment: {
-              if (context.audioPath != null)
-                'GGUF_AUDIO_PATH': context.audioPath!,
-              if (context.audioPath != null && context.expectProvided)
-                'GGUF_AUDIO_EXPECTED_TEXT': context.expect,
+            environment: const {
+              'GGUF_AUDIO_PATH': '',
+              'GGUF_AUDIO_EXPECTED_TEXT': '',
             },
             description: 'GGUF chat feature smoke',
           ),
         ];
       },
+    ),
+    LocalE2eScenario(
+      name: 'gguf-audio-chat-smoke',
+      group: LocalE2eScenarioGroup.dartLocalOnly,
+      description:
+          'Run exact-answer byte-backed audio chat through native llama.cpp.',
+      requiresDevice: false,
+      stepsBuilder: (context) => [
+        LocalE2eCommandStep(
+          workingDirectory: context.projectRoot,
+          executable: 'dart',
+          arguments: [
+            'run',
+            'tool/gguf_chat_features_smoke.dart',
+            context.modelPath!,
+            context.backend,
+            context.mmprojPath!,
+          ],
+          environment: {
+            'GGUF_AUDIO_PATH': context.audioPath!,
+            'GGUF_AUDIO_EXPECTED_TEXT': context.expect,
+          },
+          description: 'GGUF exact-answer audio chat smoke',
+        ),
+      ],
     ),
     LocalE2eScenario(
       name: 'speech-to-text-smoke',
@@ -403,6 +426,13 @@ List<LocalE2eScenario> buildLocalE2eScenarios({String? projectRoot}) {
             workingDirectory: context.projectRoot,
             executable: 'dart',
             arguments: arguments,
+            environment: {
+              'LITERT_LM_AUDIO_PATH': context.audioPath ?? '',
+              'LITERT_LM_AUDIO_EXPECTED_TEXT':
+                  context.audioPath != null && context.expectProvided
+                  ? context.expect
+                  : '',
+            },
             description: 'LiteRT-LM chat feature smoke',
           ),
         ];
@@ -723,17 +753,22 @@ Future<LocalE2eResult> runLocalE2e(
   if (parsed.imagePath != null && parsed.mmprojPath == null) {
     return LocalE2eResult(64, stderr: '--image-path requires --mmproj-path.\n');
   }
-  if (parsed.audioPath != null && parsed.mmprojPath == null) {
-    return LocalE2eResult(64, stderr: '--audio-path requires --mmproj-path.\n');
-  }
-  if (scenario.name == 'gguf-chat-features-smoke' &&
-      parsed.audioPath != null &&
-      parsed.imagePath != null) {
+  if (scenario.name == 'gguf-chat-features-smoke' && parsed.audioPath != null) {
     return const LocalE2eResult(
       64,
       stderr:
-          '--audio-path and --image-path select separate '
-          'gguf-chat-features-smoke variants.\n',
+          '--audio-path uses the dedicated gguf-audio-chat-smoke scenario.\n',
+    );
+  }
+  const audioPathScenarios = <String>{
+    'gguf-audio-chat-smoke',
+    'speech-to-text-smoke',
+    'litert-lm-chat-features-smoke',
+  };
+  if (parsed.audioPath != null && !audioPathScenarios.contains(scenario.name)) {
+    return LocalE2eResult(
+      64,
+      stderr: '--audio-path is not supported by ${scenario.name}.\n',
     );
   }
   if (scenario.name == 'speech-to-text-smoke' &&
@@ -749,14 +784,33 @@ Future<LocalE2eResult> runLocalE2e(
           'are required for speech-to-text-smoke.\n',
     );
   }
-  if (scenario.name == 'gguf-chat-features-smoke' &&
+  if (scenario.name == 'gguf-audio-chat-smoke' &&
+      (parsed.modelPath == null ||
+          parsed.mmprojPath == null ||
+          parsed.audioPath == null ||
+          !parsed.expectProvided ||
+          parsed.expect.trim().isEmpty)) {
+    return const LocalE2eResult(
+      64,
+      stderr:
+          '--model-path, --mmproj-path, --audio-path, and a nonempty --expect '
+          'are required for gguf-audio-chat-smoke.\n',
+    );
+  }
+  if (scenario.name == 'gguf-audio-chat-smoke' && parsed.imagePath != null) {
+    return const LocalE2eResult(
+      64,
+      stderr: '--image-path is not supported by gguf-audio-chat-smoke.\n',
+    );
+  }
+  if (scenario.name == 'litert-lm-chat-features-smoke' &&
       parsed.audioPath != null &&
       (!parsed.expectProvided || parsed.expect.trim().isEmpty)) {
     return const LocalE2eResult(
       64,
       stderr:
           'A nonempty --expect is required when --audio-path is set for '
-          'gguf-chat-features-smoke.\n',
+          'litert-lm-chat-features-smoke.\n',
     );
   }
   if ((scenario.name == 'llama-cpp-speculative-benchmark' ||
@@ -990,7 +1044,7 @@ Options:
   --draft-model-path <path>      Optional draft GGUF model path for llama.cpp speculative benchmark.
   --mmproj-path <path>           Optional multimodal projector path for GGUF chat smoke.
   --image-path <path>            Optional image path for GGUF chat smoke multimodal variant.
-  --audio-path <path>            Complete audio fixture for speech-to-text or GGUF audio-chat smoke.
+  --audio-path <path>            Complete audio fixture for speech-to-text or native audio-chat smoke.
   --model-url <url>              Model URL for real-model web smoke.
   --backend <name>               Backend for local model scenarios (default: auto).
   --speculative-cases <list>     Benchmark cases for llama.cpp speculative benchmark.
@@ -1013,7 +1067,7 @@ Options:
   --skip-build                   Reuse an existing Flutter web build where supported.
   -h, --help                     Show this help.
 
-Inherited environment for litert-lm-chat-features-smoke:
+Direct environment for tool/litert_lm_chat_features_smoke.dart:
   LITERT_LM_IMAGE_PATH           Optional local image fixture.
   LITERT_LM_AUDIO_PATH           Optional local encoded audio fixture.
   LITERT_LM_AUDIO_EXPECTED_TEXT  Required exact expected answer when audio is set.

--- a/tool/testing/test_matrix.dart
+++ b/tool/testing/test_matrix.dart
@@ -167,13 +167,19 @@ const List<TestMatrixRow> testMatrixRows = <TestMatrixRow>[
     mode: 'local-only',
     covers:
         'real GGUF llama.cpp chat, thinking-budget/suppression, streaming '
-        'tool calls, optional multimodal input',
+        'tool calls, and optional image input, or a separate byte-backed audio '
+        'question-answering variant with an exact expected answer',
     command:
-        'dart run tool/testing/run_local_e2e.dart --scenario '
+        'Base/image: dart run tool/testing/run_local_e2e.dart --scenario '
         'gguf-chat-features-smoke --model-path <model.gguf> --backend auto '
-        '[--mmproj-path <mmproj.gguf> --image-path <image>]',
+        '[--mmproj-path <mmproj.gguf> --image-path <image>]; audio-only: dart '
+        'run tool/testing/run_local_e2e.dart --scenario '
+        'gguf-chat-features-smoke --model-path <model.gguf> --backend auto '
+        '--mmproj-path <mmproj.gguf> --audio-path <question.wav> '
+        '--expect <expected-answer>',
     useWhen:
-        'Chat rendering, parser, tool calling, thinking, or GGUF feature work.',
+        'Chat rendering, parser, tool calling, thinking, multimodal input, or '
+        'llama.cpp Ask-with-voice work.',
   ),
   TestMatrixRow(
     id: 'speech-to-text-smoke',
@@ -212,21 +218,25 @@ const List<TestMatrixRow> testMatrixRows = <TestMatrixRow>[
     tier: 'targeted',
     mode: 'manual/device',
     covers:
-        'native Gemma 4 E2B LiteRT-LM direct-media microphone input, the '
-        '30-second cap, answer-not-transcript behavior, conversation reuse, '
-        'and temporary-WAV cleanup',
+        'native Gemma 4 E2B LiteRT-LM direct-media and experimental llama.cpp '
+        'GGUF + projector microphone input, the 30-second cap, '
+        'answer-not-transcript behavior, conversation reuse, and '
+        'temporary-WAV cleanup',
     command:
         'Run example/chat_app on a microphone-equipped native device with the '
-        'Gemma 4 E2B LiteRT-LM preset. Record a known spoken instruction, use '
-        'Stop & ask, verify the assistant answers it rather than automatically '
+        'Gemma 4 E2B LiteRT-LM preset, then repeat with the pinned E2B GGUF + '
+        'audio-capable projector. Record a known spoken instruction, use Stop '
+        '& ask, verify the assistant answers it rather than automatically '
         'transcribing it, then send a text follow-up and regenerate the answer '
         'to verify audio context reuse. Repeat with the automatic 30-second '
         'limit and Discard, and confirm temporary-WAV cleanup. Record the '
-        'platform/device, exact model artifact hash, backend, permission '
-        'result, answer, cold/warm latency, memory, and cleanup evidence.',
+        'platform/device, exact model and projector artifact hashes, backend, '
+        'permission result, answer, cold/warm latency, memory, and cleanup '
+        'evidence. llama.cpp audio input is experimental; do not generalize '
+        'the current macOS result to mobile without device evidence.',
     useWhen:
-        'Chat-app Ask with voice, native LiteRT-LM audio input, microphone '
-        'lifecycle, or byte-backed audio-history behavior changes.',
+        'Chat-app Ask with voice, native LiteRT-LM or llama.cpp audio input, '
+        'microphone lifecycle, or byte-backed audio-history behavior changes.',
   ),
   TestMatrixRow(
     id: 'llama-cpp-chat-template-smoke',

--- a/tool/testing/test_matrix.dart
+++ b/tool/testing/test_matrix.dart
@@ -167,19 +167,30 @@ const List<TestMatrixRow> testMatrixRows = <TestMatrixRow>[
     mode: 'local-only',
     covers:
         'real GGUF llama.cpp chat, thinking-budget/suppression, streaming '
-        'tool calls, and optional image input, or a separate byte-backed audio '
-        'question-answering variant with an exact expected answer',
+        'tool calls, and optional image input',
     command:
-        'Base/image: dart run tool/testing/run_local_e2e.dart --scenario '
+        'dart run tool/testing/run_local_e2e.dart --scenario '
         'gguf-chat-features-smoke --model-path <model.gguf> --backend auto '
-        '[--mmproj-path <mmproj.gguf> --image-path <image>]; audio-only: dart '
-        'run tool/testing/run_local_e2e.dart --scenario '
-        'gguf-chat-features-smoke --model-path <model.gguf> --backend auto '
+        '--mmproj-path <mmproj.gguf> --image-path <image>',
+    useWhen:
+        'Chat rendering, parser, tool calling, thinking, or llama.cpp image '
+        'input work.',
+  ),
+  TestMatrixRow(
+    id: 'gguf-audio-chat-smoke',
+    tier: 'targeted',
+    mode: 'local-only',
+    covers:
+        'experimental native llama.cpp byte-backed audio question answering '
+        'with an exact expected answer and path-free fixture identity',
+    command:
+        'dart run tool/testing/run_local_e2e.dart --scenario '
+        'gguf-audio-chat-smoke --model-path <model.gguf> --backend auto '
         '--mmproj-path <mmproj.gguf> --audio-path <question.wav> '
         '--expect <expected-answer>',
     useWhen:
-        'Chat rendering, parser, tool calling, thinking, multimodal input, or '
-        'llama.cpp Ask-with-voice work.',
+        'llama.cpp audio input or Ask-with-voice work. This engine-level row '
+        'does not establish microphone UI or mobile-platform validation.',
   ),
   TestMatrixRow(
     id: 'speech-to-text-smoke',
@@ -232,8 +243,10 @@ const List<TestMatrixRow> testMatrixRows = <TestMatrixRow>[
         'limit and Discard, and confirm temporary-WAV cleanup. Record the '
         'platform/device, exact model and projector artifact hashes, backend, '
         'permission result, answer, cold/warm latency, memory, and cleanup '
-        'evidence. llama.cpp audio input is experimental; do not generalize '
-        'the current macOS result to mobile without device evidence.',
+        'evidence. The current packaged microphone evidence is LiteRT-LM on '
+        'macOS; llama.cpp only has an engine-level Metal smoke. Do not '
+        'generalize either result to Android, iOS, or Windows without '
+        'device-level evidence.',
     useWhen:
         'Chat-app Ask with voice, native LiteRT-LM or llama.cpp audio input, '
         'microphone lifecycle, or byte-backed audio-history behavior changes.',
@@ -282,14 +295,13 @@ const List<TestMatrixRow> testMatrixRows = <TestMatrixRow>[
         'calls, and optional byte-backed audio question answering with an '
         'exact expected answer',
     command:
-        'LITERT_LM_AUDIO_PATH=<audio.wav> '
-        'LITERT_LM_AUDIO_EXPECTED_TEXT=<expected-answer> dart run '
-        'tool/testing/run_local_e2e.dart --scenario '
+        'dart run tool/testing/run_local_e2e.dart --scenario '
         'litert-lm-chat-features-smoke --model-path <model.litertlm> '
-        '--backend auto',
+        '--backend auto --audio-path <audio.wav> '
+        '--expect <expected-answer>',
     useWhen:
         'LiteRT-LM chat templates, thinking, tool calling, audio input, or '
-        'ChatSession work. Omit the audio environment variables for the base '
+        'ChatSession work. Omit --audio-path and --expect for the base '
         'chat-only smoke.',
   ),
   TestMatrixRow(

--- a/tool/testing/test_matrix.dart
+++ b/tool/testing/test_matrix.dart
@@ -208,6 +208,27 @@ const List<TestMatrixRow> testMatrixRows = <TestMatrixRow>[
         'temporary-audio handling changes.',
   ),
   TestMatrixRow(
+    id: 'chat-app-voice-question-smoke',
+    tier: 'targeted',
+    mode: 'manual/device',
+    covers:
+        'native Gemma 4 E2B LiteRT-LM direct-media microphone input, the '
+        '30-second cap, answer-not-transcript behavior, conversation reuse, '
+        'and temporary-WAV cleanup',
+    command:
+        'Run example/chat_app on a microphone-equipped native device with the '
+        'Gemma 4 E2B LiteRT-LM preset. Record a known spoken instruction, use '
+        'Stop & ask, verify the assistant answers it rather than automatically '
+        'transcribing it, then send a text follow-up and regenerate the answer '
+        'to verify audio context reuse. Repeat with the automatic 30-second '
+        'limit and Discard, and confirm temporary-WAV cleanup. Record the '
+        'platform/device, exact model artifact hash, backend, permission '
+        'result, answer, cold/warm latency, memory, and cleanup evidence.',
+    useWhen:
+        'Chat-app Ask with voice, native LiteRT-LM audio input, microphone '
+        'lifecycle, or byte-backed audio-history behavior changes.',
+  ),
+  TestMatrixRow(
     id: 'llama-cpp-chat-template-smoke',
     tier: 'targeted',
     mode: 'local-only',
@@ -247,13 +268,19 @@ const List<TestMatrixRow> testMatrixRows = <TestMatrixRow>[
     tier: 'targeted',
     mode: 'local-only',
     covers:
-        'real .litertlm chat, thinking channel reassembly, streaming tool calls',
+        'real .litertlm chat, thinking channel reassembly, streaming tool '
+        'calls, and optional byte-backed audio question answering with an '
+        'exact expected answer',
     command:
-        'dart run tool/testing/run_local_e2e.dart --scenario '
+        'LITERT_LM_AUDIO_PATH=<audio.wav> '
+        'LITERT_LM_AUDIO_EXPECTED_TEXT=<expected-answer> dart run '
+        'tool/testing/run_local_e2e.dart --scenario '
         'litert-lm-chat-features-smoke --model-path <model.litertlm> '
         '--backend auto',
     useWhen:
-        'LiteRT-LM chat templates, thinking, tool calling, or ChatSession work.',
+        'LiteRT-LM chat templates, thinking, tool calling, audio input, or '
+        'ChatSession work. Omit the audio environment variables for the base '
+        'chat-only smoke.',
   ),
   TestMatrixRow(
     id: 'chat-app-device-cache',

--- a/tool/testing/test_matrix.dart
+++ b/tool/testing/test_matrix.dart
@@ -191,6 +191,23 @@ const List<TestMatrixRow> testMatrixRows = <TestMatrixRow>[
         'Speech API, native audio routing, transcript normalization, or chat-app transcription changes.',
   ),
   TestMatrixRow(
+    id: 'chat-app-microphone-transcription-smoke',
+    tier: 'targeted',
+    mode: 'manual/device',
+    covers:
+        'microphone permission, nonempty finalized WAV capture, whole-file '
+        'transcription, discard/background cancellation, and temporary-file '
+        'cleanup',
+    command:
+        'Run example/chat_app on a microphone-equipped native device with the '
+        'Qwen3-ASR model/projector, record known speech, use Stop & transcribe, '
+        'then repeat with Discard and an app-background transition. Record '
+        'platform/device, permission result, transcript, and cleanup evidence.',
+    useWhen:
+        'Chat-app microphone capture, recording permissions, lifecycle, or '
+        'temporary-audio handling changes.',
+  ),
+  TestMatrixRow(
     id: 'llama-cpp-chat-template-smoke',
     tier: 'targeted',
     mode: 'local-only',

--- a/website/docs/changelog/recent-releases.md
+++ b/website/docs/changelog/recent-releases.md
@@ -14,6 +14,11 @@ For canonical full release notes, use:
   and foreground microphone recording. Web and the current LiteRT-LM artifacts
   remain explicitly unsupported for typed STT.
 
+- Added **Ask with voice** to the native Flutter chat example for Gemma 4 E2B
+  LiteRT-LM and audio-capable GGUF models. It sends a short microphone recording
+  through normal multimodal chat so the model answers the spoken request, while
+  remaining separate from typed speech-to-text.
+
 ## 0.8.19
 
 - Updated the native llama.cpp runtime to `b10333` and WebGPU bridge assets to

--- a/website/docs/changelog/recent-releases.md
+++ b/website/docs/changelog/recent-releases.md
@@ -9,9 +9,10 @@ For canonical full release notes, use:
 
 ## Unreleased
 
-- Added an experimental typed Qwen3-ASR whole-file transcription workflow and
-  a SHA-256-verified Qwen3-ASR 0.6B native-desktop chat-app preset. Web and the
-  current LiteRT-LM artifacts remain explicitly unsupported for typed STT.
+- Added an experimental typed Qwen3-ASR whole-file transcription workflow, a
+  SHA-256-verified Qwen3-ASR 0.6B native mobile-and-desktop chat-app preset,
+  and foreground microphone recording. Web and the current LiteRT-LM artifacts
+  remain explicitly unsupported for typed STT.
 
 ## 0.8.19
 

--- a/website/docs/examples/chat-app.md
+++ b/website/docs/examples/chat-app.md
@@ -83,18 +83,20 @@ flutter test
   when the selected native profile declares direct audio input or the loaded
   projector reports audio support; Linux recording and Web are excluded. That
   platform gating is not an end-to-end validation claim. The experimental
-  llama.cpp GGUF audio-answer path currently has engine-level real-model
-  evidence on macOS, not microphone UI/device evidence on mobile.
+  llama.cpp GGUF audio-answer path currently has engine-level Metal evidence
+  on macOS. Current packaged microphone UI evidence is LiteRT-LM on macOS;
+  Android, iOS, and Windows still need real-model/device validation.
   Real-model/device results should cite the
   `chat-app-voice-question-smoke` test-matrix row.
 - Voice-question capture makes a best-effort attempt to delete the temporary
   WAV after reading it. The encoded bytes remain in the in-memory conversation
   history for subsequent turns and regeneration, which can reprocess the
   recording and consume additional memory.
-- For the built-in Gemma 4 E2B LiteRT-LM bundle, the selected backend continues
-  to run text (and vision, when used), while the bundle-constrained audio
-  executor runs on CPU. LiteRT-LM itself is not universally limited to CPU
-  audio.
+- LiteRT-LM first initializes audio preprocessing on the selected backend, then
+  transparently retries CPU if that executor is incompatible and remembers the
+  working choice for the loaded model. For the validated Gemma 4 E2B bundle,
+  GPU text/vision with CPU audio is the resolved path; LiteRT-LM itself is not
+  universally limited to CPU audio.
 - Clipboard image/audio attachments through `Cmd/Ctrl+V` on desktop and web or
   **Paste attachment** on touch devices. Text-only clipboard content still
   follows the normal composer paste path, and media is capped at 64 MB.
@@ -154,10 +156,13 @@ The download library includes Gemma 4 E2B, E4B, 12B, 26B A4B, and 31B GGUF
 tiers. E2B, E4B, and 12B expose image, audio, and video input on the current
 native `llama.cpp` mtmd path; 26B A4B and 31B expose image/video input but do
 not support audio. The native Gemma 4 E2B LiteRT-LM bundle accepts audio
-directly without an external projector. On supported native recorder targets,
-the chat app can send a recording to that bundle with **Ask with voice**. This
-is generic audio-input chat, not typed speech-to-text. Web GGUF audio remains
-runtime-gated, and LiteRT-LM Web remains text-only.
+directly without an external projector. On code-supported native recorder
+targets, **Ask with voice** can send a recording to that bundle or to an
+audio-capable E2B, E4B, or 12B GGUF projector. This is generic audio-input chat,
+not typed speech-to-text. Current packaged microphone UI validation covers the
+LiteRT-LM E2B path on macOS; the E2B GGUF path has engine-level Metal evidence,
+not device UI validation. Web GGUF audio remains runtime-gated, and LiteRT-LM
+Web remains text-only.
 
 ## Web notes
 

--- a/website/docs/examples/chat-app.md
+++ b/website/docs/examples/chat-app.md
@@ -71,18 +71,22 @@ flutter test
   a safe external-recorder preflight, while selected-file transcription remains
   available there. Web support is tracked in
   [issue #329](https://github.com/leehack/llamadart/issues/329).
-- **Ask with voice** for the native Gemma 4 E2B LiteRT-LM direct-media preset.
-  It records up to 30 seconds, then **Stop & ask** sends the WAV bytes through
-  ordinary multimodal chat so the model can answer the spoken request. It does
-  not use `SpeechToTextEngine` and provides no transcript, timestamp,
-  confidence, or live-partial contract. Qwen3-ASR keeps the separate
+- **Ask with voice** for native Gemma 4 E2B, using either the LiteRT-LM
+  direct-media bundle or the GGUF model with its matching audio-capable
+  projector. It records up to 30 seconds, then **Stop & ask** sends the WAV
+  bytes through ordinary multimodal chat so the model can answer the spoken
+  request. It does not use `SpeechToTextEngine` and provides no transcript,
+  timestamp, confidence, or live-partial contract. Qwen3-ASR keeps the separate
   five-minute **Stop & transcribe** workflow and takes precedence for ASR
   profiles.
 - The voice-question UI is code-supported on Android, iOS, macOS, and Windows
-  when the selected native profile declares direct audio input; Linux recording and Web are
-  excluded. That platform gating is not an end-to-end validation claim.
-  Real-model/device results should cite the `chat-app-voice-question-smoke`
-  test-matrix row.
+  when the selected native profile declares direct audio input or the loaded
+  projector reports audio support; Linux recording and Web are excluded. That
+  platform gating is not an end-to-end validation claim. The experimental
+  llama.cpp GGUF audio-answer path currently has engine-level real-model
+  evidence on macOS, not microphone UI/device evidence on mobile.
+  Real-model/device results should cite the
+  `chat-app-voice-question-smoke` test-matrix row.
 - Voice-question capture makes a best-effort attempt to delete the temporary
   WAV after reading it. The encoded bytes remain in the in-memory conversation
   history for subsequent turns and regeneration, which can reprocess the

--- a/website/docs/examples/chat-app.md
+++ b/website/docs/examples/chat-app.md
@@ -61,9 +61,14 @@ flutter test
 - Runtime-verified multimodal capability gating after `mmproj` load, plus
   declared direct-media capabilities for native model bundles such as
   LiteRT-LM. The app hides unsupported attachment types for the active platform.
-- A separate **Transcribe Audio** action for compatible native GGUF models,
-  backed by the typed whole-file `SpeechToTextEngine`. This is distinct from
-  generic audio attachment and is not shown for Web or current LiteRT-LM.
+- Separate file and microphone transcription actions for compatible native
+  GGUF models, backed by the typed whole-file `SpeechToTextEngine`. The
+  microphone captures a temporary foreground WAV and transcribes it only after
+  **Stop & transcribe**; it does not emit live partial text. These actions are
+  distinct from generic audio attachment and are not shown for Web or current
+  LiteRT-LM. Microphone capture is enabled on Android, iOS, macOS, and Windows
+  when a compatible ASR model is active; Linux capture remains disabled pending
+  a safe external-recorder preflight.
 - Clipboard image/audio attachments through `Cmd/Ctrl+V` on desktop and web or
   **Paste attachment** on touch devices. Text-only clipboard content still
   follows the normal composer paste path, and media is capped at 64 MB.

--- a/website/docs/examples/chat-app.md
+++ b/website/docs/examples/chat-app.md
@@ -68,7 +68,9 @@ flutter test
   distinct from generic audio attachment and are not shown for Web or current
   LiteRT-LM. Microphone capture is enabled on Android, iOS, macOS, and Windows
   when a compatible ASR model is active; Linux capture remains disabled pending
-  a safe external-recorder preflight.
+  a safe external-recorder preflight, while selected-file transcription remains
+  available there. Web support is tracked in
+  [issue #329](https://github.com/leehack/llamadart/issues/329).
 - Clipboard image/audio attachments through `Cmd/Ctrl+V` on desktop and web or
   **Paste attachment** on touch devices. Text-only clipboard content still
   follows the normal composer paste path, and media is capped at 64 MB.
@@ -82,8 +84,9 @@ The built-in library is intentionally small and Unsloth-first:
 
 - Cross-platform: FunctionGemma 270M, Qwen3.5 0.8B, Gemma 4 E2B GGUF,
   Gemma 4 E2B LiteRT-LM, and Gemma 4 E4B GGUF.
-- Native desktop: Qwen3-ASR 0.6B, Gemma 4 12B, Gemma 4 26B A4B, Gemma 4 31B,
-  and Qwen3.6 35B A3B.
+- Native mobile and desktop: Qwen3-ASR 0.6B.
+- Native desktop: Gemma 4 12B, Gemma 4 26B A4B, Gemma 4 31B, and Qwen3.6
+  35B A3B.
 
 GGUF chat presets use [Unsloth distributions](https://huggingface.co/unsloth).
 The dedicated ASR preset uses llama.cpp's `ggml-org` Qwen3-ASR pair, while the
@@ -99,8 +102,14 @@ Model cards prioritize size, RAM, compatibility, capabilities, cache state, and
 the primary download/load action. Recommended context and output limits remain
 visible without repeating every sampling parameter on every card.
 
-Availability filters match the catalog's two actual platform tiers: **Mobile &
-Web** for portable models and **Desktop** for the complete native catalog.
+Availability filters match each preset's platform restrictions. The Qwen3-ASR
+preset appears for native mobile and desktop targets but remains unavailable on
+Web; other portable presets can appear under both **Mobile** and **Web**, while
+the largest native models remain **Desktop** only.
+
+The complete Qwen3-ASR model/projector, microphone, and final-transcript flow
+has passed on a physical Pixel using CPU inference and in the iOS Simulator.
+Physical-iPhone and Windows validation remain outstanding.
 
 For native GGUF models, Auto runtime planning uses the selected model size,
 reported device memory, conservative system headroom, and requested context. It

--- a/website/docs/examples/chat-app.md
+++ b/website/docs/examples/chat-app.md
@@ -71,6 +71,26 @@ flutter test
   a safe external-recorder preflight, while selected-file transcription remains
   available there. Web support is tracked in
   [issue #329](https://github.com/leehack/llamadart/issues/329).
+- **Ask with voice** for the native Gemma 4 E2B LiteRT-LM direct-media preset.
+  It records up to 30 seconds, then **Stop & ask** sends the WAV bytes through
+  ordinary multimodal chat so the model can answer the spoken request. It does
+  not use `SpeechToTextEngine` and provides no transcript, timestamp,
+  confidence, or live-partial contract. Qwen3-ASR keeps the separate
+  five-minute **Stop & transcribe** workflow and takes precedence for ASR
+  profiles.
+- The voice-question UI is code-supported on Android, iOS, macOS, and Windows
+  when the selected native profile declares direct audio input; Linux recording and Web are
+  excluded. That platform gating is not an end-to-end validation claim.
+  Real-model/device results should cite the `chat-app-voice-question-smoke`
+  test-matrix row.
+- Voice-question capture makes a best-effort attempt to delete the temporary
+  WAV after reading it. The encoded bytes remain in the in-memory conversation
+  history for subsequent turns and regeneration, which can reprocess the
+  recording and consume additional memory.
+- For the built-in Gemma 4 E2B LiteRT-LM bundle, the selected backend continues
+  to run text (and vision, when used), while the bundle-constrained audio
+  executor runs on CPU. LiteRT-LM itself is not universally limited to CPU
+  audio.
 - Clipboard image/audio attachments through `Cmd/Ctrl+V` on desktop and web or
   **Paste attachment** on touch devices. Text-only clipboard content still
   follows the normal composer paste path, and media is capped at 64 MB.
@@ -130,8 +150,10 @@ The download library includes Gemma 4 E2B, E4B, 12B, 26B A4B, and 31B GGUF
 tiers. E2B, E4B, and 12B expose image, audio, and video input on the current
 native `llama.cpp` mtmd path; 26B A4B and 31B expose image/video input but do
 not support audio. The native Gemma 4 E2B LiteRT-LM bundle accepts audio
-directly without an external projector. Web GGUF audio remains runtime-gated,
-and LiteRT-LM Web remains text-only.
+directly without an external projector. On supported native recorder targets,
+the chat app can send a recording to that bundle with **Ask with voice**. This
+is generic audio-input chat, not typed speech-to-text. Web GGUF audio remains
+runtime-gated, and LiteRT-LM Web remains text-only.
 
 ## Web notes
 

--- a/website/docs/guides/speech-to-text.md
+++ b/website/docs/guides/speech-to-text.md
@@ -122,25 +122,48 @@ Do not call `LlamaEngine.create` on that engine until the speech task completes.
 
 ## Chat app
 
-The Flutter chat example exposes three different audio actions on compatible
-native GGUF models:
+The Flutter chat example keeps transcription and generic audio chat as
+different user actions:
 
 - **Attach Audio** sends audio through normal multimodal chat.
-- **Transcribe Audio** selects one file and uses `SpeechToTextEngine`.
-- The microphone button records a temporary foreground WAV. **Stop &
-  transcribe** finalizes that file and passes it to `SpeechToTextEngine`, while
-  **Discard** cancels capture and removes the partial file.
+- **Transcribe Audio** selects one file and uses `SpeechToTextEngine` with a
+  compatible native GGUF ASR model.
+- With Qwen3-ASR, the microphone records a temporary foreground WAV for up to
+  five minutes. **Stop & transcribe** finalizes that file and passes it to
+  `SpeechToTextEngine`, while **Discard** cancels capture and removes the
+  partial file.
+- With the native Gemma 4 E2B LiteRT-LM direct-media preset, **Ask with voice**
+  records up to 30 seconds and **Stop & ask** sends the WAV bytes through
+  normal multimodal chat. The model is prompted to answer the spoken request;
+  this path does not promise a transcript, timestamps, confidence, detected
+  language, or live partial text. An ASR profile takes precedence when both
+  capability declarations are present.
 
 The transcription action is hidden on Web and for current LiteRT-LM bundles.
-Microphone recordings are capped at five minutes, cancelled when the app is
+ASR microphone recordings are capped at five minutes, cancelled when the app is
 backgrounded, and deleted after transcription. This remains a whole-file
 workflow: it does not produce live partial transcripts while the user speaks.
 The recorder requests 16 kHz mono WAV, but hardware may choose another valid
 sample rate; the downstream native decoder reads the WAV metadata.
-Capture is enabled on Android, iOS, macOS, and Windows. It remains disabled on
-Linux with the current recorder plugin because its external-tool startup is not
-safe to expose without a stronger preflight; selected-file transcription is
-unchanged there.
+Capture for both microphone workflows is code-supported on Android, iOS, macOS,
+and Windows. It remains disabled on Linux with the current recorder plugin
+because its external-tool startup is not safe to expose without a stronger
+preflight; selected-file transcription is unchanged there. **Ask with voice**
+also requires a native direct-media audio model and is unavailable on Web.
+These capability gates do not establish real-model behavior on every platform;
+record device evidence with the `chat-app-voice-question-smoke` test-matrix row
+before making a platform validation claim.
+
+The voice-question path makes a best-effort attempt to delete its temporary WAV
+after reading it, but keeps the encoded audio bytes in the in-memory
+conversation history so later turns and regeneration preserve context. Those
+operations can reprocess the audio and consume additional memory. It remains
+generic audio-input chat and does not change the typed STT support matrix above.
+
+For the built-in Gemma 4 E2B LiteRT-LM bundle, the selected backend continues
+to run text (and vision, when used), while the bundle-constrained audio executor
+runs on CPU. This is a property of the current supported bundle, not a universal
+LiteRT-LM audio limitation.
 
 The chat app's native mobile-and-desktop catalog includes the Qwen3-ASR 0.6B
 Q8_0 model/projector pair. It remains excluded from the Web catalog. Its

--- a/website/docs/guides/speech-to-text.md
+++ b/website/docs/guides/speech-to-text.md
@@ -153,9 +153,10 @@ preflight; selected-file transcription is unchanged there. **Ask with voice**
 also requires a native direct-media audio model or an audio-capable projector
 and is unavailable on Web. These capability gates do not establish real-model
 behavior on every platform. The experimental llama.cpp GGUF voice path has
-current real-model evidence on macOS, not Android or iOS; record device evidence
-with the `chat-app-voice-question-smoke` test-matrix row before making a
-platform validation claim.
+engine-level Metal evidence on macOS, while current packaged microphone UI
+evidence is LiteRT-LM on macOS. Android, iOS, and Windows still require
+real-model/device evidence through the `chat-app-voice-question-smoke`
+test-matrix row before making a platform validation claim.
 
 The voice-question path makes a best-effort attempt to delete its temporary WAV
 after reading it, but keeps the encoded audio bytes in the in-memory
@@ -163,10 +164,11 @@ conversation history so later turns and regeneration preserve context. Those
 operations can reprocess the audio and consume additional memory. It remains
 generic audio-input chat and does not change the typed STT support matrix above.
 
-For the built-in Gemma 4 E2B LiteRT-LM bundle, the selected backend continues
-to run text (and vision, when used), while the bundle-constrained audio executor
-runs on CPU. This is a property of the current supported bundle, not a universal
-LiteRT-LM audio limitation.
+LiteRT-LM first initializes audio preprocessing on the selected backend, then
+transparently retries CPU if that executor is incompatible and remembers the
+working choice for the loaded model. For the validated Gemma 4 E2B bundle, GPU
+text/vision with CPU audio is the resolved path. This is bundle/runtime
+compatibility behavior, not a universal LiteRT-LM CPU-audio limitation.
 
 The chat app's native mobile-and-desktop catalog includes the Qwen3-ASR 0.6B
 Q8_0 model/projector pair. It remains excluded from the Web catalog. Its

--- a/website/docs/guides/speech-to-text.md
+++ b/website/docs/guides/speech-to-text.md
@@ -132,12 +132,13 @@ different user actions:
   five minutes. **Stop & transcribe** finalizes that file and passes it to
   `SpeechToTextEngine`, while **Discard** cancels capture and removes the
   partial file.
-- With the native Gemma 4 E2B LiteRT-LM direct-media preset, **Ask with voice**
-  records up to 30 seconds and **Stop & ask** sends the WAV bytes through
-  normal multimodal chat. The model is prompted to answer the spoken request;
-  this path does not promise a transcript, timestamps, confidence, detected
-  language, or live partial text. An ASR profile takes precedence when both
-  capability declarations are present.
+- With native Gemma 4 E2B, **Ask with voice** uses either the LiteRT-LM
+  direct-media bundle or the GGUF model with its matching audio-capable
+  projector. It records up to 30 seconds and **Stop & ask** sends the WAV bytes
+  through normal multimodal chat. The model is prompted to answer the spoken
+  request; this path does not promise a transcript, timestamps, confidence,
+  detected language, or live partial text. An ASR profile takes precedence
+  when both capability declarations are present.
 
 The transcription action is hidden on Web and for current LiteRT-LM bundles.
 ASR microphone recordings are capped at five minutes, cancelled when the app is
@@ -149,10 +150,12 @@ Capture for both microphone workflows is code-supported on Android, iOS, macOS,
 and Windows. It remains disabled on Linux with the current recorder plugin
 because its external-tool startup is not safe to expose without a stronger
 preflight; selected-file transcription is unchanged there. **Ask with voice**
-also requires a native direct-media audio model and is unavailable on Web.
-These capability gates do not establish real-model behavior on every platform;
-record device evidence with the `chat-app-voice-question-smoke` test-matrix row
-before making a platform validation claim.
+also requires a native direct-media audio model or an audio-capable projector
+and is unavailable on Web. These capability gates do not establish real-model
+behavior on every platform. The experimental llama.cpp GGUF voice path has
+current real-model evidence on macOS, not Android or iOS; record device evidence
+with the `chat-app-voice-question-smoke` test-matrix row before making a
+platform validation claim.
 
 The voice-question path makes a best-effort attempt to delete its temporary WAV
 after reading it, but keeps the encoded audio bytes in the in-memory

--- a/website/docs/guides/speech-to-text.md
+++ b/website/docs/guides/speech-to-text.md
@@ -122,14 +122,25 @@ Do not call `LlamaEngine.create` on that engine until the speech task completes.
 
 ## Chat app
 
-The Flutter chat example exposes two different audio actions on compatible
+The Flutter chat example exposes three different audio actions on compatible
 native GGUF models:
 
 - **Attach Audio** sends audio through normal multimodal chat.
 - **Transcribe Audio** selects one file and uses `SpeechToTextEngine`.
+- The microphone button records a temporary foreground WAV. **Stop &
+  transcribe** finalizes that file and passes it to `SpeechToTextEngine`, while
+  **Discard** cancels capture and removes the partial file.
 
 The transcription action is hidden on Web and for current LiteRT-LM bundles.
-It is a file workflow, not live microphone capture.
+Microphone recordings are capped at five minutes, cancelled when the app is
+backgrounded, and deleted after transcription. This remains a whole-file
+workflow: it does not produce live partial transcripts while the user speaks.
+The recorder requests 16 kHz mono WAV, but hardware may choose another valid
+sample rate; the downstream native decoder reads the WAV metadata.
+Capture is enabled on Android, iOS, macOS, and Windows. It remains disabled on
+Linux with the current recorder plugin because its external-tool startup is not
+safe to expose without a stronger preflight; selected-file transcription is
+unchanged there.
 
 The chat app's desktop catalog includes the validated Qwen3-ASR 0.6B Q8_0
 model/projector pair. Its immutable artifact revision, byte sizes, and SHA-256

--- a/website/docs/guides/speech-to-text.md
+++ b/website/docs/guides/speech-to-text.md
@@ -142,10 +142,10 @@ Linux with the current recorder plugin because its external-tool startup is not
 safe to expose without a stronger preflight; selected-file transcription is
 unchanged there.
 
-The chat app's desktop catalog includes the validated Qwen3-ASR 0.6B Q8_0
-model/projector pair. Its immutable artifact revision, byte sizes, and SHA-256
-digests are pinned, and the native downloader verifies both files before the
-model can be selected.
+The chat app's native mobile-and-desktop catalog includes the Qwen3-ASR 0.6B
+Q8_0 model/projector pair. It remains excluded from the Web catalog. Its
+immutable artifact revision, byte sizes, and SHA-256 digests are pinned, and
+the native downloader verifies both files before the model can be selected.
 
 ## Known limits
 
@@ -156,10 +156,13 @@ model can be selected.
   diarization, or incremental audio frames in the current backend.
 - Native inference backend correctness and performance remain device dependent;
   establish a CPU baseline before claiming GPU support for a deployment.
-- The local real-model smoke has passed on macOS arm64 CPU. A separate
-  chat-app/manual smoke has passed on Metal. The redistributable fixture and
-  Linux, Windows, Android, and iOS validation remain tracked in
-  [issue #325](https://github.com/leehack/llamadart/issues/325).
+- The local real-model smoke has passed on macOS arm64 CPU, and a separate
+  chat-app/manual smoke has passed on Metal. The full chat-app
+  model/projector, microphone, and final-transcript flow has also passed on a
+  physical Pixel using CPU inference and in the iOS Simulator. A physical
+  iPhone and Windows remain unverified; Linux keeps selected-file STT but not
+  microphone capture. Web enablement is tracked separately in
+  [issue #329](https://github.com/leehack/llamadart/issues/329).
 - TTS is not exposed. llama.cpp's current Qwen3-TTS helper is experimental and
   requires a stable downstream native wrapper before it can support a public
   Dart `TextToSpeechEngine`.


### PR DESCRIPTION
## Summary

- add foreground microphone capture to the Flutter chat example with two separate, model-dependent workflows:
  - **Qwen3-ASR transcription** uses the typed `SpeechToTextEngine` from #326 and produces a final transcript
  - **Ask with voice** sends recorded audio through ordinary Gemma 4 multimodal chat and produces an assistant answer, not a transcript
- expose the SHA-256-pinned Qwen3-ASR 0.6B model/projector across native mobile and desktop, while keeping Web explicitly unsupported
- support native Gemma voice questions through:
  - Gemma 4 E2B LiteRT-LM direct media
  - Gemma 4 GGUF models with a configured, loaded projector that reports runtime audio support
- align Gemma 4 presets with the pinned Unsloth recommendation (`temperature=1.0`, `top_k=64`, `top_p=0.95`, `min_p=0`, repetition penalty `1.0`, thinking off by default) while honoring active user settings
- normalize template-facing OpenAI `input_audio` parts to Hugging Face/Jinja `{type: "audio"}` without changing public wire-style `toJson()` output
- harden native model downloads with immutable revisions, artifact hashes, persisted integrity stamps, and representation-safe resume handling
- retain the selected LiteRT-LM text/vision backend while retrying an incompatible audio executor on CPU
- recover validated app-managed iOS catalog paths after an app-container UUID changes; arbitrary custom paths remain untouched
- split model-library browsing into **Mobile**, **Web**, and **Desktop** filters

Related to #325. This PR does not close it.

Follow-ups:

- live/windowed/stateful transcription: #327
- typed Qwen3-ASR WebGPU validation: #329
- TTS: #322
- browser **Ask with voice** remains separate from typed STT and is not covered by #329

## Product behavior

### Qwen3-ASR: typed transcription

- selected-file or foreground microphone input
- microphone maximum: five minutes
- output: one final transcript after the whole recording is processed
- no live partials, timestamps, confidence, diarization, or automatic handoff to a second chat model

### Gemma 4: Ask with voice

- microphone maximum: 30 seconds
- output: the model's answer to the spoken request, not an ASR transcript
- recorded audio remains byte-backed in in-memory conversation history for regeneration and later text follow-ups
- the temporary WAV is best-effort deleted after it is read
- dedicated STT takes precedence when a selected profile declares both capabilities
- external-projector GGUF models require a loaded projector and a positive runtime audio probe

## Platform scope

| Platform | Qwen3-ASR typed transcription | Gemma Ask with voice | Validation status |
| --- | --- | --- | --- |
| Android native | Catalog, file input, microphone | Code-supported for compatible native audio models | Qwen microphone passed on Pixel 9 Pro; Gemma voice not device-validated |
| iOS native | Catalog, file input, microphone | Code-supported for compatible native audio models | Qwen and Gemma LiteRT manually exercised on a physical iPad; GGUF was user-smoked but not a scripted acceptance pass |
| macOS native | File input, microphone | LiteRT direct audio and experimental GGUF + projector | Qwen, LiteRT microphone UI, and GGUF Metal engine paths passed |
| Windows native | File input, microphone | Code-supported for compatible native audio models | Build/tests pass; real microphone/model behavior not validated |
| Linux native | Selected-file transcription; microphone disabled | Microphone disabled | Catalog/file contract covered; recorder intentionally unavailable |
| Web | Disabled | Disabled in the chat app | Typed Qwen Web work is #329; current LiteRT-LM Web bundle is text-only |

Platform gating is not runtime proof. Unsupported actions are hidden or disabled, and unsupported typed STT paths fail explicitly.

## Model, cache, and runtime correctness

The native Qwen3-ASR, Gemma 4 E2B GGUF/projector, and Gemma 4 E2B LiteRT-LM assets used by these presets are pinned to immutable sources with exact byte sizes and SHA-256 verification.

Download resume now rejects partial files from another source or HTTP representation, uses validators/`If-Range` where available, and does not promote an unsafe `416` partial. Verified unchanged assets can reuse a persisted integrity stamp instead of being rehashed every time the model screen opens.

On iOS, relocation is limited to a missing catalog path with the recognized app-managed shape:

`/var/mobile/Containers/Data/Application/<old-id>/Library/Caches/models/<catalog-file>`

The app validates the matching model/projector in the current managed cache before saving rebased paths. Missing or corrupt current artifacts still fail, and custom paths are not rewritten.

The current Gemma LiteRT bundle constrains its audio encoder/adapter to CPU. The app first uses the requested media backend, retries only the audio executor on CPU when compatibility initialization fails, and keeps the requested text/vision backend. This is runtime compatibility handling, not a claim that LiteRT-LM audio universally requires CPU.

## Lifecycle and privacy

- permission denial and unsupported platforms surface actionable UI
- one recording/transcription/generation transition owns the active operation
- model, projector, conversation, and lifecycle changes invalidate stale work
- **Discard**, backgrounding, unload, shutdown, and disposal cancel capture and await cleanup
- empty or malformed recordings are rejected
- raw audio and private fixture paths are not logged
- temporary WAV deletion is best effort; voice audio intentionally remains in in-memory history for follow-up/regeneration

## Validation

### Final local head: `d31eb4fd20a76a19551d4ce12ce60501c752a1dc`

```text
example/chat_app: flutter analyze
PASS

example/chat_app: flutter test -r compact
PASS: 267/267

focused chat provider/UI/catalog tests
PASS: 106/106

core audio serialization and Gemma template tests
PASS: 29/29

git diff --check origin/main...HEAD
PASS
```

Additional focused VM/Chrome, docs, build, cache/resume, recorder, and backend suites passed while developing the combined stack. An independent final review found no remaining P1/P2 issue.

### Real model and device evidence

| Scenario | Platform/model/backend | Result | Limits |
| --- | --- | --- | --- |
| Qwen microphone transcription | macOS arm64 / Qwen3-ASR / native llama.cpp | PASS | English and Korean transcripts; temporary-file cleanup confirmed |
| Qwen microphone transcription | Pixel 9 Pro / Android 17 / CPU | PASS | Final transcript and no leftover WAV; discard/background not repeated after disconnect |
| Qwen microphone transcription | iOS Simulator / Qwen3-ASR / CPU | PASS | Host microphone returned `Hello.`; discard/background cleanup passed; not physical-iPhone evidence |
| Qwen microphone transcription | Physical iPad / Qwen3-ASR | PASS | User-observed load, recording, and transcription |
| Gemma voice question | macOS arm64 / Gemma E2B LiteRT-LM | PASS | Packaged microphone UI answered the request; compatible CPU audio executor used |
| Gemma voice question | Physical iPad / Gemma E2B LiteRT-LM | PASS | User-observed answer; exact latency/memory metrics not captured |
| GGUF audio chat | macOS arm64 / pinned Gemma E2B GGUF + projector / Metal | PASS | Known WAV returned exact answer `4` in 3/3 runs with recommended sampling |
| GGUF voice UI | Physical iPad / pinned Gemma E2B GGUF + projector | PARTIAL | User reported the latest build working after model reselection; not a scripted exact-answer/regeneration/cleanup acceptance pass |
| iOS managed-path recovery | Unit/fake managed cache | PASS | Valid catalog assets relocate; invalid assets and custom paths do not. Automatic recovery has not yet been device-smoked across another reinstall |

## Out of scope

- live or partial transcription (#327)
- timestamps, confidence, language detection, diarization, or speaker labels
- automatically feeding a Qwen transcript into a second LLM
- typed STT on WebGPU (#329)
- browser microphone Ask with voice and generic browser audio-chat validation
- typed STT through the current LiteRT-LM artifacts
- Linux microphone recording
- TTS (#322)
- claiming Android or Windows Gemma voice validation from platform gating alone
- migrating arbitrary user-selected model paths

## Readiness checklist

- [x] Qwen transcription and Gemma audio-chat behavior are separately labeled and tested
- [x] unsupported platform/model combinations are gated explicitly
- [x] cancellation, stale-context handling, temporary-file cleanup, and negative paths have regression coverage
- [x] native voice artifacts use immutable provenance and SHA-256 verification
- [x] local chat-app, core audio/template, analyze, and diff checks pass
- [x] exact-head CI passes on `d31eb4fd20a76a19551d4ce12ce60501c752a1dc` (14/14 checks)
- [x] all review threads are resolved (0 unresolved)
