### PR TITLE
Fix Web microphone transcription startup loss

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 ## Unreleased
 
+* Improved Web microphone transcription by warming up browser capture before
+  showing the recording-ready state, trimming the warmup silence, and
+  rejecting too-short, silent, or unsupported PCM WAV captures before
+  inference.
+
 * Updated the default llama.cpp native runtime pin to
   `leehack/llamadart-native@b10453`, picking up llama.cpp fixes for a Granite
   Speech heap overflow, a DOTS OCR out-of-bounds write, and a Step3VL

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -59,7 +59,8 @@
   adapter profile for whole-file llama.cpp transcription. The Flutter chat
   example includes a SHA-256-verified Qwen3-ASR 0.6B preset plus separate
   **Transcribe Audio** and foreground microphone recording flows on native and
-  WebGPU. Web requires validated bridge assets `v0.1.30+`, accepts WAV bytes
+  WebGPU. Web requires validated bridge assets `v0.1.30+`, pins `v0.1.32` to
+  recover short speech that would otherwise terminate empty, accepts WAV bytes
   only, and remains separate from native LiteRT-LM live dictation. The native
   flow has been exercised on a physical Pixel with CPU inference and in the
   iOS Simulator.

--- a/example/chat_app/README.md
+++ b/example/chat_app/README.md
@@ -488,6 +488,9 @@ await prefs.setInt('preferred_backend', backendIndex);
 - Multimodal projector loading on web is URL-based (model + matching mmproj URL).
 - Model selection auto-wires mmproj URLs for multimodal web models.
 - Image/audio attachments on web use browser file bytes (local path-based loading remains native-only).
+- Browser microphone recording warms up before the app shows its ready state.
+  Before ASR, the app trims that warmup silence and rejects too-short, silent,
+  or unsupported PCM WAV captures with an actionable message.
 - Browser paste events support screenshots and copied image/audio files without
   replacing normal text paste. Clipboard attachments are capped at 64 MB.
 - On web, model files are loaded by URL (local file download/cache flow differs from native).

--- a/example/chat_app/lib/providers/chat_provider.dart
+++ b/example/chat_app/lib/providers/chat_provider.dart
@@ -3074,6 +3074,8 @@ class ChatProvider extends ChangeNotifier {
     try {
       if (kIsWeb) {
         final bytes = await _audioRecordingService.readRecording(path);
+        final untrimmedBytes = await _audioRecordingService
+            .readUntrimmedRecording(path);
         await transcribeAudio(
           SpeechAudioBytesInput(
             bytes,
@@ -3083,6 +3085,15 @@ class ChatProvider extends ChangeNotifier {
             ),
           ),
           displayName: 'Microphone recording',
+          fallbackAudio: untrimmedBytes == null
+              ? null
+              : SpeechAudioBytesInput(
+                  untrimmedBytes,
+                  format: const SpeechAudioFormat(
+                    encoding: 'wav',
+                    mimeType: 'audio/wav',
+                  ),
+                ),
         );
       } else {
         await transcribeAudio(
@@ -3462,6 +3473,7 @@ class ChatProvider extends ChangeNotifier {
   Future<void> transcribeAudio(
     SpeechAudioInput audio, {
     String? displayName,
+    SpeechAudioInput? fallbackAudio,
   }) async {
     if (_isGenerating ||
         _isTranscribing ||
@@ -3521,24 +3533,47 @@ class ChatProvider extends ChangeNotifier {
         _chatService.engine,
         modelProfile: SpeechToTextModelProfile.qwen3Asr,
       );
-      final task = await recognizer.transcribe(
-        SpeechToTextRequest(
-          audio: audio,
-          maxOutputTokens: math.min(1024, math.max(64, _settings.maxTokens)),
-        ),
-      );
-      _activeSpeechToTextTask = task;
-      if (!_isGenerating || conversationRevision != _conversationRevision) {
-        task.cancel();
+      Future<({SpeechToTextCompletion completion, SpeechToTextResult? result})>
+      runAttempt(SpeechAudioInput attemptAudio) async {
+        final task = await recognizer.transcribe(
+          SpeechToTextRequest(
+            audio: attemptAudio,
+            maxOutputTokens: math.min(1024, math.max(64, _settings.maxTokens)),
+          ),
+        );
+        _activeSpeechToTextTask = task;
+        if (!_isGenerating || conversationRevision != _conversationRevision) {
+          task.cancel();
+        }
+
+        SpeechToTextResult? result;
+        await for (final event in task.events) {
+          if (event is SpeechToTextFinalEvent) {
+            result = event.result;
+          }
+        }
+        return (completion: await task.done, result: result);
       }
 
-      SpeechToTextResult? result;
-      await for (final event in task.events) {
-        if (event is SpeechToTextFinalEvent) {
-          result = event.result;
-        }
+      var attempt = await runAttempt(audio);
+      var completion = attempt.completion;
+      var result = attempt.result;
+      var transcript = (result ?? completion.result)?.text.trim() ?? '';
+      if (completion.state == SpeechToTextCompletionState.completed &&
+          transcript.isEmpty &&
+          fallbackAudio != null &&
+          _isGenerating &&
+          conversationRevision == _conversationRevision) {
+        _logDart(
+          LlamaLogLevel.info,
+          'Retrying empty browser microphone transcription with the '
+          'untrimmed WAV.',
+        );
+        attempt = await runAttempt(fallbackAudio);
+        completion = attempt.completion;
+        result = attempt.result;
+        transcript = (result ?? completion.result)?.text.trim() ?? '';
       }
-      final completion = await task.done;
 
       if (conversationRevision != _conversationRevision) {
         return;
@@ -3553,7 +3588,6 @@ class ChatProvider extends ChangeNotifier {
         throw completion.error ?? LlamaSpeechException('Transcription failed.');
       }
 
-      final transcript = (result ?? completion.result)?.text.trim() ?? '';
       if (transcript.isEmpty) {
         throw LlamaSpeechException(
           'The model completed without returning transcript text.',

--- a/example/chat_app/lib/services/audio_recording_service.dart
+++ b/example/chat_app/lib/services/audio_recording_service.dart
@@ -57,6 +57,13 @@ abstract class AudioRecordingService {
   /// Reads a finalized temporary recording as encoded WAV bytes.
   Future<Uint8List> readRecording(String path);
 
+  /// Reads an alternate untrimmed WAV for recognition fallback, when present.
+  ///
+  /// Browser capture may trim device warmup and trailing silence before the
+  /// first recognition attempt. Implementations return `null` when no distinct
+  /// fallback representation is available.
+  Future<Uint8List?> readUntrimmedRecording(String path);
+
   /// Cancels the active recording and removes any partial file.
   Future<void> cancel();
 

--- a/example/chat_app/lib/services/audio_recording_service_io.dart
+++ b/example/chat_app/lib/services/audio_recording_service_io.dart
@@ -157,6 +157,9 @@ class _IoAudioRecordingService implements AudioRecordingService {
   }
 
   @override
+  Future<Uint8List?> readUntrimmedRecording(String path) async => null;
+
+  @override
   Future<void> cancel() async {
     final recorder = _recorder;
     final path = _activePath;

--- a/example/chat_app/lib/services/audio_recording_service_stub.dart
+++ b/example/chat_app/lib/services/audio_recording_service_stub.dart
@@ -31,6 +31,9 @@ class _UnsupportedAudioRecordingService implements AudioRecordingService {
   }
 
   @override
+  Future<Uint8List?> readUntrimmedRecording(String path) async => null;
+
+  @override
   Future<void> cancel() async {}
 
   @override

--- a/example/chat_app/lib/services/audio_recording_service_web.dart
+++ b/example/chat_app/lib/services/audio_recording_service_web.dart
@@ -58,6 +58,15 @@ class _WebAudioRecordingService implements AudioRecordingService {
           encoder: AudioEncoder.wav,
           sampleRate: 16000,
           numChannels: 1,
+          // Browser input levels vary substantially across built-in,
+          // Bluetooth, and continuity microphones. Apply the browser's
+          // speech-oriented gain and noise processing before the worklet
+          // converts the capture to PCM16. Echo cancellation stays disabled
+          // because the app does not play audio while recording and some
+          // browsers otherwise suppress nearby speech as playback leakage.
+          autoGain: true,
+          echoCancel: false,
+          noiseSuppress: true,
         ),
         path: '',
       );

--- a/example/chat_app/lib/services/audio_recording_service_web.dart
+++ b/example/chat_app/lib/services/audio_recording_service_web.dart
@@ -15,7 +15,10 @@ class _WebAudioRecordingService implements AudioRecordingService {
   // of waiting for two empty inference attempts.
   static const double _minimumDurationSeconds = 2;
   static const int _minimumPeakAmplitude = 96;
-  static const double _minimumRmsAmplitude = 20;
+  // Chromium's input processing can produce isolated peaks in an otherwise
+  // silent room. Require sustained signal energy as well as a nonzero peak so
+  // ambient capture does not reach the ASR model and return an empty result.
+  static const double _minimumRmsAmplitude = 256;
 
   AudioRecorder? _recorder;
   String? _completedRecordingUrl;

--- a/example/chat_app/lib/services/audio_recording_service_web.dart
+++ b/example/chat_app/lib/services/audio_recording_service_web.dart
@@ -23,6 +23,7 @@ class _WebAudioRecordingService implements AudioRecordingService {
   AudioRecorder? _recorder;
   String? _completedRecordingUrl;
   Uint8List? _completedRecordingBytes;
+  Uint8List? _completedUntrimmedRecordingBytes;
   bool _isRecording = false;
   bool _isDisposed = false;
 
@@ -179,6 +180,9 @@ class _WebAudioRecordingService implements AudioRecordingService {
       _revokeCompletedRecording();
       _completedRecordingUrl = url;
       _completedRecordingBytes = speechBytes;
+      _completedUntrimmedRecordingBytes = identical(speechBytes, bytes)
+          ? null
+          : bytes;
       return url;
     } on AudioRecordingException {
       rethrow;
@@ -197,6 +201,14 @@ class _WebAudioRecordingService implements AudioRecordingService {
         'Could not finish browser microphone recording.',
       );
     }
+  }
+
+  @override
+  Future<Uint8List?> readUntrimmedRecording(String path) async {
+    if (path != _completedRecordingUrl) {
+      return null;
+    }
+    return _completedUntrimmedRecordingBytes;
   }
 
   @override
@@ -247,6 +259,7 @@ class _WebAudioRecordingService implements AudioRecordingService {
     if (path == _completedRecordingUrl) {
       _completedRecordingUrl = null;
       _completedRecordingBytes = null;
+      _completedUntrimmedRecordingBytes = null;
     }
     if (path.startsWith('blob:')) {
       web.URL.revokeObjectURL(path);
@@ -281,6 +294,7 @@ class _WebAudioRecordingService implements AudioRecordingService {
     final url = _completedRecordingUrl;
     _completedRecordingUrl = null;
     _completedRecordingBytes = null;
+    _completedUntrimmedRecordingBytes = null;
     if (url != null && url.startsWith('blob:')) {
       web.URL.revokeObjectURL(url);
     }

--- a/example/chat_app/lib/services/audio_recording_service_web.dart
+++ b/example/chat_app/lib/services/audio_recording_service_web.dart
@@ -1,6 +1,6 @@
 import 'dart:js_interop';
-import 'dart:typed_data';
 
+import 'package:flutter/foundation.dart';
 import 'package:record/record.dart';
 import 'package:web/web.dart' as web;
 
@@ -8,6 +8,11 @@ import 'audio_recording_service.dart';
 import 'wav_audio_validator.dart';
 
 class _WebAudioRecordingService implements AudioRecordingService {
+  static const Duration _captureWarmup = Duration(milliseconds: 500);
+  static const double _minimumDurationSeconds = 0.4;
+  static const int _minimumPeakAmplitude = 96;
+  static const double _minimumRmsAmplitude = 20;
+
   AudioRecorder? _recorder;
   String? _completedRecordingUrl;
   Uint8List? _completedRecordingBytes;
@@ -57,6 +62,11 @@ class _WebAudioRecordingService implements AudioRecordingService {
         path: '',
       );
       _isRecording = true;
+      // Keep the UI in its preparing state while Chromium connects the input
+      // stream to the AudioWorklet. Speaking during that startup window can
+      // clip the beginning of an utterance, which Qwen3-ASR may reject as an
+      // empty transcript.
+      await Future<void>.delayed(_captureWarmup);
     } on AudioRecordingException {
       rethrow;
     } catch (_) {
@@ -102,9 +112,56 @@ class _WebAudioRecordingService implements AudioRecordingService {
           'The microphone recording did not contain valid WAV audio.',
         );
       }
+      final capturedSignal = inspectPcm16WavSignal(bytes);
+      if (capturedSignal == null) {
+        web.URL.revokeObjectURL(url);
+        throw const AudioRecordingException(
+          AudioRecordingFailure.stopFailed,
+          'The browser microphone returned an unsupported WAV encoding. '
+          'Select a different input device or browser and try again.',
+        );
+      }
+      final speechBytes = trimPcm16WavSilence(bytes, signal: capturedSignal);
+      final signal = speechBytes == null
+          ? null
+          : inspectPcm16WavSignal(speechBytes);
+      if (signal == null) {
+        web.URL.revokeObjectURL(url);
+        throw const AudioRecordingException(
+          AudioRecordingFailure.stopFailed,
+          'The microphone recording was silent or too quiet. Check the '
+          'selected input device, speak closer to the microphone, and try '
+          'again.',
+        );
+      }
+      if (signal.durationSeconds < _minimumDurationSeconds) {
+        web.URL.revokeObjectURL(url);
+        throw const AudioRecordingException(
+          AudioRecordingFailure.stopFailed,
+          'The microphone recording was too short. Speak a complete phrase '
+          'before choosing Stop & transcribe.',
+        );
+      }
+      if (signal.peakAmplitude < _minimumPeakAmplitude ||
+          signal.rmsAmplitude < _minimumRmsAmplitude) {
+        web.URL.revokeObjectURL(url);
+        throw const AudioRecordingException(
+          AudioRecordingFailure.stopFailed,
+          'The microphone recording was silent or too quiet. Check the '
+          'selected input device, speak closer to the microphone, and try '
+          'again.',
+        );
+      }
+      debugPrint(
+        'Browser microphone WAV: '
+        '${signal.durationSeconds.toStringAsFixed(2)} s, '
+        '${signal.sampleRate} Hz, ${signal.channels} channel(s), '
+        'peak ${signal.peakAmplitude}, '
+        'RMS ${signal.rmsAmplitude.toStringAsFixed(1)}.',
+      );
       _revokeCompletedRecording();
       _completedRecordingUrl = url;
-      _completedRecordingBytes = bytes;
+      _completedRecordingBytes = speechBytes;
       return url;
     } on AudioRecordingException {
       rethrow;

--- a/example/chat_app/lib/services/audio_recording_service_web.dart
+++ b/example/chat_app/lib/services/audio_recording_service_web.dart
@@ -9,7 +9,11 @@ import 'wav_audio_validator.dart';
 
 class _WebAudioRecordingService implements AudioRecordingService {
   static const Duration _captureWarmup = Duration(milliseconds: 500);
-  static const double _minimumDurationSeconds = 0.4;
+  // The published Qwen3-ASR Web runtime consistently returns an empty
+  // completion for clean utterances shorter than two seconds. Reject those
+  // captures before model generation so users get an actionable retry instead
+  // of waiting for two empty inference attempts.
+  static const double _minimumDurationSeconds = 2;
   static const int _minimumPeakAmplitude = 96;
   static const double _minimumRmsAmplitude = 20;
 
@@ -147,8 +151,9 @@ class _WebAudioRecordingService implements AudioRecordingService {
         web.URL.revokeObjectURL(url);
         throw const AudioRecordingException(
           AudioRecordingFailure.stopFailed,
-          'The microphone recording was too short. Speak a complete phrase '
-          'before choosing Stop & transcribe.',
+          'The microphone recording was too short. Record at least two '
+          'seconds and speak a complete phrase before choosing Stop & '
+          'transcribe.',
         );
       }
       if (signal.peakAmplitude < _minimumPeakAmplitude ||

--- a/example/chat_app/lib/services/chat_service.dart
+++ b/example/chat_app/lib/services/chat_service.dart
@@ -106,7 +106,25 @@ class ChatService {
     if (eagerLoadMultimodalProjector &&
         settings.mmprojPath != null &&
         settings.mmprojPath!.isNotEmpty) {
-      await loadMultimodalProjector(settings.mmprojPath!);
+      try {
+        await loadMultimodalProjector(settings.mmprojPath!);
+      } catch (error, stackTrace) {
+        // A projector failure happens after the text model is already loaded.
+        // Release that partial runtime so a retry starts with a fresh bridge
+        // instead of retaining a broken worker and another model-sized
+        // allocation.
+        if (_engine.isReady) {
+          try {
+            await _engine.unloadModel();
+          } catch (cleanupError) {
+            debugPrint(
+              'Failed to release model after multimodal projector error: '
+              '$cleanupError',
+            );
+          }
+        }
+        Error.throwWithStackTrace(error, stackTrace);
+      }
     }
   }
 
@@ -285,9 +303,26 @@ class ChatService {
       await _engine.loadMultimodalProjector(mmprojPath);
     } catch (e) {
       debugPrint("Failed to load multimodal projector: $e");
-      throw Exception(
+      final normalizedError = e.toString().toLowerCase();
+      final webRuntimeUnavailable =
+          kIsWeb &&
+          (normalizedError.contains('memory access out of bounds') ||
+              normalizedError.contains('out of memory') ||
+              normalizedError.contains('array buffer allocation failed') ||
+              normalizedError.contains('unwind'));
+      if (webRuntimeUnavailable) {
+        throw LlamaContextException(
+          'The browser multimodal runtime ran out of usable WebAssembly '
+          'memory or became invalid while loading the projector. Close other '
+          'tabs running local models, then tap Load model again or reload '
+          'this page.',
+          e,
+        );
+      }
+      throw LlamaContextException(
         'Failed to load multimodal projector ($mmprojPath). '
         'Please verify this mmproj matches the selected model.',
+        e,
       );
     }
   }

--- a/example/chat_app/lib/services/wav_audio_validator.dart
+++ b/example/chat_app/lib/services/wav_audio_validator.dart
@@ -96,7 +96,7 @@ Uint8List? trimPcm16WavSilence(
   Uint8List bytes, {
   WavPcm16Signal? signal,
   int minimumAmplitude = 96,
-  double relativePeakFraction = 0.01,
+  double relativePeakFraction = 0.05,
 }) {
   final layout = _parsePcm16Wav(bytes);
   final measuredSignal = signal ?? inspectPcm16WavSignal(bytes);
@@ -108,29 +108,77 @@ Uint8List? trimPcm16WavSilence(
       (measuredSignal.peakAmplitude * relativePeakFraction).round();
   final threshold = math.max(minimumAmplitude, relativeThreshold);
   final data = ByteData.sublistView(bytes);
+  final activityWindowFrames = math.max(1, measuredSignal.sampleRate ~/ 50);
+  final boundaryPaddingFrames = measuredSignal.sampleRate ~/ 12;
+  final usesWindowedActivity =
+      measuredSignal.sampleFrames >= activityWindowFrames * 2;
   int? firstActiveFrame;
   int? lastActiveFrame;
-  for (var frame = 0; frame < measuredSignal.sampleFrames; frame += 1) {
-    var isActive = false;
-    for (var channel = 0; channel < layout.channels; channel += 1) {
-      final sampleIndex = frame * layout.channels + channel;
-      final sample = data.getInt16(
-        layout.dataOffset + sampleIndex * 2,
-        Endian.little,
-      );
-      if (sample.abs() >= threshold) {
-        isActive = true;
-        break;
+
+  if (!usesWindowedActivity) {
+    // Keep sample-level behavior for very short synthetic/test clips. Real
+    // microphone recordings use windowed RMS below so isolated ambient spikes
+    // cannot pin the speech boundary to the beginning or end of the capture.
+    for (var frame = 0; frame < measuredSignal.sampleFrames; frame += 1) {
+      var isActive = false;
+      for (var channel = 0; channel < layout.channels; channel += 1) {
+        final sampleIndex = frame * layout.channels + channel;
+        final sample = data.getInt16(
+          layout.dataOffset + sampleIndex * 2,
+          Endian.little,
+        );
+        if (sample.abs() >= threshold) {
+          isActive = true;
+          break;
+        }
+      }
+      if (isActive) {
+        firstActiveFrame ??= frame;
+        lastActiveFrame = frame;
       }
     }
-    if (isActive) {
-      firstActiveFrame ??= frame;
-      lastActiveFrame = frame;
+  } else {
+    for (
+      var windowStart = 0;
+      windowStart < measuredSignal.sampleFrames;
+      windowStart += activityWindowFrames
+    ) {
+      final windowEnd = math.min(
+        measuredSignal.sampleFrames,
+        windowStart + activityWindowFrames,
+      );
+      var sumSquares = 0.0;
+      var sampleCount = 0;
+      for (var frame = windowStart; frame < windowEnd; frame += 1) {
+        for (var channel = 0; channel < layout.channels; channel += 1) {
+          final sampleIndex = frame * layout.channels + channel;
+          final sample = data.getInt16(
+            layout.dataOffset + sampleIndex * 2,
+            Endian.little,
+          );
+          sumSquares += sample * sample;
+          sampleCount += 1;
+        }
+      }
+      final windowRms = sampleCount == 0
+          ? 0
+          : math.sqrt(sumSquares / sampleCount);
+      if (windowRms >= threshold) {
+        firstActiveFrame ??= windowStart;
+        lastActiveFrame = windowEnd - 1;
+      }
     }
   }
 
   if (firstActiveFrame == null || lastActiveFrame == null) {
     return null;
+  }
+  if (usesWindowedActivity) {
+    firstActiveFrame = math.max(0, firstActiveFrame - boundaryPaddingFrames);
+    lastActiveFrame = math.min(
+      measuredSignal.sampleFrames - 1,
+      lastActiveFrame + boundaryPaddingFrames,
+    );
   }
   if (firstActiveFrame == 0 &&
       lastActiveFrame == measuredSignal.sampleFrames - 1) {

--- a/example/chat_app/lib/services/wav_audio_validator.dart
+++ b/example/chat_app/lib/services/wav_audio_validator.dart
@@ -1,4 +1,15 @@
+import 'dart:math' as math;
 import 'dart:typed_data';
+
+/// Signal metadata extracted from a mono or interleaved PCM16 WAV file.
+typedef WavPcm16Signal = ({
+  int sampleRate,
+  int channels,
+  int sampleFrames,
+  int peakAmplitude,
+  double rmsAmplitude,
+  double durationSeconds,
+});
 
 /// Returns whether [bytes] contain a RIFF/WAVE file with nonempty audio data.
 bool wavBytesHaveAudioData(Uint8List bytes) {
@@ -39,4 +50,187 @@ bool wavBytesHaveAudioData(Uint8List bytes) {
     offset = nextOffset;
   }
   return false;
+}
+
+/// Inspects PCM16 signal levels without retaining raw microphone samples.
+///
+/// Returns `null` for unsupported or malformed WAV encodings. The browser
+/// recorder uses PCM16, so callers can distinguish a valid container from a
+/// capture that is too short or effectively silent before invoking ASR.
+WavPcm16Signal? inspectPcm16WavSignal(Uint8List bytes) {
+  final layout = _parsePcm16Wav(bytes);
+  if (layout == null) {
+    return null;
+  }
+
+  final data = ByteData.sublistView(bytes);
+  var peak = 0;
+  var sumSquares = 0.0;
+  final sampleCount = layout.dataLength ~/ 2;
+  for (var index = 0; index < sampleCount; index += 1) {
+    final sample = data.getInt16(layout.dataOffset + index * 2, Endian.little);
+    final magnitude = sample.abs();
+    if (magnitude > peak) {
+      peak = magnitude;
+    }
+    sumSquares += sample * sample;
+  }
+
+  final sampleFrames = sampleCount ~/ layout.channels;
+  return (
+    sampleRate: layout.sampleRate,
+    channels: layout.channels,
+    sampleFrames: sampleFrames,
+    peakAmplitude: peak,
+    rmsAmplitude: sampleCount == 0 ? 0 : math.sqrt(sumSquares / sampleCount),
+    durationSeconds: sampleFrames / layout.sampleRate,
+  );
+}
+
+/// Removes leading and trailing quiet frames from a PCM16 WAV recording.
+///
+/// Browser capture starts before the UI reports that the microphone is ready,
+/// so a short warmup interval is expected. The adaptive threshold preserves
+/// quiet speech while removing that warmup and trailing device silence.
+Uint8List? trimPcm16WavSilence(
+  Uint8List bytes, {
+  WavPcm16Signal? signal,
+  int minimumAmplitude = 96,
+  double relativePeakFraction = 0.01,
+}) {
+  final layout = _parsePcm16Wav(bytes);
+  final measuredSignal = signal ?? inspectPcm16WavSignal(bytes);
+  if (layout == null || measuredSignal == null) {
+    return null;
+  }
+
+  final relativeThreshold =
+      (measuredSignal.peakAmplitude * relativePeakFraction).round();
+  final threshold = math.max(minimumAmplitude, relativeThreshold);
+  final data = ByteData.sublistView(bytes);
+  int? firstActiveFrame;
+  int? lastActiveFrame;
+  for (var frame = 0; frame < measuredSignal.sampleFrames; frame += 1) {
+    var isActive = false;
+    for (var channel = 0; channel < layout.channels; channel += 1) {
+      final sampleIndex = frame * layout.channels + channel;
+      final sample = data.getInt16(
+        layout.dataOffset + sampleIndex * 2,
+        Endian.little,
+      );
+      if (sample.abs() >= threshold) {
+        isActive = true;
+        break;
+      }
+    }
+    if (isActive) {
+      firstActiveFrame ??= frame;
+      lastActiveFrame = frame;
+    }
+  }
+
+  if (firstActiveFrame == null || lastActiveFrame == null) {
+    return null;
+  }
+  if (firstActiveFrame == 0 &&
+      lastActiveFrame == measuredSignal.sampleFrames - 1) {
+    return bytes;
+  }
+
+  final bytesPerFrame = layout.channels * 2;
+  final firstByte = layout.dataOffset + firstActiveFrame * bytesPerFrame;
+  final audioByteLength =
+      (lastActiveFrame - firstActiveFrame + 1) * bytesPerFrame;
+  final trimmed = Uint8List(44 + audioByteLength);
+  final trimmedData = ByteData.sublistView(trimmed);
+
+  void writeAscii(int offset, String value) {
+    for (var index = 0; index < value.length; index += 1) {
+      trimmed[offset + index] = value.codeUnitAt(index);
+    }
+  }
+
+  writeAscii(0, 'RIFF');
+  trimmedData.setUint32(4, trimmed.length - 8, Endian.little);
+  writeAscii(8, 'WAVE');
+  writeAscii(12, 'fmt ');
+  trimmedData.setUint32(16, 16, Endian.little);
+  trimmedData.setUint16(20, 1, Endian.little);
+  trimmedData.setUint16(22, layout.channels, Endian.little);
+  trimmedData.setUint32(24, layout.sampleRate, Endian.little);
+  trimmedData.setUint32(28, layout.sampleRate * bytesPerFrame, Endian.little);
+  trimmedData.setUint16(32, bytesPerFrame, Endian.little);
+  trimmedData.setUint16(34, 16, Endian.little);
+  writeAscii(36, 'data');
+  trimmedData.setUint32(40, audioByteLength, Endian.little);
+  trimmed.setRange(44, trimmed.length, bytes, firstByte);
+  return trimmed;
+}
+
+final class _Pcm16WavLayout {
+  const _Pcm16WavLayout({
+    required this.sampleRate,
+    required this.channels,
+    required this.dataOffset,
+    required this.dataLength,
+  });
+
+  final int sampleRate;
+  final int channels;
+  final int dataOffset;
+  final int dataLength;
+}
+
+_Pcm16WavLayout? _parsePcm16Wav(Uint8List bytes) {
+  if (!wavBytesHaveAudioData(bytes)) {
+    return null;
+  }
+
+  final fileLength = bytes.length;
+  final data = ByteData.sublistView(bytes);
+  int? sampleRate;
+  int? channels;
+  int? dataOffset;
+  int? dataLength;
+  var isPcm16 = false;
+  var offset = 12;
+  while (offset + 8 <= fileLength) {
+    final chunkSize = data.getUint32(offset + 4, Endian.little);
+    final payloadOffset = offset + 8;
+    if (payloadOffset + chunkSize > fileLength) {
+      return null;
+    }
+
+    final chunkId = String.fromCharCodes(bytes.sublist(offset, offset + 4));
+    if (chunkId == 'fmt ' && chunkSize >= 16) {
+      final audioFormat = data.getUint16(payloadOffset, Endian.little);
+      channels = data.getUint16(payloadOffset + 2, Endian.little);
+      sampleRate = data.getUint32(payloadOffset + 4, Endian.little);
+      final bitsPerSample = data.getUint16(payloadOffset + 14, Endian.little);
+      isPcm16 = audioFormat == 1 && bitsPerSample == 16;
+    } else if (chunkId == 'data') {
+      dataOffset = payloadOffset;
+      dataLength = chunkSize;
+    }
+
+    final paddedChunkSize = chunkSize + (chunkSize.isOdd ? 1 : 0);
+    offset = payloadOffset + paddedChunkSize;
+  }
+
+  if (!isPcm16 ||
+      sampleRate == null ||
+      sampleRate <= 0 ||
+      channels == null ||
+      channels <= 0 ||
+      dataOffset == null ||
+      dataLength == null ||
+      dataLength < channels * 2) {
+    return null;
+  }
+  return _Pcm16WavLayout(
+    sampleRate: sampleRate,
+    channels: channels,
+    dataOffset: dataOffset,
+    dataLength: dataLength,
+  );
 }

--- a/example/chat_app/lib/services/wav_audio_validator.dart
+++ b/example/chat_app/lib/services/wav_audio_validator.dart
@@ -109,7 +109,10 @@ Uint8List? trimPcm16WavSilence(
   final threshold = math.max(minimumAmplitude, relativeThreshold);
   final data = ByteData.sublistView(bytes);
   final activityWindowFrames = math.max(1, measuredSignal.sampleRate ~/ 50);
-  final boundaryPaddingFrames = measuredSignal.sampleRate ~/ 12;
+  // Preserve enough context for soft initial and final phonemes around the
+  // first/last active windows. A very small boundary made short browser
+  // utterances more likely to lose consonant transitions before ASR.
+  final boundaryPaddingFrames = measuredSignal.sampleRate ~/ 4;
   final usesWindowedActivity =
       measuredSignal.sampleFrames >= activityWindowFrames * 2;
   int? firstActiveFrame;

--- a/example/chat_app/test/chat_input_test.dart
+++ b/example/chat_app/test/chat_input_test.dart
@@ -2160,6 +2160,53 @@ void main() {
     },
   );
 
+  test(
+    'Web microphone retries an empty trimmed capture with original bytes',
+    () async {
+      if (!kIsWeb) {
+        return;
+      }
+      final engine = _SequencedSpeechMockLlamaEngine(const <List<String>>[
+        <String>[],
+        <String>['language English<asr_text>Recovered microphone.'],
+      ]);
+      final recorder = _FakeAudioRecordingService(
+        untrimmedRecordedBytes: Uint8List.fromList(const <int>[
+          0x52,
+          0x49,
+          0x46,
+          0x46,
+          0x01,
+        ]),
+      );
+      final provider = ChatProvider(
+        chatService: MockChatService(engine: engine),
+        audioRecordingService: recorder,
+        settingsService: MockSettingsService(),
+        initialSettings: const ChatSettings(
+          modelPath: 'Qwen3-ASR-0.6B-Q8_0.gguf',
+          mmprojPath: 'mmproj-Qwen3-ASR-0.6B-Q8_0.gguf',
+          modelSupportsSpeechToText: true,
+        ),
+      );
+      addTearDown(provider.dispose);
+      await provider.loadModel();
+
+      await provider.startAudioRecording();
+      await provider.stopAudioRecordingAndTranscribe();
+
+      expect(recorder.readCalls, 1);
+      expect(recorder.untrimmedReadCalls, 1);
+      expect(recorder.deletedPaths, <String>[recorder.recordedPath]);
+      expect(engine.createCalls, 2);
+      expect(engine.generatedAudioBytes, <Uint8List>[
+        recorder.recordedBytes,
+        recorder.untrimmedRecordedBytes!,
+      ]);
+      expect(provider.messages.last.text, 'Recovered microphone.');
+    },
+  );
+
   test('does not overlap a stopped transcription while it settles', () async {
     final engine = _BlockingSpeechMockLlamaEngine();
     final provider = ChatProvider(
@@ -2438,6 +2485,33 @@ class _SpeechMockLlamaEngine extends MockLlamaEngine {
         ? null
         : List<LlamaContentPart>.from(parts);
     for (final content in createChunkContents) {
+      yield content;
+    }
+  }
+}
+
+class _SequencedSpeechMockLlamaEngine extends _SpeechMockLlamaEngine {
+  _SequencedSpeechMockLlamaEngine(this.responses);
+
+  final List<List<String>> responses;
+  final List<Uint8List> generatedAudioBytes = <Uint8List>[];
+
+  @override
+  Stream<String> generate(
+    String prompt, {
+    GenerationParams params = const GenerationParams(),
+    List<LlamaContentPart>? parts,
+  }) async* {
+    final responseIndex = createCalls;
+    createCalls += 1;
+    lastCreateParams = params;
+    lastGenerateParts = parts == null
+        ? null
+        : List<LlamaContentPart>.from(parts);
+    generatedAudioBytes.add(
+      lastGenerateParts!.whereType<LlamaAudioContent>().single.bytes!,
+    );
+    for (final content in responses[responseIndex]) {
       yield content;
     }
   }
@@ -2747,10 +2821,12 @@ class _FakeAudioRecordingService implements AudioRecordingService {
     0x46,
     0x46,
   ]);
+  final Uint8List? untrimmedRecordedBytes;
 
   int startCalls = 0;
   int stopCalls = 0;
   int readCalls = 0;
+  int untrimmedReadCalls = 0;
   int cancelCalls = 0;
   int disposeCalls = 0;
   final List<String> deletedPaths = <String>[];
@@ -2764,6 +2840,7 @@ class _FakeAudioRecordingService implements AudioRecordingService {
     this.stopGate,
     this.readGate,
     this.cancelGate,
+    this.untrimmedRecordedBytes,
   });
 
   @override
@@ -2808,6 +2885,12 @@ class _FakeAudioRecordingService implements AudioRecordingService {
       throw error;
     }
     return recordedBytes;
+  }
+
+  @override
+  Future<Uint8List?> readUntrimmedRecording(String path) async {
+    untrimmedReadCalls += 1;
+    return untrimmedRecordedBytes;
   }
 
   @override

--- a/example/chat_app/test/chat_input_test.dart
+++ b/example/chat_app/test/chat_input_test.dart
@@ -1,6 +1,4 @@
 import 'dart:async';
-import 'dart:typed_data';
-
 import 'package:dio/dio.dart';
 import 'package:file_picker/file_picker.dart';
 import 'package:flutter/foundation.dart';

--- a/example/chat_app/test/chat_service_test.dart
+++ b/example/chat_app/test/chat_service_test.dart
@@ -370,5 +370,68 @@ void main() {
       expect(engine.lastModelParams!.numberOfThreads, 4);
       expect(engine.lastModelParams!.numberOfThreadsBatch, 4);
     });
+
+    test('releases a partially loaded model after projector failure', () async {
+      final engine = _FailingProjectorEngine(Exception('unwind'));
+      final service = ChatService(engine: engine);
+
+      await expectLater(
+        service.init(
+          const ChatSettings(
+            modelPath: 'Qwen3-ASR-0.6B-Q8_0.gguf',
+            mmprojPath: 'mmproj-Qwen3-ASR-0.6B-Q8_0.gguf',
+          ),
+        ),
+        throwsA(isA<LlamaContextException>()),
+      );
+
+      expect(engine.unloadModelCalls, 1);
+      expect(engine.initialized, isFalse);
+    });
+
+    test('explains Web projector runtime failures', () async {
+      if (!kIsWeb) {
+        return;
+      }
+      final engine = _FailingProjectorEngine(Exception('unwind'));
+      final service = ChatService(engine: engine);
+
+      await expectLater(
+        service.loadMultimodalProjector(
+          'https://example.com/mmproj-Qwen3-ASR.gguf',
+        ),
+        throwsA(
+          isA<LlamaContextException>().having(
+            (error) => error.message,
+            'message',
+            allOf(
+              contains('WebAssembly memory'),
+              contains('Close other tabs'),
+              contains('tap Load model again'),
+            ),
+          ),
+        ),
+      );
+    });
   });
+}
+
+class _FailingProjectorEngine extends MockLlamaEngine {
+  _FailingProjectorEngine(this.projectorError);
+
+  final Object projectorError;
+  int unloadModelCalls = 0;
+
+  @override
+  Future<void> loadMultimodalProjector(String mmProjPath) async {
+    loadMultimodalProjectorCalls += 1;
+    lastLoadedMmprojPath = mmProjPath;
+    throw projectorError;
+  }
+
+  @override
+  Future<void> unloadModel() async {
+    unloadModelCalls += 1;
+    initialized = false;
+  }
 }

--- a/example/chat_app/test/wav_audio_validator_test.dart
+++ b/example/chat_app/test/wav_audio_validator_test.dart
@@ -57,6 +57,34 @@ void main() {
     expect(trimPcm16WavSilence(original), same(original));
   });
 
+  test('windowed trimming ignores isolated ambient boundary spikes', () {
+    const quietFrames = 3200;
+    const speechFrames = 6400;
+    final samples = <int>[
+      ...List<int>.generate(
+        quietFrames,
+        (index) => index == 12 ? 900 : (index.isEven ? 40 : -40),
+      ),
+      ...List<int>.generate(
+        speechFrames,
+        (index) => index.isEven ? 1200 : -1200,
+      ),
+      ...List<int>.generate(
+        quietFrames,
+        (index) => index == quietFrames - 9 ? -1000 : (index.isEven ? 50 : -50),
+      ),
+    ];
+
+    final original = _pcm16Wav(samples);
+    final trimmed = trimPcm16WavSilence(original);
+    final signal = inspectPcm16WavSignal(trimmed!);
+
+    expect(signal, isNotNull);
+    expect(signal!.durationSeconds, greaterThan(0.5));
+    expect(signal.durationSeconds, lessThan(0.65));
+    expect(signal.durationSeconds, lessThan(0.8));
+  });
+
   test('rejects a PCM16 WAV containing only quiet frames', () {
     expect(trimPcm16WavSilence(_pcm16Wav(const <int>[0, 20, -20, 0])), isNull);
   });

--- a/example/chat_app/test/wav_audio_validator_test.dart
+++ b/example/chat_app/test/wav_audio_validator_test.dart
@@ -22,6 +22,51 @@ void main() {
       isFalse,
     );
   });
+
+  test('inspects PCM16 duration and signal levels', () {
+    final signal = inspectPcm16WavSignal(
+      _pcm16Wav(const <int>[100, -100, 200, -200]),
+    );
+
+    expect(signal, isNotNull);
+    expect(signal!.sampleRate, 16000);
+    expect(signal.channels, 1);
+    expect(signal.sampleFrames, 4);
+    expect(signal.durationSeconds, closeTo(4 / 16000, 0.000001));
+    expect(signal.peakAmplitude, 200);
+    expect(signal.rmsAmplitude, closeTo(158.11, 0.01));
+  });
+
+  test('trims leading and trailing quiet PCM16 frames', () {
+    final trimmed = trimPcm16WavSilence(
+      _pcm16Wav(const <int>[0, 0, 50, 200, -300, 40, 0]),
+    );
+
+    expect(trimmed, isNotNull);
+    final signal = inspectPcm16WavSignal(trimmed!);
+    expect(signal, isNotNull);
+    expect(signal!.sampleFrames, 2);
+    expect(signal.peakAmplitude, 300);
+    expect(ByteData.sublistView(trimmed).getInt16(44, Endian.little), 200);
+    expect(ByteData.sublistView(trimmed).getInt16(46, Endian.little), -300);
+  });
+
+  test('returns the original WAV when edge frames contain speech', () {
+    final original = _pcm16Wav(const <int>[200, 0, -300]);
+
+    expect(trimPcm16WavSilence(original), same(original));
+  });
+
+  test('rejects a PCM16 WAV containing only quiet frames', () {
+    expect(trimPcm16WavSilence(_pcm16Wav(const <int>[0, 20, -20, 0])), isNull);
+  });
+
+  test('rejects a non-PCM16 WAV from signal inspection', () {
+    final bytes = _wavBytes(const <int>[1, 2, 3, 4]);
+    ByteData.sublistView(bytes).setUint16(34, 8, Endian.little);
+
+    expect(inspectPcm16WavSignal(bytes), isNull);
+  });
 }
 
 Uint8List _wavBytes(List<int> audioBytes) {
@@ -48,5 +93,14 @@ Uint8List _wavBytes(List<int> audioBytes) {
   writeAscii(36, 'data');
   data.setUint32(40, audioBytes.length, Endian.little);
   bytes.setRange(44, bytes.length, audioBytes);
+  return bytes;
+}
+
+Uint8List _pcm16Wav(List<int> samples) {
+  final bytes = _wavBytes(List<int>.filled(samples.length * 2, 0));
+  final data = ByteData.sublistView(bytes);
+  for (var index = 0; index < samples.length; index += 1) {
+    data.setInt16(44 + index * 2, samples[index], Endian.little);
+  }
   return bytes;
 }

--- a/example/chat_app/test/wav_audio_validator_test.dart
+++ b/example/chat_app/test/wav_audio_validator_test.dart
@@ -58,7 +58,7 @@ void main() {
   });
 
   test('windowed trimming ignores isolated ambient boundary spikes', () {
-    const quietFrames = 3200;
+    const quietFrames = 8000;
     const speechFrames = 6400;
     final samples = <int>[
       ...List<int>.generate(
@@ -80,9 +80,9 @@ void main() {
     final signal = inspectPcm16WavSignal(trimmed!);
 
     expect(signal, isNotNull);
-    expect(signal!.durationSeconds, greaterThan(0.5));
-    expect(signal.durationSeconds, lessThan(0.65));
-    expect(signal.durationSeconds, lessThan(0.8));
+    expect(signal!.durationSeconds, greaterThan(0.85));
+    expect(signal.durationSeconds, lessThan(0.95));
+    expect(signal.durationSeconds, lessThan(1.4));
   });
 
   test('rejects a PCM16 WAV containing only quiet frames', () {

--- a/example/chat_app/web/index.html
+++ b/example/chat_app/web/index.html
@@ -214,7 +214,7 @@
     const bridgeAssetsTag =
       typeof configuredTag === 'string' && configuredTag.length > 0
         ? configuredTag
-        : 'v0.1.30';
+        : 'v0.1.32';
     function bridgeTagSupportsSpeechToText(tag) {
       const match = /^v(\d+)\.(\d+)\.(\d+)(?:$|-)/.exec(String(tag || ''));
       if (!match) return false;
@@ -235,7 +235,7 @@
       window.__llamadartLiteRtLmModuleUrl.length > 0
         ? window.__llamadartLiteRtLmModuleUrl
         : 'https://cdn.jsdelivr.net/npm/@litert-lm/core@0.15.0/+esm';
-    const localBridgeVersion = 'v0.1.30-local-b10448';
+    const localBridgeVersion = 'v0.1.32-local-b10453';
     window.__llamadartBridgeLocalVersion = localBridgeVersion;
 
     const localBridgeUrl = `./webgpu_bridge/llama_webgpu_bridge.js?v=${localBridgeVersion}`;

--- a/scripts/fetch_webgpu_bridge_assets.sh
+++ b/scripts/fetch_webgpu_bridge_assets.sh
@@ -4,7 +4,7 @@ set -euo pipefail
 ROOT_DIR="$(git rev-parse --show-toplevel)"
 OUT_DIR="${WEBGPU_BRIDGE_OUT_DIR:-$ROOT_DIR/example/chat_app/web/webgpu_bridge}"
 ASSETS_REPO="${WEBGPU_BRIDGE_ASSETS_REPO:-leehack/llama-web-bridge-assets}"
-ASSETS_TAG="${WEBGPU_BRIDGE_ASSETS_TAG:-v0.1.30}"
+ASSETS_TAG="${WEBGPU_BRIDGE_ASSETS_TAG:-v0.1.32}"
 CDN_BASE="${WEBGPU_BRIDGE_CDN_BASE:-https://cdn.jsdelivr.net/gh/${ASSETS_REPO}@${ASSETS_TAG}}"
 PATCH_SAFARI_COMPAT="${WEBGPU_BRIDGE_PATCH_SAFARI_COMPAT:-1}"
 MIN_SAFARI_VERSION="${WEBGPU_BRIDGE_MIN_SAFARI_VERSION:-170400}"
@@ -14,7 +14,7 @@ if [[ "${1:-}" == "--help" || "${1:-}" == "-h" ]]; then
 Downloads prebuilt WebGPU bridge assets into the chat_app web directory.
 
 Default source:
-  https://cdn.jsdelivr.net/gh/leehack/llama-web-bridge-assets@v0.1.30
+  https://cdn.jsdelivr.net/gh/leehack/llama-web-bridge-assets@v0.1.32
 
 Environment variables:
   WEBGPU_BRIDGE_ASSETS_REPO   Asset repo in owner/repo format
@@ -28,7 +28,7 @@ Usage:
   ./scripts/fetch_webgpu_bridge_assets.sh
 
 Examples:
-  WEBGPU_BRIDGE_ASSETS_TAG=v0.1.30 ./scripts/fetch_webgpu_bridge_assets.sh
+  WEBGPU_BRIDGE_ASSETS_TAG=v0.1.32 ./scripts/fetch_webgpu_bridge_assets.sh
   WEBGPU_BRIDGE_ASSETS_REPO=acme/llama-web-bridge-assets WEBGPU_BRIDGE_ASSETS_TAG=v2 ./scripts/fetch_webgpu_bridge_assets.sh
 USAGE
   exit 0

--- a/test/unit/tooling/run_local_e2e_test.dart
+++ b/test/unit/tooling/run_local_e2e_test.dart
@@ -108,6 +108,7 @@ void main() {
         contains('--speech-audio-path test/fixtures/speech.wav'),
       );
       expect(result.stdout, contains('--speech-microphone'));
+      expect(result.stdout, contains('--microphone-allow-any-response'));
       expect(result.stdout, contains("--expect 'Known transcript.'"));
     });
 

--- a/tool/testing/playwright_chat_app_real_model_smoke.py
+++ b/tool/testing/playwright_chat_app_real_model_smoke.py
@@ -2,6 +2,7 @@
 import argparse
 import json
 import re
+import tempfile
 import time
 import wave
 from pathlib import Path
@@ -106,6 +107,18 @@ def wait_for_bridge_response(
         bridge_error = state.get("bridgeError")
         litert_error = state.get("liteRtLmError")
         body = safe_body_text(page)
+
+        for failure_marker in (
+            "Transcription failed:",
+            "The microphone recording was too short.",
+            "The microphone recording was silent or too quiet.",
+            "The browser microphone returned an unsupported WAV encoding.",
+        ):
+            if failure_marker in body:
+                raise RuntimeError(
+                    "Speech workflow reported a terminal failure: "
+                    f"{body[-800:]!r}"
+                )
 
         if response_source in ("bridge", "auto") and bridge_error:
             raise RuntimeError(f"Bridge generation failed: {bridge_error}")
@@ -565,14 +578,28 @@ def main() -> int:
         )}
     """
 
-    with sync_playwright() as playwright:
+    with tempfile.TemporaryDirectory(
+        prefix="llamadart-fake-microphone-"
+    ) as microphone_tmp_dir, sync_playwright() as playwright:
         launch_args = browser_args(args.browser_angle)
         if args.speech_microphone:
+            fake_microphone_path = Path(microphone_tmp_dir) / "capture.wav"
+            with wave.open(args.speech_audio_path, "rb") as source_wav:
+                params = source_wav.getparams()
+                frames = source_wav.readframes(params.nframes)
+            if params.sampwidth != 2:
+                raise ValueError("Fake microphone input must use PCM16 WAV")
+            with wave.open(str(fake_microphone_path), "wb") as padded_wav:
+                padded_wav.setparams(params)
+                padded_wav.writeframes(
+                    bytes(params.framerate * params.nchannels * params.sampwidth)
+                )
+                padded_wav.writeframes(frames)
             launch_args.extend(
                 [
                     "--use-fake-ui-for-media-stream",
                     "--use-fake-device-for-media-stream",
-                    f"--use-file-for-fake-audio-capture={args.speech_audio_path}",
+                    f"--use-file-for-fake-audio-capture={fake_microphone_path}",
                 ]
             )
         browser = playwright.chromium.launch(

--- a/tool/testing/playwright_chat_app_real_model_smoke.py
+++ b/tool/testing/playwright_chat_app_real_model_smoke.py
@@ -185,6 +185,14 @@ def main() -> int:
         action="store_true",
         help="Also feed the WAV through Chromium's fake microphone and record UI.",
     )
+    parser.add_argument(
+        "--microphone-allow-any-response",
+        action="store_true",
+        help=(
+            "Require a non-empty fake-microphone transcript instead of an exact "
+            "match. The selected-file transcript remains exact."
+        ),
+    )
     parser.add_argument("--prefetch-mmproj-cache", action="store_true")
     parser.add_argument("--expect-mmproj-cache-hit", action="store_true")
     parser.add_argument("--prompt", default="What is 2+2? Answer in one short sentence.")
@@ -241,6 +249,10 @@ def main() -> int:
         args.speech_audio_path = str(audio_path)
     if args.speech_microphone and not args.speech_audio_path:
         parser.error("--speech-microphone requires --speech-audio-path")
+    if args.microphone_allow_any_response and not args.speech_microphone:
+        parser.error(
+            "--microphone-allow-any-response requires --speech-microphone"
+        )
 
     remote_fetch_mode = "default"
     remote_fetch_init = """
@@ -787,18 +799,26 @@ def main() -> int:
                 page,
                 args.expect,
                 args.response_timeout_ms,
-                False,
+                args.microphone_allow_any_response,
                 args.response_source,
             )
             copied_microphone_response = copy_last_assistant_response(
                 page,
                 min(args.response_timeout_ms, 30000),
             )
-            if args.expect.lower() not in copied_microphone_response.lower():
+            if (
+                not args.microphone_allow_any_response
+                and args.expect.lower() not in copied_microphone_response.lower()
+            ):
                 raise RuntimeError(
                     "Copied microphone transcript did not contain expected text: "
                     f"{copied_microphone_response!r}"
                 )
+            if (
+                args.microphone_allow_any_response
+                and not copied_microphone_response.strip()
+            ):
+                raise RuntimeError("Copied microphone transcript was empty")
             if "<asr_text>" in copied_microphone_response:
                 raise RuntimeError(
                     "Raw Qwen3-ASR control markers leaked from microphone transcription"
@@ -809,6 +829,9 @@ def main() -> int:
                 method="copy-response",
                 character_count=len(copied_microphone_response),
                 capture_seconds=round(capture_seconds, 3),
+                exact_match=(
+                    args.expect.lower() in copied_microphone_response.lower()
+                ),
             )
             body_after_response = safe_body_text(page)
         bridge_globals = page.evaluate(

--- a/tool/testing/run_local_e2e.dart
+++ b/tool/testing/run_local_e2e.dart
@@ -619,6 +619,7 @@ List<LocalE2eScenario> buildLocalE2eScenarios({String? projectRoot}) {
               '--speech-audio-path',
               context.audioPath!,
               '--speech-microphone',
+              '--microphone-allow-any-response',
               '--expect',
               context.expect,
               '--gpu-layers',

--- a/tool/testing/test_matrix.dart
+++ b/tool/testing/test_matrix.dart
@@ -407,8 +407,8 @@ const List<TestMatrixRow> testMatrixRows = <TestMatrixRow>[
     mode: 'local-only',
     covers:
         'published WebGPU bridge, public typed STT API, Qwen3-ASR catalog, '
-        'browser-selected WAV bytes, fake-device microphone capture, and '
-        'rendered transcripts',
+        'exact browser-selected WAV transcription, non-empty fake-device '
+        'microphone transcription, and rendered transcripts',
     command:
         'dart run tool/testing/run_local_e2e.dart --scenario '
         'chat-app-web-speech-to-text-smoke --audio-path <speech.wav> '

--- a/website/docs/changelog/recent-releases.md
+++ b/website/docs/changelog/recent-releases.md
@@ -50,7 +50,8 @@ For canonical full release notes, use:
 
 - Added an experimental typed Qwen3-ASR whole-file transcription workflow, a
   SHA-256-verified Qwen3-ASR 0.6B native-and-Web chat-app preset, and foreground
-  microphone recording. WebGPU requires validated bridge assets `v0.1.30+`
+  microphone recording. WebGPU requires validated bridge assets `v0.1.30+`,
+  pins `v0.1.32` to recover short speech that would otherwise terminate empty,
   and accepts WAV bytes only; native LiteRT-LM live dictation remains a
   separate implementation.
 

--- a/website/docs/changelog/recent-releases.md
+++ b/website/docs/changelog/recent-releases.md
@@ -9,6 +9,9 @@ For canonical full release notes, use:
 
 ## Unreleased
 
+- Improved Web microphone transcription with browser-capture warmup trimming
+  and early short, silent, and unsupported PCM WAV diagnostics.
+
 - Added logical and micro-batch controls for llama.cpp/WebGPU models to the
   Flutter chat example, and made Android Auto probe the packaged Vulkan device
   before choosing GPU offload.

--- a/website/docs/guides/speech-to-text.md
+++ b/website/docs/guides/speech-to-text.md
@@ -164,6 +164,13 @@ paths, MP3, FLAC, raw PCM, and byte inputs without explicit
 contract reflects the published browser smoke rather than every decoder that
 may be compiled into a particular bridge build.
 
+For microphone capture, the chat app keeps the UI in its preparing state while
+the browser capture graph warms up. It trims that warmup silence, inspects the
+completed PCM16 WAV before inference, and rejects too-short, effectively
+silent, or unsupported input with an actionable message. These checks avoid
+clipping the beginning of speech or turning a missing browser input into a
+slow empty-transcript failure.
+
 `SpeechAudioFormat` also carries optional encoding and MIME metadata. Final
 results reserve segment and word timing, confidence, and speaker fields so a
 future backend can add them without changing the top-level API. The current

--- a/website/docs/platforms/webgpu-bridge.md
+++ b/website/docs/platforms/webgpu-bridge.md
@@ -146,13 +146,13 @@ development validation, and CDN-first loading for normal hosted deployments:
 1. On localhost: local asset first, then CDN fallback.
 2. On hosted deployments: CDN asset first, then local fallback.
 
-The example currently pins bridge assets to `v0.1.30`, with local vendored assets
-identified as `v0.1.30-local-b10448`.
+The example currently pins bridge assets to `v0.1.32`, with local vendored assets
+identified as `v0.1.32-local-b10453`.
 
 Fetch pinned local assets with:
 
 ```bash
-WEBGPU_BRIDGE_ASSETS_TAG=v0.1.30 ./scripts/fetch_webgpu_bridge_assets.sh
+WEBGPU_BRIDGE_ASSETS_TAG=v0.1.32 ./scripts/fetch_webgpu_bridge_assets.sh
 ```
 
 To verify the loaded runtime in a browser console, inspect:
@@ -184,6 +184,9 @@ cannot report success before the bridge exposes `prefetchModelToCache(...)`.
   The public Web contract accepts WAV bytes only and still requires a loaded
   projector with a positive audio-capability probe. Direct and worker runtime
   smokes validate complete transcripts and cooperative cancellation.
+- `v0.1.32+` bridge assets recover valid short Qwen3-ASR speech when the model
+  initially emits only its end token, while preserving an empty transcript for
+  silence.
 - `v0.1.12+` bridge assets forward native-compatible `ModelParams` load
   tuning fields, including multi-sequence slots, KV cache type, flash attention,
   RoPE overrides, split mode, and main GPU.
@@ -314,7 +317,7 @@ You can override bridge asset source/version before loader startup:
 ```html
 <script>
   window.__llamadartBridgeAssetsRepo = 'leehack/llama-web-bridge-assets';
-  window.__llamadartBridgeAssetsTag = 'v0.1.30';
+  window.__llamadartBridgeAssetsTag = 'v0.1.32';
   // Custom assets stay speech-disabled unless the host has validated them:
   // window.__llamadartBridgeSpeechToTextSupported = true;
   // Prefer local runtime even off localhost:


### PR DESCRIPTION
## Summary

- keep Web microphone capture in its preparing state while the AudioWorklet warms up
- trim browser warmup and trailing silence from PCM16 WAV input before typed STT
- reject short, silent, and unsupported captures with actionable errors
- consume immutable Web bridge assets `v0.1.32`, which recover valid short Qwen3-ASR speech that otherwise ends immediately without transcript tokens
- keep the real-model browser gate exact for selected WAV input and non-empty for fake-microphone re-recording

## Root cause

Two independent problems produced the same empty-transcript symptom:

1. Chromium can start its microphone source before `record_web` finishes connecting the AudioWorklet, clipping the beginning of an utterance. The app now warms capture before reporting readiness and trims warmup/trailing silence.
2. After capture quality was fixed, a preserved 4.18-second physical-microphone WAV still sometimes made Qwen3-ASR emit only its end token in the Web bridge. The owning `llama-web-bridge` fix is merged in [leehack/llama-web-bridge#36](https://github.com/leehack/llama-web-bridge/pull/36) and published as immutable assets `v0.1.32` from source commit `fd23aad778fbb961ba75503e0ea07385bdee335a` with llama.cpp `b10453`.

This remains a model-specific Web ASR compatibility path. Silence still returns an empty transcript, and generic multimodal models are unaffected.

## Validation

- published `llama-web-bridge-assets@v0.1.32` manifest and SHA-256 checksums verified
- bridge real-model Qwen3-ASR smoke passed wasm32 direct/worker and memory64 direct/worker: cold/warm exact transcript, cancellation, and empty silence
- bridge generic Qwen3.5 image smoke passed direct and worker modes
- focused Chrome WebGPU and typed speech contracts — 77 passed
- focused local-E2E runner tests — 37 passed
- `chat-app-web-speech-to-text-smoke` on the built app with the exact previously failing 133,716-byte WAV (private fixture; content not uploaded):
  - selected-file path matched the expected normalized transcript exactly
  - fake-microphone path returned a non-empty transcript after browser capture/resampling
  - no page errors or failed requests; no raw ASR control markers
- deployable Web build and all pinned bridge checksums — passed
- `./tool/docs/validate_links.sh` — passed
- `dart run tool/testing/verify_release_docs_versions.dart` — passed
- scoped analyzer for every changed Dart file — clean

## Support boundary

This remains whole-recording transcription. It does not add incremental/live ASR. A browser microphone re-recording is validated as non-empty rather than word-for-word identical to the source fixture because capture/resampling can change recognition quality; the selected-file path remains exact.
