### PR TITLE
fix: harden chat model downloads

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 ## Unreleased
 
+* Improved Flutter chat example model downloads with bounded retries for
+  transient network failures, safe resume after truncated responses, and a
+  distinct integrity-verification state after transfer reaches 100%.
+
 * Added an experimental typed `TextToSpeechEngine` for native llama.cpp
   Qwen3-TTS models, with capability discovery, language and optional speaker
   reference input, cancellable progress, complete 24 kHz PCM output, and WAV

--- a/example/chat_app/lib/screens/manage_models_screen.dart
+++ b/example/chat_app/lib/screens/manage_models_screen.dart
@@ -1803,7 +1803,11 @@ class _ManageModelsScreenState extends State<ManageModelsScreen>
                               isCustom: _customModels.contains(model),
                               onRemoveFromLibrary: () =>
                                   unawaited(_removeCustomModelEntry(model)),
-                              onCancel: () => _cancelDownload(model),
+                              onCancel:
+                                  detail != null &&
+                                      isDownloadStageTransferComplete(detail)
+                                  ? null
+                                  : () => _cancelDownload(model),
                               includeProjector: _includeProjectorFor(model),
                               onIncludeProjectorChanged: (value) =>
                                   _setIncludeProjector(model, value),

--- a/example/chat_app/lib/screens/manage_models_screen.dart
+++ b/example/chat_app/lib/screens/manage_models_screen.dart
@@ -1803,11 +1803,7 @@ class _ManageModelsScreenState extends State<ManageModelsScreen>
                               isCustom: _customModels.contains(model),
                               onRemoveFromLibrary: () =>
                                   unawaited(_removeCustomModelEntry(model)),
-                              onCancel:
-                                  detail != null &&
-                                      isDownloadStageTransferComplete(detail)
-                                  ? null
-                                  : () => _cancelDownload(model),
+                              onCancel: () => _cancelDownload(model),
                               includeProjector: _includeProjectorFor(model),
                               onIncludeProjectorChanged: (value) =>
                                   _setIncludeProjector(model, value),

--- a/example/chat_app/lib/services/model_download_ui_controller.dart
+++ b/example/chat_app/lib/services/model_download_ui_controller.dart
@@ -190,6 +190,9 @@ class ModelDownloadUiController extends ChangeNotifier {
   }
 
   String? transferLabel(String filename, ModelDownloadProgress detail) {
+    if (isDownloadStageTransferComplete(detail)) {
+      return null;
+    }
     final bytesPerSecond = _smoothedDownloadRateBytesPerSec[filename];
     if (bytesPerSecond == null || bytesPerSecond <= 0) {
       return null;
@@ -471,6 +474,17 @@ class ModelDownloadUiState {
 }
 
 String downloadStageLabel(ModelDownloadProgress detail, {required bool isWeb}) {
+  if (isDownloadStageTransferComplete(detail)) {
+    final stageText = switch (detail.stage) {
+      ModelDownloadStage.model => 'Verifying model',
+      ModelDownloadStage.multimodalProjector => 'Verifying mmproj',
+    };
+    if (detail.stageCount > 1) {
+      return '$stageText (${detail.stageIndex}/${detail.stageCount})';
+    }
+    return stageText;
+  }
+
   final actionText = detail.resumed
       ? (isWeb ? 'Resuming cache' : 'Resuming')
       : (isWeb ? 'Caching' : 'Downloading');
@@ -483,6 +497,13 @@ String downloadStageLabel(ModelDownloadProgress detail, {required bool isWeb}) {
     return '$stageText (${detail.stageIndex}/${detail.stageCount})';
   }
   return stageText;
+}
+
+bool isDownloadStageTransferComplete(ModelDownloadProgress detail) {
+  final totalBytes = detail.stageTotalBytes;
+  return totalBytes != null &&
+      totalBytes > 0 &&
+      detail.stageDownloadedBytes >= totalBytes;
 }
 
 String? downloadTaskLabel(

--- a/example/chat_app/lib/services/model_service_io.dart
+++ b/example/chat_app/lib/services/model_service_io.dart
@@ -28,11 +28,12 @@ class ModelServiceIO implements ModelService {
 
   final Dio _dio;
   final List<Duration> _retryDelays;
-  final Future<String> Function(File file) _fileSha256;
+  final Future<String> Function(File file, CancelToken? cancelToken)
+  _fileSha256;
   final Map<String, _VerifiedRemoteAsset> _verifiedRemoteAssets = {};
 
   ModelServiceIO({
-    Future<String> Function(File file)? fileSha256,
+    Future<String> Function(File file, CancelToken? cancelToken)? fileSha256,
     Dio? dio,
     List<Duration>? retryDelays,
   }) : _dio =
@@ -48,8 +49,19 @@ class ModelServiceIO implements ModelService {
        ),
        _fileSha256 = fileSha256 ?? _computeFileSha256;
 
-  static Future<String> _computeFileSha256(File file) async {
-    return (await sha256.bind(file.openRead()).first).toString();
+  static Future<String> _computeFileSha256(
+    File file,
+    CancelToken? cancelToken,
+  ) async {
+    final digestSink = _DigestSink();
+    final inputSink = sha256.startChunkedConversion(digestSink);
+    await for (final chunk in file.openRead()) {
+      _throwIfCancelled(cancelToken, file.path);
+      inputSink.add(chunk);
+    }
+    _throwIfCancelled(cancelToken, file.path);
+    inputSink.close();
+    return digestSink.digest.toString();
   }
 
   Map<String, Object> _requestHeaders({int? rangeStart, String? ifRange}) {
@@ -197,7 +209,7 @@ class ModelServiceIO implements ModelService {
             );
           },
         );
-        await _verifyDownloadedRemoteAsset(modelsDir, source);
+        await _verifyDownloadedRemoteAsset(modelsDir, source, cancelToken);
       }
 
       if (mmprojNeedsDownload) {
@@ -221,7 +233,7 @@ class ModelServiceIO implements ModelService {
             );
           },
         );
-        await _verifyDownloadedRemoteAsset(modelsDir, source);
+        await _verifyDownloadedRemoteAsset(modelsDir, source, cancelToken);
       }
 
       if (stageCount > 0) {
@@ -325,8 +337,9 @@ class ModelServiceIO implements ModelService {
 
   Future<bool> _hasExpectedIntegrity(
     File file,
-    RemoteModelAssetSource source,
-  ) async {
+    RemoteModelAssetSource source, {
+    CancelToken? cancelToken,
+  }) async {
     final expectedSha256 = source.sha256?.trim().toLowerCase();
     if (expectedSha256 == null || expectedSha256.isEmpty) {
       return true;
@@ -353,7 +366,8 @@ class ModelServiceIO implements ModelService {
     final String actualSha256;
     final FileStat verifiedStat;
     try {
-      actualSha256 = (await _fileSha256(file)).toLowerCase();
+      actualSha256 = (await _fileSha256(file, cancelToken)).toLowerCase();
+      _throwIfCancelled(cancelToken, file.path);
       verifiedStat = await file.stat();
     } on FileSystemException {
       await _clearVerifiedRemoteAsset(file.path);
@@ -424,13 +438,15 @@ class ModelServiceIO implements ModelService {
   Future<void> _verifyDownloadedRemoteAsset(
     String modelsDir,
     RemoteModelAssetSource source,
+    CancelToken cancelToken,
   ) async {
     final expectedSha256 = source.sha256?.trim();
     if (expectedSha256 == null || expectedSha256.isEmpty) {
       return;
     }
     final file = File(_assetPath(modelsDir, source));
-    if (await file.exists() && await _hasExpectedIntegrity(file, source)) {
+    if (await file.exists() &&
+        await _hasExpectedIntegrity(file, source, cancelToken: cancelToken)) {
       return;
     }
     if (await file.exists()) {
@@ -712,7 +728,8 @@ class ModelServiceIO implements ModelService {
             expectedSha256 != null &&
             expectedSha256.isNotEmpty) {
           canTrustCompletePartial =
-              (await _fileSha256(tempFile)).toLowerCase() == expectedSha256;
+              (await _fileSha256(tempFile, cancelToken)).toLowerCase() ==
+              expectedSha256;
         }
         if (canTrustCompletePartial) {
           final finalFile = File(savePath);
@@ -843,7 +860,11 @@ class ModelServiceIO implements ModelService {
       statusCode: response.statusCode ?? HttpStatus.ok,
       startByte: startByte,
     );
-    final totalBytes = responseTotalBytes ?? expectedTotalBytes;
+    final normalizedExpectedTotal =
+        expectedTotalBytes != null && expectedTotalBytes > 0
+        ? expectedTotalBytes
+        : null;
+    final totalBytes = responseTotalBytes ?? normalizedExpectedTotal;
 
     var downloadedBytes = startByte;
     final sink = tempFile.openWrite(
@@ -921,7 +942,13 @@ class ModelServiceIO implements ModelService {
     }
   }
 
-  DioException _cancelledDownload(String filename) => DioException(
+  static void _throwIfCancelled(CancelToken? cancelToken, String filename) {
+    if (cancelToken?.isCancelled ?? false) {
+      throw _cancelledDownload(filename);
+    }
+  }
+
+  static DioException _cancelledDownload(String filename) => DioException(
     requestOptions: RequestOptions(path: filename),
     type: DioExceptionType.cancel,
     message: 'Model download was cancelled.',
@@ -1354,6 +1381,21 @@ class ModelServiceIO implements ModelService {
       await legacyMeta.delete();
     }
   }
+}
+
+class _DigestSink implements Sink<Digest> {
+  Digest? _digest;
+
+  Digest get digest =>
+      _digest ?? (throw StateError('SHA-256 conversion did not complete.'));
+
+  @override
+  void add(Digest data) {
+    _digest = data;
+  }
+
+  @override
+  void close() {}
 }
 
 class _ContentRange {

--- a/example/chat_app/lib/services/model_service_io.dart
+++ b/example/chat_app/lib/services/model_service_io.dart
@@ -13,6 +13,11 @@ import 'model_service_base.dart';
 class ModelServiceIO implements ModelService {
   static const int _integrityStampVersion = 1;
   static const int _downloadProvenanceVersion = 2;
+  static const List<Duration> _defaultRetryDelays = <Duration>[
+    Duration(milliseconds: 500),
+    Duration(seconds: 1),
+    Duration(seconds: 2),
+  ];
   static const String _hfToken = String.fromEnvironment('HF_TOKEN');
   static const bool _enableParallelRangeDownloads = bool.fromEnvironment(
     'LLAMADART_CHAT_PARALLEL_DOWNLOAD',
@@ -21,12 +26,27 @@ class ModelServiceIO implements ModelService {
   static const int _parallelThresholdBytes = 500 * 1024 * 1024;
   static const int _parallelMaxParts = 4;
 
-  final Dio _dio = Dio();
+  final Dio _dio;
+  final List<Duration> _retryDelays;
   final Future<String> Function(File file) _fileSha256;
   final Map<String, _VerifiedRemoteAsset> _verifiedRemoteAssets = {};
 
-  ModelServiceIO({Future<String> Function(File file)? fileSha256})
-    : _fileSha256 = fileSha256 ?? _computeFileSha256;
+  ModelServiceIO({
+    Future<String> Function(File file)? fileSha256,
+    Dio? dio,
+    List<Duration>? retryDelays,
+  }) : _dio =
+           dio ??
+           Dio(
+             BaseOptions(
+               connectTimeout: const Duration(seconds: 30),
+               receiveTimeout: const Duration(seconds: 60),
+             ),
+           ),
+       _retryDelays = List<Duration>.unmodifiable(
+         retryDelays ?? _defaultRetryDelays,
+       ),
+       _fileSha256 = fileSha256 ?? _computeFileSha256;
 
   static Future<String> _computeFileSha256(File file) async {
     return (await sha256.bind(file.openRead()).first).toString();
@@ -552,14 +572,32 @@ class ModelServiceIO implements ModelService {
       );
     }
     var completed = false;
+    var retryIndex = 0;
     try {
-      await _downloadFile(
-        source: source,
-        savePath: savePath,
-        cancelToken: cancelToken,
-        onProgress: onProgress,
-      );
-      completed = true;
+      while (true) {
+        try {
+          await _downloadFile(
+            source: source,
+            savePath: savePath,
+            cancelToken: cancelToken,
+            onProgress: onProgress,
+          );
+          completed = true;
+          break;
+        } catch (error) {
+          if (cancelToken.isCancelled ||
+              retryIndex >= _retryDelays.length ||
+              !_isRetryableDownloadError(error)) {
+            rethrow;
+          }
+          await _waitForRetry(
+            _retryDelays[retryIndex],
+            cancelToken,
+            source.filename,
+          );
+          retryIndex++;
+        }
+      }
     } finally {
       if (completed) {
         await _deleteIfExists(_downloadProvenanceFile(savePath));
@@ -751,6 +789,7 @@ class ModelServiceIO implements ModelService {
             finalPath: savePath,
             response: response,
             startByte: 0,
+            expectedTotalBytes: provenance?.knownTotal ?? source.sizeBytes,
             append: false,
             resumed: false,
             onProgress: onProgress,
@@ -771,6 +810,7 @@ class ModelServiceIO implements ModelService {
         finalPath: savePath,
         response: response,
         startByte: canAppend ? startByte : 0,
+        expectedTotalBytes: provenance?.knownTotal ?? source.sizeBytes,
         append: canAppend,
         resumed: canAppend,
         onProgress: onProgress,
@@ -784,6 +824,7 @@ class ModelServiceIO implements ModelService {
     required String finalPath,
     required Response<ResponseBody> response,
     required int startByte,
+    required int? expectedTotalBytes,
     required bool append,
     required bool resumed,
     required void Function(int downloadedBytes, int? totalBytes, bool resumed)
@@ -797,11 +838,12 @@ class ModelServiceIO implements ModelService {
       );
     }
 
-    final totalBytes = _resolveTotalBytes(
+    final responseTotalBytes = _resolveTotalBytes(
       headers: response.headers,
       statusCode: response.statusCode ?? HttpStatus.ok,
       startByte: startByte,
     );
+    final totalBytes = responseTotalBytes ?? expectedTotalBytes;
 
     var downloadedBytes = startByte;
     final sink = tempFile.openWrite(
@@ -820,12 +862,70 @@ class ModelServiceIO implements ModelService {
       await sink.close();
     }
 
+    if (totalBytes != null && downloadedBytes != totalBytes) {
+      throw DioException(
+        requestOptions: response.requestOptions,
+        type: DioExceptionType.connectionError,
+        message:
+            'Download stream ended at $downloadedBytes of $totalBytes bytes.',
+      );
+    }
+
     final finalFile = File(finalPath);
     if (await finalFile.exists()) {
       await finalFile.delete();
     }
     await tempFile.rename(finalPath);
   }
+
+  bool _isRetryableDownloadError(Object error) {
+    if (error is SocketException || error is HttpException) {
+      return true;
+    }
+    if (error is! DioException) {
+      return false;
+    }
+    switch (error.type) {
+      case DioExceptionType.connectionTimeout:
+      case DioExceptionType.sendTimeout:
+      case DioExceptionType.receiveTimeout:
+      case DioExceptionType.connectionError:
+        return true;
+      case DioExceptionType.badResponse:
+        final statusCode = error.response?.statusCode;
+        return statusCode == HttpStatus.requestTimeout ||
+            statusCode == HttpStatus.tooManyRequests ||
+            (statusCode != null && statusCode >= 500 && statusCode < 600);
+      case DioExceptionType.unknown:
+        return error.error is SocketException || error.error is HttpException;
+      case DioExceptionType.badCertificate:
+      case DioExceptionType.cancel:
+        return false;
+    }
+  }
+
+  Future<void> _waitForRetry(
+    Duration delay,
+    CancelToken cancelToken,
+    String filename,
+  ) async {
+    if (cancelToken.isCancelled) {
+      throw _cancelledDownload(filename);
+    }
+    await Future.any<void>([
+      Future<void>.delayed(delay),
+      cancelToken.whenCancel.then<void>((_) {}),
+    ]);
+    if (cancelToken.isCancelled) {
+      throw _cancelledDownload(filename);
+    }
+  }
+
+  DioException _cancelledDownload(String filename) => DioException(
+    requestOptions: RequestOptions(path: filename),
+    type: DioExceptionType.cancel,
+    message: 'Model download was cancelled.',
+  );
 
   Future<_RemoteFileProbe?> _probeRemoteFile({
     required String url,

--- a/example/chat_app/test/model_download_ui_controller_test.dart
+++ b/example/chat_app/test/model_download_ui_controller_test.dart
@@ -5,6 +5,55 @@ import 'package:llamadart_chat_example/services/model_service_base.dart';
 
 void main() {
   group('ModelDownloadUiController', () {
+    test('labels completed transfer as verification', () {
+      const detail = ModelDownloadProgress(
+        overallProgress: 1,
+        downloadedBytes: 30,
+        totalBytes: 30,
+        stage: ModelDownloadStage.multimodalProjector,
+        stageIndex: 2,
+        stageCount: 2,
+        stageDownloadedBytes: 20,
+        stageTotalBytes: 20,
+      );
+
+      expect(
+        downloadStageLabel(detail, isWeb: false),
+        'Verifying mmproj (2/2)',
+      );
+      expect(isDownloadStageTransferComplete(detail), isTrue);
+    });
+
+    test('hides stale transfer rate while verifying', () {
+      final controller = ModelDownloadUiController();
+      addTearDown(controller.dispose);
+      const downloading = ModelDownloadProgress(
+        overallProgress: 0.5,
+        downloadedBytes: 10,
+        totalBytes: 20,
+        stage: ModelDownloadStage.model,
+        stageIndex: 1,
+        stageCount: 1,
+        stageDownloadedBytes: 10,
+        stageTotalBytes: 20,
+      );
+      const verifying = ModelDownloadProgress(
+        overallProgress: 1,
+        downloadedBytes: 20,
+        totalBytes: 20,
+        stage: ModelDownloadStage.model,
+        stageIndex: 1,
+        stageCount: 1,
+        stageDownloadedBytes: 20,
+        stageTotalBytes: 20,
+      );
+
+      controller.updateDownloadRate('model.gguf', downloading);
+      controller.updateDownloadRate('model.gguf', verifying);
+
+      expect(controller.transferLabel('model.gguf', verifying), isNull);
+    });
+
     test('runs queued downloads in FIFO order', () async {
       final controller = ModelDownloadUiController();
       addTearDown(controller.dispose);

--- a/example/chat_app/test/model_service_test.dart
+++ b/example/chat_app/test/model_service_test.dart
@@ -189,6 +189,36 @@ void main() {
     );
   });
 
+  test('transient server failures stop after configured retries', () async {
+    transientModelFailuresRemaining = 10;
+    service = TestModelService(
+      tempDir,
+      retryDelays: const <Duration>[Duration.zero, Duration.zero],
+    );
+    final model = DownloadableModel(
+      name: 'Retry Exhaustion Model',
+      description: 'Test',
+      url: '$baseUrl/model.gguf',
+      filename: 'retry-exhaustion-model.gguf',
+      sizeBytes: testDataSize,
+    );
+    Object? failure;
+
+    await service.downloadModel(
+      model: model,
+      modelsDir: tempDir.path,
+      cancelToken: CancelToken(),
+      onProgress: (_) {},
+      onSuccess: (_) => fail('Exhausted retry unexpectedly completed.'),
+      onError: (error) => failure = error,
+    );
+
+    expect(failure, isA<DioException>());
+    expect((failure! as DioException).response?.statusCode, 503);
+    expect(getRequestCountByPath['/model.gguf'], 3);
+    expect(File(p.join(tempDir.path, model.filename)).existsSync(), isFalse);
+  });
+
   test('cancellation interrupts transient retry backoff', () async {
     transientModelFailuresRemaining = 10;
     service = TestModelService(

--- a/example/chat_app/test/model_service_test.dart
+++ b/example/chat_app/test/model_service_test.dart
@@ -22,6 +22,7 @@ void main() {
   late List<String?> modelIfRangeHeaders;
   late int transientModelFailuresRemaining;
   late int truncatedModelResponsesRemaining;
+  late int chunkedModelResponsesRemaining;
 
   const stableEtag = '"model-v1"';
 
@@ -37,6 +38,7 @@ void main() {
     modelIfRangeHeaders = <String?>[];
     transientModelFailuresRemaining = 0;
     truncatedModelResponsesRemaining = 0;
+    chunkedModelResponsesRemaining = 0;
     tempDir = await Directory.systemTemp.createTemp('model_service_test');
     service = TestModelService(tempDir);
 
@@ -98,6 +100,17 @@ void main() {
             request.response.statusCode = HttpStatus.ok;
             request.response.headers.chunkedTransferEncoding = true;
             request.response.add(payload.sublist(0, payloadSize ~/ 3));
+            await request.response.close();
+            return;
+          }
+
+          if (path == '/model.gguf' &&
+              !isPartial &&
+              chunkedModelResponsesRemaining > 0) {
+            chunkedModelResponsesRemaining--;
+            request.response.statusCode = HttpStatus.ok;
+            request.response.headers.chunkedTransferEncoding = true;
+            request.response.add(payload);
             await request.response.close();
             return;
           }
@@ -219,6 +232,35 @@ void main() {
     expect(File(p.join(tempDir.path, model.filename)).existsSync(), isFalse);
   });
 
+  test(
+    'unknown-size chunked response completes without false truncation',
+    () async {
+      chunkedModelResponsesRemaining = 1;
+      final model = DownloadableModel(
+        name: 'Unknown Size Model',
+        description: 'Test',
+        url: '$baseUrl/model.gguf',
+        filename: 'unknown-size-model.gguf',
+        sizeBytes: 0,
+      );
+
+      await service.downloadModel(
+        model: model,
+        modelsDir: tempDir.path,
+        cancelToken: CancelToken(),
+        onProgress: (_) {},
+        onSuccess: (_) {},
+        onError: (error) => fail('Chunked download failed: $error'),
+      );
+
+      expect(getRequestCountByPath['/model.gguf'], 1);
+      expect(
+        File(p.join(tempDir.path, model.filename)).readAsBytesSync(),
+        testData,
+      );
+    },
+  );
+
   test('cancellation interrupts transient retry backoff', () async {
     transientModelFailuresRemaining = 10;
     service = TestModelService(
@@ -321,6 +363,63 @@ void main() {
     expect((await service.getModelCacheState(model)).isReady, isTrue);
   });
 
+  test('cancellation interrupts integrity verification', () async {
+    final verificationStarted = Completer<void>();
+    service = TestModelService(
+      tempDir,
+      fileSha256: (file, cancelToken) async {
+        if (!verificationStarted.isCompleted) {
+          verificationStarted.complete();
+        }
+        await cancelToken!.whenCancel;
+        return sha256.convert(await file.readAsBytes()).toString();
+      },
+    );
+    final model = DownloadableModel.fromSources(
+      name: 'Cancelled Verification Model',
+      description: 'Test',
+      modelSource: RemoteModelAssetSource(
+        url: '$baseUrl/model.gguf',
+        filename: 'cancelled-verification-model.gguf',
+        sizeBytes: testDataSize,
+        sha256: sha256.convert(testData).toString(),
+      ),
+      sizeBytes: testDataSize,
+    );
+    final cancelToken = CancelToken();
+    Object? failure;
+
+    final download = service.downloadModel(
+      model: model,
+      modelsDir: tempDir.path,
+      cancelToken: cancelToken,
+      onProgress: (_) {},
+      onSuccess: (_) => fail('Cancelled verification unexpectedly completed.'),
+      onError: (error) => failure = error,
+    );
+    await verificationStarted.future.timeout(const Duration(seconds: 2));
+    cancelToken.cancel('test verification cancellation');
+    await download.timeout(const Duration(seconds: 1));
+
+    expect(failure, isA<DioException>());
+    expect((failure! as DioException).type, DioExceptionType.cancel);
+    expect(
+      File(p.join(tempDir.path, model.filename)).readAsBytesSync(),
+      testData,
+    );
+
+    final resumedService = TestModelService(tempDir);
+    await resumedService.downloadModel(
+      model: model,
+      modelsDir: tempDir.path,
+      cancelToken: CancelToken(),
+      onProgress: (_) {},
+      onSuccess: (_) {},
+      onError: (error) => fail('Verification resume failed: $error'),
+    );
+    expect(getRequestCountByPath['/model.gguf'], 1);
+  });
+
   test(
     'persisted integrity stamp avoids rehashing unchanged catalog assets',
     () async {
@@ -340,7 +439,7 @@ void main() {
       await file.writeAsBytes(testData);
 
       var digestCalls = 0;
-      Future<String> countDigest(File input) async {
+      Future<String> countDigest(File input, CancelToken? cancelToken) async {
         digestCalls += 1;
         return (await sha256.bind(input.openRead()).first).toString();
       }

--- a/example/chat_app/test/model_service_test.dart
+++ b/example/chat_app/test/model_service_test.dart
@@ -20,6 +20,8 @@ void main() {
   late Map<String, int> getRequestCountByPath;
   late List<String?> modelRangeHeaders;
   late List<String?> modelIfRangeHeaders;
+  late int transientModelFailuresRemaining;
+  late int truncatedModelResponsesRemaining;
 
   const stableEtag = '"model-v1"';
 
@@ -33,6 +35,8 @@ void main() {
     getRequestCountByPath = <String, int>{};
     modelRangeHeaders = <String?>[];
     modelIfRangeHeaders = <String?>[];
+    transientModelFailuresRemaining = 0;
+    truncatedModelResponsesRemaining = 0;
     tempDir = await Directory.systemTemp.createTemp('model_service_test');
     service = TestModelService(tempDir);
 
@@ -58,6 +62,12 @@ void main() {
             modelRangeHeaders.add(rangeHeader);
             modelIfRangeHeaders.add(request.headers.value('if-range'));
           }
+          if (path == '/model.gguf' && transientModelFailuresRemaining > 0) {
+            transientModelFailuresRemaining--;
+            request.response.statusCode = HttpStatus.serviceUnavailable;
+            await request.response.close();
+            return;
+          }
           int start = 0;
           int end = payloadSize - 1;
           var isPartial = false;
@@ -81,8 +91,17 @@ void main() {
             return;
           }
 
-          // Check if client disconnected, though difficult to detect reliably in dart:io instantly
-          // We will just stream
+          if (path == '/model.gguf' &&
+              !isPartial &&
+              truncatedModelResponsesRemaining > 0) {
+            truncatedModelResponsesRemaining--;
+            request.response.statusCode = HttpStatus.ok;
+            request.response.headers.chunkedTransferEncoding = true;
+            request.response.add(payload.sublist(0, payloadSize ~/ 3));
+            await request.response.close();
+            return;
+          }
+
           request.response.headers.contentLength = end - start + 1;
           if (isPartial) {
             request.response.headers.set(
@@ -139,6 +158,111 @@ void main() {
     expect(file.lengthSync(), testDataSize);
     expect(file.readAsBytesSync(), testData);
   });
+
+  test('transient server failure retries automatically', () async {
+    transientModelFailuresRemaining = 1;
+    service = TestModelService(
+      tempDir,
+      retryDelays: const <Duration>[Duration.zero],
+    );
+    final model = DownloadableModel(
+      name: 'Retry Model',
+      description: 'Test',
+      url: '$baseUrl/model.gguf',
+      filename: 'retry-model.gguf',
+      sizeBytes: testDataSize,
+    );
+
+    await service.downloadModel(
+      model: model,
+      modelsDir: tempDir.path,
+      cancelToken: CancelToken(),
+      onProgress: (_) {},
+      onSuccess: (_) {},
+      onError: (error) => fail('Automatic retry failed: $error'),
+    );
+
+    expect(getRequestCountByPath['/model.gguf'], 2);
+    expect(
+      File(p.join(tempDir.path, model.filename)).readAsBytesSync(),
+      testData,
+    );
+  });
+
+  test('cancellation interrupts transient retry backoff', () async {
+    transientModelFailuresRemaining = 10;
+    service = TestModelService(
+      tempDir,
+      retryDelays: const <Duration>[Duration(seconds: 30)],
+    );
+    final model = DownloadableModel(
+      name: 'Cancelled Retry Model',
+      description: 'Test',
+      url: '$baseUrl/model.gguf',
+      filename: 'cancelled-retry-model.gguf',
+      sizeBytes: testDataSize,
+    );
+    final cancelToken = CancelToken();
+    Object? failure;
+
+    final download = service.downloadModel(
+      model: model,
+      modelsDir: tempDir.path,
+      cancelToken: cancelToken,
+      onProgress: (_) {},
+      onSuccess: (_) => fail('Cancelled retry unexpectedly completed.'),
+      onError: (error) => failure = error,
+    );
+    while ((getRequestCountByPath['/model.gguf'] ?? 0) == 0) {
+      await Future<void>.delayed(const Duration(milliseconds: 10));
+    }
+    cancelToken.cancel('test cancellation');
+    await download.timeout(const Duration(seconds: 1));
+
+    expect(failure, isA<DioException>());
+    expect((failure! as DioException).type, DioExceptionType.cancel);
+    expect(getRequestCountByPath['/model.gguf'], 1);
+  });
+
+  test(
+    'truncated stream keeps its partial and resumes automatically',
+    () async {
+      truncatedModelResponsesRemaining = 1;
+      service = TestModelService(
+        tempDir,
+        retryDelays: const <Duration>[Duration.zero],
+      );
+      final model = DownloadableModel(
+        name: 'Truncated Model',
+        description: 'Test',
+        url: '$baseUrl/model.gguf',
+        filename: 'truncated-model.gguf',
+        sizeBytes: testDataSize,
+      );
+
+      await service.downloadModel(
+        model: model,
+        modelsDir: tempDir.path,
+        cancelToken: CancelToken(),
+        onProgress: (_) {},
+        onSuccess: (_) {},
+        onError: (error) => fail('Truncated-stream retry failed: $error'),
+      );
+
+      expect(getRequestCountByPath['/model.gguf'], 2);
+      expect(modelRangeHeaders.first, isNull);
+      expect(modelRangeHeaders.last, startsWith('bytes='));
+      expect(modelIfRangeHeaders.last, stableEtag);
+      expect(
+        File(p.join(tempDir.path, model.filename)).readAsBytesSync(),
+        testData,
+      );
+      expect(
+        File(p.join(tempDir.path, '${model.filename}.download')).existsSync(),
+        isFalse,
+      );
+    },
+  );
 
   test('verified remote download enforces the catalog SHA-256', () async {
     final model = DownloadableModel.fromSources(
@@ -812,7 +936,7 @@ void main() {
 
 class TestModelService extends ModelServiceIO {
   final Directory testDir;
-  TestModelService(this.testDir, {super.fileSha256});
+  TestModelService(this.testDir, {super.fileSha256, super.retryDelays});
 
   @override
   Future<String> getModelsDirectory() async {

--- a/website/docs/changelog/recent-releases.md
+++ b/website/docs/changelog/recent-releases.md
@@ -9,6 +9,10 @@ For canonical full release notes, use:
 
 ## Unreleased
 
+- Improved Flutter chat example model downloads with bounded retries for
+  transient network failures, safe resume after truncated responses, and a
+  distinct integrity-verification state after transfer reaches 100%.
+
 - Added experimental typed Qwen3-TTS synthesis on native llama.cpp, including
   capability discovery, cancellation, complete PCM/WAV output, and a dedicated
   synthesize workflow with file or microphone speaker references, automatic


### PR DESCRIPTION
## Summary

- retry transient native chat-app model download failures with bounded backoff
- preserve and safely resume partial downloads when a response stream ends early
- show a distinct verification state after transfer reaches 100%
- keep cancellation responsive during requests, retry backoff, transfer, and
  integrity verification

## Why

Large model and projector downloads can encounter transient HTTP failures or truncated response streams. Previously, these failures required manual retries and could leave the UI appearing complete while SHA-256 verification was still running.

The native chat example now retries only transient failures, validates the received byte count, retains trustworthy partial data for resume, and clearly separates transfer progress from integrity verification.

## Scope

- Native Flutter chat-app model and projector downloads.
- Existing checksum, representation-validator, and partial-provenance protections remain in effect.
- Once transfer reaches 100%, the UI labels integrity verification explicitly
  and keeps Pause available; cancelling verification preserves the completed
  file for a later verification-only retry.
- Web download behavior and the public llamadart model APIs are unchanged.

## Validation

- [x] `flutter analyze` in `example/chat_app`
- [x] `flutter test` in `example/chat_app` — 284 passed
- [x] `dart format --output=none --set-exit-if-changed` on changed Dart files
- [x] `git diff --check`
- [x] `dart run tool/testing/verify_release_docs_versions.dart`
- [x] `./tool/docs/validate_links.sh`

Focused regressions cover transient server retry and exhaustion, truncated-stream
resume, unknown-size chunked responses, cancellation during retry backoff and
integrity verification, verification-only retry, and the
transfer-to-verification UI transition.

## Follow-ups

None required for this bounded reliability fix. Platform-managed background downloads remain tracked separately by #160.
