### PR TITLE
Redesign chat app onboarding and scrolling UX

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,10 @@
   transient network failures, safe resume after truncated responses, and a
   distinct integrity-verification state after transfer reaches 100%.
 
+* Redesigned the Flutter chat example onboarding and Lab surfaces, preserved a
+  completed model card's viewport position when downloads reorder the catalog,
+  and stopped streaming responses from pulling users away from chat history.
+
 * Added an experimental typed `TextToSpeechEngine` for native llama.cpp
   Qwen3-TTS models, with capability discovery, language and optional speaker
   reference input, cancellable progress, complete 24 kHz PCM output, and WAV

--- a/example/chat_app/integration_test/model_cache_mmproj_e2e_test.dart
+++ b/example/chat_app/integration_test/model_cache_mmproj_e2e_test.dart
@@ -24,102 +24,110 @@ import 'package:llamadart_chat_example/models/downloadable_model.dart';
 import 'package:llamadart_chat_example/services/chat_service.dart';
 import 'package:llamadart_chat_example/services/model_service_base.dart';
 
+const _fixtureModelUrl =
+    'https://huggingface.co/LiquidAI/LFM2-VL-450M-GGUF/resolve/main/'
+    'LFM2-VL-450M-Q4_0.gguf?download=true';
+const _fixtureMmprojUrl =
+    'https://huggingface.co/LiquidAI/LFM2-VL-450M-GGUF/resolve/main/'
+    'mmproj-LFM2-VL-450M-Q8_0.gguf?download=true';
+
 void main() {
   IntegrationTestWidgetsFlutterBinding.ensureInitialized();
 
   testWidgets(
     'downloads, caches, and loads multimodal fixture + mmproj',
-    (tester) async {
-      final model = DownloadableModel(
-        name: 'LFM2-VL 450M integration fixture',
-        description:
-            'Small multimodal fixture for local-only cache validation.',
-        url:
-            'https://huggingface.co/LiquidAI/LFM2-VL-450M-GGUF/resolve/main/LFM2-VL-450M-Q4_0.gguf?download=true',
-        filename: 'LFM2-VL-450M-Q4_0.gguf',
-        mmprojUrl:
-            'https://huggingface.co/LiquidAI/LFM2-VL-450M-GGUF/resolve/main/mmproj-LFM2-VL-450M-Q8_0.gguf?download=true',
-        mmprojFilename: 'mmproj-LFM2-VL-450M-Q8_0.gguf',
-        sizeBytes: 323197440,
-        supportsVision: true,
-      );
-      expect(model.multimodalProjectorSource, isNotNull);
-
-      final service = ModelService();
-      final modelsDir = await service.getModelsDirectory();
-
-      await service.deleteModel(modelsDir, model);
-      var downloaded = await service.getDownloadedModels([model]);
-      expect(downloaded.contains(model.filename), isFalse);
-
-      final stages = <ModelDownloadStage>{};
-      final progressEvents = <ModelDownloadProgress>[];
-      Object? downloadError;
-      String? successFilename;
-
-      await service.downloadModel(
-        model: model,
-        modelsDir: modelsDir,
-        cancelToken: CancelToken(),
-        onProgress: (_) {},
-        onProgressDetail: (detail) {
-          stages.add(detail.stage);
-          progressEvents.add(detail);
-          debugPrint(
-            'E2E download ${detail.stage.name} '
-            '${(detail.overallProgress * 100).toStringAsFixed(1)}% '
-            '${detail.stageDownloadedBytes}/${detail.stageTotalBytes ?? -1}',
-          );
-        },
-        onSuccess: (filename) {
-          successFilename = filename;
-        },
-        onError: (error) {
-          downloadError = error;
-        },
-      );
-
-      expect(downloadError, isNull);
-      expect(successFilename, model.filename);
-      expect(stages, contains(ModelDownloadStage.model));
-      expect(stages, contains(ModelDownloadStage.multimodalProjector));
-      expect(progressEvents.last.overallProgress, 1.0);
-
-      downloaded = await service.getDownloadedModels([model]);
-      expect(downloaded, contains(model.filename));
-
-      final modelSource = model.modelSource;
-      final mmprojSource = model.multimodalProjectorSource!;
-      final modelLoadRef = kIsWeb || modelSource is LocalModelAssetSource
-          ? modelSource.loadReference
-          : p.join(modelsDir, model.filename);
-      final mmprojLoadRef = kIsWeb || mmprojSource is LocalModelAssetSource
-          ? mmprojSource.loadReference
-          : p.join(modelsDir, mmprojSource.displayName);
-
-      final chatService = ChatService();
-      try {
-        await chatService.init(
-          ChatSettings(
-            modelPath: modelLoadRef,
-            mmprojPath: mmprojLoadRef,
-            preferredBackend: GpuBackend.cpu,
-            gpuLayers: 0,
-            contextSize: 512,
-            maxTokens: 32,
-            nativeLogLevel: LlamaLogLevel.warn,
-          ),
-          eagerLoadMultimodalProjector: true,
-          onProgress: (progress) =>
-              debugPrint('E2E load ${(progress * 100).toStringAsFixed(1)}%'),
-        );
-
-        expect(chatService.engine.isReady, isTrue);
-        expect(await chatService.engine.supportsVision, isTrue);
-      } finally {
-        await chatService.dispose();
-      }
-    },
+    _downloadsCachesAndLoadsMultimodalFixture,
     timeout: const Timeout(Duration(minutes: 30)),
   );
+}
+
+Future<void> _downloadsCachesAndLoadsMultimodalFixture(
+  WidgetTester tester,
+) async {
+  final model = DownloadableModel(
+    name: 'LFM2-VL 450M integration fixture',
+    description: 'Small multimodal fixture for local-only cache validation.',
+    url: _fixtureModelUrl,
+    filename: 'LFM2-VL-450M-Q4_0.gguf',
+    mmprojUrl: _fixtureMmprojUrl,
+    mmprojFilename: 'mmproj-LFM2-VL-450M-Q8_0.gguf',
+    sizeBytes: 323197440,
+    supportsVision: true,
+  );
+  expect(model.multimodalProjectorSource, isNotNull);
+
+  final service = ModelService();
+  final modelsDir = await service.getModelsDirectory();
+
+  await service.deleteModel(modelsDir, model);
+  var downloaded = await service.getDownloadedModels([model]);
+  expect(downloaded.contains(model.filename), isFalse);
+
+  final stages = <ModelDownloadStage>{};
+  final progressEvents = <ModelDownloadProgress>[];
+  Object? downloadError;
+  String? successFilename;
+
+  await service.downloadModel(
+    model: model,
+    modelsDir: modelsDir,
+    cancelToken: CancelToken(),
+    onProgress: (_) {},
+    onProgressDetail: (detail) {
+      stages.add(detail.stage);
+      progressEvents.add(detail);
+      debugPrint(
+        'E2E download ${detail.stage.name} '
+        '${(detail.overallProgress * 100).toStringAsFixed(1)}% '
+        '${detail.stageDownloadedBytes}/${detail.stageTotalBytes ?? -1}',
+      );
+    },
+    onSuccess: (filename) {
+      successFilename = filename;
+    },
+    onError: (error) {
+      downloadError = error;
+    },
+  );
+
+  expect(downloadError, isNull);
+  expect(successFilename, model.filename);
+  expect(stages, contains(ModelDownloadStage.model));
+  expect(stages, contains(ModelDownloadStage.multimodalProjector));
+  expect(progressEvents.last.overallProgress, 1.0);
+
+  downloaded = await service.getDownloadedModels([model]);
+  expect(downloaded, contains(model.filename));
+
+  final modelSource = model.modelSource;
+  final mmprojSource = model.multimodalProjectorSource!;
+  final modelLoadRef = kIsWeb || modelSource is LocalModelAssetSource
+      ? modelSource.loadReference
+      : p.join(modelsDir, model.filename);
+  final mmprojLoadRef = kIsWeb || mmprojSource is LocalModelAssetSource
+      ? mmprojSource.loadReference
+      : p.join(modelsDir, mmprojSource.displayName);
+
+  final chatService = ChatService();
+  try {
+    await chatService.init(
+      ChatSettings(
+        modelPath: modelLoadRef,
+        mmprojPath: mmprojLoadRef,
+        preferredBackend: GpuBackend.cpu,
+        gpuLayers: 0,
+        contextSize: 512,
+        maxTokens: 32,
+        nativeLogLevel: LlamaLogLevel.warn,
+      ),
+      eagerLoadMultimodalProjector: true,
+      onProgress: (progress) =>
+          debugPrint('E2E load ${(progress * 100).toStringAsFixed(1)}%'),
+    );
+
+    expect(chatService.engine.isReady, isTrue);
+    expect(await chatService.engine.supportsVision, isTrue);
+  } finally {
+    await chatService.dispose();
+  }
 }

--- a/example/chat_app/integration_test/model_cache_mmproj_e2e_test.dart
+++ b/example/chat_app/integration_test/model_cache_mmproj_e2e_test.dart
@@ -2,7 +2,7 @@
 @Timeout(Duration(minutes: 30))
 /// Local-only chat app E2E for the model/mmproj download-cache-load path.
 ///
-/// This downloads the default LFM2-VL 450M model and its mmproj, so it is
+/// This downloads a small LFM2-VL fixture and its mmproj, so it is
 /// intentionally skipped by default. Run it manually with:
 ///
 /// ```bash
@@ -27,87 +27,99 @@ import 'package:llamadart_chat_example/services/model_service_base.dart';
 void main() {
   IntegrationTestWidgetsFlutterBinding.ensureInitialized();
 
-  testWidgets('downloads, caches, and loads tiny multimodal model + mmproj', (
-    tester,
-  ) async {
-    final model = DownloadableModel.defaultModels.firstWhere(
-      (candidate) => candidate.name == 'LFM2-VL 450M',
-    );
-    expect(model.multimodalProjectorSource, isNotNull);
+  testWidgets(
+    'downloads, caches, and loads multimodal fixture + mmproj',
+    (tester) async {
+      final model = DownloadableModel(
+        name: 'LFM2-VL 450M integration fixture',
+        description:
+            'Small multimodal fixture for local-only cache validation.',
+        url:
+            'https://huggingface.co/LiquidAI/LFM2-VL-450M-GGUF/resolve/main/LFM2-VL-450M-Q4_0.gguf?download=true',
+        filename: 'LFM2-VL-450M-Q4_0.gguf',
+        mmprojUrl:
+            'https://huggingface.co/LiquidAI/LFM2-VL-450M-GGUF/resolve/main/mmproj-LFM2-VL-450M-Q8_0.gguf?download=true',
+        mmprojFilename: 'mmproj-LFM2-VL-450M-Q8_0.gguf',
+        sizeBytes: 323197440,
+        supportsVision: true,
+      );
+      expect(model.multimodalProjectorSource, isNotNull);
 
-    final service = ModelService();
-    final modelsDir = await service.getModelsDirectory();
+      final service = ModelService();
+      final modelsDir = await service.getModelsDirectory();
 
-    await service.deleteModel(modelsDir, model);
-    var downloaded = await service.getDownloadedModels([model]);
-    expect(downloaded.contains(model.filename), isFalse);
+      await service.deleteModel(modelsDir, model);
+      var downloaded = await service.getDownloadedModels([model]);
+      expect(downloaded.contains(model.filename), isFalse);
 
-    final stages = <ModelDownloadStage>{};
-    final progressEvents = <ModelDownloadProgress>[];
-    Object? downloadError;
-    String? successFilename;
+      final stages = <ModelDownloadStage>{};
+      final progressEvents = <ModelDownloadProgress>[];
+      Object? downloadError;
+      String? successFilename;
 
-    await service.downloadModel(
-      model: model,
-      modelsDir: modelsDir,
-      cancelToken: CancelToken(),
-      onProgress: (_) {},
-      onProgressDetail: (detail) {
-        stages.add(detail.stage);
-        progressEvents.add(detail);
-        debugPrint(
-          'E2E download ${detail.stage.name} '
-          '${(detail.overallProgress * 100).toStringAsFixed(1)}% '
-          '${detail.stageDownloadedBytes}/${detail.stageTotalBytes ?? -1}',
-        );
-      },
-      onSuccess: (filename) {
-        successFilename = filename;
-      },
-      onError: (error) {
-        downloadError = error;
-      },
-    );
-
-    expect(downloadError, isNull);
-    expect(successFilename, model.filename);
-    expect(stages, contains(ModelDownloadStage.model));
-    expect(stages, contains(ModelDownloadStage.multimodalProjector));
-    expect(progressEvents.last.overallProgress, 1.0);
-
-    downloaded = await service.getDownloadedModels([model]);
-    expect(downloaded, contains(model.filename));
-
-    final modelSource = model.modelSource;
-    final mmprojSource = model.multimodalProjectorSource!;
-    final modelLoadRef = kIsWeb || modelSource is LocalModelAssetSource
-        ? modelSource.loadReference
-        : p.join(modelsDir, model.filename);
-    final mmprojLoadRef = kIsWeb || mmprojSource is LocalModelAssetSource
-        ? mmprojSource.loadReference
-        : p.join(modelsDir, mmprojSource.displayName);
-
-    final chatService = ChatService();
-    try {
-      await chatService.init(
-        ChatSettings(
-          modelPath: modelLoadRef,
-          mmprojPath: mmprojLoadRef,
-          preferredBackend: GpuBackend.cpu,
-          gpuLayers: 0,
-          contextSize: 512,
-          maxTokens: 32,
-          nativeLogLevel: LlamaLogLevel.warn,
-        ),
-        eagerLoadMultimodalProjector: true,
-        onProgress: (progress) =>
-            debugPrint('E2E load ${(progress * 100).toStringAsFixed(1)}%'),
+      await service.downloadModel(
+        model: model,
+        modelsDir: modelsDir,
+        cancelToken: CancelToken(),
+        onProgress: (_) {},
+        onProgressDetail: (detail) {
+          stages.add(detail.stage);
+          progressEvents.add(detail);
+          debugPrint(
+            'E2E download ${detail.stage.name} '
+            '${(detail.overallProgress * 100).toStringAsFixed(1)}% '
+            '${detail.stageDownloadedBytes}/${detail.stageTotalBytes ?? -1}',
+          );
+        },
+        onSuccess: (filename) {
+          successFilename = filename;
+        },
+        onError: (error) {
+          downloadError = error;
+        },
       );
 
-      expect(chatService.engine.isReady, isTrue);
-      expect(await chatService.engine.supportsVision, isTrue);
-    } finally {
-      await chatService.dispose();
-    }
-  }, timeout: const Timeout(Duration(minutes: 30)));
+      expect(downloadError, isNull);
+      expect(successFilename, model.filename);
+      expect(stages, contains(ModelDownloadStage.model));
+      expect(stages, contains(ModelDownloadStage.multimodalProjector));
+      expect(progressEvents.last.overallProgress, 1.0);
+
+      downloaded = await service.getDownloadedModels([model]);
+      expect(downloaded, contains(model.filename));
+
+      final modelSource = model.modelSource;
+      final mmprojSource = model.multimodalProjectorSource!;
+      final modelLoadRef = kIsWeb || modelSource is LocalModelAssetSource
+          ? modelSource.loadReference
+          : p.join(modelsDir, model.filename);
+      final mmprojLoadRef = kIsWeb || mmprojSource is LocalModelAssetSource
+          ? mmprojSource.loadReference
+          : p.join(modelsDir, mmprojSource.displayName);
+
+      final chatService = ChatService();
+      try {
+        await chatService.init(
+          ChatSettings(
+            modelPath: modelLoadRef,
+            mmprojPath: mmprojLoadRef,
+            preferredBackend: GpuBackend.cpu,
+            gpuLayers: 0,
+            contextSize: 512,
+            maxTokens: 32,
+            nativeLogLevel: LlamaLogLevel.warn,
+          ),
+          eagerLoadMultimodalProjector: true,
+          onProgress: (progress) =>
+              debugPrint('E2E load ${(progress * 100).toStringAsFixed(1)}%'),
+        );
+
+        expect(chatService.engine.isReady, isTrue);
+        expect(await chatService.engine.supportsVision, isTrue);
+      } finally {
+        await chatService.dispose();
+      }
+    },
+    timeout: const Timeout(Duration(minutes: 30)),
+  );
 }

--- a/example/chat_app/lib/screens/app_shell_screen.dart
+++ b/example/chat_app/lib/screens/app_shell_screen.dart
@@ -57,10 +57,9 @@ class _AppShellScreenState extends State<AppShellScreen> {
     _scaffoldKey.currentState?.openEndDrawer();
   }
 
-  void _openDownloadDetails({required bool canPin}) {
-    final activeFilename = _downloadUi.activeFilename;
+  void _openModelDetails({String? filename, required bool canPin}) {
     setState(() {
-      _focusedModelFilename = activeFilename;
+      _focusedModelFilename = filename;
       _modelFocusRequest += 1;
       if (canPin) {
         _pinnedSettingsOpen = true;
@@ -69,6 +68,10 @@ class _AppShellScreenState extends State<AppShellScreen> {
     if (!canPin) {
       _scaffoldKey.currentState?.openEndDrawer();
     }
+  }
+
+  void _openDownloadDetails({required bool canPin}) {
+    _openModelDetails(filename: _downloadUi.activeFilename, canPin: canPin);
   }
 
   void _toggleSettingsPanel({required bool canPin}) {
@@ -152,18 +155,16 @@ class _AppShellScreenState extends State<AppShellScreen> {
                               children: [
                                 IconButton(
                                   onPressed: () => Navigator.of(context).pop(),
-                                  tooltip: 'Close settings',
+                                  tooltip: 'Close Lab',
                                   icon: const Icon(
                                     Icons.close_rounded,
-                                    semanticLabel: kIsWeb
-                                        ? null
-                                        : 'Close settings',
+                                    semanticLabel: kIsWeb ? null : 'Close Lab',
                                   ),
                                 ),
                                 const SizedBox(width: 4),
                                 Expanded(
                                   child: Text(
-                                    'Settings',
+                                    'Lab',
                                     maxLines: 1,
                                     overflow: TextOverflow.ellipsis,
                                     style: Theme.of(context)
@@ -245,6 +246,11 @@ class _AppShellScreenState extends State<AppShellScreen> {
                                 onOpenModelSelection: () => _openSettingsPanel(
                                   canPin: canPinSettingsPanel,
                                 ),
+                                onOpenModelFilename: (filename) =>
+                                    _openModelDetails(
+                                      filename: filename,
+                                      canPin: canPinSettingsPanel,
+                                    ),
                                 showModelSelectionAction: true,
                               ),
                             ),
@@ -316,12 +322,20 @@ class _ShellTopBar extends StatelessWidget {
     required this.onOpenSettings,
   });
 
+  String _cleanModelName(String? pathOrUrl) {
+    if (pathOrUrl == null || pathOrUrl.isEmpty) {
+      return 'Model';
+    }
+    final withoutSensitiveSuffix = pathOrUrl.split('?').first.split('#').first;
+    final normalized = withoutSensitiveSuffix.replaceAll('\\', '/');
+    final parts = normalized.split('/').where((part) => part.isNotEmpty);
+    return parts.isEmpty ? 'Model' : parts.last;
+  }
+
   @override
   Widget build(BuildContext context) {
     final topInset = MediaQuery.paddingOf(context).top;
-    final settingsActionLabel = settingsPanelOpen
-        ? 'Close model and inference settings'
-        : 'Open model and inference settings';
+    final settingsActionLabel = settingsPanelOpen ? 'Close Lab' : 'Open Lab';
 
     return Container(
       padding: EdgeInsets.fromLTRB(12, topInset + 10, 12, 10),
@@ -357,6 +371,69 @@ class _ShellTopBar extends StatelessWidget {
                 letterSpacing: 0,
               ),
             ),
+          ),
+          Consumer<ChatProvider>(
+            builder: (context, provider, _) {
+              if (!provider.isLoaded || provider.modelPath == null) {
+                return const SizedBox.shrink();
+              }
+              final isDesktop = MediaQuery.sizeOf(context).width >= 720;
+              final backend = provider.activeBackend;
+              final modelName = _cleanModelName(provider.modelPath);
+              return Padding(
+                padding: const EdgeInsets.only(right: 6),
+                child: Tooltip(
+                  message: 'Active: $backend · $modelName. Tap to open Lab.',
+                  child: Material(
+                    color: Theme.of(
+                      context,
+                    ).colorScheme.surfaceContainerHigh.withValues(alpha: 0.7),
+                    borderRadius: BorderRadius.circular(20),
+                    child: InkWell(
+                      onTap: onOpenSettings,
+                      borderRadius: BorderRadius.circular(20),
+                      child: Padding(
+                        padding: const EdgeInsets.symmetric(
+                          horizontal: 10,
+                          vertical: 6,
+                        ),
+                        child: Row(
+                          mainAxisSize: MainAxisSize.min,
+                          children: [
+                            Container(
+                              width: 7,
+                              height: 7,
+                              decoration: BoxDecoration(
+                                shape: BoxShape.circle,
+                                color: Theme.of(context).colorScheme.primary,
+                              ),
+                            ),
+                            const SizedBox(width: 6),
+                            ConstrainedBox(
+                              constraints: BoxConstraints(
+                                maxWidth: isDesktop ? 220 : 120,
+                              ),
+                              child: Text(
+                                isDesktop ? '$backend · $modelName' : modelName,
+                                maxLines: 1,
+                                overflow: TextOverflow.ellipsis,
+                                style: TextStyle(
+                                  fontSize: 12,
+                                  fontWeight: FontWeight.w600,
+                                  color: Theme.of(
+                                    context,
+                                  ).colorScheme.onSurface,
+                                ),
+                              ),
+                            ),
+                          ],
+                        ),
+                      ),
+                    ),
+                  ),
+                ),
+              );
+            },
           ),
           _DownloadActivityButton(
             controller: downloadUi,

--- a/example/chat_app/lib/screens/app_shell_screen.dart
+++ b/example/chat_app/lib/screens/app_shell_screen.dart
@@ -322,16 +322,6 @@ class _ShellTopBar extends StatelessWidget {
     required this.onOpenSettings,
   });
 
-  String _cleanModelName(String? pathOrUrl) {
-    if (pathOrUrl == null || pathOrUrl.isEmpty) {
-      return 'Model';
-    }
-    final withoutSensitiveSuffix = pathOrUrl.split('?').first.split('#').first;
-    final normalized = withoutSensitiveSuffix.replaceAll('\\', '/');
-    final parts = normalized.split('/').where((part) => part.isNotEmpty);
-    return parts.isEmpty ? 'Model' : parts.last;
-  }
-
   @override
   Widget build(BuildContext context) {
     final topInset = MediaQuery.paddingOf(context).top;
@@ -379,7 +369,7 @@ class _ShellTopBar extends StatelessWidget {
               }
               final isDesktop = MediaQuery.sizeOf(context).width >= 720;
               final backend = provider.activeBackend;
-              final modelName = _cleanModelName(provider.modelPath);
+              final modelName = provider.activeModelName;
               return Padding(
                 padding: const EdgeInsets.only(right: 6),
                 child: Tooltip(

--- a/example/chat_app/lib/screens/chat_screen.dart
+++ b/example/chat_app/lib/screens/chat_screen.dart
@@ -14,11 +14,13 @@ import 'manage_models_screen.dart';
 
 class ChatScreen extends StatefulWidget {
   final VoidCallback? onOpenModelSelection;
+  final ValueChanged<String>? onOpenModelFilename;
   final bool showModelSelectionAction;
 
   const ChatScreen({
     super.key,
     this.onOpenModelSelection,
+    this.onOpenModelFilename,
     this.showModelSelectionAction = true,
   });
 
@@ -27,14 +29,19 @@ class ChatScreen extends StatefulWidget {
 }
 
 class _ChatScreenState extends State<ChatScreen> {
+  static const double _pinToBottomThreshold = 48.0;
+  static const double _showScrollButtonThreshold = 140.0;
+
   final TextEditingController _controller = TextEditingController();
   final ScrollController _scrollController = ScrollController();
   final FocusNode _focusNode = FocusNode();
 
+  bool _isPinnedToBottom = true;
   bool _wasGenerating = false;
   bool _showScrollToBottom = false;
   bool _autoFollowScrollScheduled = false;
   ChatProvider? _providerForListener;
+  String? _lastConversationId;
 
   @override
   void initState() {
@@ -44,7 +51,11 @@ class _ChatScreenState extends State<ChatScreen> {
       if (!mounted) return;
       final provider = context.read<ChatProvider>();
       _providerForListener = provider;
+      _lastConversationId = provider.activeConversationId;
       provider.addListener(_onProviderUpdate);
+      if (provider.messages.isNotEmpty) {
+        _scrollToBottom(force: true);
+      }
     });
   }
 
@@ -63,8 +74,12 @@ class _ChatScreenState extends State<ChatScreen> {
     if (!_scrollController.hasClients) return;
 
     final diff = _distanceFromBottom();
-    final shouldShow = diff > 220;
+    final isNearBottom = diff <= _pinToBottomThreshold;
+    if (isNearBottom != _isPinnedToBottom) {
+      _isPinnedToBottom = isNearBottom;
+    }
 
+    final shouldShow = diff > _showScrollButtonThreshold;
     if (shouldShow != _showScrollToBottom && mounted) {
       setState(() {
         _showScrollToBottom = shouldShow;
@@ -79,23 +94,43 @@ class _ChatScreenState extends State<ChatScreen> {
       return;
     }
 
-    final shouldAutoFollowAfterGeneration = _distanceFromBottom() < 1200;
-
-    if (provider.isGenerating) {
-      _scheduleAutoFollowScroll();
+    // Reset scroll state on conversation switch so the new thread starts at the bottom.
+    final currentConversationId = provider.activeConversationId;
+    if (currentConversationId != _lastConversationId) {
+      _lastConversationId = currentConversationId;
+      _isPinnedToBottom = true;
+      if (_showScrollToBottom) {
+        setState(() {
+          _showScrollToBottom = false;
+        });
+      }
+      WidgetsBinding.instance.addPostFrameCallback((_) {
+        if (!mounted) return;
+        _scrollToBottom(force: true);
+      });
+      _wasGenerating = provider.isGenerating;
+      return;
     }
 
+    // Follow streaming ONLY if the user is pinned to the bottom.
+    if (provider.isGenerating) {
+      if (_isPinnedToBottom) {
+        _scheduleAutoFollowScroll();
+      }
+    }
+
+    // When generation completes, only jump if pinned to bottom.
     if (_wasGenerating && !provider.isGenerating) {
       WidgetsBinding.instance.addPostFrameCallback((_) {
         if (!mounted) {
           return;
         }
 
-        if (shouldAutoFollowAfterGeneration) {
+        if (_isPinnedToBottom) {
           _scrollToBottom(force: true);
-        }
-        if (provider.isReady) {
-          _focusNode.requestFocus();
+          if (provider.isReady) {
+            _focusNode.requestFocus();
+          }
         }
       });
     }
@@ -110,10 +145,10 @@ class _ChatScreenState extends State<ChatScreen> {
     _autoFollowScrollScheduled = true;
     WidgetsBinding.instance.addPostFrameCallback((_) {
       _autoFollowScrollScheduled = false;
-      if (!mounted) {
+      if (!mounted || !_isPinnedToBottom) {
         return;
       }
-      _scrollToBottom();
+      _scrollToBottom(force: true);
     });
   }
 
@@ -125,6 +160,14 @@ class _ChatScreenState extends State<ChatScreen> {
 
     if (force || diff < 50) {
       _scrollController.jumpTo(pos.maxScrollExtent);
+      if (force) {
+        WidgetsBinding.instance.addPostFrameCallback((_) {
+          if (!mounted || !_isPinnedToBottom || !_scrollController.hasClients) {
+            return;
+          }
+          _scrollController.jumpTo(_scrollController.position.maxScrollExtent);
+        });
+      }
     } else if (diff < 500) {
       _scrollController.animateTo(
         pos.maxScrollExtent,
@@ -133,7 +176,8 @@ class _ChatScreenState extends State<ChatScreen> {
       );
     }
 
-    if (_showScrollToBottom) {
+    _isPinnedToBottom = true;
+    if (_showScrollToBottom && mounted) {
       setState(() {
         _showScrollToBottom = false;
       });
@@ -155,9 +199,15 @@ class _ChatScreenState extends State<ChatScreen> {
     final provider = context.read<ChatProvider>();
     if (text.isEmpty && provider.stagedParts.isEmpty) return;
 
+    _isPinnedToBottom = true;
     provider.sendMessage(text);
     _controller.value = TextEditingValue.empty;
     _focusNode.requestFocus();
+    WidgetsBinding.instance.addPostFrameCallback((_) {
+      if (mounted) {
+        _scrollToBottom(force: true);
+      }
+    });
   }
 
   void _openModelSelection() {
@@ -170,6 +220,15 @@ class _ChatScreenState extends State<ChatScreen> {
     Navigator.of(
       context,
     ).push(MaterialPageRoute(builder: (context) => const ManageModelsScreen()));
+  }
+
+  void _openQuickStartModel(String filename) {
+    final callback = widget.onOpenModelFilename;
+    if (callback != null) {
+      callback(filename);
+      return;
+    }
+    _openModelSelection();
   }
 
   @override
@@ -196,6 +255,9 @@ class _ChatScreenState extends State<ChatScreen> {
                         onRetry: () => provider.loadModel(),
                         onSelectModel: widget.showModelSelectionAction
                             ? _openModelSelection
+                            : null,
+                        onQuickStartModel: widget.showModelSelectionAction
+                            ? _openQuickStartModel
                             : null,
                       );
                     }
@@ -245,7 +307,7 @@ class _ChatScreenState extends State<ChatScreen> {
               bottom: 100,
               child: FloatingActionButton.small(
                 heroTag: 'scroll-to-bottom',
-                onPressed: _scrollToBottom,
+                onPressed: () => _scrollToBottom(force: true),
                 tooltip: 'Jump to latest',
                 child: const Icon(
                   Icons.keyboard_arrow_down_rounded,

--- a/example/chat_app/lib/screens/chat_screen.dart
+++ b/example/chat_app/lib/screens/chat_screen.dart
@@ -54,7 +54,7 @@ class _ChatScreenState extends State<ChatScreen> {
       _lastConversationId = provider.activeConversationId;
       provider.addListener(_onProviderUpdate);
       if (provider.messages.isNotEmpty) {
-        _scrollToBottom(force: true);
+        _scrollToBottom();
       }
     });
   }
@@ -106,7 +106,7 @@ class _ChatScreenState extends State<ChatScreen> {
       }
       WidgetsBinding.instance.addPostFrameCallback((_) {
         if (!mounted) return;
-        _scrollToBottom(force: true);
+        _scrollToBottom();
       });
       _wasGenerating = provider.isGenerating;
       return;
@@ -127,7 +127,7 @@ class _ChatScreenState extends State<ChatScreen> {
         }
 
         if (_isPinnedToBottom) {
-          _scrollToBottom(force: true);
+          _scrollToBottom();
           if (provider.isReady) {
             _focusNode.requestFocus();
           }
@@ -148,33 +148,20 @@ class _ChatScreenState extends State<ChatScreen> {
       if (!mounted || !_isPinnedToBottom) {
         return;
       }
-      _scrollToBottom(force: true);
+      _scrollToBottom();
     });
   }
 
-  void _scrollToBottom({bool force = false}) {
+  void _scrollToBottom() {
     if (!_scrollController.hasClients) return;
 
-    final pos = _scrollController.position;
-    final diff = _distanceFromBottom();
-
-    if (force || diff < 50) {
-      _scrollController.jumpTo(pos.maxScrollExtent);
-      if (force) {
-        WidgetsBinding.instance.addPostFrameCallback((_) {
-          if (!mounted || !_isPinnedToBottom || !_scrollController.hasClients) {
-            return;
-          }
-          _scrollController.jumpTo(_scrollController.position.maxScrollExtent);
-        });
+    _scrollController.jumpTo(_scrollController.position.maxScrollExtent);
+    WidgetsBinding.instance.addPostFrameCallback((_) {
+      if (!mounted || !_isPinnedToBottom || !_scrollController.hasClients) {
+        return;
       }
-    } else if (diff < 500) {
-      _scrollController.animateTo(
-        pos.maxScrollExtent,
-        duration: const Duration(milliseconds: 220),
-        curve: Curves.easeOutCubic,
-      );
-    }
+      _scrollController.jumpTo(_scrollController.position.maxScrollExtent);
+    });
 
     _isPinnedToBottom = true;
     if (_showScrollToBottom && mounted) {
@@ -205,7 +192,7 @@ class _ChatScreenState extends State<ChatScreen> {
     _focusNode.requestFocus();
     WidgetsBinding.instance.addPostFrameCallback((_) {
       if (mounted) {
-        _scrollToBottom(force: true);
+        _scrollToBottom();
       }
     });
   }
@@ -307,7 +294,7 @@ class _ChatScreenState extends State<ChatScreen> {
               bottom: 100,
               child: FloatingActionButton.small(
                 heroTag: 'scroll-to-bottom',
-                onPressed: () => _scrollToBottom(force: true),
+                onPressed: _scrollToBottom,
                 tooltip: 'Jump to latest',
                 child: const Icon(
                   Icons.keyboard_arrow_down_rounded,

--- a/example/chat_app/lib/screens/manage_models_screen.dart
+++ b/example/chat_app/lib/screens/manage_models_screen.dart
@@ -69,6 +69,7 @@ class _ManageModelsScreenState extends State<ManageModelsScreen>
   final HuggingFaceModelDiscoveryService _hfDiscoveryService =
       HuggingFaceModelDiscoveryService();
   final TextEditingController _modelSearchController = TextEditingController();
+  final ScrollController _scrollController = ScrollController();
   final List<DownloadableModel> _models = <DownloadableModel>[];
   final List<DownloadableModel> _customModels = <DownloadableModel>[];
   final Map<String, GlobalKey> _modelCardKeys = {};
@@ -283,10 +284,46 @@ class _ManageModelsScreenState extends State<ManageModelsScreen>
       return;
     }
 
+    final cardKey = _modelCardKeys[filename];
+    final beforeTop = _globalTop(cardKey?.currentContext);
     await _refreshDownloadedModelState(cacheModels: <DownloadableModel>[model]);
     if (mounted) {
-      setState(() {});
+      setState(() {
+        _focusedModelFilename = filename;
+      });
+      WidgetsBinding.instance.addPostFrameCallback((_) {
+        if (!mounted) return;
+        final cardContext = cardKey?.currentContext;
+        final afterTop = _globalTop(cardContext);
+        if (beforeTop != null &&
+            afterTop != null &&
+            _scrollController.hasClients) {
+          final position = _scrollController.position;
+          final anchoredOffset = (position.pixels + afterTop - beforeTop).clamp(
+            position.minScrollExtent,
+            position.maxScrollExtent,
+          );
+          _scrollController.jumpTo(anchoredOffset);
+        } else if (cardContext != null) {
+          unawaited(
+            Scrollable.ensureVisible(
+              cardContext,
+              alignment: 0.12,
+              duration: const Duration(milliseconds: 360),
+              curve: Curves.easeOutCubic,
+            ),
+          );
+        }
+      });
     }
+  }
+
+  double? _globalTop(BuildContext? context) {
+    final renderObject = context?.findRenderObject();
+    if (renderObject is! RenderBox || !renderObject.hasSize) {
+      return null;
+    }
+    return renderObject.localToGlobal(Offset.zero).dy;
   }
 
   Future<void> _loadCustomModels() async {
@@ -1454,6 +1491,7 @@ class _ManageModelsScreenState extends State<ManageModelsScreen>
             .length;
 
         return ListView(
+          controller: _scrollController,
           padding: EdgeInsets.fromLTRB(
             horizontalPadding,
             isEmbedded ? 14 : 24,
@@ -2552,6 +2590,7 @@ class _ManageModelsScreenState extends State<ManageModelsScreen>
   void dispose() {
     WidgetsBinding.instance.removeObserver(this);
     _modelSearchController.dispose();
+    _scrollController.dispose();
     unawaited(_downloadFinishedSubscription?.cancel());
     if (_ownsDownloadUi) {
       _downloadUi.dispose();

--- a/example/chat_app/lib/screens/manage_models_screen.dart
+++ b/example/chat_app/lib/screens/manage_models_screen.dart
@@ -64,6 +64,9 @@ class _ManageModelsScreenState extends State<ManageModelsScreen>
     with WidgetsBindingObserver {
   static const String _customModelsPrefsKey = 'custom_hf_models_v1';
   static const int _webLargeModelWarningBytes = 1900 * 1024 * 1024;
+  static const Duration _completedDownloadHighlightDuration = Duration(
+    seconds: 2,
+  );
 
   late final ModelService _modelService;
   final HuggingFaceModelDiscoveryService _hfDiscoveryService =
@@ -79,6 +82,7 @@ class _ManageModelsScreenState extends State<ManageModelsScreen>
   late final ModelDownloadUiController _downloadUi;
   late final bool _ownsDownloadUi;
   StreamSubscription<String>? _downloadFinishedSubscription;
+  Timer? _completedDownloadHighlightTimer;
 
   Set<String> _downloadedFiles = {};
   String? _modelsDir;
@@ -123,6 +127,7 @@ class _ManageModelsScreenState extends State<ManageModelsScreen>
       return;
     }
 
+    _completedDownloadHighlightTimer?.cancel();
     _modelSearchController.clear();
     setState(() {
       _showModelLibrary = true;
@@ -291,6 +296,7 @@ class _ManageModelsScreenState extends State<ManageModelsScreen>
       setState(() {
         _focusedModelFilename = filename;
       });
+      _scheduleCompletedDownloadHighlightClear(filename);
       WidgetsBinding.instance.addPostFrameCallback((_) {
         if (!mounted) return;
         final cardContext = cardKey?.currentContext;
@@ -316,6 +322,21 @@ class _ManageModelsScreenState extends State<ManageModelsScreen>
         }
       });
     }
+  }
+
+  void _scheduleCompletedDownloadHighlightClear(String filename) {
+    _completedDownloadHighlightTimer?.cancel();
+    _completedDownloadHighlightTimer = Timer(
+      _completedDownloadHighlightDuration,
+      () {
+        if (!mounted || _focusedModelFilename != filename) {
+          return;
+        }
+        setState(() {
+          _focusedModelFilename = null;
+        });
+      },
+    );
   }
 
   double? _globalTop(BuildContext? context) {
@@ -2591,6 +2612,7 @@ class _ManageModelsScreenState extends State<ManageModelsScreen>
     WidgetsBinding.instance.removeObserver(this);
     _modelSearchController.dispose();
     _scrollController.dispose();
+    _completedDownloadHighlightTimer?.cancel();
     unawaited(_downloadFinishedSubscription?.cancel());
     if (_ownsDownloadUi) {
       _downloadUi.dispose();

--- a/example/chat_app/lib/widgets/welcome_view.dart
+++ b/example/chat_app/lib/widgets/welcome_view.dart
@@ -1,6 +1,8 @@
 import 'package:flutter/material.dart';
 
 class WelcomeView extends StatelessWidget {
+  static const String recommendedQuickStartModel = 'Qwen3.5-0.8B-Q4_K_M.gguf';
+
   final bool isInitializing;
   final String? error;
   final String? modelPath;
@@ -8,6 +10,7 @@ class WelcomeView extends StatelessWidget {
   final double loadingProgress;
   final VoidCallback onRetry;
   final VoidCallback? onSelectModel;
+  final ValueChanged<String>? onQuickStartModel;
 
   const WelcomeView({
     super.key,
@@ -18,6 +21,7 @@ class WelcomeView extends StatelessWidget {
     this.loadingProgress = 0.0,
     required this.onRetry,
     required this.onSelectModel,
+    this.onQuickStartModel,
   });
 
   @override
@@ -114,6 +118,139 @@ class WelcomeView extends StatelessWidget {
 
     final canSelectModel = onSelectModel != null;
 
+    if (modelPath == null) {
+      return _ScrollableWelcomeContent(
+        maxWidth: 540,
+        child: Column(
+          mainAxisSize: MainAxisSize.min,
+          children: [
+            Container(
+              padding: const EdgeInsets.all(18),
+              decoration: BoxDecoration(
+                color: colorScheme.primaryContainer.withValues(alpha: 0.25),
+                borderRadius: BorderRadius.circular(18),
+                border: Border.all(
+                  color: colorScheme.outlineVariant.withValues(alpha: 0.35),
+                ),
+              ),
+              child: Icon(
+                Icons.auto_awesome_rounded,
+                size: 38,
+                color: colorScheme.primary,
+              ),
+            ),
+            const SizedBox(height: 20),
+            Text(
+              'Start with a model',
+              textAlign: TextAlign.center,
+              style: const TextStyle(fontSize: 24, fontWeight: FontWeight.w800),
+            ),
+            const SizedBox(height: 8),
+            Text(
+              'Download once, then run private AI directly on your device.',
+              textAlign: TextAlign.center,
+              style: TextStyle(
+                fontSize: 14,
+                color: colorScheme.onSurfaceVariant,
+              ),
+            ),
+            const SizedBox(height: 24),
+            if (canSelectModel) ...[
+              Container(
+                width: double.infinity,
+                padding: const EdgeInsets.all(18),
+                decoration: BoxDecoration(
+                  color: colorScheme.surfaceContainerHighest.withValues(
+                    alpha: 0.45,
+                  ),
+                  borderRadius: BorderRadius.circular(16),
+                  border: Border.all(
+                    color: colorScheme.outlineVariant.withValues(alpha: 0.4),
+                  ),
+                ),
+                child: Column(
+                  crossAxisAlignment: CrossAxisAlignment.start,
+                  children: [
+                    Row(
+                      children: [
+                        Container(
+                          padding: const EdgeInsets.symmetric(
+                            horizontal: 8,
+                            vertical: 3,
+                          ),
+                          decoration: BoxDecoration(
+                            color: colorScheme.primary.withValues(alpha: 0.15),
+                            borderRadius: BorderRadius.circular(6),
+                          ),
+                          child: Text(
+                            'RECOMMENDED',
+                            style: TextStyle(
+                              fontSize: 10,
+                              fontWeight: FontWeight.w800,
+                              letterSpacing: 0.5,
+                              color: colorScheme.primary,
+                            ),
+                          ),
+                        ),
+                        const SizedBox(width: 8),
+                        Text(
+                          'GENERAL ASSISTANT',
+                          style: TextStyle(
+                            fontSize: 11,
+                            color: colorScheme.secondary,
+                            fontWeight: FontWeight.w600,
+                          ),
+                        ),
+                      ],
+                    ),
+                    const SizedBox(height: 10),
+                    const Text(
+                      'Qwen3.5 0.8B Instruct',
+                      style: TextStyle(
+                        fontSize: 16,
+                        fontWeight: FontWeight.w700,
+                      ),
+                    ),
+                    const SizedBox(height: 4),
+                    Text(
+                      '720 MB base model • Tools and reasoning, with an optional vision asset.',
+                      style: TextStyle(
+                        fontSize: 13,
+                        color: colorScheme.onSurfaceVariant,
+                      ),
+                    ),
+                    const SizedBox(height: 16),
+                    Wrap(
+                      spacing: 10,
+                      runSpacing: 10,
+                      children: [
+                        FilledButton.icon(
+                          onPressed: () {
+                            if (onQuickStartModel != null) {
+                              onQuickStartModel!(recommendedQuickStartModel);
+                            } else if (onSelectModel != null) {
+                              onSelectModel!();
+                            }
+                          },
+                          icon: const Icon(Icons.download_rounded),
+                          label: const Text('Choose Qwen3.5 0.8B'),
+                        ),
+                        OutlinedButton.icon(
+                          onPressed: onSelectModel,
+                          icon: const Icon(Icons.tune_rounded),
+                          label: const Text('Browse all models'),
+                        ),
+                      ],
+                    ),
+                  ],
+                ),
+              ),
+            ],
+          ],
+        ),
+      );
+    }
+
     return _ScrollableWelcomeContent(
       maxWidth: 520,
       child: Column(
@@ -156,16 +293,14 @@ class WelcomeView extends StatelessWidget {
             child: Row(
               children: [
                 Icon(
-                  selectedModelName == null
-                      ? Icons.folder_open_rounded
-                      : Icons.sd_storage_outlined,
+                  Icons.sd_storage_outlined,
                   size: 18,
                   color: colorScheme.secondary,
                 ),
                 const SizedBox(width: 10),
                 Expanded(
                   child: Text(
-                    selectedModelName ?? 'No model selected',
+                    selectedModelName ?? 'Selected model',
                     maxLines: 1,
                     overflow: TextOverflow.ellipsis,
                     style: TextStyle(color: colorScheme.onSurfaceVariant),
@@ -175,24 +310,18 @@ class WelcomeView extends StatelessWidget {
             ),
           ),
           const SizedBox(height: 20),
-          if (!isLoaded && (canSelectModel || modelPath != null))
+          if (!isLoaded)
             Wrap(
               spacing: 10,
               runSpacing: 10,
               alignment: WrapAlignment.center,
               children: [
                 FilledButton.icon(
-                  onPressed: modelPath == null ? onSelectModel : onRetry,
-                  icon: Icon(
-                    modelPath == null
-                        ? Icons.file_open_rounded
-                        : Icons.power_settings_new_rounded,
-                  ),
-                  label: Text(
-                    modelPath == null ? 'Select model' : 'Load model',
-                  ),
+                  onPressed: onRetry,
+                  icon: const Icon(Icons.power_settings_new_rounded),
+                  label: const Text('Load model'),
                 ),
-                if (modelPath != null && canSelectModel)
+                if (canSelectModel)
                   OutlinedButton.icon(
                     onPressed: onSelectModel,
                     icon: const Icon(Icons.tune_rounded),

--- a/example/chat_app/test/app_shell_screen_test.dart
+++ b/example/chat_app/test/app_shell_screen_test.dart
@@ -90,6 +90,47 @@ void main() {
       downloadUi.completeActiveDownload(activeModel.filename);
     });
 
+    testWidgets('quick start opens Lab focused on the recommended model', (
+      tester,
+    ) async {
+      final oldSize = tester.view.physicalSize;
+      final oldRatio = tester.view.devicePixelRatio;
+      tester.view
+        ..physicalSize = const Size(1440, 920)
+        ..devicePixelRatio = 1.0;
+      addTearDown(() {
+        tester.view
+          ..physicalSize = oldSize
+          ..devicePixelRatio = oldRatio;
+      });
+
+      final provider = ChatProvider(
+        chatService: MockChatService(),
+        settingsService: MockSettingsService(),
+      );
+      addTearDown(provider.dispose);
+
+      await tester.pumpWidget(
+        ChangeNotifierProvider<ChatProvider>.value(
+          value: provider,
+          child: const MaterialApp(home: AppShellScreen()),
+        ),
+      );
+      await tester.pumpAndSettle();
+
+      await tester.tap(find.text('Choose Qwen3.5 0.8B'));
+      await _pumpUntil(
+        tester,
+        () => find.byType(ManageModelsScreen).evaluate().isNotEmpty,
+      );
+
+      final lab = tester.widget<ManageModelsScreen>(
+        find.byType(ManageModelsScreen),
+      );
+      expect(lab.focusModelFilename, 'Qwen3.5-0.8B-Q4_K_M.gguf');
+      expect(lab.focusRequestId, 1);
+    });
+
     testWidgets('download activity keeps an open pinned settings panel open', (
       tester,
     ) async {
@@ -128,7 +169,7 @@ void main() {
       );
       await tester.pumpAndSettle();
 
-      await tester.tap(find.byTooltip('Open model and inference settings'));
+      await tester.tap(find.byTooltip('Open Lab'));
       await tester.pumpAndSettle();
       expect(find.text('Model parameters'), findsOneWidget);
 
@@ -191,14 +232,9 @@ void main() {
       expect(find.text('New conversation'), findsWidgets);
       expect(find.text('Inference parameters'), findsNothing);
       expect(find.text('Change model'), findsOneWidget);
-      expect(
-        find.byTooltip('Open model and inference settings'),
-        findsOneWidget,
-      );
+      expect(find.byTooltip('Open Lab'), findsOneWidget);
 
-      await tester.tap(
-        find.byTooltip('Open model and inference settings').first,
-      );
+      await tester.tap(find.byTooltip('Open Lab').first);
       await tester.pumpAndSettle();
       expect(find.text('Inference parameters'), findsOneWidget);
 
@@ -280,9 +316,7 @@ void main() {
         ),
       );
       await tester.pumpAndSettle();
-      await tester.tap(
-        find.byTooltip('Open model and inference settings').first,
-      );
+      await tester.tap(find.byTooltip('Open Lab').first);
       await tester.pumpAndSettle();
       await tester.tap(find.text('Model parameters'));
       await tester.pumpAndSettle();
@@ -365,13 +399,11 @@ void main() {
       );
       await tester.pumpAndSettle();
 
-      await tester.tap(
-        find.byTooltip('Open model and inference settings').first,
-      );
+      await tester.tap(find.byTooltip('Open Lab').first);
       await tester.pumpAndSettle();
 
-      expect(find.text('Settings'), findsOneWidget);
-      expect(find.byTooltip('Close settings'), findsOneWidget);
+      expect(find.text('Lab'), findsOneWidget);
+      expect(find.byTooltip('Close Lab'), findsOneWidget);
       expect(tester.takeException(), isNull);
     });
 
@@ -406,10 +438,7 @@ void main() {
       await tester.pumpAndSettle();
 
       expect(find.bySemanticsLabel('Open navigation menu'), findsOneWidget);
-      expect(
-        find.bySemanticsLabel('Open model and inference settings'),
-        findsOneWidget,
-      );
+      expect(find.bySemanticsLabel('Open Lab'), findsOneWidget);
       expect(find.bySemanticsLabel('Send message'), findsOneWidget);
       semantics.dispose();
     });
@@ -464,9 +493,7 @@ void main() {
         );
         await tester.pumpAndSettle();
 
-        await tester.tap(
-          find.byTooltip('Open model and inference settings').first,
-        );
+        await tester.tap(find.byTooltip('Open Lab').first);
         await tester.pumpAndSettle();
 
         expect(

--- a/example/chat_app/test/chat_screen_scroll_test.dart
+++ b/example/chat_app/test/chat_screen_scroll_test.dart
@@ -1,0 +1,204 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:llamadart_chat_example/models/chat_message.dart';
+import 'package:llamadart_chat_example/models/chat_settings.dart';
+import 'package:llamadart_chat_example/providers/chat_provider.dart';
+import 'package:llamadart_chat_example/screens/chat_screen.dart';
+import 'package:provider/provider.dart';
+
+import 'mocks.dart';
+
+class _ScrollTestChatProvider extends ChatProvider {
+  final List<ChatMessage> _testMessages = [];
+  String _testConversationId = 'conversation-1';
+  bool _testIsGenerating = false;
+
+  _ScrollTestChatProvider()
+    : super(
+        chatService: MockChatService(
+          engine: MockLlamaEngine()..initialized = true,
+        ),
+        settingsService: MockSettingsService(),
+        initialSettings: const ChatSettings(modelPath: 'test_model.gguf'),
+      ) {
+    _testMessages.addAll(_longConversation('Initial'));
+  }
+
+  static List<ChatMessage> _longConversation(String label) => List.generate(
+    30,
+    (index) => ChatMessage(
+      text:
+          '$label message $index. This deliberately long message gives the '
+          'conversation enough height to exercise user-controlled scrolling.',
+      isUser: index.isEven,
+    ),
+  );
+
+  @override
+  List<ChatMessage> get messages => List.unmodifiable(_testMessages);
+
+  @override
+  String get activeConversationId => _testConversationId;
+
+  @override
+  bool get isGenerating => _testIsGenerating;
+
+  @override
+  bool get isLoaded => true;
+
+  @override
+  bool get isReady => true;
+
+  @override
+  bool get canRegenerateLastResponse => false;
+
+  void beginStreaming() {
+    _testIsGenerating = true;
+    _testMessages.add(ChatMessage(text: 'Starting', isUser: false));
+    notifyListeners();
+  }
+
+  void growStreamingMessage() {
+    final current = _testMessages.removeLast();
+    _testMessages.add(
+      current.copyWith(
+        text:
+            '${current.text}\nMore streamed content that increases the height '
+            'of the response without taking over the reader’s scroll.',
+      ),
+    );
+    notifyListeners();
+  }
+
+  void finishStreaming() {
+    _testIsGenerating = false;
+    notifyListeners();
+  }
+
+  void showConversation(String id) {
+    _testConversationId = id;
+    _testMessages
+      ..clear()
+      ..addAll(_longConversation('Other'));
+    notifyListeners();
+  }
+
+  @override
+  Future<void> sendMessage(String text) async {
+    _testMessages
+      ..add(ChatMessage(text: text, isUser: true))
+      ..add(
+        ChatMessage(
+          text: 'A new assistant response after the explicit send action.',
+          isUser: false,
+        ),
+      );
+    notifyListeners();
+  }
+}
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  Future<_ScrollTestChatProvider> pumpChat(WidgetTester tester) async {
+    final provider = _ScrollTestChatProvider();
+    addTearDown(provider.dispose);
+    await tester.pumpWidget(
+      ChangeNotifierProvider<ChatProvider>.value(
+        value: provider,
+        child: const MaterialApp(home: Scaffold(body: ChatScreen())),
+      ),
+    );
+    await tester.pumpAndSettle();
+    return provider;
+  }
+
+  ScrollController chatScrollController(WidgetTester tester) {
+    final scrollable = tester.state<ScrollableState>(
+      find.byType(Scrollable).first,
+    );
+    return scrollable.widget.controller!;
+  }
+
+  group('ChatScreen scrolling behavior', () {
+    testWidgets(
+      'an existing conversation initially opens at the latest message',
+      (tester) async {
+        await pumpChat(tester);
+        final controller = chatScrollController(tester);
+
+        expect(controller.position.maxScrollExtent, greaterThan(0));
+        expect(
+          controller.position.pixels,
+          closeTo(controller.position.maxScrollExtent, 1),
+        );
+      },
+    );
+
+    testWidgets(
+      'manual scrolling during streaming is preserved through completion',
+      (tester) async {
+        final provider = await pumpChat(tester);
+        final controller = chatScrollController(tester);
+
+        provider.beginStreaming();
+        await tester.pumpAndSettle();
+        controller.jumpTo(100);
+        await tester.pump();
+
+        for (var index = 0; index < 4; index += 1) {
+          provider.growStreamingMessage();
+          await tester.pump();
+        }
+        expect(controller.position.pixels, closeTo(100, 1));
+
+        provider.finishStreaming();
+        await tester.pumpAndSettle();
+        expect(controller.position.pixels, closeTo(100, 1));
+
+        await tester.tap(find.byTooltip('Jump to latest'));
+        await tester.pumpAndSettle();
+        expect(
+          controller.position.pixels,
+          closeTo(controller.position.maxScrollExtent, 1),
+        );
+      },
+    );
+
+    testWidgets('switching conversations opens the new thread at the bottom', (
+      tester,
+    ) async {
+      final provider = await pumpChat(tester);
+      final controller = chatScrollController(tester);
+      controller.jumpTo(50);
+      await tester.pump();
+
+      provider.showConversation('conversation-2');
+      await tester.pumpAndSettle();
+
+      expect(
+        controller.position.pixels,
+        closeTo(controller.position.maxScrollExtent, 1),
+      );
+    });
+
+    testWidgets('sending a message explicitly re-pins the conversation', (
+      tester,
+    ) async {
+      await pumpChat(tester);
+      final controller = chatScrollController(tester);
+      controller.jumpTo(50);
+      await tester.pump();
+
+      await tester.enterText(find.byType(TextField).last, 'New question');
+      await tester.pump();
+      await tester.tap(find.byTooltip('Send message'));
+      await tester.pumpAndSettle();
+
+      expect(
+        controller.position.pixels,
+        closeTo(controller.position.maxScrollExtent, 1),
+      );
+    });
+  });
+}

--- a/example/chat_app/test/manage_models_screen_download_test.dart
+++ b/example/chat_app/test/manage_models_screen_download_test.dart
@@ -625,6 +625,67 @@ void main() {
       },
     );
 
+    testWidgets(
+      'anchors and highlights completed model card across download reorder',
+      (tester) async {
+        SharedPreferences.setMockInitialValues({});
+        final firstModel = _remoteModel();
+        final secondModel = _secondRemoteModel();
+        final modelService = _HoldingModelService();
+        final downloadUi = ModelDownloadUiController();
+        addTearDown(downloadUi.dispose);
+
+        await _pumpScreen(
+          tester,
+          modelService: modelService,
+          models: [firstModel, secondModel],
+          downloadUiController: downloadUi,
+        );
+
+        final downloadButtons = find.widgetWithText(OutlinedButton, 'Download');
+        expect(downloadButtons, findsNWidgets(2));
+
+        // Start downloading the second model
+        await _tapVisible(tester, downloadButtons.last);
+        await modelService.downloadStarted.future.timeout(_testTimeout);
+        await tester.pump();
+
+        final highlightedCard = find.byKey(
+          ValueKey('model-card-highlight-${secondModel.filename}'),
+        );
+        final scrollable = tester.state<ScrollableState>(
+          find
+              .ancestor(of: highlightedCard, matching: find.byType(Scrollable))
+              .first,
+        );
+        final scrollController = scrollable.widget.controller!;
+        final currentTop = tester.getTopLeft(highlightedCard).dy;
+        scrollController.jumpTo(
+          (scrollController.position.pixels + currentTop - 140).clamp(
+            scrollController.position.minScrollExtent,
+            scrollController.position.maxScrollExtent,
+          ),
+        );
+        await tester.pump();
+        final beforeTop = tester.getTopLeft(highlightedCard).dy;
+
+        // Complete the download
+        modelService.completeDownload();
+        await tester.pump(const Duration(milliseconds: 20));
+        await modelService.downloadCompleted.future.timeout(_testTimeout);
+        await tester.pumpAndSettle();
+
+        // The second model was reordered to downloaded, and should be highlighted & visible
+        expect(highlightedCard, findsOneWidget);
+        expect(tester.getTopLeft(highlightedCard).dy, closeTo(beforeTop, 6));
+        expect(highlightedCard.hitTestable(), findsOneWidget);
+        final container = tester.widget<AnimatedContainer>(highlightedCard);
+        final decoration = container.decoration! as BoxDecoration;
+        expect(decoration.border, isNotNull);
+        expect(find.text(secondModel.name), findsOneWidget);
+      },
+    );
+
     testWidgets('second model waits while first download is active', (
       tester,
     ) async {

--- a/example/chat_app/test/manage_models_screen_download_test.dart
+++ b/example/chat_app/test/manage_models_screen_download_test.dart
@@ -683,6 +683,14 @@ void main() {
         final decoration = container.decoration! as BoxDecoration;
         expect(decoration.border, isNotNull);
         expect(find.text(secondModel.name), findsOneWidget);
+
+        await tester.pump(const Duration(seconds: 2));
+        await tester.pumpAndSettle();
+        final clearedContainer = tester.widget<AnimatedContainer>(
+          highlightedCard,
+        );
+        final clearedDecoration = clearedContainer.decoration! as BoxDecoration;
+        expect(clearedDecoration.border, isNull);
       },
     );
 

--- a/example/chat_app/test/welcome_view_test.dart
+++ b/example/chat_app/test/welcome_view_test.dart
@@ -73,4 +73,53 @@ void main() {
     expect(find.textContaining('token=secret'), findsNothing);
     expect(find.textContaining('signed-fragment'), findsNothing);
   });
+
+  testWidgets(
+    'shows quick-start recommendation and triggers callback when no model is loaded',
+    (tester) async {
+      String? quickStartModel;
+      var browsedModels = false;
+
+      await tester.pumpWidget(
+        MaterialApp(
+          home: Scaffold(
+            body: WelcomeView(
+              isInitializing: false,
+              error: null,
+              modelPath: null,
+              isLoaded: false,
+              onRetry: () {},
+              onSelectModel: () {
+                browsedModels = true;
+              },
+              onQuickStartModel: (model) {
+                quickStartModel = model;
+              },
+            ),
+          ),
+        ),
+      );
+
+      expect(find.text('Start with a model'), findsOneWidget);
+      expect(find.text('Qwen3.5 0.8B Instruct'), findsOneWidget);
+      expect(
+        find.widgetWithText(FilledButton, 'Choose Qwen3.5 0.8B'),
+        findsOneWidget,
+      );
+      expect(
+        find.widgetWithText(OutlinedButton, 'Browse all models'),
+        findsOneWidget,
+      );
+
+      await tester.tap(
+        find.widgetWithText(FilledButton, 'Choose Qwen3.5 0.8B'),
+      );
+      expect(quickStartModel, 'Qwen3.5-0.8B-Q4_K_M.gguf');
+
+      await tester.tap(
+        find.widgetWithText(OutlinedButton, 'Browse all models'),
+      );
+      expect(browsedModels, isTrue);
+    },
+  );
 }


### PR DESCRIPTION
## Summary

- redesign the chat example onboarding and Lab navigation so model selection, runtime status, and advanced controls are easier to discover
- preserve a completed model card's viewport position and briefly highlight it when downloaded models reorder to the top of the catalog
- follow streaming output only while the conversation remains pinned to the bottom, preserve deliberate history scrolling, and expose a Jump to latest action
- keep the local-only multimodal cache E2E independent from the user-facing model catalog by giving it an explicit small fixture

## Why

The example app should remain approachable while making llamadart capabilities easy to explore. The previous hierarchy made the primary model/chat flow and advanced controls compete for attention. It also had two disruptive state transitions:

- streaming updates could pull users back to the bottom after they intentionally scrolled into history
- completing a download reordered the catalog and moved the model card away from the user's viewport

## User impact

The first-run path now leads with model selection and clearer runtime context, while advanced functionality lives behind a consistently named Lab surface. Chat history stays where the user leaves it during streaming, and completed downloads remain visible through catalog reordering.

## Validation

- `flutter analyze` in `example/chat_app`
- `flutter test` in `example/chat_app` — 321 tests passed
- `dart run tool/testing/run_local_e2e.dart --scenario chat-app-web-mock-smoke --skip-build ...`
- real Web Qwen smoke with `Qwen3.5-0.8B-Q4_K_M.gguf` — model loaded and generated the expected answer with no page errors or request failures
- real model-plus-projector downloads reached 100% for Qwen and the explicit LFM2-VL fixture
- `git diff --check`

## Validation caveat

The local-only iOS Simulator integration completed both model and projector downloads, then native model initialization remained at 18%. The same downstream stall reproduced with Qwen and the smaller LFM2-VL fixture. This PR does not change native initialization; the completed download/cache evidence and the UI regression coverage are kept separate from that simulator runtime limitation.
