### PR TITLE
Enable Qwen3-ASR speech-to-text on Web

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -43,12 +43,13 @@
   as unsupported.
 
 * Added an experimental typed `SpeechToTextEngine` with an explicit Qwen3-ASR
-  adapter profile for whole-file native llama.cpp transcription, plus a
-  SHA-256-verified Qwen3-ASR 0.6B native mobile-and-desktop preset and separate
-  **Transcribe Audio** and foreground microphone recording flows in the Flutter
-  chat example. The flow has been exercised on a physical Pixel with CPU
-  inference and in the iOS Simulator; Web and the current LiteRT-LM artifacts
-  fail explicitly as unsupported.
+  adapter profile for whole-file llama.cpp transcription. The Flutter chat
+  example includes a SHA-256-verified Qwen3-ASR 0.6B preset plus separate
+  **Transcribe Audio** and foreground microphone recording flows on native and
+  WebGPU. Web requires validated bridge assets `v0.1.30+`, accepts WAV bytes
+  only, and remains separate from native LiteRT-LM live dictation. The native
+  flow has been exercised on a physical Pixel with CPU inference and in the
+  iOS Simulator.
 
 * Added **Ask with voice** to the native Flutter chat example for Gemma 4 E2B
   through both the LiteRT-LM direct-media bundle and the audio-capable GGUF +

--- a/README.md
+++ b/README.md
@@ -28,9 +28,10 @@ models through LiteRT-LM.
 - Streaming chat completions, llama.cpp thinking budgets, tool-call parsing,
   multimodal GGUF projectors, structured JSON output, embeddings, LoRA, state
   persistence, and runtime diagnostics where the active backend supports them.
-- Experimental typed speech recognition through `SpeechToTextEngine`: native
-  llama.cpp whole-file Qwen3-ASR and worker-isolated, CPU-only LiteRT-LM
-  streaming ASR with bounded 16 kHz PCM input and partial transcripts.
+- Experimental typed speech recognition through `SpeechToTextEngine`:
+  llama.cpp whole-file Qwen3-ASR on native and validated WebGPU bridge assets,
+  plus worker-isolated, CPU-only native LiteRT-LM streaming ASR with bounded
+  16 kHz PCM input and partial transcripts.
 - Experimental typed Qwen3-TTS synthesis on native llama.cpp through
   `TextToSpeechEngine`, returning complete PCM with WAV encoding.
 
@@ -144,7 +145,7 @@ Current default runtime pins:
 | --- | --- |
 | Native llama.cpp / GGUF | `leehack/llamadart-native@b10356-llamadart.1` |
 | Native LiteRT-LM / `.litertlm` | `leehack/litert-lm-native@v0.16.0-native.2` |
-| Web llama.cpp / GGUF | `leehack/llama-web-bridge-assets@v0.1.27` |
+| Web llama.cpp / GGUF | `leehack/llama-web-bridge-assets@v0.1.30` |
 | Web LiteRT-LM / `.litertlm` | `@litert-lm/core@0.15.0` |
 
 ## Common Tasks

--- a/doc/testing_matrix.md
+++ b/doc/testing_matrix.md
@@ -68,11 +68,11 @@ Pick targeted rows based on the touched surface:
 | Chat template, parser, tools, thinking extraction | `template-parity`, `llama-cpp-chat-template-smoke`, `gguf-chat-features-smoke`, `litert-lm-chat-features-smoke` |
 | LiteRT-LM native backend | `litert-lm-engine-smoke`, `litert-lm-chat-features-smoke`, `litert-lm-asr-smoke` |
 | Web bridge bootstrap or interop | `web-bridge-smoke`, `web-mock-chat-smoke`, `web-real-model-smoke` |
-| WebGPU multimodal | `webgpu-multimodal-regression` |
+| WebGPU multimodal | `webgpu-multimodal-regression`, plus `web-speech-to-text-smoke` for typed Qwen3-ASR |
 | Large WebGPU GGUF / wasm64 selection | `gemma4-webgpu-mem64` |
 | LiteRT-LM web / Gemma 4 web bundle | `gemma4-litert-web` |
 | Chat app model cache/download/projector | `chat-app-device-cache` |
-| Speech-to-text API or adapter | `speech-to-text-smoke`, plus `litert-lm-asr-smoke` for the dedicated LiteRT-LM streaming engine |
+| Speech-to-text API or adapter | `speech-to-text-smoke`, `web-speech-to-text-smoke`, plus `litert-lm-asr-smoke` for the dedicated LiteRT-LM streaming engine |
 | Text-to-speech API or adapter | `text-to-speech-smoke` |
 | Chat-app microphone transcription flow | `chat-app-microphone-transcription-smoke` |
 | Chat-app live LiteRT-LM dictation | `litert-lm-asr-smoke`, `chat-app-live-speech-smoke` |
@@ -92,7 +92,7 @@ The matrix is designed to cover these essential axes:
 | Axis | Covered by |
 | --- | --- |
 | llama.cpp native GGUF | `root-vm`, `native-prompt-reuse-parity`, `native-inference-benchmark`, `gguf-chat-features-smoke`, `gguf-audio-chat-smoke` |
-| llama.cpp WebGPU GGUF | `web-bridge-smoke`, `web-mock-chat-smoke`, `web-real-model-smoke`, `webgpu-multimodal-regression`, `gemma4-webgpu-mem64` |
+| llama.cpp WebGPU GGUF | `web-bridge-smoke`, `web-mock-chat-smoke`, `web-real-model-smoke`, `webgpu-multimodal-regression`, `web-speech-to-text-smoke`, `gemma4-webgpu-mem64` |
 | LiteRT-LM native `.litertlm` | `litert-lm-engine-smoke`, `litert-lm-chat-features-smoke`, `native-hook-bundles` |
 | LiteRT-LM web `.litertlm` | `gemma4-litert-web` |
 | Model families | Qwen 2.5 prompt reuse, Qwen 3/3.5 chat/multimodal, Gemma 4 tool/thinking/mem64/LiteRT-LM/audio |
@@ -176,6 +176,16 @@ dart run tool/testing/run_local_e2e.dart --scenario speech-to-text-smoke \
   --mmproj-path /path/to/mmproj-Qwen3-ASR-0.6B-Q8_0.gguf \
   --audio-path /path/to/known-speech.wav \
   --expect "Exact expected transcript."
+
+dart run tool/testing/run_local_e2e.dart \
+  --scenario chat-app-web-speech-to-text-smoke \
+  --audio-path /path/to/known-speech.wav \
+  --expect "Exact expected transcript."
+
+# The Web scenario validates both file selection and Chromium's fake
+# microphone path with the same WAV fixture. The selected-file result is exact;
+# the fake microphone must contain the full expected transcript because its
+# artificial input can loop at the capture boundary.
 
 dart run tool/testing/run_local_e2e.dart --scenario text-to-speech-smoke \
   --model-path /path/to/Qwen3-TTS-12Hz-1.7B-Base-Q4_K_M.gguf \

--- a/doc/webgpu_bridge.md
+++ b/doc/webgpu_bridge.md
@@ -19,7 +19,14 @@ pipelines.
    `https://cdn.jsdelivr.net/gh/leehack/llama-web-bridge-assets@<tag>/llama_webgpu_bridge.js`
 2. Local fallback: `./webgpu_bridge/llama_webgpu_bridge.js`
 
-Default pinned tag in the example is `v0.1.27`.
+Default pinned tag in the example is `v0.1.30`.
+
+That release embeds llama.cpp `b10448` and is the first published asset set
+validated for Qwen3-ASR typed speech-to-text in direct and worker modes. The
+chat bootstrap opts `SpeechToTextEngine` into that contract from the immutable
+tag; older or custom assets remain disabled unless the host explicitly sets
+`window.__llamadartBridgeSpeechToTextSupported = true` after equivalent
+validation.
 
 For broader browser coverage in this repository, fetched/local assets are patched
 to a universal Safari-compatible gate by default (`MIN_SAFARI_VERSION=170400`).
@@ -32,7 +39,7 @@ model bytes.
 To vendor pinned assets into local app web files:
 
 ```bash
-WEBGPU_BRIDGE_ASSETS_TAG=v0.1.27 ./scripts/fetch_webgpu_bridge_assets.sh
+WEBGPU_BRIDGE_ASSETS_TAG=v0.1.30 ./scripts/fetch_webgpu_bridge_assets.sh
 ```
 
 Optional compatibility env vars:
@@ -113,7 +120,7 @@ You can override CDN source/version before the bridge loader runs:
 ```html
 <script>
   window.__llamadartBridgeAssetsRepo = 'leehack/llama-web-bridge-assets';
-  window.__llamadartBridgeAssetsTag = 'v0.1.27';
+  window.__llamadartBridgeAssetsTag = 'v0.1.30';
 </script>
 ```
 

--- a/example/chat_app/README.md
+++ b/example/chat_app/README.md
@@ -88,7 +88,7 @@ flutter test --run-skipped -t local-only \
 2. Select one of the focused pre-configured models:
    - Cross-platform: FunctionGemma 270M, Qwen3.5 0.8B, Gemma 4 E2B
      GGUF, Gemma 4 E2B LiteRT-LM, and Gemma 4 E4B GGUF.
-   - Native mobile and desktop: Qwen3-ASR 0.6B.
+   - Native and Web: Qwen3-ASR 0.6B.
    - Native desktop: Qwen3-TTS 1.7B Base, Gemma 4 12B, Gemma 4 26B A4B,
      Gemma 4 31B, and Qwen3.6 35B A3B.
    - Built-in GGUF chat presets use [Unsloth distributions](https://huggingface.co/unsloth).
@@ -110,14 +110,15 @@ flutter test --run-skipped -t local-only \
      a separate action, with an explicit combined option in the confirmation.
 3. Tap the **Download** icon. The app uses `Dio` to download the model directly to your device's app-specific cache directory. Additional model downloads enter a FIFO queue and start one at a time. A persistent progress pill remains in the app header when settings is closed; tap it to reopen download details.
 4. Once downloaded, tap **Select** to load the model.
-   - The native Qwen3-ASR preset exposes **Attach Audio** and **Transcribe
-     Audio** on mobile and desktop builds. On Android, iOS, macOS, and Windows
-     it also shows a microphone button. File transcription accepts WAV, MP3,
-     or FLAC. The microphone records a temporary mono WAV for up to five
-     minutes; **Stop & transcribe** finalizes it, runs whole-file STT, and
-     deletes it.
-     Capture is foreground-only and cancelling discards the temporary file.
-     This Qwen path remains whole-file rather than live. For native chat
+   - The Qwen3-ASR preset exposes **Attach Audio** and **Transcribe Audio** on
+     native and Web builds. Native selected-file transcription accepts WAV,
+     MP3, or FLAC; Web accepts WAV bytes with bridge assets `v0.1.30+`. On
+     Android, iOS, macOS, Windows, and supported secure browser origins it also
+     shows a microphone button. The microphone records a temporary mono WAV
+     for up to five minutes; **Stop & transcribe** finalizes it, runs whole-file
+     STT, and deletes the native file or revokes the browser blob.
+     Capture is foreground-only and cancelling discards the temporary
+     recording. This Qwen path remains whole-file rather than live. For native chat
      models, including generic audio-chat models, the composer can separately
      install a live-dictation model/tokenizer and expose **Live transcription**
      on Android, iOS, macOS, and Windows. Moonshine Tiny is the recommended
@@ -135,10 +136,9 @@ flutter test --run-skipped -t local-only \
      [LiteRT Community](https://huggingface.co/litert-community/parakeet-tdt-0.6b-v3)
      from NVIDIA's
      [CC-BY-4.0 model](https://huggingface.co/nvidia/parakeet-tdt-0.6b-v3).
-     Web support is tracked in
-     [issue #329](https://github.com/leehack/llamadart/issues/329). All STT
-     actions require the matching projector, and the preset's pinned downloads
-     are SHA-256 verified.
+     All STT actions require the matching projector and a positive runtime
+     audio probe. The preset's native and Web sources use immutable revisions,
+     exact sizes, and SHA-256 metadata.
    - The native-desktop Qwen3-TTS preset uses a separate typed synthesis flow,
      not chat generation. Enter text, optionally select a language and choose
      or record a speaker reference, then synthesize. The app reports generation
@@ -148,11 +148,11 @@ flutter test --run-skipped -t local-only \
      model/projector downloads are immutable and SHA-256 verified.
      Current output is complete-buffer only, not streaming playback. Web,
      LiteRT-LM, and automatic read-aloud of chat responses remain unsupported.
-   - Microphone capture is enabled on Android, iOS, macOS, and Windows when a
-     compatible ASR model is active. It remains hidden on Linux because the
-     recorder plugin can report startup before its required external tools are
-     ready; selected-file transcription still works there.
-   - The complete Qwen3-ASR model/projector, microphone, and final-transcript
+   - Microphone capture is enabled on Android, iOS, macOS, Windows, and secure
+     browser origins when a compatible ASR model is active and WAV recording is
+     supported. It remains hidden on Linux because the recorder plugin can
+     report startup before its required external tools are ready; selected-file
+     transcription still works there.
      flow has passed on a physical Pixel using CPU inference and in the iOS
      Simulator. This is not yet physical-iPhone or Windows validation.
    - The native Gemma 4 E2B presets expose **Ask with voice** when either the

--- a/example/chat_app/lib/models/downloadable_model.dart
+++ b/example/chat_app/lib/models/downloadable_model.dart
@@ -473,13 +473,29 @@ class DownloadableModel {
         sha256:
             '41a342b5e4c514e968cb756de6cd1b7be39eff43c44c57a2ef5fc6522e36603d',
       ),
+      webModelSource: const RemoteModelAssetSource(
+        url:
+            'https://huggingface.co/ggml-org/Qwen3-ASR-0.6B-GGUF/resolve/928ab958557df9aa2ef1c93e0e83c7ad0933fae2/Qwen3-ASR-0.6B-Q8_0.gguf',
+        filename: 'Qwen3-ASR-0.6B-Q8_0.gguf',
+        sizeBytes: 804749248,
+        sha256:
+            'bca259818b50ca7c4c05e9bdb35a5dc04fa039653a6d6f3f0f331f96f6aa1971',
+      ),
+      webMultimodalProjectorSource: const RemoteModelAssetSource(
+        url:
+            'https://huggingface.co/ggml-org/Qwen3-ASR-0.6B-GGUF/resolve/928ab958557df9aa2ef1c93e0e83c7ad0933fae2/mmproj-Qwen3-ASR-0.6B-Q8_0.gguf',
+        filename: 'mmproj-Qwen3-ASR-0.6B-Q8_0.gguf',
+        sizeBytes: 214392480,
+        sha256:
+            '41a342b5e4c514e968cb756de6cd1b7be39eff43c44c57a2ef5fc6522e36603d',
+      ),
       sizeBytes: 1019141728,
       supportsAudio: true,
       supportsSpeechToText: true,
-      webSupportsAudio: false,
-      webSupportsSpeechToText: false,
+      webSupportsAudio: true,
+      webSupportsSpeechToText: true,
       distribution: 'ggml-org',
-      availability: ModelAvailability.native,
+      availability: ModelAvailability.all,
       minRamGb: 4,
       preset: const ModelPreset(
         temperature: 0,

--- a/example/chat_app/lib/providers/chat_provider.dart
+++ b/example/chat_app/lib/providers/chat_provider.dart
@@ -385,7 +385,6 @@ class ChatProvider extends ChangeNotifier {
   bool get supportsVision => _supportsVision;
   bool get supportsAudio => _supportsAudio;
   bool get canTranscribeAudio =>
-      !kIsWeb &&
       _isLoaded &&
       !_isInitializing &&
       !_isGenerating &&
@@ -466,7 +465,6 @@ class ChatProvider extends ChangeNotifier {
   /// This remains true while the model is busy so the composer can keep the
   /// control visible but disabled instead of shifting its layout.
   bool get supportsMicrophoneRecording =>
-      !kIsWeb &&
       _audioRecordingService.isSupported &&
       (_settings.modelSupportsSpeechToText || _supportsVoiceQuestionInput);
 
@@ -3074,10 +3072,24 @@ class ChatProvider extends ChangeNotifier {
     }
 
     try {
-      await transcribeAudio(
-        SpeechAudioFileInput(path),
-        displayName: 'Microphone recording',
-      );
+      if (kIsWeb) {
+        final bytes = await _audioRecordingService.readRecording(path);
+        await transcribeAudio(
+          SpeechAudioBytesInput(
+            bytes,
+            format: const SpeechAudioFormat(
+              encoding: 'wav',
+              mimeType: 'audio/wav',
+            ),
+          ),
+          displayName: 'Microphone recording',
+        );
+      } else {
+        await transcribeAudio(
+          SpeechAudioFileInput(path),
+          displayName: 'Microphone recording',
+        );
+      }
     } finally {
       await _audioRecordingService.deleteRecording(path);
     }
@@ -3380,25 +3392,35 @@ class ChatProvider extends ChangeNotifier {
 
   /// Picks one complete audio file and transcribes it with the loaded model.
   Future<void> pickAudioForTranscription() async {
-    if (kIsWeb) {
-      _addInfoMessage(
-        'Dedicated speech-to-text is not available in the Web chat app yet.',
-      );
-      notifyListeners();
-      return;
-    }
-
     try {
       final result = await FilePicker.platform.pickFiles(
         type: FileType.custom,
-        allowedExtensions: const <String>['wav', 'mp3', 'flac'],
+        allowedExtensions: kIsWeb
+            ? const <String>['wav']
+            : const <String>['wav', 'mp3', 'flac'],
         allowMultiple: false,
+        withData: kIsWeb,
       );
       if (result == null || result.files.isEmpty) {
         return;
       }
 
       final file = result.files.single;
+      final bytes = file.bytes;
+      final extension = p.extension(file.name).replaceFirst('.', '');
+      if (kIsWeb && bytes != null && bytes.isNotEmpty) {
+        await transcribeAudio(
+          SpeechAudioBytesInput(
+            bytes,
+            format: SpeechAudioFormat(
+              encoding: extension.isEmpty ? null : extension,
+            ),
+          ),
+          displayName: file.name,
+        );
+        return;
+      }
+
       final path = file.path;
       if (path != null && path.isNotEmpty) {
         await transcribeAudio(
@@ -3408,10 +3430,14 @@ class ChatProvider extends ChangeNotifier {
         return;
       }
 
-      final bytes = file.bytes;
       if (bytes != null && bytes.isNotEmpty) {
         await transcribeAudio(
-          SpeechAudioBytesInput(bytes),
+          SpeechAudioBytesInput(
+            bytes,
+            format: SpeechAudioFormat(
+              encoding: extension.isEmpty ? null : extension,
+            ),
+          ),
           displayName: file.name,
         );
         return;
@@ -3441,13 +3467,6 @@ class ChatProvider extends ChangeNotifier {
         _isTranscribing ||
         _session == null ||
         !_chatService.engine.isReady) {
-      return;
-    }
-    if (kIsWeb) {
-      _addInfoMessage(
-        'Dedicated speech-to-text is not available in the Web chat app yet.',
-      );
-      notifyListeners();
       return;
     }
     if (!_settings.modelSupportsSpeechToText) {

--- a/example/chat_app/lib/providers/chat_provider.dart
+++ b/example/chat_app/lib/providers/chat_provider.dart
@@ -3413,7 +3413,7 @@ class ChatProvider extends ChangeNotifier {
           SpeechAudioBytesInput(
             bytes,
             format: SpeechAudioFormat(
-              encoding: extension.isEmpty ? null : extension,
+              encoding: extension.isEmpty ? 'wav' : extension,
             ),
           ),
           displayName: file.name,

--- a/example/chat_app/lib/services/audio_recording_service.dart
+++ b/example/chat_app/lib/services/audio_recording_service.dart
@@ -1,7 +1,8 @@
 import 'dart:typed_data';
 
 import 'audio_recording_service_stub.dart'
-    if (dart.library.io) 'audio_recording_service_io.dart';
+    if (dart.library.io) 'audio_recording_service_io.dart'
+    if (dart.library.js_interop) 'audio_recording_service_web.dart';
 
 /// The reason a microphone recording operation could not be completed.
 enum AudioRecordingFailure {
@@ -36,7 +37,7 @@ class AudioRecordingException implements Exception {
   String toString() => message;
 }
 
-/// Captures temporary audio files for the chat app's transcription flow.
+/// Captures temporary audio for the chat app's speech flows.
 abstract class AudioRecordingService {
   /// Creates the platform recording service.
   factory AudioRecordingService() => createAudioRecordingService();
@@ -47,7 +48,10 @@ abstract class AudioRecordingService {
   /// Starts a new temporary recording.
   Future<void> start();
 
-  /// Stops the active recording and returns its temporary WAV path.
+  /// Stops the active recording and returns its temporary WAV reference.
+  ///
+  /// Native implementations return a filesystem path. Browser implementations
+  /// return an object URL that remains valid until [deleteRecording].
   Future<String> stop();
 
   /// Reads a finalized temporary recording as encoded WAV bytes.

--- a/example/chat_app/lib/services/audio_recording_service_io.dart
+++ b/example/chat_app/lib/services/audio_recording_service_io.dart
@@ -6,7 +6,7 @@ import 'package:path_provider/path_provider.dart';
 import 'package:record/record.dart';
 
 import 'audio_recording_service.dart';
-import 'wav_audio_validator.dart';
+import 'wav_audio_file_validator_io.dart';
 
 class _IoAudioRecordingService implements AudioRecordingService {
   AudioRecorder? _recorder;
@@ -106,8 +106,7 @@ class _IoAudioRecordingService implements AudioRecordingService {
       _isRecording = false;
       _activePath = null;
       final path = stoppedPath ?? fallbackPath;
-      final bytes = await File(path).readAsBytes();
-      if (!wavBytesHaveAudioData(bytes)) {
+      if (!await wavFileHasAudioData(path)) {
         await _deleteFile(path);
         if (path != fallbackPath) {
           await _deleteFile(fallbackPath);

--- a/example/chat_app/lib/services/audio_recording_service_io.dart
+++ b/example/chat_app/lib/services/audio_recording_service_io.dart
@@ -106,7 +106,8 @@ class _IoAudioRecordingService implements AudioRecordingService {
       _isRecording = false;
       _activePath = null;
       final path = stoppedPath ?? fallbackPath;
-      if (!await wavHasAudioData(path)) {
+      final bytes = await File(path).readAsBytes();
+      if (!wavBytesHaveAudioData(bytes)) {
         await _deleteFile(path);
         if (path != fallbackPath) {
           await _deleteFile(fallbackPath);

--- a/example/chat_app/lib/services/audio_recording_service_web.dart
+++ b/example/chat_app/lib/services/audio_recording_service_web.dart
@@ -9,6 +9,8 @@ import 'wav_audio_validator.dart';
 
 class _WebAudioRecordingService implements AudioRecordingService {
   AudioRecorder? _recorder;
+  String? _completedRecordingUrl;
+  Uint8List? _completedRecordingBytes;
   bool _isRecording = false;
   bool _isDisposed = false;
 
@@ -100,6 +102,9 @@ class _WebAudioRecordingService implements AudioRecordingService {
           'The microphone recording did not contain valid WAV audio.',
         );
       }
+      _revokeCompletedRecording();
+      _completedRecordingUrl = url;
+      _completedRecordingBytes = bytes;
       return url;
     } on AudioRecordingException {
       rethrow;
@@ -123,7 +128,15 @@ class _WebAudioRecordingService implements AudioRecordingService {
   @override
   Future<Uint8List> readRecording(String path) async {
     try {
-      final bytes = await _readBlobUrl(path);
+      final bytes = path == _completedRecordingUrl
+          ? _completedRecordingBytes
+          : await _readBlobUrl(path);
+      if (bytes == null) {
+        throw const AudioRecordingException(
+          AudioRecordingFailure.readFailed,
+          'The microphone recording could not be read.',
+        );
+      }
       if (bytes.isEmpty) {
         throw const AudioRecordingException(
           AudioRecordingFailure.readFailed,
@@ -157,6 +170,10 @@ class _WebAudioRecordingService implements AudioRecordingService {
 
   @override
   Future<void> deleteRecording(String path) async {
+    if (path == _completedRecordingUrl) {
+      _completedRecordingUrl = null;
+      _completedRecordingBytes = null;
+    }
     if (path.startsWith('blob:')) {
       web.URL.revokeObjectURL(path);
     }
@@ -169,6 +186,7 @@ class _WebAudioRecordingService implements AudioRecordingService {
     }
     _isDisposed = true;
     await cancel();
+    _revokeCompletedRecording();
     final recorder = _recorder;
     _recorder = null;
     await recorder?.dispose();
@@ -183,6 +201,15 @@ class _WebAudioRecordingService implements AudioRecordingService {
     }
     final buffer = await response.arrayBuffer().toDart;
     return buffer.toDart.asUint8List();
+  }
+
+  void _revokeCompletedRecording() {
+    final url = _completedRecordingUrl;
+    _completedRecordingUrl = null;
+    _completedRecordingBytes = null;
+    if (url != null && url.startsWith('blob:')) {
+      web.URL.revokeObjectURL(url);
+    }
   }
 }
 

--- a/example/chat_app/lib/services/audio_recording_service_web.dart
+++ b/example/chat_app/lib/services/audio_recording_service_web.dart
@@ -1,0 +1,191 @@
+import 'dart:js_interop';
+import 'dart:typed_data';
+
+import 'package:record/record.dart';
+import 'package:web/web.dart' as web;
+
+import 'audio_recording_service.dart';
+import 'wav_audio_validator.dart';
+
+class _WebAudioRecordingService implements AudioRecordingService {
+  AudioRecorder? _recorder;
+  bool _isRecording = false;
+  bool _isDisposed = false;
+
+  @override
+  bool get isSupported => web.window.isSecureContext;
+
+  @override
+  Future<void> start() async {
+    if (_isDisposed || !isSupported) {
+      throw const AudioRecordingException(
+        AudioRecordingFailure.unsupported,
+        'Browser microphone recording requires a secure HTTPS or localhost '
+        'context.',
+      );
+    }
+    if (_isRecording) {
+      throw const AudioRecordingException(
+        AudioRecordingFailure.startFailed,
+        'A microphone recording is already in progress.',
+      );
+    }
+
+    final recorder = _recorder ??= AudioRecorder();
+    try {
+      if (!await recorder.hasPermission()) {
+        throw const AudioRecordingException(
+          AudioRecordingFailure.permissionDenied,
+          'Microphone permission was denied. Allow microphone access in the '
+          'browser site settings and try again.',
+        );
+      }
+      if (!await recorder.isEncoderSupported(AudioEncoder.wav)) {
+        throw const AudioRecordingException(
+          AudioRecordingFailure.unsupported,
+          'WAV microphone recording is unavailable in this browser.',
+        );
+      }
+      await recorder.start(
+        const RecordConfig(
+          encoder: AudioEncoder.wav,
+          sampleRate: 16000,
+          numChannels: 1,
+        ),
+        path: '',
+      );
+      _isRecording = true;
+    } on AudioRecordingException {
+      rethrow;
+    } catch (_) {
+      _isRecording = false;
+      try {
+        await recorder.cancel();
+      } catch (_) {
+        // Preserve the actionable recorder failure below.
+      }
+      throw const AudioRecordingException(
+        AudioRecordingFailure.startFailed,
+        'Could not start browser microphone recording. Check the selected '
+        'input device and site permission.',
+      );
+    }
+  }
+
+  @override
+  Future<String> stop() async {
+    final recorder = _recorder;
+    if (!_isRecording || recorder == null) {
+      throw const AudioRecordingException(
+        AudioRecordingFailure.stopFailed,
+        'No microphone recording is in progress.',
+      );
+    }
+
+    String? url;
+    try {
+      url = await recorder.stop();
+      _isRecording = false;
+      if (url == null || url.isEmpty) {
+        throw const AudioRecordingException(
+          AudioRecordingFailure.stopFailed,
+          'The browser did not return a completed microphone recording.',
+        );
+      }
+      final bytes = await _readBlobUrl(url);
+      if (!wavBytesHaveAudioData(bytes)) {
+        web.URL.revokeObjectURL(url);
+        throw const AudioRecordingException(
+          AudioRecordingFailure.stopFailed,
+          'The microphone recording did not contain valid WAV audio.',
+        );
+      }
+      return url;
+    } on AudioRecordingException {
+      rethrow;
+    } catch (_) {
+      _isRecording = false;
+      if (url != null && url.startsWith('blob:')) {
+        web.URL.revokeObjectURL(url);
+      }
+      try {
+        await recorder.cancel();
+      } catch (_) {
+        // Preserve the actionable recorder failure below.
+      }
+      throw const AudioRecordingException(
+        AudioRecordingFailure.stopFailed,
+        'Could not finish browser microphone recording.',
+      );
+    }
+  }
+
+  @override
+  Future<Uint8List> readRecording(String path) async {
+    try {
+      final bytes = await _readBlobUrl(path);
+      if (bytes.isEmpty) {
+        throw const AudioRecordingException(
+          AudioRecordingFailure.readFailed,
+          'The microphone recording could not be read.',
+        );
+      }
+      return bytes;
+    } on AudioRecordingException {
+      rethrow;
+    } catch (_) {
+      throw const AudioRecordingException(
+        AudioRecordingFailure.readFailed,
+        'The microphone recording could not be read.',
+      );
+    }
+  }
+
+  @override
+  Future<void> cancel() async {
+    final recorder = _recorder;
+    final shouldCancel = _isRecording;
+    _isRecording = false;
+    if (recorder != null && shouldCancel) {
+      try {
+        await recorder.cancel();
+      } catch (_) {
+        // Browser microphone cleanup is best effort.
+      }
+    }
+  }
+
+  @override
+  Future<void> deleteRecording(String path) async {
+    if (path.startsWith('blob:')) {
+      web.URL.revokeObjectURL(path);
+    }
+  }
+
+  @override
+  Future<void> dispose() async {
+    if (_isDisposed) {
+      return;
+    }
+    _isDisposed = true;
+    await cancel();
+    final recorder = _recorder;
+    _recorder = null;
+    await recorder?.dispose();
+  }
+
+  Future<Uint8List> _readBlobUrl(String url) async {
+    final response = await web.window.fetch(url.toJS).toDart;
+    if (!response.ok) {
+      throw StateError(
+        'Recording fetch failed with status ${response.status}.',
+      );
+    }
+    final buffer = await response.arrayBuffer().toDart;
+    return buffer.toDart.asUint8List();
+  }
+}
+
+/// Creates the browser microphone recorder implementation.
+AudioRecordingService createAudioRecordingService() =>
+    _WebAudioRecordingService();

--- a/example/chat_app/lib/services/chat_service.dart
+++ b/example/chat_app/lib/services/chat_service.dart
@@ -225,6 +225,14 @@ class ChatService {
 
     var batchSize = settings.batchSize;
     var microBatchSize = settings.microBatchSize;
+    if (kIsWeb && settings.modelSupportsSpeechToText) {
+      if (batchSize <= 0) {
+        batchSize = math.min(safeContextSize, 512);
+      }
+      if (microBatchSize <= 0) {
+        microBatchSize = math.min(batchSize, 128);
+      }
+    }
     if (isAndroidNative && usesGpuBackend) {
       if (usesVulkanBackend) {
         final preferredBatchCap = _isQwen35SmallModel(settings.modelPath)

--- a/example/chat_app/lib/services/wav_audio_file_validator_io.dart
+++ b/example/chat_app/lib/services/wav_audio_file_validator_io.dart
@@ -1,0 +1,60 @@
+import 'dart:io';
+import 'dart:typed_data';
+
+/// Returns whether [path] is a RIFF/WAVE file with a nonempty data chunk.
+Future<bool> wavFileHasAudioData(String path) async {
+  RandomAccessFile? input;
+  try {
+    final file = File(path);
+    final fileLength = await file.length();
+    if (fileLength < 20) {
+      return false;
+    }
+    input = await file.open();
+    final riffHeader = await input.read(12);
+    if (riffHeader.length != 12 ||
+        riffHeader[0] != 0x52 ||
+        riffHeader[1] != 0x49 ||
+        riffHeader[2] != 0x46 ||
+        riffHeader[3] != 0x46 ||
+        riffHeader[8] != 0x57 ||
+        riffHeader[9] != 0x41 ||
+        riffHeader[10] != 0x56 ||
+        riffHeader[11] != 0x45) {
+      return false;
+    }
+
+    var offset = 12;
+    while (offset + 8 <= fileLength) {
+      await input.setPosition(offset);
+      final chunkHeader = await input.read(8);
+      if (chunkHeader.length != 8) {
+        return false;
+      }
+      final chunkSize = ByteData.sublistView(
+        chunkHeader,
+      ).getUint32(4, Endian.little);
+      final payloadOffset = offset + 8;
+      final isDataChunk =
+          chunkHeader[0] == 0x64 &&
+          chunkHeader[1] == 0x61 &&
+          chunkHeader[2] == 0x74 &&
+          chunkHeader[3] == 0x61;
+      if (isDataChunk) {
+        return chunkSize > 0 && fileLength - payloadOffset >= chunkSize;
+      }
+
+      final paddedChunkSize = chunkSize + (chunkSize.isOdd ? 1 : 0);
+      final nextOffset = payloadOffset + paddedChunkSize;
+      if (nextOffset <= offset || nextOffset > fileLength) {
+        return false;
+      }
+      offset = nextOffset;
+    }
+    return false;
+  } catch (_) {
+    return false;
+  } finally {
+    await input?.close();
+  }
+}

--- a/example/chat_app/lib/services/wav_audio_validator.dart
+++ b/example/chat_app/lib/services/wav_audio_validator.dart
@@ -1,60 +1,42 @@
-import 'dart:io';
 import 'dart:typed_data';
 
-/// Returns whether [path] is a RIFF/WAVE file with a nonempty data chunk.
-Future<bool> wavHasAudioData(String path) async {
-  RandomAccessFile? input;
-  try {
-    final file = File(path);
-    final fileLength = await file.length();
-    if (fileLength < 20) {
-      return false;
-    }
-    input = await file.open();
-    final riffHeader = await input.read(12);
-    if (riffHeader.length != 12 ||
-        riffHeader[0] != 0x52 ||
-        riffHeader[1] != 0x49 ||
-        riffHeader[2] != 0x46 ||
-        riffHeader[3] != 0x46 ||
-        riffHeader[8] != 0x57 ||
-        riffHeader[9] != 0x41 ||
-        riffHeader[10] != 0x56 ||
-        riffHeader[11] != 0x45) {
-      return false;
-    }
-
-    var offset = 12;
-    while (offset + 8 <= fileLength) {
-      await input.setPosition(offset);
-      final chunkHeader = await input.read(8);
-      if (chunkHeader.length != 8) {
-        return false;
-      }
-      final chunkSize = ByteData.sublistView(
-        chunkHeader,
-      ).getUint32(4, Endian.little);
-      final payloadOffset = offset + 8;
-      final isDataChunk =
-          chunkHeader[0] == 0x64 &&
-          chunkHeader[1] == 0x61 &&
-          chunkHeader[2] == 0x74 &&
-          chunkHeader[3] == 0x61;
-      if (isDataChunk) {
-        return chunkSize > 0 && fileLength - payloadOffset >= chunkSize;
-      }
-
-      final paddedChunkSize = chunkSize + (chunkSize.isOdd ? 1 : 0);
-      final nextOffset = payloadOffset + paddedChunkSize;
-      if (nextOffset <= offset || nextOffset > fileLength) {
-        return false;
-      }
-      offset = nextOffset;
-    }
+/// Returns whether [bytes] contain a RIFF/WAVE file with nonempty audio data.
+bool wavBytesHaveAudioData(Uint8List bytes) {
+  final fileLength = bytes.length;
+  if (fileLength < 20 ||
+      bytes[0] != 0x52 ||
+      bytes[1] != 0x49 ||
+      bytes[2] != 0x46 ||
+      bytes[3] != 0x46 ||
+      bytes[8] != 0x57 ||
+      bytes[9] != 0x41 ||
+      bytes[10] != 0x56 ||
+      bytes[11] != 0x45) {
     return false;
-  } catch (_) {
-    return false;
-  } finally {
-    await input?.close();
   }
+
+  var offset = 12;
+  while (offset + 8 <= fileLength) {
+    final chunkHeader = Uint8List.sublistView(bytes, offset, offset + 8);
+    final chunkSize = ByteData.sublistView(
+      chunkHeader,
+    ).getUint32(4, Endian.little);
+    final payloadOffset = offset + 8;
+    final isDataChunk =
+        chunkHeader[0] == 0x64 &&
+        chunkHeader[1] == 0x61 &&
+        chunkHeader[2] == 0x74 &&
+        chunkHeader[3] == 0x61;
+    if (isDataChunk) {
+      return chunkSize > 0 && fileLength - payloadOffset >= chunkSize;
+    }
+
+    final paddedChunkSize = chunkSize + (chunkSize.isOdd ? 1 : 0);
+    final nextOffset = payloadOffset + paddedChunkSize;
+    if (nextOffset <= offset || nextOffset > fileLength) {
+      return false;
+    }
+    offset = nextOffset;
+  }
+  return false;
 }

--- a/example/chat_app/test/audio_recording_service_web_test.dart
+++ b/example/chat_app/test/audio_recording_service_web_test.dart
@@ -1,0 +1,14 @@
+@TestOn('browser')
+library;
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:llamadart_chat_example/services/audio_recording_service.dart';
+
+void main() {
+  test('browser recorder is exposed from a secure test origin', () async {
+    final recorder = AudioRecordingService();
+    addTearDown(recorder.dispose);
+
+    expect(recorder.isSupported, isTrue);
+  });
+}

--- a/example/chat_app/test/chat_input_test.dart
+++ b/example/chat_app/test/chat_input_test.dart
@@ -1,6 +1,7 @@
 import 'dart:async';
 
 import 'package:dio/dio.dart';
+import 'package:file_picker/file_picker.dart';
 import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
@@ -2085,6 +2086,43 @@ void main() {
     expect(provider.canRegenerateLastResponse, isFalse);
   });
 
+  test('Web treats an extensionless selected speech file as WAV', () async {
+    if (!kIsWeb) {
+      return;
+    }
+    final filePicker = _FakeFilePicker(
+      FilePickerResult(<PlatformFile>[
+        PlatformFile(
+          name: 'speech-recording',
+          size: 4,
+          bytes: Uint8List.fromList(const <int>[0x52, 0x49, 0x46, 0x46]),
+        ),
+      ]),
+    );
+    FilePicker.platform = filePicker;
+    addTearDown(() => FilePicker.platform = _FakeFilePicker(null));
+
+    final engine = _SpeechMockLlamaEngine()
+      ..createChunkContents = const <String>['Extensionless WAV.'];
+    final provider = ChatProvider(
+      chatService: MockChatService(engine: engine),
+      settingsService: MockSettingsService(),
+      initialSettings: const ChatSettings(
+        modelPath: 'Qwen3-ASR-0.6B-Q8_0.gguf',
+        mmprojPath: 'mmproj-Qwen3-ASR-0.6B-Q8_0.gguf',
+        modelSupportsSpeechToText: true,
+      ),
+    );
+    addTearDown(provider.dispose);
+    await provider.loadModel();
+
+    await provider.pickAudioForTranscription();
+
+    expect(filePicker.allowedExtensions, <String>['wav']);
+    expect(filePicker.withData, isTrue);
+    expect(provider.messages.last.text, 'Extensionless WAV.');
+  });
+
   test(
     'Web microphone transcribes finalized WAV bytes and revokes the blob',
     () async {
@@ -2790,6 +2828,34 @@ class _FakeAudioRecordingService implements AudioRecordingService {
   @override
   Future<void> dispose() async {
     disposeCalls += 1;
+  }
+}
+
+class _FakeFilePicker extends FilePicker {
+  final FilePickerResult? result;
+  List<String>? allowedExtensions;
+  bool? withData;
+
+  _FakeFilePicker(this.result);
+
+  @override
+  Future<FilePickerResult?> pickFiles({
+    String? dialogTitle,
+    String? initialDirectory,
+    FileType type = FileType.any,
+    List<String>? allowedExtensions,
+    Function(FilePickerStatus)? onFileLoading,
+    bool allowCompression = false,
+    int compressionQuality = 0,
+    bool allowMultiple = false,
+    bool withData = false,
+    bool withReadStream = false,
+    bool lockParentWindow = false,
+    bool readSequential = false,
+  }) async {
+    this.allowedExtensions = allowedExtensions;
+    this.withData = withData;
+    return result;
   }
 }
 

--- a/example/chat_app/test/chat_input_test.dart
+++ b/example/chat_app/test/chat_input_test.dart
@@ -1,7 +1,7 @@
 import 'dart:async';
-import 'dart:typed_data';
 
 import 'package:dio/dio.dart';
+import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:llamadart/llamadart.dart';
@@ -2085,6 +2085,44 @@ void main() {
     expect(provider.canRegenerateLastResponse, isFalse);
   });
 
+  test(
+    'Web microphone transcribes finalized WAV bytes and revokes the blob',
+    () async {
+      if (!kIsWeb) {
+        return;
+      }
+      final engine = _SpeechMockLlamaEngine()
+        ..createChunkContents = const <String>[
+          'language English<asr_text>Browser microphone.',
+        ];
+      final recorder = _FakeAudioRecordingService();
+      final provider = ChatProvider(
+        chatService: MockChatService(engine: engine),
+        audioRecordingService: recorder,
+        settingsService: MockSettingsService(),
+        initialSettings: const ChatSettings(
+          modelPath: 'Qwen3-ASR-0.6B-Q8_0.gguf',
+          mmprojPath: 'mmproj-Qwen3-ASR-0.6B-Q8_0.gguf',
+          modelSupportsSpeechToText: true,
+        ),
+      );
+      addTearDown(provider.dispose);
+      await provider.loadModel();
+
+      await provider.startAudioRecording();
+      await provider.stopAudioRecordingAndTranscribe();
+
+      expect(recorder.readCalls, 1);
+      expect(recorder.deletedPaths, <String>[recorder.recordedPath]);
+      expect(engine.createCalls, 1);
+      final audio = engine.lastGenerateParts!
+          .whereType<LlamaAudioContent>()
+          .single;
+      expect(audio.bytes, recorder.recordedBytes);
+      expect(provider.messages.last.text, 'Browser microphone.');
+    },
+  );
+
   test('does not overlap a stopped transcription while it settles', () async {
     final engine = _BlockingSpeechMockLlamaEngine();
     final provider = ChatProvider(
@@ -2346,8 +2384,26 @@ class _ReadyTextToSpeechProvider extends ChatProvider {
 }
 
 class _SpeechMockLlamaEngine extends MockLlamaEngine {
+  List<LlamaContentPart>? lastGenerateParts;
+
   @override
   Future<bool> get supportsAudio async => mmprojLoaded;
+
+  @override
+  Stream<String> generate(
+    String prompt, {
+    GenerationParams params = const GenerationParams(),
+    List<LlamaContentPart>? parts,
+  }) async* {
+    createCalls += 1;
+    lastCreateParams = params;
+    lastGenerateParts = parts == null
+        ? null
+        : List<LlamaContentPart>.from(parts);
+    for (final content in createChunkContents) {
+      yield content;
+    }
+  }
 }
 
 class _AlwaysAudioMockLlamaEngine extends MockLlamaEngine {
@@ -2381,6 +2437,7 @@ class _BlockingSpeechMockLlamaEngine extends _SpeechMockLlamaEngine {
   }) async* {
     createCalls += 1;
     lastCreateParams = params;
+    lastCreateMessages = List<LlamaChatMessage>.from(messages);
     if (!createStarted.isCompleted) {
       createStarted.complete();
     }
@@ -2398,6 +2455,26 @@ class _BlockingSpeechMockLlamaEngine extends _SpeechMockLlamaEngine {
           ),
         ],
       );
+    }
+  }
+
+  @override
+  Stream<String> generate(
+    String prompt, {
+    GenerationParams params = const GenerationParams(),
+    List<LlamaContentPart>? parts,
+  }) async* {
+    createCalls += 1;
+    lastCreateParams = params;
+    lastGenerateParts = parts == null
+        ? null
+        : List<LlamaContentPart>.from(parts);
+    if (!createStarted.isCompleted) {
+      createStarted.complete();
+    }
+    await _release.future;
+    for (final content in createChunkContents) {
+      yield content;
     }
   }
 }

--- a/example/chat_app/test/chat_input_test.dart
+++ b/example/chat_app/test/chat_input_test.dart
@@ -1,4 +1,5 @@
 import 'dart:async';
+import 'dart:typed_data';
 
 import 'package:dio/dio.dart';
 import 'package:file_picker/file_picker.dart';

--- a/example/chat_app/test/chat_service_test.dart
+++ b/example/chat_app/test/chat_service_test.dart
@@ -14,6 +14,27 @@ void main() {
       debugDefaultTargetPlatformOverride = null;
     });
 
+    test('bounds automatic Web speech batching', () async {
+      if (!kIsWeb) {
+        return;
+      }
+      final engine = MockLlamaEngine();
+      final service = ChatService(engine: engine);
+
+      await service.init(
+        const ChatSettings(
+          modelPath: 'Qwen3-ASR-0.6B-Q8_0.gguf',
+          preferredBackend: GpuBackend.cpu,
+          contextSize: 4096,
+          modelSupportsSpeechToText: true,
+        ),
+        eagerLoadMultimodalProjector: false,
+      );
+
+      expect(engine.lastModelParams!.batchSize, 512);
+      expect(engine.lastModelParams!.microBatchSize, 128);
+    });
+
     test(
       'uses less restrictive Android Vulkan batch defaults for Qwen3.5 0.8B',
       () async {

--- a/example/chat_app/test/manage_models_screen_download_test.dart
+++ b/example/chat_app/test/manage_models_screen_download_test.dart
@@ -141,7 +141,7 @@ void main() {
           );
 
           expect(find.text(asr.name), findsOneWidget);
-          expect(find.text('Native platforms'), findsOneWidget);
+          expect(find.text('All platforms'), findsOneWidget);
           expect(find.text('Download Model + Projector'), findsOneWidget);
         } finally {
           debugDefaultTargetPlatformOverride = null;

--- a/example/chat_app/test/mocks.dart
+++ b/example/chat_app/test/mocks.dart
@@ -6,7 +6,11 @@ import 'package:llamadart_chat_example/models/chat_settings.dart';
 import 'package:llamadart_chat_example/services/chat_service.dart';
 import 'package:llamadart_chat_example/services/settings_service.dart';
 
-class MockLlamaBackend implements LlamaBackend, BackendAvailability {
+class MockLlamaBackend
+    implements
+        LlamaBackend,
+        BackendAvailability,
+        BackendPromptSpeechToTextSupport {
   @override
   bool get isReady => true;
   @override
@@ -68,6 +72,10 @@ class MockLlamaBackend implements LlamaBackend, BackendAvailability {
   Future<String> getBackendName() async => "Mock";
   @override
   Future<String> getAvailableBackends() async => "Mock";
+  @override
+  bool get supportsPromptSpeechToText => true;
+  @override
+  String? get promptSpeechToTextUnsupportedReason => null;
   @override
   bool get supportsUrlLoading => false;
   @override

--- a/example/chat_app/test/unit_test.dart
+++ b/example/chat_app/test/unit_test.dart
@@ -1638,16 +1638,21 @@ void main() {
       final modelSource = model.modelSource as RemoteModelAssetSource;
       final projectorSource =
           model.multimodalProjectorSource as RemoteModelAssetSource;
+      final webModelSource = model.webModelSource as RemoteModelAssetSource;
+      final webProjectorSource =
+          model.webMultimodalProjectorSource as RemoteModelAssetSource;
 
       expect(model.supportsAudio, isTrue);
       expect(model.supportsSpeechToTextFor(web: false), isTrue);
-      expect(model.supportsSpeechToTextFor(web: true), isFalse);
-      expect(model.isNativeOnly, isTrue);
+      expect(model.supportsSpeechToTextFor(web: true), isTrue);
+      expect(model.supportsAudioFor(web: true), isTrue);
+      expect(model.isNativeOnly, isFalse);
       expect(model.isNativeDesktopOnly, isFalse);
       expect(model.isAvailableFor(web: false, mobile: true), isTrue);
       expect(model.isAvailableFor(web: false, mobile: false), isTrue);
-      expect(model.isAvailableFor(web: true, mobile: false), isFalse);
+      expect(model.isAvailableFor(web: true, mobile: false), isTrue);
       expect(model.sizeBytesFor(web: false), 1019141728);
+      expect(model.sizeBytesFor(web: true), 1019141728);
       expect(model.preset.temperature, 0);
       expect(model.preset.topK, 1);
       expect(model.preset.topP, 1);
@@ -1673,6 +1678,20 @@ void main() {
         projectorSource.url,
         contains('928ab958557df9aa2ef1c93e0e83c7ad0933fae2'),
       );
+      expect(
+        webModelSource.url,
+        contains('928ab958557df9aa2ef1c93e0e83c7ad0933fae2'),
+      );
+      expect(webModelSource.filename, modelSource.filename);
+      expect(webModelSource.sizeBytes, modelSource.sizeBytes);
+      expect(webModelSource.sha256, modelSource.sha256);
+      expect(
+        webProjectorSource.url,
+        contains('928ab958557df9aa2ef1c93e0e83c7ad0933fae2'),
+      );
+      expect(webProjectorSource.filename, projectorSource.filename);
+      expect(webProjectorSource.sizeBytes, projectorSource.sizeBytes);
+      expect(webProjectorSource.sha256, projectorSource.sha256);
     });
 
     test('Qwen3-TTS catalog entry pins its complete verified bundle', () {
@@ -1758,7 +1777,7 @@ void main() {
       }
     });
 
-    test('large models remain desktop-only while Qwen3-ASR is native', () {
+    test('large models remain desktop-only while Qwen3-ASR is universal', () {
       final desktopModels = DownloadableModel.defaultModels
           .where((model) => model.isNativeDesktopOnly)
           .toList(growable: false);
@@ -1782,10 +1801,10 @@ void main() {
       final qwenAsr = DownloadableModel.defaultModels.singleWhere(
         (model) => model.name == 'Qwen3-ASR 0.6B',
       );
-      expect(qwenAsr.isNativeOnly, isTrue);
+      expect(qwenAsr.isNativeOnly, isFalse);
       expect(qwenAsr.isAvailableFor(web: false, mobile: true), isTrue);
       expect(qwenAsr.isAvailableFor(web: false, mobile: false), isTrue);
-      expect(qwenAsr.isAvailableFor(web: true, mobile: false), isFalse);
+      expect(qwenAsr.isAvailableFor(web: true, mobile: false), isTrue);
 
       final gemmaE4b = DownloadableModel.defaultModels.singleWhere(
         (model) => model.name == 'Gemma 4 E4B it',

--- a/example/chat_app/test/wav_audio_file_validator_io_test.dart
+++ b/example/chat_app/test/wav_audio_file_validator_io_test.dart
@@ -1,3 +1,6 @@
+@TestOn('vm')
+library;
+
 import 'dart:io';
 import 'dart:typed_data';
 

--- a/example/chat_app/test/wav_audio_file_validator_io_test.dart
+++ b/example/chat_app/test/wav_audio_file_validator_io_test.dart
@@ -1,0 +1,55 @@
+import 'dart:io';
+import 'dart:typed_data';
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:llamadart_chat_example/services/wav_audio_file_validator_io.dart';
+
+void main() {
+  late Directory temporaryDirectory;
+
+  setUp(() async {
+    temporaryDirectory = await Directory.systemTemp.createTemp(
+      'llamadart_wav_file_validator_',
+    );
+  });
+
+  tearDown(() async {
+    if (await temporaryDirectory.exists()) {
+      await temporaryDirectory.delete(recursive: true);
+    }
+  });
+
+  test('validates WAV data without loading the complete file', () async {
+    final valid = File('${temporaryDirectory.path}/speech.wav');
+    await valid.writeAsBytes(_wavBytes(const <int>[1, 2, 3, 4]));
+    final empty = File('${temporaryDirectory.path}/empty.wav');
+    await empty.writeAsBytes(_wavBytes(const <int>[]));
+
+    expect(await wavFileHasAudioData(valid.path), isTrue);
+    expect(await wavFileHasAudioData(empty.path), isFalse);
+    expect(
+      await wavFileHasAudioData('${temporaryDirectory.path}/missing.wav'),
+      isFalse,
+    );
+  });
+}
+
+Uint8List _wavBytes(List<int> samples) {
+  final bytes = Uint8List(44 + samples.length);
+  bytes.setAll(0, 'RIFF'.codeUnits);
+  final data = ByteData.sublistView(bytes);
+  data.setUint32(4, bytes.length - 8, Endian.little);
+  bytes.setAll(8, 'WAVE'.codeUnits);
+  bytes.setAll(12, 'fmt '.codeUnits);
+  data.setUint32(16, 16, Endian.little);
+  data.setUint16(20, 1, Endian.little);
+  data.setUint16(22, 1, Endian.little);
+  data.setUint32(24, 16000, Endian.little);
+  data.setUint32(28, 32000, Endian.little);
+  data.setUint16(32, 2, Endian.little);
+  data.setUint16(34, 16, Endian.little);
+  bytes.setAll(36, 'data'.codeUnits);
+  data.setUint32(40, samples.length, Endian.little);
+  bytes.setAll(44, samples);
+  return bytes;
+}

--- a/example/chat_app/test/wav_audio_validator_test.dart
+++ b/example/chat_app/test/wav_audio_validator_test.dart
@@ -1,50 +1,24 @@
-import 'dart:io';
 import 'dart:typed_data';
 
 import 'package:flutter_test/flutter_test.dart';
 import 'package:llamadart_chat_example/services/wav_audio_validator.dart';
 
 void main() {
-  late Directory temporaryDirectory;
-
-  setUp(() async {
-    temporaryDirectory = await Directory.systemTemp.createTemp(
-      'llamadart_wav_validator_',
-    );
+  test('accepts a WAV with PCM bytes in its data chunk', () {
+    expect(wavBytesHaveAudioData(_wavBytes(const <int>[1, 2, 3, 4])), isTrue);
   });
 
-  tearDown(() async {
-    if (await temporaryDirectory.exists()) {
-      await temporaryDirectory.delete(recursive: true);
-    }
+  test('rejects a header-only WAV', () {
+    expect(wavBytesHaveAudioData(_wavBytes(const <int>[])), isFalse);
   });
 
-  test('accepts a WAV with PCM bytes in its data chunk', () async {
-    final file = File('${temporaryDirectory.path}/speech.wav');
-    await file.writeAsBytes(_wavBytes(const <int>[1, 2, 3, 4]));
-
-    expect(await wavHasAudioData(file.path), isTrue);
-  });
-
-  test('rejects a header-only WAV', () async {
-    final file = File('${temporaryDirectory.path}/silent.wav');
-    await file.writeAsBytes(_wavBytes(const <int>[]));
-
-    expect(await wavHasAudioData(file.path), isFalse);
-  });
-
-  test('rejects a truncated data chunk and a non-WAV file', () async {
-    final truncated = File('${temporaryDirectory.path}/truncated.wav');
+  test('rejects a truncated data chunk and a non-WAV file', () {
     final truncatedBytes = _wavBytes(const <int>[1, 2]);
     ByteData.sublistView(truncatedBytes).setUint32(40, 64, Endian.little);
-    await truncated.writeAsBytes(truncatedBytes);
-    final invalid = File('${temporaryDirectory.path}/invalid.wav');
-    await invalid.writeAsString('not audio');
 
-    expect(await wavHasAudioData(truncated.path), isFalse);
-    expect(await wavHasAudioData(invalid.path), isFalse);
+    expect(wavBytesHaveAudioData(truncatedBytes), isFalse);
     expect(
-      await wavHasAudioData('${temporaryDirectory.path}/missing.wav'),
+      wavBytesHaveAudioData(Uint8List.fromList('not audio'.codeUnits)),
       isFalse,
     );
   });

--- a/example/chat_app/test/web_bootstrap_contract_test.dart
+++ b/example/chat_app/test/web_bootstrap_contract_test.dart
@@ -1,3 +1,6 @@
+@TestOn('vm')
+library;
+
 import 'dart:io';
 
 import 'package:flutter_test/flutter_test.dart';

--- a/example/chat_app/test/web_bootstrap_contract_test.dart
+++ b/example/chat_app/test/web_bootstrap_contract_test.dart
@@ -1,0 +1,21 @@
+import 'dart:io';
+
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  test('custom bridge repositories require an explicit speech opt-in', () {
+    final bootstrap = File('web/index.html').readAsStringSync();
+
+    expect(
+      bootstrap,
+      contains("bridgeAssetsRepo === 'leehack/llama-web-bridge-assets'"),
+    );
+    expect(
+      bootstrap,
+      contains(
+        'isOfficialBridgeAssetsRepo &&\n'
+        '          bridgeTagSupportsSpeechToText(bridgeAssetsTag)',
+      ),
+    );
+  });
+}

--- a/example/chat_app/web/index.html
+++ b/example/chat_app/web/index.html
@@ -214,13 +214,25 @@
     const bridgeAssetsTag =
       typeof configuredTag === 'string' && configuredTag.length > 0
         ? configuredTag
-        : 'v0.1.27';
+        : 'v0.1.30';
+    function bridgeTagSupportsSpeechToText(tag) {
+      const match = /^v(\d+)\.(\d+)\.(\d+)(?:$|-)/.exec(String(tag || ''));
+      if (!match) return false;
+      const major = Number(match[1]);
+      const minor = Number(match[2]);
+      const patch = Number(match[3]);
+      return major > 0 || minor > 1 || (minor === 1 && patch >= 30);
+    }
+    window.__llamadartBridgeSpeechToTextSupported =
+      typeof window.__llamadartBridgeSpeechToTextSupported === 'boolean'
+        ? window.__llamadartBridgeSpeechToTextSupported
+        : bridgeTagSupportsSpeechToText(bridgeAssetsTag);
     window.__llamadartLiteRtLmModuleUrl =
       typeof window.__llamadartLiteRtLmModuleUrl === 'string' &&
       window.__llamadartLiteRtLmModuleUrl.length > 0
         ? window.__llamadartLiteRtLmModuleUrl
         : 'https://cdn.jsdelivr.net/npm/@litert-lm/core@0.15.0/+esm';
-    const localBridgeVersion = 'v0.1.27-local-b10333';
+    const localBridgeVersion = 'v0.1.30-local-b10448';
     window.__llamadartBridgeLocalVersion = localBridgeVersion;
 
     const localBridgeUrl = `./webgpu_bridge/llama_webgpu_bridge.js?v=${localBridgeVersion}`;

--- a/example/chat_app/web/index.html
+++ b/example/chat_app/web/index.html
@@ -223,10 +223,13 @@
       const patch = Number(match[3]);
       return major > 0 || minor > 1 || (minor === 1 && patch >= 30);
     }
+    const isOfficialBridgeAssetsRepo =
+      bridgeAssetsRepo === 'leehack/llama-web-bridge-assets';
     window.__llamadartBridgeSpeechToTextSupported =
       typeof window.__llamadartBridgeSpeechToTextSupported === 'boolean'
         ? window.__llamadartBridgeSpeechToTextSupported
-        : bridgeTagSupportsSpeechToText(bridgeAssetsTag);
+        : isOfficialBridgeAssetsRepo &&
+          bridgeTagSupportsSpeechToText(bridgeAssetsTag);
     window.__llamadartLiteRtLmModuleUrl =
       typeof window.__llamadartLiteRtLmModuleUrl === 'string' &&
       window.__llamadartLiteRtLmModuleUrl.length > 0

--- a/lib/llamadart.dart
+++ b/lib/llamadart.dart
@@ -55,6 +55,7 @@ export 'src/backends/backend.dart'
         BackendGpuEnumeration,
         BackendNativeChatGeneration,
         BackendRuntimeDiagnostics,
+        BackendPromptSpeechToTextSupport,
         BackendTextToSpeech,
         BackendTextToSpeechCapabilities,
         BackendTextToSpeechModel,

--- a/lib/src/backends/backend.dart
+++ b/lib/src/backends/backend.dart
@@ -177,6 +177,19 @@ abstract class BackendRuntimeDiagnostics {
   Future<int?> getResolvedGpuLayers();
 }
 
+/// Optional backend capability for prompt-adapted speech recognition.
+///
+/// Web runtimes use this explicit opt-in to distinguish a bridge release that
+/// has passed the speech-to-text cancellation and audio-ingestion contract
+/// from an older bridge that merely reports generic audio support.
+abstract class BackendPromptSpeechToTextSupport {
+  /// Whether the active runtime is validated for prompt-adapted speech-to-text.
+  bool get supportsPromptSpeechToText;
+
+  /// Actionable reason when [supportsPromptSpeechToText] is false.
+  String? get promptSpeechToTextUnsupportedReason;
+}
+
 /// Model family reported by a backend-native text-to-speech implementation.
 enum BackendTextToSpeechModel {
   /// Qwen3-TTS audio generation through llama.cpp mtmd.

--- a/lib/src/backends/web/web_backend.dart
+++ b/lib/src/backends/web/web_backend.dart
@@ -16,6 +16,7 @@ class WebAutoBackend
         BackendAvailability,
         BackendEmbeddingsSupport,
         BackendBatchEmbeddings,
+        BackendPromptSpeechToTextSupport,
         BackendStatePersistence,
         BackendStatePersistenceSupport {
   final LlamaBackend Function() _webGpuFactory;
@@ -62,6 +63,28 @@ class WebAutoBackend
       return (delegate as BackendEmbeddingsSupport).supportsEmbeddings;
     }
     return delegate is BackendEmbeddings;
+  }
+
+  @override
+  bool get supportsPromptSpeechToText {
+    final delegate = _delegate;
+    final speechDelegate = delegate is BackendPromptSpeechToTextSupport
+        ? delegate as BackendPromptSpeechToTextSupport
+        : null;
+    return speechDelegate?.supportsPromptSpeechToText ?? false;
+  }
+
+  @override
+  String? get promptSpeechToTextUnsupportedReason {
+    final delegate = _delegate;
+    final speechDelegate = delegate is BackendPromptSpeechToTextSupport
+        ? delegate as BackendPromptSpeechToTextSupport
+        : null;
+    if (speechDelegate != null) {
+      return speechDelegate.promptSpeechToTextUnsupportedReason;
+    }
+    return 'The active Web runtime does not expose validated typed '
+        'speech-to-text support.';
   }
 
   @override

--- a/lib/src/backends/webgpu/webgpu_backend.dart
+++ b/lib/src/backends/webgpu/webgpu_backend.dart
@@ -1794,13 +1794,13 @@ class WebGpuLlamaBackend
     final tokenEventFlushChars = hasStopSequences
         ? null
         : (mediaParts == null ? 48 : 24);
-    final emittedOutputBytes = <int>[];
+    final emittedOutputBytes = hasStopSequences ? null : <int>[];
 
     void emitBytes(List<int> bytes) {
       if (bytes.isEmpty || controller.isClosed) {
         return;
       }
-      emittedOutputBytes.addAll(bytes);
+      emittedOutputBytes?.addAll(bytes);
       controller.add(bytes);
     }
 
@@ -1809,11 +1809,12 @@ class WebGpuLlamaBackend
     }
 
     bool emittedBytesArePrefixOf(List<int> bytes) {
-      if (emittedOutputBytes.length > bytes.length) {
+      final emittedBytes = emittedOutputBytes;
+      if (emittedBytes == null || emittedBytes.length > bytes.length) {
         return false;
       }
-      for (int index = 0; index < emittedOutputBytes.length; index++) {
-        if (emittedOutputBytes[index] != bytes[index]) {
+      for (int index = 0; index < emittedBytes.length; index++) {
+        if (emittedBytes[index] != bytes[index]) {
           return false;
         }
       }
@@ -1906,11 +1907,12 @@ class WebGpuLlamaBackend
             emitText(latestText.substring(emittedLength));
             emittedLength = latestText.length;
           } else if (!hasStopSequences) {
+            final emittedBytes = emittedOutputBytes!;
             final completionText = _jsValueAsString(completionResult);
             final finalBytes = utf8.encode(completionText ?? '');
             if (emittedBytesArePrefixOf(finalBytes) &&
-                emittedOutputBytes.length < finalBytes.length) {
-              emitBytes(finalBytes.sublist(emittedOutputBytes.length));
+                emittedBytes.length < finalBytes.length) {
+              emitBytes(finalBytes.sublist(emittedBytes.length));
             }
           }
         } catch (e, st) {

--- a/lib/src/backends/webgpu/webgpu_backend.dart
+++ b/lib/src/backends/webgpu/webgpu_backend.dart
@@ -1673,7 +1673,9 @@ class WebGpuLlamaBackend
     LlamaWebGpuBridge bridge, {
     required bool isCpuMultimodalRuntime,
   }) async {
-    if (isCpuMultimodalRuntime || !_mmContextActive) {
+    if (isCpuMultimodalRuntime ||
+        !_mmContextActive ||
+        !(bridge.supportsVision() ?? false)) {
       return;
     }
     if (_webGpuMultimodalWarmupDone || _webGpuMultimodalWarmupAttempted) {

--- a/lib/src/backends/webgpu/webgpu_backend.dart
+++ b/lib/src/backends/webgpu/webgpu_backend.dart
@@ -26,6 +26,7 @@ class WebGpuLlamaBackend
         LlamaBackend,
         BackendAvailability,
         BackendBatchEmbeddings,
+        BackendPromptSpeechToTextSupport,
         BackendStatePersistence,
         BackendStatePersistenceSupport {
   static const Duration _bridgeReadyTimeout = Duration(seconds: 12);
@@ -54,6 +55,7 @@ class WebGpuLlamaBackend
   final String? _bridgeWorkerUrl;
   final LlamaWebGpuBridge Function([WebGpuBridgeConfig? config])?
   _bridgeFactory;
+  final bool? _promptSpeechToTextSupportOverride;
 
   LlamaWebGpuBridge? _bridge;
   bool _usingBridge = false;
@@ -73,10 +75,12 @@ class WebGpuLlamaBackend
     String? wasmUrl,
     String? workerUrl,
     LlamaWebGpuBridge Function([WebGpuBridgeConfig? config])? bridgeFactory,
+    bool? promptSpeechToTextSupported,
   }) : _bridgeScriptUrl = bridgeScriptUrl,
        _bridgeWasmUrl = wasmUrl,
        _bridgeWorkerUrl = workerUrl,
-       _bridgeFactory = bridgeFactory;
+       _bridgeFactory = bridgeFactory,
+       _promptSpeechToTextSupportOverride = promptSpeechToTextSupported;
 
   @override
   bool get isReady => _isReady;
@@ -89,6 +93,18 @@ class WebGpuLlamaBackend
         _hasBridgeFunction(bridge, 'stateSaveFile') &&
         _hasBridgeFunction(bridge, 'stateLoadFile');
   }
+
+  @override
+  bool get supportsPromptSpeechToText =>
+      _promptSpeechToTextSupportOverride ??
+      _getGlobalOptionalBool('__llamadartBridgeSpeechToTextSupported') == true;
+
+  @override
+  String? get promptSpeechToTextUnsupportedReason => supportsPromptSpeechToText
+      ? null
+      : 'Web typed speech-to-text requires validated '
+            'llama-web-bridge-assets v0.1.30 or newer and an explicit runtime '
+            'capability opt-in.';
 
   bool _hasBridgeFunction(LlamaWebGpuBridge bridge, String name) {
     final value = bridge.getProperty(name.toJS);
@@ -1778,12 +1794,30 @@ class WebGpuLlamaBackend
     final tokenEventFlushChars = hasStopSequences
         ? null
         : (mediaParts == null ? 48 : 24);
+    final emittedOutputBytes = <int>[];
 
-    void emitText(String text) {
-      if (text.isEmpty || controller.isClosed) {
+    void emitBytes(List<int> bytes) {
+      if (bytes.isEmpty || controller.isClosed) {
         return;
       }
-      controller.add(utf8.encode(text));
+      emittedOutputBytes.addAll(bytes);
+      controller.add(bytes);
+    }
+
+    void emitText(String text) {
+      emitBytes(utf8.encode(text));
+    }
+
+    bool emittedBytesArePrefixOf(List<int> bytes) {
+      if (emittedOutputBytes.length > bytes.length) {
+        return false;
+      }
+      for (int index = 0; index < emittedOutputBytes.length; index++) {
+        if (emittedOutputBytes[index] != bytes[index]) {
+          return false;
+        }
+      }
+      return true;
     }
 
     final onToken = (JSAny? piece, JSAny? currentText) {
@@ -1829,9 +1863,7 @@ class WebGpuLlamaBackend
         return;
       }
 
-      if (!controller.isClosed) {
-        controller.add(bytes);
-      }
+      emitBytes(bytes);
     }.toJS;
 
     final options = WebGpuCompletionOptions(
@@ -1866,13 +1898,20 @@ class WebGpuLlamaBackend
           }
           final normalizedPrompt = _normalizePromptForBridge(prompt, bridge);
           final completion = bridge.createCompletion(normalizedPrompt, options);
-          await _toFuture(completion);
+          final completionResult = await _toFuture(completion);
 
           if (hasStopSequences &&
               !stoppedBySequence &&
               latestText.length > emittedLength) {
             emitText(latestText.substring(emittedLength));
             emittedLength = latestText.length;
+          } else if (!hasStopSequences) {
+            final completionText = _jsValueAsString(completionResult);
+            final finalBytes = utf8.encode(completionText ?? '');
+            if (emittedBytesArePrefixOf(finalBytes) &&
+                emittedOutputBytes.length < finalBytes.length) {
+              emitBytes(finalBytes.sublist(emittedOutputBytes.length));
+            }
           }
         } catch (e, st) {
           if (!stoppedBySequence && !canceledByCaller && !controller.isClosed) {
@@ -2304,10 +2343,12 @@ class WebGpuLlamaBackend
       );
       _mmContextActive = true;
       _resetWebGpuMultimodalWarmupState();
-      await _ensureWebGpuMultimodalWarmup(
-        bridge,
-        isCpuMultimodalRuntime: _isCpuRuntimeForMultimodal(bridge),
-      );
+      if (bridge.supportsVision() ?? false) {
+        await _ensureWebGpuMultimodalWarmup(
+          bridge,
+          isCpuMultimodalRuntime: _isCpuRuntimeForMultimodal(bridge),
+        );
+      }
 
       if (result == null) {
         return 1;

--- a/lib/src/core/speech/speech_platform_stub.dart
+++ b/lib/src/core/speech/speech_platform_stub.dart
@@ -3,3 +3,19 @@ bool get isSpeechToTextPlatformSupported => true;
 
 /// Actionable explanation when speech-to-text is unavailable.
 String? get speechToTextPlatformUnsupportedReason => null;
+
+/// Whether this platform requires a backend runtime opt-in for prompt ASR.
+bool get speechToTextRequiresBackendCapability => false;
+
+/// Whether local filesystem speech input is available on this platform.
+bool get speechToTextSupportsFileInput => true;
+
+/// Whether byte inputs require explicit encoding metadata on this platform.
+bool get speechToTextRequiresEncodedAudioFormat => false;
+
+/// Encoded formats validated for prompt-adapted speech input.
+Set<String> get speechToTextEncodedAudioFormats => const <String>{
+  'wav',
+  'mp3',
+  'flac',
+};

--- a/lib/src/core/speech/speech_platform_web.dart
+++ b/lib/src/core/speech/speech_platform_web.dart
@@ -1,7 +1,17 @@
 /// Whether the typed speech-to-text adapter is available on Web.
-bool get isSpeechToTextPlatformSupported => false;
+bool get isSpeechToTextPlatformSupported => true;
 
-/// Actionable explanation for the current Web limitation.
-String get speechToTextPlatformUnsupportedReason =>
-    'Typed speech-to-text is not available on Web yet. WebGPU audio '
-    'content remains model-dependent generic audio input.';
+/// Web support is refined by the active backend capability probe.
+String? get speechToTextPlatformUnsupportedReason => null;
+
+/// Web requires an explicitly validated bridge runtime.
+bool get speechToTextRequiresBackendCapability => true;
+
+/// Browsers do not expose local filesystem paths to the runtime.
+bool get speechToTextSupportsFileInput => false;
+
+/// Browser byte inputs must declare their encoded container.
+bool get speechToTextRequiresEncodedAudioFormat => true;
+
+/// WAV is the encoded format validated by the published WebGPU smoke.
+Set<String> get speechToTextEncodedAudioFormats => const <String>{'wav'};

--- a/lib/src/core/speech/speech_to_text.dart
+++ b/lib/src/core/speech/speech_to_text.dart
@@ -918,9 +918,7 @@ class SpeechToTextEngine {
       final output = StringBuffer();
       await for (final text in _engine!.generate(
         prompt,
-        parts: <LlamaContentPart>[
-          _contentFor(request.audio),
-        ],
+        parts: <LlamaContentPart>[_contentFor(request.audio)],
         params: GenerationParams(
           maxTokens: request.maxOutputTokens,
           temp: 0,

--- a/lib/src/core/speech/speech_to_text.dart
+++ b/lib/src/core/speech/speech_to_text.dart
@@ -1,11 +1,10 @@
 import 'dart:async';
 import 'dart:typed_data';
 
+import '../../backends/backend.dart';
 import '../../backends/litert_lm/litert_lm_asr_types.dart';
 import '../engine/engine.dart';
 import '../exceptions.dart';
-import '../models/chat/chat_message.dart';
-import '../models/chat/chat_role.dart';
 import '../models/chat/content_part.dart';
 import '../models/inference/generation_params.dart';
 import 'litert_lm_speech_to_text_driver.dart';
@@ -581,6 +580,21 @@ class SpeechToTextEngine {
       );
     }
     final engine = _engine!;
+    if (speechToTextRequiresBackendCapability) {
+      final backend = engine.backend;
+      final speechBackend = backend is BackendPromptSpeechToTextSupport
+          ? backend as BackendPromptSpeechToTextSupport
+          : null;
+      if (speechBackend == null || !speechBackend.supportsPromptSpeechToText) {
+        return SpeechToTextCapabilities(
+          isSupported: false,
+          unsupportedReason: speechBackend != null
+              ? speechBackend.promptSpeechToTextUnsupportedReason
+              : 'The active Web runtime does not expose validated typed '
+                    'speech-to-text support.',
+        );
+      }
+    }
     if (!engine.isReady) {
       return const SpeechToTextCapabilities(
         isSupported: false,
@@ -628,11 +642,11 @@ class SpeechToTextEngine {
       isSupported: true,
       backendName: backendName,
       implementation: SpeechToTextImplementation.multimodalPromptAdapter,
-      inputKinds: const <SpeechAudioInputKind>{
-        SpeechAudioInputKind.file,
+      inputKinds: <SpeechAudioInputKind>{
+        if (speechToTextSupportsFileInput) SpeechAudioInputKind.file,
         SpeechAudioInputKind.encodedBytes,
       },
-      encodedAudioFormats: const <String>{'wav', 'mp3', 'flac'},
+      encodedAudioFormats: speechToTextEncodedAudioFormats,
       supportsCancellation: true,
       maxConcurrentTasks: 1,
     );
@@ -813,22 +827,28 @@ class SpeechToTextEngine {
 
     switch (request.audio) {
       case SpeechAudioFileInput(:final path):
+        if (!speechToTextSupportsFileInput) {
+          throw LlamaUnsupportedException(
+            'Web speech-to-text accepts encoded audio bytes only; browser '
+            'local filesystem paths are not available to the runtime.',
+          );
+        }
         if (path.trim().isEmpty) {
           throw LlamaAudioFormatException('Audio file path must not be empty.');
         }
         final encoding = request.audio.format?.encoding?.trim().toLowerCase();
         final extension = _fileExtension(path);
         if (encoding != null && encoding.isNotEmpty) {
-          if (!const <String>{'wav', 'mp3', 'flac'}.contains(encoding)) {
+          if (!speechToTextEncodedAudioFormats.contains(encoding)) {
             throw LlamaAudioFormatException(
-              'Encoded audio files must use WAV, MP3, or FLAC.',
+              'Encoded audio files must use ${_encodedFormatList()}.',
               encoding,
             );
           }
         } else if (extension.isNotEmpty &&
-            !const <String>{'wav', 'mp3', 'flac'}.contains(extension)) {
+            !speechToTextEncodedAudioFormats.contains(extension)) {
           throw LlamaAudioFormatException(
-            'Encoded audio files must use WAV, MP3, or FLAC.',
+            'Encoded audio files must use ${_encodedFormatList()}.',
             extension,
           );
         }
@@ -839,11 +859,18 @@ class SpeechToTextEngine {
           );
         }
         final encoding = request.audio.format?.encoding?.trim().toLowerCase();
+        if (speechToTextRequiresEncodedAudioFormat &&
+            (encoding == null || encoding.isEmpty)) {
+          throw LlamaAudioFormatException(
+            'Web encoded audio bytes require SpeechAudioFormat.encoding; '
+            'the validated format is WAV.',
+          );
+        }
         if (encoding != null &&
             encoding.isNotEmpty &&
-            !const <String>{'wav', 'mp3', 'flac'}.contains(encoding)) {
+            !speechToTextEncodedAudioFormats.contains(encoding)) {
           throw LlamaAudioFormatException(
-            'Encoded audio bytes must use WAV, MP3, or FLAC.',
+            'Encoded audio bytes must use ${_encodedFormatList()}.',
             encoding,
           );
         }
@@ -852,6 +879,16 @@ class SpeechToTextEngine {
           'The Qwen3-ASR prompt adapter accepts encoded audio only.',
         );
     }
+  }
+
+  String _encodedFormatList() {
+    final formats = speechToTextEncodedAudioFormats
+        .map((format) => format.toUpperCase())
+        .toList(growable: false);
+    if (formats.length == 1) {
+      return formats.single;
+    }
+    return '${formats.take(formats.length - 1).join(', ')}, or ${formats.last}';
   }
 
   void _validateLiteRtLmPcmFormat(SpeechAudioFormat format) {
@@ -877,16 +914,12 @@ class SpeechToTextEngine {
         return;
       }
 
+      final prompt = _promptFor(request);
       final output = StringBuffer();
-      await for (final chunk in _engine!.create(
-        <LlamaChatMessage>[
-          LlamaChatMessage.withContent(
-            role: LlamaChatRole.user,
-            content: <LlamaContentPart>[
-              LlamaTextContent(_promptFor(request)),
-              _contentFor(request.audio),
-            ],
-          ),
+      await for (final text in _engine!.generate(
+        prompt,
+        parts: <LlamaContentPart>[
+          _contentFor(request.audio),
         ],
         params: GenerationParams(
           maxTokens: request.maxOutputTokens,
@@ -897,18 +930,11 @@ class SpeechToTextEngine {
           seed: 1,
           streamBatchTokenThreshold: 1,
         ),
-        enableThinking: false,
       )) {
         if (task.isCancellationRequested) {
           break;
         }
-        if (chunk.choices.isEmpty) {
-          continue;
-        }
-        final text = chunk.choices.first.delta.content;
-        if (text != null) {
-          output.write(text);
-        }
+        output.write(text);
       }
 
       if (task.isCancellationRequested) {

--- a/scripts/fetch_webgpu_bridge_assets.sh
+++ b/scripts/fetch_webgpu_bridge_assets.sh
@@ -4,7 +4,7 @@ set -euo pipefail
 ROOT_DIR="$(git rev-parse --show-toplevel)"
 OUT_DIR="${WEBGPU_BRIDGE_OUT_DIR:-$ROOT_DIR/example/chat_app/web/webgpu_bridge}"
 ASSETS_REPO="${WEBGPU_BRIDGE_ASSETS_REPO:-leehack/llama-web-bridge-assets}"
-ASSETS_TAG="${WEBGPU_BRIDGE_ASSETS_TAG:-v0.1.27}"
+ASSETS_TAG="${WEBGPU_BRIDGE_ASSETS_TAG:-v0.1.30}"
 CDN_BASE="${WEBGPU_BRIDGE_CDN_BASE:-https://cdn.jsdelivr.net/gh/${ASSETS_REPO}@${ASSETS_TAG}}"
 PATCH_SAFARI_COMPAT="${WEBGPU_BRIDGE_PATCH_SAFARI_COMPAT:-1}"
 MIN_SAFARI_VERSION="${WEBGPU_BRIDGE_MIN_SAFARI_VERSION:-170400}"
@@ -14,7 +14,7 @@ if [[ "${1:-}" == "--help" || "${1:-}" == "-h" ]]; then
 Downloads prebuilt WebGPU bridge assets into the chat_app web directory.
 
 Default source:
-  https://cdn.jsdelivr.net/gh/leehack/llama-web-bridge-assets@v0.1.27
+  https://cdn.jsdelivr.net/gh/leehack/llama-web-bridge-assets@v0.1.30
 
 Environment variables:
   WEBGPU_BRIDGE_ASSETS_REPO   Asset repo in owner/repo format
@@ -28,7 +28,7 @@ Usage:
   ./scripts/fetch_webgpu_bridge_assets.sh
 
 Examples:
-  WEBGPU_BRIDGE_ASSETS_TAG=v0.1.27 ./scripts/fetch_webgpu_bridge_assets.sh
+  WEBGPU_BRIDGE_ASSETS_TAG=v0.1.30 ./scripts/fetch_webgpu_bridge_assets.sh
   WEBGPU_BRIDGE_ASSETS_REPO=acme/llama-web-bridge-assets WEBGPU_BRIDGE_ASSETS_TAG=v2 ./scripts/fetch_webgpu_bridge_assets.sh
 USAGE
   exit 0

--- a/test/unit/backends/web/web_backend_test.dart
+++ b/test/unit/backends/web/web_backend_test.dart
@@ -20,8 +20,22 @@ void main() {
     expect(backend, isA<BackendBatchEmbeddings>());
     expect(backend, isA<BackendStatePersistence>());
     expect(backend, isA<BackendStatePersistenceSupport>());
+    expect(backend, isA<BackendPromptSpeechToTextSupport>());
     expect((backend as WebAutoBackend).supportsStatePersistence, isFalse);
     expect(backend.supportsEmbeddings, isFalse);
+  });
+
+  test('WebAutoBackend forwards prompt speech runtime support', () async {
+    final unsupported = WebAutoBackend(webBackend: _NoStateBackend());
+    expect(unsupported.supportsPromptSpeechToText, isFalse);
+    expect(
+      unsupported.promptSpeechToTextUnsupportedReason,
+      contains('does not expose'),
+    );
+
+    final supported = WebAutoBackend(webBackend: _SpeechSupportBackend());
+    expect(supported.supportsPromptSpeechToText, isTrue);
+    expect(supported.promptSpeechToTextUnsupportedReason, isNull);
   });
 
   test(
@@ -174,6 +188,15 @@ class _RecordingBackend implements LlamaBackend {
 
   @override
   dynamic noSuchMethod(Invocation invocation) => super.noSuchMethod(invocation);
+}
+
+class _SpeechSupportBackend extends _NoStateBackend
+    implements BackendPromptSpeechToTextSupport {
+  @override
+  bool get supportsPromptSpeechToText => true;
+
+  @override
+  String? get promptSpeechToTextUnsupportedReason => null;
 }
 
 class _EmbeddingSupportBackend

--- a/test/unit/backends/webgpu/webgpu_backend_test.dart
+++ b/test/unit/backends/webgpu/webgpu_backend_test.dart
@@ -2100,6 +2100,7 @@ void main() {
 
       expect(chunks, isNotEmpty);
       expect(sawAudioParts, isTrue);
+      expect(warmupCallCount, 0);
     });
 
     test('forwards encoded audio bytes parts', () async {

--- a/test/unit/backends/webgpu/webgpu_backend_test.dart
+++ b/test/unit/backends/webgpu/webgpu_backend_test.dart
@@ -541,6 +541,18 @@ void main() {
       expect(await backend.getContextSize(1), 4096);
     });
 
+    test('requires explicit prompt speech runtime capability', () async {
+      expect(backend.supportsPromptSpeechToText, isFalse);
+      expect(backend.promptSpeechToTextUnsupportedReason, contains('v0.1.30'));
+
+      final supportedBackend = WebGpuLlamaBackend(
+        promptSpeechToTextSupported: true,
+      );
+      expect(supportedBackend.supportsPromptSpeechToText, isTrue);
+      expect(supportedBackend.promptSpeechToTextUnsupportedReason, isNull);
+      await supportedBackend.dispose();
+    });
+
     bool? capturedPreferMemory64() {
       final config = lastBridgeConfig;
       if (config == null) {
@@ -898,6 +910,60 @@ void main() {
       expect(lastTokenEventFlushMs, 28);
       expect(lastTokenEventFlushChars, 48);
     });
+
+    test(
+      'emits a returned completion when token callbacks are absent',
+      () async {
+        bridge.setProperty(
+          'createCompletion'.toJS,
+          ((String prompt, JSObject opts) {
+            return Future<JSString>.value('Final transcript'.toJS).toJS;
+          }).toJS,
+        );
+
+        await backend.modelLoadFromUrl(
+          'https://example.com/model.gguf',
+          const ModelParams(),
+        );
+
+        final chunks = await backend
+            .generate(1, 'Transcribe', const GenerationParams())
+            .toList();
+
+        expect(
+          utf8.decode(chunks.expand((chunk) => chunk).toList()),
+          'Final transcript',
+        );
+      },
+    );
+
+    test(
+      'reconciles a returned completion after partial token callbacks',
+      () async {
+        bridge.setProperty(
+          'createCompletion'.toJS,
+          ((String prompt, JSObject opts) {
+            final onToken = opts.getProperty('onToken'.toJS) as JSFunction?;
+            onToken?.callAsFunction(null, 'Final '.toJS, null);
+            return Future<JSString>.value('Final transcript'.toJS).toJS;
+          }).toJS,
+        );
+
+        await backend.modelLoadFromUrl(
+          'https://example.com/model.gguf',
+          const ModelParams(),
+        );
+
+        final chunks = await backend
+            .generate(1, 'Transcribe', const GenerationParams())
+            .toList();
+
+        expect(
+          utf8.decode(chunks.expand((chunk) => chunk).toList()),
+          'Final transcript',
+        );
+      },
+    );
 
     test('rejects speculative decoding', () {
       expect(
@@ -2002,6 +2068,7 @@ void main() {
     );
 
     test('reports audio support and forwards audio parts', () async {
+      bridge.setProperty('supportsVision'.toJS, (() => false).toJS);
       bridge.setProperty('supportsAudio'.toJS, (() => mmLoaded).toJS);
 
       await backend.modelLoadFromUrl(
@@ -2016,6 +2083,7 @@ void main() {
 
       expect(mmHandle, isNotNull);
       expect(await backend.supportsAudio(mmHandle!), isTrue);
+      expect(warmupCallCount, 0);
 
       final chunks = await backend
           .generate(

--- a/test/unit/core/speech/speech_platform_web_test.dart
+++ b/test/unit/core/speech/speech_platform_web_test.dart
@@ -5,8 +5,12 @@ import 'package:llamadart/src/core/speech/speech_platform_web.dart';
 import 'package:test/test.dart';
 
 void main() {
-  test('web platform reports dedicated speech-to-text as unsupported', () {
-    expect(isSpeechToTextPlatformSupported, isFalse);
-    expect(speechToTextPlatformUnsupportedReason, contains('not available'));
+  test('web platform exposes byte-only WAV prompt speech support', () {
+    expect(isSpeechToTextPlatformSupported, isTrue);
+    expect(speechToTextPlatformUnsupportedReason, isNull);
+    expect(speechToTextRequiresBackendCapability, isTrue);
+    expect(speechToTextSupportsFileInput, isFalse);
+    expect(speechToTextRequiresEncodedAudioFormat, isTrue);
+    expect(speechToTextEncodedAudioFormats, equals(<String>{'wav'}));
   });
 }

--- a/test/unit/core/speech/speech_to_text_test.dart
+++ b/test/unit/core/speech/speech_to_text_test.dart
@@ -109,10 +109,10 @@ void main() {
         expect(finalEvent.result.segments.single.text, finalEvent.result.text);
         expect(completion.state, SpeechToTextCompletionState.completed);
         expect(completion.result, same(finalEvent.result));
-        expect(backend.lastParts, hasLength(2));
-        expect(backend.lastParts![1], isA<LlamaAudioContent>());
+        expect(backend.lastParts, hasLength(1));
+        expect(backend.lastParts!.single, isA<LlamaAudioContent>());
         expect(
-          (backend.lastParts![1] as LlamaAudioContent).path,
+          (backend.lastParts!.single as LlamaAudioContent).path,
           '/tmp/test.wav',
         );
         expect(backend.lastGenerationPrompt, contains('Context: llamadart'));
@@ -135,7 +135,7 @@ void main() {
 
       expect(result.text, 'Byte-backed transcript.');
       expect(result.language, isNull);
-      final audio = backend.lastParts![1] as LlamaAudioContent;
+      final audio = backend.lastParts!.single as LlamaAudioContent;
       expect(audio.bytes, <int>[1, 2, 3]);
     });
 
@@ -218,7 +218,7 @@ void main() {
       );
 
       expect((await task.done).result?.text, 'Transcript.');
-      final audio = backend.lastParts![1] as LlamaAudioContent;
+      final audio = backend.lastParts!.single as LlamaAudioContent;
       expect(audio.path, '/tmp/content-addressed-audio');
     });
 
@@ -392,17 +392,6 @@ void main() {
         ),
       );
       expect((await task.done).state, SpeechToTextCompletionState.completed);
-    });
-
-    test('ignores generation chunks without choices', () async {
-      llamaEngine.emitEmptyChoice = true;
-      await _loadSpeechModel(llamaEngine);
-
-      final task = await speechEngine.transcribe(
-        const SpeechToTextRequest(audio: SpeechAudioFileInput('/tmp/test.wav')),
-      );
-
-      expect((await task.done).result?.text, 'transcript');
     });
 
     test('preserves typed backend failures', () async {
@@ -609,45 +598,5 @@ class _SpeechBackend implements LlamaBackend {
 }
 
 class _SpeechLlamaEngine extends LlamaEngine {
-  bool emitEmptyChoice = false;
-
   _SpeechLlamaEngine(super.backend);
-
-  @override
-  Stream<LlamaCompletionChunk> create(
-    List<LlamaChatMessage> messages, {
-    GenerationParams? params,
-    List<ToolDefinition>? tools,
-    ToolChoice? toolChoice,
-    bool parallelToolCalls = false,
-    bool enableThinking = true,
-    Map<String, dynamic>? responseFormat,
-    String? sourceLangCode,
-    String? targetLangCode,
-    Map<String, dynamic>? chatTemplateKwargs,
-    DateTime? templateNow,
-  }) async* {
-    if (emitEmptyChoice) {
-      yield LlamaCompletionChunk(
-        id: 'empty',
-        object: 'chat.completion.chunk',
-        created: 0,
-        model: 'test',
-        choices: const <LlamaCompletionChunkChoice>[],
-      );
-    }
-    yield* super.create(
-      messages,
-      params: params,
-      tools: tools,
-      toolChoice: toolChoice,
-      parallelToolCalls: parallelToolCalls,
-      enableThinking: enableThinking,
-      responseFormat: responseFormat,
-      sourceLangCode: sourceLangCode,
-      targetLangCode: targetLangCode,
-      chatTemplateKwargs: chatTemplateKwargs,
-      templateNow: templateNow,
-    );
-  }
 }

--- a/test/unit/core/speech/speech_to_text_web_test.dart
+++ b/test/unit/core/speech/speech_to_text_web_test.dart
@@ -1,32 +1,157 @@
 @TestOn('browser')
 library;
 
+import 'dart:async';
+import 'dart:convert';
+import 'dart:typed_data';
+
 import 'package:llamadart/llamadart.dart';
 import 'package:test/test.dart';
 
 void main() {
-  test('dedicated speech-to-text is explicitly unsupported on Web', () async {
-    final engine = SpeechToTextEngine(
-      LlamaEngine(_WebBackend()),
+  test('old or unvalidated Web bridge remains unsupported', () async {
+    final engine = await _loadedEngine(promptSpeechToTextSupported: false);
+    final recognizer = SpeechToTextEngine(
+      engine,
       modelProfile: SpeechToTextModelProfile.qwen3Asr,
     );
 
-    final capabilities = await engine.capabilities;
+    final capabilities = await recognizer.capabilities;
 
     expect(capabilities.isSupported, isFalse);
-    expect(capabilities.unsupportedReason, contains('not available on Web'));
-    expect(capabilities.unsupportedReason, contains('generic audio input'));
+    expect(capabilities.unsupportedReason, contains('v0.1.30'));
+    await engine.dispose();
+  });
+
+  test('validated Web bridge advertises WAV byte input only', () async {
+    final engine = await _loadedEngine(promptSpeechToTextSupported: true);
+    final recognizer = SpeechToTextEngine(
+      engine,
+      modelProfile: SpeechToTextModelProfile.qwen3Asr,
+    );
+
+    final capabilities = await recognizer.capabilities;
+
+    expect(capabilities.isSupported, isTrue);
+    expect(
+      capabilities.implementation,
+      SpeechToTextImplementation.multimodalPromptAdapter,
+    );
+    expect(
+      capabilities.inputKinds,
+      equals(<SpeechAudioInputKind>{SpeechAudioInputKind.encodedBytes}),
+    );
+    expect(capabilities.encodedAudioFormats, equals(<String>{'wav'}));
+    await engine.dispose();
+  });
+
+  test('validated Web bridge transcribes encoded WAV bytes', () async {
+    final engine = await _loadedEngine(promptSpeechToTextSupported: true);
+    final recognizer = SpeechToTextEngine(
+      engine,
+      modelProfile: SpeechToTextModelProfile.qwen3Asr,
+    );
+
+    final task = await recognizer.transcribe(
+      SpeechToTextRequest(
+        audio: SpeechAudioBytesInput(
+          Uint8List.fromList(<int>[0x52, 0x49, 0x46, 0x46]),
+          format: const SpeechAudioFormat(encoding: 'wav'),
+        ),
+      ),
+    );
+    final events = await task.events.toList();
+    final completion = await task.done;
+
+    expect(events, hasLength(1));
+    expect((events.single as SpeechToTextFinalEvent).result.text, 'Hello.');
+    expect(completion.state, SpeechToTextCompletionState.completed);
+    await engine.dispose();
+  });
+
+  test('validated Web bridge cancels an active transcription', () async {
+    final generationGate = Completer<void>();
+    final backend = _WebSpeechBackend(
+      promptSpeechToTextSupported: true,
+      generationGate: generationGate,
+    );
+    final engine = LlamaEngine(backend);
+    await engine.loadModel('https://example.com/qwen3-asr.gguf');
+    await engine.loadMultimodalProjector(
+      'https://example.com/qwen3-asr-mmproj.gguf',
+    );
+    final recognizer = SpeechToTextEngine(
+      engine,
+      modelProfile: SpeechToTextModelProfile.qwen3Asr,
+    );
+
+    final task = await recognizer.transcribe(
+      SpeechToTextRequest(
+        audio: SpeechAudioBytesInput(
+          Uint8List.fromList(<int>[0x52, 0x49, 0x46, 0x46]),
+          format: const SpeechAudioFormat(encoding: 'wav'),
+        ),
+      ),
+    );
+    task.cancel();
+    final completion = await task.done;
+
+    expect(backend.cancelCalled, isTrue);
+    expect(completion.state, SpeechToTextCompletionState.cancelled);
+    expect(await task.events.toList(), isEmpty);
+    await engine.dispose();
+  });
+
+  test('Web rejects local paths and unvalidated encoded formats', () async {
+    final engine = await _loadedEngine(promptSpeechToTextSupported: true);
+    final recognizer = SpeechToTextEngine(
+      engine,
+      modelProfile: SpeechToTextModelProfile.qwen3Asr,
+    );
+
     await expectLater(
-      engine.transcribe(
+      recognizer.transcribe(
+        SpeechToTextRequest(
+          audio: SpeechAudioBytesInput(Uint8List.fromList(<int>[1])),
+        ),
+      ),
+      throwsA(
+        isA<LlamaAudioFormatException>().having(
+          (error) => error.toString(),
+          'message',
+          contains('SpeechAudioFormat.encoding'),
+        ),
+      ),
+    );
+    await expectLater(
+      recognizer.transcribe(
         const SpeechToTextRequest(
           audio: SpeechAudioFileInput('/tmp/fixture.wav'),
         ),
       ),
-      throwsA(isA<LlamaUnsupportedException>()),
+      throwsA(
+        isA<LlamaUnsupportedException>().having(
+          (error) => error.toString(),
+          'message',
+          contains('encoded audio bytes only'),
+        ),
+      ),
     );
+    await expectLater(
+      recognizer.transcribe(
+        SpeechToTextRequest(
+          audio: SpeechAudioBytesInput(
+            Uint8List.fromList(<int>[1]),
+            format: const SpeechAudioFormat(encoding: 'mp3'),
+          ),
+        ),
+      ),
+      throwsA(isA<LlamaAudioFormatException>()),
+    );
+    await engine.dispose();
   });
 
-  test('dedicated LiteRT-LM speech is explicitly unsupported on Web', () async {
+  test('dedicated LiteRT-LM speech remains unsupported on Web', () async {
     final engine = SpeechToTextEngine.liteRtLm(
       const LiteRtLmAsrRuntimeConfig(
         modelPath: '/models/moonshine.tflite',
@@ -46,12 +171,122 @@ void main() {
   });
 }
 
-class _WebBackend implements LlamaBackend {
+Future<LlamaEngine> _loadedEngine({
+  required bool promptSpeechToTextSupported,
+}) async {
+  final engine = LlamaEngine(
+    _WebSpeechBackend(promptSpeechToTextSupported: promptSpeechToTextSupported),
+  );
+  await engine.loadModel('https://example.com/qwen3-asr.gguf');
+  await engine.loadMultimodalProjector(
+    'https://example.com/qwen3-asr-mmproj.gguf',
+  );
+  return engine;
+}
+
+class _WebSpeechBackend
+    implements LlamaBackend, BackendPromptSpeechToTextSupport {
   @override
-  bool get isReady => false;
+  final bool supportsPromptSpeechToText;
+  final Completer<void>? generationGate;
+  bool cancelCalled = false;
+
+  _WebSpeechBackend({
+    required bool promptSpeechToTextSupported,
+    this.generationGate,
+  }) : supportsPromptSpeechToText = promptSpeechToTextSupported;
+
+  @override
+  String? get promptSpeechToTextUnsupportedReason => supportsPromptSpeechToText
+      ? null
+      : 'Web typed speech-to-text requires bridge v0.1.30 or newer.';
+
+  @override
+  bool get isReady => true;
 
   @override
   bool get supportsUrlLoading => true;
+
+  @override
+  Future<int> modelLoadFromUrl(
+    String url,
+    ModelParams params, {
+    Function(double progress)? onProgress,
+  }) async => 1;
+
+  @override
+  Future<int> contextCreate(int modelHandle, ModelParams params) async => 2;
+
+  @override
+  Future<int?> multimodalContextCreate(
+    int modelHandle,
+    String mmProjPath,
+  ) async => 3;
+
+  @override
+  Future<bool> supportsAudio(int mmContextHandle) async => true;
+
+  @override
+  Future<bool> supportsVision(int mmContextHandle) async => false;
+
+  @override
+  Future<String> getBackendName() async => 'WebGPU test';
+
+  @override
+  Future<void> setLogLevel(LlamaLogLevel level) async {}
+
+  @override
+  Future<int> getContextSize(int contextHandle) async => 4096;
+
+  @override
+  Future<Map<String, String>> modelMetadata(int modelHandle) async => const {
+    'llm.context_length': '4096',
+  };
+
+  @override
+  Future<String> applyChatTemplate(
+    int modelHandle,
+    List<Map<String, dynamic>> messages, {
+    String? customTemplate,
+    bool addAssistant = true,
+  }) async => 'prompt';
+
+  @override
+  Stream<List<int>> generate(
+    int contextHandle,
+    String prompt,
+    GenerationParams params, {
+    List<LlamaContentPart>? parts,
+  }) async* {
+    final gate = generationGate;
+    if (gate != null) {
+      await gate.future;
+    }
+    if (!cancelCalled) {
+      yield utf8.encode('Hello.');
+    }
+  }
+
+  @override
+  Future<void> modelFree(int modelHandle) async {}
+
+  @override
+  Future<void> contextFree(int contextHandle) async {}
+
+  @override
+  Future<void> multimodalContextFree(int mmContextHandle) async {}
+
+  @override
+  void cancelGeneration() {
+    cancelCalled = true;
+    final gate = generationGate;
+    if (gate != null && !gate.isCompleted) {
+      gate.complete();
+    }
+  }
+
+  @override
+  Future<void> dispose() async {}
 
   @override
   dynamic noSuchMethod(Invocation invocation) => super.noSuchMethod(invocation);

--- a/test/unit/tooling/run_local_e2e_test.dart
+++ b/test/unit/tooling/run_local_e2e_test.dart
@@ -17,6 +17,7 @@ void main() {
       expect(result.stdout, contains('--ngram-cache-build-text <txt>'));
       expect(result.stdout, contains('--ngram-token-max <n>'));
       expect(result.stdout, contains('--allow-any-response'));
+      expect(result.stdout, contains('--mmproj-url <url>'));
       expect(result.stdout, contains('GGUF_AUDIO_EXPECTED_TEXT'));
       expect(result.stdout, contains('LLAMADART_LITERT_LM_LIBRARY_PATH'));
       expect(
@@ -41,6 +42,7 @@ void main() {
       expect(result.stdout, contains('webgpu-multimodal-regression'));
       expect(result.stdout, contains('chat-app-model-cache'));
       expect(result.stdout, contains('chat-app-web-real-model-smoke'));
+      expect(result.stdout, contains('chat-app-web-speech-to-text-smoke'));
       expect(result.stdout, contains('chat-app-web-mock-smoke'));
       expect(result.stdout, contains('chat-app-web-litert-gemma4-smoke'));
       expect(result.stdout, contains('bridge-smoke'));
@@ -72,6 +74,54 @@ void main() {
         );
       },
     );
+
+    test('dry-runs Web Qwen3-ASR file and microphone transcription', () async {
+      final result = await runLocalE2e(const [
+        '--scenario',
+        'chat-app-web-speech-to-text-smoke',
+        '--audio-path',
+        'test/fixtures/speech.wav',
+        '--model-url',
+        'https://example.com/qwen-asr.gguf',
+        '--mmproj-url',
+        'https://example.com/qwen-asr-mmproj.gguf',
+        '--expect',
+        'Known transcript.',
+        '--skip-build',
+        '--python',
+        '/custom/python',
+        '--dry-run',
+      ], projectRoot: '/repo');
+
+      expect(result.exitCode, 0);
+      expect(result.stdout, contains('validate_chat_app_web_build.sh'));
+      expect(
+        result.stdout,
+        contains('--model-url https://example.com/qwen-asr.gguf'),
+      );
+      expect(
+        result.stdout,
+        contains('--mmproj-url https://example.com/qwen-asr-mmproj.gguf'),
+      );
+      expect(
+        result.stdout,
+        contains('--speech-audio-path test/fixtures/speech.wav'),
+      );
+      expect(result.stdout, contains('--speech-microphone'));
+      expect(result.stdout, contains("--expect 'Known transcript.'"));
+    });
+
+    test('requires a fixture and expected text for Web speech smoke', () async {
+      final result = await runLocalE2e(const [
+        '--scenario',
+        'chat-app-web-speech-to-text-smoke',
+        '--dry-run',
+      ], projectRoot: '/repo');
+
+      expect(result.exitCode, 64);
+      expect(result.stderr, contains('--audio-path'));
+      expect(result.stderr, contains('--expect'));
+    });
 
     test(
       'dry-runs Web real-model smoke with build, serve, and Playwright steps',

--- a/tool/testing/playwright_chat_app_real_model_smoke.py
+++ b/tool/testing/playwright_chat_app_real_model_smoke.py
@@ -3,7 +3,10 @@ import argparse
 import json
 import re
 import time
+import wave
+from pathlib import Path
 from typing import Any
+from urllib.parse import urlsplit
 
 from playwright.sync_api import TimeoutError as PlaywrightTimeoutError
 from playwright.sync_api import sync_playwright
@@ -54,6 +57,13 @@ def wait_for_text(page, needle: str, timeout_ms: int, label: str) -> str:
     raise TimeoutError(f"Timed out waiting for {label}: {needle}")
 
 
+def copy_last_assistant_response(page, timeout_ms: int) -> str:
+    copy_button = page.get_by_role("button", name="Copy response").last
+    copy_button.wait_for(timeout=timeout_ms)
+    copy_button.click()
+    return str(page.evaluate("() => navigator.clipboard.readText()") or "")
+
+
 def wait_for_bridge_response(
     page,
     expected: str,
@@ -69,6 +79,13 @@ def wait_for_bridge_response(
             """() => ({
               bridgeResponse: window.__llamadartRealBridgeLastResponse,
               bridgeError: window.__llamadartRealBridgeLastError,
+              bridgePrompt: window.__llamadartRealBridgeLastPrompt,
+              bridgeOptions: window.__llamadartRealBridgeLastOptions,
+              bridgeTokenEvents: window.__llamadartRealBridgeTokenEvents,
+              bridgeTokenBytes: window.__llamadartRealBridgeTokenBytes,
+              bridgeLastPieceType: window.__llamadartRealBridgeLastPieceType,
+              bridgeLastCurrentTextLength:
+                window.__llamadartRealBridgeLastCurrentTextLength,
               liteRtLmResponse: window.__llamadartRealLiteRtLmLastResponse,
               liteRtLmError: window.__llamadartRealLiteRtLmLastError,
               liteRtLmPrompt: window.__llamadartRealLiteRtLmLastPrompt,
@@ -96,7 +113,16 @@ def wait_for_bridge_response(
             raise RuntimeError(f"LiteRT-LM generation failed: {litert_error}")
         for source, candidate in responses:
             if lower_expected in candidate.lower():
-                emit("response_observed", source=source)
+                emit(
+                    "response_observed",
+                    source=source,
+                    bridge_token_events=state.get("bridgeTokenEvents"),
+                    bridge_token_bytes=state.get("bridgeTokenBytes"),
+                    bridge_last_piece_type=state.get("bridgeLastPieceType"),
+                    bridge_last_current_text_length=state.get(
+                        "bridgeLastCurrentTextLength"
+                    ),
+                )
                 return candidate, body
         if allow_any_response and response.strip():
             return response, body
@@ -110,6 +136,14 @@ def wait_for_bridge_response(
                 elapsed_seconds=round(now - (deadline - timeout_ms / 1000), 1),
                 response_source=response_source,
                 bridge_response=bridge_response[-500:],
+                bridge_prompt=str(state.get("bridgePrompt") or "")[-500:],
+                bridge_options=state.get("bridgeOptions"),
+                bridge_token_events=state.get("bridgeTokenEvents"),
+                bridge_token_bytes=state.get("bridgeTokenBytes"),
+                bridge_last_piece_type=state.get("bridgeLastPieceType"),
+                bridge_last_current_text_length=state.get(
+                    "bridgeLastCurrentTextLength"
+                ),
                 litert_response=litert_response[-500:],
                 litert_prompt=str(state.get("liteRtLmPrompt") or "")[-500:],
                 litert_settings=state.get("liteRtLmSettings"),
@@ -129,6 +163,15 @@ def main() -> int:
     parser.add_argument("app_url")
     parser.add_argument("--model-url", required=True)
     parser.add_argument("--mmproj-url")
+    parser.add_argument(
+        "--speech-audio-path",
+        help="Select a local WAV through the chat app's typed transcription action.",
+    )
+    parser.add_argument(
+        "--speech-microphone",
+        action="store_true",
+        help="Also feed the WAV through Chromium's fake microphone and record UI.",
+    )
     parser.add_argument("--prefetch-mmproj-cache", action="store_true")
     parser.add_argument("--expect-mmproj-cache-hit", action="store_true")
     parser.add_argument("--prompt", default="What is 2+2? Answer in one short sentence.")
@@ -174,6 +217,17 @@ def main() -> int:
     args = parser.parse_args()
     if args.expect_mmproj_cache_hit and not args.prefetch_mmproj_cache:
         parser.error("--expect-mmproj-cache-hit requires --prefetch-mmproj-cache")
+    if args.speech_audio_path:
+        audio_path = Path(args.speech_audio_path).resolve()
+        if not audio_path.is_file():
+            parser.error(f"--speech-audio-path does not exist: {audio_path}")
+        if audio_path.suffix.lower() != ".wav":
+            parser.error("--speech-audio-path must be a WAV file")
+        if not args.mmproj_url:
+            parser.error("--speech-audio-path requires --mmproj-url")
+        args.speech_audio_path = str(audio_path)
+    if args.speech_microphone and not args.speech_audio_path:
+        parser.error("--speech-microphone requires --speech-audio-path")
 
     remote_fetch_mode = "default"
     remote_fetch_init = """
@@ -228,6 +282,9 @@ def main() -> int:
     }
     if args.mmproj_url:
         seeded_settings["flutter.mmproj_path"] = json.dumps(args.mmproj_url)
+    if args.speech_audio_path:
+        seeded_settings["flutter.model_supports_audio"] = json.dumps(True)
+        seeded_settings["flutter.model_supports_speech_to_text"] = json.dumps(True)
 
     init_script = f"""
         window.__llamadartPreferLocalBridgeRuntime = true;
@@ -238,6 +295,12 @@ def main() -> int:
         {remote_fetch_init}
         window.__llamadartRealBridgeLastResponse = null;
         window.__llamadartRealBridgeLastError = null;
+        window.__llamadartRealBridgeLastPrompt = null;
+        window.__llamadartRealBridgeLastOptions = null;
+        window.__llamadartRealBridgeTokenEvents = 0;
+        window.__llamadartRealBridgeTokenBytes = 0;
+        window.__llamadartRealBridgeLastPieceType = null;
+        window.__llamadartRealBridgeLastCurrentTextLength = 0;
         window.__llamadartRealLiteRtLmLastResponse = null;
         window.__llamadartRealLiteRtLmLastError = null;
         window.__llamadartRealLiteRtLmLastSettings = null;
@@ -260,6 +323,33 @@ def main() -> int:
           BridgeClass.prototype.createCompletion = async function(prompt, options) {{
             window.__llamadartRealBridgeLastResponse = null;
             window.__llamadartRealBridgeLastError = null;
+            window.__llamadartRealBridgeLastPrompt = String(prompt ?? '');
+            window.__llamadartRealBridgeLastOptions = {{
+              nPredict: options?.nPredict ?? null,
+              temp: options?.temp ?? null,
+              topK: options?.topK ?? null,
+              topP: options?.topP ?? null,
+              penalty: options?.penalty ?? null,
+              seed: options?.seed ?? null,
+              partTypes: Array.from(options?.parts ?? []).map(
+                part => String(part?.type ?? ''),
+              ),
+            }};
+            const downstreamOnToken = options?.onToken;
+            if (typeof downstreamOnToken === 'function') {{
+              options.onToken = function(piece, currentText) {{
+                window.__llamadartRealBridgeTokenEvents += 1;
+                window.__llamadartRealBridgeLastPieceType =
+                  piece?.constructor?.name ?? typeof piece;
+                window.__llamadartRealBridgeTokenBytes +=
+                  typeof piece === 'string'
+                    ? new TextEncoder().encode(piece).byteLength
+                    : Number(piece?.byteLength ?? piece?.length ?? 0);
+                window.__llamadartRealBridgeLastCurrentTextLength =
+                  String(currentText ?? '').length;
+                return downstreamOnToken(piece, currentText);
+              }};
+            }}
             try {{
               const result = await original.call(this, prompt, options);
               window.__llamadartRealBridgeLastResponse = String(result ?? '');
@@ -476,11 +566,27 @@ def main() -> int:
     """
 
     with sync_playwright() as playwright:
+        launch_args = browser_args(args.browser_angle)
+        if args.speech_microphone:
+            launch_args.extend(
+                [
+                    "--use-fake-ui-for-media-stream",
+                    "--use-fake-device-for-media-stream",
+                    f"--use-file-for-fake-audio-capture={args.speech_audio_path}",
+                ]
+            )
         browser = playwright.chromium.launch(
             headless=not args.headed,
-            args=browser_args(args.browser_angle),
+            args=launch_args,
         )
-        page = browser.new_page(viewport={"width": 1440, "height": 1100})
+        app_url_parts = urlsplit(args.app_url)
+        app_origin = f"{app_url_parts.scheme}://{app_url_parts.netloc}"
+        context = browser.new_context(viewport={"width": 1440, "height": 1100})
+        context.grant_permissions(
+            ["clipboard-read", "clipboard-write", "microphone"],
+            origin=app_origin,
+        )
+        page = context.new_page()
         page.set_default_timeout(120000)
         page.add_init_script(init_script)
 
@@ -555,8 +661,35 @@ def main() -> int:
             body_tail=body_after_load[-500:],
         )
 
-        enter_chat_prompt(page, args.prompt)
-        page.get_by_role("button", name="Send message").click()
+        if args.speech_audio_path:
+            attachment_button = page.get_by_role("button", name="Add attachment")
+            attachment_box = attachment_button.bounding_box()
+            if attachment_box is None:
+                raise RuntimeError("Add attachment button has no bounding box")
+            attachment_button.click()
+            page.wait_for_timeout(500)
+            emit(
+                "attachment_menu_opened",
+                body_tail=safe_body_text(page)[-800:],
+            )
+            with page.expect_file_chooser() as file_chooser_info:
+                # Flutter's canvas-backed popup exposes only its dismiss
+                # barrier to Chromium accessibility. The final transcription
+                # item opens over the attachment button, so a second click at
+                # the anchor activates it without depending on painted text.
+                page.mouse.click(
+                    attachment_box["x"] + attachment_box["width"] / 2,
+                    attachment_box["y"] + attachment_box["height"] / 2,
+                )
+            file_chooser_info.value.set_files(args.speech_audio_path)
+            emit(
+                "speech_file_selected",
+                filename=Path(args.speech_audio_path).name,
+                encodedByteLength=Path(args.speech_audio_path).stat().st_size,
+            )
+        else:
+            enter_chat_prompt(page, args.prompt)
+            page.get_by_role("button", name="Send message").click()
 
         try:
             page.get_by_role("button", name="Stop generation").wait_for(timeout=10000)
@@ -571,6 +704,86 @@ def main() -> int:
             args.allow_any_response,
             args.response_source,
         )
+        if args.speech_audio_path:
+            copied_response = copy_last_assistant_response(
+                page,
+                min(args.response_timeout_ms, 30000),
+            )
+            if args.expect.lower() not in copied_response.lower():
+                raise RuntimeError(
+                    "Copied speech transcript did not contain expected text: "
+                    f"{copied_response!r}"
+                )
+            if "<asr_text>" in copied_response:
+                raise RuntimeError("Raw Qwen3-ASR control markers leaked into the chat UI")
+            emit(
+                "rendered_speech_transcript_verified",
+                source="selected-file",
+                method="copy-response",
+                character_count=len(copied_response),
+            )
+            body_after_response = safe_body_text(page)
+        microphone_bridge_response = None
+        if args.speech_microphone:
+            page.evaluate("() => { window.__llamadartRealBridgeLastResponse = null; }")
+            record_button = page.get_by_role(
+                "button", name="Record for transcription"
+            )
+            record_button.click()
+            stop_recording_button = page.get_by_role(
+                "button", name="Stop & transcribe"
+            )
+            try:
+                stop_recording_button.wait_for(timeout=30000)
+            except PlaywrightTimeoutError as error:
+                emit(
+                    "microphone_recording_start_failed",
+                    body_tail=safe_body_text(page)[-1200:],
+                    console_tail=console_logs[-20:],
+                    page_errors=page_errors[-10:],
+                )
+                raise RuntimeError(
+                    "Browser microphone recording did not enter the active state."
+                ) from error
+            with wave.open(args.speech_audio_path, "rb") as wav_input:
+                capture_seconds = wav_input.getnframes() / wav_input.getframerate()
+            page.wait_for_timeout(int((capture_seconds + 0.75) * 1000))
+            stop_recording_button.click()
+            try:
+                page.get_by_role("button", name="Stop generation").wait_for(
+                    timeout=30000
+                )
+                emit("microphone_generation_started")
+            except PlaywrightTimeoutError:
+                emit("microphone_generation_start_not_observed")
+            microphone_bridge_response, _ = wait_for_bridge_response(
+                page,
+                args.expect,
+                args.response_timeout_ms,
+                False,
+                args.response_source,
+            )
+            copied_microphone_response = copy_last_assistant_response(
+                page,
+                min(args.response_timeout_ms, 30000),
+            )
+            if args.expect.lower() not in copied_microphone_response.lower():
+                raise RuntimeError(
+                    "Copied microphone transcript did not contain expected text: "
+                    f"{copied_microphone_response!r}"
+                )
+            if "<asr_text>" in copied_microphone_response:
+                raise RuntimeError(
+                    "Raw Qwen3-ASR control markers leaked from microphone transcription"
+                )
+            emit(
+                "rendered_speech_transcript_verified",
+                source="microphone",
+                method="copy-response",
+                character_count=len(copied_microphone_response),
+                capture_seconds=round(capture_seconds, 3),
+            )
+            body_after_response = safe_body_text(page)
         bridge_globals = page.evaluate(
             """() => ({
               crossOriginIsolated: window.crossOriginIsolated,
@@ -590,6 +803,8 @@ def main() -> int:
                 window.__llamadartBridgeForceRemoteFetchBackend ?? null,
               liteRtLmModuleUrl: window.__llamadartLiteRtLmModuleUrl ?? null,
               liteRtLmPatched: window.LiteRtLmEngine?.__llamadartRealE2ePatched ?? null,
+              promptSpeechToTextSupported:
+                window.__llamadartBridgeSpeechToTextSupported ?? null,
             })"""
         )
         if args.expect_mmproj_cache_hit and len(mmproj_requests) != 1:
@@ -604,7 +819,21 @@ def main() -> int:
             modelUrl=args.model_url,
             mmprojUrl=args.mmproj_url,
             expectedText=args.expect,
+            variant=(
+                "speechToTextWithMicrophone"
+                if args.speech_microphone
+                else ("speechToText" if args.speech_audio_path else "chat")
+            ),
+            speechAudio=(
+                {
+                    "filename": Path(args.speech_audio_path).name,
+                    "encodedByteLength": Path(args.speech_audio_path).stat().st_size,
+                }
+                if args.speech_audio_path
+                else None
+            ),
             bridgeResponse=bridge_response,
+            microphoneBridgeResponse=microphone_bridge_response,
             remoteFetchMode=remote_fetch_mode,
             mmprojRequestCount=len(mmproj_requests),
             bridgeGlobals=bridge_globals,

--- a/tool/testing/run_local_e2e.dart
+++ b/tool/testing/run_local_e2e.dart
@@ -78,6 +78,7 @@ class LocalE2eRunContext {
     required this.imagePath,
     required this.audioPath,
     required this.modelUrl,
+    required this.mmprojUrl,
     required this.backend,
     required this.speculativeCases,
     required this.benchmarkGpuLayers,
@@ -110,6 +111,7 @@ class LocalE2eRunContext {
   final String? imagePath;
   final String? audioPath;
   final String? modelUrl;
+  final String? mmprojUrl;
   final String backend;
   final String speculativeCases;
   final String benchmarkGpuLayers;
@@ -139,6 +141,10 @@ class LocalE2eRunContext {
       'https://huggingface.co/litert-community/gemma-4-E2B-it-litert-lm/resolve/main/gemma-4-E2B-it-web.litertlm?download=true';
   String get defaultGemma4WebGpuModelUrl =>
       'http://127.0.0.1:$port/example/llamadart_server/models/gemma-4-E2B-it-Q4_K_S.gguf';
+  String get defaultQwen3AsrWebModelUrl =>
+      'https://huggingface.co/ggml-org/Qwen3-ASR-0.6B-GGUF/resolve/928ab958557df9aa2ef1c93e0e83c7ad0933fae2/Qwen3-ASR-0.6B-Q8_0.gguf';
+  String get defaultQwen3AsrWebMmprojUrl =>
+      'https://huggingface.co/ggml-org/Qwen3-ASR-0.6B-GGUF/resolve/928ab958557df9aa2ef1c93e0e83c7ad0933fae2/mmproj-Qwen3-ASR-0.6B-Q8_0.gguf';
 }
 
 class LocalE2eScenario {
@@ -578,6 +584,61 @@ List<LocalE2eScenario> buildLocalE2eScenarios({String? projectRoot}) {
       },
     ),
     LocalE2eScenario(
+      name: 'chat-app-web-speech-to-text-smoke',
+      group: LocalE2eScenarioGroup.webSmoke,
+      description:
+          'Build chat_app web and transcribe a selected WAV with Qwen3-ASR.',
+      requiresDevice: false,
+      stepsBuilder: (context) {
+        final steps = <LocalE2eCommandStep>[_prepareChatAppWebBuild(context)];
+        steps.addAll([
+          LocalE2eCommandStep(
+            workingDirectory: context.projectRoot,
+            executable: context.python,
+            arguments: [
+              'tool/testing/serve_static_with_headers.py',
+              '--directory',
+              '.',
+              '--port',
+              '${context.port}',
+            ],
+            description: 'Serve repo root with COOP/COEP headers',
+            background: true,
+            waitForPort: context.port,
+          ),
+          LocalE2eCommandStep(
+            workingDirectory: context.projectRoot,
+            executable: context.python,
+            arguments: [
+              'tool/testing/playwright_chat_app_real_model_smoke.py',
+              context.webBuildUrl,
+              '--model-url',
+              context.modelUrl ?? context.defaultQwen3AsrWebModelUrl,
+              '--mmproj-url',
+              context.mmprojUrl ?? context.defaultQwen3AsrWebMmprojUrl,
+              '--speech-audio-path',
+              context.audioPath!,
+              '--speech-microphone',
+              '--expect',
+              context.expect,
+              '--gpu-layers',
+              '0',
+              '--context-size',
+              '4096',
+              '--max-tokens',
+              '512',
+              '--load-timeout-ms',
+              '${40 * 60 * 1000}',
+              '--response-timeout-ms',
+              '${10 * 60 * 1000}',
+            ],
+            description: 'Run Playwright Qwen3-ASR Web speech smoke',
+          ),
+        ]);
+        return steps;
+      },
+    ),
+    LocalE2eScenario(
       name: 'chat-app-web-mock-smoke',
       group: LocalE2eScenarioGroup.webSmoke,
       description:
@@ -819,6 +880,7 @@ Future<LocalE2eResult> runLocalE2e(
     'speech-to-text-smoke',
     'litert-lm-asr-smoke',
     'litert-lm-chat-features-smoke',
+    'chat-app-web-speech-to-text-smoke',
   };
   if (parsed.audioPath != null && !audioPathScenarios.contains(scenario.name)) {
     return LocalE2eResult(
@@ -837,6 +899,17 @@ Future<LocalE2eResult> runLocalE2e(
       stderr:
           '--model-path, --mmproj-path, --audio-path, and a nonempty --expect '
           'are required for speech-to-text-smoke.\n',
+    );
+  }
+  if (scenario.name == 'chat-app-web-speech-to-text-smoke' &&
+      (parsed.audioPath == null ||
+          !parsed.expectProvided ||
+          parsed.expect.trim().isEmpty)) {
+    return const LocalE2eResult(
+      64,
+      stderr:
+          '--audio-path and a nonempty --expect are required for '
+          'chat-app-web-speech-to-text-smoke.\n',
     );
   }
   if (scenario.name == 'litert-lm-asr-smoke' &&
@@ -912,6 +985,7 @@ Future<LocalE2eResult> runLocalE2e(
     imagePath: parsed.imagePath,
     audioPath: parsed.audioPath,
     modelUrl: parsed.modelUrl,
+    mmprojUrl: parsed.mmprojUrl,
     backend: parsed.backend,
     speculativeCases: parsed.speculativeCases,
     benchmarkGpuLayers: parsed.benchmarkGpuLayers,
@@ -1126,6 +1200,7 @@ Options:
   --image-path <path>            Optional image path for GGUF chat smoke multimodal variant.
   --audio-path <path>            Complete audio fixture for speech-to-text or native audio-chat smoke.
   --model-url <url>              Model URL for real-model web smoke.
+  --mmproj-url <url>             Projector URL for real-model web smoke.
   --backend <name>               Backend for local model scenarios (default: auto).
   --speculative-cases <list>     Benchmark cases for llama.cpp speculative benchmark.
   --benchmark-gpu-layers <n>     GPU layers for benchmark scenarios (default: 0).
@@ -1202,6 +1277,7 @@ class _ParsedArgs {
     this.imagePath,
     this.audioPath,
     this.modelUrl,
+    this.mmprojUrl,
     this.ngramSize,
     this.ngramSizeM,
     this.ngramTokenMax,
@@ -1227,6 +1303,7 @@ class _ParsedArgs {
   final String? imagePath;
   final String? audioPath;
   final String? modelUrl;
+  final String? mmprojUrl;
   final String backend;
   final String speculativeCases;
   final String benchmarkGpuLayers;
@@ -1275,6 +1352,7 @@ class _ParsedArgs {
     String? imagePath;
     String? audioPath;
     String? modelUrl;
+    String? mmprojUrl;
     String? ngramSize;
     String? ngramSizeM;
     String? ngramTokenMax;
@@ -1321,6 +1399,8 @@ class _ParsedArgs {
           audioPath = _readValue(args, ++index, arg);
         case '--model-url':
           modelUrl = _readValue(args, ++index, arg);
+        case '--mmproj-url':
+          mmprojUrl = _readValue(args, ++index, arg);
         case '--backend':
           backend = _readValue(args, ++index, arg);
         case '--speculative-cases':
@@ -1374,6 +1454,7 @@ class _ParsedArgs {
       imagePath: imagePath,
       audioPath: audioPath,
       modelUrl: modelUrl,
+      mmprojUrl: mmprojUrl,
       backend: backend,
       speculativeCases: speculativeCases,
       benchmarkGpuLayers: benchmarkGpuLayers,

--- a/tool/testing/test_matrix.dart
+++ b/tool/testing/test_matrix.dart
@@ -402,6 +402,22 @@ const List<TestMatrixRow> testMatrixRows = <TestMatrixRow>[
         'Web chat app, web model loading, or WebGPU bridge runtime changes.',
   ),
   TestMatrixRow(
+    id: 'web-speech-to-text-smoke',
+    tier: 'targeted',
+    mode: 'local-only',
+    covers:
+        'published WebGPU bridge, public typed STT API, Qwen3-ASR catalog, '
+        'browser-selected WAV bytes, fake-device microphone capture, and '
+        'rendered transcripts',
+    command:
+        'dart run tool/testing/run_local_e2e.dart --scenario '
+        'chat-app-web-speech-to-text-smoke --audio-path <speech.wav> '
+        '--expect <exact-transcript>',
+    useWhen:
+        'Web bridge pins, prompt speech capability gating, Qwen3-ASR Web, '
+        'or browser transcription UI changes.',
+  ),
+  TestMatrixRow(
     id: 'webgpu-multimodal-regression',
     tier: 'targeted',
     mode: 'local-only',

--- a/website/docs/changelog/recent-releases.md
+++ b/website/docs/changelog/recent-releases.md
@@ -45,9 +45,10 @@ For canonical full release notes, use:
   refreshed Apple SwiftPM artifact.
 
 - Added an experimental typed Qwen3-ASR whole-file transcription workflow, a
-  SHA-256-verified Qwen3-ASR 0.6B native mobile-and-desktop chat-app preset,
-  and foreground microphone recording. Web and the current LiteRT-LM artifacts
-  remain explicitly unsupported for typed STT.
+  SHA-256-verified Qwen3-ASR 0.6B native-and-Web chat-app preset, and foreground
+  microphone recording. WebGPU requires validated bridge assets `v0.1.30+`
+  and accepts WAV bytes only; native LiteRT-LM live dictation remains a
+  separate implementation.
 
 - Added **Ask with voice** to the native Flutter chat example for Gemma 4 E2B
   LiteRT-LM and audio-capable GGUF models. It sends a short microphone recording

--- a/website/docs/examples/chat-app.md
+++ b/website/docs/examples/chat-app.md
@@ -65,16 +65,16 @@ flutter test
 - Runtime-verified multimodal capability gating after `mmproj` load, plus
   declared direct-media capabilities for native model bundles such as
   LiteRT-LM. The app hides unsupported attachment types for the active platform.
-- Separate file and microphone transcription actions for compatible native
-  GGUF models, backed by the typed whole-file `SpeechToTextEngine`. The
-  microphone captures a temporary foreground WAV and transcribes it only after
-  **Stop & transcribe**; it does not emit live partial text. These actions are
-  distinct from generic audio attachment and are not shown for Web or current
-  LiteRT-LM. Microphone capture is enabled on Android, iOS, macOS, and Windows
-  when a compatible ASR model is active; Linux capture remains disabled pending
-  a safe external-recorder preflight, while selected-file transcription remains
-  available there. Web support is tracked in
-  [issue #329](https://github.com/leehack/llamadart/issues/329).
+- Separate file and microphone transcription actions for compatible Qwen3-ASR
+  GGUF models, backed by the typed whole-file `SpeechToTextEngine`. Native file
+  selection accepts WAV, MP3, and FLAC; WebGPU bridge assets `v0.1.30+` accept
+  WAV bytes. The microphone captures a temporary foreground WAV and transcribes
+  it only after **Stop & transcribe**; it does not emit live partial text. These
+  actions are distinct from generic audio attachment and are not shown for
+  current LiteRT-LM chat bundles. Microphone capture is enabled on Android,
+  iOS, macOS, Windows, and supported secure browser origins; Linux capture
+  remains disabled pending a safe external-recorder preflight, while
+  selected-file transcription remains available there.
 - Experimental live English dictation for native chat models, including
   generic audio-chat models, through independently installed, checksum-pinned
   LiteRT sidecars. Moonshine Tiny is the recommended 54 MB default; Parakeet
@@ -133,9 +133,8 @@ flutter test
 
 The built-in library is intentionally small and Unsloth-first:
 
-- Cross-platform: FunctionGemma 270M, Qwen3.5 0.8B, Gemma 4 E2B GGUF,
-  Gemma 4 E2B LiteRT-LM, and Gemma 4 E4B GGUF.
-- Native mobile and desktop: Qwen3-ASR 0.6B.
+- Cross-platform: FunctionGemma 270M, Qwen3.5 0.8B, Qwen3-ASR 0.6B,
+  Gemma 4 E2B GGUF, Gemma 4 E2B LiteRT-LM, and Gemma 4 E4B GGUF.
 - Native desktop: Qwen3-TTS 1.7B Base, Gemma 4 12B, Gemma 4 26B A4B,
   Gemma 4 31B, and Qwen3.6 35B A3B.
 
@@ -154,9 +153,9 @@ the primary download/load action. Recommended context and output limits remain
 visible without repeating every sampling parameter on every card.
 
 Availability filters match each preset's platform restrictions. The Qwen3-ASR
-preset appears for native mobile and desktop targets but remains unavailable on
-Web; other portable presets can appear under both **Mobile** and **Web**, while
-Qwen3-TTS and the largest native models remain **Desktop** only. The first TTS
+preset appears under native and **Web** with its validated platform-specific
+input contract, while Qwen3-TTS and the largest native models remain
+**Desktop** only. The first TTS
 catalog scope reflects macOS CPU/Metal real-model evidence; other native targets
 still require packaged-runtime validation.
 

--- a/website/docs/guides/speech-to-text.md
+++ b/website/docs/guides/speech-to-text.md
@@ -1,6 +1,6 @@
 ---
 title: Speech to Text
-description: Transcribe encoded audio or stream PCM with the experimental typed native speech API.
+description: Transcribe encoded audio or stream PCM with the experimental typed speech API.
 ---
 
 `SpeechToTextEngine` is the typed API for speech recognition. It is separate
@@ -8,19 +8,20 @@ from `LlamaEngine` because transcript events, timestamps, confidence, language,
 speaker labels, cancellation, and audio metadata have a different contract from
 chat-completion tokens.
 
-The API currently has two experimental native implementations. llama.cpp adapts
-Qwen3-ASR audio input to whole-file transcription. LiteRT-LM uses a dedicated
-CPU ASR engine for incremental mono 16 kHz PCM, partial text, and finalization
-from a worker isolate. Recognition quality and language behavior remain model
-dependent. Generic `LlamaAudioContent` chat input still exists separately for
-audio-capable multimodal models.
+The API currently has two experimental implementations. llama.cpp adapts
+Qwen3-ASR audio input to whole-file transcription on native targets and on
+validated WebGPU bridge assets. Native LiteRT-LM uses a dedicated CPU ASR engine
+for incremental mono 16 kHz PCM, partial text, and finalization from a worker
+isolate. Recognition quality and language behavior remain model dependent.
+Generic `LlamaAudioContent` chat input still exists separately for audio-capable
+multimodal models.
 
 ## Current support matrix
 
 | Runtime | Generic audio-input chat | Typed `SpeechToTextEngine` | Text to speech |
 | --- | --- | --- | --- |
 | Native llama.cpp / GGUF | Model + projector dependent | Experimental Qwen3-ASR adapter; complete WAV/MP3/FLAC file or bytes, final transcript only | Experimental Qwen3-TTS adapter; see [Text to Speech](./text-to-speech) |
-| WebGPU / GGUF | Bridge + model dependent | Unsupported | Unsupported |
+| WebGPU / GGUF | Bridge + model dependent | Experimental Qwen3-ASR adapter with bridge assets `v0.1.30+`; complete WAV bytes, final transcript only | Unsupported |
 | Native LiteRT-LM | Separate `.litertlm` audio chat remains bundle dependent | Experimental dedicated CPU ASR through `SpeechToTextEngine.liteRtLm`; mono 16 kHz float PCM, partial/final text, streaming input | Unsupported |
 | LiteRT-LM Web | Unsupported | Unsupported | Unsupported |
 
@@ -115,6 +116,13 @@ success alone does not prove audio support. The required `modelProfile` is an
 explicit declaration that prevents an ordinary audio-understanding model from
 being advertised as ASR merely because it accepts audio.
 
+On Web, the active backend must also expose the validated prompt-speech
+capability. The hosted chat app derives that opt-in from immutable
+`llama-web-bridge-assets` tags `v0.1.30+`; custom hosts can explicitly set
+`window.__llamadartBridgeSpeechToTextSupported` before the backend is created.
+An older bridge, a missing or mismatched projector, or a failed runtime audio
+probe leaves `capabilities.isSupported` false with an actionable reason.
+
 ## Transcribe a complete file
 
 ```dart
@@ -148,6 +156,13 @@ Native llama.cpp currently decodes WAV, MP3, and FLAC file or byte inputs. Raw
 PCM remains unsupported for that prompt adapter because projector sample rates
 are model-specific. Dedicated LiteRT-LM accepts `SpeechAudioPcmInput` for a
 complete mono 16 kHz float buffer, or the incremental session shown above.
+
+WebGPU accepts encoded WAV bytes only. Browser file pickers must read the
+selected file into memory and use `SpeechAudioBytesInput`; local filesystem
+paths, MP3, FLAC, raw PCM, and byte inputs without explicit
+`SpeechAudioFormat(encoding: 'wav')` metadata are rejected. This narrower
+contract reflects the published browser smoke rather than every decoder that
+may be compiled into a particular bridge build.
 
 `SpeechAudioFormat` also carries optional encoding and MIME metadata. Final
 results reserve segment and word timing, confidence, and speaker fields so a
@@ -184,11 +199,11 @@ different user actions:
 
 - **Attach Audio** sends audio through normal multimodal chat.
 - **Transcribe Audio** selects one file and uses `SpeechToTextEngine` with a
-  compatible native GGUF ASR model.
+  compatible GGUF ASR model. Native accepts WAV, MP3, and FLAC; Web accepts WAV.
 - With Qwen3-ASR, the microphone records a temporary foreground WAV for up to
-  five minutes. **Stop & transcribe** finalizes that file and passes it to
-  `SpeechToTextEngine`, while **Discard** cancels capture and removes the
-  partial file.
+  five minutes. **Stop & transcribe** finalizes that recording and passes its
+  file on native or its encoded bytes on Web to `SpeechToTextEngine`, while
+  **Discard** cancels capture and removes or revokes the partial recording.
 - With a native chat model, **Live transcription** uses a separately installed,
   checksum-pinned LiteRT model and tokenizer. Moonshine Tiny is the recommended
   54 MB default; Parakeet TDT 0.6B is an optional higher-capacity, heavier
@@ -208,28 +223,32 @@ different user actions:
   detected language, or live partial text. An ASR profile takes precedence
   when both capability declarations are present.
 
-The dedicated **Transcribe Audio** action remains hidden on Web and for normal
-LiteRT-LM chat bundles. Live dictation uses the public LiteRT-LM streaming STT
+The dedicated **Transcribe Audio** action is available on Web only for the
+validated Qwen3-ASR preset and runtime capability. It remains hidden for normal
+LiteRT-LM chat bundles. Live dictation uses the native LiteRT-LM streaming STT
 API with an app-managed sidecar; it is not a capability of the selected chat
-bundle.
+bundle and remains unavailable on Web.
 ASR microphone recordings are capped at five minutes, cancelled when the app is
-backgrounded, and deleted after transcription. This remains a whole-file
-workflow: it does not produce live partial transcripts while the user speaks.
-The recorder requests 16 kHz mono WAV, but hardware may choose another valid
-sample rate; the downstream native decoder reads the WAV metadata.
+backgrounded, and deleted on native or revoked on Web after transcription. This
+remains a whole-file workflow: it does not produce live partial transcripts
+while the user speaks. The recorder requests 16 kHz mono WAV, but hardware or
+the browser may choose another valid sample rate; the downstream decoder reads
+the WAV metadata.
 The live sidecar path instead requests PCM16 mono 16 kHz streaming, preserves
 samples split across arbitrary byte-chunk boundaries, applies one in-flight
 worker push at a time, and caps each session at five minutes. It is currently
 English-only and CPU-only. The composer integration is enabled on Android,
 iOS, macOS, and Windows, cancelled on foreground lifecycle changes, and
 disabled on Linux and Web.
-Capture for both microphone workflows is code-supported on Android, iOS, macOS,
-and Windows. It remains disabled on Linux with the current recorder plugin
-because its external-tool startup is not safe to expose without a stronger
-preflight; selected-file transcription is unchanged there. **Ask with voice**
-also requires a native direct-media audio model or an audio-capable projector
-and is unavailable on Web. These capability gates do not establish real-model
-behavior on every platform. The experimental llama.cpp GGUF voice path has
+Typed Qwen3-ASR microphone capture is code-supported on Android, iOS, macOS,
+Windows, and secure browser origins. Browser startup still checks microphone
+permission and WAV encoder support before recording. Capture remains disabled
+on Linux with the current recorder plugin because its external-tool startup is
+not safe to expose without a stronger preflight; selected-file transcription
+is unchanged there. **Ask with voice** also requires a native direct-media
+audio model or an audio-capable projector and is unavailable on Web. These
+capability gates do not establish real-model behavior on every platform. The
+experimental llama.cpp GGUF voice path has
 engine-level Metal evidence on macOS, while current packaged microphone UI
 evidence is LiteRT-LM on macOS. Android, iOS, and Windows still require
 real-model/device evidence through the `chat-app-voice-question-smoke`
@@ -247,10 +266,10 @@ working choice for the loaded model. For the validated Gemma 4 E2B bundle, GPU
 text/vision with CPU audio is the resolved path. This is bundle/runtime
 compatibility behavior, not a universal LiteRT-LM CPU-audio limitation.
 
-The chat app's native mobile-and-desktop catalog includes the Qwen3-ASR 0.6B
-Q8_0 model/projector pair. It remains excluded from the Web catalog. Its
-immutable artifact revision, byte sizes, and SHA-256 digests are pinned, and
-the native downloader verifies both files before the model can be selected.
+The chat app catalog includes the Qwen3-ASR 0.6B Q8_0 model/projector pair on
+native and Web. Its immutable artifact revision, byte sizes, and SHA-256
+digests are pinned. Native downloads verify both files before selection; Web
+uses origin-scoped Cache Storage and the pinned source metadata.
 
 ## Known limits
 
@@ -259,14 +278,20 @@ the native downloader verifies both files before the model can be selected.
   metadata until language behavior has a dedicated validation contract.
 - There are no word/segment timestamps, confidence scores, or speaker
   diarization. Incremental audio and partial text are LiteRT-LM-only.
-- Native inference backend correctness and performance remain device dependent;
+- Inference backend correctness and performance remain device dependent;
   establish a CPU baseline before claiming GPU support for a deployment.
 - The local real-model smoke has passed on macOS arm64 CPU, and a separate
   chat-app/manual smoke has passed on Metal. The full chat-app
   model/projector, microphone, and final-transcript flow has also passed on a
   physical Pixel using CPU inference and in the iOS Simulator. A physical
   iPhone and Windows remain unverified; Linux keeps selected-file STT but not
-  microphone capture. Web enablement is tracked separately in
-  [issue #329](https://github.com/leehack/llamadart/issues/329).
+  microphone capture. Web requires `v0.1.30+`, a browser with enough memory for
+  the roughly 1.02 GB model/projector pair, and the targeted
+  `web-speech-to-text-smoke` validation row. That row verifies both browser
+  file selection and Chromium fake-device microphone capture with the same WAV
+  fixture. File selection returns the exact expected transcript; the microphone
+  assertion requires the full expected transcript because Chromium loops its
+  artificial input at the capture boundary. Real microphone hardware and
+  browser/device combinations remain deployment-specific checks.
 - TTS is a separate typed API with different models, projector capabilities,
   inputs, and output events. See [Text to Speech](./text-to-speech).

--- a/website/docs/platforms/support-matrix.md
+++ b/website/docs/platforms/support-matrix.md
@@ -16,17 +16,18 @@ override the llama.cpp native GitHub source with
 bundle source with `hooks.user_defines.llamadart.llamadart_native_path`. Module
 availability below is for the pinned/default artifacts.
 
-Speech support is narrower than general runtime availability. Native
-llama.cpp/GGUF has an experimental whole-file `SpeechToTextEngine` adapter when
-the caller explicitly selects the Qwen3-ASR profile and the loaded projector
-reports audio capability. This path is real-model validated on macOS arm64;
-other native targets still need representative validation. Native llama.cpp
+Speech support is narrower than general runtime availability. llama.cpp/GGUF
+has an experimental whole-file `SpeechToTextEngine` adapter when the caller
+explicitly selects the Qwen3-ASR profile and the loaded projector reports audio
+capability. Native accepts WAV, MP3, and FLAC file or byte inputs. WebGPU bridge
+assets `v0.1.30+` opt into the validated Qwen3-ASR path with WAV bytes only;
+older or custom runtimes stay unsupported unless the host explicitly declares
+the capability. Native llama.cpp
 also exposes experimental Qwen3-TTS synthesis through the separate typed
 [`TextToSpeechEngine`](../guides/text-to-speech). Native LiteRT-LM v0.16 also
 supports experimental CPU-only streaming ASR through
 `SpeechToTextEngine.liteRtLm`, with the native session owned by a worker
-isolate. WebGPU and LiteRT-LM Web do not currently expose either typed speech
-path. See the
+isolate. LiteRT-LM Web does not expose typed speech. See the
 [speech recognition support matrix](../guides/speech-to-text#current-support-matrix).
 
 Available override tags are published on the

--- a/website/docs/platforms/webgpu-bridge.md
+++ b/website/docs/platforms/webgpu-bridge.md
@@ -146,13 +146,13 @@ development validation, and CDN-first loading for normal hosted deployments:
 1. On localhost: local asset first, then CDN fallback.
 2. On hosted deployments: CDN asset first, then local fallback.
 
-The example currently pins bridge assets to `v0.1.27`, with local vendored assets
-identified as `v0.1.27-local-b10333`.
+The example currently pins bridge assets to `v0.1.30`, with local vendored assets
+identified as `v0.1.30-local-b10448`.
 
 Fetch pinned local assets with:
 
 ```bash
-WEBGPU_BRIDGE_ASSETS_TAG=v0.1.27 ./scripts/fetch_webgpu_bridge_assets.sh
+WEBGPU_BRIDGE_ASSETS_TAG=v0.1.30 ./scripts/fetch_webgpu_bridge_assets.sh
 ```
 
 To verify the loaded runtime in a browser console, inspect:
@@ -169,6 +169,7 @@ window.__llamadartBridgeModuleUrl;     // actual bridge module URL
 window.__llamadartBridgeCoreModuleUrl; // wasm32 JS core module URL
 window.__llamadartBridgeCoreModuleUrlMem64; // optional wasm64 JS core module URL
 window.__llamadartBridgeWorkerUrl;     // dedicated worker module, if available
+window.__llamadartBridgeSpeechToTextSupported; // validated Qwen3-ASR opt-in
 ```
 
 The readiness promise rejects if both CDN and local bridge loading fail, and the
@@ -179,6 +180,10 @@ cannot report success before the bridge exposes `prefetchModelToCache(...)`.
 ## Compatibility and safeguards
 
 - Web backend remains experimental.
+- `v0.1.30+` bridge assets opt into typed Qwen3-ASR whole-file transcription.
+  The public Web contract accepts WAV bytes only and still requires a loaded
+  projector with a positive audio-capability probe. Direct and worker runtime
+  smokes validate complete transcripts and cooperative cancellation.
 - `v0.1.12+` bridge assets forward native-compatible `ModelParams` load
   tuning fields, including multi-sequence slots, KV cache type, flash attention,
   RoPE overrides, split mode, and main GPU.
@@ -309,7 +314,9 @@ You can override bridge asset source/version before loader startup:
 ```html
 <script>
   window.__llamadartBridgeAssetsRepo = 'leehack/llama-web-bridge-assets';
-  window.__llamadartBridgeAssetsTag = 'v0.1.27';
+  window.__llamadartBridgeAssetsTag = 'v0.1.30';
+  // Custom assets stay speech-disabled unless the host has validated them:
+  // window.__llamadartBridgeSpeechToTextSupported = true;
   // Prefer local runtime even off localhost:
   // window.__llamadartPreferLocalBridgeRuntime = true;
   // Enable verbose bridge bootstrap console logs:


### PR DESCRIPTION
## Summary

- enable capability-gated `SpeechToTextEngine` support on WebGPU with validated `llama-web-bridge-assets@v0.1.30`
- expose the pinned Qwen3-ASR 0.6B model/projector in the Web chat catalog
- add browser-selected WAV transcription and secure-origin WAV microphone recording
- keep generic audio chat, typed whole-file STT, and native LiteRT-LM live dictation as separate capabilities
- add a durable real-model browser scenario plus unit, Chrome, docs, and support-matrix coverage

Progresses #329.

## Why

The published v0.1.30 bridge now passes the upstream Qwen3-ASR direct and worker runtime controls. llamadart previously hard-disabled typed STT on Web even though its bridge could ingest encoded audio. This change adds an explicit runtime opt-in so older or merely audio-capable bridges are not mislabeled as product STT.

## Behavior

- Web typed STT accepts encoded WAV bytes only and rejects local filesystem paths, missing encoding metadata, and unvalidated formats.
- Qwen3-ASR remains an explicit model profile; generic `LlamaAudioContent` does not imply typed STT.
- Browser file selection reads WAV bytes instead of manufacturing a path.
- Browser microphone recording uses the existing recorder Web AudioWorklet path, validates the completed WAV, reads bytes before revoking the object URL, and preserves the existing five-minute/cancel lifecycle.
- The chat app uses conservative automatic Web ASR batches (`n_batch=512`, `n_ubatch=128`) to avoid the oversized WASM compute buffer observed with generic defaults.
- Older/custom bridges remain unsupported unless they explicitly implement `BackendPromptSpeechToTextSupport` or set the documented bootstrap capability.
- LiteRT-LM Web speech, generic Web Ask-with-voice, live partial transcripts, timestamps, confidence, and diarization remain out of scope.

## Real-model evidence

`chat-app-web-speech-to-text-smoke` passed on macOS arm64 Chromium with the deployable Flutter Web build, published v0.1.30 worker/WASM assets, and the immutable Qwen3-ASR Q8_0 pair:

- model: 804,749,248 bytes, SHA-256 `bca259818b50ca7c4c05e9bdb35a5dc04fa039653a6d6f3f0f331f96f6aa1971`
- projector: 214,392,480 bytes, SHA-256 `41a342b5e4c514e968cb756de6cd1b7be39eff43c44c57a2ef5fc6522e36603d`
- fixture: 325,754-byte WAV, SHA-256 `c020025e0650ec3a31e01e5b2cbd4d66ef09e64fe93ef5b30e32516c5174522b`
- selected-file result: exact expected 224-character transcript
- microphone result: full expected transcript present; Chromium's looping fake input added a short repeated prefix at the capture boundary
- runtime: worker/WASM CPU, `crossOriginIsolated=true`, 40 token events for file input, no page errors or request failures

Real microphone hardware/browser combinations, WebGPU offload for this model, and the memory64 Qwen path remain deployment/follow-up validation rather than claims of this PR.

## Validation

- `dart format --output=none --set-exit-if-changed <changed Dart files>`
- scoped root `dart analyze`
- `cd example/chat_app && flutter analyze`
- `dart run tool/testing/check_platform_boundaries.dart`
- root VM: 1,404 passed, 66 skipped
- root Chrome: 759 passed, 1 skipped
- chat app VM: 322 passed
- chat Chrome generation contract: 4 passed
- focused WebGPU/Web STT Chrome: 76 passed
- coverage: 73.80% (11,456 / 15,523 lines; threshold 70%)
- `dart run tool/testing/verify_release_docs_versions.dart`
- `./tool/docs/build_site.sh`
- `./tool/docs/validate_links.sh`
- deployable Web build and v0.1.30 asset checksum validation
- real `chat-app-web-speech-to-text-smoke`: PASS for selected file and fake-device microphone

## Follow-up gates

- run exact-head CI, especially Web Chat Contract and coverage
- classify Qwen3-ASR WebGPU offload and memory64 behavior separately
- test real microphone hardware across supported browsers/devices
