### PR TITLE
feat: expose LiteRT-LM streaming speech-to-text

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,24 +6,24 @@
   models do not fall back to CPU merely because the dynamic GPU module was not
   registered yet.
 
-* Updated the native LiteRT-LM runtime to `v0.16.0-native.2` and added
-  experimental CPU-only dedicated ASR runtime sessions with bridge capability
-  discovery, bounded mono 16 kHz PCM input,
-  confirmed/unconfirmed transcript updates, finalization, reset, and
-  cooperative cancellation. The Apple companion now packages the iOS Gemma
-  constraint provider and Metal accelerator/sampler plugins required by the
-  published runtime. This low-level synchronous API is separate from
-  `SpeechToTextEngine` and should run from a worker isolate.
+* Updated the native LiteRT-LM runtime to `v0.16.0-native.2` and added an
+  experimental dedicated `SpeechToTextEngine.liteRtLm` path with runtime
+  capability discovery, worker-isolated CPU inference, bounded mono 16 kHz
+  float PCM input, partial/final transcript events, finalization, and
+  cooperative cancellation. The low-level synchronous ASR session remains
+  available for advanced integrations. The Apple companion packages the iOS
+  Gemma constraint provider and Metal accelerator/sampler plugins required by
+  the published runtime.
 
 * Added experimental live dictation to the native Flutter chat example for
   chat models, including generic audio-chat models. The app offers the
   recommended 54 MB Moonshine Tiny sidecar and an optional higher-capacity,
   heavier 615 MB Parakeet TDT 0.6B sidecar with checksum-pinned assets,
   persistent selection, explicit download progress, cancellation, and retry.
-  It captures mono 16 kHz PCM, runs the synchronous ASR session in a worker
-  isolate, renders confirmed and pending text, and returns the finalized
-  transcript to the editable composer. A persisted settings switch explains
-  and enables or disables the optional workflow. The first path is CPU-only,
+  It captures mono 16 kHz PCM, uses the public worker-isolated streaming speech
+  API, renders confirmed and pending text, and returns the finalized transcript
+  to the editable composer. A persisted settings switch explains and enables
+  or disables the optional workflow. The first path is CPU-only,
   English-only, capped at five minutes, and unavailable on Linux and Web.
 
 * Improved Flutter chat example model downloads with bounded retries for

--- a/README.md
+++ b/README.md
@@ -28,10 +28,9 @@ models through LiteRT-LM.
 - Streaming chat completions, llama.cpp thinking budgets, tool-call parsing,
   multimodal GGUF projectors, structured JSON output, embeddings, LoRA, state
   persistence, and runtime diagnostics where the active backend supports them.
-- Experimental typed whole-file speech recognition on native llama.cpp through
-  `SpeechToTextEngine`, with explicit capability and cancellation contracts.
-- Experimental CPU-only dedicated LiteRT-LM ASR runtime sessions for bounded
-  16 kHz PCM input and confirmed/unconfirmed transcript updates.
+- Experimental typed speech recognition through `SpeechToTextEngine`: native
+  llama.cpp whole-file Qwen3-ASR and worker-isolated, CPU-only LiteRT-LM
+  streaming ASR with bounded 16 kHz PCM input and partial transcripts.
 - Experimental typed Qwen3-TTS synthesis on native llama.cpp through
   `TextToSpeechEngine`, returning complete PCM with WAV encoding.
 

--- a/doc/testing_matrix.md
+++ b/doc/testing_matrix.md
@@ -72,7 +72,7 @@ Pick targeted rows based on the touched surface:
 | Large WebGPU GGUF / wasm64 selection | `gemma4-webgpu-mem64` |
 | LiteRT-LM web / Gemma 4 web bundle | `gemma4-litert-web` |
 | Chat app model cache/download/projector | `chat-app-device-cache` |
-| Speech-to-text API or adapter | `speech-to-text-smoke`, plus `litert-lm-asr-smoke` for the dedicated LiteRT-LM session API |
+| Speech-to-text API or adapter | `speech-to-text-smoke`, plus `litert-lm-asr-smoke` for the dedicated LiteRT-LM streaming engine |
 | Text-to-speech API or adapter | `text-to-speech-smoke` |
 | Chat-app microphone transcription flow | `chat-app-microphone-transcription-smoke` |
 | Chat-app live LiteRT-LM dictation | `litert-lm-asr-smoke`, `chat-app-live-speech-smoke` |

--- a/example/chat_app/README.md
+++ b/example/chat_app/README.md
@@ -123,15 +123,14 @@ flutter test --run-skipped -t local-only \
      on Android, iOS, macOS, and Windows. Moonshine Tiny is the recommended
      54 MB default; Parakeet TDT 0.6B is an optional 615 MB higher-capacity,
      heavier choice. Both process mono 16 kHz PCM in five-second windows on a
-     worker isolate, show confirmed and replaceable pending English text, and
-     put the finalized transcript into the composer for review instead of
+     worker isolate through `SpeechToTextEngine.liteRtLm`, show confirmed and
+     replaceable pending English text, and put the finalized transcript into the composer for review instead of
      sending it automatically. The selected sidecar is remembered, and the UI
      shows its size, installed state, determinate download progress, cancel,
      and retry. Sessions are capped at five minutes and cancelled when the app
      leaves the foreground. Audio-chat models keep **Ask with voice** as a
-     separate action. Linux and Web remain
-     disabled, and this app-owned flow does not change the public
-     `SpeechToTextEngine` whole-input contract.
+     separate action. Linux and Web remain disabled; dedicated streaming ASR
+     is native-only.
      Parakeet TDT is converted by
      [LiteRT Community](https://huggingface.co/litert-community/parakeet-tdt-0.6b-v3)
      from NVIDIA's

--- a/example/chat_app/lib/providers/chat_provider.dart
+++ b/example/chat_app/lib/providers/chat_provider.dart
@@ -3470,6 +3470,9 @@ class ChatProvider extends ChangeNotifier {
       final llamaAudio = switch (audio) {
         SpeechAudioFileInput(:final path) => LlamaAudioContent(path: path),
         SpeechAudioBytesInput(:final bytes) => LlamaAudioContent(bytes: bytes),
+        SpeechAudioPcmInput() => throw LlamaUnsupportedException(
+          'The chat model transcription flow accepts encoded audio only.',
+        ),
       };
       if (!await _ensureMultimodalProjectorForMedia(<LlamaContentPart>[
         llamaAudio,

--- a/example/chat_app/lib/services/live_speech_transcription_service_io.dart
+++ b/example/chat_app/lib/services/live_speech_transcription_service_io.dart
@@ -1,6 +1,5 @@
 import 'dart:async';
 import 'dart:io';
-import 'dart:isolate';
 import 'dart:typed_data';
 
 import 'package:llamadart/llamadart.dart';
@@ -9,31 +8,6 @@ import 'package:record/record.dart';
 import 'live_speech_transcription_service.dart';
 
 const int _sampleRateHz = 16000;
-const String _incompleteBpeSequenceDetails =
-    'The set of token IDs passed to the tokenizer is part of a BPE sequence '
-    'and needs more tokens to be decoded.';
-
-/// Processes one live-ASR window, tolerating LiteRT-LM's incomplete trailing
-/// BPE result so the overlapping next window can recover the omitted suffix.
-///
-/// Independent-window presets such as Moonshine can end a window in the middle
-/// of a UTF-8 BPE sequence, which LiteRT-LM v0.16 reports as a data-loss error
-/// even though the session remains usable. Returning `null` skips only that
-/// incomplete window; unrelated inference failures still propagate.
-LiteRtLmAsrProcessResult? processLiveAsrWindow(
-  LiteRtLmAsrRuntimeSession session,
-) {
-  try {
-    return session.processNext();
-  } on LlamaSpeechException catch (error) {
-    if (error.message ==
-            'LiteRT-LM ASR inference failed with native status 9.' &&
-        error.details == _incompleteBpeSequenceDetails) {
-      return null;
-    }
-    rethrow;
-  }
-}
 
 class _IoLiveSpeechTranscriptionService
     implements LiveSpeechTranscriptionService {
@@ -69,7 +43,7 @@ class _IoLiveSpeechTranscriptionService
     }
 
     final recorder = AudioRecorder();
-    _LiveAsrWorkerClient? worker;
+    SpeechToTextStreamingSession? speechSession;
     try {
       if (!await recorder.hasPermission()) {
         throw StateError(
@@ -82,11 +56,14 @@ class _IoLiveSpeechTranscriptionService
           'PCM16 microphone streaming is unavailable on this device.',
         );
       }
-      worker = await _LiveAsrWorkerClient.create(
-        modelPath: modelPath,
-        tokenizerPath: tokenizerPath,
-        preset: preset,
+      final speechEngine = SpeechToTextEngine.liteRtLm(
+        LiteRtLmAsrRuntimeConfig(
+          modelPath: modelPath,
+          tokenizerPath: tokenizerPath,
+          modelPreset: preset,
+        ),
       );
+      speechSession = await speechEngine.startStream();
       final stream = await recorder.startStream(
         const RecordConfig(
           encoder: AudioEncoder.pcm16bits,
@@ -98,7 +75,7 @@ class _IoLiveSpeechTranscriptionService
       late final _IoLiveSpeechTranscriptionTask task;
       task = _IoLiveSpeechTranscriptionTask(
         recorder: recorder,
-        worker: worker,
+        speechSession: speechSession,
         microphoneStream: stream,
         onClosed: () {
           if (identical(_activeTask, task)) {
@@ -110,7 +87,7 @@ class _IoLiveSpeechTranscriptionService
       return task;
     } catch (_) {
       await recorder.dispose();
-      await worker?.dispose();
+      await speechSession?.cancel();
       rethrow;
     }
   }
@@ -129,7 +106,7 @@ class _IoLiveSpeechTranscriptionService
 
 class _IoLiveSpeechTranscriptionTask implements LiveSpeechTranscriptionTask {
   final AudioRecorder _recorder;
-  final _LiveAsrWorkerClient _worker;
+  final SpeechToTextStreamingSession _speechSession;
   final void Function() _onClosed;
   final StreamController<LiveSpeechTranscriptUpdate> _updates =
       StreamController<LiveSpeechTranscriptUpdate>();
@@ -137,6 +114,7 @@ class _IoLiveSpeechTranscriptionTask implements LiveSpeechTranscriptionTask {
       Completer<LiveSpeechTranscriptionResult>();
 
   StreamSubscription<Uint8List>? _microphoneSubscription;
+  StreamSubscription<SpeechToTextEvent>? _speechSubscription;
   Future<void> _feedTail = Future<void>.value();
   final Pcm16ByteStreamAligner _pcmAligner = Pcm16ByteStreamAligner();
   bool _finishing = false;
@@ -147,13 +125,18 @@ class _IoLiveSpeechTranscriptionTask implements LiveSpeechTranscriptionTask {
 
   _IoLiveSpeechTranscriptionTask({
     required AudioRecorder recorder,
-    required _LiveAsrWorkerClient worker,
+    required SpeechToTextStreamingSession speechSession,
     required Stream<Uint8List> microphoneStream,
     required void Function() onClosed,
   }) : _recorder = recorder,
-       _worker = worker,
+       _speechSession = speechSession,
        _onClosed = onClosed {
-    _worker.onUpdate = _handleWorkerUpdate;
+    _speechSubscription = _speechSession.events.listen(
+      _handleSpeechEvent,
+      onError: (Object error, StackTrace stackTrace) {
+        unawaited(_fail(error, stackTrace));
+      },
+    );
     _microphoneSubscription = microphoneStream.listen(
       _handleMicrophoneBytes,
       onError: (Object error, StackTrace stackTrace) {
@@ -183,8 +166,9 @@ class _IoLiveSpeechTranscriptionTask implements LiveSpeechTranscriptionTask {
           if (_closed) {
             return;
           }
-          final accepted = await _worker.pushPcm16(alignedBytes);
-          _acceptedSamples += accepted;
+          final samples = pcm16BytesToFloat32(alignedBytes);
+          await _speechSession.addPcm(samples);
+          _acceptedSamples += samples.length;
         })
         .whenComplete(() {
           if (_acceptingMicrophoneBytes && !_closed) {
@@ -196,28 +180,44 @@ class _IoLiveSpeechTranscriptionTask implements LiveSpeechTranscriptionTask {
         });
   }
 
-  void _handleWorkerUpdate(_WorkerTranscriptUpdate update) {
+  void _handleSpeechEvent(SpeechToTextEvent event) {
     if (_closed) {
       return;
     }
-    _latestConfirmedText = update.confirmedText;
-    _updates.add(
-      LiveSpeechTranscriptUpdate(
-        confirmedText: update.confirmedText,
-        pendingText: update.pendingText,
-        acceptedAudioDuration: _durationForSamples(update.acceptedSamples),
-        isFinal: update.isFinal,
-      ),
-    );
+    switch (event) {
+      case SpeechToTextPartialEvent(
+        :final text,
+        :final confirmedText,
+        :final pendingText,
+        :final acceptedAudioDuration,
+      ):
+        _latestConfirmedText = confirmedText ?? text;
+        _updates.add(
+          LiveSpeechTranscriptUpdate(
+            confirmedText: confirmedText ?? text,
+            pendingText: pendingText ?? '',
+            acceptedAudioDuration:
+                acceptedAudioDuration ?? _acceptedAudioDuration,
+            isFinal: false,
+          ),
+        );
+      case SpeechToTextFinalEvent(:final result):
+        _latestConfirmedText = result.text;
+        _updates.add(
+          LiveSpeechTranscriptUpdate(
+            confirmedText: result.text,
+            pendingText: '',
+            acceptedAudioDuration:
+                result.audioDuration ?? _acceptedAudioDuration,
+            isFinal: true,
+          ),
+        );
+    }
   }
 
   Duration get _acceptedAudioDuration => Duration(
     microseconds:
         (_acceptedSamples * Duration.microsecondsPerSecond) ~/ _sampleRateHz,
-  );
-
-  Duration _durationForSamples(int samples) => Duration(
-    microseconds: (samples * Duration.microsecondsPerSecond) ~/ _sampleRateHz,
   );
 
   @override
@@ -233,9 +233,16 @@ class _IoLiveSpeechTranscriptionTask implements LiveSpeechTranscriptionTask {
       _pcmAligner.finish();
       await _microphoneSubscription?.cancel();
       _microphoneSubscription = null;
-      final transcript = await _worker.finish();
-      if (!_closed) {
-        await _complete(transcript);
+      await _speechSession.finish();
+      final completion = await _speechSession.done;
+      switch (completion.state) {
+        case SpeechToTextCompletionState.completed:
+          await _complete(completion.result?.text ?? '');
+        case SpeechToTextCompletionState.cancelled:
+          throw StateError('Live transcription was cancelled.');
+        case SpeechToTextCompletionState.failed:
+          throw completion.error ??
+              LlamaSpeechException('Live transcription failed.');
       }
     } catch (error, stackTrace) {
       await _fail(error, stackTrace);
@@ -252,7 +259,7 @@ class _IoLiveSpeechTranscriptionTask implements LiveSpeechTranscriptionTask {
     try {
       await _recorder.cancel();
     } catch (_) {
-      // Native cancellation remains best effort; worker cleanup still runs.
+      // Native cancellation remains best effort; ASR cleanup still runs.
     }
     await _microphoneSubscription?.cancel();
     _microphoneSubscription = null;
@@ -261,7 +268,7 @@ class _IoLiveSpeechTranscriptionTask implements LiveSpeechTranscriptionTask {
     } catch (_) {
       // The task is being cancelled, so a queued feed error is terminal too.
     }
-    await _worker.cancel();
+    await _speechSession.cancel();
     await _close();
     if (!_done.isCompleted) {
       _done.completeError(StateError('Live transcription was cancelled.'));
@@ -295,6 +302,11 @@ class _IoLiveSpeechTranscriptionTask implements LiveSpeechTranscriptionTask {
     }
     await _microphoneSubscription?.cancel();
     _microphoneSubscription = null;
+    try {
+      await _speechSession.cancel();
+    } catch (_) {
+      // Preserve the first capture or inference failure.
+    }
     await _close();
     if (!_done.isCompleted) {
       _done.completeError(error, stackTrace);
@@ -306,363 +318,14 @@ class _IoLiveSpeechTranscriptionTask implements LiveSpeechTranscriptionTask {
       return;
     }
     _closed = true;
-    await _worker.dispose();
+    await _speechSubscription?.cancel();
+    _speechSubscription = null;
     await _recorder.dispose();
-    unawaited(_updates.close());
+    if (!_updates.isClosed) {
+      unawaited(_updates.close());
+    }
     _onClosed();
   }
-}
-
-class _WorkerTranscriptUpdate {
-  final String confirmedText;
-  final String pendingText;
-  final bool isFinal;
-  final int acceptedSamples;
-
-  const _WorkerTranscriptUpdate({
-    required this.confirmedText,
-    required this.pendingText,
-    required this.isFinal,
-    required this.acceptedSamples,
-  });
-}
-
-class _LiveAsrWorkerClient {
-  final Isolate _isolate;
-  final ReceivePort _messages;
-  final ReceivePort _errors;
-  final ReceivePort _exits;
-  final Map<int, Completer<Object?>> _pending = <int, Completer<Object?>>{};
-  final Completer<SendPort> _commandPort = Completer<SendPort>();
-  int _nextRequestId = 0;
-  bool _disposed = false;
-
-  void Function(_WorkerTranscriptUpdate update)? onUpdate;
-
-  _LiveAsrWorkerClient._(
-    this._isolate,
-    this._messages,
-    this._errors,
-    this._exits,
-  ) {
-    _messages.listen(_handleMessage);
-    _errors.listen((dynamic message) {
-      final summary = message is List && message.isNotEmpty
-          ? message.first
-          : message;
-      _failPending(
-        LlamaSpeechException('Live transcription worker failed.', summary),
-      );
-    });
-    _exits.listen((dynamic _) {
-      if (!_disposed) {
-        _failPending(StateError('Live transcription worker exited.'));
-      }
-    });
-  }
-
-  static Future<_LiveAsrWorkerClient> create({
-    required String modelPath,
-    required String tokenizerPath,
-    required LiteRtLmAsrModelPreset preset,
-  }) async {
-    final messages = ReceivePort();
-    final errors = ReceivePort();
-    final exits = ReceivePort();
-    final isolate = await Isolate.spawn<SendPort>(
-      _liveAsrWorkerMain,
-      messages.sendPort,
-      errorsAreFatal: true,
-      onError: errors.sendPort,
-      onExit: exits.sendPort,
-      debugName: 'llamadart-live-asr',
-    );
-    final client = _LiveAsrWorkerClient._(isolate, messages, errors, exits);
-    try {
-      await client._request('initialize', <String, Object>{
-        'modelPath': modelPath,
-        'tokenizerPath': tokenizerPath,
-        'preset': preset.index,
-      });
-      return client;
-    } catch (_) {
-      await client.dispose();
-      rethrow;
-    }
-  }
-
-  Future<int> pushPcm16(Uint8List bytes) async {
-    final result = await _request(
-      'push',
-      TransferableTypedData.fromList(<Uint8List>[bytes]),
-    );
-    return result as int;
-  }
-
-  Future<String> finish() async => (await _request('finish', null)) as String;
-
-  Future<void> cancel() async {
-    if (_disposed) {
-      return;
-    }
-    try {
-      await _request('cancel', null);
-    } catch (_) {
-      // Cooperative cancellation remains best effort during worker teardown.
-    }
-  }
-
-  Future<Object?> _request(String command, Object? payload) async {
-    if (_disposed) {
-      throw StateError('Live transcription worker is disposed.');
-    }
-    final port = await _commandPort.future;
-    final id = ++_nextRequestId;
-    final completer = Completer<Object?>();
-    _pending[id] = completer;
-    port.send(<String, Object?>{
-      'id': id,
-      'command': command,
-      'payload': payload,
-    });
-    return completer.future;
-  }
-
-  void _handleMessage(dynamic message) {
-    if (message is! Map) {
-      return;
-    }
-    final kind = message['kind'];
-    if (kind == 'ready') {
-      final port = message['port'];
-      if (port is SendPort && !_commandPort.isCompleted) {
-        _commandPort.complete(port);
-      }
-      return;
-    }
-    if (kind == 'update') {
-      onUpdate?.call(
-        _WorkerTranscriptUpdate(
-          confirmedText: message['confirmedText'] as String? ?? '',
-          pendingText: message['pendingText'] as String? ?? '',
-          isFinal: message['isFinal'] as bool? ?? false,
-          acceptedSamples: message['acceptedSamples'] as int? ?? 0,
-        ),
-      );
-      return;
-    }
-    if (kind != 'response') {
-      return;
-    }
-    final id = message['id'];
-    if (id is! int) {
-      return;
-    }
-    final completer = _pending.remove(id);
-    if (completer == null) {
-      return;
-    }
-    final error = message['error'];
-    if (error != null) {
-      completer.completeError(
-        LlamaSpeechException('Live transcription failed.', error.toString()),
-      );
-    } else {
-      completer.complete(message['result']);
-    }
-  }
-
-  void _failPending(Object error) {
-    if (!_commandPort.isCompleted) {
-      _commandPort.completeError(error);
-    }
-    for (final completer in _pending.values) {
-      if (!completer.isCompleted) {
-        completer.completeError(error);
-      }
-    }
-    _pending.clear();
-  }
-
-  Future<void> dispose() async {
-    if (_disposed) {
-      return;
-    }
-    try {
-      await _request('dispose', null);
-    } catch (_) {
-      // The isolate may already have exited after an error.
-    }
-    _disposed = true;
-    _isolate.kill(priority: Isolate.immediate);
-    _messages.close();
-    _errors.close();
-    _exits.close();
-    _failPending(StateError('Live transcription worker is disposed.'));
-  }
-}
-
-void _liveAsrWorkerMain(SendPort mainPort) {
-  final commands = ReceivePort();
-  mainPort.send(<String, Object>{'kind': 'ready', 'port': commands.sendPort});
-  LiteRtLmRuntimeClient? runtime;
-  LiteRtLmAsrRuntimeSession? session;
-  final confirmed = <String>[];
-  var acceptedSamples = 0;
-
-  void sendUpdate(LiteRtLmAsrProcessResult result) {
-    final value = result.confirmedText.trim();
-    if (value.isNotEmpty) {
-      confirmed.add(value);
-    }
-    mainPort.send(<String, Object>{
-      'kind': 'update',
-      'confirmedText': confirmed.join(' ').trim(),
-      'pendingText': result.unconfirmedText,
-      'isFinal': result.isFinal,
-      'acceptedSamples': acceptedSamples,
-    });
-  }
-
-  LiteRtLmAsrProcessState processAvailable() {
-    final activeSession = session;
-    if (activeSession == null) {
-      throw StateError('Live transcription session is not initialized.');
-    }
-    for (var attempt = 0; attempt < 10000; attempt++) {
-      final result = processLiveAsrWindow(activeSession);
-      if (result == null) {
-        return LiteRtLmAsrProcessState.needsMoreAudio;
-      }
-      if (result.state != LiteRtLmAsrProcessState.update) {
-        return result.state;
-      }
-      sendUpdate(result);
-      if (result.isFinal) {
-        return LiteRtLmAsrProcessState.endOfStream;
-      }
-    }
-    throw StateError('Live transcription processing did not quiesce.');
-  }
-
-  commands.listen((dynamic raw) {
-    if (raw is! Map) {
-      return;
-    }
-    final id = raw['id'];
-    final command = raw['command'];
-    if (id is! int || command is! String) {
-      return;
-    }
-    try {
-      Object? result;
-      switch (command) {
-        case 'initialize':
-          final payload = raw['payload'] as Map;
-          runtime = LiteRtLmRuntimeClient();
-          if (!runtime!.supportsAsrBridge) {
-            throw StateError(
-              'The installed LiteRT-LM runtime does not expose live ASR.',
-            );
-          }
-          final presetIndex = payload['preset'] as int;
-          session = runtime!.createAsrSession(
-            LiteRtLmAsrRuntimeConfig(
-              modelPath: payload['modelPath'] as String,
-              tokenizerPath: payload['tokenizerPath'] as String,
-              modelPreset: LiteRtLmAsrModelPreset.values[presetIndex],
-            ),
-          );
-        case 'push':
-          final transfer = raw['payload'] as TransferableTypedData;
-          final bytes = transfer.materialize().asUint8List();
-          final samples = pcm16BytesToFloat32(bytes);
-          final activeSession = session;
-          if (activeSession == null) {
-            throw StateError('Live transcription session is not initialized.');
-          }
-          var offset = 0;
-          while (offset < samples.length) {
-            final push = activeSession.pushAudio(
-              Float32List.sublistView(samples, offset),
-            );
-            if (push.acceptedSamples == 0 && !push.wouldBlock) {
-              throw StateError(
-                'LiteRT-LM ASR accepted no audio without backpressure.',
-              );
-            }
-            offset += push.acceptedSamples;
-            acceptedSamples += push.acceptedSamples;
-            final state = processAvailable();
-            if (push.wouldBlock &&
-                push.acceptedSamples == 0 &&
-                state == LiteRtLmAsrProcessState.needsMoreAudio) {
-              throw StateError(
-                'LiteRT-LM ASR reported backpressure without processing a window.',
-              );
-            }
-            if (state == LiteRtLmAsrProcessState.endOfStream) {
-              break;
-            }
-          }
-          result = offset;
-        case 'finish':
-          final activeSession = session;
-          if (activeSession == null) {
-            throw StateError('Live transcription session is not initialized.');
-          }
-          activeSession.finishAudio();
-          var finalized = false;
-          for (var attempt = 0; attempt < 10000; attempt++) {
-            final update = processLiveAsrWindow(activeSession);
-            if (update == null) {
-              continue;
-            }
-            if (update.state == LiteRtLmAsrProcessState.endOfStream) {
-              finalized = true;
-              break;
-            }
-            if (update.state == LiteRtLmAsrProcessState.needsMoreAudio) {
-              throw StateError(
-                'LiteRT-LM ASR requested audio after finalization.',
-              );
-            }
-            sendUpdate(update);
-            if (update.isFinal) {
-              finalized = true;
-              break;
-            }
-          }
-          if (!finalized) {
-            throw StateError('LiteRT-LM ASR did not produce a final result.');
-          }
-          result = confirmed.join(' ').trim();
-        case 'cancel':
-          session?.cancel();
-        case 'dispose':
-          session?.dispose();
-          session = null;
-          runtime?.dispose();
-          runtime = null;
-        default:
-          throw StateError('Unknown live transcription command: $command');
-      }
-      mainPort.send(<String, Object?>{
-        'kind': 'response',
-        'id': id,
-        'result': result,
-      });
-      if (command == 'dispose') {
-        commands.close();
-      }
-    } catch (error) {
-      mainPort.send(<String, Object?>{
-        'kind': 'response',
-        'id': id,
-        'error': error.toString(),
-      });
-    }
-  });
 }
 
 /// Creates the native live-transcription service.

--- a/example/chat_app/test/live_speech_transcription_service_test.dart
+++ b/example/chat_app/test/live_speech_transcription_service_test.dart
@@ -1,10 +1,8 @@
 import 'dart:typed_data';
 
 import 'package:flutter_test/flutter_test.dart';
-import 'package:llamadart/llamadart.dart';
 import 'package:llamadart_chat_example/models/live_speech_model.dart';
 import 'package:llamadart_chat_example/services/live_speech_transcription_service.dart';
-import 'package:llamadart_chat_example/services/live_speech_transcription_service_io.dart';
 
 void main() {
   test('converts little-endian PCM16 to normalized float samples', () {
@@ -78,63 +76,4 @@ void main() {
     expect(model.sizeBytes, 53922426);
     expect(model.languages, <String>['English']);
   });
-
-  test('skips only LiteRT-LM incomplete BPE ASR windows', () {
-    final session = _FakeAsrSession(<Object>[
-      LlamaSpeechException(
-        'LiteRT-LM ASR inference failed with native status 9.',
-        'The set of token IDs passed to the tokenizer is part of a BPE '
-            'sequence and needs more tokens to be decoded.',
-      ),
-      const LiteRtLmAsrProcessResult(
-        state: LiteRtLmAsrProcessState.update,
-        confirmedText: 'recovered',
-      ),
-    ]);
-
-    expect(processLiveAsrWindow(session), isNull);
-    expect(processLiveAsrWindow(session)?.confirmedText, 'recovered');
-  });
-
-  test('does not hide unrelated LiteRT-LM ASR failures', () {
-    final error = LlamaSpeechException(
-      'LiteRT-LM ASR inference failed with native status 9.',
-      'Model invocation failed.',
-    );
-    final session = _FakeAsrSession(<Object>[error]);
-
-    expect(() => processLiveAsrWindow(session), throwsA(same(error)));
-  });
-}
-
-class _FakeAsrSession implements LiteRtLmAsrRuntimeSession {
-  _FakeAsrSession(this._results);
-
-  final List<Object> _results;
-  int _index = 0;
-
-  @override
-  LiteRtLmAsrProcessResult processNext() {
-    final value = _results[_index++];
-    if (value is Exception) {
-      throw value;
-    }
-    return value as LiteRtLmAsrProcessResult;
-  }
-
-  @override
-  void cancel() {}
-
-  @override
-  void dispose() {}
-
-  @override
-  void finishAudio() {}
-
-  @override
-  LiteRtLmAsrPushResult pushAudio(Float32List samples) =>
-      LiteRtLmAsrPushResult(acceptedSamples: samples.length, wouldBlock: false);
-
-  @override
-  void reset() {}
 }

--- a/lib/src/core/speech/litert_lm_speech_to_text_driver.dart
+++ b/lib/src/core/speech/litert_lm_speech_to_text_driver.dart
@@ -1,0 +1,74 @@
+import 'dart:typed_data';
+
+import '../../backends/litert_lm/litert_lm_asr_types.dart';
+
+/// Internal capability result for the dedicated LiteRT-LM ASR runtime.
+class LiteRtLmSpeechToTextSupport {
+  /// Whether the packaged runtime exposes the required ASR ABI.
+  final bool isSupported;
+
+  /// Actionable diagnostic when [isSupported] is false.
+  final String? unsupportedReason;
+
+  /// Creates an internal capability result.
+  const LiteRtLmSpeechToTextSupport({
+    required this.isSupported,
+    this.unsupportedReason,
+  });
+}
+
+/// Internal cumulative transcript update emitted by the ASR worker.
+class LiteRtLmSpeechToTextUpdate {
+  /// Stable transcript prefix.
+  final String confirmedText;
+
+  /// Replaceable hypothesis for the current inference window.
+  final String pendingText;
+
+  /// Whether this update completes the input stream.
+  final bool isFinal;
+
+  /// Total mono samples accepted by the native session.
+  final int acceptedSamples;
+
+  /// Creates an internal transcript update.
+  const LiteRtLmSpeechToTextUpdate({
+    required this.confirmedText,
+    required this.pendingText,
+    required this.isFinal,
+    required this.acceptedSamples,
+  });
+}
+
+/// Platform-specific dedicated LiteRT-LM ASR driver.
+abstract interface class LiteRtLmSpeechToTextDriver {
+  /// Probes the packaged runtime without loading an ASR model.
+  Future<LiteRtLmSpeechToTextSupport> probeSupport({String? libraryPath});
+
+  /// Creates one worker-isolated native session.
+  Future<LiteRtLmSpeechToTextWorker> start(
+    LiteRtLmAsrRuntimeConfig config, {
+    String? libraryPath,
+  });
+}
+
+/// Worker-isolated dedicated LiteRT-LM ASR session.
+abstract interface class LiteRtLmSpeechToTextWorker {
+  /// Cumulative confirmed and replaceable pending transcript updates.
+  Stream<LiteRtLmSpeechToTextUpdate> get updates;
+
+  /// Pushes mono 16 kHz float PCM with bounded asynchronous backpressure.
+  Future<int> pushAudio(Float32List samples);
+
+  /// Flushes the final partial inference window and returns final text.
+  Future<String> finish();
+
+  /// Requests cooperative cancellation between inference windows.
+  Future<void> cancel();
+
+  /// Releases the worker isolate and native resources.
+  Future<void> dispose();
+}
+
+/// Test-only driver override used by focused public API tests.
+LiteRtLmSpeechToTextDriver? debugLiteRtLmSpeechToTextDriverOverride;

--- a/lib/src/core/speech/litert_lm_speech_to_text_driver_io.dart
+++ b/lib/src/core/speech/litert_lm_speech_to_text_driver_io.dart
@@ -1,0 +1,461 @@
+import 'dart:async';
+import 'dart:isolate';
+import 'dart:typed_data';
+
+import '../../backends/litert_lm/litert_lm_runtime.dart';
+import '../exceptions.dart';
+import 'litert_lm_speech_to_text_driver.dart';
+
+const String _incompleteBpeSequenceDetails =
+    'The set of token IDs passed to the tokenizer is part of a BPE sequence '
+    'and needs more tokens to be decoded.';
+
+/// Processes one ASR window while tolerating an incomplete trailing BPE token.
+///
+/// Independent-window models can end a window in the middle of a UTF-8 BPE
+/// sequence. LiteRT-LM reports that recoverable suffix as data loss even though
+/// the overlapping next window remains usable. Unrelated failures propagate.
+LiteRtLmAsrProcessResult? processLiteRtLmSpeechWindow(
+  LiteRtLmAsrRuntimeSession session,
+) {
+  try {
+    return session.processNext();
+  } on LlamaSpeechException catch (error) {
+    if (error.message ==
+            'LiteRT-LM ASR inference failed with native status 9.' &&
+        error.details == _incompleteBpeSequenceDetails) {
+      return null;
+    }
+    rethrow;
+  }
+}
+
+/// Creates the native LiteRT-LM speech driver.
+LiteRtLmSpeechToTextDriver createLiteRtLmSpeechToTextDriver() =>
+    const _IoLiteRtLmSpeechToTextDriver();
+
+class _IoLiteRtLmSpeechToTextDriver implements LiteRtLmSpeechToTextDriver {
+  const _IoLiteRtLmSpeechToTextDriver();
+
+  @override
+  Future<LiteRtLmSpeechToTextSupport> probeSupport({
+    String? libraryPath,
+  }) async {
+    LiteRtLmRuntimeClient? runtime;
+    try {
+      runtime = LiteRtLmRuntimeClient(libraryPath: libraryPath);
+      if (runtime.supportsAsrBridge) {
+        return const LiteRtLmSpeechToTextSupport(isSupported: true);
+      }
+      return const LiteRtLmSpeechToTextSupport(
+        isSupported: false,
+        unsupportedReason:
+            'The packaged LiteRT-LM runtime does not expose the v0.16+ ASR ABI.',
+      );
+    } catch (error) {
+      return LiteRtLmSpeechToTextSupport(
+        isSupported: false,
+        unsupportedReason: 'The LiteRT-LM ASR capability probe failed: $error',
+      );
+    } finally {
+      runtime?.dispose();
+    }
+  }
+
+  @override
+  Future<LiteRtLmSpeechToTextWorker> start(
+    LiteRtLmAsrRuntimeConfig config, {
+    String? libraryPath,
+  }) => _LiteRtLmSpeechWorkerClient.create(config, libraryPath: libraryPath);
+}
+
+class _LiteRtLmSpeechWorkerClient implements LiteRtLmSpeechToTextWorker {
+  final Isolate _isolate;
+  final ReceivePort _messages;
+  final ReceivePort _errors;
+  final ReceivePort _exits;
+  final StreamController<LiteRtLmSpeechToTextUpdate> _updates =
+      StreamController<LiteRtLmSpeechToTextUpdate>();
+  final Map<int, Completer<Object?>> _pending = <int, Completer<Object?>>{};
+  final Completer<SendPort> _commandPort = Completer<SendPort>();
+
+  int _nextRequestId = 0;
+  bool _disposing = false;
+  bool _disposed = false;
+
+  _LiteRtLmSpeechWorkerClient._(
+    this._isolate,
+    this._messages,
+    this._errors,
+    this._exits,
+  ) {
+    _messages.listen(_handleMessage);
+    _errors.listen((dynamic message) {
+      final summary = message is List && message.isNotEmpty
+          ? message.first
+          : message;
+      _failPending(
+        LlamaSpeechException('LiteRT-LM ASR worker failed.', summary),
+      );
+    });
+    _exits.listen((dynamic _) {
+      if (!_disposing && !_disposed) {
+        _failPending(
+          LlamaSpeechException('LiteRT-LM ASR worker exited unexpectedly.'),
+        );
+      }
+    });
+  }
+
+  static Future<_LiteRtLmSpeechWorkerClient> create(
+    LiteRtLmAsrRuntimeConfig config, {
+    String? libraryPath,
+  }) async {
+    final messages = ReceivePort();
+    final errors = ReceivePort();
+    final exits = ReceivePort();
+    final isolate = await Isolate.spawn<SendPort>(
+      _liteRtLmSpeechWorkerMain,
+      messages.sendPort,
+      errorsAreFatal: true,
+      onError: errors.sendPort,
+      onExit: exits.sendPort,
+      debugName: 'llamadart-litert-asr',
+    );
+    final client = _LiteRtLmSpeechWorkerClient._(
+      isolate,
+      messages,
+      errors,
+      exits,
+    );
+    try {
+      await client._request('initialize', <String, Object>{
+        'modelPath': config.modelPath,
+        'tokenizerPath': config.tokenizerPath,
+        'modelPreset': config.modelPreset.index,
+        'backend': config.backend.index,
+        'numberOfThreads': config.numberOfThreads,
+        'maxBufferedAudioMilliseconds': config.maxBufferedAudio.inMilliseconds,
+        'overlapRatio': config.overlapRatio,
+        'libraryPath': ?libraryPath,
+      });
+      return client;
+    } catch (_) {
+      await client.dispose();
+      rethrow;
+    }
+  }
+
+  @override
+  Stream<LiteRtLmSpeechToTextUpdate> get updates => _updates.stream;
+
+  @override
+  Future<int> pushAudio(Float32List samples) async {
+    final copy = Float32List.fromList(samples);
+    final bytes = Uint8List.view(copy.buffer);
+    final result = await _request(
+      'push',
+      TransferableTypedData.fromList(<Uint8List>[bytes]),
+    );
+    return result as int;
+  }
+
+  @override
+  Future<String> finish() async => (await _request('finish', null)) as String;
+
+  @override
+  Future<void> cancel() async {
+    if (_disposed) {
+      return;
+    }
+    try {
+      await _request('cancel', null);
+    } catch (_) {
+      // Cooperative cancellation remains best effort during worker teardown.
+    }
+  }
+
+  Future<Object?> _request(String command, Object? payload) async {
+    if (_disposed) {
+      throw LlamaStateException('LiteRT-LM ASR worker is disposed.');
+    }
+    final port = await _commandPort.future;
+    final id = ++_nextRequestId;
+    final completer = Completer<Object?>();
+    _pending[id] = completer;
+    port.send(<String, Object?>{
+      'id': id,
+      'command': command,
+      'payload': payload,
+    });
+    return completer.future;
+  }
+
+  void _handleMessage(dynamic message) {
+    if (message is! Map) {
+      return;
+    }
+    final kind = message['kind'];
+    if (kind == 'ready') {
+      final port = message['port'];
+      if (port is SendPort && !_commandPort.isCompleted) {
+        _commandPort.complete(port);
+      }
+      return;
+    }
+    if (kind == 'update') {
+      if (!_updates.isClosed) {
+        _updates.add(
+          LiteRtLmSpeechToTextUpdate(
+            confirmedText: message['confirmedText'] as String? ?? '',
+            pendingText: message['pendingText'] as String? ?? '',
+            isFinal: message['isFinal'] as bool? ?? false,
+            acceptedSamples: message['acceptedSamples'] as int? ?? 0,
+          ),
+        );
+      }
+      return;
+    }
+    if (kind != 'response') {
+      return;
+    }
+    final id = message['id'];
+    if (id is! int) {
+      return;
+    }
+    final completer = _pending.remove(id);
+    if (completer == null) {
+      return;
+    }
+    final error = message['error'];
+    if (error != null) {
+      completer.completeError(
+        LlamaSpeechException('LiteRT-LM speech recognition failed.', error),
+      );
+    } else {
+      completer.complete(message['result']);
+    }
+  }
+
+  void _failPending(Object error) {
+    if (!_commandPort.isCompleted) {
+      _commandPort.completeError(error);
+    }
+    for (final completer in _pending.values) {
+      if (!completer.isCompleted) {
+        completer.completeError(error);
+      }
+    }
+    _pending.clear();
+    if (!_updates.isClosed) {
+      _updates.addError(error);
+    }
+  }
+
+  @override
+  Future<void> dispose() async {
+    if (_disposing || _disposed) {
+      return;
+    }
+    _disposing = true;
+    try {
+      await _request('dispose', null);
+    } catch (_) {
+      // The isolate may already have exited after an error.
+    }
+    _disposed = true;
+    _isolate.kill(priority: Isolate.immediate);
+    _messages.close();
+    _errors.close();
+    _exits.close();
+    for (final completer in _pending.values) {
+      if (!completer.isCompleted) {
+        completer.completeError(
+          LlamaStateException('LiteRT-LM ASR worker is disposed.'),
+        );
+      }
+    }
+    _pending.clear();
+    if (!_updates.isClosed) {
+      await _updates.close();
+    }
+  }
+}
+
+void _liteRtLmSpeechWorkerMain(SendPort mainPort) {
+  final commands = ReceivePort();
+  mainPort.send(<String, Object>{'kind': 'ready', 'port': commands.sendPort});
+  LiteRtLmRuntimeClient? runtime;
+  LiteRtLmAsrRuntimeSession? session;
+  final confirmed = <String>[];
+  var acceptedSamples = 0;
+
+  void sendUpdate(LiteRtLmAsrProcessResult result) {
+    final value = result.confirmedText.trim();
+    if (value.isNotEmpty) {
+      confirmed.add(value);
+    }
+    mainPort.send(<String, Object>{
+      'kind': 'update',
+      'confirmedText': confirmed.join(' ').trim(),
+      'pendingText': result.unconfirmedText,
+      'isFinal': result.isFinal,
+      'acceptedSamples': acceptedSamples,
+    });
+  }
+
+  LiteRtLmAsrProcessState processAvailable() {
+    final activeSession = session;
+    if (activeSession == null) {
+      throw StateError('LiteRT-LM ASR session is not initialized.');
+    }
+    for (var attempt = 0; attempt < 10000; attempt++) {
+      final result = processLiteRtLmSpeechWindow(activeSession);
+      if (result == null) {
+        return LiteRtLmAsrProcessState.needsMoreAudio;
+      }
+      if (result.state != LiteRtLmAsrProcessState.update) {
+        return result.state;
+      }
+      sendUpdate(result);
+      if (result.isFinal) {
+        return LiteRtLmAsrProcessState.endOfStream;
+      }
+    }
+    throw StateError('LiteRT-LM ASR processing did not quiesce.');
+  }
+
+  commands.listen((dynamic raw) {
+    if (raw is! Map) {
+      return;
+    }
+    final id = raw['id'];
+    final command = raw['command'];
+    if (id is! int || command is! String) {
+      return;
+    }
+    try {
+      Object? result;
+      switch (command) {
+        case 'initialize':
+          final payload = raw['payload'] as Map;
+          runtime = LiteRtLmRuntimeClient(
+            libraryPath: payload['libraryPath'] as String?,
+          );
+          if (!runtime!.supportsAsrBridge) {
+            throw StateError(
+              'The installed LiteRT-LM runtime does not expose the v0.16+ ASR ABI.',
+            );
+          }
+          session = runtime!.createAsrSession(
+            LiteRtLmAsrRuntimeConfig(
+              modelPath: payload['modelPath'] as String,
+              tokenizerPath: payload['tokenizerPath'] as String,
+              modelPreset:
+                  LiteRtLmAsrModelPreset.values[payload['modelPreset'] as int],
+              backend: LiteRtLmAsrBackend.values[payload['backend'] as int],
+              numberOfThreads: payload['numberOfThreads'] as int,
+              maxBufferedAudio: Duration(
+                milliseconds: payload['maxBufferedAudioMilliseconds'] as int,
+              ),
+              overlapRatio: payload['overlapRatio'] as double,
+            ),
+          );
+        case 'push':
+          final transfer = raw['payload'] as TransferableTypedData;
+          final bytes = transfer.materialize().asUint8List();
+          if (bytes.lengthInBytes % Float32List.bytesPerElement != 0) {
+            throw StateError('Float PCM payload is not sample-aligned.');
+          }
+          final samples = Float32List.view(
+            bytes.buffer,
+            bytes.offsetInBytes,
+            bytes.lengthInBytes ~/ Float32List.bytesPerElement,
+          );
+          final activeSession = session;
+          if (activeSession == null) {
+            throw StateError('LiteRT-LM ASR session is not initialized.');
+          }
+          var offset = 0;
+          while (offset < samples.length) {
+            final push = activeSession.pushAudio(
+              Float32List.sublistView(samples, offset),
+            );
+            if (push.acceptedSamples == 0 && !push.wouldBlock) {
+              throw StateError(
+                'LiteRT-LM ASR accepted no audio without backpressure.',
+              );
+            }
+            offset += push.acceptedSamples;
+            acceptedSamples += push.acceptedSamples;
+            final state = processAvailable();
+            if (push.wouldBlock &&
+                push.acceptedSamples == 0 &&
+                state == LiteRtLmAsrProcessState.needsMoreAudio) {
+              throw StateError(
+                'LiteRT-LM ASR reported backpressure without processing a window.',
+              );
+            }
+            if (state == LiteRtLmAsrProcessState.endOfStream) {
+              break;
+            }
+          }
+          result = offset;
+        case 'finish':
+          final activeSession = session;
+          if (activeSession == null) {
+            throw StateError('LiteRT-LM ASR session is not initialized.');
+          }
+          activeSession.finishAudio();
+          var finalized = false;
+          for (var attempt = 0; attempt < 10000; attempt++) {
+            final update = processLiteRtLmSpeechWindow(activeSession);
+            if (update == null) {
+              continue;
+            }
+            if (update.state == LiteRtLmAsrProcessState.endOfStream) {
+              finalized = true;
+              break;
+            }
+            if (update.state == LiteRtLmAsrProcessState.needsMoreAudio) {
+              throw StateError(
+                'LiteRT-LM ASR requested audio after finalization.',
+              );
+            }
+            sendUpdate(update);
+            if (update.isFinal) {
+              finalized = true;
+              break;
+            }
+          }
+          if (!finalized) {
+            throw StateError('LiteRT-LM ASR did not produce a final result.');
+          }
+          result = confirmed.join(' ').trim();
+        case 'cancel':
+          session?.cancel();
+        case 'dispose':
+          session?.dispose();
+          session = null;
+          runtime?.dispose();
+          runtime = null;
+        default:
+          throw StateError('Unknown LiteRT-LM ASR command: $command');
+      }
+      mainPort.send(<String, Object?>{
+        'kind': 'response',
+        'id': id,
+        'result': result,
+      });
+      if (command == 'dispose') {
+        commands.close();
+      }
+    } catch (error) {
+      mainPort.send(<String, Object?>{
+        'kind': 'response',
+        'id': id,
+        'error': error.toString(),
+      });
+    }
+  });
+}

--- a/lib/src/core/speech/litert_lm_speech_to_text_driver_io.dart
+++ b/lib/src/core/speech/litert_lm_speech_to_text_driver_io.dart
@@ -151,8 +151,11 @@ class _LiteRtLmSpeechWorkerClient implements LiteRtLmSpeechToTextWorker {
 
   @override
   Future<int> pushAudio(Float32List samples) async {
-    final copy = Float32List.fromList(samples);
-    final bytes = Uint8List.view(copy.buffer);
+    final bytes = Uint8List.view(
+      samples.buffer,
+      samples.offsetInBytes,
+      samples.lengthInBytes,
+    );
     final result = await _request(
       'push',
       TransferableTypedData.fromList(<Uint8List>[bytes]),

--- a/lib/src/core/speech/litert_lm_speech_to_text_driver_stub.dart
+++ b/lib/src/core/speech/litert_lm_speech_to_text_driver_stub.dart
@@ -1,0 +1,30 @@
+import '../../backends/litert_lm/litert_lm_asr_types.dart';
+import 'litert_lm_speech_to_text_driver.dart';
+
+/// Creates the unsupported non-native LiteRT-LM speech driver.
+LiteRtLmSpeechToTextDriver createLiteRtLmSpeechToTextDriver() =>
+    const _UnsupportedLiteRtLmSpeechToTextDriver();
+
+class _UnsupportedLiteRtLmSpeechToTextDriver
+    implements LiteRtLmSpeechToTextDriver {
+  const _UnsupportedLiteRtLmSpeechToTextDriver();
+
+  @override
+  Future<LiteRtLmSpeechToTextSupport> probeSupport({
+    String? libraryPath,
+  }) async => const LiteRtLmSpeechToTextSupport(
+    isSupported: false,
+    unsupportedReason:
+        'Dedicated LiteRT-LM speech recognition requires a native runtime.',
+  );
+
+  @override
+  Future<LiteRtLmSpeechToTextWorker> start(
+    LiteRtLmAsrRuntimeConfig config, {
+    String? libraryPath,
+  }) {
+    throw UnsupportedError(
+      'Dedicated LiteRT-LM speech recognition requires a native runtime.',
+    );
+  }
+}

--- a/lib/src/core/speech/speech_to_text.dart
+++ b/lib/src/core/speech/speech_to_text.dart
@@ -1,12 +1,16 @@
 import 'dart:async';
 import 'dart:typed_data';
 
+import '../../backends/litert_lm/litert_lm_asr_types.dart';
 import '../engine/engine.dart';
 import '../exceptions.dart';
 import '../models/chat/chat_message.dart';
 import '../models/chat/chat_role.dart';
 import '../models/chat/content_part.dart';
 import '../models/inference/generation_params.dart';
+import 'litert_lm_speech_to_text_driver.dart';
+import 'litert_lm_speech_to_text_driver_stub.dart'
+    if (dart.library.io) 'litert_lm_speech_to_text_driver_io.dart';
 import 'speech_engine_lease.dart';
 import 'speech_platform_stub.dart'
     if (dart.library.js_interop) 'speech_platform_web.dart';
@@ -18,6 +22,9 @@ enum SpeechAudioInputKind {
 
   /// Encoded audio held in memory.
   encodedBytes,
+
+  /// Mono float PCM held in memory.
+  pcmFloat32,
 }
 
 /// Model-specific adapter used by [SpeechToTextEngine].
@@ -27,6 +34,9 @@ enum SpeechAudioInputKind {
 enum SpeechToTextModelProfile {
   /// Qwen3-ASR with its matching llama.cpp multimodal projector.
   qwen3Asr,
+
+  /// Dedicated LiteRT-LM ASR selected by [LiteRtLmAsrRuntimeConfig].
+  liteRtLmDedicated,
 }
 
 /// How the active backend implements speech recognition.
@@ -49,7 +59,8 @@ class SpeechAudioFormat {
   /// Number of interleaved audio channels, when known.
   final int? channelCount;
 
-  /// Container or codec hint such as `wav`, `mp3`, or `flac`.
+  /// Container, codec, or sample encoding such as `wav`, `flac`, or
+  /// `pcm-f32le`.
   final String? encoding;
 
   /// MIME type supplied by the caller, when available.
@@ -100,6 +111,27 @@ class SpeechAudioBytesInput extends SpeechAudioInput {
   SpeechAudioInputKind get kind => SpeechAudioInputKind.encodedBytes;
 }
 
+/// Mono float PCM held in memory.
+class SpeechAudioPcmInput extends SpeechAudioInput {
+  /// Normalized PCM samples in the range -1.0 to 1.0.
+  final Float32List samples;
+
+  /// Creates a float PCM input.
+  ///
+  /// Dedicated LiteRT-LM ASR currently requires mono 16 kHz input.
+  SpeechAudioPcmInput(
+    this.samples, {
+    super.format = const SpeechAudioFormat(
+      sampleRateHz: 16000,
+      channelCount: 1,
+      encoding: 'pcm-f32le',
+    ),
+  });
+
+  @override
+  SpeechAudioInputKind get kind => SpeechAudioInputKind.pcmFloat32;
+}
+
 /// A request to recognize speech from one complete audio input.
 class SpeechToTextRequest {
   /// Audio to transcribe.
@@ -115,6 +147,9 @@ class SpeechToTextRequest {
   final String? contextPrompt;
 
   /// Maximum number of generated transcript tokens.
+  ///
+  /// This applies to prompt-adapted recognition. Dedicated ASR backends ignore
+  /// it after validating that it is positive.
   final int maxOutputTokens;
 
   /// Creates a speech recognition request.
@@ -128,7 +163,7 @@ class SpeechToTextRequest {
 
 /// Runtime speech-to-text capabilities for the loaded engine.
 class SpeechToTextCapabilities {
-  /// Whether [SpeechToTextEngine.transcribe] can be used now.
+  /// Whether recognition can be started with the configured engine.
   final bool isSupported;
 
   /// Actionable reason when [isSupported] is false.
@@ -180,7 +215,10 @@ class SpeechToTextCapabilities {
   /// Whether pausing the output subscription throttles native inference.
   final bool supportsOutputBackpressure;
 
-  /// Maximum number of concurrent tasks owned by one underlying engine.
+  /// Whether awaiting an input push applies bounded native backpressure.
+  final bool supportsInputBackpressure;
+
+  /// Maximum number of concurrent tasks owned by one recognizer or engine.
   final int maxConcurrentTasks;
 
   /// Creates a capability snapshot.
@@ -201,6 +239,7 @@ class SpeechToTextCapabilities {
     this.supportsLanguageHints = false,
     this.supportsCancellation = false,
     this.supportsOutputBackpressure = false,
+    this.supportsInputBackpressure = false,
     this.maxConcurrentTasks = 0,
   });
 }
@@ -279,12 +318,16 @@ class SpeechToTextResult {
   /// Metadata describing the supplied source audio, when available.
   final SpeechAudioFormat? sourceFormat;
 
+  /// Audio duration accepted by the recognizer, when known.
+  final Duration? audioDuration;
+
   /// Creates a final recognition result.
   const SpeechToTextResult({
     required this.text,
     this.language,
     this.segments = const <TranscriptSegment>[],
     this.sourceFormat,
+    this.audioDuration,
   });
 }
 
@@ -299,8 +342,22 @@ class SpeechToTextPartialEvent extends SpeechToTextEvent {
   /// Current best transcript text.
   final String text;
 
+  /// Stable transcript prefix that will not be revised.
+  final String? confirmedText;
+
+  /// Replaceable hypothesis for the current inference window.
+  final String? pendingText;
+
+  /// Audio duration accepted when this update was produced.
+  final Duration? acceptedAudioDuration;
+
   /// Creates a partial transcript event.
-  const SpeechToTextPartialEvent(this.text);
+  const SpeechToTextPartialEvent(
+    this.text, {
+    this.confirmedText,
+    this.pendingText,
+    this.acceptedAudioDuration,
+  });
 }
 
 /// The final transcript event for a task.
@@ -381,8 +438,8 @@ class SpeechToTextTask {
   ///
   /// This is a single-subscription stream. Runtime failures are emitted as a
   /// stream error and are also reported by [done] as a failed completion.
-  /// The first backend emits one [SpeechToTextFinalEvent]. The event model is
-  /// intentionally future-compatible with backends that support partial text.
+  /// Prompt-adapted recognition emits one [SpeechToTextFinalEvent]. Dedicated
+  /// backends can emit [SpeechToTextPartialEvent] updates first.
   Stream<SpeechToTextEvent> get events => _eventsController.stream;
 
   /// Completes once the task succeeds, is cancelled, or fails.
@@ -401,39 +458,130 @@ class SpeechToTextTask {
   }
 }
 
-/// Typed speech-to-text API backed by a loaded [LlamaEngine].
+/// An active incremental speech-recognition session.
 ///
-/// The first implementation supports complete Qwen3-ASR audio inputs on native
-/// llama.cpp with a matching audio-capable multimodal projector.
-/// It does not yet provide live microphone ingestion, partial transcripts,
-/// timestamps, confidence values, or diarization.
+/// Callers must await each [addPcm] operation. This applies bounded input
+/// backpressure while native inference runs in a worker isolate.
+abstract interface class SpeechToTextStreamingSession {
+  /// Partial and final transcript events.
+  ///
+  /// This is a single-subscription stream. Runtime failures are emitted as a
+  /// stream error and are also reported by [done] as a failed completion.
+  Stream<SpeechToTextEvent> get events;
+
+  /// Terminal completion state.
+  Future<SpeechToTextCompletion> get done;
+
+  /// Adds mono 16 kHz normalized float PCM.
+  ///
+  /// The caller must not mutate [samples] until the returned future completes.
+  Future<void> addPcm(Float32List samples);
+
+  /// Marks input complete and flushes the final partial inference window.
+  Future<void> finish();
+
+  /// Requests cooperative cancellation and releases native resources.
+  Future<void> cancel();
+}
+
+/// Typed speech-to-text API for prompt-adapted and dedicated ASR runtimes.
+///
+/// The default constructor adapts a loaded llama.cpp Qwen3-ASR model and its
+/// audio projector. [SpeechToTextEngine.liteRtLm] creates a dedicated native
+/// LiteRT-LM recognizer with incremental PCM input and partial transcripts.
 class SpeechToTextEngine {
-  final LlamaEngine _engine;
-  final SpeechEngineLease _engineLease;
   static const String _leaseOwner = 'speech-to-text';
+  static const SpeechAudioFormat _liteRtLmPcmFormat = SpeechAudioFormat(
+    sampleRateHz: 16000,
+    channelCount: 1,
+    encoding: 'pcm-f32le',
+  );
+
+  final LlamaEngine? _engine;
+  final SpeechEngineLease? _engineLease;
+  final LiteRtLmAsrRuntimeConfig? _liteRtLmConfig;
+  final LiteRtLmSpeechToTextDriver? _liteRtLmDriver;
+  final String? _liteRtLmLibraryPath;
+  Future<LiteRtLmSpeechToTextSupport>? _liteRtLmSupportFuture;
+  bool _liteRtLmTaskActive = false;
 
   /// Model-specific adapter selected by the caller.
   final SpeechToTextModelProfile modelProfile;
 
-  /// Creates a speech recognizer over an existing loaded engine.
+  /// Creates a Qwen3-ASR prompt adapter over an existing loaded engine.
   ///
-  /// The engine must be used exclusively for this task until [SpeechToTextTask.done]
-  /// completes. The recognizer prevents two speech wrappers over the same
-  /// engine from running together, but direct [LlamaEngine.create] calls are
-  /// owned by the caller.
+  /// The engine must be used exclusively until [SpeechToTextTask.done]
+  /// completes. Separate speech wrappers over the same engine share a lease,
+  /// but direct [LlamaEngine.create] calls remain caller-owned.
   SpeechToTextEngine(LlamaEngine engine, {required this.modelProfile})
     : _engine = engine,
-      _engineLease = SpeechEngineLease.forEngine(engine);
+      _engineLease = SpeechEngineLease.forEngine(engine),
+      _liteRtLmConfig = null,
+      _liteRtLmDriver = null,
+      _liteRtLmLibraryPath = null {
+    if (modelProfile == SpeechToTextModelProfile.liteRtLmDedicated) {
+      throw ArgumentError.value(
+        modelProfile,
+        'modelProfile',
+        'Use SpeechToTextEngine.liteRtLm for dedicated LiteRT-LM ASR.',
+      );
+    }
+  }
 
-  /// Discovers speech recognition support for the current runtime and model.
+  /// Creates a dedicated native LiteRT-LM recognizer.
+  ///
+  /// The configured model and tokenizer are independent of any chat model
+  /// loaded through [LlamaEngine]. The current runtime accepts mono 16 kHz
+  /// float PCM and supports one active task per recognizer instance.
+  /// [libraryPath] is an advanced local-validation override; packaged apps
+  /// should omit it and use the runtime resolved by native assets.
+  SpeechToTextEngine.liteRtLm(
+    LiteRtLmAsrRuntimeConfig config, {
+    String? libraryPath,
+  }) : _engine = null,
+       _engineLease = null,
+       _liteRtLmConfig = config,
+       _liteRtLmDriver =
+           debugLiteRtLmSpeechToTextDriverOverride ??
+           createLiteRtLmSpeechToTextDriver(),
+       _liteRtLmLibraryPath = libraryPath,
+       modelProfile = SpeechToTextModelProfile.liteRtLmDedicated;
+
+  bool get _usesLiteRtLm => _liteRtLmConfig != null;
+
+  /// Discovers speech recognition support for the configured runtime and model.
   Future<SpeechToTextCapabilities> get capabilities async {
+    if (_usesLiteRtLm) {
+      final support = await (_liteRtLmSupportFuture ??= _liteRtLmDriver!
+          .probeSupport(libraryPath: _liteRtLmLibraryPath));
+      if (!support.isSupported) {
+        return SpeechToTextCapabilities(
+          isSupported: false,
+          unsupportedReason: support.unsupportedReason,
+          backendName: 'LiteRT-LM ASR',
+        );
+      }
+      return const SpeechToTextCapabilities(
+        isSupported: true,
+        backendName: 'LiteRT-LM ASR CPU',
+        implementation: SpeechToTextImplementation.dedicatedBackend,
+        inputKinds: <SpeechAudioInputKind>{SpeechAudioInputKind.pcmFloat32},
+        supportsPartialResults: true,
+        supportsStreamingInput: true,
+        supportsCancellation: true,
+        supportsInputBackpressure: true,
+        maxConcurrentTasks: 1,
+      );
+    }
+
     if (!isSpeechToTextPlatformSupported) {
       return SpeechToTextCapabilities(
         isSupported: false,
         unsupportedReason: speechToTextPlatformUnsupportedReason,
       );
     }
-    if (!_engine.isReady) {
+    final engine = _engine!;
+    if (!engine.isReady) {
       return const SpeechToTextCapabilities(
         isSupported: false,
         unsupportedReason:
@@ -443,7 +591,7 @@ class SpeechToTextEngine {
 
     String? backendName;
     try {
-      backendName = await _engine.getBackendName();
+      backendName = await engine.getBackendName();
     } catch (_) {
       // Capability discovery can still use the explicit audio probe.
     }
@@ -451,15 +599,15 @@ class SpeechToTextEngine {
       return SpeechToTextCapabilities(
         isSupported: false,
         unsupportedReason:
-            'Dedicated LiteRT-LM speech APIs are not exported by the current '
-            'native artifact.',
+            'A chat-model LiteRT-LM engine is not a dedicated ASR session. '
+            'Use SpeechToTextEngine.liteRtLm with an ASR model and tokenizer.',
         backendName: backendName,
       );
     }
 
     bool supportsAudio;
     try {
-      supportsAudio = await _engine.supportsAudio;
+      supportsAudio = await engine.supportsAudio;
     } catch (error) {
       return SpeechToTextCapabilities(
         isSupported: false,
@@ -485,8 +633,6 @@ class SpeechToTextEngine {
         SpeechAudioInputKind.encodedBytes,
       },
       encodedAudioFormats: const <String>{'wav', 'mp3', 'flac'},
-      supportsLanguageHints: false,
-      supportsLanguageDetection: false,
       supportsCancellation: true,
       maxConcurrentTasks: 1,
     );
@@ -494,17 +640,21 @@ class SpeechToTextEngine {
 
   /// Starts recognition for one complete audio input.
   ///
-  /// The returned task exposes a future-compatible event stream and explicit
-  /// cancellation/completion state. Only one speech task may run per
-  /// [LlamaEngine], including through separate [SpeechToTextEngine] wrappers.
-  /// Invalid input and unsupported runtime/model preflight checks throw before
+  /// Qwen3-ASR accepts encoded files or bytes. Dedicated LiteRT-LM ASR accepts
+  /// [SpeechAudioPcmInput] and emits any intermediate partial events before its
+  /// final result. Invalid input and unsupported preflight checks throw before
   /// a task is returned; failures after startup are reported by the task.
   Future<SpeechToTextTask> transcribe(SpeechToTextRequest request) async {
     _validateRequest(request);
-    if (!_engineLease.acquire(_leaseOwner)) {
+    if (_usesLiteRtLm) {
+      return _transcribeLiteRtLm(request);
+    }
+
+    final lease = _engineLease!;
+    if (!lease.acquire(_leaseOwner)) {
       throw LlamaStateException(
         'This LlamaEngine already has an active typed speech task '
-        '(${_engineLease.activeOwner}).',
+        '(${lease.activeOwner}).',
       );
     }
 
@@ -517,12 +667,111 @@ class SpeechToTextEngine {
         );
       }
 
-      final task = SpeechToTextTask._(onCancel: _engine.cancelGeneration);
-      unawaited(_runTask(task, request));
+      final engine = _engine!;
+      final task = SpeechToTextTask._(onCancel: engine.cancelGeneration);
+      unawaited(_runPromptAdapterTask(task, request));
       return task;
     } catch (_) {
-      _engineLease.release(_leaseOwner);
+      lease.release(_leaseOwner);
       rethrow;
+    }
+  }
+
+  /// Starts an incremental dedicated-ASR session.
+  ///
+  /// This is currently available only for [SpeechToTextEngine.liteRtLm]. The
+  /// accepted [format] is mono 16 kHz `pcm-f32le`. Await every
+  /// [SpeechToTextStreamingSession.addPcm] call so bounded native backpressure
+  /// can throttle the producer.
+  Future<SpeechToTextStreamingSession> startStream({
+    SpeechAudioFormat format = _liteRtLmPcmFormat,
+  }) async {
+    if (!_usesLiteRtLm) {
+      throw LlamaUnsupportedException(
+        'The Qwen3-ASR prompt adapter accepts complete encoded audio only.',
+      );
+    }
+    _validateLiteRtLmPcmFormat(format);
+    if (_liteRtLmTaskActive) {
+      throw LlamaStateException(
+        'This SpeechToTextEngine already has an active LiteRT-LM ASR task.',
+      );
+    }
+    _liteRtLmTaskActive = true;
+    try {
+      final currentCapabilities = await capabilities;
+      if (!currentCapabilities.isSupported) {
+        throw LlamaUnsupportedException(
+          currentCapabilities.unsupportedReason ??
+              'Dedicated LiteRT-LM speech recognition is unavailable.',
+        );
+      }
+      final worker = await _liteRtLmDriver!.start(
+        _liteRtLmConfig!,
+        libraryPath: _liteRtLmLibraryPath,
+      );
+      return _LiteRtLmStreamingSession(
+        worker: worker,
+        sourceFormat: format,
+        onClosed: () => _liteRtLmTaskActive = false,
+      );
+    } catch (_) {
+      _liteRtLmTaskActive = false;
+      rethrow;
+    }
+  }
+
+  Future<SpeechToTextTask> _transcribeLiteRtLm(
+    SpeechToTextRequest request,
+  ) async {
+    final audio = request.audio as SpeechAudioPcmInput;
+    final session = await startStream(format: audio.format!);
+    late final SpeechToTextTask task;
+    task = SpeechToTextTask._(onCancel: () => unawaited(session.cancel()));
+    unawaited(_pipeLiteRtLmTask(task, session, audio.samples));
+    return task;
+  }
+
+  Future<void> _pipeLiteRtLmTask(
+    SpeechToTextTask task,
+    SpeechToTextStreamingSession session,
+    Float32List samples,
+  ) async {
+    final subscription = session.events.listen(
+      task._eventsController.add,
+      onError: task._eventsController.addError,
+    );
+    try {
+      await session.addPcm(samples);
+      if (!task.isCancellationRequested) {
+        await session.finish();
+      }
+      final completion = await session.done;
+      if (!task._doneCompleter.isCompleted) {
+        task._doneCompleter.complete(completion);
+      }
+    } catch (error, stackTrace) {
+      try {
+        await session.cancel();
+      } catch (_) {
+        // Preserve the first recognition failure.
+      }
+      if (task.isCancellationRequested) {
+        await _completeCancelled(task);
+      } else {
+        final speechError = _speechError(error);
+        task._eventsController.addError(speechError, stackTrace);
+        if (!task._doneCompleter.isCompleted) {
+          task._doneCompleter.complete(
+            SpeechToTextCompletion.failed(speechError),
+          );
+        }
+      }
+    } finally {
+      await subscription.cancel();
+      if (!task._eventsController.isClosed) {
+        await task._eventsController.close();
+      }
     }
   }
 
@@ -533,8 +782,33 @@ class SpeechToTextEngine {
     final languageHint = request.languageHint?.trim();
     if (languageHint != null && languageHint.isNotEmpty) {
       throw LlamaUnsupportedException(
-        'The Qwen3-ASR prompt adapter does not expose validated language hints.',
+        'The selected speech recognizer does not expose validated language hints.',
       );
+    }
+    if (_usesLiteRtLm) {
+      final contextPrompt = request.contextPrompt?.trim();
+      if (contextPrompt != null && contextPrompt.isNotEmpty) {
+        throw LlamaUnsupportedException(
+          'Dedicated LiteRT-LM ASR does not expose context prompting.',
+        );
+      }
+      final audio = request.audio;
+      if (audio is! SpeechAudioPcmInput) {
+        throw LlamaUnsupportedException(
+          'Dedicated LiteRT-LM ASR accepts SpeechAudioPcmInput only.',
+        );
+      }
+      if (audio.samples.isEmpty) {
+        throw LlamaAudioFormatException('Float PCM samples must not be empty.');
+      }
+      final format = audio.format;
+      if (format == null) {
+        throw LlamaAudioFormatException(
+          'Dedicated LiteRT-LM ASR requires explicit PCM metadata.',
+        );
+      }
+      _validateLiteRtLmPcmFormat(format);
+      return;
     }
 
     switch (request.audio) {
@@ -573,10 +847,27 @@ class SpeechToTextEngine {
             encoding,
           );
         }
+      case SpeechAudioPcmInput():
+        throw LlamaUnsupportedException(
+          'The Qwen3-ASR prompt adapter accepts encoded audio only.',
+        );
     }
   }
 
-  Future<void> _runTask(
+  void _validateLiteRtLmPcmFormat(SpeechAudioFormat format) {
+    final encoding = format.encoding?.trim().toLowerCase();
+    if (format.sampleRateHz != 16000 ||
+        format.channelCount != 1 ||
+        (encoding != null && encoding.isNotEmpty && encoding != 'pcm-f32le')) {
+      throw LlamaAudioFormatException(
+        'Dedicated LiteRT-LM ASR requires mono 16 kHz pcm-f32le audio.',
+        'sampleRateHz=${format.sampleRateHz}, '
+            'channelCount=${format.channelCount}, encoding=${format.encoding}',
+      );
+    }
+  }
+
+  Future<void> _runPromptAdapterTask(
     SpeechToTextTask task,
     SpeechToTextRequest request,
   ) async {
@@ -587,7 +878,7 @@ class SpeechToTextEngine {
       }
 
       final output = StringBuffer();
-      await for (final chunk in _engine.create(
+      await for (final chunk in _engine!.create(
         <LlamaChatMessage>[
           LlamaChatMessage.withContent(
             role: LlamaChatRole.user,
@@ -642,19 +933,19 @@ class SpeechToTextEngine {
         await _completeCancelled(task);
         return;
       }
-      final speechError = error is LlamaException
-          ? error
-          : LlamaSpeechException('Speech recognition failed.', error);
+      final speechError = _speechError(error);
       task._eventsController.addError(speechError, stackTrace);
       unawaited(task._eventsController.close());
       task._doneCompleter.complete(SpeechToTextCompletion.failed(speechError));
     } finally {
-      _engineLease.release(_leaseOwner);
+      _engineLease!.release(_leaseOwner);
     }
   }
 
   Future<void> _completeCancelled(SpeechToTextTask task) async {
-    unawaited(task._eventsController.close());
+    if (!task._eventsController.isClosed) {
+      unawaited(task._eventsController.close());
+    }
     if (!task._doneCompleter.isCompleted) {
       task._doneCompleter.complete(const SpeechToTextCompletion.cancelled());
     }
@@ -673,6 +964,9 @@ class SpeechToTextEngine {
     return switch (audio) {
       SpeechAudioFileInput(:final path) => LlamaAudioContent(path: path),
       SpeechAudioBytesInput(:final bytes) => LlamaAudioContent(bytes: bytes),
+      SpeechAudioPcmInput() => throw LlamaUnsupportedException(
+        'The Qwen3-ASR prompt adapter accepts encoded audio only.',
+      ),
     };
   }
 
@@ -705,3 +999,196 @@ class SpeechToTextEngine {
     );
   }
 }
+
+class _LiteRtLmStreamingSession implements SpeechToTextStreamingSession {
+  static const int _sampleRateHz = 16000;
+
+  final LiteRtLmSpeechToTextWorker _worker;
+  final SpeechAudioFormat _sourceFormat;
+  final void Function() _onClosed;
+  final StreamController<SpeechToTextEvent> _events =
+      StreamController<SpeechToTextEvent>();
+  final Completer<SpeechToTextCompletion> _done =
+      Completer<SpeechToTextCompletion>();
+  late final StreamSubscription<LiteRtLmSpeechToTextUpdate> _workerSubscription;
+
+  Future<void> _operationTail = Future<void>.value();
+  bool _finishing = false;
+  bool _closed = false;
+  int _acceptedSamples = 0;
+  String _latestConfirmedText = '';
+
+  _LiteRtLmStreamingSession({
+    required LiteRtLmSpeechToTextWorker worker,
+    required SpeechAudioFormat sourceFormat,
+    required void Function() onClosed,
+  }) : _worker = worker,
+       _sourceFormat = sourceFormat,
+       _onClosed = onClosed {
+    _workerSubscription = _worker.updates.listen(
+      _handleUpdate,
+      onError: (Object error, StackTrace stackTrace) {
+        unawaited(_fail(error, stackTrace));
+      },
+    );
+  }
+
+  @override
+  Stream<SpeechToTextEvent> get events => _events.stream;
+
+  @override
+  Future<SpeechToTextCompletion> get done => _done.future;
+
+  @override
+  Future<void> addPcm(Float32List samples) {
+    if (_finishing || _closed) {
+      throw LlamaStateException(
+        'Cannot add audio after the speech stream has finished.',
+      );
+    }
+    if (samples.isEmpty) {
+      return Future<void>.value();
+    }
+    final operation = _operationTail.then((_) async {
+      if (_finishing || _closed) {
+        throw LlamaStateException(
+          'Cannot add audio after the speech stream has finished.',
+        );
+      }
+      final accepted = await _worker.pushAudio(samples);
+      if (accepted != samples.length) {
+        throw LlamaSpeechException(
+          'LiteRT-LM ASR did not accept the complete PCM input.',
+          'acceptedSamples=$accepted, suppliedSamples=${samples.length}',
+        );
+      }
+      _acceptedSamples += accepted;
+    });
+    final guarded = operation.catchError((
+      Object error,
+      StackTrace stackTrace,
+    ) async {
+      await _fail(error, stackTrace);
+      Error.throwWithStackTrace(error, stackTrace);
+    });
+    _operationTail = guarded;
+    return guarded;
+  }
+
+  @override
+  Future<void> finish() async {
+    if (_finishing || _closed) {
+      return;
+    }
+    _finishing = true;
+    try {
+      await _operationTail;
+      final transcript = await _worker.finish();
+      final normalized = transcript.trim().isEmpty
+          ? _latestConfirmedText.trim()
+          : transcript.trim();
+      final result = SpeechToTextResult(
+        text: normalized,
+        segments: normalized.isEmpty
+            ? const <TranscriptSegment>[]
+            : <TranscriptSegment>[TranscriptSegment(text: normalized)],
+        sourceFormat: _sourceFormat,
+        audioDuration: _durationForSamples(_acceptedSamples),
+      );
+      if (!_events.isClosed) {
+        _events.add(SpeechToTextFinalEvent(result));
+      }
+      await _close();
+      if (!_done.isCompleted) {
+        _done.complete(SpeechToTextCompletion.completed(result));
+      }
+    } catch (error, stackTrace) {
+      await _fail(error, stackTrace);
+    }
+  }
+
+  @override
+  Future<void> cancel() async {
+    if (_closed) {
+      return;
+    }
+    _finishing = true;
+    try {
+      await _worker.cancel();
+    } finally {
+      await _close();
+      if (!_done.isCompleted) {
+        _done.complete(const SpeechToTextCompletion.cancelled());
+      }
+    }
+  }
+
+  void _handleUpdate(LiteRtLmSpeechToTextUpdate update) {
+    if (_closed) {
+      return;
+    }
+    _latestConfirmedText = update.confirmedText;
+    _acceptedSamples = update.acceptedSamples;
+    if (update.isFinal) {
+      return;
+    }
+    final confirmed = update.confirmedText.trim();
+    final pending = update.pendingText.trim();
+    final text = <String>[
+      confirmed,
+      pending,
+    ].where((part) => part.isNotEmpty).join(' ');
+    _events.add(
+      SpeechToTextPartialEvent(
+        text,
+        confirmedText: confirmed,
+        pendingText: pending,
+        acceptedAudioDuration: _durationForSamples(update.acceptedSamples),
+      ),
+    );
+  }
+
+  Duration _durationForSamples(int samples) => Duration(
+    microseconds: (samples * Duration.microsecondsPerSecond) ~/ _sampleRateHz,
+  );
+
+  Future<void> _fail(Object error, StackTrace stackTrace) async {
+    if (_closed) {
+      return;
+    }
+    final speechError = _speechError(error);
+    if (!_events.isClosed) {
+      _events.addError(speechError, stackTrace);
+    }
+    await _close();
+    if (!_done.isCompleted) {
+      _done.complete(SpeechToTextCompletion.failed(speechError));
+    }
+  }
+
+  Future<void> _close() async {
+    if (_closed) {
+      return;
+    }
+    _closed = true;
+    try {
+      await _workerSubscription.cancel();
+    } catch (_) {
+      // Continue releasing the worker and public task lease.
+    }
+    try {
+      await _worker.dispose();
+    } catch (_) {
+      // Native teardown is best effort after the task has reached a terminal
+      // state. The original recognition error remains authoritative.
+    }
+    if (!_events.isClosed) {
+      unawaited(_events.close());
+    }
+    _onClosed();
+  }
+}
+
+LlamaException _speechError(Object error) => error is LlamaException
+    ? error
+    : LlamaSpeechException('Speech recognition failed.', error);

--- a/lib/src/core/speech/text_to_speech.dart
+++ b/lib/src/core/speech/text_to_speech.dart
@@ -559,6 +559,10 @@ class TextToSpeechEngine {
             'Speaker reference bytes must not be empty.',
           );
         }
+      case SpeechAudioPcmInput():
+        throw LlamaUnsupportedException(
+          'Text-to-speech speaker references require encoded audio.',
+        );
       case null:
         break;
     }

--- a/test/unit/core/speech/litert_lm_speech_to_text_driver_io_test.dart
+++ b/test/unit/core/speech/litert_lm_speech_to_text_driver_io_test.dart
@@ -1,0 +1,69 @@
+@TestOn('vm')
+library;
+
+import 'dart:typed_data';
+
+import 'package:llamadart/llamadart.dart';
+import 'package:llamadart/src/core/speech/litert_lm_speech_to_text_driver_io.dart';
+import 'package:test/test.dart';
+
+void main() {
+  test('skips only LiteRT-LM incomplete BPE ASR windows', () {
+    final session = _FakeAsrSession(<Object>[
+      LlamaSpeechException(
+        'LiteRT-LM ASR inference failed with native status 9.',
+        'The set of token IDs passed to the tokenizer is part of a BPE '
+            'sequence and needs more tokens to be decoded.',
+      ),
+      const LiteRtLmAsrProcessResult(
+        state: LiteRtLmAsrProcessState.update,
+        confirmedText: 'recovered',
+      ),
+    ]);
+
+    expect(processLiteRtLmSpeechWindow(session), isNull);
+    expect(processLiteRtLmSpeechWindow(session)?.confirmedText, 'recovered');
+  });
+
+  test('does not hide unrelated LiteRT-LM ASR failures', () {
+    final error = LlamaSpeechException(
+      'LiteRT-LM ASR inference failed with native status 9.',
+      'Model invocation failed.',
+    );
+    final session = _FakeAsrSession(<Object>[error]);
+
+    expect(() => processLiteRtLmSpeechWindow(session), throwsA(same(error)));
+  });
+}
+
+class _FakeAsrSession implements LiteRtLmAsrRuntimeSession {
+  _FakeAsrSession(this._results);
+
+  final List<Object> _results;
+  int _index = 0;
+
+  @override
+  LiteRtLmAsrProcessResult processNext() {
+    final value = _results[_index++];
+    if (value is Exception) {
+      throw value;
+    }
+    return value as LiteRtLmAsrProcessResult;
+  }
+
+  @override
+  void cancel() {}
+
+  @override
+  void dispose() {}
+
+  @override
+  void finishAudio() {}
+
+  @override
+  LiteRtLmAsrPushResult pushAudio(Float32List samples) =>
+      LiteRtLmAsrPushResult(acceptedSamples: samples.length, wouldBlock: false);
+
+  @override
+  void reset() {}
+}

--- a/test/unit/core/speech/litert_lm_speech_to_text_driver_stub_test.dart
+++ b/test/unit/core/speech/litert_lm_speech_to_text_driver_stub_test.dart
@@ -1,0 +1,24 @@
+import 'package:llamadart/src/backends/litert_lm/litert_lm_asr_types.dart';
+import 'package:llamadart/src/core/speech/litert_lm_speech_to_text_driver_stub.dart';
+import 'package:test/test.dart';
+
+void main() {
+  test('stub reports dedicated ASR as native-only', () async {
+    final driver = createLiteRtLmSpeechToTextDriver();
+
+    final support = await driver.probeSupport();
+
+    expect(support.isSupported, isFalse);
+    expect(support.unsupportedReason, contains('native runtime'));
+    expect(
+      () => driver.start(
+        const LiteRtLmAsrRuntimeConfig(
+          modelPath: '/models/moonshine.tflite',
+          tokenizerPath: '/models/tokenizer.json',
+          modelPreset: LiteRtLmAsrModelPreset.moonshineTiny,
+        ),
+      ),
+      throwsA(isA<UnsupportedError>()),
+    );
+  });
+}

--- a/test/unit/core/speech/litert_lm_speech_to_text_driver_test.dart
+++ b/test/unit/core/speech/litert_lm_speech_to_text_driver_test.dart
@@ -1,0 +1,28 @@
+import 'package:llamadart/src/core/speech/litert_lm_speech_to_text_driver.dart';
+import 'package:test/test.dart';
+
+void main() {
+  test('support result preserves capability diagnostics', () {
+    const support = LiteRtLmSpeechToTextSupport(
+      isSupported: false,
+      unsupportedReason: 'missing ASR ABI',
+    );
+
+    expect(support.isSupported, isFalse);
+    expect(support.unsupportedReason, 'missing ASR ABI');
+  });
+
+  test('worker update preserves cumulative transcript state', () {
+    const update = LiteRtLmSpeechToTextUpdate(
+      confirmedText: 'hello',
+      pendingText: 'world',
+      isFinal: false,
+      acceptedSamples: 16000,
+    );
+
+    expect(update.confirmedText, 'hello');
+    expect(update.pendingText, 'world');
+    expect(update.isFinal, isFalse);
+    expect(update.acceptedSamples, 16000);
+  });
+}

--- a/test/unit/core/speech/speech_to_text_litert_lm_test.dart
+++ b/test/unit/core/speech/speech_to_text_litert_lm_test.dart
@@ -1,0 +1,356 @@
+@TestOn('vm')
+library;
+
+import 'dart:async';
+import 'dart:typed_data';
+
+import 'package:llamadart/llamadart.dart';
+import 'package:llamadart/src/core/speech/litert_lm_speech_to_text_driver.dart';
+import 'package:test/test.dart';
+
+void main() {
+  late _FakeLiteRtLmSpeechDriver driver;
+
+  const config = LiteRtLmAsrRuntimeConfig(
+    modelPath: '/models/moonshine.tflite',
+    tokenizerPath: '/models/tokenizer.json',
+    modelPreset: LiteRtLmAsrModelPreset.moonshineTiny,
+  );
+
+  setUp(() {
+    driver = _FakeLiteRtLmSpeechDriver();
+    debugLiteRtLmSpeechToTextDriverOverride = driver;
+  });
+
+  tearDown(() async {
+    debugLiteRtLmSpeechToTextDriverOverride = null;
+    await driver.close();
+  });
+
+  test('reports dedicated streaming PCM capabilities', () async {
+    final engine = SpeechToTextEngine.liteRtLm(config);
+
+    final capabilities = await engine.capabilities;
+
+    expect(capabilities.isSupported, isTrue);
+    expect(capabilities.backendName, 'LiteRT-LM ASR CPU');
+    expect(
+      capabilities.implementation,
+      SpeechToTextImplementation.dedicatedBackend,
+    );
+    expect(capabilities.inputKinds, {SpeechAudioInputKind.pcmFloat32});
+    expect(capabilities.encodedAudioFormats, isEmpty);
+    expect(capabilities.supportsPartialResults, isTrue);
+    expect(capabilities.supportsStreamingInput, isTrue);
+    expect(capabilities.supportsInputBackpressure, isTrue);
+    expect(capabilities.supportsOutputBackpressure, isFalse);
+    expect(capabilities.supportsCancellation, isTrue);
+    expect(capabilities.maxConcurrentTasks, 1);
+    expect(driver.probeCalls, 1);
+  });
+
+  test('reports a version-skewed native runtime as unsupported', () async {
+    driver.support = const LiteRtLmSpeechToTextSupport(
+      isSupported: false,
+      unsupportedReason: 'missing v0.16 ASR ABI',
+    );
+    final engine = SpeechToTextEngine.liteRtLm(config);
+
+    final capabilities = await engine.capabilities;
+
+    expect(capabilities.isSupported, isFalse);
+    expect(capabilities.unsupportedReason, contains('v0.16'));
+    await expectLater(
+      engine.startStream(),
+      throwsA(isA<LlamaUnsupportedException>()),
+    );
+    expect(driver.startCalls, 0);
+  });
+
+  test('forwards an advanced native library override', () async {
+    final engine = SpeechToTextEngine.liteRtLm(
+      config,
+      libraryPath: '/runtime/libLiteRtLm.so',
+    );
+
+    await engine.capabilities;
+    final session = await engine.startStream();
+    await session.cancel();
+
+    expect(driver.lastProbeLibraryPath, '/runtime/libLiteRtLm.so');
+    expect(driver.lastStartLibraryPath, '/runtime/libLiteRtLm.so');
+    expect(driver.probeCalls, 1);
+  });
+
+  test('streams partial text and produces a final result', () async {
+    final engine = SpeechToTextEngine.liteRtLm(config);
+    final session = await engine.startStream();
+    final eventsFuture = session.events.toList();
+
+    await session.addPcm(Float32List.fromList(<double>[0.25, -0.25]));
+    await session.finish();
+
+    final completion = await session.done;
+    final events = await eventsFuture;
+    expect(events.whereType<SpeechToTextPartialEvent>(), hasLength(1));
+    final first = events.first as SpeechToTextPartialEvent;
+    expect(first.confirmedText, 'hello');
+    expect(first.pendingText, 'wor');
+    expect(first.text, 'hello wor');
+    expect(first.acceptedAudioDuration, const Duration(microseconds: 125));
+    final finalEvent = events.last as SpeechToTextFinalEvent;
+    expect(finalEvent.result.text, 'hello world');
+    expect(finalEvent.result.audioDuration, const Duration(microseconds: 125));
+    expect(completion.state, SpeechToTextCompletionState.completed);
+    expect(completion.result, same(finalEvent.result));
+    expect(driver.worker.pushedSamples, <double>[0.25, -0.25]);
+    expect(driver.worker.disposed, isTrue);
+  });
+
+  test('transcribes complete PCM through the dedicated backend', () async {
+    final engine = SpeechToTextEngine.liteRtLm(config);
+
+    final task = await engine.transcribe(
+      SpeechToTextRequest(audio: SpeechAudioPcmInput(Float32List(16000))),
+    );
+    final events = await task.events.toList();
+    final completion = await task.done;
+
+    expect(events.whereType<SpeechToTextPartialEvent>(), hasLength(1));
+    expect((events.last as SpeechToTextFinalEvent).result.text, 'hello world');
+    expect(completion.result?.text, 'hello world');
+    expect(completion.result?.audioDuration, const Duration(seconds: 1));
+  });
+
+  test('applies async input backpressure and preserves push order', () async {
+    final engine = SpeechToTextEngine.liteRtLm(config);
+    final session = await engine.startStream();
+    driver.worker.blockPush = true;
+
+    final first = session.addPcm(Float32List.fromList(<double>[1]));
+    final second = session.addPcm(Float32List.fromList(<double>[2]));
+    await Future<void>.delayed(Duration.zero);
+
+    expect(driver.worker.pushCalls, 1);
+    driver.worker.releasePushes();
+    await Future.wait<void>(<Future<void>>[first, second]);
+    await session.cancel();
+    expect(driver.worker.pushedSamples, <double>[1, 2]);
+  });
+
+  test('allows only one active dedicated task per engine', () async {
+    final engine = SpeechToTextEngine.liteRtLm(config);
+    final first = await engine.startStream();
+
+    await expectLater(
+      engine.startStream(),
+      throwsA(isA<LlamaStateException>()),
+    );
+
+    await first.cancel();
+    final second = await engine.startStream();
+    await second.cancel();
+    expect(driver.startCalls, 2);
+  });
+
+  test(
+    'turns a push failure into terminal state and releases the engine',
+    () async {
+      final engine = SpeechToTextEngine.liteRtLm(config);
+      final session = await engine.startStream();
+      driver.worker.pushError = StateError('native inference failed');
+
+      await expectLater(
+        session.addPcm(Float32List(1)),
+        throwsA(isA<StateError>()),
+      );
+      final completion = await session.done;
+
+      expect(completion.state, SpeechToTextCompletionState.failed);
+      expect(completion.error, isA<LlamaSpeechException>());
+      expect(
+        completion.error?.details.toString(),
+        contains('native inference failed'),
+      );
+      final next = await engine.startStream();
+      await next.cancel();
+    },
+  );
+
+  test('cancels a dedicated session idempotently', () async {
+    final engine = SpeechToTextEngine.liteRtLm(config);
+    final session = await engine.startStream();
+
+    await session.cancel();
+    await session.cancel();
+
+    expect((await session.done).state, SpeechToTextCompletionState.cancelled);
+    expect(driver.worker.cancelCalls, 1);
+    expect(driver.worker.disposeCalls, 1);
+  });
+
+  test('rejects encoded inputs and incompatible PCM metadata', () async {
+    final engine = SpeechToTextEngine.liteRtLm(config);
+
+    await expectLater(
+      engine.transcribe(
+        SpeechToTextRequest(
+          audio: SpeechAudioBytesInput(Uint8List.fromList(<int>[1, 2])),
+        ),
+      ),
+      throwsA(isA<LlamaUnsupportedException>()),
+    );
+    await expectLater(
+      engine.transcribe(
+        SpeechToTextRequest(
+          audio: SpeechAudioPcmInput(
+            Float32List(1),
+            format: const SpeechAudioFormat(
+              sampleRateHz: 48000,
+              channelCount: 2,
+              encoding: 'pcm-f32le',
+            ),
+          ),
+        ),
+      ),
+      throwsA(isA<LlamaAudioFormatException>()),
+    );
+    await expectLater(
+      engine.startStream(
+        format: const SpeechAudioFormat(
+          sampleRateHz: 16000,
+          channelCount: 1,
+          encoding: 'pcm-s16le',
+        ),
+      ),
+      throwsA(isA<LlamaAudioFormatException>()),
+    );
+    await expectLater(
+      engine.transcribe(
+        SpeechToTextRequest(
+          audio: SpeechAudioPcmInput(Float32List(1), format: null),
+        ),
+      ),
+      throwsA(isA<LlamaAudioFormatException>()),
+    );
+  });
+}
+
+class _FakeLiteRtLmSpeechDriver implements LiteRtLmSpeechToTextDriver {
+  LiteRtLmSpeechToTextSupport support = const LiteRtLmSpeechToTextSupport(
+    isSupported: true,
+  );
+  int probeCalls = 0;
+  int startCalls = 0;
+  String? lastProbeLibraryPath;
+  String? lastStartLibraryPath;
+  _FakeLiteRtLmSpeechWorker worker = _FakeLiteRtLmSpeechWorker();
+
+  @override
+  Future<LiteRtLmSpeechToTextSupport> probeSupport({
+    String? libraryPath,
+  }) async {
+    probeCalls++;
+    lastProbeLibraryPath = libraryPath;
+    return support;
+  }
+
+  @override
+  Future<LiteRtLmSpeechToTextWorker> start(
+    LiteRtLmAsrRuntimeConfig config, {
+    String? libraryPath,
+  }) async {
+    startCalls++;
+    lastStartLibraryPath = libraryPath;
+    worker = _FakeLiteRtLmSpeechWorker();
+    return worker;
+  }
+
+  Future<void> close() => worker.close();
+}
+
+class _FakeLiteRtLmSpeechWorker implements LiteRtLmSpeechToTextWorker {
+  final StreamController<LiteRtLmSpeechToTextUpdate> _updates =
+      StreamController<LiteRtLmSpeechToTextUpdate>();
+  final List<double> pushedSamples = <double>[];
+  final List<Completer<void>> _pushBlockers = <Completer<void>>[];
+  bool blockPush = false;
+  Object? pushError;
+  bool disposed = false;
+  int pushCalls = 0;
+  int cancelCalls = 0;
+  int disposeCalls = 0;
+  int _acceptedSamples = 0;
+
+  @override
+  Stream<LiteRtLmSpeechToTextUpdate> get updates => _updates.stream;
+
+  @override
+  Future<int> pushAudio(Float32List samples) async {
+    pushCalls++;
+    final error = pushError;
+    if (error != null) {
+      throw error;
+    }
+    if (blockPush) {
+      final blocker = Completer<void>();
+      _pushBlockers.add(blocker);
+      await blocker.future;
+    }
+    pushedSamples.addAll(samples);
+    _acceptedSamples += samples.length;
+    _updates.add(
+      LiteRtLmSpeechToTextUpdate(
+        confirmedText: 'hello',
+        pendingText: 'wor',
+        isFinal: false,
+        acceptedSamples: _acceptedSamples,
+      ),
+    );
+    return samples.length;
+  }
+
+  void releasePushes() {
+    blockPush = false;
+    for (final blocker in _pushBlockers) {
+      if (!blocker.isCompleted) {
+        blocker.complete();
+      }
+    }
+  }
+
+  @override
+  Future<String> finish() async {
+    _updates.add(
+      LiteRtLmSpeechToTextUpdate(
+        confirmedText: 'hello world',
+        pendingText: '',
+        isFinal: true,
+        acceptedSamples: _acceptedSamples,
+      ),
+    );
+    return 'hello world';
+  }
+
+  @override
+  Future<void> cancel() async {
+    cancelCalls++;
+    releasePushes();
+  }
+
+  @override
+  Future<void> dispose() async {
+    if (disposed) {
+      return;
+    }
+    disposeCalls++;
+    disposed = true;
+    unawaited(_updates.close());
+  }
+
+  Future<void> close() async {
+    if (!disposed) {
+      await dispose();
+    }
+  }
+}

--- a/test/unit/core/speech/speech_to_text_test.dart
+++ b/test/unit/core/speech/speech_to_text_test.dart
@@ -43,7 +43,10 @@ void main() {
         capabilities.implementation,
         SpeechToTextImplementation.multimodalPromptAdapter,
       );
-      expect(capabilities.inputKinds, containsAll(SpeechAudioInputKind.values));
+      expect(capabilities.inputKinds, {
+        SpeechAudioInputKind.file,
+        SpeechAudioInputKind.encodedBytes,
+      });
       expect(capabilities.encodedAudioFormats, {'wav', 'mp3', 'flac'});
       expect(capabilities.supportsPartialResults, isFalse);
       expect(capabilities.supportsStreamingInput, isFalse);
@@ -261,7 +264,7 @@ void main() {
       final capabilities = await speechEngine.capabilities;
 
       expect(capabilities.isSupported, isFalse);
-      expect(capabilities.unsupportedReason, contains('not exported'));
+      expect(capabilities.unsupportedReason, contains('not a dedicated ASR'));
       expect(
         () => speechEngine.transcribe(
           const SpeechToTextRequest(

--- a/test/unit/core/speech/speech_to_text_web_test.dart
+++ b/test/unit/core/speech/speech_to_text_web_test.dart
@@ -25,6 +25,25 @@ void main() {
       throwsA(isA<LlamaUnsupportedException>()),
     );
   });
+
+  test('dedicated LiteRT-LM speech is explicitly unsupported on Web', () async {
+    final engine = SpeechToTextEngine.liteRtLm(
+      const LiteRtLmAsrRuntimeConfig(
+        modelPath: '/models/moonshine.tflite',
+        tokenizerPath: '/models/tokenizer.json',
+        modelPreset: LiteRtLmAsrModelPreset.moonshineTiny,
+      ),
+    );
+
+    final capabilities = await engine.capabilities;
+
+    expect(capabilities.isSupported, isFalse);
+    expect(capabilities.unsupportedReason, contains('native runtime'));
+    await expectLater(
+      engine.startStream(),
+      throwsA(isA<LlamaUnsupportedException>()),
+    );
+  });
 }
 
 class _WebBackend implements LlamaBackend {

--- a/test/unit/core/speech/text_to_speech_test.dart
+++ b/test/unit/core/speech/text_to_speech_test.dart
@@ -61,10 +61,10 @@ void main() {
         ]),
       );
       expect(capabilities.supportsSpeakerReference, isTrue);
-      expect(
-        capabilities.speakerReferenceInputKinds,
-        containsAll(SpeechAudioInputKind.values),
-      );
+      expect(capabilities.speakerReferenceInputKinds, {
+        SpeechAudioInputKind.file,
+        SpeechAudioInputKind.encodedBytes,
+      });
       expect(capabilities.supportsIncrementalAudio, isFalse);
       expect(capabilities.supportsCancellation, isTrue);
       expect(capabilities.supportsOutputBackpressure, isFalse);

--- a/tool/litert_lm_asr_smoke.dart
+++ b/tool/litert_lm_asr_smoke.dart
@@ -33,27 +33,44 @@ Future<void> main(List<String> args) async {
   final fixture = await _readPcm16MonoWav(audioPath);
   final libraryPath = Platform.environment['LLAMADART_LITERT_LM_LIBRARY_PATH']
       ?.trim();
-  final client = LiteRtLmRuntimeClient(
+  final recognizer = SpeechToTextEngine.liteRtLm(
+    LiteRtLmAsrRuntimeConfig(
+      modelPath: modelPath,
+      tokenizerPath: tokenizerPath,
+      modelPreset: preset,
+    ),
     libraryPath: libraryPath == null || libraryPath.isEmpty
         ? null
         : libraryPath,
   );
   final stopwatch = Stopwatch()..start();
-  LiteRtLmAsrRuntimeSession? session;
+  SpeechToTextStreamingSession? session;
   try {
-    if (!client.supportsAsrBridge) {
+    final capabilities = await recognizer.capabilities;
+    if (!capabilities.isSupported) {
       throw StateError(
-        'The loaded LiteRT-LM runtime does not expose the dedicated ASR bridge.',
+        capabilities.unsupportedReason ??
+            'The loaded LiteRT-LM runtime does not expose dedicated ASR.',
       );
     }
-    session = client.createAsrSession(
-      LiteRtLmAsrRuntimeConfig(
-        modelPath: modelPath,
-        tokenizerPath: tokenizerPath,
-        modelPreset: preset,
-      ),
-    );
-    final transcript = _transcribe(session, fixture.samples);
+    session = await recognizer.startStream();
+    final eventsFuture = session.events.toList();
+    for (var offset = 0; offset < fixture.samples.length;) {
+      final end = math.min(offset + _pushSamples, fixture.samples.length);
+      await session.addPcm(
+        Float32List.sublistView(fixture.samples, offset, end),
+      );
+      offset = end;
+    }
+    await session.finish();
+    final completion = await session.done;
+    final events = await eventsFuture;
+    if (completion.state != SpeechToTextCompletionState.completed ||
+        completion.result == null) {
+      throw completion.error ??
+          StateError('LiteRT-LM ASR did not complete successfully.');
+    }
+    final transcript = completion.result!.text;
     stopwatch.stop();
     final normalizedTranscript = _normalize(transcript);
     final normalizedExpected = _normalize(expected);
@@ -66,98 +83,17 @@ Future<void> main(List<String> args) async {
     final result = <String, Object>{
       'modelPreset': preset.name,
       'backend': LiteRtLmAsrBackend.cpu.name,
+      'implementation': capabilities.implementation.name,
       'sampleRateHz': _sampleRateHz,
       'sampleCount': fixture.samples.length,
+      'partialEventCount': events.whereType<SpeechToTextPartialEvent>().length,
       'fixtureId': fixture.fixtureId,
       'elapsedMilliseconds': stopwatch.elapsedMilliseconds,
       'transcript': transcript,
     };
     print('RESULT litert_lm_asr ${jsonEncode(result)}');
   } finally {
-    session?.dispose();
-    client.dispose();
-  }
-}
-
-String _transcribe(LiteRtLmAsrRuntimeSession session, Float32List samples) {
-  final confirmed = <String>[];
-  var offset = 0;
-  var finalSeen = false;
-
-  while (offset < samples.length) {
-    final end = math.min(offset + _pushSamples, samples.length);
-    final chunk = Float32List.sublistView(samples, offset, end);
-    final push = session.pushAudio(chunk);
-    if (push.acceptedSamples == 0) {
-      if (!push.wouldBlock) {
-        throw StateError(
-          'LiteRT-LM ASR accepted no audio without backpressure.',
-        );
-      }
-      final state = _processAvailable(session, confirmed);
-      if (state == LiteRtLmAsrProcessState.needsMoreAudio) {
-        throw StateError(
-          'LiteRT-LM ASR reported backpressure but could not process a window.',
-        );
-      }
-      finalSeen = state == LiteRtLmAsrProcessState.endOfStream;
-      continue;
-    }
-    offset += push.acceptedSamples;
-    final state = _processAvailable(session, confirmed);
-    if (state == LiteRtLmAsrProcessState.endOfStream) {
-      finalSeen = true;
-      break;
-    }
-  }
-
-  if (!finalSeen) {
-    session.finishAudio();
-    for (var attempt = 0; attempt < 10000; attempt++) {
-      final result = session.processNext();
-      if (result.state == LiteRtLmAsrProcessState.endOfStream) {
-        finalSeen = true;
-        break;
-      }
-      if (result.state == LiteRtLmAsrProcessState.needsMoreAudio) {
-        throw StateError(
-          'LiteRT-LM ASR requested more audio after input finalization.',
-        );
-      }
-      _appendConfirmed(confirmed, result.confirmedText);
-      if (result.isFinal) {
-        finalSeen = true;
-        break;
-      }
-    }
-  }
-  if (!finalSeen) {
-    throw StateError('LiteRT-LM ASR did not produce a final result.');
-  }
-  return confirmed.join(' ').trim();
-}
-
-LiteRtLmAsrProcessState _processAvailable(
-  LiteRtLmAsrRuntimeSession session,
-  List<String> confirmed,
-) {
-  for (var attempt = 0; attempt < 10000; attempt++) {
-    final result = session.processNext();
-    if (result.state != LiteRtLmAsrProcessState.update) {
-      return result.state;
-    }
-    _appendConfirmed(confirmed, result.confirmedText);
-    if (result.isFinal) {
-      return LiteRtLmAsrProcessState.endOfStream;
-    }
-  }
-  throw StateError('LiteRT-LM ASR processing did not quiesce.');
-}
-
-void _appendConfirmed(List<String> confirmed, String value) {
-  final normalized = value.trim();
-  if (normalized.isNotEmpty) {
-    confirmed.add(normalized);
+    await session?.cancel();
   }
 }
 

--- a/tool/testing/run_local_e2e.dart
+++ b/tool/testing/run_local_e2e.dart
@@ -310,7 +310,7 @@ List<LocalE2eScenario> buildLocalE2eScenarios({String? projectRoot}) {
       name: 'litert-lm-asr-smoke',
       group: LocalE2eScenarioGroup.dartLocalOnly,
       description:
-          'Run the dedicated LiteRT-LM ASR session API against a known PCM16 fixture.',
+          'Run the public dedicated LiteRT-LM speech engine against a known PCM16 fixture.',
       requiresDevice: false,
       stepsBuilder: (context) => [
         LocalE2eCommandStep(
@@ -325,7 +325,7 @@ List<LocalE2eScenario> buildLocalE2eScenarios({String? projectRoot}) {
             context.modelPreset,
             context.expect,
           ],
-          description: 'Dedicated LiteRT-LM ASR real-model smoke',
+          description: 'Public LiteRT-LM speech engine real-model smoke',
         ),
       ],
     ),

--- a/tool/testing/test_matrix.dart
+++ b/tool/testing/test_matrix.dart
@@ -212,15 +212,16 @@ const List<TestMatrixRow> testMatrixRows = <TestMatrixRow>[
     tier: 'targeted',
     mode: 'local-only',
     covers:
-        'dedicated native LiteRT-LM ASR bridge discovery, bounded PCM push, '
-        'window processing, finalization, and expected real-model transcript',
+        'public dedicated LiteRT-LM SpeechToTextEngine discovery, worker-isolated '
+        'bounded PCM streaming, partial events, finalization, and expected '
+        'real-model transcript',
     command:
         'dart run tool/testing/run_local_e2e.dart --scenario '
         'litert-lm-asr-smoke --model-path <model.tflite> '
         '--tokenizer-path <tokenizer.json> --audio-path <fixture.wav> '
         '--model-preset moonshine-tiny --expect "<expected transcript>"',
     useWhen:
-        'LiteRT-LM ASR bridge, runtime sessions, native pins, or streaming '
+        'LiteRT-LM ASR bridge, public speech API, native pins, or streaming '
         'speech work. This CPU-only engine row does not establish microphone UI.',
   ),
   TestMatrixRow(

--- a/website/docs/changelog/recent-releases.md
+++ b/website/docs/changelog/recent-releases.md
@@ -13,20 +13,21 @@ For canonical full release notes, use:
   Flutter chat example, and made Android Auto probe the packaged Vulkan device
   before choosing GPU offload.
 
-- Updated the native LiteRT-LM runtime to `v0.16.0-native.2` and added
-  experimental CPU-only dedicated ASR runtime sessions with bounded PCM input
-  and confirmed/unconfirmed transcript updates. The Apple companion also
-  packages the iOS Gemma constraint provider and Metal plugins required by the
-  published runtime. This is a low-level native API and is not yet a
-  `SpeechToTextEngine` backend.
+- Updated the native LiteRT-LM runtime to `v0.16.0-native.2` and added an
+  experimental dedicated `SpeechToTextEngine.liteRtLm` path with bounded mono
+  16 kHz float PCM input, partial/final transcript events, worker-isolated CPU
+  inference, backpressure, and cancellation. The Apple companion also packages
+  the iOS Gemma constraint provider and Metal plugins required by the published
+  runtime.
 
 - Added experimental live English dictation to native Flutter chat models,
   including generic audio-chat models, using selectable checksum-pinned
   Moonshine Tiny (recommended, 54 MB) and Parakeet TDT 0.6B (optional, 615 MB)
   LiteRT sidecars. The UI reports determinate download progress and supports
-  cancellation/retry; worker-isolated PCM streaming produces confirmed/pending
-  text and editable composer finalization. A persisted settings switch explains
-  and enables or disables the optional workflow. Audio-chat models retain
+  cancellation/retry; the public worker-isolated streaming STT API produces
+  confirmed/pending text and editable composer finalization. A persisted
+  settings switch explains and enables or disables the optional workflow.
+  Audio-chat models retain
   **Ask with voice** as a separate action.
 
 - Improved Flutter chat example model downloads with bounded retries for

--- a/website/docs/examples/chat-app.md
+++ b/website/docs/examples/chat-app.md
@@ -81,13 +81,12 @@ flutter test
   TDT 0.6B is an optional higher-capacity, heavier 615 MB choice. Selection is
   persistent and the composer shows size, installed state, determinate
   download progress, cancel, and retry. The app streams mono 16 kHz PCM to a
-  worker-isolated, CPU-only session, shows confirmed and pending
+  worker-isolated, CPU-only `SpeechToTextEngine.liteRtLm` session, shows confirmed and pending
   five-second-window text, and returns the final transcript to the editable
   composer without auto-sending. A persisted **Live dictation** switch in the
-  settings explains and enables or disables this optional workflow. This
-  app-owned path is enabled on Android, iOS, macOS, and Windows, capped at five
-  minutes, and remains separate from
-  whole-file `SpeechToTextEngine`, Linux recording, and Web. Audio-chat models
+  settings explains and enables or disables this optional workflow. This path
+  is enabled on Android, iOS, macOS, and Windows, capped at five minutes, and
+  remains unavailable for Linux recording and Web. Audio-chat models
   retain **Ask with voice** as a separate action. Parakeet TDT follows its
   upstream [CC-BY-4.0 license](https://huggingface.co/nvidia/parakeet-tdt-0.6b-v3).
 - **Ask with voice** for native Gemma 4 E2B, using either the LiteRT-LM

--- a/website/docs/guides/speech-to-text.md
+++ b/website/docs/guides/speech-to-text.md
@@ -1,6 +1,6 @@
 ---
 title: Speech to Text
-description: Transcribe complete audio files with the experimental typed native llama.cpp speech API.
+description: Transcribe encoded audio or stream PCM with the experimental typed native speech API.
 ---
 
 `SpeechToTextEngine` is the typed API for speech recognition. It is separate
@@ -8,9 +8,10 @@ from `LlamaEngine` because transcript events, timestamps, confidence, language,
 speaker labels, cancellation, and audio metadata have a different contract from
 chat-completion tokens.
 
-The first implementation is experimental and deliberately narrow: it adapts
-native llama.cpp audio input to whole-file transcription. It has been validated
-with Qwen3-ASR 0.6B, but recognition quality and language behavior remain model
+The API currently has two experimental native implementations. llama.cpp adapts
+Qwen3-ASR audio input to whole-file transcription. LiteRT-LM uses a dedicated
+CPU ASR engine for incremental mono 16 kHz PCM, partial text, and finalization
+from a worker isolate. Recognition quality and language behavior remain model
 dependent. Generic `LlamaAudioContent` chat input still exists separately for
 audio-capable multimodal models.
 
@@ -20,31 +21,26 @@ audio-capable multimodal models.
 | --- | --- | --- | --- |
 | Native llama.cpp / GGUF | Model + projector dependent | Experimental Qwen3-ASR adapter; complete WAV/MP3/FLAC file or bytes, final transcript only | Experimental Qwen3-TTS adapter; see [Text to Speech](./text-to-speech) |
 | WebGPU / GGUF | Bridge + model dependent | Unsupported | Unsupported |
-| Native LiteRT-LM | Separate `.litertlm` audio chat remains bundle dependent | Experimental CPU-only dedicated ASR runtime sessions; not yet wired to `SpeechToTextEngine` | Unsupported |
+| Native LiteRT-LM | Separate `.litertlm` audio chat remains bundle dependent | Experimental dedicated CPU ASR through `SpeechToTextEngine.liteRtLm`; mono 16 kHz float PCM, partial/final text, streaming input | Unsupported |
 | LiteRT-LM Web | Unsupported | Unsupported | Unsupported |
 
 “Generic audio-input chat” means an audio content part is processed by normal
 generation. It does not imply a transcript schema, stable ASR behavior, or TTS.
-The typed STT API adds a stable Dart result/cancellation boundary, but the first
-backend still performs whole-audio llama.cpp generation internally. Its
-`SpeechToTextImplementation.multimodalPromptAdapter` capability makes that
-distinction inspectable; it is not a dedicated native ASR engine.
+The typed STT API adds a stable Dart result/cancellation boundary. The llama.cpp
+backend still performs whole-audio generation internally and reports
+`SpeechToTextImplementation.multimodalPromptAdapter`. LiteRT-LM reports
+`SpeechToTextImplementation.dedicatedBackend` and does not use the selected
+chat model.
 
-## Dedicated LiteRT-LM ASR sessions
+## Stream with dedicated LiteRT-LM ASR
 
-LiteRT-LM v0.16 adds a different speech path: dedicated ASR engines that
-consume streaming PCM windows instead of an audio part in normal chat. The
-experimental `LiteRtLmRuntimeClient` bridge exposes that low-level native
-session boundary while the higher-level `SpeechToTextEngine` adapter is still
-being designed.
+LiteRT-LM v0.16 adds dedicated ASR engines that consume PCM windows instead of
+an audio part in normal chat. Configure the local model/tokenizer pair, start a
+stream, and await every input push so bounded native backpressure can throttle
+the producer.
 
 ```dart
-final runtime = LiteRtLmRuntimeClient();
-if (!runtime.supportsAsrBridge) {
-  throw StateError('Install the pinned speech-capable LiteRT-LM runtime.');
-}
-
-final session = runtime.createAsrSession(
+final recognizer = SpeechToTextEngine.liteRtLm(
   const LiteRtLmAsrRuntimeConfig(
     modelPath: '/models/moonshine_tiny.tflite',
     tokenizerPath: '/models/tokenizer.json',
@@ -52,58 +48,42 @@ final session = runtime.createAsrSession(
   ),
 );
 
-try {
-  var offset = 0;
-  while (offset < mono16KhzFloatPcm.length) {
-    final push = session.pushAudio(
-      Float32List.sublistView(mono16KhzFloatPcm, offset),
-    );
-    offset += push.acceptedSamples;
-    if (push.acceptedSamples == 0 && !push.wouldBlock) {
-      throw StateError('ASR input made no progress.');
-    }
-    if (!push.wouldBlock) continue;
-
-    final update = session.processNext();
-    print('${update.confirmedText}${update.unconfirmedText}');
-  }
-
-  session.finishAudio();
-  while (true) {
-    final update = session.processNext();
-    if (update.state == LiteRtLmAsrProcessState.endOfStream) break;
-    if (update.state == LiteRtLmAsrProcessState.needsMoreAudio) {
-      throw StateError('Finalized ASR input requested more audio.');
-    }
-    print('${update.confirmedText}${update.unconfirmedText}');
-    if (update.isFinal) break;
-  }
-} finally {
-  session.dispose();
-  runtime.dispose();
+final capabilities = await recognizer.capabilities;
+if (!capabilities.isSupported) {
+  throw StateError(capabilities.unsupportedReason);
 }
+
+final session = await recognizer.startStream();
+final events = session.events.listen((event) {
+  if (event is SpeechToTextPartialEvent) {
+    print('stable=${event.confirmedText} pending=${event.pendingText}');
+  } else if (event is SpeechToTextFinalEvent) {
+    print('final=${event.result.text}');
+  }
+});
+
+for (final chunk in mono16KhzFloatPcmChunks) {
+  await session.addPcm(chunk);
+}
+await session.finish();
+final completion = await session.done;
+await events.cancel();
 ```
 
-The input contract is mono 16 kHz `Float32List` PCM. `pushAudio` can accept a
-prefix and report backpressure; callers must process a window before retrying
-the unaccepted suffix. `confirmedText` is stable, while `unconfirmedText` may
-change after the next window. `finishAudio` flushes a partial final window,
-`reset` reuses the session for another stream, and `cancel` is cooperative
-between native inference windows.
+The input contract is mono 16 kHz normalized `Float32List` PCM. The public
+session owns synchronous inference in a worker isolate. `confirmedText` is
+stable, while `pendingText` may change after the next inference window.
+`finish` flushes a partial final window, and `cancel` is cooperative between
+native windows. Pausing the event subscription does not throttle inference;
+awaiting `addPcm` is the input-backpressure boundary.
 
-Inference is synchronous and potentially expensive. Own the session from a
-worker isolate rather than calling `processNext` on a Flutter UI isolate. The
-validated v0.16 contract is CPU-only; accelerator enum values are deliberately
-not exposed until their transcripts pass the same real-model correctness
-gates. Supported metadata presets currently cover Parakeet TDT, Parakeet CTC,
-Moonshine Tiny, Whisper Tiny, and Qwen3-ASR 0.6B, but callers must provide the
-matching model and tokenizer artifacts.
-
-This low-level API does not itself provide microphone capture, a Dart event
-stream, timestamps, confidence, diarization, or automatic resampling. The chat
-example now demonstrates an app-owned microphone/worker wrapper with selectable
-Moonshine Tiny and Parakeet TDT sidecars. That example integration is not yet a
-public streaming `SpeechToTextEngine` adapter.
+The validated v0.16 contract is CPU-only. Supported metadata presets cover
+Parakeet TDT, Parakeet CTC, Moonshine Tiny, Whisper Tiny, and Qwen3-ASR 0.6B,
+but callers must supply a matching model and tokenizer. The API does not
+capture a microphone, resample audio, or provide timestamps, confidence, or
+diarization. Advanced callers can still use `LiteRtLmRuntimeClient` and
+`LiteRtLmAsrRuntimeSession` directly, but those synchronous calls must not run
+on a Flutter UI isolate.
 
 ## Load a Qwen3-ASR model
 
@@ -165,9 +145,9 @@ single-subscription stream: runtime failure is emitted as a stream error and
 the same terminal condition is available through `task.done`.
 
 Native llama.cpp currently decodes WAV, MP3, and FLAC file or byte inputs. Raw
-PCM is intentionally not exposed by the typed API yet: projector sample rates
-are model-specific, and the current public engine capability does not report
-the loaded projector's required rate.
+PCM remains unsupported for that prompt adapter because projector sample rates
+are model-specific. Dedicated LiteRT-LM accepts `SpeechAudioPcmInput` for a
+complete mono 16 kHz float buffer, or the incremental session shown above.
 
 `SpeechAudioFormat` also carries optional encoding and MIME metadata. Final
 results reserve segment and word timing, confidence, and speaker fields so a
@@ -176,10 +156,10 @@ llama.cpp adapter returns one untimed segment and no confidence or diarization.
 
 ## Streaming, cancellation, and concurrency
 
-The event stream is future-compatible with partial transcripts, but the first
-backend consumes the complete input before inference and emits only one final
-event. It does not accept live microphone frames, and pausing the Dart event
-subscription does not throttle native inference.
+The llama.cpp prompt adapter consumes complete encoded input and emits one final
+event. Dedicated LiteRT-LM emits replaceable partial events while accepting
+incremental PCM. Pausing either event stream does not throttle native
+inference; LiteRT-LM producers must await `addPcm` for input backpressure.
 
 Call `task.cancel()` to request cooperative cancellation:
 
@@ -191,9 +171,11 @@ final completion = await task.done;
 assert(completion.state == SpeechToTextCompletionState.cancelled);
 ```
 
-Cancelling a stream subscription does not cancel the native task. All
-`SpeechToTextEngine` wrappers over one `LlamaEngine` share a one-task lease.
-Do not call `LlamaEngine.create` on that engine until the speech task completes.
+Cancelling an event subscription does not cancel the native task. Call
+`task.cancel()` for whole-input recognition or `await session.cancel()` for an
+incremental session. All prompt-adapter wrappers over one `LlamaEngine` share a
+one-task lease. A dedicated LiteRT-LM recognizer allows one active task per
+`SpeechToTextEngine` instance.
 
 ## Chat app
 
@@ -212,9 +194,9 @@ different user actions:
   54 MB default; Parakeet TDT 0.6B is an optional higher-capacity, heavier
   615 MB choice. The selector remembers the choice and reports model size,
   installed state, determinate download progress, cancellation, and retry. The
-  app captures mono 16 kHz PCM, owns the synchronous LiteRT-LM session in a
-  worker isolate, and renders monotonic confirmed text plus a replaceable
-  pending suffix after each five-second window. **Use text** finalizes the
+  app captures mono 16 kHz PCM, feeds the public worker-isolated
+  `SpeechToTextEngine.liteRtLm` session, and renders monotonic confirmed text
+  plus a replaceable pending suffix after each five-second window. **Use text** finalizes the
   session and inserts the result into the editable composer; it never submits
   the message automatically. Generic audio-chat models retain **Ask with
   voice** as a separate action.
@@ -227,9 +209,9 @@ different user actions:
   when both capability declarations are present.
 
 The dedicated **Transcribe Audio** action remains hidden on Web and for normal
-LiteRT-LM chat bundles. Live dictation is a separate app-owned sidecar flow,
-not a capability of the selected chat bundle or the current public
-`SpeechToTextEngine`.
+LiteRT-LM chat bundles. Live dictation uses the public LiteRT-LM streaming STT
+API with an app-managed sidecar; it is not a capability of the selected chat
+bundle.
 ASR microphone recordings are capped at five minutes, cancelled when the app is
 backgrounded, and deleted after transcription. This remains a whole-file
 workflow: it does not produce live partial transcripts while the user speaks.
@@ -275,8 +257,8 @@ the native downloader verifies both files before the model can be selected.
 - Qwen3-ASR may emit a leading `language English<asr_text>` marker. llamadart
   strips that marker, but does not expose it as reliable detected-language
   metadata until language behavior has a dedicated validation contract.
-- There are no word/segment timestamps, confidence scores, speaker
-  diarization, or incremental audio frames in the current backend.
+- There are no word/segment timestamps, confidence scores, or speaker
+  diarization. Incremental audio and partial text are LiteRT-LM-only.
 - Native inference backend correctness and performance remain device dependent;
   establish a CPU baseline before claiming GPU support for a deployment.
 - The local real-model smoke has passed on macOS arm64 CPU, and a separate

--- a/website/docs/platforms/support-matrix.md
+++ b/website/docs/platforms/support-matrix.md
@@ -22,10 +22,11 @@ the caller explicitly selects the Qwen3-ASR profile and the loaded projector
 reports audio capability. This path is real-model validated on macOS arm64;
 other native targets still need representative validation. Native llama.cpp
 also exposes experimental Qwen3-TTS synthesis through the separate typed
-[`TextToSpeechEngine`](../guides/text-to-speech). Native LiteRT-LM v0.16 adds
-an experimental CPU-only, low-level dedicated ASR session API, but it is not
-yet a `SpeechToTextEngine` backend. WebGPU and LiteRT-LM Web do not currently
-expose either typed speech path. See the
+[`TextToSpeechEngine`](../guides/text-to-speech). Native LiteRT-LM v0.16 also
+supports experimental CPU-only streaming ASR through
+`SpeechToTextEngine.liteRtLm`, with the native session owned by a worker
+isolate. WebGPU and LiteRT-LM Web do not currently expose either typed speech
+path. See the
 [speech recognition support matrix](../guides/speech-to-text#current-support-matrix).
 
 Available override tags are published on the


### PR DESCRIPTION
## Summary

- expose the released LiteRT-LM v0.16 dedicated ASR path through the typed
  `SpeechToTextEngine.liteRtLm` API
- add worker-isolated incremental mono 16 kHz float PCM input, confirmed and
  pending transcript events, bounded input backpressure, finalization, and
  cooperative cancellation
- support complete PCM transcription through the existing task/completion API
- migrate the Flutter chat example's live dictation worker to the public API,
  leaving microphone capture, sidecar downloads, and composer UX app-owned
- keep Web explicitly unsupported and capability-gated

## Public API

The new dedicated path is separate from a loaded chat `LlamaEngine`:

```dart
final recognizer = SpeechToTextEngine.liteRtLm(
  const LiteRtLmAsrRuntimeConfig(
    modelPath: '/models/moonshine.tflite',
    tokenizerPath: '/models/tokenizer.json',
    modelPreset: LiteRtLmAsrModelPreset.moonshineTiny,
  ),
);

final session = await recognizer.startStream();
for (final chunk in mono16KhzFloatPcmChunks) {
  await session.addPcm(chunk);
}
await session.finish();
final completion = await session.done;
```

`addPcm` is the bounded producer-backpressure boundary. Partial events expose
monotonic `confirmedText`, replaceable `pendingText`, and accepted-audio
duration. The current validated runtime remains CPU-only and does not claim
timestamps, confidence, language detection, diarization, capture, or
resampling.

The existing Qwen3-ASR llama.cpp prompt adapter remains a whole-encoded-audio
path. Generic audio chat remains separate from typed STT.

## Compatibility

| Path | Status in this PR |
| --- | --- |
| Native LiteRT-LM | Experimental dedicated streaming/complete PCM STT |
| Native llama.cpp | Existing whole-file Qwen3-ASR behavior unchanged |
| WebGPU | Explicitly unsupported; Chrome contract tests pass |
| LiteRT-LM Web | Explicitly unsupported |

The API probes the packaged ASR ABI and reports an actionable unsupported
capability with older/version-skewed runtimes. The worker isolate owns the
synchronous native session so inference does not run on Flutter's UI isolate.

## Validation

- rebased exact-head CI: 12/12 checks passed
- `dart analyze lib test tool`
- `dart run tool/testing/check_platform_boundaries.dart`
- root VM: 1,403 passed, 66 skipped
- root Chrome: 751 passed, 1 skipped
- Flutter chat example: `flutter analyze`; 319 tests passed
- LCOV line coverage: 73.82% (11,439 / 15,495)
- Docusaurus build and link validation
- release-doc version consistency
- macOS debug chat-app build
- published-runtime real model smoke on macOS arm64 CPU:
  - Moonshine Tiny 5-second-window model
  - 11-second mono 16 kHz JFK fixture
  - 3 partial events
  - expected `my fellow Americans` transcript matched
  - 2,694 ms elapsed

## Out of scope / follow-up

- WebGPU Qwen3-ASR validation and browser capture remain tracked by #329.
- llama.cpp stateful streaming remains unavailable; the remaining multi-mode
  work stays tracked by #327.
- The chat app still owns microphone permission/capture and model downloads.
- No automatic chat submission, VAD, timestamps, confidence, or diarization.

Related to #327 and #329. This PR intentionally does not close either tracker.
