### PR TITLE
feat: add live dictation and runtime controls

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 ## Unreleased
 
+* Added logical batch-size (`n_batch`) and micro-batch-size (`n_ubatch`)
+  controls for llama.cpp/WebGPU models in the Flutter chat example. Android
+  Auto now probes the packaged Vulkan device before memory planning so capable
+  models do not fall back to CPU merely because the dynamic GPU module was not
+  registered yet.
+
 * Updated the native LiteRT-LM runtime to `v0.16.0-native.2` and added
   experimental CPU-only dedicated ASR runtime sessions with bridge capability
   discovery, bounded mono 16 kHz PCM input,
@@ -8,6 +14,17 @@
   constraint provider and Metal accelerator/sampler plugins required by the
   published runtime. This low-level synchronous API is separate from
   `SpeechToTextEngine` and should run from a worker isolate.
+
+* Added experimental live dictation to the native Flutter chat example for
+  chat models, including generic audio-chat models. The app offers the
+  recommended 54 MB Moonshine Tiny sidecar and an optional higher-capacity,
+  heavier 615 MB Parakeet TDT 0.6B sidecar with checksum-pinned assets,
+  persistent selection, explicit download progress, cancellation, and retry.
+  It captures mono 16 kHz PCM, runs the synchronous ASR session in a worker
+  isolate, renders confirmed and pending text, and returns the finalized
+  transcript to the editable composer. A persisted settings switch explains
+  and enables or disables the optional workflow. The first path is CPU-only,
+  English-only, capped at five minutes, and unavailable on Linux and Web.
 
 * Improved Flutter chat example model downloads with bounded retries for
   transient network failures, safe resume after truncated responses, and a

--- a/doc/testing_matrix.md
+++ b/doc/testing_matrix.md
@@ -75,6 +75,7 @@ Pick targeted rows based on the touched surface:
 | Speech-to-text API or adapter | `speech-to-text-smoke`, plus `litert-lm-asr-smoke` for the dedicated LiteRT-LM session API |
 | Text-to-speech API or adapter | `text-to-speech-smoke` |
 | Chat-app microphone transcription flow | `chat-app-microphone-transcription-smoke` |
+| Chat-app live LiteRT-LM dictation | `litert-lm-asr-smoke`, `chat-app-live-speech-smoke` |
 | Chat-app Ask with voice | `gguf-audio-chat-smoke`, `litert-lm-chat-features-smoke`, `chat-app-voice-question-smoke` |
 | Example app, CLI, or server package | `examples-tests` |
 

--- a/example/chat_app/README.md
+++ b/example/chat_app/README.md
@@ -14,6 +14,15 @@ A Flutter chat application demonstrating real-world usage of llamadart with UI.
 - 🎙️ **Whole-file transcription**: Compatible native GGUF ASR models can
   transcribe a selected file or capture a foreground microphone recording,
   then transcribe it after **Stop & transcribe**.
+- 📝 **Live dictation**: Native chat models, including generic audio-chat
+  models, can use a separately installed LiteRT sidecar to show confirmed and
+  pending English text while the user speaks, then place the final text in the
+  editable composer. Choose the recommended 54 MB Moonshine Tiny model or the
+  optional higher-capacity, heavier 615 MB Parakeet TDT 0.6B model. The app
+  shows model size, installed state, determinate download progress, cancel,
+  and retry. A persisted settings switch explains and enables or disables this
+  optional workflow. Audio-chat models keep their separate **Ask with voice**
+  action.
 - 🗣️ **Ask with voice**: Compatible native direct-media models or GGUF models
   with an audio-capable projector can receive a short microphone recording as
   ordinary multimodal chat and answer the request after **Stop & ask**.
@@ -21,7 +30,9 @@ A Flutter chat application demonstrating real-world usage of llamadart with UI.
   composer into a dedicated synthesis mode with language, optional speaker
   reference, cancellation, playback, and WAV export.
 - 📱 Material Design 3 UI
-- ⚙️ Model configuration (path, runtime-detected backend selection, GPU layers, context size)
+- ⚙️ Model configuration (path, runtime-detected backend selection, GPU layers,
+  context size, logical batch size, and micro-batch size; LiteRT-LM does not
+  expose the llama.cpp/WebGPU batch controls)
 - 🧩 Capability badges per model (Tools / Thinking / Vision / Audio / Video)
 - 🧪 GGUF and LiteRT-LM model routing through the same high-level engine APIs
 - 🎯 Per-model presets for temperature, Top-K, Top-P, context, and max tokens
@@ -106,7 +117,25 @@ flutter test --run-skipped -t local-only \
      minutes; **Stop & transcribe** finalizes it, runs whole-file STT, and
      deletes it.
      Capture is foreground-only and cancelling discards the temporary file.
-     Live partial transcription, Web, and LiteRT-LM STT are not enabled yet.
+     This Qwen path remains whole-file rather than live. For native chat
+     models, including generic audio-chat models, the composer can separately
+     install a live-dictation model/tokenizer and expose **Live transcription**
+     on Android, iOS, macOS, and Windows. Moonshine Tiny is the recommended
+     54 MB default; Parakeet TDT 0.6B is an optional 615 MB higher-capacity,
+     heavier choice. Both process mono 16 kHz PCM in five-second windows on a
+     worker isolate, show confirmed and replaceable pending English text, and
+     put the finalized transcript into the composer for review instead of
+     sending it automatically. The selected sidecar is remembered, and the UI
+     shows its size, installed state, determinate download progress, cancel,
+     and retry. Sessions are capped at five minutes and cancelled when the app
+     leaves the foreground. Audio-chat models keep **Ask with voice** as a
+     separate action. Linux and Web remain
+     disabled, and this app-owned flow does not change the public
+     `SpeechToTextEngine` whole-input contract.
+     Parakeet TDT is converted by
+     [LiteRT Community](https://huggingface.co/litert-community/parakeet-tdt-0.6b-v3)
+     from NVIDIA's
+     [CC-BY-4.0 model](https://huggingface.co/nvidia/parakeet-tdt-0.6b-v3).
      Web support is tracked in
      [issue #329](https://github.com/leehack/llamadart/issues/329). All STT
      actions require the matching projector, and the preset's pinned downloads

--- a/example/chat_app/lib/models/chat_settings.dart
+++ b/example/chat_app/lib/models/chat_settings.dart
@@ -26,6 +26,8 @@ class ChatSettings {
 
   final int numberOfThreads;
   final int numberOfThreadsBatch;
+  final int batchSize;
+  final int microBatchSize;
 
   /// Dart-side logger verbosity (llamadart logger).
   final LlamaLogLevel logLevel;
@@ -70,6 +72,8 @@ class ChatSettings {
     this.autoTuneRequestedContextSize,
     this.numberOfThreads = 0,
     this.numberOfThreadsBatch = 0,
+    this.batchSize = 0,
+    this.microBatchSize = 0,
     this.logLevel = LlamaLogLevel.none,
     this.nativeLogLevel = LlamaLogLevel.warn,
     this.toolsEnabled = false,
@@ -101,6 +105,8 @@ class ChatSettings {
     int? autoTuneRequestedContextSize,
     int? numberOfThreads,
     int? numberOfThreadsBatch,
+    int? batchSize,
+    int? microBatchSize,
     LlamaLogLevel? logLevel,
     LlamaLogLevel? nativeLogLevel,
     bool? toolsEnabled,
@@ -132,6 +138,8 @@ class ChatSettings {
           autoTuneRequestedContextSize ?? this.autoTuneRequestedContextSize,
       numberOfThreads: numberOfThreads ?? this.numberOfThreads,
       numberOfThreadsBatch: numberOfThreadsBatch ?? this.numberOfThreadsBatch,
+      batchSize: batchSize ?? this.batchSize,
+      microBatchSize: microBatchSize ?? this.microBatchSize,
       logLevel: logLevel ?? this.logLevel,
       nativeLogLevel: nativeLogLevel ?? this.nativeLogLevel,
       toolsEnabled: toolsEnabled ?? this.toolsEnabled,

--- a/example/chat_app/lib/models/downloadable_model.dart
+++ b/example/chat_app/lib/models/downloadable_model.dart
@@ -19,7 +19,7 @@ String _assetCacheKey(String canonicalKey) {
   return sha256.convert(utf8.encode(canonicalKey)).toString();
 }
 
-enum ModelAssetRole { model, multimodalProjector }
+enum ModelAssetRole { model, multimodalProjector, tokenizer }
 
 enum ModelMediaInputMode { externalProjector, direct, none }
 

--- a/example/chat_app/lib/models/live_speech_model.dart
+++ b/example/chat_app/lib/models/live_speech_model.dart
@@ -1,0 +1,138 @@
+import 'package:llamadart/llamadart.dart';
+
+import 'downloadable_model.dart';
+
+/// Native LiteRT-LM assets used by the chat app's live dictation flow.
+class LiveSpeechModel {
+  /// Stable model identifier.
+  final String id;
+
+  /// User-facing model name.
+  final String name;
+
+  /// Short user-facing model description.
+  final String description;
+
+  /// LiteRT model graph.
+  final RemoteModelAssetSource modelSource;
+
+  /// Tokenizer matching [modelSource].
+  final RemoteModelAssetSource tokenizerSource;
+
+  /// LiteRT-LM ASR metadata preset.
+  final LiteRtLmAsrModelPreset preset;
+
+  /// Languages validated for this model.
+  final List<String> languages;
+
+  /// Whether the chat app recommends this model as the default choice.
+  final bool isRecommended;
+
+  /// Creates an immutable live-speech model profile.
+  const LiveSpeechModel({
+    required this.id,
+    required this.name,
+    required this.description,
+    required this.modelSource,
+    required this.tokenizerSource,
+    required this.preset,
+    required this.languages,
+    this.isRecommended = false,
+  });
+
+  /// Combined download size when both remote assets declare their sizes.
+  int get sizeBytes =>
+      (modelSource.sizeBytes ?? 0) + (tokenizerSource.sizeBytes ?? 0);
+
+  /// Human-readable combined download size.
+  String get sizeLabel {
+    if (sizeBytes >= 1000 * 1000 * 1000) {
+      return '${(sizeBytes / (1000 * 1000 * 1000)).toStringAsFixed(1)} GB';
+    }
+    return '${(sizeBytes / (1000 * 1000)).round()} MB';
+  }
+
+  /// First live transcription model shipped by the example.
+  static const LiveSpeechModel moonshineTiny = LiveSpeechModel(
+    id: 'litert-moonshine-tiny-i8',
+    name: 'Moonshine Tiny Live STT',
+    description:
+        'Fast English live transcription using 5-second LiteRT windows.',
+    modelSource: RemoteModelAssetSource(
+      url:
+          'https://huggingface.co/litert-community/moonshine-tiny/resolve/beb49ee5028b4fb21eb989bcbd2db30a433373db/moonshine_tiny_5s_i8.tflite?download=true',
+      filename: 'moonshine_tiny_5s_i8.tflite',
+      sizeBytes: 51936896,
+      sha256:
+          '97abdeea122d579229091659c24c59d988c6419d453a200f6471241a53b9a9b9',
+    ),
+    tokenizerSource: RemoteModelAssetSource(
+      url:
+          'https://huggingface.co/moonshine-ai/moonshine-tiny/resolve/390624ed33d594443aa4aa221f5b9f283b545b5a/tokenizer.json?download=true',
+      filename: 'moonshine_tokenizer.json',
+      sizeBytes: 1985530,
+      sha256:
+          '6579793438bc4fbafffacf699169ff53e3769c5a0a0f5e71cdee8853e8130deb',
+    ),
+    preset: LiteRtLmAsrModelPreset.moonshineTiny,
+    languages: <String>['English'],
+    isRecommended: true,
+  );
+
+  /// Higher-capacity English dictation model with a substantially larger graph.
+  static const LiveSpeechModel parakeetTdt = LiveSpeechModel(
+    id: 'litert-parakeet-tdt-0.6b-v3-i8',
+    name: 'Parakeet TDT 0.6B Live STT',
+    description:
+        'Higher-capacity English transcription using 5-second LiteRT windows.',
+    modelSource: RemoteModelAssetSource(
+      url:
+          'https://huggingface.co/litert-community/parakeet-tdt-0.6b-v3/resolve/e3a6f2dec6800733f97c87ff55822f32c405983a/parakeet_tdt_0.6b_v3_5s_i8_stateful.tflite?download=true',
+      filename: 'parakeet_tdt_0.6b_v3_5s_i8_stateful.tflite',
+      sizeBytes: 614261072,
+      sha256:
+          '334745b8bc7fd372b1c213516f0b6338bb827b1a2abb3e77ad35fe6fea5cd16b',
+    ),
+    tokenizerSource: RemoteModelAssetSource(
+      url:
+          'https://huggingface.co/nvidia/parakeet-tdt-0.6b-v3/resolve/541d1f99c6b0c3cd0b11a95167540bb8edefd82b/tokenizer.json?download=true',
+      filename: 'parakeet_tdt_0.6b_v3_tokenizer.json',
+      sizeBytes: 1159960,
+      sha256:
+          'bd321b096832a3f270bd3b2a88823957920f1a5c5ada71114a26ea729d0cbe91',
+    ),
+    preset: LiteRtLmAsrModelPreset.parakeetTdt0_6bV3,
+    languages: <String>['English'],
+  );
+
+  /// Live dictation models exposed by the example app.
+  static const List<LiveSpeechModel> defaultModels = <LiveSpeechModel>[
+    moonshineTiny,
+    parakeetTdt,
+  ];
+
+  /// Resolves a built-in model by its stable identifier.
+  static LiveSpeechModel byId(String? id) => defaultModels.firstWhere(
+    (model) => model.id == id,
+    orElse: () => moonshineTiny,
+  );
+}
+
+/// Resolved native paths for one installed live-speech model.
+class InstalledLiveSpeechModel {
+  /// Model profile that owns these assets.
+  final LiveSpeechModel model;
+
+  /// Local LiteRT graph path.
+  final String modelPath;
+
+  /// Local tokenizer path.
+  final String tokenizerPath;
+
+  /// Creates an installed model descriptor.
+  const InstalledLiveSpeechModel({
+    required this.model,
+    required this.modelPath,
+    required this.tokenizerPath,
+  });
+}

--- a/example/chat_app/lib/providers/chat_provider.dart
+++ b/example/chat_app/lib/providers/chat_provider.dart
@@ -13,6 +13,7 @@ import '../models/chat_conversation.dart';
 import '../models/chat_message.dart';
 import '../models/chat_settings.dart';
 import '../models/downloadable_model.dart';
+import '../models/live_speech_model.dart';
 import '../services/assistant_output_service.dart';
 import '../services/audio_recording_service.dart';
 import '../services/chat_service.dart';
@@ -22,6 +23,8 @@ import '../services/conversation_state_service.dart';
 import '../services/runtime_profile_service.dart';
 import '../services/settings_service.dart';
 import '../services/model_service_base.dart' as model_service;
+import '../services/live_speech_model_service.dart';
+import '../services/live_speech_transcription_service.dart';
 import '../services/tool_declaration_service.dart';
 import '../utils/backend_utils.dart';
 
@@ -106,6 +109,11 @@ class ChatProvider extends ChangeNotifier {
   /// The maximum microphone recording length before automatic transcription.
   static const Duration maxAudioRecordingDuration = Duration(minutes: 5);
 
+  /// The maximum live-dictation session before automatic finalization.
+  static const Duration maxLiveSpeechTranscriptionDuration = Duration(
+    minutes: 5,
+  );
+
   /// The maximum voice-question recording accepted by Gemma 4 audio input.
   static const Duration maxVoiceQuestionRecordingDuration = Duration(
     seconds: 30,
@@ -133,6 +141,8 @@ class ChatProvider extends ChangeNotifier {
   final RuntimeProfileService _runtimeProfileService;
   final SettingsService _settingsService;
   final model_service.ModelService _modelService;
+  final LiveSpeechModelService _liveSpeechModelService;
+  final LiveSpeechTranscriptionService _liveSpeechTranscriptionService;
   final AssistantOutputService _assistantOutputService;
   final ToolDeclarationService _toolDeclarationService;
   final bool _enableWebModelPrefetch;
@@ -171,6 +181,25 @@ class ChatProvider extends ChangeNotifier {
   CancelToken? _activeModelPrefetchCancelToken;
   SpeechToTextTask? _activeSpeechToTextTask;
   Completer<void>? _activeTranscriptionDone;
+  LiveSpeechTranscriptionTask? _activeLiveSpeechTask;
+  StreamSubscription<LiveSpeechTranscriptUpdate>? _liveSpeechUpdates;
+  Completer<void>? _activeLiveSpeechDone;
+  Completer<void>? _activeLiveSpeechTransitionDone;
+  LiveSpeechModel _selectedLiveSpeechModel = LiveSpeechModel.moonshineTiny;
+  InstalledLiveSpeechModel? _installedLiveSpeechModel;
+  CancelToken? _liveSpeechModelDownloadCancelToken;
+  bool _isInspectingLiveSpeechModel = false;
+  bool _isInstallingLiveSpeechModel = false;
+  bool _isVerifyingLiveSpeechModel = false;
+  bool _isLiveTranscribing = false;
+  bool _liveSpeechEnabled = true;
+  double _liveSpeechModelDownloadProgress = 0;
+  String _liveSpeechConfirmedText = '';
+  String _liveSpeechPendingText = '';
+  Duration _liveSpeechAcceptedAudioDuration = Duration.zero;
+  String? _liveSpeechError;
+  String? _pendingLiveSpeechDraft;
+  int _liveSpeechOperationSequence = 0;
   TextToSpeechTask? _activeTextToSpeechTask;
   Completer<void>? _activeTextToSpeechDone;
   TextToSpeechResult? _textToSpeechResult;
@@ -242,6 +271,57 @@ class ChatProvider extends ChangeNotifier {
   bool get isGenerating => _isGenerating;
   bool get isTranscribing => _isTranscribing;
 
+  /// Whether the LiteRT-LM live dictation model is being installed.
+  bool get isInstallingLiveSpeechModel => _isInstallingLiveSpeechModel;
+
+  /// Whether the user has enabled the optional live-dictation workflow.
+  bool get liveSpeechEnabled => _liveSpeechEnabled;
+
+  /// Whether downloaded live-dictation assets are being checksum-verified.
+  bool get isVerifyingLiveSpeechModel => _isVerifyingLiveSpeechModel;
+
+  /// Live-dictation sidecars available in the example app.
+  List<LiveSpeechModel> get availableLiveSpeechModels =>
+      LiveSpeechModel.defaultModels;
+
+  /// Sidecar selected for the next live-dictation session.
+  LiveSpeechModel get selectedLiveSpeechModel => _selectedLiveSpeechModel;
+
+  /// Whether the selected sidecar's managed cache is being inspected.
+  bool get isInspectingLiveSpeechModel => _isInspectingLiveSpeechModel;
+
+  /// Aggregate progress for the live dictation model and tokenizer.
+  double get liveSpeechModelDownloadProgress =>
+      _liveSpeechModelDownloadProgress;
+
+  /// Whether microphone PCM is currently feeding the live ASR worker.
+  bool get isLiveTranscribing => _isLiveTranscribing;
+
+  /// Stable transcript prefix from the active live ASR session.
+  String get liveSpeechConfirmedText => _liveSpeechConfirmedText;
+
+  /// Replaceable transcript suffix from the active live ASR session.
+  String get liveSpeechPendingText => _liveSpeechPendingText;
+
+  /// Audio duration accepted by the active live recognizer.
+  Duration get liveSpeechAcceptedAudioDuration =>
+      _liveSpeechAcceptedAudioDuration;
+
+  /// Current live transcript for display.
+  String get liveSpeechDisplayText => <String>[
+    _liveSpeechConfirmedText.trim(),
+    _liveSpeechPendingText.trim(),
+  ].where((part) => part.isNotEmpty).join(' ');
+
+  /// Latest actionable live transcription error.
+  String? get liveSpeechError => _liveSpeechError;
+
+  /// Whether a finalized transcript is waiting to be inserted in the composer.
+  bool get hasPendingLiveSpeechDraft => _pendingLiveSpeechDraft != null;
+
+  /// Whether the managed Moonshine model and tokenizer are installed.
+  bool get isLiveSpeechModelReady => _installedLiveSpeechModel != null;
+
   /// Whether a text-to-speech task is currently generating audio.
   bool get isSynthesizingSpeech => _isSynthesizingSpeech;
 
@@ -280,6 +360,7 @@ class ChatProvider extends ChangeNotifier {
   bool get canRegenerateLastResponse {
     if (_isGenerating ||
         _isTranscribing ||
+        _isLiveTranscribing ||
         hasActiveAudioRecording ||
         _session == null ||
         !_chatService.engine.isReady ||
@@ -309,6 +390,7 @@ class ChatProvider extends ChangeNotifier {
       !_isInitializing &&
       !_isGenerating &&
       !_isTranscribing &&
+      !_isLiveTranscribing &&
       !hasActiveAudioRecording &&
       _supportsAudio &&
       _settings.modelSupportsSpeechToText;
@@ -324,6 +406,7 @@ class ChatProvider extends ChangeNotifier {
       !_isInitializing &&
       !_isGenerating &&
       !_isTranscribing &&
+      !_isLiveTranscribing &&
       !_isSynthesizingSpeech &&
       !hasActiveAudioRecording &&
       _mmprojLoaded &&
@@ -340,6 +423,7 @@ class ChatProvider extends ChangeNotifier {
       !_isInitializing &&
       !_isGenerating &&
       !_isTranscribing &&
+      !_isLiveTranscribing &&
       !_isSynthesizingSpeech &&
       !hasActiveAudioRecording &&
       _mmprojLoaded &&
@@ -372,6 +456,7 @@ class ChatProvider extends ChangeNotifier {
       !_isInitializing &&
       !_isGenerating &&
       !_isTranscribing &&
+      !_isLiveTranscribing &&
       !hasActiveAudioRecording &&
       _supportsAudio &&
       _supportsVoiceQuestionInput;
@@ -389,6 +474,53 @@ class ChatProvider extends ChangeNotifier {
   bool get canStartAudioRecording =>
       _audioRecordingService.isSupported &&
       (canTranscribeAudio || canAskWithVoice);
+
+  /// Whether this platform packages the services required for live dictation.
+  bool get supportsLiveSpeechFeature =>
+      !kIsWeb &&
+      _liveSpeechModelService.isSupported &&
+      _liveSpeechTranscriptionService.isSupported;
+
+  /// Whether this app configuration can offer LiteRT-LM live dictation
+  /// alongside the selected chat model.
+  ///
+  /// Dedicated ASR and TTS profiles keep their specialized composer modes.
+  /// Generic audio-chat models can expose both Ask with voice and live
+  /// dictation because the two actions have different user-visible results.
+  bool get supportsLiveSpeechTranscription =>
+      _liveSpeechEnabled &&
+      supportsLiveSpeechFeature &&
+      !_settings.modelSupportsSpeechToText &&
+      !supportsTextToSpeech;
+
+  /// Whether live dictation can start immediately with the installed sidecar
+  /// model.
+  bool get canStartLiveSpeechTranscription =>
+      supportsLiveSpeechTranscription &&
+      _installedLiveSpeechModel != null &&
+      _isLoaded &&
+      !_isInitializing &&
+      !_isGenerating &&
+      !_isTranscribing &&
+      !_isLiveTranscribing &&
+      _activeLiveSpeechTransitionDone == null &&
+      !_isInspectingLiveSpeechModel &&
+      !_isInstallingLiveSpeechModel &&
+      !hasActiveAudioRecording;
+
+  /// Whether the selected live-dictation sidecar can be installed.
+  bool get canInstallLiveSpeechModel =>
+      supportsLiveSpeechTranscription &&
+      _installedLiveSpeechModel == null &&
+      _isLoaded &&
+      !_isInitializing &&
+      !_isGenerating &&
+      !_isTranscribing &&
+      !_isInspectingLiveSpeechModel &&
+      !_isInstallingLiveSpeechModel &&
+      !_isLiveTranscribing &&
+      _activeLiveSpeechTransitionDone == null &&
+      !hasActiveAudioRecording;
   bool get templateSupportsTools => _templateSupportsTools;
   bool get thinkingControlsSupported => _thinkingControlsSupported;
   String? get error => _error;
@@ -402,6 +534,8 @@ class ChatProvider extends ChangeNotifier {
   bool get autoTuneModelParams => _settings.autoTuneModelParams;
   int get numberOfThreads => _settings.numberOfThreads;
   int get numberOfThreadsBatch => _settings.numberOfThreadsBatch;
+  int get batchSize => _settings.batchSize;
+  int get microBatchSize => _settings.microBatchSize;
   LlamaLogLevel get dartLogLevel => _settings.logLevel;
   LlamaLogLevel get nativeLogLevel => _settings.nativeLogLevel;
   int get contextLimit => _contextLimit; // Renamed from maxTokens
@@ -464,6 +598,8 @@ class ChatProvider extends ChangeNotifier {
     RuntimeProfileService? runtimeProfileService,
     SettingsService? settingsService,
     model_service.ModelService? modelService,
+    LiveSpeechModelService? liveSpeechModelService,
+    LiveSpeechTranscriptionService? liveSpeechTranscriptionService,
     AssistantOutputService? assistantOutputService,
     ToolDeclarationService? toolDeclarationService,
     ChatSettings? initialSettings,
@@ -480,6 +616,10 @@ class ChatProvider extends ChangeNotifier {
            runtimeProfileService ?? const RuntimeProfileService(),
        _settingsService = settingsService ?? SettingsService(),
        _modelService = modelService ?? model_service.ModelService(),
+       _liveSpeechModelService =
+           liveSpeechModelService ?? LiveSpeechModelService(),
+       _liveSpeechTranscriptionService =
+           liveSpeechTranscriptionService ?? LiveSpeechTranscriptionService(),
        _assistantOutputService =
            assistantOutputService ?? const AssistantOutputService(),
        _toolDeclarationService =
@@ -541,6 +681,7 @@ class ChatProvider extends ChangeNotifier {
 
   void createConversation() {
     unawaited(_cancelAndAwaitAudioRecording());
+    unawaited(cancelLiveSpeechTranscription());
     _invalidateActiveTextToSpeech(clearOutput: true);
     final hadActiveGeneration = _activeGenerationOperationId != null;
     _invalidateActiveVoiceQuestion(releaseGeneration: true);
@@ -604,6 +745,7 @@ class ChatProvider extends ChangeNotifier {
       _restoreSessionFromMessages();
     }
     await _cancelAndAwaitAudioRecording();
+    await cancelLiveSpeechTranscription();
     await _cancelAndAwaitActiveTranscription();
     await _cancelAndAwaitActiveTextToSpeech();
     _clearTextToSpeechOutput();
@@ -698,6 +840,13 @@ class ChatProvider extends ChangeNotifier {
 
   Future<void> _init() async {
     _settings = await _settingsService.loadSettings();
+    _liveSpeechEnabled = await _settingsService.loadLiveSpeechEnabled();
+    _selectedLiveSpeechModel = LiveSpeechModel.byId(
+      await _settingsService.loadLiveSpeechModelId(),
+    );
+    if (_liveSpeechEnabled) {
+      await refreshLiveSpeechModel();
+    }
     _rebuildDeclaredToolsFromSettings();
     final index = _conversationStateService.activeConversationIndex(
       conversations: _conversations,
@@ -2441,6 +2590,342 @@ class ChatProvider extends ChangeNotifier {
     );
   }
 
+  /// Selects the managed sidecar used by subsequent live-dictation sessions.
+  Future<void> selectLiveSpeechModel(String modelId) async {
+    final model = LiveSpeechModel.byId(modelId);
+    if (model.id == _selectedLiveSpeechModel.id ||
+        _isInstallingLiveSpeechModel ||
+        _isLiveTranscribing ||
+        _activeLiveSpeechTransitionDone != null) {
+      return;
+    }
+    _selectedLiveSpeechModel = model;
+    _installedLiveSpeechModel = null;
+    _liveSpeechModelDownloadProgress = 0;
+    _liveSpeechError = null;
+    notifyListeners();
+    try {
+      await _settingsService.saveLiveSpeechModelId(model.id);
+    } catch (error) {
+      _logDart(
+        LlamaLogLevel.warn,
+        'Could not persist live speech model selection: $error',
+      );
+    }
+    await refreshLiveSpeechModel();
+  }
+
+  /// Enables or disables the optional app-owned live-dictation workflow.
+  Future<void> updateLiveSpeechEnabled(bool enabled) async {
+    if (_liveSpeechEnabled == enabled || _isDisposed) {
+      return;
+    }
+    _liveSpeechEnabled = enabled;
+    if (!enabled) {
+      cancelLiveSpeechModelInstall();
+      await cancelLiveSpeechTranscription();
+      _pendingLiveSpeechDraft = null;
+      _liveSpeechError = null;
+      _liveSpeechModelDownloadProgress = 0;
+    }
+    if (!_isDisposed) {
+      notifyListeners();
+    }
+    try {
+      await _settingsService.saveLiveSpeechEnabled(enabled);
+    } catch (error) {
+      _logDart(
+        LlamaLogLevel.warn,
+        'Could not persist live dictation preference: $error',
+      );
+    }
+    if (enabled && !_isDisposed) {
+      await refreshLiveSpeechModel();
+    }
+  }
+
+  /// Refreshes integrity-checked availability for the selected live STT model.
+  Future<void> refreshLiveSpeechModel() async {
+    if (!_liveSpeechModelService.isSupported || _isDisposed) {
+      _installedLiveSpeechModel = null;
+      return;
+    }
+    final model = _selectedLiveSpeechModel;
+    _isInspectingLiveSpeechModel = true;
+    if (!_isDisposed) {
+      notifyListeners();
+    }
+    try {
+      final installed = await _liveSpeechModelService.resolve(model);
+      if (_selectedLiveSpeechModel.id == model.id) {
+        _installedLiveSpeechModel = installed;
+        _liveSpeechError = null;
+      }
+    } catch (error) {
+      if (_selectedLiveSpeechModel.id == model.id) {
+        _installedLiveSpeechModel = null;
+        _liveSpeechError =
+            'Could not inspect the live transcription model: '
+            '${_formatDisplayError(error)}';
+      }
+    } finally {
+      if (_selectedLiveSpeechModel.id == model.id) {
+        _isInspectingLiveSpeechModel = false;
+      }
+    }
+    if (!_isDisposed) {
+      notifyListeners();
+    }
+  }
+
+  /// Installs the checksum-pinned selected model and tokenizer.
+  Future<bool> installLiveSpeechModel() async {
+    if (!canInstallLiveSpeechModel) {
+      return _installedLiveSpeechModel != null;
+    }
+    final cancelToken = CancelToken();
+    _liveSpeechModelDownloadCancelToken = cancelToken;
+    _isInstallingLiveSpeechModel = true;
+    _liveSpeechModelDownloadProgress = 0;
+    _liveSpeechError = null;
+    notifyListeners();
+    final model = _selectedLiveSpeechModel;
+    try {
+      _installedLiveSpeechModel = await _liveSpeechModelService.install(
+        model,
+        cancelToken: cancelToken,
+        onProgress: (progress) {
+          if (!identical(_liveSpeechModelDownloadCancelToken, cancelToken) ||
+              _selectedLiveSpeechModel.id != model.id ||
+              _isDisposed) {
+            return;
+          }
+          _isVerifyingLiveSpeechModel = false;
+          _liveSpeechModelDownloadProgress = progress;
+          notifyListeners();
+        },
+        onVerifying: () {
+          if (!identical(_liveSpeechModelDownloadCancelToken, cancelToken) ||
+              _selectedLiveSpeechModel.id != model.id ||
+              _isDisposed) {
+            return;
+          }
+          _isVerifyingLiveSpeechModel = true;
+          notifyListeners();
+        },
+      );
+      _liveSpeechModelDownloadProgress = 1;
+      return true;
+    } catch (error) {
+      if (!cancelToken.isCancelled && !_isDisposed) {
+        _liveSpeechError =
+            'Could not install live transcription: '
+            '${_formatDisplayError(error)}';
+      } else {
+        _liveSpeechModelDownloadProgress = 0;
+      }
+      return false;
+    } finally {
+      if (identical(_liveSpeechModelDownloadCancelToken, cancelToken)) {
+        _liveSpeechModelDownloadCancelToken = null;
+        _isInstallingLiveSpeechModel = false;
+        _isVerifyingLiveSpeechModel = false;
+      }
+      if (!_isDisposed) {
+        notifyListeners();
+      }
+    }
+  }
+
+  /// Cancels the selected sidecar download without deleting completed assets.
+  void cancelLiveSpeechModelInstall() {
+    _liveSpeechModelDownloadCancelToken?.cancel(
+      'Live transcription model download cancelled by the user.',
+    );
+  }
+
+  /// Starts worker-isolated LiteRT-LM live microphone transcription.
+  Future<void> startLiveSpeechTranscription() async {
+    if (_installedLiveSpeechModel == null) {
+      if (!await installLiveSpeechModel()) {
+        return;
+      }
+    }
+    if (!canStartLiveSpeechTranscription) {
+      return;
+    }
+    final installed = _installedLiveSpeechModel!;
+    final operationId = ++_liveSpeechOperationSequence;
+    final transitionDone = Completer<void>();
+    _activeLiveSpeechTransitionDone = transitionDone;
+    _isLiveTranscribing = true;
+    _liveSpeechConfirmedText = '';
+    _liveSpeechPendingText = '';
+    _liveSpeechAcceptedAudioDuration = Duration.zero;
+    _liveSpeechError = null;
+    notifyListeners();
+
+    try {
+      final task = await _liveSpeechTranscriptionService.start(
+        modelPath: installed.modelPath,
+        tokenizerPath: installed.tokenizerPath,
+        preset: installed.model.preset,
+      );
+      if (_isDisposed || operationId != _liveSpeechOperationSequence) {
+        final settled = task.done.then<void>(
+          (_) {},
+          onError: (Object _, StackTrace _) {},
+        );
+        await task.cancel();
+        await settled;
+        return;
+      }
+      _activeLiveSpeechTask = task;
+      final done = Completer<void>();
+      _activeLiveSpeechDone = done;
+      _liveSpeechUpdates = task.updates.listen((update) {
+        if (_isDisposed || operationId != _liveSpeechOperationSequence) {
+          return;
+        }
+        _liveSpeechConfirmedText = update.confirmedText;
+        _liveSpeechPendingText = update.pendingText;
+        _liveSpeechAcceptedAudioDuration = update.acceptedAudioDuration;
+        notifyListeners();
+        if (!update.isFinal &&
+            update.acceptedAudioDuration >=
+                maxLiveSpeechTranscriptionDuration) {
+          unawaited(stopLiveSpeechTranscription());
+        }
+      });
+      unawaited(_monitorLiveSpeechTask(task, operationId, done));
+    } catch (error) {
+      if (!_isDisposed && operationId == _liveSpeechOperationSequence) {
+        _isLiveTranscribing = false;
+        _liveSpeechError =
+            'Could not start live transcription: '
+            '${_formatDisplayError(error)}';
+        notifyListeners();
+      }
+    } finally {
+      if (identical(_activeLiveSpeechTransitionDone, transitionDone)) {
+        _activeLiveSpeechTransitionDone = null;
+      }
+      if (!transitionDone.isCompleted) {
+        transitionDone.complete();
+      }
+    }
+  }
+
+  Future<void> _monitorLiveSpeechTask(
+    LiveSpeechTranscriptionTask task,
+    int operationId,
+    Completer<void> done,
+  ) async {
+    try {
+      final result = await task.done;
+      if (_isDisposed || operationId != _liveSpeechOperationSequence) {
+        return;
+      }
+      final transcript = result.text.trim();
+      _liveSpeechAcceptedAudioDuration = result.acceptedAudioDuration;
+      if (transcript.isEmpty) {
+        _liveSpeechError =
+            'Live transcription completed without returning text.';
+      } else {
+        _liveSpeechConfirmedText = transcript;
+        _liveSpeechPendingText = '';
+        _pendingLiveSpeechDraft = transcript;
+      }
+    } catch (error) {
+      if (!_isDisposed && operationId == _liveSpeechOperationSequence) {
+        _liveSpeechError = _formatDisplayError(error);
+      }
+    } finally {
+      if (operationId == _liveSpeechOperationSequence) {
+        final updates = _liveSpeechUpdates;
+        _liveSpeechUpdates = null;
+        if (updates != null) {
+          unawaited(updates.cancel());
+        }
+        _activeLiveSpeechTask = null;
+        _activeLiveSpeechDone = null;
+        _isLiveTranscribing = false;
+        if (!_isDisposed) {
+          notifyListeners();
+        }
+      }
+      if (!done.isCompleted) {
+        done.complete();
+      }
+    }
+  }
+
+  /// Stops live capture and flushes the final partial inference window.
+  Future<void> stopLiveSpeechTranscription() async {
+    final task = _activeLiveSpeechTask;
+    final done = _activeLiveSpeechDone;
+    if (task == null || !_isLiveTranscribing) {
+      return;
+    }
+    await task.stop();
+    await done?.future;
+  }
+
+  /// Cancels live capture without producing a composer draft.
+  Future<void> cancelLiveSpeechTranscription() async {
+    final task = _activeLiveSpeechTask;
+    final done = _activeLiveSpeechDone;
+    final priorTransition = _activeLiveSpeechTransitionDone;
+    if (task == null && !_isLiveTranscribing && priorTransition == null) {
+      return;
+    }
+    if (task == null && !_isLiveTranscribing && priorTransition != null) {
+      await priorTransition.future;
+      return;
+    }
+    final cancellationDone = Completer<void>();
+    _activeLiveSpeechTransitionDone = cancellationDone;
+    _liveSpeechOperationSequence += 1;
+    _activeLiveSpeechTask = null;
+    _activeLiveSpeechDone = null;
+    _isLiveTranscribing = false;
+    _liveSpeechConfirmedText = '';
+    _liveSpeechPendingText = '';
+    _liveSpeechAcceptedAudioDuration = Duration.zero;
+    _liveSpeechError = null;
+    await _liveSpeechUpdates?.cancel();
+    _liveSpeechUpdates = null;
+    if (!_isDisposed) {
+      notifyListeners();
+    }
+    try {
+      await priorTransition?.future;
+      if (task != null) {
+        await task.cancel();
+        try {
+          await task.done;
+        } catch (_) {
+          // Cancellation is the expected terminal state.
+        }
+      }
+      await done?.future;
+    } finally {
+      if (identical(_activeLiveSpeechTransitionDone, cancellationDone)) {
+        _activeLiveSpeechTransitionDone = null;
+      }
+      if (!cancellationDone.isCompleted) {
+        cancellationDone.complete();
+      }
+    }
+  }
+
+  /// Returns the next finalized live transcript exactly once.
+  String? takeLiveSpeechDraft() {
+    final draft = _pendingLiveSpeechDraft;
+    _pendingLiveSpeechDraft = null;
+    return draft;
+  }
+
   /// Starts foreground microphone capture for the active model's voice flow.
   Future<void> startAudioRecording({ChatAudioRecordingPurpose? purpose}) async {
     if (!_audioRecordingService.isSupported) {
@@ -2832,7 +3317,10 @@ class ChatProvider extends ChangeNotifier {
 
   /// Discards an active microphone recording without processing it.
   Future<void> cancelAudioRecording({bool showMessage = true}) async {
-    await _cancelAndAwaitAudioRecording(showMessage: showMessage);
+    await Future.wait<void>(<Future<void>>[
+      _cancelAndAwaitAudioRecording(showMessage: showMessage),
+      cancelLiveSpeechTranscription(),
+    ]);
   }
 
   void _startAudioRecordingTimer(int revision) {
@@ -3489,6 +3977,25 @@ class ChatProvider extends ChangeNotifier {
   void updateNumberOfThreadsBatch(int value) => _updateSettings(
     _settings.copyWith(numberOfThreadsBatch: value.clamp(0, 128)),
   );
+  void updateBatchSize(int value) {
+    final normalized = value.clamp(0, 32768);
+    final microBatchSize =
+        normalized > 0 && _settings.microBatchSize > normalized
+        ? normalized
+        : _settings.microBatchSize;
+    _updateSettings(
+      _settings.copyWith(batchSize: normalized, microBatchSize: microBatchSize),
+    );
+  }
+
+  void updateMicroBatchSize(int value) {
+    final normalized = value.clamp(0, 32768);
+    final capped = _settings.batchSize > 0
+        ? math.min(normalized, _settings.batchSize)
+        : normalized;
+    _updateSettings(_settings.copyWith(microBatchSize: capped));
+  }
+
   void updateLogLevel(LlamaLogLevel value) {
     _updateSettings(_settings.copyWith(logLevel: value));
     _chatService.engine.setDartLogLevel(value);
@@ -3565,6 +4072,10 @@ class ChatProvider extends ChangeNotifier {
     _clearTextToSpeechOutput();
     stopGeneration();
     _cancelActiveModelPrefetch();
+    _liveSpeechModelDownloadCancelToken?.cancel(
+      'Live transcription model download cancelled during disposal.',
+    );
+    _liveSpeechModelDownloadCancelToken = null;
     _session?.reset();
     _session = null;
     await _chatService.unloadModel();
@@ -3868,6 +4379,7 @@ class ChatProvider extends ChangeNotifier {
     unawaited(_settingsService.saveSettings(_settings));
     final recordingDone = _cancelAndAwaitAudioRecording();
     final transcriptionDone = _cancelAndAwaitActiveTranscription();
+    final liveSpeechDone = cancelLiveSpeechTranscription();
     final textToSpeechDone = _cancelAndAwaitActiveTextToSpeech();
     stopGeneration();
     _cancelActiveModelPrefetch();
@@ -3876,8 +4388,10 @@ class ChatProvider extends ChangeNotifier {
     unawaited(() async {
       await recordingDone;
       await transcriptionDone;
+      await liveSpeechDone;
       await textToSpeechDone;
       await _audioRecordingService.dispose();
+      await _liveSpeechTranscriptionService.dispose();
       await _chatService.dispose();
     }());
     super.dispose();
@@ -3892,10 +4406,15 @@ class ChatProvider extends ChangeNotifier {
     try {
       await _saveSettingsNow();
       await _cancelAndAwaitAudioRecording();
+      await cancelLiveSpeechTranscription();
       await _cancelAndAwaitActiveTranscription();
       await _cancelAndAwaitActiveTextToSpeech();
       stopGeneration();
       _cancelActiveModelPrefetch();
+      _liveSpeechModelDownloadCancelToken?.cancel(
+        'Live transcription model download cancelled during shutdown.',
+      );
+      _liveSpeechModelDownloadCancelToken = null;
       _session?.reset();
       _session = null;
       _isLoaded = false;
@@ -3914,6 +4433,7 @@ class ChatProvider extends ChangeNotifier {
       _runtimeModelSource = null;
       _runtimeModelCacheState = null;
       await _audioRecordingService.dispose();
+      await _liveSpeechTranscriptionService.dispose();
       await _chatService.dispose();
     } finally {
       _isShuttingDown = false;
@@ -4024,8 +4544,38 @@ class ChatProvider extends ChangeNotifier {
 
   Future<void> estimateDynamicSettings() async {
     try {
+      String? probedBackendInfo;
+      if (!kIsWeb &&
+          defaultTargetPlatform == TargetPlatform.android &&
+          (_settings.preferredBackend == GpuBackend.auto ||
+              _settings.preferredBackend == GpuBackend.vulkan)) {
+        try {
+          final devices = await _chatService.engine.listGpuDevices(
+            probeBackends: const [GpuBackend.vulkan],
+          );
+          if (devices.isNotEmpty) {
+            probedBackendInfo = devices
+                .map((device) => device.backend.name.toUpperCase())
+                .toSet()
+                .join(', ');
+            _availableDevices = {
+              ..._availableDevices,
+              ...devices.map(
+                (device) =>
+                    '${device.backend.name.toUpperCase()}: ${device.description}',
+              ),
+            }.toList(growable: false);
+          }
+        } catch (e) {
+          _logDart(
+            LlamaLogLevel.warn,
+            'Vulkan capability probe failed during Auto tuning: $e',
+          );
+        }
+      }
       final vram = await _chatService.engine.getVramInfo();
-      final backendInfo = await _getAvailableBackendInfoBestEffort();
+      final backendInfo =
+          probedBackendInfo ?? await _getAvailableBackendInfoBestEffort();
       final catalogModel = _downloadableModelForCurrentSettings();
       final modelBytes =
           _settings.modelBytesHint ??

--- a/example/chat_app/lib/screens/manage_models_screen.dart
+++ b/example/chat_app/lib/screens/manage_models_screen.dart
@@ -1209,6 +1209,8 @@ class _ManageModelsScreenState extends State<ManageModelsScreen>
 
     provider.updateNumberOfThreads(0);
     provider.updateNumberOfThreadsBatch(0);
+    provider.updateBatchSize(0);
+    provider.updateMicroBatchSize(0);
   }
 
   void _resetInferenceParams(ChatProvider provider) {
@@ -1402,6 +1404,13 @@ class _ManageModelsScreenState extends State<ManageModelsScreen>
         final contextOptions = _buildContextSizeOptions(provider.contextSize);
         final hasModelPath =
             provider.modelPath != null && provider.modelPath!.isNotEmpty;
+        final usesLiteRtLmModel =
+            provider.modelPath
+                ?.split('?')
+                .first
+                .toLowerCase()
+                .endsWith('.litertlm') ??
+            false;
         final hasMmprojPath = (provider.settings.mmprojPath ?? '')
             .trim()
             .isNotEmpty;
@@ -1415,6 +1424,10 @@ class _ManageModelsScreenState extends State<ManageModelsScreen>
         final threadBatchLabel = provider.numberOfThreadsBatch == 0
             ? '(auto detected)'
             : provider.numberOfThreadsBatch.toString();
+        final batchSizeOptions = _buildBatchSizeOptions(provider.batchSize);
+        final microBatchSizeOptions = _buildBatchSizeOptions(
+          provider.microBatchSize,
+        );
         final isMaximumGpuLayers = provider.gpuLayers >= 99;
         final isAutoTuning =
             selectedBackend == GpuBackend.auto && provider.autoTuneModelParams;
@@ -1937,10 +1950,30 @@ class _ManageModelsScreenState extends State<ManageModelsScreen>
                     ),
                   ),
                   subtitle: Text(
-                    'GPU layers, backend, context, and runtime threads',
+                    'GPU layers, backend, context, batching, and runtime threads',
                     style: Theme.of(context).textTheme.bodySmall,
                   ),
                   children: [
+                    if (provider.supportsLiveSpeechFeature) ...[
+                      SwitchListTile.adaptive(
+                        key: const ValueKey<String>(
+                          'live_speech_enabled_switch',
+                        ),
+                        value: provider.liveSpeechEnabled,
+                        secondary: const Icon(Icons.subtitles_rounded),
+                        title: const Text('Live dictation'),
+                        subtitle: const Text(
+                          'Use a separate on-device English speech model to '
+                          'put microphone text in the composer. Nothing is '
+                          'sent until you tap Send.',
+                        ),
+                        contentPadding: EdgeInsets.zero,
+                        onChanged: (enabled) => unawaited(
+                          provider.updateLiveSpeechEnabled(enabled),
+                        ),
+                      ),
+                      const SizedBox(height: 10),
+                    ],
                     _LabeledSlider(
                       label: 'GPU layers',
                       valueLabel: gpuLayersLabel,
@@ -1994,6 +2027,56 @@ class _ManageModelsScreenState extends State<ManageModelsScreen>
                           provider.updateContextSize(value);
                         }
                       },
+                    ),
+                    const SizedBox(height: 10),
+                    DropdownButtonFormField<int>(
+                      initialValue: provider.batchSize,
+                      decoration: InputDecoration(
+                        labelText: 'Batch size (n_batch)',
+                        helperText: usesLiteRtLmModel
+                            ? 'Not used by LiteRT-LM'
+                            : null,
+                      ),
+                      items: batchSizeOptions
+                          .map(
+                            (option) => DropdownMenuItem<int>(
+                              value: option,
+                              child: Text(option == 0 ? 'Auto' : '$option'),
+                            ),
+                          )
+                          .toList(growable: false),
+                      onChanged: usesLiteRtLmModel
+                          ? null
+                          : (value) {
+                              if (value != null) {
+                                provider.updateBatchSize(value);
+                              }
+                            },
+                    ),
+                    const SizedBox(height: 10),
+                    DropdownButtonFormField<int>(
+                      initialValue: provider.microBatchSize,
+                      decoration: InputDecoration(
+                        labelText: 'Micro-batch size (n_ubatch)',
+                        helperText: usesLiteRtLmModel
+                            ? 'Not used by LiteRT-LM'
+                            : null,
+                      ),
+                      items: microBatchSizeOptions
+                          .map(
+                            (option) => DropdownMenuItem<int>(
+                              value: option,
+                              child: Text(option == 0 ? 'Auto' : '$option'),
+                            ),
+                          )
+                          .toList(growable: false),
+                      onChanged: usesLiteRtLmModel
+                          ? null
+                          : (value) {
+                              if (value != null) {
+                                provider.updateMicroBatchSize(value);
+                              }
+                            },
                     ),
                     const SizedBox(height: 10),
                     DropdownButtonFormField<GpuBackend>(
@@ -2409,6 +2492,23 @@ class _ManageModelsScreenState extends State<ManageModelsScreen>
   List<int> _buildContextSizeOptions(int current) {
     final values = <int>{0, 2048, 4096, 8192, 16384, 32768, current}.toList()
       ..sort();
+    return values;
+  }
+
+  List<int> _buildBatchSizeOptions(int current) {
+    final values = <int>{
+      0,
+      1,
+      16,
+      32,
+      64,
+      128,
+      256,
+      512,
+      1024,
+      2048,
+      current,
+    }.toList()..sort();
     return values;
   }
 

--- a/example/chat_app/lib/services/chat_service.dart
+++ b/example/chat_app/lib/services/chat_service.dart
@@ -223,18 +223,26 @@ class ChatService {
       }
     }
 
-    var batchSize = 0;
-    var microBatchSize = 0;
+    var batchSize = settings.batchSize;
+    var microBatchSize = settings.microBatchSize;
     if (isAndroidNative && usesGpuBackend) {
       if (usesVulkanBackend) {
         final preferredBatchCap = _isQwen35SmallModel(settings.modelPath)
             ? 64
             : 32;
-        batchSize = math.min(safeContextSize, preferredBatchCap);
-        microBatchSize = 1;
+        if (batchSize <= 0) {
+          batchSize = math.min(safeContextSize, preferredBatchCap);
+        }
+        if (microBatchSize <= 0) {
+          microBatchSize = 1;
+        }
       } else {
-        batchSize = math.min(safeContextSize, 256);
-        microBatchSize = math.min(batchSize, 64);
+        if (batchSize <= 0) {
+          batchSize = math.min(safeContextSize, 256);
+        }
+        if (microBatchSize <= 0) {
+          microBatchSize = math.min(batchSize, 64);
+        }
       }
     }
 

--- a/example/chat_app/lib/services/chat_service.dart
+++ b/example/chat_app/lib/services/chat_service.dart
@@ -245,6 +245,9 @@ class ChatService {
         }
       }
     }
+    if (batchSize > 0 && microBatchSize > batchSize) {
+      microBatchSize = batchSize;
+    }
 
     // On web, forward the known model size so the WebGPU backend can select the
     // 64-bit (mem64) core up front for models that exceed the wasm32 address

--- a/example/chat_app/lib/services/live_speech_model_service.dart
+++ b/example/chat_app/lib/services/live_speech_model_service.dart
@@ -1,0 +1,28 @@
+import 'package:dio/dio.dart';
+
+import '../models/live_speech_model.dart';
+import 'live_speech_model_service_stub.dart'
+    if (dart.library.io) 'live_speech_model_service_io.dart';
+
+/// Downloads and resolves managed sidecar models used for live dictation.
+abstract class LiveSpeechModelService {
+  /// Creates the platform implementation.
+  factory LiveSpeechModelService() => createLiveSpeechModelService();
+
+  /// Whether native live-speech model installation is supported.
+  bool get isSupported;
+
+  /// Returns installed paths when both model assets pass integrity checks.
+  Future<InstalledLiveSpeechModel?> resolve(LiveSpeechModel model);
+
+  /// Downloads and verifies both model assets.
+  Future<InstalledLiveSpeechModel> install(
+    LiveSpeechModel model, {
+    required CancelToken cancelToken,
+    required void Function(double progress) onProgress,
+    required void Function() onVerifying,
+  });
+
+  /// Removes both managed model assets.
+  Future<void> delete(LiveSpeechModel model);
+}

--- a/example/chat_app/lib/services/live_speech_model_service_io.dart
+++ b/example/chat_app/lib/services/live_speech_model_service_io.dart
@@ -1,0 +1,138 @@
+import 'dart:io';
+
+import 'package:dio/dio.dart';
+
+import '../models/downloadable_model.dart';
+import '../models/live_speech_model.dart';
+import 'live_speech_model_service.dart';
+import 'model_service_io.dart';
+
+class _IoLiveSpeechModelService implements LiveSpeechModelService {
+  final ModelServiceIO _modelService;
+
+  _IoLiveSpeechModelService({ModelServiceIO? modelService})
+    : _modelService = modelService ?? ModelServiceIO();
+
+  @override
+  bool get isSupported =>
+      Platform.isAndroid ||
+      Platform.isIOS ||
+      Platform.isMacOS ||
+      Platform.isLinux ||
+      Platform.isWindows;
+
+  @override
+  Future<InstalledLiveSpeechModel?> resolve(LiveSpeechModel model) async {
+    if (!isSupported) {
+      return null;
+    }
+    final modelsDir = await _modelService.getModelsDirectory();
+    final modelReady = await _modelService.isManagedAssetAvailable(
+      modelsDir,
+      model.modelSource,
+      role: ModelAssetRole.model,
+    );
+    final tokenizerReady = await _modelService.isManagedAssetAvailable(
+      modelsDir,
+      model.tokenizerSource,
+      role: ModelAssetRole.tokenizer,
+    );
+    if (!modelReady || !tokenizerReady) {
+      return null;
+    }
+    return _installed(model, modelsDir);
+  }
+
+  @override
+  Future<InstalledLiveSpeechModel> install(
+    LiveSpeechModel model, {
+    required CancelToken cancelToken,
+    required void Function(double progress) onProgress,
+    required void Function() onVerifying,
+  }) async {
+    if (!isSupported) {
+      throw UnsupportedError('Live speech transcription is native-only.');
+    }
+    final modelsDir = await _modelService.getModelsDirectory();
+    final modelBytes = model.modelSource.sizeBytes ?? 0;
+    final tokenizerBytes = model.tokenizerSource.sizeBytes ?? 0;
+    final totalBytes = modelBytes + tokenizerBytes;
+    var downloadedModelBytes = 0;
+    var downloadedTokenizerBytes = 0;
+
+    void reportProgress() {
+      if (totalBytes <= 0) {
+        onProgress(0);
+        return;
+      }
+      onProgress(
+        ((downloadedModelBytes + downloadedTokenizerBytes) / totalBytes).clamp(
+          0.0,
+          1.0,
+        ),
+      );
+    }
+
+    await _modelService.downloadManagedAsset(
+      modelsDir: modelsDir,
+      source: model.modelSource,
+      role: ModelAssetRole.model,
+      cancelToken: cancelToken,
+      onProgress: (downloadedBytes, _, _) {
+        downloadedModelBytes = downloadedBytes.clamp(0, modelBytes);
+        reportProgress();
+      },
+      onVerifying: onVerifying,
+    );
+    downloadedModelBytes = modelBytes;
+    reportProgress();
+
+    await _modelService.downloadManagedAsset(
+      modelsDir: modelsDir,
+      source: model.tokenizerSource,
+      role: ModelAssetRole.tokenizer,
+      cancelToken: cancelToken,
+      onProgress: (downloadedBytes, _, _) {
+        downloadedTokenizerBytes = downloadedBytes.clamp(0, tokenizerBytes);
+        reportProgress();
+      },
+      onVerifying: onVerifying,
+    );
+    downloadedTokenizerBytes = tokenizerBytes;
+    onProgress(1);
+
+    final installed = await resolve(model);
+    if (installed == null) {
+      throw StateError(
+        'Live speech model download completed, but integrity validation failed.',
+      );
+    }
+    return installed;
+  }
+
+  @override
+  Future<void> delete(LiveSpeechModel model) async {
+    final modelsDir = await _modelService.getModelsDirectory();
+    await _modelService.deleteManagedAsset(modelsDir, model.modelSource);
+    await _modelService.deleteManagedAsset(modelsDir, model.tokenizerSource);
+  }
+
+  InstalledLiveSpeechModel _installed(
+    LiveSpeechModel model,
+    String modelsDir,
+  ) => InstalledLiveSpeechModel(
+    model: model,
+    modelPath: _modelService.resolveManagedAssetPath(
+      modelsDir,
+      model.modelSource,
+    ),
+    tokenizerPath: _modelService.resolveManagedAssetPath(
+      modelsDir,
+      model.tokenizerSource,
+    ),
+  );
+}
+
+/// Creates the native live-speech model service.
+LiveSpeechModelService createLiveSpeechModelService() =>
+    _IoLiveSpeechModelService();

--- a/example/chat_app/lib/services/live_speech_model_service_stub.dart
+++ b/example/chat_app/lib/services/live_speech_model_service_stub.dart
@@ -18,7 +18,7 @@ class _UnsupportedLiveSpeechModelService implements LiveSpeechModelService {
     required void Function(double progress) onProgress,
     required void Function() onVerifying,
   }) {
-    throw UnsupportedError('Live speech transcription is native-only.');
+    throw UnsupportedError('Live speech model installation is native-only.');
   }
 
   @override

--- a/example/chat_app/lib/services/live_speech_model_service_stub.dart
+++ b/example/chat_app/lib/services/live_speech_model_service_stub.dart
@@ -1,0 +1,30 @@
+import 'package:dio/dio.dart';
+
+import '../models/live_speech_model.dart';
+import 'live_speech_model_service.dart';
+
+class _UnsupportedLiveSpeechModelService implements LiveSpeechModelService {
+  @override
+  bool get isSupported => false;
+
+  @override
+  Future<InstalledLiveSpeechModel?> resolve(LiveSpeechModel model) async =>
+      null;
+
+  @override
+  Future<InstalledLiveSpeechModel> install(
+    LiveSpeechModel model, {
+    required CancelToken cancelToken,
+    required void Function(double progress) onProgress,
+    required void Function() onVerifying,
+  }) {
+    throw UnsupportedError('Live speech transcription is native-only.');
+  }
+
+  @override
+  Future<void> delete(LiveSpeechModel model) async {}
+}
+
+/// Creates the unsupported non-IO implementation.
+LiveSpeechModelService createLiveSpeechModelService() =>
+    _UnsupportedLiveSpeechModelService();

--- a/example/chat_app/lib/services/live_speech_transcription_service.dart
+++ b/example/chat_app/lib/services/live_speech_transcription_service.dart
@@ -1,0 +1,140 @@
+import 'dart:typed_data';
+
+import 'package:llamadart/llamadart.dart';
+
+import 'live_speech_transcription_service_stub.dart'
+    if (dart.library.io) 'live_speech_transcription_service_io.dart';
+
+/// One replaceable live-transcription update.
+class LiveSpeechTranscriptUpdate {
+  /// Stable transcript prefix.
+  final String confirmedText;
+
+  /// Replaceable hypothesis for the current inference window.
+  final String pendingText;
+
+  /// Audio duration accepted by the native session.
+  final Duration acceptedAudioDuration;
+
+  /// Whether this update completes the stream.
+  final bool isFinal;
+
+  /// Creates a live transcript update.
+  const LiveSpeechTranscriptUpdate({
+    required this.confirmedText,
+    required this.pendingText,
+    required this.acceptedAudioDuration,
+    required this.isFinal,
+  });
+
+  /// Current display text with confirmed and pending regions joined once.
+  String get text => <String>[
+    confirmedText.trim(),
+    pendingText.trim(),
+  ].where((part) => part.isNotEmpty).join(' ');
+}
+
+/// Terminal result from a live microphone transcription task.
+class LiveSpeechTranscriptionResult {
+  /// Final confirmed transcript.
+  final String text;
+
+  /// Audio duration accepted by the native session.
+  final Duration acceptedAudioDuration;
+
+  /// Creates a live transcription result.
+  const LiveSpeechTranscriptionResult({
+    required this.text,
+    required this.acceptedAudioDuration,
+  });
+}
+
+/// Active microphone and LiteRT-LM ASR session.
+abstract class LiveSpeechTranscriptionTask {
+  /// Confirmed and pending transcript updates.
+  Stream<LiveSpeechTranscriptUpdate> get updates;
+
+  /// Terminal completion, error, or cancellation.
+  Future<LiveSpeechTranscriptionResult> get done;
+
+  /// Stops capture and flushes the final partial window.
+  Future<void> stop();
+
+  /// Cancels capture and native inference without producing a draft.
+  Future<void> cancel();
+}
+
+/// Captures mono PCM and runs the synchronous LiteRT-LM ASR session in a
+/// worker isolate.
+abstract class LiveSpeechTranscriptionService {
+  /// Creates the platform implementation.
+  factory LiveSpeechTranscriptionService() =>
+      createLiveSpeechTranscriptionService();
+
+  /// Whether microphone streaming and worker isolates are supported.
+  bool get isSupported;
+
+  /// Starts live transcription with a locally installed model and tokenizer.
+  Future<LiveSpeechTranscriptionTask> start({
+    required String modelPath,
+    required String tokenizerPath,
+    required LiteRtLmAsrModelPreset preset,
+  });
+
+  /// Releases the recorder and any active task.
+  Future<void> dispose();
+}
+
+/// Converts little-endian signed PCM16 bytes to normalized float samples.
+Float32List pcm16BytesToFloat32(Uint8List bytes) {
+  if (bytes.length.isOdd) {
+    throw const FormatException('PCM16 input must contain complete samples.');
+  }
+  final data = ByteData.sublistView(bytes);
+  final samples = Float32List(bytes.length ~/ 2);
+  for (var index = 0; index < samples.length; index++) {
+    samples[index] = data.getInt16(index * 2, Endian.little) / 32768.0;
+  }
+  return samples;
+}
+
+/// Reassembles arbitrary byte chunks into complete little-endian PCM16
+/// samples without dropping a split sample at a chunk boundary.
+class Pcm16ByteStreamAligner {
+  int? _pendingByte;
+
+  /// Adds one byte chunk and returns the complete PCM16 sample bytes now
+  /// available. The returned length is always even.
+  Uint8List add(Uint8List bytes) {
+    if (bytes.isEmpty) {
+      return Uint8List(0);
+    }
+    final pending = _pendingByte;
+    if (pending == null && bytes.length.isEven) {
+      return bytes;
+    }
+
+    final joined = Uint8List(bytes.length + (pending == null ? 0 : 1));
+    var offset = 0;
+    if (pending != null) {
+      joined[0] = pending;
+      offset = 1;
+      _pendingByte = null;
+    }
+    joined.setRange(offset, joined.length, bytes);
+    if (joined.length.isOdd) {
+      _pendingByte = joined.last;
+      return Uint8List.sublistView(joined, 0, joined.length - 1);
+    }
+    return joined;
+  }
+
+  /// Verifies that the source stream ended on a complete PCM16 sample.
+  void finish() {
+    if (_pendingByte != null) {
+      throw const FormatException(
+        'PCM16 microphone stream ended with an incomplete sample.',
+      );
+    }
+  }
+}

--- a/example/chat_app/lib/services/live_speech_transcription_service_io.dart
+++ b/example/chat_app/lib/services/live_speech_transcription_service_io.dart
@@ -1,0 +1,670 @@
+import 'dart:async';
+import 'dart:io';
+import 'dart:isolate';
+import 'dart:typed_data';
+
+import 'package:llamadart/llamadart.dart';
+import 'package:record/record.dart';
+
+import 'live_speech_transcription_service.dart';
+
+const int _sampleRateHz = 16000;
+const String _incompleteBpeSequenceDetails =
+    'The set of token IDs passed to the tokenizer is part of a BPE sequence '
+    'and needs more tokens to be decoded.';
+
+/// Processes one live-ASR window, tolerating LiteRT-LM's incomplete trailing
+/// BPE result so the overlapping next window can recover the omitted suffix.
+///
+/// Independent-window presets such as Moonshine can end a window in the middle
+/// of a UTF-8 BPE sequence, which LiteRT-LM v0.16 reports as a data-loss error
+/// even though the session remains usable. Returning `null` skips only that
+/// incomplete window; unrelated inference failures still propagate.
+LiteRtLmAsrProcessResult? processLiveAsrWindow(
+  LiteRtLmAsrRuntimeSession session,
+) {
+  try {
+    return session.processNext();
+  } on LlamaSpeechException catch (error) {
+    if (error.message ==
+            'LiteRT-LM ASR inference failed with native status 9.' &&
+        error.details == _incompleteBpeSequenceDetails) {
+      return null;
+    }
+    rethrow;
+  }
+}
+
+class _IoLiveSpeechTranscriptionService
+    implements LiveSpeechTranscriptionService {
+  _IoLiveSpeechTranscriptionTask? _activeTask;
+  bool _isDisposed = false;
+
+  @override
+  bool get isSupported =>
+      Platform.isAndroid ||
+      Platform.isIOS ||
+      Platform.isMacOS ||
+      Platform.isWindows;
+
+  @override
+  Future<LiveSpeechTranscriptionTask> start({
+    required String modelPath,
+    required String tokenizerPath,
+    required LiteRtLmAsrModelPreset preset,
+  }) async {
+    if (_isDisposed || !isSupported) {
+      throw UnsupportedError(
+        'Live microphone transcription is unavailable on this platform.',
+      );
+    }
+    if (_activeTask != null) {
+      throw StateError('A live transcription task is already active.');
+    }
+    if (!await File(modelPath).exists()) {
+      throw StateError('Live transcription model is not installed.');
+    }
+    if (!await File(tokenizerPath).exists()) {
+      throw StateError('Live transcription tokenizer is not installed.');
+    }
+
+    final recorder = AudioRecorder();
+    _LiveAsrWorkerClient? worker;
+    try {
+      if (!await recorder.hasPermission()) {
+        throw StateError(
+          'Microphone permission was denied. Enable microphone access in '
+          'system settings and try again.',
+        );
+      }
+      if (!await recorder.isEncoderSupported(AudioEncoder.pcm16bits)) {
+        throw UnsupportedError(
+          'PCM16 microphone streaming is unavailable on this device.',
+        );
+      }
+      worker = await _LiveAsrWorkerClient.create(
+        modelPath: modelPath,
+        tokenizerPath: tokenizerPath,
+        preset: preset,
+      );
+      final stream = await recorder.startStream(
+        const RecordConfig(
+          encoder: AudioEncoder.pcm16bits,
+          sampleRate: _sampleRateHz,
+          numChannels: 1,
+          androidConfig: AndroidRecordConfig(manageBluetooth: false),
+        ),
+      );
+      late final _IoLiveSpeechTranscriptionTask task;
+      task = _IoLiveSpeechTranscriptionTask(
+        recorder: recorder,
+        worker: worker,
+        microphoneStream: stream,
+        onClosed: () {
+          if (identical(_activeTask, task)) {
+            _activeTask = null;
+          }
+        },
+      );
+      _activeTask = task;
+      return task;
+    } catch (_) {
+      await recorder.dispose();
+      await worker?.dispose();
+      rethrow;
+    }
+  }
+
+  @override
+  Future<void> dispose() async {
+    if (_isDisposed) {
+      return;
+    }
+    _isDisposed = true;
+    final task = _activeTask;
+    _activeTask = null;
+    await task?.cancel();
+  }
+}
+
+class _IoLiveSpeechTranscriptionTask implements LiveSpeechTranscriptionTask {
+  final AudioRecorder _recorder;
+  final _LiveAsrWorkerClient _worker;
+  final void Function() _onClosed;
+  final StreamController<LiveSpeechTranscriptUpdate> _updates =
+      StreamController<LiveSpeechTranscriptUpdate>();
+  final Completer<LiveSpeechTranscriptionResult> _done =
+      Completer<LiveSpeechTranscriptionResult>();
+
+  StreamSubscription<Uint8List>? _microphoneSubscription;
+  Future<void> _feedTail = Future<void>.value();
+  final Pcm16ByteStreamAligner _pcmAligner = Pcm16ByteStreamAligner();
+  bool _finishing = false;
+  bool _acceptingMicrophoneBytes = true;
+  bool _closed = false;
+  int _acceptedSamples = 0;
+  String _latestConfirmedText = '';
+
+  _IoLiveSpeechTranscriptionTask({
+    required AudioRecorder recorder,
+    required _LiveAsrWorkerClient worker,
+    required Stream<Uint8List> microphoneStream,
+    required void Function() onClosed,
+  }) : _recorder = recorder,
+       _worker = worker,
+       _onClosed = onClosed {
+    _worker.onUpdate = _handleWorkerUpdate;
+    _microphoneSubscription = microphoneStream.listen(
+      _handleMicrophoneBytes,
+      onError: (Object error, StackTrace stackTrace) {
+        unawaited(_fail(error, stackTrace));
+      },
+    );
+  }
+
+  @override
+  Stream<LiveSpeechTranscriptUpdate> get updates => _updates.stream;
+
+  @override
+  Future<LiveSpeechTranscriptionResult> get done => _done.future;
+
+  void _handleMicrophoneBytes(Uint8List bytes) {
+    if (!_acceptingMicrophoneBytes || _closed || bytes.isEmpty) {
+      return;
+    }
+    final alignedBytes = _pcmAligner.add(bytes);
+    if (alignedBytes.isEmpty) {
+      return;
+    }
+    final subscription = _microphoneSubscription;
+    subscription?.pause();
+    _feedTail = _feedTail
+        .then((_) async {
+          if (_closed) {
+            return;
+          }
+          final accepted = await _worker.pushPcm16(alignedBytes);
+          _acceptedSamples += accepted;
+        })
+        .whenComplete(() {
+          if (_acceptingMicrophoneBytes && !_closed) {
+            subscription?.resume();
+          }
+        })
+        .catchError((Object error, StackTrace stackTrace) {
+          unawaited(_fail(error, stackTrace));
+        });
+  }
+
+  void _handleWorkerUpdate(_WorkerTranscriptUpdate update) {
+    if (_closed) {
+      return;
+    }
+    _latestConfirmedText = update.confirmedText;
+    _updates.add(
+      LiveSpeechTranscriptUpdate(
+        confirmedText: update.confirmedText,
+        pendingText: update.pendingText,
+        acceptedAudioDuration: _durationForSamples(update.acceptedSamples),
+        isFinal: update.isFinal,
+      ),
+    );
+  }
+
+  Duration get _acceptedAudioDuration => Duration(
+    microseconds:
+        (_acceptedSamples * Duration.microsecondsPerSecond) ~/ _sampleRateHz,
+  );
+
+  Duration _durationForSamples(int samples) => Duration(
+    microseconds: (samples * Duration.microsecondsPerSecond) ~/ _sampleRateHz,
+  );
+
+  @override
+  Future<void> stop() async {
+    if (_finishing || _closed) {
+      return;
+    }
+    _finishing = true;
+    try {
+      await _recorder.stop();
+      _acceptingMicrophoneBytes = false;
+      await _feedTail;
+      _pcmAligner.finish();
+      await _microphoneSubscription?.cancel();
+      _microphoneSubscription = null;
+      final transcript = await _worker.finish();
+      if (!_closed) {
+        await _complete(transcript);
+      }
+    } catch (error, stackTrace) {
+      await _fail(error, stackTrace);
+    }
+  }
+
+  @override
+  Future<void> cancel() async {
+    if (_closed) {
+      return;
+    }
+    _finishing = true;
+    _acceptingMicrophoneBytes = false;
+    try {
+      await _recorder.cancel();
+    } catch (_) {
+      // Native cancellation remains best effort; worker cleanup still runs.
+    }
+    await _microphoneSubscription?.cancel();
+    _microphoneSubscription = null;
+    try {
+      await _feedTail;
+    } catch (_) {
+      // The task is being cancelled, so a queued feed error is terminal too.
+    }
+    await _worker.cancel();
+    await _close();
+    if (!_done.isCompleted) {
+      _done.completeError(StateError('Live transcription was cancelled.'));
+    }
+  }
+
+  Future<void> _complete(String transcript) async {
+    final normalized = transcript.trim().isEmpty
+        ? _latestConfirmedText.trim()
+        : transcript.trim();
+    final result = LiveSpeechTranscriptionResult(
+      text: normalized,
+      acceptedAudioDuration: _acceptedAudioDuration,
+    );
+    await _close();
+    if (!_done.isCompleted) {
+      _done.complete(result);
+    }
+  }
+
+  Future<void> _fail(Object error, StackTrace stackTrace) async {
+    if (_closed) {
+      return;
+    }
+    _finishing = true;
+    _acceptingMicrophoneBytes = false;
+    try {
+      await _recorder.cancel();
+    } catch (_) {
+      // Best-effort native cleanup.
+    }
+    await _microphoneSubscription?.cancel();
+    _microphoneSubscription = null;
+    await _close();
+    if (!_done.isCompleted) {
+      _done.completeError(error, stackTrace);
+    }
+  }
+
+  Future<void> _close() async {
+    if (_closed) {
+      return;
+    }
+    _closed = true;
+    await _worker.dispose();
+    await _recorder.dispose();
+    unawaited(_updates.close());
+    _onClosed();
+  }
+}
+
+class _WorkerTranscriptUpdate {
+  final String confirmedText;
+  final String pendingText;
+  final bool isFinal;
+  final int acceptedSamples;
+
+  const _WorkerTranscriptUpdate({
+    required this.confirmedText,
+    required this.pendingText,
+    required this.isFinal,
+    required this.acceptedSamples,
+  });
+}
+
+class _LiveAsrWorkerClient {
+  final Isolate _isolate;
+  final ReceivePort _messages;
+  final ReceivePort _errors;
+  final ReceivePort _exits;
+  final Map<int, Completer<Object?>> _pending = <int, Completer<Object?>>{};
+  final Completer<SendPort> _commandPort = Completer<SendPort>();
+  int _nextRequestId = 0;
+  bool _disposed = false;
+
+  void Function(_WorkerTranscriptUpdate update)? onUpdate;
+
+  _LiveAsrWorkerClient._(
+    this._isolate,
+    this._messages,
+    this._errors,
+    this._exits,
+  ) {
+    _messages.listen(_handleMessage);
+    _errors.listen((dynamic message) {
+      final summary = message is List && message.isNotEmpty
+          ? message.first
+          : message;
+      _failPending(
+        LlamaSpeechException('Live transcription worker failed.', summary),
+      );
+    });
+    _exits.listen((dynamic _) {
+      if (!_disposed) {
+        _failPending(StateError('Live transcription worker exited.'));
+      }
+    });
+  }
+
+  static Future<_LiveAsrWorkerClient> create({
+    required String modelPath,
+    required String tokenizerPath,
+    required LiteRtLmAsrModelPreset preset,
+  }) async {
+    final messages = ReceivePort();
+    final errors = ReceivePort();
+    final exits = ReceivePort();
+    final isolate = await Isolate.spawn<SendPort>(
+      _liveAsrWorkerMain,
+      messages.sendPort,
+      errorsAreFatal: true,
+      onError: errors.sendPort,
+      onExit: exits.sendPort,
+      debugName: 'llamadart-live-asr',
+    );
+    final client = _LiveAsrWorkerClient._(isolate, messages, errors, exits);
+    try {
+      await client._request('initialize', <String, Object>{
+        'modelPath': modelPath,
+        'tokenizerPath': tokenizerPath,
+        'preset': preset.index,
+      });
+      return client;
+    } catch (_) {
+      await client.dispose();
+      rethrow;
+    }
+  }
+
+  Future<int> pushPcm16(Uint8List bytes) async {
+    final result = await _request(
+      'push',
+      TransferableTypedData.fromList(<Uint8List>[bytes]),
+    );
+    return result as int;
+  }
+
+  Future<String> finish() async => (await _request('finish', null)) as String;
+
+  Future<void> cancel() async {
+    if (_disposed) {
+      return;
+    }
+    try {
+      await _request('cancel', null);
+    } catch (_) {
+      // Cooperative cancellation remains best effort during worker teardown.
+    }
+  }
+
+  Future<Object?> _request(String command, Object? payload) async {
+    if (_disposed) {
+      throw StateError('Live transcription worker is disposed.');
+    }
+    final port = await _commandPort.future;
+    final id = ++_nextRequestId;
+    final completer = Completer<Object?>();
+    _pending[id] = completer;
+    port.send(<String, Object?>{
+      'id': id,
+      'command': command,
+      'payload': payload,
+    });
+    return completer.future;
+  }
+
+  void _handleMessage(dynamic message) {
+    if (message is! Map) {
+      return;
+    }
+    final kind = message['kind'];
+    if (kind == 'ready') {
+      final port = message['port'];
+      if (port is SendPort && !_commandPort.isCompleted) {
+        _commandPort.complete(port);
+      }
+      return;
+    }
+    if (kind == 'update') {
+      onUpdate?.call(
+        _WorkerTranscriptUpdate(
+          confirmedText: message['confirmedText'] as String? ?? '',
+          pendingText: message['pendingText'] as String? ?? '',
+          isFinal: message['isFinal'] as bool? ?? false,
+          acceptedSamples: message['acceptedSamples'] as int? ?? 0,
+        ),
+      );
+      return;
+    }
+    if (kind != 'response') {
+      return;
+    }
+    final id = message['id'];
+    if (id is! int) {
+      return;
+    }
+    final completer = _pending.remove(id);
+    if (completer == null) {
+      return;
+    }
+    final error = message['error'];
+    if (error != null) {
+      completer.completeError(
+        LlamaSpeechException('Live transcription failed.', error.toString()),
+      );
+    } else {
+      completer.complete(message['result']);
+    }
+  }
+
+  void _failPending(Object error) {
+    if (!_commandPort.isCompleted) {
+      _commandPort.completeError(error);
+    }
+    for (final completer in _pending.values) {
+      if (!completer.isCompleted) {
+        completer.completeError(error);
+      }
+    }
+    _pending.clear();
+  }
+
+  Future<void> dispose() async {
+    if (_disposed) {
+      return;
+    }
+    try {
+      await _request('dispose', null);
+    } catch (_) {
+      // The isolate may already have exited after an error.
+    }
+    _disposed = true;
+    _isolate.kill(priority: Isolate.immediate);
+    _messages.close();
+    _errors.close();
+    _exits.close();
+    _failPending(StateError('Live transcription worker is disposed.'));
+  }
+}
+
+void _liveAsrWorkerMain(SendPort mainPort) {
+  final commands = ReceivePort();
+  mainPort.send(<String, Object>{'kind': 'ready', 'port': commands.sendPort});
+  LiteRtLmRuntimeClient? runtime;
+  LiteRtLmAsrRuntimeSession? session;
+  final confirmed = <String>[];
+  var acceptedSamples = 0;
+
+  void sendUpdate(LiteRtLmAsrProcessResult result) {
+    final value = result.confirmedText.trim();
+    if (value.isNotEmpty) {
+      confirmed.add(value);
+    }
+    mainPort.send(<String, Object>{
+      'kind': 'update',
+      'confirmedText': confirmed.join(' ').trim(),
+      'pendingText': result.unconfirmedText,
+      'isFinal': result.isFinal,
+      'acceptedSamples': acceptedSamples,
+    });
+  }
+
+  LiteRtLmAsrProcessState processAvailable() {
+    final activeSession = session;
+    if (activeSession == null) {
+      throw StateError('Live transcription session is not initialized.');
+    }
+    for (var attempt = 0; attempt < 10000; attempt++) {
+      final result = processLiveAsrWindow(activeSession);
+      if (result == null) {
+        return LiteRtLmAsrProcessState.needsMoreAudio;
+      }
+      if (result.state != LiteRtLmAsrProcessState.update) {
+        return result.state;
+      }
+      sendUpdate(result);
+      if (result.isFinal) {
+        return LiteRtLmAsrProcessState.endOfStream;
+      }
+    }
+    throw StateError('Live transcription processing did not quiesce.');
+  }
+
+  commands.listen((dynamic raw) {
+    if (raw is! Map) {
+      return;
+    }
+    final id = raw['id'];
+    final command = raw['command'];
+    if (id is! int || command is! String) {
+      return;
+    }
+    try {
+      Object? result;
+      switch (command) {
+        case 'initialize':
+          final payload = raw['payload'] as Map;
+          runtime = LiteRtLmRuntimeClient();
+          if (!runtime!.supportsAsrBridge) {
+            throw StateError(
+              'The installed LiteRT-LM runtime does not expose live ASR.',
+            );
+          }
+          final presetIndex = payload['preset'] as int;
+          session = runtime!.createAsrSession(
+            LiteRtLmAsrRuntimeConfig(
+              modelPath: payload['modelPath'] as String,
+              tokenizerPath: payload['tokenizerPath'] as String,
+              modelPreset: LiteRtLmAsrModelPreset.values[presetIndex],
+            ),
+          );
+        case 'push':
+          final transfer = raw['payload'] as TransferableTypedData;
+          final bytes = transfer.materialize().asUint8List();
+          final samples = pcm16BytesToFloat32(bytes);
+          final activeSession = session;
+          if (activeSession == null) {
+            throw StateError('Live transcription session is not initialized.');
+          }
+          var offset = 0;
+          while (offset < samples.length) {
+            final push = activeSession.pushAudio(
+              Float32List.sublistView(samples, offset),
+            );
+            if (push.acceptedSamples == 0 && !push.wouldBlock) {
+              throw StateError(
+                'LiteRT-LM ASR accepted no audio without backpressure.',
+              );
+            }
+            offset += push.acceptedSamples;
+            acceptedSamples += push.acceptedSamples;
+            final state = processAvailable();
+            if (push.wouldBlock &&
+                push.acceptedSamples == 0 &&
+                state == LiteRtLmAsrProcessState.needsMoreAudio) {
+              throw StateError(
+                'LiteRT-LM ASR reported backpressure without processing a window.',
+              );
+            }
+            if (state == LiteRtLmAsrProcessState.endOfStream) {
+              break;
+            }
+          }
+          result = samples.length;
+        case 'finish':
+          final activeSession = session;
+          if (activeSession == null) {
+            throw StateError('Live transcription session is not initialized.');
+          }
+          activeSession.finishAudio();
+          var finalized = false;
+          for (var attempt = 0; attempt < 10000; attempt++) {
+            final update = processLiveAsrWindow(activeSession);
+            if (update == null) {
+              continue;
+            }
+            if (update.state == LiteRtLmAsrProcessState.endOfStream) {
+              finalized = true;
+              break;
+            }
+            if (update.state == LiteRtLmAsrProcessState.needsMoreAudio) {
+              throw StateError(
+                'LiteRT-LM ASR requested audio after finalization.',
+              );
+            }
+            sendUpdate(update);
+            if (update.isFinal) {
+              finalized = true;
+              break;
+            }
+          }
+          if (!finalized) {
+            throw StateError('LiteRT-LM ASR did not produce a final result.');
+          }
+          result = confirmed.join(' ').trim();
+        case 'cancel':
+          session?.cancel();
+        case 'dispose':
+          session?.dispose();
+          session = null;
+          runtime?.dispose();
+          runtime = null;
+        default:
+          throw StateError('Unknown live transcription command: $command');
+      }
+      mainPort.send(<String, Object?>{
+        'kind': 'response',
+        'id': id,
+        'result': result,
+      });
+      if (command == 'dispose') {
+        commands.close();
+      }
+    } catch (error) {
+      mainPort.send(<String, Object?>{
+        'kind': 'response',
+        'id': id,
+        'error': error.toString(),
+      });
+    }
+  });
+}
+
+/// Creates the native live-transcription service.
+LiveSpeechTranscriptionService createLiveSpeechTranscriptionService() =>
+    _IoLiveSpeechTranscriptionService();

--- a/example/chat_app/lib/services/live_speech_transcription_service_io.dart
+++ b/example/chat_app/lib/services/live_speech_transcription_service_io.dart
@@ -605,7 +605,7 @@ void _liveAsrWorkerMain(SendPort mainPort) {
               break;
             }
           }
-          result = samples.length;
+          result = offset;
         case 'finish':
           final activeSession = session;
           if (activeSession == null) {

--- a/example/chat_app/lib/services/live_speech_transcription_service_stub.dart
+++ b/example/chat_app/lib/services/live_speech_transcription_service_stub.dart
@@ -1,0 +1,25 @@
+import 'package:llamadart/llamadart.dart';
+
+import 'live_speech_transcription_service.dart';
+
+class _UnsupportedLiveSpeechTranscriptionService
+    implements LiveSpeechTranscriptionService {
+  @override
+  bool get isSupported => false;
+
+  @override
+  Future<LiveSpeechTranscriptionTask> start({
+    required String modelPath,
+    required String tokenizerPath,
+    required LiteRtLmAsrModelPreset preset,
+  }) {
+    throw UnsupportedError('Live speech transcription is native-only.');
+  }
+
+  @override
+  Future<void> dispose() async {}
+}
+
+/// Creates the unsupported non-IO implementation.
+LiveSpeechTranscriptionService createLiveSpeechTranscriptionService() =>
+    _UnsupportedLiveSpeechTranscriptionService();

--- a/example/chat_app/lib/services/model_service_io.dart
+++ b/example/chat_app/lib/services/model_service_io.dart
@@ -88,6 +88,48 @@ class ModelServiceIO implements ModelService {
     return modelsDir.path;
   }
 
+  /// Resolves the managed-cache path for one native model asset.
+  String resolveManagedAssetPath(String modelsDir, ModelAssetSource source) =>
+      _assetPath(modelsDir, source);
+
+  /// Checks one native model asset using the same integrity and partial-file
+  /// rules as the main model library.
+  Future<bool> isManagedAssetAvailable(
+    String modelsDir,
+    ModelAssetSource source, {
+    required ModelAssetRole role,
+  }) => _isAssetAvailable(modelsDir, source, role: role);
+
+  /// Downloads and verifies one native model asset with resumable transfer
+  /// provenance.
+  Future<void> downloadManagedAsset({
+    required String modelsDir,
+    required RemoteModelAssetSource source,
+    required ModelAssetRole role,
+    required CancelToken cancelToken,
+    required void Function(int downloadedBytes, int? totalBytes, bool resumed)
+    onProgress,
+    void Function()? onVerifying,
+  }) async {
+    if (await _isAssetAvailable(modelsDir, source, role: role)) {
+      final size = await File(_assetPath(modelsDir, source)).length();
+      onProgress(size, source.sizeBytes ?? size, false);
+      return;
+    }
+    await _downloadFileWithResume(
+      source: source,
+      savePath: _assetPath(modelsDir, source),
+      cancelToken: cancelToken,
+      onProgress: onProgress,
+    );
+    onVerifying?.call();
+    await _verifyDownloadedRemoteAsset(modelsDir, source, cancelToken);
+  }
+
+  /// Deletes one managed native model asset and its integrity metadata.
+  Future<void> deleteManagedAsset(String modelsDir, ModelAssetSource source) =>
+      _deleteCachedAsset(modelsDir, source);
+
   Future<String> _defaultModelsDirectory() async {
     if (Platform.isAndroid || Platform.isIOS) {
       final dir = await getApplicationCacheDirectory();

--- a/example/chat_app/lib/services/settings_service.dart
+++ b/example/chat_app/lib/services/settings_service.dart
@@ -22,6 +22,8 @@ class SettingsService {
       'auto_tune_requested_context_size';
   static const _keyThreads = 'threads';
   static const _keyThreadsBatch = 'threads_batch';
+  static const _keyBatchSize = 'batch_size';
+  static const _keyMicroBatchSize = 'micro_batch_size';
   static const _keyLogLevel = 'log_level';
   static const _keyNativeLogLevel = 'native_log_level';
   static const _keyToolsEnabled = 'tools_enabled';
@@ -35,6 +37,8 @@ class SettingsService {
   static const _keyModelSupportsTextToSpeech = 'model_supports_text_to_speech';
   static const _keyDirectMediaInput = 'direct_media_input';
   static const _keyModelBytesHint = 'model_bytes_hint';
+  static const _keyLiveSpeechEnabled = 'live_speech_enabled';
+  static const _keyLiveSpeechModelId = 'live_speech_model_id';
 
   static const Map<String, String> _modelPathMigrations = {
     'https://huggingface.co/unsloth/Qwen3.5-0.8B-GGUF/resolve/main/Qwen3.5-0.8B-UD-Q4_K_XL.gguf?download=true':
@@ -148,6 +152,8 @@ class SettingsService {
           prefs.getInt(_keyAutoTuneRequestedContext) ?? effectiveContextSize,
       numberOfThreads: prefs.getInt(_keyThreads) ?? 0,
       numberOfThreadsBatch: prefs.getInt(_keyThreadsBatch) ?? 0,
+      batchSize: prefs.getInt(_keyBatchSize) ?? 0,
+      microBatchSize: prefs.getInt(_keyMicroBatchSize) ?? 0,
       logLevel: _parseLogLevel(prefs.getInt(_keyLogLevel), LlamaLogLevel.none),
       nativeLogLevel: _parseLogLevel(
         prefs.getInt(_keyNativeLogLevel),
@@ -171,6 +177,30 @@ class SettingsService {
           prefs.getBool(_keyDirectMediaInput) ?? migrateNativeGemma4Audio,
       modelBytesHint: prefs.getInt(_keyModelBytesHint),
     );
+  }
+
+  /// Loads the globally selected live-dictation sidecar identifier.
+  Future<String?> loadLiveSpeechModelId() async {
+    final prefs = await SharedPreferences.getInstance();
+    return prefs.getString(_keyLiveSpeechModelId);
+  }
+
+  /// Loads whether the app-owned live-dictation feature is enabled.
+  Future<bool> loadLiveSpeechEnabled() async {
+    final prefs = await SharedPreferences.getInstance();
+    return prefs.getBool(_keyLiveSpeechEnabled) ?? true;
+  }
+
+  /// Persists whether the app-owned live-dictation feature is enabled.
+  Future<void> saveLiveSpeechEnabled(bool enabled) async {
+    final prefs = await SharedPreferences.getInstance();
+    await prefs.setBool(_keyLiveSpeechEnabled, enabled);
+  }
+
+  /// Persists the globally selected live-dictation sidecar identifier.
+  Future<void> saveLiveSpeechModelId(String modelId) async {
+    final prefs = await SharedPreferences.getInstance();
+    await prefs.setString(_keyLiveSpeechModelId, modelId);
   }
 
   Future<void> saveSettings(ChatSettings settings) async {
@@ -204,6 +234,8 @@ class SettingsService {
     }
     await prefs.setInt(_keyThreads, settings.numberOfThreads);
     await prefs.setInt(_keyThreadsBatch, settings.numberOfThreadsBatch);
+    await prefs.setInt(_keyBatchSize, settings.batchSize);
+    await prefs.setInt(_keyMicroBatchSize, settings.microBatchSize);
     await prefs.setInt(_keyLogLevel, settings.logLevel.index);
     await prefs.setInt(_keyNativeLogLevel, settings.nativeLogLevel.index);
     await prefs.setBool(_keyToolsEnabled, settings.toolsEnabled);

--- a/example/chat_app/lib/widgets/chat_input.dart
+++ b/example/chat_app/lib/widgets/chat_input.dart
@@ -41,6 +41,7 @@ class _ChatInputState extends State<ChatInput> {
   StreamSubscription<void>? _speechCompleteSubscription;
   bool _isPlayingSpeech = false;
   bool _speechPlaybackStopScheduled = false;
+  bool _liveSpeechDraftApplyScheduled = false;
   TextToSpeechResult? _playingSpeechResult;
   String? _textToSpeechLanguage;
   SpeechAudioInput? _speakerReference;
@@ -189,19 +190,33 @@ class _ChatInputState extends State<ChatInput> {
     return false;
   }
 
-  void _insertTextAtSelection(String text) {
+  void _insertTextAtSelection(String text, {bool addBoundarySpacing = false}) {
     final value = widget.controller.value;
     final selection = value.selection.isValid
         ? value.selection
         : TextSelection.collapsed(offset: value.text.length);
+    var insertedText = text;
+    if (addBoundarySpacing && insertedText.isNotEmpty) {
+      final textBefore = value.text.substring(0, selection.start);
+      final textAfter = value.text.substring(selection.end);
+      if (textBefore.isNotEmpty && !RegExp(r'[\s(\[{]$').hasMatch(textBefore)) {
+        insertedText = ' $insertedText';
+      }
+      if (textAfter.isNotEmpty &&
+          !RegExp(r'^[\s.,!?;:)\]}]').hasMatch(textAfter)) {
+        insertedText = '$insertedText ';
+      }
+    }
     final nextText = value.text.replaceRange(
       selection.start,
       selection.end,
-      text,
+      insertedText,
     );
     widget.controller.value = value.copyWith(
       text: nextText,
-      selection: TextSelection.collapsed(offset: selection.start + text.length),
+      selection: TextSelection.collapsed(
+        offset: selection.start + insertedText.length,
+      ),
       composing: TextRange.empty,
     );
   }
@@ -348,6 +363,40 @@ class _ChatInputState extends State<ChatInput> {
     });
   }
 
+  void _synchronizeLiveSpeechDraft(ChatProvider provider) {
+    if (_liveSpeechDraftApplyScheduled ||
+        provider.isLiveTranscribing ||
+        !provider.hasPendingLiveSpeechDraft) {
+      return;
+    }
+    _liveSpeechDraftApplyScheduled = true;
+    WidgetsBinding.instance.addPostFrameCallback((_) {
+      _liveSpeechDraftApplyScheduled = false;
+      if (!mounted) {
+        return;
+      }
+      final draft = context.read<ChatProvider>().takeLiveSpeechDraft();
+      if (draft == null || draft.trim().isEmpty) {
+        return;
+      }
+      _insertTextAtSelection(draft.trim(), addBoundarySpacing: true);
+      widget.focusNode.requestFocus();
+    });
+  }
+
+  Future<void> _stopLiveSpeechTranscription(ChatProvider provider) async {
+    await provider.stopLiveSpeechTranscription();
+    if (!mounted) {
+      return;
+    }
+    final draft = provider.takeLiveSpeechDraft();
+    if (draft == null || draft.trim().isEmpty) {
+      return;
+    }
+    _insertTextAtSelection(draft.trim(), addBoundarySpacing: true);
+    widget.focusNode.requestFocus();
+  }
+
   Future<void> _clearSynthesizedSpeech(ChatProvider provider) async {
     if (_isPlayingSpeech) {
       await _stopSynthesizedSpeechPlayback();
@@ -377,14 +426,17 @@ class _ChatInputState extends State<ChatInput> {
     return Consumer<ChatProvider>(
       builder: (context, provider, _) {
         _synchronizeSynthesizedSpeechPlayback(provider.textToSpeechResult);
+        _synchronizeLiveSpeechDraft(provider);
         final isGenerating = provider.isGenerating;
         final hasActiveAudioRecording = provider.hasActiveAudioRecording;
+        final hasActiveMicrophone =
+            hasActiveAudioRecording || provider.isLiveTranscribing;
         final isReady = provider.isReady;
         final stagedParts = provider.stagedParts;
         final hasAttachments = stagedParts.isNotEmpty;
         final canSubmit =
             !isGenerating &&
-            !hasActiveAudioRecording &&
+            !hasActiveMicrophone &&
             isReady &&
             (provider.supportsTextToSpeech
                 ? _hasDraftText && provider.canSynthesizeSpeech
@@ -412,6 +464,13 @@ class _ChatInputState extends State<ChatInput> {
         final VoidCallback? startAudioRecordingAction =
             provider.canStartAudioRecording
             ? () => unawaited(provider.startAudioRecording())
+            : null;
+        final showsLiveSpeechAction =
+            provider.supportsLiveSpeechTranscription &&
+            provider.isLiveSpeechModelReady;
+        final VoidCallback? startLiveSpeechAction =
+            provider.canStartLiveSpeechTranscription
+            ? () => unawaited(provider.startLiveSpeechTranscription())
             : null;
         final shortcutBindings = <ShortcutActivator, VoidCallback>{
           const SingleActivator(
@@ -460,7 +519,7 @@ class _ChatInputState extends State<ChatInput> {
           },
         };
 
-        return Container(
+        final input = Container(
           padding: EdgeInsets.fromLTRB(
             isDesktop ? 22 : 12,
             10,
@@ -496,6 +555,20 @@ class _ChatInputState extends State<ChatInput> {
                       _buildTextToSpeechOutput(context, provider),
                       const SizedBox(height: 8),
                     ],
+                    if (provider.supportsLiveSpeechTranscription &&
+                        provider.isLoaded &&
+                        !provider.isLiveTranscribing &&
+                        !provider.isInstallingLiveSpeechModel &&
+                        provider.liveSpeechError == null) ...[
+                      _buildLiveSpeechSetupRow(context, provider),
+                      const SizedBox(height: 8),
+                    ],
+                    if (provider.isLiveTranscribing ||
+                        provider.isInstallingLiveSpeechModel ||
+                        provider.liveSpeechError != null) ...[
+                      _buildLiveSpeechRow(context, provider),
+                      const SizedBox(height: 8),
+                    ],
                     if (hasActiveAudioRecording) ...[
                       _buildAudioRecordingRow(context, provider),
                       const SizedBox(height: 8),
@@ -505,13 +578,13 @@ class _ChatInputState extends State<ChatInput> {
                     Row(
                       crossAxisAlignment: CrossAxisAlignment.end,
                       children: [
-                        if (provider.canAttachMedia && !hasActiveAudioRecording)
+                        if (provider.canAttachMedia && !hasActiveMicrophone)
                           _buildAttachmentMenu(context, provider),
                         if (provider.supportsMicrophoneRecording)
                           Semantics(
                             label: microphoneActionLabel,
                             button: true,
-                            enabled: provider.canStartAudioRecording,
+                            enabled: startAudioRecordingAction != null,
                             onTap: startAudioRecordingAction,
                             excludeSemantics: true,
                             child: IconButton(
@@ -525,7 +598,26 @@ class _ChatInputState extends State<ChatInput> {
                               onPressed: startAudioRecordingAction,
                               icon: Icon(
                                 Icons.mic_none_rounded,
-                                color: provider.canStartAudioRecording
+                                color: startAudioRecordingAction != null
+                                    ? colorScheme.primary
+                                    : null,
+                              ),
+                            ),
+                          ),
+                        if (showsLiveSpeechAction)
+                          Semantics(
+                            label: 'Start live transcription.',
+                            button: true,
+                            enabled: startLiveSpeechAction != null,
+                            onTap: startLiveSpeechAction,
+                            excludeSemantics: true,
+                            child: IconButton(
+                              key: const ValueKey<String>('live_speech_button'),
+                              tooltip: 'Live transcription',
+                              onPressed: startLiveSpeechAction,
+                              icon: Icon(
+                                Icons.graphic_eq_rounded,
+                                color: startLiveSpeechAction != null
                                     ? colorScheme.primary
                                     : null,
                               ),
@@ -537,7 +629,7 @@ class _ChatInputState extends State<ChatInput> {
                             child: TextField(
                               controller: widget.controller,
                               focusNode: widget.focusNode,
-                              enabled: isReady && !hasActiveAudioRecording,
+                              enabled: isReady && !hasActiveMicrophone,
                               maxLines: 6,
                               minLines: 1,
                               textCapitalization: TextCapitalization.sentences,
@@ -610,6 +702,20 @@ class _ChatInputState extends State<ChatInput> {
               ),
             ),
           ),
+        );
+        final viewInsets = MediaQuery.viewInsetsOf(context);
+        if (viewInsets.bottom <= 0) {
+          return input;
+        }
+        final availableHeight =
+            MediaQuery.sizeOf(context).height - viewInsets.bottom;
+        final proportionalHeight = availableHeight * 0.72;
+        final maxInputHeight = proportionalHeight > 560
+            ? 560.0
+            : proportionalHeight;
+        return ConstrainedBox(
+          constraints: BoxConstraints(maxHeight: maxInputHeight),
+          child: SingleChildScrollView(reverse: true, child: input),
         );
       },
     );
@@ -1019,6 +1125,286 @@ class _ChatInputState extends State<ChatInput> {
             ),
           ),
       ],
+    );
+  }
+
+  Widget _buildLiveSpeechSetupRow(BuildContext context, ChatProvider provider) {
+    final colorScheme = Theme.of(context).colorScheme;
+    final selected = provider.selectedLiveSpeechModel;
+    return Container(
+      key: const ValueKey<String>('live_speech_setup'),
+      padding: const EdgeInsets.symmetric(horizontal: 14, vertical: 10),
+      decoration: BoxDecoration(
+        color: colorScheme.surfaceContainerHighest,
+        borderRadius: BorderRadius.circular(14),
+      ),
+      child: Column(
+        mainAxisSize: MainAxisSize.min,
+        children: [
+          Row(
+            children: [
+              Icon(Icons.subtitles_rounded, color: colorScheme.primary),
+              const SizedBox(width: 10),
+              Expanded(
+                child: Column(
+                  crossAxisAlignment: CrossAxisAlignment.start,
+                  children: [
+                    Text(
+                      selected.name,
+                      maxLines: 1,
+                      overflow: TextOverflow.ellipsis,
+                    ),
+                    Text(
+                      '${selected.sizeLabel} · English'
+                      '${provider.isLiveSpeechModelReady ? ' · Installed' : ''}',
+                      style: Theme.of(context).textTheme.bodySmall?.copyWith(
+                        color: colorScheme.onSurfaceVariant,
+                      ),
+                    ),
+                  ],
+                ),
+              ),
+              PopupMenuButton<String>(
+                key: const ValueKey<String>('live_speech_model_selector'),
+                tooltip: 'Choose live transcription model',
+                enabled:
+                    !provider.isInspectingLiveSpeechModel &&
+                    !provider.isInstallingLiveSpeechModel,
+                initialValue: selected.id,
+                onSelected: (modelId) =>
+                    unawaited(provider.selectLiveSpeechModel(modelId)),
+                itemBuilder: (context) => provider.availableLiveSpeechModels
+                    .map(
+                      (model) => PopupMenuItem<String>(
+                        value: model.id,
+                        child: ListTile(
+                          contentPadding: EdgeInsets.zero,
+                          title: Text(model.name),
+                          subtitle: Text(
+                            '${model.sizeLabel}'
+                            '${model.isRecommended ? ' · Recommended' : ' · Heavier'}',
+                          ),
+                        ),
+                      ),
+                    )
+                    .toList(growable: false),
+                icon: const Icon(Icons.expand_more_rounded),
+              ),
+              if (provider.isInspectingLiveSpeechModel)
+                const Padding(
+                  padding: EdgeInsets.all(10),
+                  child: SizedBox.square(
+                    dimension: 18,
+                    child: CircularProgressIndicator(strokeWidth: 2),
+                  ),
+                )
+              else if (!provider.isLiveSpeechModelReady)
+                TextButton(
+                  key: const ValueKey<String>('install_live_speech_button'),
+                  onPressed: provider.canInstallLiveSpeechModel
+                      ? () => unawaited(provider.installLiveSpeechModel())
+                      : null,
+                  child: const Text('Install'),
+                ),
+            ],
+          ),
+        ],
+      ),
+    );
+  }
+
+  Widget _buildLiveSpeechRow(BuildContext context, ChatProvider provider) {
+    final colorScheme = Theme.of(context).colorScheme;
+    if (provider.isInstallingLiveSpeechModel) {
+      final percent = (provider.liveSpeechModelDownloadProgress * 100).round();
+      final isVerifying = provider.isVerifyingLiveSpeechModel;
+      return Semantics(
+        liveRegion: true,
+        label: isVerifying
+            ? 'Verifying live transcription model integrity'
+            : 'Installing live transcription model, $percent percent',
+        child: Container(
+          key: const ValueKey<String>('live_speech_model_installing'),
+          padding: const EdgeInsets.symmetric(horizontal: 14, vertical: 12),
+          decoration: BoxDecoration(
+            color: colorScheme.surfaceContainerHighest,
+            borderRadius: BorderRadius.circular(14),
+          ),
+          child: Column(
+            mainAxisSize: MainAxisSize.min,
+            children: [
+              Row(
+                children: [
+                  const SizedBox.square(
+                    dimension: 20,
+                    child: CircularProgressIndicator(strokeWidth: 2),
+                  ),
+                  const SizedBox(width: 12),
+                  Expanded(
+                    child: Text(
+                      isVerifying
+                          ? 'Verifying ${provider.selectedLiveSpeechModel.name}…'
+                          : 'Installing '
+                                '${provider.selectedLiveSpeechModel.name} · '
+                                '$percent%',
+                    ),
+                  ),
+                  IconButton(
+                    key: const ValueKey<String>(
+                      'cancel_live_speech_model_install_button',
+                    ),
+                    tooltip: 'Cancel live transcription model download',
+                    onPressed: provider.cancelLiveSpeechModelInstall,
+                    icon: const Icon(Icons.close_rounded),
+                  ),
+                ],
+              ),
+              const SizedBox(height: 8),
+              LinearProgressIndicator(
+                value: provider.liveSpeechModelDownloadProgress,
+              ),
+            ],
+          ),
+        ),
+      );
+    }
+
+    if (provider.isLiveTranscribing) {
+      final transcript = provider.liveSpeechDisplayText;
+      return Container(
+        key: const ValueKey<String>('live_speech_transcription_status'),
+        padding: const EdgeInsets.fromLTRB(14, 10, 8, 10),
+        decoration: BoxDecoration(
+          color: colorScheme.primaryContainer.withValues(alpha: 0.38),
+          borderRadius: BorderRadius.circular(14),
+          border: Border.all(
+            color: colorScheme.primary.withValues(alpha: 0.42),
+          ),
+        ),
+        child: LayoutBuilder(
+          builder: (context, constraints) {
+            Widget buildTranscript() => Row(
+              crossAxisAlignment: CrossAxisAlignment.center,
+              children: [
+                Icon(Icons.graphic_eq_rounded, color: colorScheme.primary),
+                const SizedBox(width: 10),
+                Expanded(
+                  child: Column(
+                    crossAxisAlignment: CrossAxisAlignment.start,
+                    children: [
+                      Text(
+                        'Live transcription · '
+                        '${_formatRecordingDuration(provider.liveSpeechAcceptedAudioDuration)} '
+                        '/ ${_formatRecordingDuration(ChatProvider.maxLiveSpeechTranscriptionDuration)}',
+                        style: Theme.of(context).textTheme.labelLarge,
+                      ),
+                      const SizedBox(height: 2),
+                      Text(
+                        transcript.isEmpty ? 'Listening…' : transcript,
+                        maxLines: 3,
+                        overflow: TextOverflow.ellipsis,
+                        style: Theme.of(context).textTheme.bodyMedium?.copyWith(
+                          color: transcript.isEmpty
+                              ? colorScheme.onSurfaceVariant
+                              : colorScheme.onSurface,
+                        ),
+                      ),
+                    ],
+                  ),
+                ),
+              ],
+            );
+
+            Widget buildActions() => Row(
+              mainAxisSize: MainAxisSize.min,
+              children: [
+                IconButton(
+                  key: const ValueKey<String>('cancel_live_speech_button'),
+                  tooltip: 'Cancel live transcription',
+                  onPressed: () =>
+                      unawaited(provider.cancelLiveSpeechTranscription()),
+                  icon: const Icon(Icons.close_rounded),
+                ),
+                FilledButton.tonalIcon(
+                  key: const ValueKey<String>('stop_live_speech_button'),
+                  onPressed: () =>
+                      unawaited(_stopLiveSpeechTranscription(provider)),
+                  icon: const Icon(Icons.stop_rounded, size: 18),
+                  label: const Text('Use text'),
+                ),
+              ],
+            );
+
+            if (constraints.maxWidth < 520) {
+              return Column(
+                crossAxisAlignment: CrossAxisAlignment.stretch,
+                children: [
+                  buildTranscript(),
+                  const SizedBox(height: 6),
+                  Align(
+                    alignment: Alignment.centerRight,
+                    child: buildActions(),
+                  ),
+                ],
+              );
+            }
+            return Row(
+              crossAxisAlignment: CrossAxisAlignment.center,
+              children: [
+                Expanded(child: buildTranscript()),
+                buildActions(),
+              ],
+            );
+          },
+        ),
+      );
+    }
+
+    return Container(
+      key: const ValueKey<String>('live_speech_error'),
+      padding: const EdgeInsets.symmetric(horizontal: 14, vertical: 10),
+      decoration: BoxDecoration(
+        color: colorScheme.errorContainer,
+        borderRadius: BorderRadius.circular(14),
+      ),
+      child: Row(
+        children: [
+          Icon(
+            Icons.error_outline_rounded,
+            color: colorScheme.onErrorContainer,
+          ),
+          const SizedBox(width: 10),
+          Expanded(
+            child: Text(
+              provider.liveSpeechError ?? 'Live transcription failed.',
+              style: TextStyle(color: colorScheme.onErrorContainer),
+            ),
+          ),
+          PopupMenuButton<String>(
+            key: const ValueKey<String>('live_speech_error_model_selector'),
+            tooltip: 'Choose a different live transcription model',
+            onSelected: (modelId) =>
+                unawaited(provider.selectLiveSpeechModel(modelId)),
+            itemBuilder: (context) => provider.availableLiveSpeechModels
+                .map(
+                  (model) => PopupMenuItem<String>(
+                    value: model.id,
+                    child: Text('${model.name} · ${model.sizeLabel}'),
+                  ),
+                )
+                .toList(growable: false),
+            icon: const Icon(Icons.swap_horiz_rounded),
+          ),
+          if (provider.canInstallLiveSpeechModel)
+            TextButton(
+              key: const ValueKey<String>(
+                'retry_live_speech_model_install_button',
+              ),
+              onPressed: () => unawaited(provider.installLiveSpeechModel()),
+              child: const Text('Retry'),
+            ),
+        ],
+      ),
     );
   }
 

--- a/example/chat_app/test/app_shell_screen_test.dart
+++ b/example/chat_app/test/app_shell_screen_test.dart
@@ -1,13 +1,18 @@
+import 'package:dio/dio.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
-import 'package:llamadart/llamadart.dart' show GpuBackend;
+import 'package:llamadart/llamadart.dart'
+    show GpuBackend, LiteRtLmAsrModelPreset;
 import 'package:provider/provider.dart';
 
 import 'package:llamadart_chat_example/models/chat_settings.dart';
 import 'package:llamadart_chat_example/models/downloadable_model.dart';
+import 'package:llamadart_chat_example/models/live_speech_model.dart';
 import 'package:llamadart_chat_example/providers/chat_provider.dart';
 import 'package:llamadart_chat_example/screens/app_shell_screen.dart';
 import 'package:llamadart_chat_example/screens/manage_models_screen.dart';
+import 'package:llamadart_chat_example/services/live_speech_model_service.dart';
+import 'package:llamadart_chat_example/services/live_speech_transcription_service.dart';
 import 'package:llamadart_chat_example/services/model_download_ui_controller.dart';
 
 import 'mocks.dart';
@@ -163,6 +168,9 @@ void main() {
       final provider = ChatProvider(
         chatService: MockChatService(),
         settingsService: MockSettingsService(),
+        liveSpeechModelService: _SupportedLiveSpeechModelService(),
+        liveSpeechTranscriptionService:
+            _SupportedLiveSpeechTranscriptionService(),
         initialSettings: const ChatSettings(
           modelPath: 'test_model.gguf',
           gpuLayers: 99,
@@ -196,7 +204,21 @@ void main() {
 
       await tester.tap(find.text('Model parameters'));
       await tester.pumpAndSettle();
+      expect(find.text('Live dictation'), findsOneWidget);
+      expect(
+        find.textContaining('Nothing is sent until you tap Send'),
+        findsOneWidget,
+      );
+      expect(provider.liveSpeechEnabled, isTrue);
+      await tester.tap(
+        find.byKey(const ValueKey<String>('live_speech_enabled_switch')),
+      );
+      await tester.pumpAndSettle();
+      expect(provider.liveSpeechEnabled, isFalse);
+
       expect(find.text('Auto · Max'), findsOneWidget);
+      expect(find.text('Batch size (n_batch)'), findsOneWidget);
+      expect(find.text('Micro-batch size (n_ubatch)'), findsOneWidget);
       expect(
         find.textContaining(
           'Auto tuning recalculates GPU layers and context headroom',
@@ -233,6 +255,52 @@ void main() {
         findsOneWidget,
       );
       await tester.pump(const Duration(milliseconds: 300));
+    });
+
+    testWidgets('disables llama.cpp batch controls for LiteRT-LM models', (
+      tester,
+    ) async {
+      tester.view
+        ..physicalSize = const Size(1440, 920)
+        ..devicePixelRatio = 1.0;
+      addTearDown(tester.view.resetPhysicalSize);
+      addTearDown(tester.view.resetDevicePixelRatio);
+
+      final provider = ChatProvider(
+        chatService: MockChatService(),
+        settingsService: MockSettingsService(),
+        initialSettings: const ChatSettings(modelPath: 'test_model.litertlm'),
+      );
+      addTearDown(provider.dispose);
+
+      await tester.pumpWidget(
+        ChangeNotifierProvider<ChatProvider>.value(
+          value: provider,
+          child: const MaterialApp(home: AppShellScreen()),
+        ),
+      );
+      await tester.pumpAndSettle();
+      await tester.tap(
+        find.byTooltip('Open model and inference settings').first,
+      );
+      await tester.pumpAndSettle();
+      await tester.tap(find.text('Model parameters'));
+      await tester.pumpAndSettle();
+
+      final batchControls = tester.widgetList<DropdownButtonFormField<int>>(
+        find.byWidgetPredicate(
+          (widget) =>
+              widget is DropdownButtonFormField<int> &&
+              (widget.decoration.labelText == 'Batch size (n_batch)' ||
+                  widget.decoration.labelText == 'Micro-batch size (n_ubatch)'),
+        ),
+      );
+      expect(batchControls, hasLength(2));
+      expect(
+        batchControls.every((control) => control.onChanged == null),
+        isTrue,
+      );
+      expect(find.text('Not used by LiteRT-LM'), findsNWidgets(2));
     });
 
     testWidgets('shows change model action when settings panel is hidden', (
@@ -475,6 +543,42 @@ void main() {
       expect(provider.conversations, hasLength(1));
     });
   });
+}
+
+class _SupportedLiveSpeechModelService implements LiveSpeechModelService {
+  @override
+  bool get isSupported => true;
+
+  @override
+  Future<InstalledLiveSpeechModel?> resolve(LiveSpeechModel model) async =>
+      null;
+
+  @override
+  Future<InstalledLiveSpeechModel> install(
+    LiveSpeechModel model, {
+    required CancelToken cancelToken,
+    required void Function(double progress) onProgress,
+    required void Function() onVerifying,
+  }) => throw UnimplementedError();
+
+  @override
+  Future<void> delete(LiveSpeechModel model) async {}
+}
+
+class _SupportedLiveSpeechTranscriptionService
+    implements LiveSpeechTranscriptionService {
+  @override
+  bool get isSupported => true;
+
+  @override
+  Future<LiveSpeechTranscriptionTask> start({
+    required String modelPath,
+    required String tokenizerPath,
+    required LiteRtLmAsrModelPreset preset,
+  }) => throw UnimplementedError();
+
+  @override
+  Future<void> dispose() async {}
 }
 
 Future<void> _pumpUntil(WidgetTester tester, bool Function() condition) async {

--- a/example/chat_app/test/chat_input_test.dart
+++ b/example/chat_app/test/chat_input_test.dart
@@ -1,13 +1,17 @@
 import 'dart:async';
 import 'dart:typed_data';
 
+import 'package:dio/dio.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:llamadart/llamadart.dart';
 import 'package:llamadart_chat_example/models/chat_settings.dart';
+import 'package:llamadart_chat_example/models/live_speech_model.dart';
 import 'package:llamadart_chat_example/providers/chat_provider.dart';
 import 'package:llamadart_chat_example/services/audio_recording_service.dart';
 import 'package:llamadart_chat_example/services/chat_generation_service.dart';
+import 'package:llamadart_chat_example/services/live_speech_model_service.dart';
+import 'package:llamadart_chat_example/services/live_speech_transcription_service.dart';
 import 'package:llamadart_chat_example/services/speech_playback_service.dart';
 import 'package:llamadart_chat_example/widgets/chat_input.dart';
 import 'package:provider/provider.dart';
@@ -47,6 +51,615 @@ void main() {
 
     await tester.enterText(find.byType(TextField), 'draft next prompt');
     expect(controller.text, 'draft next prompt');
+  });
+
+  testWidgets('live LiteRT transcription becomes an editable composer draft', (
+    tester,
+  ) async {
+    final liveTask = _FakeLiveSpeechTranscriptionTask(
+      finalText: 'hello from live speech',
+    );
+    final liveService = _FakeLiveSpeechTranscriptionService(task: liveTask);
+    final provider = ChatProvider(
+      chatService: MockChatService(),
+      settingsService: MockSettingsService(),
+      audioRecordingService: _FakeAudioRecordingService(),
+      liveSpeechModelService: _FakeLiveSpeechModelService(installed: true),
+      liveSpeechTranscriptionService: liveService,
+      initialSettings: const ChatSettings(modelPath: 'chat-model.gguf'),
+    );
+    addTearDown(provider.dispose);
+    await provider.loadModel();
+    await provider.refreshLiveSpeechModel();
+
+    final controller = TextEditingController(text: 'existing draft')
+      ..selection = const TextSelection.collapsed(offset: 14);
+    final focusNode = FocusNode();
+    addTearDown(controller.dispose);
+    addTearDown(focusNode.dispose);
+
+    await tester.pumpWidget(
+      ChangeNotifierProvider<ChatProvider>.value(
+        value: provider,
+        child: MaterialApp(
+          home: Scaffold(
+            body: ChatInput(
+              controller: controller,
+              focusNode: focusNode,
+              onSend: () {},
+            ),
+          ),
+        ),
+      ),
+    );
+
+    expect(find.byTooltip('Live transcription'), findsOneWidget);
+    await tester.tap(find.byTooltip('Live transcription'));
+    await tester.pump();
+    expect(liveService.startCalls, 1);
+
+    liveTask.emit(
+      const LiveSpeechTranscriptUpdate(
+        confirmedText: 'hello from',
+        pendingText: 'live',
+        acceptedAudioDuration: Duration(seconds: 5),
+        isFinal: false,
+      ),
+    );
+    await tester.pump();
+    expect(find.text('hello from live'), findsOneWidget);
+
+    await tester.tap(
+      find.byKey(const ValueKey<String>('stop_live_speech_button')),
+    );
+    for (var index = 0; index < 20 && provider.isLiveTranscribing; index++) {
+      await tester.pump(const Duration(milliseconds: 10));
+    }
+    await tester.pumpAndSettle();
+    expect(controller.text, 'existing draft hello from live speech');
+    expect(provider.isLiveTranscribing, isFalse);
+  });
+
+  testWidgets('live dictation preference hides composer controls', (
+    tester,
+  ) async {
+    final settingsService = MockSettingsService();
+    final provider = ChatProvider(
+      chatService: MockChatService(),
+      settingsService: settingsService,
+      audioRecordingService: _FakeAudioRecordingService(),
+      liveSpeechModelService: _FakeLiveSpeechModelService(installed: true),
+      liveSpeechTranscriptionService: _FakeLiveSpeechTranscriptionService(
+        task: _FakeLiveSpeechTranscriptionTask(finalText: 'unused'),
+      ),
+      initialSettings: const ChatSettings(modelPath: 'chat-model.gguf'),
+    );
+    addTearDown(provider.dispose);
+    await provider.loadModel();
+    await provider.refreshLiveSpeechModel();
+
+    final controller = TextEditingController();
+    final focusNode = FocusNode();
+    addTearDown(controller.dispose);
+    addTearDown(focusNode.dispose);
+    await tester.pumpWidget(
+      ChangeNotifierProvider<ChatProvider>.value(
+        value: provider,
+        child: MaterialApp(
+          home: Scaffold(
+            body: ChatInput(
+              controller: controller,
+              focusNode: focusNode,
+              onSend: () {},
+            ),
+          ),
+        ),
+      ),
+    );
+    expect(find.byTooltip('Live transcription'), findsOneWidget);
+    await provider.updateLiveSpeechEnabled(false);
+    await tester.pump();
+
+    expect(settingsService.liveSpeechEnabled, isFalse);
+    expect(provider.supportsLiveSpeechTranscription, isFalse);
+    expect(find.byTooltip('Live transcription'), findsNothing);
+
+    await provider
+        .updateLiveSpeechEnabled(true)
+        .timeout(const Duration(seconds: 2));
+    await tester.pump();
+    expect(settingsService.liveSpeechEnabled, isTrue);
+    expect(find.byTooltip('Live transcription'), findsOneWidget);
+    await tester.pump(const Duration(milliseconds: 300));
+  });
+
+  test('disabling live dictation cancels an active capture', () async {
+    final liveTask = _FakeLiveSpeechTranscriptionTask(finalText: 'unused');
+    final settingsService = MockSettingsService();
+    final provider = ChatProvider(
+      chatService: MockChatService(),
+      settingsService: settingsService,
+      audioRecordingService: _FakeAudioRecordingService(),
+      liveSpeechModelService: _FakeLiveSpeechModelService(installed: true),
+      liveSpeechTranscriptionService: _FakeLiveSpeechTranscriptionService(
+        task: liveTask,
+      ),
+      initialSettings: const ChatSettings(modelPath: 'chat-model.gguf'),
+    );
+    addTearDown(provider.dispose);
+    await provider.loadModel();
+    await provider.refreshLiveSpeechModel();
+    await provider.startLiveSpeechTranscription();
+
+    await provider.updateLiveSpeechEnabled(false);
+
+    expect(liveTask.cancelCalls, 1);
+    expect(provider.isLiveTranscribing, isFalse);
+    expect(provider.supportsLiveSpeechTranscription, isFalse);
+    expect(settingsService.liveSpeechEnabled, isFalse);
+  });
+
+  testWidgets('live transcription controls fit a narrow mobile composer', (
+    tester,
+  ) async {
+    tester.view.physicalSize = const Size(320, 800);
+    tester.view.devicePixelRatio = 1;
+    tester.view.viewInsets = const FakeViewPadding(bottom: 400);
+    addTearDown(tester.view.resetPhysicalSize);
+    addTearDown(tester.view.resetDevicePixelRatio);
+    addTearDown(tester.view.resetViewInsets);
+
+    final liveTask = _FakeLiveSpeechTranscriptionTask(finalText: 'mobile');
+    final provider = ChatProvider(
+      chatService: MockChatService(),
+      settingsService: MockSettingsService(),
+      audioRecordingService: _FakeAudioRecordingService(),
+      liveSpeechModelService: _FakeLiveSpeechModelService(installed: true),
+      liveSpeechTranscriptionService: _FakeLiveSpeechTranscriptionService(
+        task: liveTask,
+      ),
+      initialSettings: const ChatSettings(modelPath: 'chat-model.gguf'),
+    );
+    addTearDown(provider.dispose);
+    await provider.loadModel();
+    await provider.refreshLiveSpeechModel();
+    await provider.startLiveSpeechTranscription();
+    liveTask.emit(
+      const LiveSpeechTranscriptUpdate(
+        confirmedText: 'narrow screen transcript',
+        pendingText: '',
+        acceptedAudioDuration: Duration(seconds: 5),
+        isFinal: false,
+      ),
+    );
+
+    final controller = TextEditingController(
+      text: List<String>.filled(30, 'editable').join(' '),
+    );
+    final focusNode = FocusNode();
+    addTearDown(controller.dispose);
+    addTearDown(focusNode.dispose);
+    await tester.pumpWidget(
+      ChangeNotifierProvider<ChatProvider>.value(
+        value: provider,
+        child: MaterialApp(
+          home: Scaffold(
+            body: ChatInput(
+              controller: controller,
+              focusNode: focusNode,
+              onSend: () {},
+            ),
+          ),
+        ),
+      ),
+    );
+    await tester.pump(const Duration(milliseconds: 300));
+
+    expect(find.text('narrow screen transcript'), findsOneWidget);
+    expect(
+      find.byKey(const ValueKey<String>('cancel_live_speech_button')),
+      findsOneWidget,
+    );
+    expect(
+      find.byKey(const ValueKey<String>('stop_live_speech_button')),
+      findsOneWidget,
+    );
+    expect(tester.takeException(), isNull);
+  });
+
+  test('first live transcription use installs both sidecar assets', () async {
+    final modelService = _FakeLiveSpeechModelService(installed: false);
+    final liveTask = _FakeLiveSpeechTranscriptionTask(finalText: 'installed');
+    final liveService = _FakeLiveSpeechTranscriptionService(task: liveTask);
+    final provider = ChatProvider(
+      chatService: MockChatService(),
+      settingsService: MockSettingsService(),
+      audioRecordingService: _FakeAudioRecordingService(),
+      liveSpeechModelService: modelService,
+      liveSpeechTranscriptionService: liveService,
+      initialSettings: const ChatSettings(modelPath: 'chat-model.gguf'),
+    );
+    addTearDown(provider.dispose);
+    await provider.loadModel();
+    await provider.refreshLiveSpeechModel();
+
+    expect(provider.isLiveSpeechModelReady, isFalse);
+    await provider.startLiveSpeechTranscription();
+
+    expect(modelService.installCalls, 1);
+    expect(provider.isLiveSpeechModelReady, isTrue);
+    expect(liveService.startCalls, 1);
+    await provider.cancelLiveSpeechTranscription();
+  });
+
+  testWidgets(
+    'live dictation selector shows model size and explicit download progress',
+    (tester) async {
+      final installGate = Completer<void>();
+      final verificationGate = Completer<void>();
+      final modelService = _FakeLiveSpeechModelService(
+        installed: false,
+        installGate: installGate,
+        verificationGate: verificationGate,
+      );
+      final settingsService = MockSettingsService();
+      final provider = ChatProvider(
+        chatService: MockChatService(),
+        settingsService: settingsService,
+        audioRecordingService: _FakeAudioRecordingService(),
+        liveSpeechModelService: modelService,
+        liveSpeechTranscriptionService: _FakeLiveSpeechTranscriptionService(
+          task: _FakeLiveSpeechTranscriptionTask(finalText: 'unused'),
+        ),
+        initialSettings: const ChatSettings(modelPath: 'chat-model.gguf'),
+      );
+      addTearDown(provider.dispose);
+      await provider.loadModel();
+      await provider.refreshLiveSpeechModel();
+
+      final controller = TextEditingController();
+      final focusNode = FocusNode();
+      addTearDown(controller.dispose);
+      addTearDown(focusNode.dispose);
+      await tester.pumpWidget(
+        ChangeNotifierProvider<ChatProvider>.value(
+          value: provider,
+          child: MaterialApp(
+            home: Scaffold(
+              body: ChatInput(
+                controller: controller,
+                focusNode: focusNode,
+                onSend: () {},
+              ),
+            ),
+          ),
+        ),
+      );
+
+      expect(find.text('Moonshine Tiny Live STT'), findsOneWidget);
+      expect(find.text('54 MB · English'), findsOneWidget);
+      await tester.tap(
+        find.byKey(const ValueKey<String>('live_speech_model_selector')),
+      );
+      await tester.pumpAndSettle();
+      await tester.tap(find.text('Parakeet TDT 0.6B Live STT').last);
+      await tester.pumpAndSettle();
+
+      expect(provider.selectedLiveSpeechModel, LiveSpeechModel.parakeetTdt);
+      expect(settingsService.liveSpeechModelId, LiveSpeechModel.parakeetTdt.id);
+      expect(find.text('615 MB · English'), findsOneWidget);
+
+      await tester.tap(
+        find.byKey(const ValueKey<String>('install_live_speech_button')),
+      );
+      await tester.pump();
+      expect(
+        find.text('Installing Parakeet TDT 0.6B Live STT · 50%'),
+        findsOneWidget,
+      );
+      expect(find.byType(LinearProgressIndicator), findsOneWidget);
+      expect(
+        find.byKey(
+          const ValueKey<String>('cancel_live_speech_model_install_button'),
+        ),
+        findsOneWidget,
+      );
+
+      installGate.complete();
+      await tester.pump();
+      expect(
+        find.text('Verifying Parakeet TDT 0.6B Live STT…'),
+        findsOneWidget,
+      );
+
+      verificationGate.complete();
+      await tester.pumpAndSettle();
+      expect(provider.isLiveSpeechModelReady, isTrue);
+      expect(find.text('615 MB · English · Installed'), findsOneWidget);
+    },
+  );
+
+  testWidgets('live model setup and download controls fit a narrow composer', (
+    tester,
+  ) async {
+    tester.view.physicalSize = const Size(320, 800);
+    tester.view.devicePixelRatio = 1;
+    addTearDown(tester.view.resetPhysicalSize);
+    addTearDown(tester.view.resetDevicePixelRatio);
+
+    final modelService = _FakeLiveSpeechModelService(installed: false);
+    final provider = ChatProvider(
+      chatService: MockChatService(),
+      settingsService: MockSettingsService(),
+      audioRecordingService: _FakeAudioRecordingService(),
+      liveSpeechModelService: modelService,
+      liveSpeechTranscriptionService: _FakeLiveSpeechTranscriptionService(
+        task: _FakeLiveSpeechTranscriptionTask(finalText: 'unused'),
+      ),
+      initialSettings: const ChatSettings(modelPath: 'chat-model.gguf'),
+    );
+    addTearDown(provider.dispose);
+    await provider.loadModel();
+    await provider.refreshLiveSpeechModel();
+
+    final controller = TextEditingController();
+    final focusNode = FocusNode();
+    addTearDown(controller.dispose);
+    addTearDown(focusNode.dispose);
+    await tester.pumpWidget(
+      ChangeNotifierProvider<ChatProvider>.value(
+        value: provider,
+        child: MaterialApp(
+          home: Scaffold(
+            body: ChatInput(
+              controller: controller,
+              focusNode: focusNode,
+              onSend: () {},
+            ),
+          ),
+        ),
+      ),
+    );
+
+    expect(find.text('Moonshine Tiny Live STT'), findsOneWidget);
+    expect(
+      find.byKey(const ValueKey<String>('install_live_speech_button')),
+      findsOneWidget,
+    );
+    expect(tester.takeException(), isNull);
+    await tester.pump(const Duration(milliseconds: 250));
+  });
+
+  testWidgets('live model download can be cancelled from its progress row', (
+    tester,
+  ) async {
+    final installGate = Completer<void>();
+    final modelService = _FakeLiveSpeechModelService(
+      installed: false,
+      installGate: installGate,
+    );
+    final provider = ChatProvider(
+      chatService: MockChatService(),
+      settingsService: MockSettingsService(),
+      audioRecordingService: _FakeAudioRecordingService(),
+      liveSpeechModelService: modelService,
+      liveSpeechTranscriptionService: _FakeLiveSpeechTranscriptionService(
+        task: _FakeLiveSpeechTranscriptionTask(finalText: 'unused'),
+      ),
+      initialSettings: const ChatSettings(modelPath: 'chat-model.gguf'),
+    );
+    addTearDown(provider.dispose);
+    await provider.loadModel();
+    await provider.refreshLiveSpeechModel();
+
+    final controller = TextEditingController();
+    final focusNode = FocusNode();
+    addTearDown(controller.dispose);
+    addTearDown(focusNode.dispose);
+    await tester.pumpWidget(
+      ChangeNotifierProvider<ChatProvider>.value(
+        value: provider,
+        child: MaterialApp(
+          home: Scaffold(
+            body: ChatInput(
+              controller: controller,
+              focusNode: focusNode,
+              onSend: () {},
+            ),
+          ),
+        ),
+      ),
+    );
+
+    await tester.tap(
+      find.byKey(const ValueKey<String>('install_live_speech_button')),
+    );
+    await tester.pump();
+    await tester.tap(
+      find.byKey(
+        const ValueKey<String>('cancel_live_speech_model_install_button'),
+      ),
+    );
+    await tester.pumpAndSettle();
+
+    expect(modelService.lastCancelToken?.isCancelled, isTrue);
+    expect(provider.isInstallingLiveSpeechModel, isFalse);
+    expect(provider.isLiveSpeechModelReady, isFalse);
+    expect(provider.liveSpeechError, isNull);
+    expect(
+      find.byKey(const ValueKey<String>('install_live_speech_button')),
+      findsOneWidget,
+    );
+    await tester.pump(const Duration(milliseconds: 250));
+  });
+
+  testWidgets('failed live model download can retry or switch models', (
+    tester,
+  ) async {
+    final modelService = _FakeLiveSpeechModelService(
+      installed: false,
+      installError: StateError('network unavailable'),
+    );
+    final provider = ChatProvider(
+      chatService: MockChatService(),
+      settingsService: MockSettingsService(),
+      audioRecordingService: _FakeAudioRecordingService(),
+      liveSpeechModelService: modelService,
+      liveSpeechTranscriptionService: _FakeLiveSpeechTranscriptionService(
+        task: _FakeLiveSpeechTranscriptionTask(finalText: 'unused'),
+      ),
+      initialSettings: const ChatSettings(modelPath: 'chat-model.gguf'),
+    );
+    addTearDown(provider.dispose);
+    await provider.loadModel();
+    await provider.refreshLiveSpeechModel();
+
+    final controller = TextEditingController();
+    final focusNode = FocusNode();
+    addTearDown(controller.dispose);
+    addTearDown(focusNode.dispose);
+    await tester.pumpWidget(
+      ChangeNotifierProvider<ChatProvider>.value(
+        value: provider,
+        child: MaterialApp(
+          home: Scaffold(
+            body: ChatInput(
+              controller: controller,
+              focusNode: focusNode,
+              onSend: () {},
+            ),
+          ),
+        ),
+      ),
+    );
+
+    await tester.tap(
+      find.byKey(const ValueKey<String>('install_live_speech_button')),
+    );
+    await tester.pumpAndSettle();
+    expect(find.byKey(const ValueKey<String>('live_speech_error')), findsOne);
+    expect(
+      find.byKey(
+        const ValueKey<String>('retry_live_speech_model_install_button'),
+      ),
+      findsOne,
+    );
+
+    await tester.tap(
+      find.byKey(const ValueKey<String>('live_speech_error_model_selector')),
+    );
+    await tester.pumpAndSettle();
+    await tester.tap(find.text('Parakeet TDT 0.6B Live STT · 615 MB').last);
+    await tester.pumpAndSettle();
+
+    expect(provider.selectedLiveSpeechModel, LiveSpeechModel.parakeetTdt);
+    expect(provider.liveSpeechError, isNull);
+    expect(find.text('615 MB · English'), findsOneWidget);
+    await tester.pump(const Duration(milliseconds: 250));
+  });
+
+  test(
+    'live startup cancellation settles before another task can start',
+    () async {
+      final startGate = Completer<void>();
+      final liveTask = _FakeLiveSpeechTranscriptionTask(finalText: 'stale');
+      final liveService = _FakeLiveSpeechTranscriptionService(
+        task: liveTask,
+        startGate: startGate,
+      );
+      final provider = ChatProvider(
+        chatService: MockChatService(),
+        settingsService: MockSettingsService(),
+        audioRecordingService: _FakeAudioRecordingService(),
+        liveSpeechModelService: _FakeLiveSpeechModelService(installed: true),
+        liveSpeechTranscriptionService: liveService,
+        initialSettings: const ChatSettings(modelPath: 'chat-model.gguf'),
+      );
+      addTearDown(provider.dispose);
+      await provider.loadModel();
+      await provider.refreshLiveSpeechModel();
+
+      final start = provider.startLiveSpeechTranscription();
+      await Future<void>.delayed(Duration.zero);
+      expect(liveService.startCalls, 1);
+
+      final cancel = provider.cancelLiveSpeechTranscription();
+      expect(provider.canStartLiveSpeechTranscription, isFalse);
+      startGate.complete();
+      await Future.wait<void>(<Future<void>>[start, cancel]);
+
+      expect(provider.isLiveTranscribing, isFalse);
+      expect(provider.canStartLiveSpeechTranscription, isTrue);
+    },
+  );
+
+  test(
+    'live cancellation stays reserved until the native task settles',
+    () async {
+      final cancelGate = Completer<void>();
+      final liveTask = _FakeLiveSpeechTranscriptionTask(
+        finalText: 'cancelled',
+        cancelGate: cancelGate,
+      );
+      final liveService = _FakeLiveSpeechTranscriptionService(task: liveTask);
+      final provider = ChatProvider(
+        chatService: MockChatService(),
+        settingsService: MockSettingsService(),
+        audioRecordingService: _FakeAudioRecordingService(),
+        liveSpeechModelService: _FakeLiveSpeechModelService(installed: true),
+        liveSpeechTranscriptionService: liveService,
+        initialSettings: const ChatSettings(modelPath: 'chat-model.gguf'),
+      );
+      addTearDown(provider.dispose);
+      await provider.loadModel();
+      await provider.refreshLiveSpeechModel();
+      await provider.startLiveSpeechTranscription();
+
+      final cancel = provider.cancelLiveSpeechTranscription();
+      await Future<void>.delayed(Duration.zero);
+      expect(provider.canStartLiveSpeechTranscription, isFalse);
+      await provider.startLiveSpeechTranscription();
+      expect(liveService.startCalls, 1);
+
+      cancelGate.complete();
+      await cancel;
+      expect(provider.canStartLiveSpeechTranscription, isTrue);
+    },
+  );
+
+  test('live transcription automatically finalizes at five minutes', () async {
+    final liveTask = _FakeLiveSpeechTranscriptionTask(finalText: 'final words');
+    final provider = ChatProvider(
+      chatService: MockChatService(),
+      settingsService: MockSettingsService(),
+      audioRecordingService: _FakeAudioRecordingService(),
+      liveSpeechModelService: _FakeLiveSpeechModelService(installed: true),
+      liveSpeechTranscriptionService: _FakeLiveSpeechTranscriptionService(
+        task: liveTask,
+      ),
+      initialSettings: const ChatSettings(modelPath: 'chat-model.gguf'),
+    );
+    addTearDown(provider.dispose);
+    await provider.loadModel();
+    await provider.refreshLiveSpeechModel();
+    await provider.startLiveSpeechTranscription();
+
+    liveTask.emit(
+      const LiveSpeechTranscriptUpdate(
+        confirmedText: 'almost done',
+        pendingText: '',
+        acceptedAudioDuration: ChatProvider.maxLiveSpeechTranscriptionDuration,
+        isFinal: false,
+      ),
+    );
+    for (var index = 0; index < 20 && provider.isLiveTranscribing; index++) {
+      await Future<void>.delayed(Duration.zero);
+    }
+
+    expect(liveTask.stopCalls, 1);
+    expect(provider.isLiveTranscribing, isFalse);
+    expect(provider.liveSpeechDisplayText, 'final words');
+    expect(provider.hasPendingLiveSpeechDraft, isTrue);
   });
 
   testWidgets('dedicated TTS mode synthesizes typed text', (tester) async {
@@ -305,6 +918,10 @@ void main() {
       chatService: MockChatService(),
       settingsService: MockSettingsService(),
       audioRecordingService: _FakeAudioRecordingService(),
+      liveSpeechModelService: _FakeLiveSpeechModelService(installed: true),
+      liveSpeechTranscriptionService: _FakeLiveSpeechTranscriptionService(
+        task: _FakeLiveSpeechTranscriptionTask(finalText: 'dictated text'),
+      ),
       initialSettings: const ChatSettings(
         modelPath: 'gemma-4-E2B-it.litertlm',
         modelSupportsAudio: true,
@@ -313,6 +930,7 @@ void main() {
     );
     addTearDown(provider.dispose);
     await provider.loadModel();
+    await provider.refreshLiveSpeechModel();
 
     final controller = TextEditingController();
     final focusNode = FocusNode();
@@ -342,10 +960,12 @@ void main() {
     expect(find.text('Transcribe Audio'), findsNothing);
     expect(find.text('Attach Image'), findsNothing);
     expect(find.byTooltip('Ask with voice'), findsOneWidget);
+    expect(find.byTooltip('Live transcription'), findsOneWidget);
     expect(
       find.bySemanticsLabel('Ask with voice. Records up to 30 seconds.'),
       findsOneWidget,
     );
+    expect(find.bySemanticsLabel('Start live transcription.'), findsOneWidget);
   });
 
   testWidgets('microphone controls stop and ask from the composer', (
@@ -443,6 +1063,10 @@ void main() {
       chatService: MockChatService(engine: engine),
       audioRecordingService: _FakeAudioRecordingService(),
       settingsService: MockSettingsService(),
+      liveSpeechModelService: _FakeLiveSpeechModelService(installed: true),
+      liveSpeechTranscriptionService: _FakeLiveSpeechTranscriptionService(
+        task: _FakeLiveSpeechTranscriptionTask(finalText: 'not used'),
+      ),
       initialSettings: const ChatSettings(
         modelPath: 'Qwen3-ASR-0.6B-Q8_0.gguf',
         mmprojPath: 'mmproj-Qwen3-ASR-0.6B-Q8_0.gguf',
@@ -451,6 +1075,7 @@ void main() {
     );
     addTearDown(provider.dispose);
     await provider.loadModel();
+    await provider.refreshLiveSpeechModel();
 
     final controller = TextEditingController();
     final focusNode = FocusNode();
@@ -478,6 +1103,7 @@ void main() {
     expect(find.text('Attach Audio'), findsOneWidget);
     expect(find.text('Transcribe Audio'), findsOneWidget);
     expect(find.byTooltip('Record for transcription'), findsOneWidget);
+    expect(find.byTooltip('Live transcription'), findsNothing);
     expect(find.bySemanticsLabel('Record for transcription.'), findsOneWidget);
   });
 
@@ -1856,6 +2482,138 @@ class _BlockingAudioProbeSpeechMockLlamaEngine extends _SpeechMockLlamaEngine {
       await _releaseAudioProbe.future;
     }
     return super.supportsAudio;
+  }
+}
+
+class _FakeLiveSpeechModelService implements LiveSpeechModelService {
+  bool installed;
+  int installCalls = 0;
+  final Completer<void>? installGate;
+  final Completer<void>? verificationGate;
+  final Object? installError;
+  CancelToken? lastCancelToken;
+
+  _FakeLiveSpeechModelService({
+    required this.installed,
+    this.installGate,
+    this.verificationGate,
+    this.installError,
+  });
+
+  @override
+  bool get isSupported => true;
+
+  InstalledLiveSpeechModel _resolved(LiveSpeechModel model) =>
+      InstalledLiveSpeechModel(
+        model: model,
+        modelPath: '/models/${model.modelSource.filename}',
+        tokenizerPath: '/models/${model.tokenizerSource.filename}',
+      );
+
+  @override
+  Future<InstalledLiveSpeechModel?> resolve(LiveSpeechModel model) async =>
+      installed ? _resolved(model) : null;
+
+  @override
+  Future<InstalledLiveSpeechModel> install(
+    LiveSpeechModel model, {
+    required CancelToken cancelToken,
+    required void Function(double progress) onProgress,
+    required void Function() onVerifying,
+  }) async {
+    installCalls += 1;
+    lastCancelToken = cancelToken;
+    onProgress(0.5);
+    if (installGate != null) {
+      await Future.any<void>([
+        installGate!.future,
+        cancelToken.whenCancel.then<void>((error) => throw error),
+      ]);
+    }
+    if (installError != null) {
+      throw installError!;
+    }
+    onVerifying();
+    await verificationGate?.future;
+    installed = true;
+    onProgress(1);
+    return _resolved(model);
+  }
+
+  @override
+  Future<void> delete(LiveSpeechModel model) async {
+    installed = false;
+  }
+}
+
+class _FakeLiveSpeechTranscriptionService
+    implements LiveSpeechTranscriptionService {
+  final _FakeLiveSpeechTranscriptionTask task;
+  final Completer<void>? startGate;
+  int startCalls = 0;
+
+  _FakeLiveSpeechTranscriptionService({required this.task, this.startGate});
+
+  @override
+  bool get isSupported => true;
+
+  @override
+  Future<LiveSpeechTranscriptionTask> start({
+    required String modelPath,
+    required String tokenizerPath,
+    required LiteRtLmAsrModelPreset preset,
+  }) async {
+    startCalls += 1;
+    await startGate?.future;
+    return task;
+  }
+
+  @override
+  Future<void> dispose() async {}
+}
+
+class _FakeLiveSpeechTranscriptionTask implements LiveSpeechTranscriptionTask {
+  final String finalText;
+  final Completer<void>? cancelGate;
+  final StreamController<LiveSpeechTranscriptUpdate> _updates =
+      StreamController<LiveSpeechTranscriptUpdate>();
+  final Completer<LiveSpeechTranscriptionResult> _done =
+      Completer<LiveSpeechTranscriptionResult>();
+  int stopCalls = 0;
+  int cancelCalls = 0;
+
+  _FakeLiveSpeechTranscriptionTask({required this.finalText, this.cancelGate});
+
+  @override
+  Stream<LiveSpeechTranscriptUpdate> get updates => _updates.stream;
+
+  @override
+  Future<LiveSpeechTranscriptionResult> get done => _done.future;
+
+  void emit(LiveSpeechTranscriptUpdate update) => _updates.add(update);
+
+  @override
+  Future<void> stop() async {
+    stopCalls += 1;
+    if (!_done.isCompleted) {
+      unawaited(_updates.close());
+      _done.complete(
+        LiveSpeechTranscriptionResult(
+          text: finalText,
+          acceptedAudioDuration: const Duration(seconds: 5),
+        ),
+      );
+    }
+  }
+
+  @override
+  Future<void> cancel() async {
+    cancelCalls += 1;
+    await cancelGate?.future;
+    if (!_done.isCompleted) {
+      unawaited(_updates.close());
+      _done.completeError(StateError('cancelled'));
+    }
   }
 }
 

--- a/example/chat_app/test/chat_service_test.dart
+++ b/example/chat_app/test/chat_service_test.dart
@@ -61,6 +61,27 @@ void main() {
       expect(engine.lastModelParams!.numberOfThreadsBatch, 0);
     });
 
+    test('honors explicit Android Vulkan batch sizes', () async {
+      debugDefaultTargetPlatformOverride = TargetPlatform.android;
+      final engine = MockLlamaEngine();
+      final service = ChatService(engine: engine);
+
+      await service.init(
+        const ChatSettings(
+          modelPath: 'gemma-4-E2B-it-Q4_K_S.gguf',
+          preferredBackend: GpuBackend.vulkan,
+          contextSize: 4096,
+          gpuLayers: 32,
+          batchSize: 128,
+          microBatchSize: 16,
+        ),
+        eagerLoadMultimodalProjector: false,
+      );
+
+      expect(engine.lastModelParams!.batchSize, 128);
+      expect(engine.lastModelParams!.microBatchSize, 16);
+    });
+
     test(
       'keeps roomier Android GPU defaults for non-Vulkan backends',
       () async {
@@ -157,6 +178,8 @@ void main() {
             gpuLayers: 99,
             numberOfThreads: 8,
             numberOfThreadsBatch: 8,
+            batchSize: 256,
+            microBatchSize: 64,
           ),
           eagerLoadMultimodalProjector: false,
         );

--- a/example/chat_app/test/chat_service_test.dart
+++ b/example/chat_app/test/chat_service_test.dart
@@ -83,6 +83,29 @@ void main() {
     });
 
     test(
+      'caps an explicit micro-batch to the resolved Android batch',
+      () async {
+        debugDefaultTargetPlatformOverride = TargetPlatform.android;
+        final engine = MockLlamaEngine();
+        final service = ChatService(engine: engine);
+
+        await service.init(
+          const ChatSettings(
+            modelPath: 'gemma-4-E2B-it-Q4_K_S.gguf',
+            preferredBackend: GpuBackend.vulkan,
+            contextSize: 4096,
+            gpuLayers: 32,
+            microBatchSize: 128,
+          ),
+          eagerLoadMultimodalProjector: false,
+        );
+
+        expect(engine.lastModelParams!.batchSize, 32);
+        expect(engine.lastModelParams!.microBatchSize, 32);
+      },
+    );
+
+    test(
       'keeps roomier Android GPU defaults for non-Vulkan backends',
       () async {
         debugDefaultTargetPlatformOverride = TargetPlatform.android;

--- a/example/chat_app/test/live_speech_model_test.dart
+++ b/example/chat_app/test/live_speech_model_test.dart
@@ -1,0 +1,55 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:llamadart/llamadart.dart';
+import 'package:llamadart_chat_example/models/live_speech_model.dart';
+
+void main() {
+  test('live speech catalog pins the recommended Moonshine assets', () {
+    final model = LiveSpeechModel.moonshineTiny;
+
+    expect(model.isRecommended, isTrue);
+    expect(model.preset, LiteRtLmAsrModelPreset.moonshineTiny);
+    expect(model.sizeBytes, 53922426);
+    expect(model.sizeLabel, '54 MB');
+    expect(
+      model.modelSource.url,
+      contains('beb49ee5028b4fb21eb989bcbd2db30a433373db'),
+    );
+    expect(
+      model.modelSource.sha256,
+      '97abdeea122d579229091659c24c59d988c6419d453a200f6471241a53b9a9b9',
+    );
+  });
+
+  test('live speech catalog pins the optional Parakeet TDT assets', () {
+    final model = LiveSpeechModel.parakeetTdt;
+
+    expect(model.isRecommended, isFalse);
+    expect(model.preset, LiteRtLmAsrModelPreset.parakeetTdt0_6bV3);
+    expect(model.sizeBytes, 615421032);
+    expect(model.sizeLabel, '615 MB');
+    expect(
+      model.modelSource.url,
+      contains('e3a6f2dec6800733f97c87ff55822f32c405983a'),
+    );
+    expect(
+      model.modelSource.sha256,
+      '334745b8bc7fd372b1c213516f0b6338bb827b1a2abb3e77ad35fe6fea5cd16b',
+    );
+    expect(
+      model.tokenizerSource.url,
+      contains('541d1f99c6b0c3cd0b11a95167540bb8edefd82b'),
+    );
+    expect(
+      model.tokenizerSource.sha256,
+      'bd321b096832a3f270bd3b2a88823957920f1a5c5ada71114a26ea729d0cbe91',
+    );
+  });
+
+  test('unknown persisted live speech selection falls back to Moonshine', () {
+    expect(LiveSpeechModel.byId('missing'), LiveSpeechModel.moonshineTiny);
+    expect(
+      LiveSpeechModel.byId(LiveSpeechModel.parakeetTdt.id),
+      LiveSpeechModel.parakeetTdt,
+    );
+  });
+}

--- a/example/chat_app/test/live_speech_transcription_service_test.dart
+++ b/example/chat_app/test/live_speech_transcription_service_test.dart
@@ -1,0 +1,140 @@
+import 'dart:typed_data';
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:llamadart/llamadart.dart';
+import 'package:llamadart_chat_example/models/live_speech_model.dart';
+import 'package:llamadart_chat_example/services/live_speech_transcription_service.dart';
+import 'package:llamadart_chat_example/services/live_speech_transcription_service_io.dart';
+
+void main() {
+  test('converts little-endian PCM16 to normalized float samples', () {
+    final bytes = Uint8List.fromList(const <int>[
+      0x00,
+      0x80,
+      0x00,
+      0x00,
+      0xff,
+      0x7f,
+    ]);
+
+    expect(pcm16BytesToFloat32(bytes), <double>[-1, 0, 32767 / 32768]);
+  });
+
+  test('rejects incomplete PCM16 samples', () {
+    expect(
+      () => pcm16BytesToFloat32(Uint8List.fromList(const <int>[0x01])),
+      throwsFormatException,
+    );
+  });
+
+  test('reassembles PCM16 samples across arbitrary byte boundaries', () {
+    final source = Uint8List.fromList(<int>[
+      0x00,
+      0x80,
+      0xff,
+      0xff,
+      0x00,
+      0x00,
+      0xff,
+      0x7f,
+    ]);
+    final aligner = Pcm16ByteStreamAligner();
+    final output = BytesBuilder(copy: false);
+
+    for (final byte in source) {
+      output.add(aligner.add(Uint8List.fromList(<int>[byte])));
+    }
+    aligner.finish();
+
+    expect(output.takeBytes(), source);
+    expect(
+      pcm16BytesToFloat32(source),
+      orderedEquals(<double>[-1, -1 / 32768, 0, 32767 / 32768]),
+    );
+  });
+
+  test('rejects a trailing split PCM16 sample', () {
+    final aligner = Pcm16ByteStreamAligner();
+
+    expect(aligner.add(Uint8List.fromList(<int>[0x01])), isEmpty);
+    expect(aligner.finish, throwsFormatException);
+  });
+
+  test('Moonshine live model pins graph and tokenizer integrity', () {
+    final model = LiveSpeechModel.moonshineTiny;
+
+    expect(model.modelSource.filename, 'moonshine_tiny_5s_i8.tflite');
+    expect(model.modelSource.sizeBytes, 51936896);
+    expect(
+      model.modelSource.sha256,
+      '97abdeea122d579229091659c24c59d988c6419d453a200f6471241a53b9a9b9',
+    );
+    expect(model.tokenizerSource.filename, 'moonshine_tokenizer.json');
+    expect(model.tokenizerSource.sizeBytes, 1985530);
+    expect(
+      model.tokenizerSource.sha256,
+      '6579793438bc4fbafffacf699169ff53e3769c5a0a0f5e71cdee8853e8130deb',
+    );
+    expect(model.sizeBytes, 53922426);
+    expect(model.languages, <String>['English']);
+  });
+
+  test('skips only LiteRT-LM incomplete BPE ASR windows', () {
+    final session = _FakeAsrSession(<Object>[
+      LlamaSpeechException(
+        'LiteRT-LM ASR inference failed with native status 9.',
+        'The set of token IDs passed to the tokenizer is part of a BPE '
+            'sequence and needs more tokens to be decoded.',
+      ),
+      const LiteRtLmAsrProcessResult(
+        state: LiteRtLmAsrProcessState.update,
+        confirmedText: 'recovered',
+      ),
+    ]);
+
+    expect(processLiveAsrWindow(session), isNull);
+    expect(processLiveAsrWindow(session)?.confirmedText, 'recovered');
+  });
+
+  test('does not hide unrelated LiteRT-LM ASR failures', () {
+    final error = LlamaSpeechException(
+      'LiteRT-LM ASR inference failed with native status 9.',
+      'Model invocation failed.',
+    );
+    final session = _FakeAsrSession(<Object>[error]);
+
+    expect(() => processLiveAsrWindow(session), throwsA(same(error)));
+  });
+}
+
+class _FakeAsrSession implements LiteRtLmAsrRuntimeSession {
+  _FakeAsrSession(this._results);
+
+  final List<Object> _results;
+  int _index = 0;
+
+  @override
+  LiteRtLmAsrProcessResult processNext() {
+    final value = _results[_index++];
+    if (value is Exception) {
+      throw value;
+    }
+    return value as LiteRtLmAsrProcessResult;
+  }
+
+  @override
+  void cancel() {}
+
+  @override
+  void dispose() {}
+
+  @override
+  void finishAudio() {}
+
+  @override
+  LiteRtLmAsrPushResult pushAudio(Float32List samples) =>
+      LiteRtLmAsrPushResult(acceptedSamples: samples.length, wouldBlock: false);
+
+  @override
+  void reset() {}
+}

--- a/example/chat_app/test/mocks.dart
+++ b/example/chat_app/test/mocks.dart
@@ -289,13 +289,31 @@ class MockLlamaEngine extends LlamaEngine {
 
 class MockSettingsService implements SettingsService {
   ChatSettings settings = const ChatSettings(modelPath: "mock.gguf");
+  bool liveSpeechEnabled = true;
+  String? liveSpeechModelId;
 
   @override
   Future<ChatSettings> loadSettings() async => settings;
 
   @override
+  Future<bool> loadLiveSpeechEnabled() async => liveSpeechEnabled;
+
+  @override
+  Future<String?> loadLiveSpeechModelId() async => liveSpeechModelId;
+
+  @override
   Future<void> saveSettings(ChatSettings newSettings) async {
     settings = newSettings;
+  }
+
+  @override
+  Future<void> saveLiveSpeechEnabled(bool enabled) async {
+    liveSpeechEnabled = enabled;
+  }
+
+  @override
+  Future<void> saveLiveSpeechModelId(String modelId) async {
+    liveSpeechModelId = modelId;
   }
 }
 

--- a/example/chat_app/test/model_service_test.dart
+++ b/example/chat_app/test/model_service_test.dart
@@ -363,6 +363,48 @@ void main() {
     expect((await service.getModelCacheState(model)).isReady, isTrue);
   });
 
+  test(
+    'managed tokenizer asset reuses verified download infrastructure',
+    () async {
+      final ioService = TestModelService(tempDir);
+      final source = RemoteModelAssetSource(
+        url: '$baseUrl/mmproj.gguf',
+        filename: 'tokenizer.json',
+        sizeBytes: mmprojDataSize,
+        sha256: sha256.convert(mmprojData).toString(),
+      );
+      final progress = <int>[];
+      var verificationStarted = false;
+
+      await ioService.downloadManagedAsset(
+        modelsDir: tempDir.path,
+        source: source,
+        role: ModelAssetRole.tokenizer,
+        cancelToken: CancelToken(),
+        onProgress: (downloadedBytes, _, _) => progress.add(downloadedBytes),
+        onVerifying: () => verificationStarted = true,
+      );
+
+      expect(progress, isNotEmpty);
+      expect(progress.last, mmprojDataSize);
+      expect(verificationStarted, isTrue);
+      expect(
+        await ioService.isManagedAssetAvailable(
+          tempDir.path,
+          source,
+          role: ModelAssetRole.tokenizer,
+        ),
+        isTrue,
+      );
+      expect(
+        File(
+          ioService.resolveManagedAssetPath(tempDir.path, source),
+        ).readAsBytesSync(),
+        mmprojData,
+      );
+    },
+  );
+
   test('cancellation interrupts integrity verification', () async {
     final verificationStarted = Completer<void>();
     service = TestModelService(

--- a/example/chat_app/test/settings_service_test.dart
+++ b/example/chat_app/test/settings_service_test.dart
@@ -35,6 +35,40 @@ void main() {
 
       expect(settings.preferredBackend, GpuBackend.auto);
       expect(settings.autoTuneModelParams, isTrue);
+      expect(settings.batchSize, 0);
+      expect(settings.microBatchSize, 0);
+    });
+
+    test('persists logical and micro batch sizes', () async {
+      final service = SettingsService();
+      const settings = ChatSettings(batchSize: 256, microBatchSize: 64);
+
+      await service.saveSettings(settings);
+      final restored = await service.loadSettings();
+
+      expect(restored.batchSize, 256);
+      expect(restored.microBatchSize, 64);
+    });
+
+    test('persists the selected live speech sidecar independently', () async {
+      final service = SettingsService();
+
+      expect(await service.loadLiveSpeechModelId(), isNull);
+      await service.saveLiveSpeechModelId('litert-parakeet-tdt-0.6b-v3-i8');
+
+      expect(
+        await service.loadLiveSpeechModelId(),
+        'litert-parakeet-tdt-0.6b-v3-i8',
+      );
+    });
+
+    test('enables live dictation by default and persists opt-out', () async {
+      final service = SettingsService();
+
+      expect(await service.loadLiveSpeechEnabled(), isTrue);
+      await service.saveLiveSpeechEnabled(false);
+
+      expect(await service.loadLiveSpeechEnabled(), isFalse);
     });
 
     test('persists Auto intent after resolving partial GPU offload', () async {

--- a/example/chat_app/test/unit_test.dart
+++ b/example/chat_app/test/unit_test.dart
@@ -1368,6 +1368,15 @@ void main() {
       provider.updateTopK(20);
       expect(provider.settings.topK, 20);
 
+      provider.updateBatchSize(256);
+      provider.updateMicroBatchSize(64);
+      expect(provider.settings.batchSize, 256);
+      expect(provider.settings.microBatchSize, 64);
+
+      provider.updateBatchSize(32);
+      expect(provider.settings.batchSize, 32);
+      expect(provider.settings.microBatchSize, 32);
+
       provider.updateLogLevel(LlamaLogLevel.info);
       expect(provider.settings.logLevel, LlamaLogLevel.info);
 
@@ -1480,6 +1489,34 @@ void main() {
       expect(customProvider.settings.gpuLayers, ModelParams.maxGpuLayers);
       expect(customProvider.settings.contextSize, 16384);
       expect(customProvider.settings.autoTuneModelParams, isTrue);
+    });
+
+    test('Android Auto probes Vulkan before estimating GPU offload', () async {
+      debugDefaultTargetPlatformOverride = TargetPlatform.android;
+      final engine = _AndroidVulkanProbeEstimateEngine();
+      final customProvider = ChatProvider(
+        chatService: MockChatService(engine: engine),
+        settingsService: mockSettingsService,
+        initialSettings: const ChatSettings(
+          modelPath: 'gemma-4-E2B-it-Q4_K_S.gguf',
+          preferredBackend: GpuBackend.auto,
+          gpuLayers: 99,
+          autoTuneModelParams: true,
+          contextSize: 8192,
+          modelBytesHint: 4029586368,
+        ),
+      );
+
+      await customProvider.loadModel();
+
+      expect(engine.probeBackends, const [GpuBackend.vulkan]);
+      expect(customProvider.settings.gpuLayers, greaterThan(0));
+      expect(
+        customProvider.availableDevices.any(
+          (device) => device.toUpperCase().contains('VULKAN'),
+        ),
+        isTrue,
+      );
     });
 
     test('applyModelPreset disables tools when unsupported', () {
@@ -2213,6 +2250,40 @@ class _LargeMemoryEstimateEngine extends MockLlamaEngine {
 
   @override
   Future<String> getAvailableBackends() async => 'CPU, METAL';
+}
+
+class _AndroidVulkanProbeEstimateEngine extends MockLlamaEngine {
+  List<GpuBackend> probeBackends = const [];
+  bool _probed = false;
+
+  @override
+  Future<List<GpuDeviceInfo>> listGpuDevices({
+    List<GpuBackend> probeBackends = const [],
+  }) async {
+    this.probeBackends = List<GpuBackend>.from(probeBackends);
+    _probed = true;
+    return const [
+      GpuDeviceInfo(
+        backend: GpuBackend.vulkan,
+        mainGpu: 0,
+        name: 'Vulkan0',
+        description: 'Pixel GPU',
+        deviceId: 'pixel-gpu',
+        type: GpuDeviceType.integratedGpu,
+        memoryFreeBytes: 6 * 1024 * 1024 * 1024,
+        memoryTotalBytes: 8 * 1024 * 1024 * 1024,
+      ),
+    ];
+  }
+
+  @override
+  Future<({int total, int free})> getVramInfo() async => _probed
+      ? (total: 8 * 1024 * 1024 * 1024, free: 6 * 1024 * 1024 * 1024)
+      : (total: 0, free: 0);
+
+  @override
+  Future<String> getAvailableBackends() async =>
+      _probed ? 'CPU, VULKAN' : 'llama.cpp, LiteRT-LM';
 }
 
 class _UnloadRecordingEngine extends MockLlamaEngine {

--- a/tool/testing/test_matrix.dart
+++ b/tool/testing/test_matrix.dart
@@ -256,6 +256,28 @@ const List<TestMatrixRow> testMatrixRows = <TestMatrixRow>[
         'temporary-audio handling changes.',
   ),
   TestMatrixRow(
+    id: 'chat-app-live-speech-smoke',
+    tier: 'targeted',
+    mode: 'manual/device',
+    covers:
+        'selectable live-ASR sidecar download integrity/progress/cancellation, '
+        'PCM16 microphone streaming, confirmed/pending updates, editable '
+        'draft finalization, bounded session lifecycle, and cancellation',
+    command:
+        'Run example/chat_app on a microphone-equipped Android, iOS, macOS, '
+        'or Windows device with a native chat model loaded. Install Moonshine, '
+        'verify determinate progress, dictate for at least two five-second '
+        'windows, verify confirmed/pending text, choose Use text, edit the '
+        'draft, and send it. Repeat with Parakeet TDT where device storage/RAM '
+        'permit, then test download cancellation and an app-background '
+        'transition. Record device, runtime version, selected model, exact '
+        'asset hashes, transcript, update/finalization latency, peak memory, '
+        'and cleanup.',
+    useWhen:
+        'LiteRT-LM live ASR, worker isolation, PCM streaming, sidecar model '
+        'downloads, chat composer dictation, or microphone lifecycle changes.',
+  ),
+  TestMatrixRow(
     id: 'chat-app-voice-question-smoke',
     tier: 'targeted',
     mode: 'manual/device',

--- a/website/docs/changelog/recent-releases.md
+++ b/website/docs/changelog/recent-releases.md
@@ -9,12 +9,25 @@ For canonical full release notes, use:
 
 ## Unreleased
 
+- Added logical and micro-batch controls for llama.cpp/WebGPU models to the
+  Flutter chat example, and made Android Auto probe the packaged Vulkan device
+  before choosing GPU offload.
+
 - Updated the native LiteRT-LM runtime to `v0.16.0-native.2` and added
   experimental CPU-only dedicated ASR runtime sessions with bounded PCM input
   and confirmed/unconfirmed transcript updates. The Apple companion also
   packages the iOS Gemma constraint provider and Metal plugins required by the
   published runtime. This is a low-level native API and is not yet a
   `SpeechToTextEngine` backend.
+
+- Added experimental live English dictation to native Flutter chat models,
+  including generic audio-chat models, using selectable checksum-pinned
+  Moonshine Tiny (recommended, 54 MB) and Parakeet TDT 0.6B (optional, 615 MB)
+  LiteRT sidecars. The UI reports determinate download progress and supports
+  cancellation/retry; worker-isolated PCM streaming produces confirmed/pending
+  text and editable composer finalization. A persisted settings switch explains
+  and enables or disables the optional workflow. Audio-chat models retain
+  **Ask with voice** as a separate action.
 
 - Improved Flutter chat example model downloads with bounded retries for
   transient network failures, safe resume after truncated responses, and a

--- a/website/docs/examples/chat-app.md
+++ b/website/docs/examples/chat-app.md
@@ -55,7 +55,11 @@ flutter test
   Range resume. A true sleep-proof UX should be built as an opt-in native
   background downloader/model-store manager and injected through
   `ModelDownloadManager`.
-- Runtime backend preference and GPU layer controls.
+- Runtime backend preference, GPU layer, logical batch-size (`n_batch`), and
+  micro-batch-size (`n_ubatch`) controls. `Auto` preserves backend-specific
+  safe defaults; explicit values apply on the next model load. The app disables
+  these llama.cpp/WebGPU controls for LiteRT-LM bundles, whose runtime does not
+  expose them.
 - Persistent settings and split Dart/native logging controls.
 - Tool-calling toggles and model capability badges.
 - Runtime-verified multimodal capability gating after `mmproj` load, plus
@@ -71,6 +75,21 @@ flutter test
   a safe external-recorder preflight, while selected-file transcription remains
   available there. Web support is tracked in
   [issue #329](https://github.com/leehack/llamadart/issues/329).
+- Experimental live English dictation for native chat models, including
+  generic audio-chat models, through independently installed, checksum-pinned
+  LiteRT sidecars. Moonshine Tiny is the recommended 54 MB default; Parakeet
+  TDT 0.6B is an optional higher-capacity, heavier 615 MB choice. Selection is
+  persistent and the composer shows size, installed state, determinate
+  download progress, cancel, and retry. The app streams mono 16 kHz PCM to a
+  worker-isolated, CPU-only session, shows confirmed and pending
+  five-second-window text, and returns the final transcript to the editable
+  composer without auto-sending. A persisted **Live dictation** switch in the
+  settings explains and enables or disables this optional workflow. This
+  app-owned path is enabled on Android, iOS, macOS, and Windows, capped at five
+  minutes, and remains separate from
+  whole-file `SpeechToTextEngine`, Linux recording, and Web. Audio-chat models
+  retain **Ask with voice** as a separate action. Parakeet TDT follows its
+  upstream [CC-BY-4.0 license](https://huggingface.co/nvidia/parakeet-tdt-0.6b-v3).
 - **Ask with voice** for native Gemma 4 E2B, using either the LiteRT-LM
   direct-media bundle or the GGUF model with its matching audio-capable
   projector. It records up to 30 seconds, then **Stop & ask** sends the WAV

--- a/website/docs/guides/speech-to-text.md
+++ b/website/docs/guides/speech-to-text.md
@@ -99,9 +99,11 @@ gates. Supported metadata presets currently cover Parakeet TDT, Parakeet CTC,
 Moonshine Tiny, Whisper Tiny, and Qwen3-ASR 0.6B, but callers must provide the
 matching model and tokenizer artifacts.
 
-This API does not yet provide microphone capture, a Dart event stream,
-timestamps, confidence, diarization, or automatic resampling. Those belong in
-the future high-level adapter rather than the synchronous FFI boundary.
+This low-level API does not itself provide microphone capture, a Dart event
+stream, timestamps, confidence, diarization, or automatic resampling. The chat
+example now demonstrates an app-owned microphone/worker wrapper with selectable
+Moonshine Tiny and Parakeet TDT sidecars. That example integration is not yet a
+public streaming `SpeechToTextEngine` adapter.
 
 ## Load a Qwen3-ASR model
 
@@ -205,6 +207,17 @@ different user actions:
   five minutes. **Stop & transcribe** finalizes that file and passes it to
   `SpeechToTextEngine`, while **Discard** cancels capture and removes the
   partial file.
+- With a native chat model, **Live transcription** uses a separately installed,
+  checksum-pinned LiteRT model and tokenizer. Moonshine Tiny is the recommended
+  54 MB default; Parakeet TDT 0.6B is an optional higher-capacity, heavier
+  615 MB choice. The selector remembers the choice and reports model size,
+  installed state, determinate download progress, cancellation, and retry. The
+  app captures mono 16 kHz PCM, owns the synchronous LiteRT-LM session in a
+  worker isolate, and renders monotonic confirmed text plus a replaceable
+  pending suffix after each five-second window. **Use text** finalizes the
+  session and inserts the result into the editable composer; it never submits
+  the message automatically. Generic audio-chat models retain **Ask with
+  voice** as a separate action.
 - With native Gemma 4 E2B, **Ask with voice** uses either the LiteRT-LM
   direct-media bundle or the GGUF model with its matching audio-capable
   projector. It records up to 30 seconds and **Stop & ask** sends the WAV bytes
@@ -213,12 +226,21 @@ different user actions:
   detected language, or live partial text. An ASR profile takes precedence
   when both capability declarations are present.
 
-The transcription action is hidden on Web and for current LiteRT-LM bundles.
+The dedicated **Transcribe Audio** action remains hidden on Web and for normal
+LiteRT-LM chat bundles. Live dictation is a separate app-owned sidecar flow,
+not a capability of the selected chat bundle or the current public
+`SpeechToTextEngine`.
 ASR microphone recordings are capped at five minutes, cancelled when the app is
 backgrounded, and deleted after transcription. This remains a whole-file
 workflow: it does not produce live partial transcripts while the user speaks.
 The recorder requests 16 kHz mono WAV, but hardware may choose another valid
 sample rate; the downstream native decoder reads the WAV metadata.
+The live sidecar path instead requests PCM16 mono 16 kHz streaming, preserves
+samples split across arbitrary byte-chunk boundaries, applies one in-flight
+worker push at a time, and caps each session at five minutes. It is currently
+English-only and CPU-only. The composer integration is enabled on Android,
+iOS, macOS, and Windows, cancelled on foreground lifecycle changes, and
+disabled on Linux and Web.
 Capture for both microphone workflows is code-supported on Android, iOS, macOS,
 and Windows. It remains disabled on Linux with the current recorder plugin
 because its external-tool startup is not safe to expose without a stronger


### PR DESCRIPTION
## Summary

- add optional app-owned live dictation to the Flutter chat example using checksum-pinned Moonshine Tiny or Parakeet TDT LiteRT-LM ASR sidecars
- stream microphone PCM through a worker isolate, show confirmed and pending text, and place the finalized transcript in the editable composer without automatically sending it
- add persisted `n_batch` / `n_ubatch` controls for llama.cpp and WebGPU models, and probe packaged Vulkan capability before Android Auto memory planning

Related to #327. This PR intentionally delivers the chat-app sidecar workflow; it does not close the broader public streaming-STT API tracker.

## Production-readiness scope

- **User-facing scope:** Native chat users can enable or disable **Live dictation**, install a separate English ASR sidecar with visible progress/cancel/retry, dictate while confirmed/pending text updates, then insert and edit the final text before pressing Send. llama.cpp/WebGPU users can also configure logical and micro batch sizes.
- **Supported platforms/paths:** Live microphone dictation is enabled for Android, iOS, macOS, and Windows when the packaged LiteRT-LM ASR capability is available. Batch controls apply to llama.cpp and WebGPU; LiteRT-LM chat models clearly disable them. Android Auto probes Vulkan before selecting GPU offload.
- **Unsupported or intentionally unavailable paths:** Live dictation remains unavailable on Linux and Web. It is CPU-only and English-only in this first app-owned path. Dedicated whole-file STT, Ask with voice, and TTS retain their existing specialized flows. Partial ASR text is never submitted to the selected chat model automatically.
- **Out of scope / follow-ups:** Public `SpeechToTextEngine` live-session APIs, llama.cpp streaming input, Web support, VAD auto-submit, timestamps, confidence, and diarization remain in #327.

## Completeness checklist

- [x] Declared scope is fully implemented, or explicitly reduced above.
- [x] Unsupported platform/option combinations fail loudly with actionable diagnostics or are clearly documented as unavailable.
- [x] Public API docs, README/website docs, examples, support matrices, and changelog entries are updated where relevant.
- [x] Regression coverage covers the original issue plus key negative/version-skew paths where relevant.
- [x] Security/privacy review completed: model metadata uses immutable URLs/checksums; logs and UI do not expose raw audio or signed URLs.
- [x] Follow-up work that is useful but not required for this PR is tracked in GitHub Issues, or explicitly marked above.

## PR type guidance

- **Feature PR:** includes app API/docs/example updates, platform boundaries, unsupported-path behavior, lifecycle and download-integrity tests.

## Test Plan

- [x] All touched Dart files pass `dart format --output=none --set-exit-if-changed <changed files>`.
- [x] `dart analyze`
- [x] `dart test -p vm -j 1 --exclude-tags local-only` — 1,388 passed, 66 skipped.
- [ ] `dart test -p chrome --exclude-tags local-only` — left to exact-head CI; live microphone dictation is Web-disabled, while shared settings/UI contracts remain covered there.
- [x] `cd example/chat_app && flutter analyze`
- [x] `cd example/chat_app && flutter test` — 313 tests passed.
- [x] `./tool/docs/build_site.sh`
- [x] `./tool/docs/validate_links.sh`
- [x] `dart run tool/testing/verify_release_docs_versions.dart`
- [x] `cd example/chat_app && flutter build apk --debug --no-pub`
- [x] `git diff --check`
- [x] Exact-head macOS real-model ASR: `litert-lm-asr-smoke` with Moonshine Tiny, the 16 kHz JFK fixture, and the exact expected transcript — PASS in 529 ms.
- [x] Exact-head macOS chat-app live microphone flow: start, partial transcript display, `Use text`, and editable composer insertion — PASS; the room-audio sample was noisy, so transcript quality was not used as the deterministic correctness gate.
- [x] Exact-head physical iPad chat-app live dictation — PASS, user-confirmed on the installed build.

The repository-wide formatter command with the locally installed newer Dart formatter also reports five unchanged-main files that it would reflow; every file touched by this PR passes the formatter without changes.

## Matrix Evidence

| Matrix row | Scope covered | Platform / model / backend | Result | Evidence / notes |
| --- | --- | --- | --- | --- |
| `chat-app-live-speech-smoke` | Sidecar install, live microphone ASR, composer finalization, opt-in setting | Physical Pixel 9 Pro / Moonshine Tiny / LiteRT-LM CPU sidecar | PASS | Current committed APK installed in place; existing models/settings preserved; user confirmed the live-dictation UI and flow looked good. |
| `litert-lm-asr-smoke` | Real-model ASR runtime and deterministic transcript | macOS arm64 / Moonshine Tiny / LiteRT-LM CPU | PASS | Exact-head runner processed the pinned 16 kHz JFK fixture in 529 ms and matched the exact expected transcript. |
| `chat-app-live-speech-smoke` | Live partial UI, stop/finalize, and editable composer insertion | macOS arm64 / Moonshine Tiny sidecar | PASS | Independently operated on the exact-head app. Room-audio quality was noisy; deterministic correctness is covered by the fixture row above. |
| `chat-app-live-speech-smoke` | Physical-device microphone capture and live composer flow | Physical M1 iPad Pro / default Moonshine Tiny sidecar | PASS | User-confirmed on the exact-head installed build; app build/install/launch and attached runtime logs were independently observed. |
| Chat example tests | Lifecycle, cancellation, progress, model switching, draft insertion, narrow UI, persisted enable/disable | Flutter VM | PASS | 313 tests. |
| Android build | Native packaging and plugin integration | Android debug APK | PASS | Built and installed over the existing app without clearing data. |
| Docs | README, guide, changelog, testing matrix | Local docs toolchain | PASS | Site build, link validation, and release-doc version verification passed. |

## Review Notes

- Independent review status: all three initial GitHub review threads are resolved; batch sizing and diagnostics were fixed, and the Dart switch false positive has a recorded rationale.
- CI status / head SHA: all 12 exact-head checks passed on `6b7cd30e8592d1c898f04dbdfb2f9d6f82c228b6`.
- Device evidence: physical Pixel, physical iPad, macOS real-model runtime, and macOS live UI flow passed. Windows remains code-supported but unvalidated with a real microphone/model.
