### PR TITLE
feat: add WebGPU text-to-speech

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -55,13 +55,15 @@
   with file or microphone speaker references, automatic playback, replay, and
   WAV save controls. Web accepts byte-backed speaker references and complete
   PCM/WAV output, with a bounded example-app utterance length for browser
-  stability; current LiteRT-LM artifacts fail explicitly as unsupported.
+  stability. The example pins bridge assets `v0.1.34`, which retry a failed
+  worker WebGPU synthesis once on CPU; current LiteRT-LM artifacts fail
+  explicitly as unsupported.
 
 * Added an experimental typed `SpeechToTextEngine` with an explicit Qwen3-ASR
   adapter profile for whole-file llama.cpp transcription. The Flutter chat
   example includes a SHA-256-verified Qwen3-ASR 0.6B preset plus separate
   **Transcribe Audio** and foreground microphone recording flows on native and
-  WebGPU. Web requires validated bridge assets `v0.1.30+`, pins `v0.1.33` (with
+  WebGPU. Web requires validated bridge assets `v0.1.30+`, pins `v0.1.34` (with
   the short-speech recovery introduced in `v0.1.32`) to
   recover short speech that would otherwise terminate empty, accepts WAV bytes
   only, and remains separate from native LiteRT-LM live dictation. The native

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -47,19 +47,21 @@
   completed model card's viewport position when downloads reorder the catalog,
   and stopped streaming responses from pulling users away from chat history.
 
-* Added an experimental typed `TextToSpeechEngine` for native llama.cpp
-  Qwen3-TTS models, with capability discovery, language and optional speaker
+* Added an experimental typed `TextToSpeechEngine` for native llama.cpp and
+  WebGPU bridge assets `v0.1.33+` with Qwen3-TTS models, including capability
+  discovery, language and optional speaker
   reference input, cancellable progress, complete 24 kHz PCM output, and WAV
   encoding. The Flutter chat example adds a checksum-pinned Qwen3-TTS preset
   with file or microphone speaker references, automatic playback, replay, and
-  WAV save controls; Web and the current LiteRT-LM artifacts fail explicitly
-  as unsupported.
+  WAV save controls. Web accepts byte-backed speaker references and complete
+  PCM/WAV output; current LiteRT-LM artifacts fail explicitly as unsupported.
 
 * Added an experimental typed `SpeechToTextEngine` with an explicit Qwen3-ASR
   adapter profile for whole-file llama.cpp transcription. The Flutter chat
   example includes a SHA-256-verified Qwen3-ASR 0.6B preset plus separate
   **Transcribe Audio** and foreground microphone recording flows on native and
-  WebGPU. Web requires validated bridge assets `v0.1.30+`, pins `v0.1.32` to
+  WebGPU. Web requires validated bridge assets `v0.1.30+`, pins `v0.1.33` (with
+  the short-speech recovery introduced in `v0.1.32`) to
   recover short speech that would otherwise terminate empty, accepts WAV bytes
   only, and remains separate from native LiteRT-LM live dictation. The native
   flow has been exercised on a physical Pixel with CPU inference and in the

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -54,7 +54,8 @@
   encoding. The Flutter chat example adds a checksum-pinned Qwen3-TTS preset
   with file or microphone speaker references, automatic playback, replay, and
   WAV save controls. Web accepts byte-backed speaker references and complete
-  PCM/WAV output; current LiteRT-LM artifacts fail explicitly as unsupported.
+  PCM/WAV output, with a bounded example-app utterance length for browser
+  stability; current LiteRT-LM artifacts fail explicitly as unsupported.
 
 * Added an experimental typed `SpeechToTextEngine` with an explicit Qwen3-ASR
   adapter profile for whole-file llama.cpp transcription. The Flutter chat

--- a/doc/testing_matrix.md
+++ b/doc/testing_matrix.md
@@ -68,12 +68,12 @@ Pick targeted rows based on the touched surface:
 | Chat template, parser, tools, thinking extraction | `template-parity`, `llama-cpp-chat-template-smoke`, `gguf-chat-features-smoke`, `litert-lm-chat-features-smoke` |
 | LiteRT-LM native backend | `litert-lm-engine-smoke`, `litert-lm-chat-features-smoke`, `litert-lm-asr-smoke` |
 | Web bridge bootstrap or interop | `web-bridge-smoke`, `web-mock-chat-smoke`, `web-real-model-smoke` |
-| WebGPU multimodal | `webgpu-multimodal-regression`, plus `web-speech-to-text-smoke` for typed Qwen3-ASR |
+| WebGPU multimodal | `webgpu-multimodal-regression`, plus `web-speech-to-text-smoke` for typed Qwen3-ASR and `web-text-to-speech-smoke` for typed Qwen3-TTS |
 | Large WebGPU GGUF / wasm64 selection | `gemma4-webgpu-mem64` |
 | LiteRT-LM web / Gemma 4 web bundle | `gemma4-litert-web` |
 | Chat app model cache/download/projector | `chat-app-device-cache` |
 | Speech-to-text API or adapter | `speech-to-text-smoke`, `web-speech-to-text-smoke`, plus `litert-lm-asr-smoke` for the dedicated LiteRT-LM streaming engine |
-| Text-to-speech API or adapter | `text-to-speech-smoke` |
+| Text-to-speech API or adapter | `text-to-speech-smoke`, plus `web-text-to-speech-smoke` for browser synthesis/playback/export |
 | Chat-app microphone transcription flow | `chat-app-microphone-transcription-smoke` |
 | Chat-app live LiteRT-LM dictation | `litert-lm-asr-smoke`, `chat-app-live-speech-smoke` |
 | Chat-app Ask with voice | `gguf-audio-chat-smoke`, `litert-lm-chat-features-smoke`, `chat-app-voice-question-smoke` |
@@ -92,7 +92,7 @@ The matrix is designed to cover these essential axes:
 | Axis | Covered by |
 | --- | --- |
 | llama.cpp native GGUF | `root-vm`, `native-prompt-reuse-parity`, `native-inference-benchmark`, `gguf-chat-features-smoke`, `gguf-audio-chat-smoke` |
-| llama.cpp WebGPU GGUF | `web-bridge-smoke`, `web-mock-chat-smoke`, `web-real-model-smoke`, `webgpu-multimodal-regression`, `web-speech-to-text-smoke`, `gemma4-webgpu-mem64` |
+| llama.cpp WebGPU GGUF | `web-bridge-smoke`, `web-mock-chat-smoke`, `web-real-model-smoke`, `webgpu-multimodal-regression`, `web-speech-to-text-smoke`, `web-text-to-speech-smoke`, `gemma4-webgpu-mem64` |
 | LiteRT-LM native `.litertlm` | `litert-lm-engine-smoke`, `litert-lm-chat-features-smoke`, `native-hook-bundles` |
 | LiteRT-LM web `.litertlm` | `gemma4-litert-web` |
 | Model families | Qwen 2.5 prompt reuse, Qwen 3/3.5 chat/multimodal, Gemma 4 tool/thinking/mem64/LiteRT-LM/audio |
@@ -190,6 +190,10 @@ dart run tool/testing/run_local_e2e.dart \
 dart run tool/testing/run_local_e2e.dart --scenario text-to-speech-smoke \
   --model-path /path/to/Qwen3-TTS-12Hz-1.7B-Base-Q4_K_M.gguf \
   --mmproj-path /path/to/mmproj-Qwen3-TTS-12Hz-1.7B-Base-Q8_0.gguf
+
+dart run tool/testing/run_local_e2e.dart \
+  --scenario chat-app-web-text-to-speech-smoke \
+  [--audio-path /path/to/speaker-reference.wav]
 
 dart run tool/testing/run_local_e2e.dart --scenario chat-app-web-mock-smoke
 

--- a/example/chat_app/README.md
+++ b/example/chat_app/README.md
@@ -26,7 +26,7 @@ A Flutter chat application demonstrating real-world usage of llamadart with UI.
 - 🗣️ **Ask with voice**: Compatible native direct-media models or GGUF models
   with an audio-capable projector can receive a short microphone recording as
   ordinary multimodal chat and answer the request after **Stop & ask**.
-- 🔊 **Text to speech**: The native-desktop Qwen3-TTS preset switches the
+- 🔊 **Text to speech**: The cross-platform Qwen3-TTS preset switches the
   composer into a dedicated synthesis mode with language, optional speaker
   reference, cancellation, playback, and WAV export.
 - 📱 Material Design 3 UI
@@ -88,8 +88,8 @@ flutter test --run-skipped -t local-only \
 2. Select one of the focused pre-configured models:
    - Cross-platform: FunctionGemma 270M, Qwen3.5 0.8B, Gemma 4 E2B
      GGUF, Gemma 4 E2B LiteRT-LM, and Gemma 4 E4B GGUF.
-   - Native and Web: Qwen3-ASR 0.6B.
-   - Native desktop: Qwen3-TTS 1.7B Base, Gemma 4 12B, Gemma 4 26B A4B,
+   - Native and Web: Qwen3-ASR 0.6B and Qwen3-TTS 1.7B Base.
+   - Native desktop: Gemma 4 12B, Gemma 4 26B A4B,
      Gemma 4 31B, and Qwen3.6 35B A3B.
    - Built-in GGUF chat presets use [Unsloth distributions](https://huggingface.co/unsloth).
      The speech presets use llama.cpp's `ggml-org` Qwen3-ASR and Qwen3-TTS
@@ -139,15 +139,18 @@ flutter test --run-skipped -t local-only \
      All STT actions require the matching projector and a positive runtime
      audio probe. The preset's native and Web sources use immutable revisions,
      exact sizes, and SHA-256 metadata.
-   - The native-desktop Qwen3-TTS preset uses a separate typed synthesis flow,
+   - The cross-platform Qwen3-TTS preset uses a separate typed synthesis flow,
      not chat generation. Enter text, optionally select a language and choose
      or record a speaker reference, then synthesize. The app reports generation
      progress, automatically plays the completed 24 kHz mono output, and lets
      you stop, replay, or save it as WAV. Recorded references are read into
-     memory and their temporary WAV files are best-effort deleted. The matching
-     model/projector downloads are immutable and SHA-256 verified.
-     Current output is complete-buffer only, not streaming playback. Web,
-     LiteRT-LM, and automatic read-aloud of chat responses remain unsupported.
+     memory and their temporary WAV files are best-effort deleted. Web accepts
+     selected speaker-reference files as bytes but does not record speaker
+     references. The matching model/projector downloads are immutable and
+     SHA-256 verified. Current output is complete-buffer only, not streaming
+     playback. Web requires bridge assets `v0.1.33+` and memory64 for the roughly
+     1.48 GB pair. LiteRT-LM and automatic read-aloud of chat responses remain
+     unsupported.
    - Microphone capture is enabled on Android, iOS, macOS, Windows, and secure
      browser origins when a compatible ASR model is active and WAV recording is
      supported. It remains hidden on Linux because the recorder plugin can

--- a/example/chat_app/README.md
+++ b/example/chat_app/README.md
@@ -149,8 +149,10 @@ flutter test --run-skipped -t local-only \
      references. The matching model/projector downloads are immutable and
      SHA-256 verified. Current output is complete-buffer only, not streaming
      playback. Web requires bridge assets `v0.1.33+` and memory64 for the roughly
-     1.48 GB pair. LiteRT-LM and automatic read-aloud of chat responses remain
-     unsupported.
+     1.48 GB pair. To bound browser memory and generation time, the Web example
+     limits one utterance to 96 codec frames (about 7.7 seconds) and labels
+     output that reaches the limit; short sentences are recommended. LiteRT-LM
+     and automatic read-aloud of chat responses remain unsupported.
    - Microphone capture is enabled on Android, iOS, macOS, Windows, and secure
      browser origins when a compatible ASR model is active and WAV recording is
      supported. It remains hidden on Linux because the recorder plugin can

--- a/example/chat_app/lib/models/downloadable_model.dart
+++ b/example/chat_app/lib/models/downloadable_model.dart
@@ -529,11 +529,28 @@ class DownloadableModel {
         sha256:
             '6fd65188839bcd6ecc91b277ad471e22a0edfada4699a0fe82f1165c18cfcce2',
       ),
+      webModelSource: const RemoteModelAssetSource(
+        url:
+            'https://huggingface.co/ggml-org/Qwen3-TTS-12Hz-1.7B-Base-GGUF/resolve/ca27d74bc954b73dadab5b71ca265d87fc861a7c/Qwen3-TTS-12Hz-1.7B-Base-Q4_K_M.gguf',
+        filename: 'Qwen3-TTS-12Hz-1.7B-Base-Q4_K_M.gguf',
+        sizeBytes: 1035965280,
+        sha256:
+            '8d18c94acb2addd042f97da63c98be144eafa76d0d9495177eab65130cf85129',
+      ),
+      webMultimodalProjectorSource: const RemoteModelAssetSource(
+        url:
+            'https://huggingface.co/ggml-org/Qwen3-TTS-12Hz-1.7B-Base-GGUF/resolve/ca27d74bc954b73dadab5b71ca265d87fc861a7c/mmproj-Qwen3-TTS-12Hz-1.7B-Base-Q8_0.gguf',
+        filename: 'mmproj-Qwen3-TTS-12Hz-1.7B-Base-Q8_0.gguf',
+        sizeBytes: 446422912,
+        sha256:
+            '6fd65188839bcd6ecc91b277ad471e22a0edfada4699a0fe82f1165c18cfcce2',
+      ),
       sizeBytes: 1482388192,
+      webSizeBytes: 1482388192,
       supportsTextToSpeech: true,
-      webSupportsTextToSpeech: false,
+      webSupportsTextToSpeech: true,
       distribution: 'ggml-org',
-      availability: ModelAvailability.nativeDesktop,
+      availability: ModelAvailability.all,
       minRamGb: 6,
       preset: const ModelPreset(
         temperature: 0.8,

--- a/example/chat_app/lib/providers/chat_provider.dart
+++ b/example/chat_app/lib/providers/chat_provider.dart
@@ -105,6 +105,7 @@ class ChatProvider extends ChangeNotifier {
     milliseconds: 220,
   );
   static const int _multimodalMaxImageEdge = 384;
+  static const int _webTextToSpeechMaxFrames = 96;
 
   /// The maximum microphone recording length before automatic transcription.
   static const Duration maxAudioRecordingDuration = Duration(minutes: 5);
@@ -3701,7 +3702,12 @@ class ChatProvider extends ChangeNotifier {
               ? null
               : language!.trim(),
           speakerReference: speakerReference,
-          maxFrames: _settings.maxTokens.clamp(1, 4096).toInt(),
+          maxFrames: kIsWeb
+              ? math.min(
+                  _settings.maxTokens.clamp(1, 4096).toInt(),
+                  _webTextToSpeechMaxFrames,
+                )
+              : _settings.maxTokens.clamp(1, 4096).toInt(),
           topK: _settings.topK.clamp(1, 1000).toInt(),
           topP: _settings.topP.clamp(0.000001, 1).toDouble(),
           minP: _settings.minP.clamp(0, 1).toDouble(),
@@ -3755,7 +3761,7 @@ class ChatProvider extends ChangeNotifier {
       if (_textToSpeechContextMatches(context)) {
         _textToSpeechError = error is LlamaUnsupportedException
             ? error.message
-            : 'Speech synthesis failed: ${_formatDisplayError(error)}';
+            : _formatTextToSpeechError(error);
       }
       return false;
     } finally {
@@ -3785,6 +3791,16 @@ class ChatProvider extends ChangeNotifier {
         }
       }
     }
+  }
+
+  String _formatTextToSpeechError(Object error) {
+    final displayError = _formatDisplayError(error);
+    if (kIsWeb && displayError.contains('Aborted()')) {
+      return 'WebGPU speech synthesis stopped, usually because the browser '
+          'lost its GPU device or ran out of memory. Close other GPU-heavy '
+          'tabs, reload the model, and retry a shorter sentence.';
+    }
+    return 'Speech synthesis failed: $displayError';
   }
 
   /// Cancels an active text-to-speech task.

--- a/example/chat_app/lib/providers/chat_provider.dart
+++ b/example/chat_app/lib/providers/chat_provider.dart
@@ -395,8 +395,7 @@ class ChatProvider extends ChangeNotifier {
       _settings.modelSupportsSpeechToText;
 
   /// Whether the selected profile exposes the dedicated synthesis experience.
-  bool get supportsTextToSpeech =>
-      !kIsWeb && _settings.modelSupportsTextToSpeech;
+  bool get supportsTextToSpeech => _settings.modelSupportsTextToSpeech;
 
   /// Whether a new utterance can be synthesized now.
   bool get canSynthesizeSpeech =>
@@ -3659,8 +3658,8 @@ class ChatProvider extends ChangeNotifier {
 
   /// Synthesizes [text] with the selected dedicated text-to-speech model.
   ///
-  /// The current native runtime reports progress while generating, then makes
-  /// one complete PCM buffer available for playback or WAV export.
+  /// The active runtime reports progress while generating, then makes one
+  /// complete PCM buffer available for playback or WAV export.
   Future<bool> synthesizeSpeech(
     String text, {
     String? language,

--- a/example/chat_app/lib/providers/chat_provider.dart
+++ b/example/chat_app/lib/providers/chat_provider.dart
@@ -329,7 +329,7 @@ class ChatProvider extends ChangeNotifier {
   /// Latest complete synthesized audio for the active conversation and model.
   TextToSpeechResult? get textToSpeechResult => _textToSpeechResult;
 
-  /// Latest synthesis progress reported by the native runtime.
+  /// Latest synthesis progress reported by the active runtime.
   TextToSpeechProgressEvent? get textToSpeechProgress => _textToSpeechProgress;
 
   /// Latest actionable text-to-speech failure.

--- a/example/chat_app/lib/widgets/chat_input.dart
+++ b/example/chat_app/lib/widgets/chat_input.dart
@@ -13,6 +13,27 @@ import '../services/clipboard_attachment_service.dart';
 import '../services/speech_playback_service.dart';
 import 'tool_declarations_dialog.dart';
 
+/// Converts a picker result into the audio input supported by the platform.
+@visibleForTesting
+SpeechAudioInput? speechAudioInputFromPickedFile(
+  PlatformFile file, {
+  required bool isWeb,
+}) {
+  final path = file.path;
+  final bytes = file.bytes;
+  if (isWeb) {
+    return bytes != null && bytes.isNotEmpty
+        ? SpeechAudioBytesInput(bytes)
+        : null;
+  }
+  if (path != null && path.isNotEmpty) {
+    return SpeechAudioFileInput(path);
+  }
+  return bytes != null && bytes.isNotEmpty
+      ? SpeechAudioBytesInput(bytes)
+      : null;
+}
+
 class ChatInput extends StatefulWidget {
   final VoidCallback onSend;
   final TextEditingController controller;
@@ -276,13 +297,7 @@ class _ChatInputState extends State<ChatInput> {
         return;
       }
       final file = selection.files.single;
-      final path = file.path;
-      final bytes = file.bytes;
-      final SpeechAudioInput? input = path != null && path.isNotEmpty
-          ? SpeechAudioFileInput(path)
-          : bytes != null && bytes.isNotEmpty
-          ? SpeechAudioBytesInput(bytes)
-          : null;
+      final input = speechAudioInputFromPickedFile(file, isWeb: kIsWeb);
       if (input == null) {
         _showMessage('Could not read the selected speaker reference.');
         return;
@@ -739,6 +754,22 @@ class _ChatInputState extends State<ChatInput> {
     final recordedReference = provider.recordedSpeakerReference;
     final hasSpeakerReference =
         recordedReference != null || _speakerReference != null;
+    final speakerReferenceLabel = recordedReference != null
+        ? 'Recorded reference'
+        : _speakerReferenceName ?? 'Add speaker reference';
+    final VoidCallback? pickSpeakerReference = controlsEnabled
+        ? () => unawaited(_pickSpeakerReference())
+        : null;
+    final VoidCallback? clearSpeakerReference =
+        hasSpeakerReference && controlsEnabled
+        ? () {
+            setState(() {
+              _speakerReference = null;
+              _speakerReferenceName = null;
+            });
+            provider.clearRecordedSpeakerReference();
+          }
+        : null;
     const languages = <String>[
       'Auto',
       'English',
@@ -808,26 +839,23 @@ class _ChatInputState extends State<ChatInput> {
                   label: Text(_textToSpeechLanguage ?? 'Auto language'),
                 ),
               ),
-              InputChip(
-                key: const ValueKey<String>('speaker_reference_chip'),
-                avatar: const Icon(Icons.record_voice_over_outlined, size: 17),
-                label: Text(
-                  recordedReference != null
-                      ? 'Recorded reference'
-                      : _speakerReferenceName ?? 'Add speaker reference',
+              Semantics(
+                button: true,
+                label: speakerReferenceLabel,
+                enabled: controlsEnabled,
+                onTap: pickSpeakerReference,
+                onDismiss: clearSpeakerReference,
+                excludeSemantics: true,
+                child: InputChip(
+                  key: const ValueKey<String>('speaker_reference_chip'),
+                  avatar: const Icon(
+                    Icons.record_voice_over_outlined,
+                    size: 17,
+                  ),
+                  label: Text(speakerReferenceLabel),
+                  onPressed: pickSpeakerReference,
+                  onDeleted: clearSpeakerReference,
                 ),
-                onPressed: !controlsEnabled
-                    ? null
-                    : () => unawaited(_pickSpeakerReference()),
-                onDeleted: !hasSpeakerReference || !controlsEnabled
-                    ? null
-                    : () {
-                        setState(() {
-                          _speakerReference = null;
-                          _speakerReferenceName = null;
-                        });
-                        provider.clearRecordedSpeakerReference();
-                      },
               ),
               if (provider.supportsSpeakerReferenceRecording)
                 ActionChip(

--- a/example/chat_app/lib/widgets/chat_input.dart
+++ b/example/chat_app/lib/widgets/chat_input.dart
@@ -916,7 +916,8 @@ class _ChatInputState extends State<ChatInput> {
                   child: Text(
                     'Speech ready · $durationLabel · '
                     '${result!.sampleRateHz ~/ 1000} kHz '
-                    '${result.channelCount == 1 ? 'mono' : '${result.channelCount} channel'} WAV',
+                    '${result.channelCount == 1 ? 'mono' : '${result.channelCount} channel'} WAV'
+                    '${result.truncated ? ' · length limit reached' : ''}',
                     style: const TextStyle(fontWeight: FontWeight.w600),
                   ),
                 ),

--- a/example/chat_app/test/chat_input_test.dart
+++ b/example/chat_app/test/chat_input_test.dart
@@ -691,6 +691,7 @@ void main() {
       find.byKey(const ValueKey<String>('text_to_speech_options')),
       findsOneWidget,
     );
+    expect(find.bySemanticsLabel('Add speaker reference'), findsOneWidget);
     expect(find.text('Enter text to speak…'), findsOneWidget);
 
     await tester.enterText(find.byType(TextField), 'Hello from TTS.');
@@ -719,6 +720,22 @@ void main() {
       find.byKey(const ValueKey<String>('save_synthesized_speech_button')),
       findsOneWidget,
     );
+  });
+
+  test('Web speaker reference picker prefers bytes over its blob URL', () {
+    final speakerBytes = Uint8List.fromList(const <int>[1, 2, 3, 4]);
+    final input = speechAudioInputFromPickedFile(
+      PlatformFile(
+        name: 'speaker.wav',
+        path: 'blob:https://example.test/speaker',
+        size: speakerBytes.length,
+        bytes: speakerBytes,
+      ),
+      isWeb: true,
+    );
+
+    expect(input, isA<SpeechAudioBytesInput>());
+    expect((input as SpeechAudioBytesInput).bytes, speakerBytes);
   });
 
   testWidgets('records and uses a TTS speaker reference', (tester) async {

--- a/example/chat_app/test/chat_input_test.dart
+++ b/example/chat_app/test/chat_input_test.dart
@@ -722,6 +722,38 @@ void main() {
     );
   });
 
+  testWidgets('dedicated TTS mode labels length-limited output', (
+    tester,
+  ) async {
+    final provider = _ReadyTextToSpeechProvider(truncated: true);
+    addTearDown(provider.dispose);
+    final controller = TextEditingController(text: 'A longer utterance.');
+    final focusNode = FocusNode();
+    final playback = _FakeSpeechPlaybackService();
+    addTearDown(controller.dispose);
+    addTearDown(focusNode.dispose);
+
+    await tester.pumpWidget(
+      ChangeNotifierProvider<ChatProvider>.value(
+        value: provider,
+        child: MaterialApp(
+          home: Scaffold(
+            body: ChatInput(
+              controller: controller,
+              focusNode: focusNode,
+              speechPlaybackService: playback,
+              onSend: () {},
+            ),
+          ),
+        ),
+      ),
+    );
+    await tester.tap(find.byTooltip('Synthesize speech'));
+    await tester.pumpAndSettle();
+
+    expect(find.textContaining('length limit reached'), findsOneWidget);
+  });
+
   test('Web speaker reference picker prefers bytes over its blob URL', () {
     final speakerBytes = Uint8List.fromList(const <int>[1, 2, 3, 4]);
     final input = speechAudioInputFromPickedFile(
@@ -2436,7 +2468,7 @@ class _BusyVoiceProvider extends _GeneratingReadyProvider {
 }
 
 class _ReadyTextToSpeechProvider extends ChatProvider {
-  _ReadyTextToSpeechProvider()
+  _ReadyTextToSpeechProvider({this.truncated = false})
     : super(
         chatService: MockChatService(),
         settingsService: MockSettingsService(),
@@ -2449,6 +2481,7 @@ class _ReadyTextToSpeechProvider extends ChatProvider {
 
   String? synthesizedText;
   TextToSpeechResult? _result;
+  final bool truncated;
 
   @override
   bool get isGenerating => false;
@@ -2477,7 +2510,7 @@ class _ReadyTextToSpeechProvider extends ChatProvider {
       sampleRateHz: 24000,
       channelCount: 1,
       framesGenerated: 2,
-      truncated: false,
+      truncated: truncated,
     );
     notifyListeners();
     return true;

--- a/example/chat_app/test/unit_test.dart
+++ b/example/chat_app/test/unit_test.dart
@@ -760,6 +760,33 @@ void main() {
       expect(mockEngine.lastTextToSpeechRequest?.speakerAudioBytes, [1, 2, 3]);
       expect(mockEngine.lastTextToSpeechRequest?.topK, 40);
       expect(mockEngine.lastTextToSpeechRequest?.topP, 0.95);
+      expect(mockEngine.lastTextToSpeechRequest?.maxFrames, kIsWeb ? 96 : 512);
+    });
+
+    test('Web TTS abort reports an actionable recovery message', () async {
+      final ttsProvider = ChatProvider(
+        chatService: mockChatService,
+        settingsService: mockSettingsService,
+        initialSettings: const ChatSettings(
+          modelPath: 'qwen3-tts.gguf',
+          mmprojPath: 'qwen3-tts-mmproj.gguf',
+          modelSupportsTextToSpeech: true,
+        ),
+      );
+      addTearDown(ttsProvider.dispose);
+      await ttsProvider.loadModel();
+      final resultCompleter = Completer<BackendTextToSpeechResult>();
+      mockEngine.textToSpeechResultCompleter = resultCompleter;
+
+      final pending = ttsProvider.synthesizeSpeech('Hello.');
+      await Future<void>.delayed(Duration.zero);
+      resultCompleter.completeError(Exception('Aborted().'));
+
+      expect(await pending, isFalse);
+      expect(
+        ttsProvider.textToSpeechError,
+        kIsWeb ? contains('Close other GPU-heavy tabs') : contains('Aborted()'),
+      );
     });
 
     test(

--- a/example/chat_app/test/unit_test.dart
+++ b/example/chat_app/test/unit_test.dart
@@ -1701,13 +1701,17 @@ void main() {
       final modelSource = model.modelSource as RemoteModelAssetSource;
       final projectorSource =
           model.multimodalProjectorSource as RemoteModelAssetSource;
+      final webModelSource = model.webModelSource as RemoteModelAssetSource;
+      final webProjectorSource =
+          model.webMultimodalProjectorSource as RemoteModelAssetSource;
 
       expect(model.supportsTextToSpeechFor(web: false), isTrue);
-      expect(model.supportsTextToSpeechFor(web: true), isFalse);
+      expect(model.supportsTextToSpeechFor(web: true), isTrue);
       expect(model.supportsAudio, isFalse);
       expect(model.supportsSpeechToText, isFalse);
-      expect(model.isNativeDesktopOnly, isTrue);
+      expect(model.availability, ModelAvailability.all);
       expect(model.sizeBytesFor(web: false), 1482388192);
+      expect(model.sizeBytesFor(web: true), 1482388192);
       expect(model.preset.temperature, 0.8);
       expect(model.preset.topK, 40);
       expect(model.preset.topP, 0.95);
@@ -1730,6 +1734,14 @@ void main() {
         projectorSource.url,
         contains('ca27d74bc954b73dadab5b71ca265d87fc861a7c'),
       );
+      expect(webModelSource.url, isNot(contains('?download=true')));
+      expect(webModelSource.filename, modelSource.filename);
+      expect(webModelSource.sizeBytes, modelSource.sizeBytes);
+      expect(webModelSource.sha256, modelSource.sha256);
+      expect(webProjectorSource.url, isNot(contains('?download=true')));
+      expect(webProjectorSource.filename, projectorSource.filename);
+      expect(webProjectorSource.sizeBytes, projectorSource.sizeBytes);
+      expect(webProjectorSource.sha256, projectorSource.sha256);
 
       provider.applyModelPreset(model);
       expect(provider.settings.modelSupportsTextToSpeech, isTrue);
@@ -1777,42 +1789,52 @@ void main() {
       }
     });
 
-    test('large models remain desktop-only while Qwen3-ASR is universal', () {
-      final desktopModels = DownloadableModel.defaultModels
-          .where((model) => model.isNativeDesktopOnly)
-          .toList(growable: false);
+    test(
+      'large models remain desktop-only while speech models are universal',
+      () {
+        final desktopModels = DownloadableModel.defaultModels
+            .where((model) => model.isNativeDesktopOnly)
+            .toList(growable: false);
 
-      expect(
-        desktopModels.map((model) => model.name),
-        orderedEquals(const [
-          'Qwen3-TTS 1.7B Base',
-          'Gemma 4 12B it',
-          'Gemma 4 26B A4B it',
-          'Gemma 4 31B it',
-          'Qwen3.6 35B A3B',
-        ]),
-      );
-      for (final model in desktopModels) {
-        expect(model.isAvailableFor(web: false, mobile: false), isTrue);
-        expect(model.isAvailableFor(web: false, mobile: true), isFalse);
-        expect(model.isAvailableFor(web: true, mobile: false), isFalse);
-      }
+        expect(
+          desktopModels.map((model) => model.name),
+          orderedEquals(const [
+            'Gemma 4 12B it',
+            'Gemma 4 26B A4B it',
+            'Gemma 4 31B it',
+            'Qwen3.6 35B A3B',
+          ]),
+        );
+        for (final model in desktopModels) {
+          expect(model.isAvailableFor(web: false, mobile: false), isTrue);
+          expect(model.isAvailableFor(web: false, mobile: true), isFalse);
+          expect(model.isAvailableFor(web: true, mobile: false), isFalse);
+        }
 
-      final qwenAsr = DownloadableModel.defaultModels.singleWhere(
-        (model) => model.name == 'Qwen3-ASR 0.6B',
-      );
-      expect(qwenAsr.isNativeOnly, isFalse);
-      expect(qwenAsr.isAvailableFor(web: false, mobile: true), isTrue);
-      expect(qwenAsr.isAvailableFor(web: false, mobile: false), isTrue);
-      expect(qwenAsr.isAvailableFor(web: true, mobile: false), isTrue);
+        final qwenAsr = DownloadableModel.defaultModels.singleWhere(
+          (model) => model.name == 'Qwen3-ASR 0.6B',
+        );
+        expect(qwenAsr.isNativeOnly, isFalse);
+        expect(qwenAsr.isAvailableFor(web: false, mobile: true), isTrue);
+        expect(qwenAsr.isAvailableFor(web: false, mobile: false), isTrue);
+        expect(qwenAsr.isAvailableFor(web: true, mobile: false), isTrue);
 
-      final gemmaE4b = DownloadableModel.defaultModels.singleWhere(
-        (model) => model.name == 'Gemma 4 E4B it',
-      );
-      expect(gemmaE4b.isNativeDesktopOnly, isFalse);
-      expect(gemmaE4b.isAvailableFor(web: false, mobile: true), isTrue);
-      expect(gemmaE4b.supportsAudioFor(web: false), isTrue);
-    });
+        final qwenTts = DownloadableModel.defaultModels.singleWhere(
+          (model) => model.name == 'Qwen3-TTS 1.7B Base',
+        );
+        expect(qwenTts.isNativeDesktopOnly, isFalse);
+        expect(qwenTts.isAvailableFor(web: false, mobile: true), isTrue);
+        expect(qwenTts.isAvailableFor(web: false, mobile: false), isTrue);
+        expect(qwenTts.isAvailableFor(web: true, mobile: false), isTrue);
+
+        final gemmaE4b = DownloadableModel.defaultModels.singleWhere(
+          (model) => model.name == 'Gemma 4 E4B it',
+        );
+        expect(gemmaE4b.isNativeDesktopOnly, isFalse);
+        expect(gemmaE4b.isAvailableFor(web: false, mobile: true), isTrue);
+        expect(gemmaE4b.supportsAudioFor(web: false), isTrue);
+      },
+    );
 
     test('Qwen3-ASR preset persists the dedicated STT declaration', () {
       final model = DownloadableModel.defaultModels.singleWhere(

--- a/example/chat_app/web/index.html
+++ b/example/chat_app/web/index.html
@@ -214,7 +214,7 @@
     const bridgeAssetsTag =
       typeof configuredTag === 'string' && configuredTag.length > 0
         ? configuredTag
-        : 'v0.1.32';
+        : 'v0.1.33';
     function bridgeTagSupportsSpeechToText(tag) {
       const match = /^v(\d+)\.(\d+)\.(\d+)(?:$|-)/.exec(String(tag || ''));
       if (!match) return false;
@@ -235,7 +235,7 @@
       window.__llamadartLiteRtLmModuleUrl.length > 0
         ? window.__llamadartLiteRtLmModuleUrl
         : 'https://cdn.jsdelivr.net/npm/@litert-lm/core@0.15.0/+esm';
-    const localBridgeVersion = 'v0.1.32-local-b10453';
+    const localBridgeVersion = 'v0.1.33-local-b10453';
     window.__llamadartBridgeLocalVersion = localBridgeVersion;
 
     const localBridgeUrl = `./webgpu_bridge/llama_webgpu_bridge.js?v=${localBridgeVersion}`;

--- a/example/chat_app/web/index.html
+++ b/example/chat_app/web/index.html
@@ -214,7 +214,7 @@
     const bridgeAssetsTag =
       typeof configuredTag === 'string' && configuredTag.length > 0
         ? configuredTag
-        : 'v0.1.33';
+        : 'v0.1.34';
     function bridgeTagSupportsSpeechToText(tag) {
       const match = /^v(\d+)\.(\d+)\.(\d+)(?:$|-)/.exec(String(tag || ''));
       if (!match) return false;
@@ -235,7 +235,7 @@
       window.__llamadartLiteRtLmModuleUrl.length > 0
         ? window.__llamadartLiteRtLmModuleUrl
         : 'https://cdn.jsdelivr.net/npm/@litert-lm/core@0.15.0/+esm';
-    const localBridgeVersion = 'v0.1.33-local-b10453';
+    const localBridgeVersion = 'v0.1.34-local-b10453';
     window.__llamadartBridgeLocalVersion = localBridgeVersion;
 
     const localBridgeUrl = `./webgpu_bridge/llama_webgpu_bridge.js?v=${localBridgeVersion}`;

--- a/lib/src/backends/backend.dart
+++ b/lib/src/backends/backend.dart
@@ -190,7 +190,7 @@ abstract class BackendPromptSpeechToTextSupport {
   String? get promptSpeechToTextUnsupportedReason;
 }
 
-/// Model family reported by a backend-native text-to-speech implementation.
+/// Model family reported by a backend text-to-speech implementation.
 enum BackendTextToSpeechModel {
   /// Qwen3-TTS audio generation through llama.cpp mtmd.
   qwen3Tts,
@@ -355,8 +355,8 @@ abstract class BackendTextToSpeech {
 
   /// Synthesizes one complete utterance.
   ///
-  /// Current native implementations return PCM only after generation has
-  /// completed. [onProgress] does not imply incremental audio output.
+  /// Current implementations return PCM only after generation has completed.
+  /// [onProgress] does not imply incremental audio output.
   Future<BackendTextToSpeechResult> synthesizeTextToSpeech(
     int contextHandle,
     int mmContextHandle,

--- a/lib/src/backends/web/web_backend.dart
+++ b/lib/src/backends/web/web_backend.dart
@@ -1,8 +1,9 @@
-import '../backend.dart';
+import '../../core/exceptions.dart';
 import '../../core/models/chat/content_part.dart';
 import '../../core/models/config/log_level.dart';
 import '../../core/models/inference/generation_params.dart';
 import '../../core/models/inference/model_params.dart';
+import '../backend.dart';
 import '../litert_lm/litert_lm_backend_web.dart';
 import '../webgpu/webgpu_backend.dart';
 
@@ -181,7 +182,7 @@ class WebAutoBackend
         onProgress: onProgress,
       );
     }
-    throw UnsupportedError(
+    throw LlamaUnsupportedException(
       'Text-to-speech is not supported by the active Web runtime.',
     );
   }

--- a/lib/src/backends/web/web_backend.dart
+++ b/lib/src/backends/web/web_backend.dart
@@ -17,6 +17,7 @@ class WebAutoBackend
         BackendEmbeddingsSupport,
         BackendBatchEmbeddings,
         BackendPromptSpeechToTextSupport,
+        BackendTextToSpeech,
         BackendStatePersistence,
         BackendStatePersistenceSupport {
   final LlamaBackend Function() _webGpuFactory;
@@ -141,6 +142,56 @@ class WebAutoBackend
   @override
   void cancelGeneration() {
     _delegate?.cancelGeneration();
+  }
+
+  @override
+  Future<BackendTextToSpeechCapabilities> textToSpeechCapabilities(
+    int contextHandle,
+    int mmContextHandle,
+  ) {
+    final delegate = _delegate;
+    if (delegate is BackendTextToSpeech) {
+      return (delegate as BackendTextToSpeech).textToSpeechCapabilities(
+        contextHandle,
+        mmContextHandle,
+      );
+    }
+    return Future<BackendTextToSpeechCapabilities>.value(
+      const BackendTextToSpeechCapabilities(
+        isSupported: false,
+        unsupportedReason:
+            'The active Web runtime does not expose dedicated text-to-speech.',
+      ),
+    );
+  }
+
+  @override
+  Future<BackendTextToSpeechResult> synthesizeTextToSpeech(
+    int contextHandle,
+    int mmContextHandle,
+    BackendTextToSpeechRequest request, {
+    void Function(BackendTextToSpeechProgress progress)? onProgress,
+  }) {
+    final delegate = _delegate;
+    if (delegate is BackendTextToSpeech) {
+      return (delegate as BackendTextToSpeech).synthesizeTextToSpeech(
+        contextHandle,
+        mmContextHandle,
+        request,
+        onProgress: onProgress,
+      );
+    }
+    throw UnsupportedError(
+      'Text-to-speech is not supported by the active Web runtime.',
+    );
+  }
+
+  @override
+  void cancelTextToSpeech() {
+    final delegate = _delegate;
+    if (delegate is BackendTextToSpeech) {
+      (delegate as BackendTextToSpeech).cancelTextToSpeech();
+    }
   }
 
   @override

--- a/lib/src/backends/webgpu/interop.dart
+++ b/lib/src/backends/webgpu/interop.dart
@@ -45,6 +45,14 @@ extension type LlamaWebGpuBridge._(JSObject _) implements JSObject {
   /// Returns whether loaded projector supports audio.
   external bool? supportsAudio();
 
+  /// Returns dedicated text-to-speech capabilities for the loaded projector.
+  external JSPromise<JSAny?>? getTextToSpeechCapabilities();
+
+  /// Synthesizes one complete speech buffer.
+  external JSPromise<JSAny?>? synthesizeSpeech(
+    WebGpuTextToSpeechOptions options,
+  );
+
   /// Tokenizes text.
   external JSPromise<JSAny>? tokenize(String text, [bool? addSpecial]);
 
@@ -195,4 +203,25 @@ extension type WebGpuCompletionOptions._(JSObject _) implements JSObject {
 extension type WebGpuEmbeddingOptions._(JSObject _) implements JSObject {
   /// Creates embedding options.
   external factory WebGpuEmbeddingOptions({bool? normalize});
+}
+
+/// Dedicated text-to-speech options accepted by the WebGPU bridge.
+@JS()
+@anonymous
+extension type WebGpuTextToSpeechOptions._(JSObject _) implements JSObject {
+  /// Creates a complete synthesis request.
+  external factory WebGpuTextToSpeechOptions({
+    required String text,
+    String? language,
+    JSUint8Array? speakerAudio,
+    int? promptBatchSize,
+    int? maxFrames,
+    int? topK,
+    double? topP,
+    double? minP,
+    double? temperature,
+    int? seed,
+    JSAny? signal,
+    JSFunction? onProgress,
+  });
 }

--- a/lib/src/backends/webgpu/webgpu_backend.dart
+++ b/lib/src/backends/webgpu/webgpu_backend.dart
@@ -9,6 +9,7 @@ import 'package:web/web.dart';
 
 import '../../core/models/chat/content_part.dart';
 import '../../core/cache_policy.dart';
+import '../../core/exceptions.dart';
 import '../../core/models/config/gpu_backend.dart';
 import '../../core/models/config/llama_cpp_param_values.dart';
 import '../../core/models/config/log_level.dart';
@@ -27,6 +28,7 @@ class WebGpuLlamaBackend
         BackendAvailability,
         BackendBatchEmbeddings,
         BackendPromptSpeechToTextSupport,
+        BackendTextToSpeech,
         BackendStatePersistence,
         BackendStatePersistenceSupport {
   static const Duration _bridgeReadyTimeout = Duration(seconds: 12);
@@ -62,6 +64,7 @@ class WebGpuLlamaBackend
   bool _isReady = false;
   LlamaLogLevel _logLevel = LlamaLogLevel.info;
   AbortController? _abortController;
+  AbortController? _textToSpeechAbortController;
   int? _lastNCtx;
   bool _mmContextActive = false;
   String? _cachedMmProjectorBlobUrl;
@@ -110,6 +113,21 @@ class WebGpuLlamaBackend
   bool _hasBridgeFunction(LlamaWebGpuBridge bridge, String name) {
     final value = bridge.getProperty(name.toJS);
     return value.isA<JSFunction>();
+  }
+
+  int? _jsIntProperty(JSObject object, String name) {
+    final value = object.getProperty(name.toJS);
+    return value.isA<JSNumber>() ? (value as JSNumber).toDartInt : null;
+  }
+
+  bool? _jsBoolProperty(JSObject object, String name) {
+    final value = object.getProperty(name.toJS);
+    return value.isA<JSBoolean>() ? (value as JSBoolean).toDart : null;
+  }
+
+  String? _jsStringProperty(JSObject object, String name) {
+    final value = object.getProperty(name.toJS);
+    return value.isA<JSString>() ? (value as JSString).toDart : null;
   }
 
   Future<void> _loadBridgeScript() async {
@@ -1948,6 +1966,223 @@ class WebGpuLlamaBackend
   }
 
   @override
+  Future<BackendTextToSpeechCapabilities> textToSpeechCapabilities(
+    int contextHandle,
+    int mmContextHandle,
+  ) async {
+    final bridge = _requireBridge();
+    if (!_mmContextActive) {
+      return const BackendTextToSpeechCapabilities(
+        isSupported: false,
+        unsupportedReason: 'Load a text-to-speech multimodal projector first.',
+      );
+    }
+    if (!_hasBridgeFunction(bridge, 'getTextToSpeechCapabilities') ||
+        !_hasBridgeFunction(bridge, 'synthesizeSpeech')) {
+      return const BackendTextToSpeechCapabilities(
+        isSupported: false,
+        unsupportedReason:
+            'Web text-to-speech requires llama-web-bridge-assets v0.1.33 '
+            'or newer.',
+      );
+    }
+
+    try {
+      final raw = await _toFuture(bridge.getTextToSpeechCapabilities());
+      if (raw == null || !raw.isA<JSObject>()) {
+        return const BackendTextToSpeechCapabilities(
+          isSupported: false,
+          unsupportedReason:
+              'The Web text-to-speech capability response is invalid.',
+        );
+      }
+      final value = raw as JSObject;
+      final apiVersion = _jsIntProperty(value, 'apiVersion') ?? 0;
+      if (apiVersion != 1) {
+        return BackendTextToSpeechCapabilities(
+          isSupported: false,
+          unsupportedReason:
+              'The Web text-to-speech API version is unsupported '
+              '(received $apiVersion, expected 1).',
+        );
+      }
+      if (_jsBoolProperty(value, 'supported') != true) {
+        return BackendTextToSpeechCapabilities(
+          isSupported: false,
+          unsupportedReason:
+              _jsStringProperty(value, 'reason') ??
+              'The loaded Web model/projector does not support text-to-speech.',
+        );
+      }
+      if (_jsIntProperty(value, 'modelType') != 1) {
+        return const BackendTextToSpeechCapabilities(
+          isSupported: false,
+          unsupportedReason:
+              'The loaded Web projector is not a supported Qwen3-TTS '
+              'projector.',
+        );
+      }
+      final sampleRate = _jsIntProperty(value, 'sampleRate');
+      final channels = _jsIntProperty(value, 'channels');
+      if (sampleRate == null ||
+          sampleRate <= 0 ||
+          channels == null ||
+          channels <= 0) {
+        return const BackendTextToSpeechCapabilities(
+          isSupported: false,
+          unsupportedReason:
+              'The Web text-to-speech runtime reported an invalid audio '
+              'format.',
+        );
+      }
+      return BackendTextToSpeechCapabilities(
+        isSupported: true,
+        model: BackendTextToSpeechModel.qwen3Tts,
+        sampleRateHz: sampleRate,
+        channelCount: channels,
+        supportsLanguage: _jsBoolProperty(value, 'supportsLanguage') == true,
+        supportsSpeakerReference:
+            _jsBoolProperty(value, 'supportsSpeakerReference') == true,
+        supportsCancellation: true,
+      );
+    } catch (error) {
+      return BackendTextToSpeechCapabilities(
+        isSupported: false,
+        unsupportedReason:
+            'The Web text-to-speech capability probe failed: $error',
+      );
+    }
+  }
+
+  @override
+  Future<BackendTextToSpeechResult> synthesizeTextToSpeech(
+    int contextHandle,
+    int mmContextHandle,
+    BackendTextToSpeechRequest request, {
+    void Function(BackendTextToSpeechProgress progress)? onProgress,
+  }) async {
+    if (request.speakerAudioPath != null) {
+      throw LlamaUnsupportedException(
+        'Web text-to-speech speaker references require encoded bytes; '
+        'browser runtimes cannot read local file paths.',
+      );
+    }
+    if (_textToSpeechAbortController != null) {
+      throw LlamaStateException(
+        'Text-to-speech synthesis is already active in this Web runtime.',
+      );
+    }
+
+    final bridge = _requireBridge();
+    final capabilities = await textToSpeechCapabilities(
+      contextHandle,
+      mmContextHandle,
+    );
+    if (!capabilities.isSupported) {
+      throw LlamaUnsupportedException(
+        capabilities.unsupportedReason ??
+            'Web text-to-speech is not supported by the active runtime.',
+      );
+    }
+
+    final abortController = AbortController();
+    _textToSpeechAbortController = abortController;
+    final onProgressCallback = (JSAny? raw) {
+      if (raw == null || !raw.isA<JSObject>()) {
+        return;
+      }
+      final value = raw as JSObject;
+      onProgress?.call(
+        BackendTextToSpeechProgress(
+          phase: _jsIntProperty(value, 'state') == 1
+              ? BackendTextToSpeechPhase.processingPrompt
+              : BackendTextToSpeechPhase.generating,
+          promptTokensRemaining:
+              _jsIntProperty(value, 'promptTokensRemaining') ?? 0,
+          framesGenerated: _jsIntProperty(value, 'framesGenerated') ?? 0,
+          truncated: _jsBoolProperty(value, 'truncated') == true,
+        ),
+      );
+    }.toJS;
+
+    try {
+      final raw = await _toFuture(
+        bridge.synthesizeSpeech(
+          WebGpuTextToSpeechOptions(
+            text: request.text,
+            language: request.language,
+            speakerAudio: request.speakerAudioBytes?.toJS,
+            promptBatchSize: request.promptBatchSize,
+            maxFrames: request.maxFrames,
+            topK: request.topK,
+            topP: request.topP,
+            minP: request.minP,
+            temperature: request.temperature,
+            seed: request.seed,
+            signal: abortController.signal,
+            onProgress: onProgressCallback as JSFunction,
+          ),
+        ),
+      );
+      if (raw == null || !raw.isA<JSObject>()) {
+        throw LlamaTextToSpeechException(
+          'The Web text-to-speech runtime returned an invalid result.',
+        );
+      }
+      final value = raw as JSObject;
+      final rawPcm = value.getProperty('pcm'.toJS);
+      if (!rawPcm.isA<JSFloat32Array>()) {
+        throw LlamaTextToSpeechException(
+          'The Web text-to-speech runtime returned invalid PCM audio.',
+        );
+      }
+      final samples = (rawPcm as JSFloat32Array).toDart;
+      final sampleRate = _jsIntProperty(value, 'sampleRate') ?? 0;
+      final channels = _jsIntProperty(value, 'channels') ?? 0;
+      if (samples.isEmpty || sampleRate <= 0 || channels <= 0) {
+        throw LlamaTextToSpeechException(
+          'The Web text-to-speech runtime returned empty or malformed audio.',
+        );
+      }
+      return BackendTextToSpeechResult(
+        samples: samples,
+        sampleRateHz: sampleRate,
+        channelCount: channels,
+        framesGenerated: _jsIntProperty(value, 'framesGenerated') ?? 0,
+        truncated: _jsBoolProperty(value, 'truncated') == true,
+      );
+    } catch (error) {
+      if (abortController.signal.aborted) {
+        throw LlamaTextToSpeechException(
+          'Text-to-speech synthesis was cancelled.',
+          error,
+        );
+      }
+      if (error is LlamaException) {
+        rethrow;
+      }
+      throw LlamaTextToSpeechException(
+        'Web text-to-speech synthesis failed.',
+        error,
+      );
+    } finally {
+      if (identical(_textToSpeechAbortController, abortController)) {
+        _textToSpeechAbortController = null;
+      }
+    }
+  }
+
+  @override
+  void cancelTextToSpeech() {
+    final controller = _textToSpeechAbortController;
+    if (controller == null) {
+      return;
+    }
+    controller.abort();
+    _bridge?.cancel();
+  }
+
+  @override
   Future<List<double>> embed(
     int contextHandle,
     String text, {
@@ -2335,6 +2570,7 @@ class WebGpuLlamaBackend
 
   @override
   Future<void> dispose() async {
+    cancelTextToSpeech();
     await _safeDisposeBridge();
   }
 

--- a/lib/src/core/speech/text_to_speech.dart
+++ b/lib/src/core/speech/text_to_speech.dart
@@ -22,6 +22,9 @@ enum TextToSpeechImplementation {
 
   /// Dedicated native audio generation through llama.cpp mtmd.
   nativeAudioGeneration,
+
+  /// Complete audio generation through the WebGPU bridge.
+  webAudioGeneration,
 }
 
 /// A request to synthesize one complete utterance.
@@ -38,7 +41,7 @@ class TextToSpeechRequest {
 
   /// Optional encoded speaker-reference audio.
   ///
-  /// File and in-memory inputs are supported on the first native backend.
+  /// Native backends accept files and bytes. Web accepts encoded bytes only.
   final SpeechAudioInput? speakerReference;
 
   /// Maximum number of audio-codec frames to generate.
@@ -450,12 +453,14 @@ class TextToSpeechEngine {
     return TextToSpeechCapabilities(
       isSupported: true,
       backendName: backendName,
-      implementation: TextToSpeechImplementation.nativeAudioGeneration,
+      implementation: textToSpeechSupportsFileInput
+          ? TextToSpeechImplementation.nativeAudioGeneration
+          : TextToSpeechImplementation.webAudioGeneration,
       sampleRateHz: backendCapabilities.sampleRateHz,
       channelCount: backendCapabilities.channelCount,
       speakerReferenceInputKinds: backendCapabilities.supportsSpeakerReference
-          ? const <SpeechAudioInputKind>{
-              SpeechAudioInputKind.file,
+          ? <SpeechAudioInputKind>{
+              if (textToSpeechSupportsFileInput) SpeechAudioInputKind.file,
               SpeechAudioInputKind.encodedBytes,
             }
           : const <SpeechAudioInputKind>{},
@@ -551,6 +556,12 @@ class TextToSpeechEngine {
         if (path.trim().isEmpty) {
           throw LlamaAudioFormatException(
             'Speaker reference file path must not be empty.',
+          );
+        }
+        if (!textToSpeechSupportsFileInput) {
+          throw LlamaUnsupportedException(
+            'Web text-to-speech speaker references require encoded bytes; '
+            'browser runtimes cannot read local file paths.',
           );
         }
       case SpeechAudioBytesInput(:final bytes):

--- a/lib/src/core/speech/text_to_speech.dart
+++ b/lib/src/core/speech/text_to_speech.dart
@@ -460,7 +460,7 @@ class TextToSpeechEngine {
       sampleRateHz: backendCapabilities.sampleRateHz,
       channelCount: backendCapabilities.channelCount,
       speakerReferenceInputKinds: backendCapabilities.supportsSpeakerReference
-          ? <SpeechAudioInputKind>{
+          ? const <SpeechAudioInputKind>{
               if (textToSpeechSupportsFileInput) SpeechAudioInputKind.file,
               SpeechAudioInputKind.encodedBytes,
             }

--- a/lib/src/core/speech/text_to_speech.dart
+++ b/lib/src/core/speech/text_to_speech.dart
@@ -112,13 +112,13 @@ class TextToSpeechCapabilities {
   /// Whether speaker-reference audio can be supplied.
   final bool supportsSpeakerReference;
 
-  /// Whether PCM can be emitted while native synthesis is still running.
+  /// Whether PCM can be emitted while synthesis is still running.
   final bool supportsIncrementalAudio;
 
   /// Whether an active task can be cancelled cooperatively.
   final bool supportsCancellation;
 
-  /// Whether pausing the event subscription throttles native synthesis.
+  /// Whether pausing the event subscription throttles synthesis.
   final bool supportsOutputBackpressure;
 
   /// Maximum number of typed speech tasks per underlying engine.
@@ -266,7 +266,7 @@ class TextToSpeechProgressEvent extends TextToSpeechEvent {
   });
 }
 
-/// Final PCM event emitted after native generation completes.
+/// Final PCM event emitted after generation completes.
 class TextToSpeechFinalEvent extends TextToSpeechEvent {
   /// Complete synthesis result.
   final TextToSpeechResult result;
@@ -343,8 +343,8 @@ class TextToSpeechTask {
   /// Progress followed by one final PCM event.
   ///
   /// This is a single-subscription stream. Runtime failures are emitted as a
-  /// stream error and are also reported by [done]. Current native synthesis
-  /// exposes PCM only after generation completes; progress is not live audio.
+  /// stream error and are also reported by [done]. Current synthesis exposes
+  /// PCM only after generation completes; progress is not live audio.
   Stream<TextToSpeechEvent> get events => _eventsController.stream;
 
   /// Completes once the task succeeds, is cancelled, or fails.
@@ -365,9 +365,10 @@ class TextToSpeechTask {
 
 /// Typed text-to-speech API backed by a loaded [LlamaEngine].
 ///
-/// The first implementation supports Qwen3-TTS on native llama.cpp with its
-/// matching audio-generation projector. It reports progress and cancellation,
-/// but PCM becomes available only after native generation has completed.
+/// Supports Qwen3-TTS on native llama.cpp and compatible WebGPU bridge
+/// runtimes with the matching audio-generation projector. It reports progress
+/// and cancellation, but PCM becomes available only after generation has
+/// completed.
 class TextToSpeechEngine {
   static const String _leaseOwner = 'text-to-speech';
   static const Map<String, String> _qwen3LanguageAliases = <String, String>{
@@ -420,7 +421,7 @@ class TextToSpeechEngine {
     try {
       backendName = await _engine.getBackendName();
     } catch (_) {
-      // The native capability result remains actionable without this label.
+      // The capability result remains actionable without this label.
     }
 
     BackendTextToSpeechCapabilities backendCapabilities;
@@ -479,7 +480,7 @@ class TextToSpeechEngine {
   /// Starts one complete synthesis task.
   ///
   /// Invalid input and unsupported preflight checks throw before the task is
-  /// returned. Failures after native startup are reported through the task.
+  /// returned. Failures after backend startup are reported through the task.
   Future<TextToSpeechTask> synthesize(TextToSpeechRequest request) async {
     _validateRequest(request);
     if (!_engineLease.acquire(_leaseOwner)) {

--- a/lib/src/core/speech/text_to_speech.dart
+++ b/lib/src/core/speech/text_to_speech.dart
@@ -62,10 +62,10 @@ class TextToSpeechRequest {
   /// Sampling temperature.
   final double temperature;
 
-  /// Random seed. `0xffffffff` requests the native random default.
+  /// Random seed. `0xffffffff` requests the runtime's random default.
   final int seed;
 
-  /// Creates a text-to-speech request using native Qwen3-TTS defaults.
+  /// Creates a text-to-speech request using Qwen3-TTS defaults.
   const TextToSpeechRequest({
     required this.text,
     this.language,

--- a/lib/src/core/speech/text_to_speech_platform_stub.dart
+++ b/lib/src/core/speech/text_to_speech_platform_stub.dart
@@ -3,3 +3,6 @@ const bool isTextToSpeechPlatformSupported = true;
 
 /// Actionable unsupported reason for platforms without typed TTS.
 const String textToSpeechPlatformUnsupportedReason = '';
+
+/// Native runtimes can read local speaker-reference paths.
+const bool textToSpeechSupportsFileInput = true;

--- a/lib/src/core/speech/text_to_speech_platform_web.dart
+++ b/lib/src/core/speech/text_to_speech_platform_web.dart
@@ -1,7 +1,8 @@
-/// Typed text-to-speech is not available in the published Web runtime.
-const bool isTextToSpeechPlatformSupported = false;
+/// Typed text-to-speech is available through a compatible WebGPU bridge.
+const bool isTextToSpeechPlatformSupported = true;
 
 /// Actionable reason returned by Web capability discovery.
-const String textToSpeechPlatformUnsupportedReason =
-    'Typed text-to-speech is not available on Web. The published WebGPU '
-    'runtime does not export the native audio-generation ABI.';
+const String textToSpeechPlatformUnsupportedReason = '';
+
+/// Browsers do not expose local filesystem paths to the runtime.
+const bool textToSpeechSupportsFileInput = false;

--- a/scripts/fetch_webgpu_bridge_assets.sh
+++ b/scripts/fetch_webgpu_bridge_assets.sh
@@ -4,7 +4,7 @@ set -euo pipefail
 ROOT_DIR="$(git rev-parse --show-toplevel)"
 OUT_DIR="${WEBGPU_BRIDGE_OUT_DIR:-$ROOT_DIR/example/chat_app/web/webgpu_bridge}"
 ASSETS_REPO="${WEBGPU_BRIDGE_ASSETS_REPO:-leehack/llama-web-bridge-assets}"
-ASSETS_TAG="${WEBGPU_BRIDGE_ASSETS_TAG:-v0.1.32}"
+ASSETS_TAG="${WEBGPU_BRIDGE_ASSETS_TAG:-v0.1.33}"
 CDN_BASE="${WEBGPU_BRIDGE_CDN_BASE:-https://cdn.jsdelivr.net/gh/${ASSETS_REPO}@${ASSETS_TAG}}"
 PATCH_SAFARI_COMPAT="${WEBGPU_BRIDGE_PATCH_SAFARI_COMPAT:-1}"
 MIN_SAFARI_VERSION="${WEBGPU_BRIDGE_MIN_SAFARI_VERSION:-170400}"
@@ -14,7 +14,7 @@ if [[ "${1:-}" == "--help" || "${1:-}" == "-h" ]]; then
 Downloads prebuilt WebGPU bridge assets into the chat_app web directory.
 
 Default source:
-  https://cdn.jsdelivr.net/gh/leehack/llama-web-bridge-assets@v0.1.32
+  https://cdn.jsdelivr.net/gh/leehack/llama-web-bridge-assets@v0.1.33
 
 Environment variables:
   WEBGPU_BRIDGE_ASSETS_REPO   Asset repo in owner/repo format
@@ -28,7 +28,7 @@ Usage:
   ./scripts/fetch_webgpu_bridge_assets.sh
 
 Examples:
-  WEBGPU_BRIDGE_ASSETS_TAG=v0.1.32 ./scripts/fetch_webgpu_bridge_assets.sh
+  WEBGPU_BRIDGE_ASSETS_TAG=v0.1.33 ./scripts/fetch_webgpu_bridge_assets.sh
   WEBGPU_BRIDGE_ASSETS_REPO=acme/llama-web-bridge-assets WEBGPU_BRIDGE_ASSETS_TAG=v2 ./scripts/fetch_webgpu_bridge_assets.sh
 USAGE
   exit 0

--- a/scripts/fetch_webgpu_bridge_assets.sh
+++ b/scripts/fetch_webgpu_bridge_assets.sh
@@ -4,7 +4,7 @@ set -euo pipefail
 ROOT_DIR="$(git rev-parse --show-toplevel)"
 OUT_DIR="${WEBGPU_BRIDGE_OUT_DIR:-$ROOT_DIR/example/chat_app/web/webgpu_bridge}"
 ASSETS_REPO="${WEBGPU_BRIDGE_ASSETS_REPO:-leehack/llama-web-bridge-assets}"
-ASSETS_TAG="${WEBGPU_BRIDGE_ASSETS_TAG:-v0.1.33}"
+ASSETS_TAG="${WEBGPU_BRIDGE_ASSETS_TAG:-v0.1.34}"
 CDN_BASE="${WEBGPU_BRIDGE_CDN_BASE:-https://cdn.jsdelivr.net/gh/${ASSETS_REPO}@${ASSETS_TAG}}"
 PATCH_SAFARI_COMPAT="${WEBGPU_BRIDGE_PATCH_SAFARI_COMPAT:-1}"
 MIN_SAFARI_VERSION="${WEBGPU_BRIDGE_MIN_SAFARI_VERSION:-170400}"
@@ -14,7 +14,7 @@ if [[ "${1:-}" == "--help" || "${1:-}" == "-h" ]]; then
 Downloads prebuilt WebGPU bridge assets into the chat_app web directory.
 
 Default source:
-  https://cdn.jsdelivr.net/gh/leehack/llama-web-bridge-assets@v0.1.33
+  https://cdn.jsdelivr.net/gh/leehack/llama-web-bridge-assets@v0.1.34
 
 Environment variables:
   WEBGPU_BRIDGE_ASSETS_REPO   Asset repo in owner/repo format
@@ -28,7 +28,7 @@ Usage:
   ./scripts/fetch_webgpu_bridge_assets.sh
 
 Examples:
-  WEBGPU_BRIDGE_ASSETS_TAG=v0.1.33 ./scripts/fetch_webgpu_bridge_assets.sh
+  WEBGPU_BRIDGE_ASSETS_TAG=v0.1.34 ./scripts/fetch_webgpu_bridge_assets.sh
   WEBGPU_BRIDGE_ASSETS_REPO=acme/llama-web-bridge-assets WEBGPU_BRIDGE_ASSETS_TAG=v2 ./scripts/fetch_webgpu_bridge_assets.sh
 USAGE
   exit 0

--- a/test/unit/backends/web/web_backend_test.dart
+++ b/test/unit/backends/web/web_backend_test.dart
@@ -64,6 +64,25 @@ void main() {
     },
   );
 
+  test('WebAutoBackend throws typed unsupported TTS errors', () {
+    final backend = WebAutoBackend(webBackend: _NoStateBackend());
+
+    expect(
+      () => backend.synthesizeTextToSpeech(
+        3,
+        4,
+        const BackendTextToSpeechRequest(text: 'Hello'),
+      ),
+      throwsA(
+        isA<LlamaUnsupportedException>().having(
+          (error) => error.message,
+          'message',
+          contains('active Web runtime'),
+        ),
+      ),
+    );
+  });
+
   test(
     'WebAutoBackend reports embedding support from active delegate',
     () async {

--- a/test/unit/backends/web/web_backend_test.dart
+++ b/test/unit/backends/web/web_backend_test.dart
@@ -1,6 +1,8 @@
 @TestOn('browser')
 library;
 
+import 'dart:typed_data';
+
 import 'package:llamadart/src/backends/backend.dart';
 import 'package:llamadart/src/backends/web/web_backend.dart';
 import 'package:llamadart/src/core/engine/engine.dart';
@@ -21,6 +23,7 @@ void main() {
     expect(backend, isA<BackendStatePersistence>());
     expect(backend, isA<BackendStatePersistenceSupport>());
     expect(backend, isA<BackendPromptSpeechToTextSupport>());
+    expect(backend, isA<BackendTextToSpeech>());
     expect((backend as WebAutoBackend).supportsStatePersistence, isFalse);
     expect(backend.supportsEmbeddings, isFalse);
   });
@@ -37,6 +40,29 @@ void main() {
     expect(supported.supportsPromptSpeechToText, isTrue);
     expect(supported.promptSpeechToTextUnsupportedReason, isNull);
   });
+
+  test(
+    'WebAutoBackend forwards typed text-to-speech to its delegate',
+    () async {
+      final delegate = _TextToSpeechBackend();
+      final backend = WebAutoBackend(webBackend: delegate);
+
+      final capabilities = await backend.textToSpeechCapabilities(3, 4);
+      expect(capabilities.isSupported, isTrue);
+      expect(capabilities.sampleRateHz, 24000);
+
+      final result = await backend.synthesizeTextToSpeech(
+        3,
+        4,
+        const BackendTextToSpeechRequest(text: 'Hello'),
+      );
+      expect(result.samples, <double>[0.25, -0.25]);
+      expect(delegate.lastText, 'Hello');
+
+      backend.cancelTextToSpeech();
+      expect(delegate.cancelCalls, 1);
+    },
+  );
 
   test(
     'WebAutoBackend reports embedding support from active delegate',
@@ -229,4 +255,43 @@ class _EmbeddingSupportBackend
 
   @override
   dynamic noSuchMethod(Invocation invocation) => super.noSuchMethod(invocation);
+}
+
+class _TextToSpeechBackend extends _NoStateBackend
+    implements BackendTextToSpeech {
+  String? lastText;
+  var cancelCalls = 0;
+
+  @override
+  Future<BackendTextToSpeechCapabilities> textToSpeechCapabilities(
+    int contextHandle,
+    int mmContextHandle,
+  ) async => const BackendTextToSpeechCapabilities(
+    isSupported: true,
+    model: BackendTextToSpeechModel.qwen3Tts,
+    sampleRateHz: 24000,
+    channelCount: 1,
+  );
+
+  @override
+  Future<BackendTextToSpeechResult> synthesizeTextToSpeech(
+    int contextHandle,
+    int mmContextHandle,
+    BackendTextToSpeechRequest request, {
+    void Function(BackendTextToSpeechProgress progress)? onProgress,
+  }) async {
+    lastText = request.text;
+    return BackendTextToSpeechResult(
+      samples: Float32List.fromList(<double>[0.25, -0.25]),
+      sampleRateHz: 24000,
+      channelCount: 1,
+      framesGenerated: 1,
+      truncated: false,
+    );
+  }
+
+  @override
+  void cancelTextToSpeech() {
+    cancelCalls += 1;
+  }
 }

--- a/test/unit/backends/webgpu/webgpu_backend_test.dart
+++ b/test/unit/backends/webgpu/webgpu_backend_test.dart
@@ -2176,5 +2176,179 @@ void main() {
       expect(sawAudioParts, isTrue);
       expect(sawAudioBytes, isTrue);
     });
+
+    test('requires versioned bridge methods for text-to-speech', () async {
+      await backend.modelLoadFromUrl(
+        'https://example.com/model.gguf',
+        const ModelParams(),
+      );
+      final mmHandle = await backend.multimodalContextCreate(
+        1,
+        'https://example.com/mmproj.gguf',
+      );
+
+      final capabilities = await backend.textToSpeechCapabilities(1, mmHandle!);
+
+      expect(capabilities.isSupported, isFalse);
+      expect(capabilities.unsupportedReason, contains('v0.1.33'));
+    });
+
+    test(
+      'routes text-to-speech capability, progress, PCM, and bytes',
+      () async {
+        JSObject? capturedOptions;
+        bridge.setProperty(
+          'getTextToSpeechCapabilities'.toJS,
+          (() {
+            final result = JSObject()
+              ..setProperty('apiVersion'.toJS, 1.toJS)
+              ..setProperty('supported'.toJS, true.toJS)
+              ..setProperty('modelType'.toJS, 1.toJS)
+              ..setProperty('capabilities'.toJS, 3.toJS)
+              ..setProperty('supportsLanguage'.toJS, true.toJS)
+              ..setProperty('supportsSpeakerReference'.toJS, true.toJS)
+              ..setProperty('sampleRate'.toJS, 24000.toJS)
+              ..setProperty('channels'.toJS, 1.toJS)
+              ..setProperty('reason'.toJS, ''.toJS);
+            return Future<JSObject>.value(result).toJS;
+          }).toJS,
+        );
+        bridge.setProperty(
+          'synthesizeSpeech'.toJS,
+          ((JSObject options) {
+            capturedOptions = options;
+            final progress = JSObject()
+              ..setProperty('state'.toJS, 1.toJS)
+              ..setProperty('promptTokensRemaining'.toJS, 4.toJS)
+              ..setProperty('framesGenerated'.toJS, 2.toJS)
+              ..setProperty('truncated'.toJS, false.toJS);
+            final callback = options.getProperty('onProgress'.toJS);
+            if (callback.isA<JSFunction>()) {
+              (callback as JSFunction).callAsFunction(null, progress);
+            }
+            final pcm = JSFloat32Array.withLength(3);
+            pcm.toDart.setAll(0, <double>[0.25, -0.5, 0.75]);
+            final result = JSObject()
+              ..setProperty('pcm'.toJS, pcm)
+              ..setProperty('sampleRate'.toJS, 24000.toJS)
+              ..setProperty('channels'.toJS, 1.toJS)
+              ..setProperty('sampleCount'.toJS, 3.toJS)
+              ..setProperty('framesGenerated'.toJS, 8.toJS)
+              ..setProperty('truncated'.toJS, false.toJS);
+            return Future<JSObject>.value(result).toJS;
+          }).toJS,
+        );
+
+        await backend.modelLoadFromUrl(
+          'https://example.com/model.gguf',
+          const ModelParams(),
+        );
+        final mmHandle = await backend.multimodalContextCreate(
+          1,
+          'https://example.com/mmproj.gguf',
+        );
+        final capabilities = await backend.textToSpeechCapabilities(
+          1,
+          mmHandle!,
+        );
+        final progress = <BackendTextToSpeechProgress>[];
+        final result = await backend.synthesizeTextToSpeech(
+          1,
+          mmHandle,
+          BackendTextToSpeechRequest(
+            text: 'Hello from Web.',
+            language: 'en',
+            speakerAudioBytes: Uint8List.fromList(<int>[1, 2, 3]),
+            promptBatchSize: 128,
+            maxFrames: 64,
+            topK: 20,
+            topP: 0.9,
+            minP: 0.1,
+            temperature: 0.7,
+            seed: 7,
+          ),
+          onProgress: progress.add,
+        );
+
+        expect(capabilities.isSupported, isTrue);
+        expect(capabilities.model, BackendTextToSpeechModel.qwen3Tts);
+        expect(capabilities.sampleRateHz, 24000);
+        expect(capabilities.supportsSpeakerReference, isTrue);
+        expect(progress, hasLength(1));
+        expect(
+          progress.single.phase,
+          BackendTextToSpeechPhase.processingPrompt,
+        );
+        expect(progress.single.promptTokensRemaining, 4);
+        expect(result.samples, <double>[0.25, -0.5, 0.75]);
+        expect(result.sampleRateHz, 24000);
+        expect(result.framesGenerated, 8);
+        expect(
+          (capturedOptions!.getProperty('speakerAudio'.toJS) as JSUint8Array)
+              .toDart,
+          <int>[1, 2, 3],
+        );
+        expect(
+          (capturedOptions!.getProperty('language'.toJS) as JSString).toDart,
+          'en',
+        );
+      },
+    );
+
+    test(
+      'rejects local speaker paths and routes active cancellation',
+      () async {
+        final synthesis = Completer<JSAny?>();
+        bridge.setProperty(
+          'getTextToSpeechCapabilities'.toJS,
+          (() {
+            final result = JSObject()
+              ..setProperty('apiVersion'.toJS, 1.toJS)
+              ..setProperty('supported'.toJS, true.toJS)
+              ..setProperty('modelType'.toJS, 1.toJS)
+              ..setProperty('supportsLanguage'.toJS, true.toJS)
+              ..setProperty('supportsSpeakerReference'.toJS, true.toJS)
+              ..setProperty('sampleRate'.toJS, 24000.toJS)
+              ..setProperty('channels'.toJS, 1.toJS);
+            return Future<JSObject>.value(result).toJS;
+          }).toJS,
+        );
+        bridge.setProperty(
+          'synthesizeSpeech'.toJS,
+          ((JSObject options) => synthesis.future.toJS).toJS,
+        );
+        await backend.modelLoadFromUrl(
+          'https://example.com/model.gguf',
+          const ModelParams(),
+        );
+        final mmHandle = await backend.multimodalContextCreate(
+          1,
+          'https://example.com/mmproj.gguf',
+        );
+
+        await expectLater(
+          backend.synthesizeTextToSpeech(
+            1,
+            mmHandle!,
+            const BackendTextToSpeechRequest(
+              text: 'Hello.',
+              speakerAudioPath: '/tmp/speaker.wav',
+            ),
+          ),
+          throwsA(isA<LlamaUnsupportedException>()),
+        );
+
+        final active = backend.synthesizeTextToSpeech(
+          1,
+          mmHandle,
+          const BackendTextToSpeechRequest(text: 'Cancel me.'),
+        );
+        await Future<void>.delayed(Duration.zero);
+        backend.cancelTextToSpeech();
+        expect(cancelCallCount, 1);
+        synthesis.completeError(StateError('cancelled'));
+        await expectLater(active, throwsA(isA<LlamaTextToSpeechException>()));
+      },
+    );
   });
 }

--- a/test/unit/core/speech/text_to_speech_platform_stub_test.dart
+++ b/test/unit/core/speech/text_to_speech_platform_stub_test.dart
@@ -8,5 +8,6 @@ void main() {
   test('native platform enables typed text-to-speech', () {
     expect(isTextToSpeechPlatformSupported, isTrue);
     expect(textToSpeechPlatformUnsupportedReason, isEmpty);
+    expect(textToSpeechSupportsFileInput, isTrue);
   });
 }

--- a/test/unit/core/speech/text_to_speech_platform_web_test.dart
+++ b/test/unit/core/speech/text_to_speech_platform_web_test.dart
@@ -5,9 +5,9 @@ import 'package:llamadart/src/core/speech/text_to_speech_platform_web.dart';
 import 'package:test/test.dart';
 
 void main() {
-  test('web platform reports typed text-to-speech as unsupported', () {
-    expect(isTextToSpeechPlatformSupported, isFalse);
-    expect(textToSpeechPlatformUnsupportedReason, contains('not available'));
-    expect(textToSpeechPlatformUnsupportedReason, contains('audio-generation'));
+  test('web platform enables byte-backed typed text-to-speech', () {
+    expect(isTextToSpeechPlatformSupported, isTrue);
+    expect(textToSpeechPlatformUnsupportedReason, isEmpty);
+    expect(textToSpeechSupportsFileInput, isFalse);
   });
 }

--- a/test/unit/core/speech/text_to_speech_test.dart
+++ b/test/unit/core/speech/text_to_speech_test.dart
@@ -65,6 +65,10 @@ void main() {
         SpeechAudioInputKind.file,
         SpeechAudioInputKind.encodedBytes,
       });
+      expect(
+        () => capabilities.speakerReferenceInputKinds.clear(),
+        throwsUnsupportedError,
+      );
       expect(capabilities.supportsIncrementalAudio, isFalse);
       expect(capabilities.supportsCancellation, isTrue);
       expect(capabilities.supportsOutputBackpressure, isFalse);

--- a/test/unit/core/speech/text_to_speech_web_test.dart
+++ b/test/unit/core/speech/text_to_speech_web_test.dart
@@ -1,33 +1,150 @@
 @TestOn('browser')
 library;
 
+import 'dart:typed_data';
+
 import 'package:llamadart/llamadart.dart';
 import 'package:test/test.dart';
 
 void main() {
-  test('typed text-to-speech is explicitly unsupported on Web', () async {
+  test('typed text-to-speech exposes byte-only Web capabilities', () async {
+    final backend = _WebBackend();
+    final engine = LlamaEngine(backend);
+    addTearDown(engine.dispose);
+    await engine.loadModelFromUrl('https://example.com/qwen3-tts.gguf');
+    await engine.loadMultimodalProjector(
+      'https://example.com/qwen3-tts-mmproj.gguf',
+    );
+    final speechEngine = TextToSpeechEngine(
+      engine,
+      modelProfile: TextToSpeechModelProfile.qwen3Tts,
+    );
+
+    final capabilities = await speechEngine.capabilities;
+    final task = await speechEngine.synthesize(
+      TextToSpeechRequest(
+        text: 'Hello from Web.',
+        speakerReference: SpeechAudioBytesInput(
+          Uint8List.fromList(<int>[82, 73, 70, 70]),
+        ),
+      ),
+    );
+    final completion = await task.done;
+
+    expect(capabilities.isSupported, isTrue);
+    expect(
+      capabilities.implementation,
+      TextToSpeechImplementation.webAudioGeneration,
+    );
+    expect(capabilities.speakerReferenceInputKinds, {
+      SpeechAudioInputKind.encodedBytes,
+    });
+    expect(completion.state, TextToSpeechCompletionState.completed);
+    expect(completion.result?.samples, <double>[0.25, -0.25]);
+    expect(backend.lastRequest?.speakerAudioBytes, isNotEmpty);
+  });
+
+  test('typed text-to-speech rejects browser-local speaker paths', () async {
     final speechEngine = TextToSpeechEngine(
       LlamaEngine(_WebBackend()),
       modelProfile: TextToSpeechModelProfile.qwen3Tts,
     );
 
-    final capabilities = await speechEngine.capabilities;
-
-    expect(capabilities.isSupported, isFalse);
-    expect(capabilities.unsupportedReason, contains('not available on Web'));
     await expectLater(
-      speechEngine.synthesize(const TextToSpeechRequest(text: 'Hello.')),
-      throwsA(isA<LlamaUnsupportedException>()),
+      speechEngine.synthesize(
+        const TextToSpeechRequest(
+          text: 'Hello.',
+          speakerReference: SpeechAudioFileInput('/tmp/speaker.wav'),
+        ),
+      ),
+      throwsA(
+        isA<LlamaUnsupportedException>().having(
+          (error) => error.message,
+          'message',
+          contains('encoded bytes'),
+        ),
+      ),
     );
   });
 }
 
-class _WebBackend implements LlamaBackend {
+class _WebBackend implements LlamaBackend, BackendTextToSpeech {
+  bool _ready = false;
+  BackendTextToSpeechRequest? lastRequest;
+
   @override
-  bool get isReady => false;
+  bool get isReady => _ready;
 
   @override
   bool get supportsUrlLoading => true;
+
+  @override
+  Future<int> modelLoadFromUrl(
+    String url,
+    ModelParams params, {
+    void Function(double progress)? onProgress,
+  }) async {
+    _ready = true;
+    return 1;
+  }
+
+  @override
+  Future<int> contextCreate(int modelHandle, ModelParams params) async => 2;
+
+  @override
+  Future<int?> multimodalContextCreate(
+    int modelHandle,
+    String mmProjPath,
+  ) async => 3;
+
+  @override
+  Future<void> multimodalContextFree(int mmContextHandle) async {}
+
+  @override
+  Future<void> contextFree(int contextHandle) async {}
+
+  @override
+  Future<void> modelFree(int modelHandle) async {}
+
+  @override
+  Future<String> getBackendName() async => 'WebGPU';
+
+  @override
+  Future<void> setLogLevel(LlamaLogLevel level) async {}
+
+  @override
+  Future<BackendTextToSpeechCapabilities> textToSpeechCapabilities(
+    int contextHandle,
+    int mmContextHandle,
+  ) async => const BackendTextToSpeechCapabilities(
+    isSupported: true,
+    model: BackendTextToSpeechModel.qwen3Tts,
+    sampleRateHz: 24000,
+    channelCount: 1,
+    supportsLanguage: true,
+    supportsSpeakerReference: true,
+    supportsCancellation: true,
+  );
+
+  @override
+  Future<BackendTextToSpeechResult> synthesizeTextToSpeech(
+    int contextHandle,
+    int mmContextHandle,
+    BackendTextToSpeechRequest request, {
+    void Function(BackendTextToSpeechProgress progress)? onProgress,
+  }) async {
+    lastRequest = request;
+    return BackendTextToSpeechResult(
+      samples: Float32List.fromList(<double>[0.25, -0.25]),
+      sampleRateHz: 24000,
+      channelCount: 1,
+      framesGenerated: 1,
+      truncated: false,
+    );
+  }
+
+  @override
+  void cancelTextToSpeech() {}
 
   @override
   void cancelGeneration() {}

--- a/test/unit/core/speech/text_to_speech_web_test.dart
+++ b/test/unit/core/speech/text_to_speech_web_test.dart
@@ -39,6 +39,10 @@ void main() {
     expect(capabilities.speakerReferenceInputKinds, {
       SpeechAudioInputKind.encodedBytes,
     });
+    expect(
+      () => capabilities.speakerReferenceInputKinds.clear(),
+      throwsUnsupportedError,
+    );
     expect(completion.state, TextToSpeechCompletionState.completed);
     expect(completion.result?.samples, <double>[0.25, -0.25]);
     expect(backend.lastRequest?.speakerAudioBytes, isNotEmpty);

--- a/test/unit/tooling/run_local_e2e_test.dart
+++ b/test/unit/tooling/run_local_e2e_test.dart
@@ -43,6 +43,7 @@ void main() {
       expect(result.stdout, contains('chat-app-model-cache'));
       expect(result.stdout, contains('chat-app-web-real-model-smoke'));
       expect(result.stdout, contains('chat-app-web-speech-to-text-smoke'));
+      expect(result.stdout, contains('chat-app-web-text-to-speech-smoke'));
       expect(result.stdout, contains('chat-app-web-mock-smoke'));
       expect(result.stdout, contains('chat-app-web-litert-gemma4-smoke'));
       expect(result.stdout, contains('bridge-smoke'));
@@ -122,6 +123,42 @@ void main() {
       expect(result.exitCode, 64);
       expect(result.stderr, contains('--audio-path'));
       expect(result.stderr, contains('--expect'));
+    });
+
+    test('dry-runs Web Qwen3-TTS synthesis and WAV export', () async {
+      final result = await runLocalE2e(const [
+        '--scenario',
+        'chat-app-web-text-to-speech-smoke',
+        '--model-url',
+        'https://example.com/qwen-tts.gguf',
+        '--mmproj-url',
+        'https://example.com/qwen-tts-mmproj.gguf',
+        '--audio-path',
+        'test/fixtures/speaker.wav',
+        '--skip-build',
+        '--python',
+        '/custom/python',
+        '--dry-run',
+      ], projectRoot: '/repo');
+
+      expect(result.exitCode, 0);
+      expect(result.stdout, contains('validate_chat_app_web_build.sh'));
+      expect(
+        result.stdout,
+        contains('playwright_chat_app_text_to_speech_smoke.py'),
+      );
+      expect(
+        result.stdout,
+        contains('--model-url https://example.com/qwen-tts.gguf'),
+      );
+      expect(
+        result.stdout,
+        contains('--mmproj-url https://example.com/qwen-tts-mmproj.gguf'),
+      );
+      expect(
+        result.stdout,
+        contains('--speaker-audio-path test/fixtures/speaker.wav'),
+      );
     });
 
     test(

--- a/tool/testing/playwright_chat_app_text_to_speech_smoke.py
+++ b/tool/testing/playwright_chat_app_text_to_speech_smoke.py
@@ -99,6 +99,10 @@ def main() -> int:
     parser.add_argument("--mmproj-url", required=True)
     parser.add_argument("--prompt", default="Hello from llamadart Web.")
     parser.add_argument("--speaker-audio-path")
+    parser.add_argument("--max-frames", type=int, default=96)
+    parser.add_argument("--top-k", type=int, default=50)
+    parser.add_argument("--top-p", type=float, default=1.0)
+    parser.add_argument("--temperature", type=float, default=0.8)
     parser.add_argument("--load-timeout-ms", type=int, default=40 * 60 * 1000)
     parser.add_argument("--response-timeout-ms", type=int, default=15 * 60 * 1000)
     parser.add_argument(
@@ -108,7 +112,6 @@ def main() -> int:
     )
     parser.add_argument("--headed", action="store_true")
     args = parser.parse_args()
-
     speaker_audio_path = None
     if args.speaker_audio_path:
         speaker_audio_path = Path(args.speaker_audio_path).resolve()
@@ -120,14 +123,14 @@ def main() -> int:
         "flutter.mmproj_path": json.dumps(args.mmproj_url),
         "flutter.preferred_backend": json.dumps(0),
         "flutter.context_size": json.dumps(4096),
-        "flutter.max_tokens": json.dumps(96),
+        "flutter.max_tokens": json.dumps(args.max_frames),
         "flutter.gpu_layers": json.dumps(999),
         "flutter.auto_tune_model_params": json.dumps(False),
         "flutter.threads": json.dumps(2),
         "flutter.threads_batch": json.dumps(2),
-        "flutter.temperature": json.dumps(0.8),
-        "flutter.top_k": json.dumps(50),
-        "flutter.top_p": json.dumps(1.0),
+        "flutter.temperature": json.dumps(args.temperature),
+        "flutter.top_k": json.dumps(args.top_k),
+        "flutter.top_p": json.dumps(args.top_p),
         "flutter.min_p": json.dumps(0.0),
         "flutter.penalty": json.dumps(1.0),
         "flutter.tools_enabled": json.dumps(False),

--- a/tool/testing/playwright_chat_app_text_to_speech_smoke.py
+++ b/tool/testing/playwright_chat_app_text_to_speech_smoke.py
@@ -28,7 +28,6 @@ def wait_for_text(page, needle: str, timeout_ms: int, label: str) -> str:
             return body
         if (
             "Speech synthesis failed:" in body
-            or "Could not play" in body
             or "does not expose dedicated text-to-speech" in body
             or "speaker references require encoded bytes" in body
         ):
@@ -85,9 +84,6 @@ def wait_for_play_attempt(page, timeout_ms: int = 30000) -> None:
         play_calls = page.evaluate("window.__llamadartTtsPlayCalls ?? 0")
         if int(play_calls or 0) > 0:
             return
-        body = safe_body_text(page)
-        if "Could not play the synthesized audio." in body:
-            raise RuntimeError("The chat app reported an autoplay failure")
         time.sleep(0.25)
     raise RuntimeError("The chat app did not attempt TTS autoplay")
 
@@ -309,7 +305,7 @@ def main() -> int:
         synthesize_button.wait_for(state="visible")
         emit("synthesize_click", character_count=len(args.prompt))
         synthesize_button.click()
-        body = wait_for_text(
+        wait_for_text(
             page,
             "Speech ready",
             args.response_timeout_ms,
@@ -339,8 +335,6 @@ def main() -> int:
             raise RuntimeError(f"Bridge returned empty PCM: {result}")
         if int(state.get("progressEvents") or 0) <= 0:
             raise RuntimeError("Bridge did not emit TTS progress")
-        if "Could not play the synthesized audio." in body:
-            raise RuntimeError("The chat app reported an autoplay failure")
 
         with tempfile.TemporaryDirectory(prefix="llamadart-web-tts-") as temp_dir:
             with page.expect_download(timeout=120000) as download_info:

--- a/tool/testing/playwright_chat_app_text_to_speech_smoke.py
+++ b/tool/testing/playwright_chat_app_text_to_speech_smoke.py
@@ -1,0 +1,378 @@
+#!/usr/bin/env python3
+import argparse
+import json
+import tempfile
+import time
+import wave
+from pathlib import Path
+from urllib.parse import urlsplit
+
+from playwright.sync_api import sync_playwright
+
+from playwright_chat_app_utils import (
+    append_console_log,
+    browser_args,
+    emit,
+    enable_flutter_semantics,
+    local_storage_init_script,
+    safe_body_text,
+)
+
+
+def wait_for_text(page, needle: str, timeout_ms: int, label: str) -> str:
+    deadline = time.monotonic() + timeout_ms / 1000
+    last_status = 0.0
+    while time.monotonic() < deadline:
+        body = safe_body_text(page)
+        if needle.lower() in body.lower():
+            return body
+        if (
+            "Speech synthesis failed:" in body
+            or "Could not play" in body
+            or "does not expose dedicated text-to-speech" in body
+            or "speaker references require encoded bytes" in body
+        ):
+            state = page.evaluate(
+                """() => ({
+                  error: window.__llamadartTtsLastError ?? null,
+                  result: window.__llamadartTtsLastResult ?? null,
+                  progressEvents: window.__llamadartTtsProgressEvents ?? 0,
+                  playCalls: window.__llamadartTtsPlayCalls ?? 0,
+                })"""
+            )
+            raise RuntimeError(
+                f"TTS UI failed while waiting for {label}: "
+                f"{json.dumps(state, ensure_ascii=False)}\n{body[-1200:]}"
+            )
+        now = time.monotonic()
+        if now - last_status >= 30:
+            last_status = now
+            emit(
+                "waiting",
+                label=label,
+                elapsed_seconds=round(now - (deadline - timeout_ms / 1000), 1),
+                body_tail=body[-600:],
+            )
+        time.sleep(1)
+    raise TimeoutError(f"Timed out waiting for {label}: {needle}")
+
+
+def validate_wav(path: Path) -> dict[str, int | float]:
+    with wave.open(str(path), "rb") as wav_file:
+        channels = wav_file.getnchannels()
+        sample_rate = wav_file.getframerate()
+        sample_width = wav_file.getsampwidth()
+        frame_count = wav_file.getnframes()
+    if channels != 1 or sample_rate != 24000 or sample_width != 2:
+        raise RuntimeError(
+            "Exported WAV format mismatch: "
+            f"{channels} channel(s), {sample_rate} Hz, {sample_width * 8}-bit"
+        )
+    if frame_count <= 0:
+        raise RuntimeError("Exported WAV contains no audio frames")
+    return {
+        "channels": channels,
+        "sampleRate": sample_rate,
+        "sampleWidth": sample_width,
+        "frameCount": frame_count,
+        "durationSeconds": round(frame_count / sample_rate, 3),
+    }
+
+
+def wait_for_play_attempt(page, timeout_ms: int = 30000) -> None:
+    deadline = time.monotonic() + timeout_ms / 1000
+    while time.monotonic() < deadline:
+        play_calls = page.evaluate("window.__llamadartTtsPlayCalls ?? 0")
+        if int(play_calls or 0) > 0:
+            return
+        body = safe_body_text(page)
+        if "Could not play the synthesized audio." in body:
+            raise RuntimeError("The chat app reported an autoplay failure")
+        time.sleep(0.25)
+    raise RuntimeError("The chat app did not attempt TTS autoplay")
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("app_url")
+    parser.add_argument("--model-url", required=True)
+    parser.add_argument("--mmproj-url", required=True)
+    parser.add_argument("--prompt", default="Hello from llamadart Web.")
+    parser.add_argument("--speaker-audio-path")
+    parser.add_argument("--load-timeout-ms", type=int, default=40 * 60 * 1000)
+    parser.add_argument("--response-timeout-ms", type=int, default=15 * 60 * 1000)
+    parser.add_argument(
+        "--browser-angle",
+        choices=["auto", "default", "metal", "vulkan"],
+        default="auto",
+    )
+    parser.add_argument("--headed", action="store_true")
+    args = parser.parse_args()
+
+    speaker_audio_path = None
+    if args.speaker_audio_path:
+        speaker_audio_path = Path(args.speaker_audio_path).resolve()
+        if not speaker_audio_path.is_file():
+            parser.error(f"--speaker-audio-path does not exist: {speaker_audio_path}")
+
+    seeded_settings = {
+        "flutter.model_path": json.dumps(args.model_url),
+        "flutter.mmproj_path": json.dumps(args.mmproj_url),
+        "flutter.preferred_backend": json.dumps(0),
+        "flutter.context_size": json.dumps(4096),
+        "flutter.max_tokens": json.dumps(96),
+        "flutter.gpu_layers": json.dumps(999),
+        "flutter.auto_tune_model_params": json.dumps(False),
+        "flutter.threads": json.dumps(2),
+        "flutter.threads_batch": json.dumps(2),
+        "flutter.temperature": json.dumps(0.8),
+        "flutter.top_k": json.dumps(50),
+        "flutter.top_p": json.dumps(1.0),
+        "flutter.min_p": json.dumps(0.0),
+        "flutter.penalty": json.dumps(1.0),
+        "flutter.tools_enabled": json.dumps(False),
+        "flutter.thinking_enabled": json.dumps(False),
+        "flutter.single_turn_mode": json.dumps(True),
+        "flutter.model_supports_audio": json.dumps(False),
+        "flutter.model_supports_speech_to_text": json.dumps(False),
+        "flutter.model_supports_text_to_speech": json.dumps(True),
+        "flutter.model_bytes_hint": json.dumps(1482388192),
+        "flutter.log_level": json.dumps(0),
+        "flutter.native_log_level": json.dumps(2),
+    }
+    init_script = f"""
+      window.__llamadartPreferLocalBridgeRuntime = true;
+      window.__llamadartBridgeBootstrapVerbose = true;
+      window.__llamadartBridgeEnableMem64 = true;
+      window.__llamadartBridgePreferMemory64 = true;
+      window.__llamadartBridgeThreadPoolSize = 2;
+      window.__llamadartTtsLastCapabilities = null;
+      window.__llamadartTtsLastOptions = null;
+      window.__llamadartTtsLastResult = null;
+      window.__llamadartTtsLastError = null;
+      window.__llamadartTtsProgressEvents = 0;
+      window.__llamadartTtsPlayCalls = 0;
+
+      const originalPlay = HTMLMediaElement.prototype.play;
+      HTMLMediaElement.prototype.play = function(...args) {{
+        window.__llamadartTtsPlayCalls += 1;
+        return originalPlay.apply(this, args);
+      }};
+
+      window.__llamadartTtsPatchTimer = setInterval(() => {{
+        const BridgeClass = window.LlamaWebGpuBridge;
+        if (typeof BridgeClass !== 'function') return;
+        if (BridgeClass.__llamadartTtsE2ePatched === true) {{
+          clearInterval(window.__llamadartTtsPatchTimer);
+          return;
+        }}
+        const originalCapabilities =
+          BridgeClass.prototype?.getTextToSpeechCapabilities;
+        const originalSynthesize = BridgeClass.prototype?.synthesizeSpeech;
+        if (typeof originalCapabilities !== 'function' ||
+            typeof originalSynthesize !== 'function') return;
+
+        BridgeClass.prototype.getTextToSpeechCapabilities = async function() {{
+          const result = await originalCapabilities.call(this);
+          window.__llamadartTtsLastCapabilities = {{
+            apiVersion: result?.apiVersion ?? null,
+            supported: result?.supported ?? null,
+            modelType: result?.modelType ?? null,
+            sampleRate: result?.sampleRate ?? null,
+            channels: result?.channels ?? null,
+          }};
+          return result;
+        }};
+        BridgeClass.prototype.synthesizeSpeech = async function(options) {{
+          window.__llamadartTtsLastError = null;
+          window.__llamadartTtsLastResult = null;
+          window.__llamadartTtsProgressEvents = 0;
+          window.__llamadartTtsLastOptions = {{
+            text: String(options?.text ?? ''),
+            hasSpeakerAudio: Number(options?.speakerAudio?.byteLength ?? 0) > 0,
+            maxFrames: options?.maxFrames ?? null,
+            topK: options?.topK ?? null,
+            topP: options?.topP ?? null,
+            minP: options?.minP ?? null,
+            temperature: options?.temperature ?? null,
+          }};
+          const downstreamProgress = options?.onProgress;
+          if (typeof downstreamProgress === 'function') {{
+            options.onProgress = function(progress) {{
+              window.__llamadartTtsProgressEvents += 1;
+              return downstreamProgress(progress);
+            }};
+          }}
+          try {{
+            const result = await originalSynthesize.call(this, options);
+            window.__llamadartTtsLastResult = {{
+              sampleRate: result?.sampleRate ?? null,
+              channels: result?.channels ?? null,
+              sampleCount: result?.sampleCount ?? result?.pcm?.length ?? 0,
+              framesGenerated: result?.framesGenerated ?? null,
+              truncated: result?.truncated ?? null,
+            }};
+            return result;
+          }} catch (error) {{
+            window.__llamadartTtsLastError = String(error);
+            throw error;
+          }}
+        }};
+        BridgeClass.__llamadartTtsE2ePatched = true;
+        clearInterval(window.__llamadartTtsPatchTimer);
+      }}, 20);
+      {local_storage_init_script(seeded_settings)}
+    """
+
+    console_logs: list[dict[str, str]] = []
+    page_errors: list[str] = []
+    request_failures: list[str] = []
+    started_at = time.monotonic()
+
+    with sync_playwright() as playwright:
+        browser = playwright.chromium.launch(
+            headless=not args.headed,
+            args=browser_args(args.browser_angle),
+        )
+        app_parts = urlsplit(args.app_url)
+        app_origin = f"{app_parts.scheme}://{app_parts.netloc}"
+        context = browser.new_context(
+            viewport={"width": 1440, "height": 1100},
+            accept_downloads=True,
+        )
+        context.grant_permissions(
+            ["clipboard-read", "clipboard-write"], origin=app_origin
+        )
+        page = context.new_page()
+        page.set_default_timeout(120000)
+        page.add_init_script(init_script)
+        page.on(
+            "console",
+            lambda message: append_console_log(
+                console_logs,
+                message,
+                echo_predicate=lambda record: record["type"] in ("warning", "error")
+                or "llamadart" in record["text"],
+            ),
+        )
+        page.on("pageerror", lambda error: page_errors.append(str(error)))
+        page.on(
+            "requestfailed",
+            lambda request: request_failures.append(
+                f"{request.method} {request.url}: {request.failure}"
+            ),
+        )
+
+        emit("goto", app_url=args.app_url)
+        page.goto(args.app_url, wait_until="domcontentloaded")
+        enable_flutter_semantics(page)
+
+        load_button = page.get_by_role("button", name="Load Model")
+        load_button.wait_for(timeout=120000)
+        emit("load_click", model_url=args.model_url, mmproj_url=args.mmproj_url)
+        load_button.click()
+        body = wait_for_text(
+            page,
+            "Model loaded successfully! Ready to chat.",
+            args.load_timeout_ms,
+            "model load",
+        )
+        emit(
+            "loaded",
+            elapsed_seconds=round(time.monotonic() - started_at, 1),
+            body_tail=body[-500:],
+        )
+
+        if speaker_audio_path is not None:
+            speaker_reference_control = page.get_by_role(
+                "button", name="Add speaker reference", exact=True
+            )
+            speaker_reference_control.wait_for(state="visible", timeout=120000)
+            with page.expect_file_chooser() as chooser:
+                speaker_reference_control.click()
+            chooser.value.set_files(str(speaker_audio_path))
+            page.get_by_role(
+                "button", name=speaker_audio_path.name, exact=True
+            ).wait_for(state="visible", timeout=120000)
+            emit(
+                "speaker_reference_selected",
+                filename=speaker_audio_path.name,
+                encodedByteLength=speaker_audio_path.stat().st_size,
+            )
+
+        textbox = page.get_by_role("textbox").last
+        textbox.fill(args.prompt)
+        synthesize_button = page.get_by_role("button", name="Synthesize speech")
+        synthesize_button.wait_for(state="visible")
+        emit("synthesize_click", character_count=len(args.prompt))
+        synthesize_button.click()
+        body = wait_for_text(
+            page,
+            "Speech ready",
+            args.response_timeout_ms,
+            "speech synthesis",
+        )
+        wait_for_play_attempt(page)
+        state = page.evaluate(
+            """() => ({
+              capabilities: window.__llamadartTtsLastCapabilities,
+              options: window.__llamadartTtsLastOptions,
+              result: window.__llamadartTtsLastResult,
+              error: window.__llamadartTtsLastError,
+              progressEvents: window.__llamadartTtsProgressEvents,
+              playCalls: window.__llamadartTtsPlayCalls,
+              crossOriginIsolated: window.crossOriginIsolated,
+              preferMemory64: window.__llamadartBridgePreferMemory64 ?? null,
+              assetSource: window.__llamadartBridgeAssetSource ?? null,
+              loadError: window.__llamadartBridgeLoadError ?? null,
+            })"""
+        )
+        result = state.get("result") or {}
+        if state.get("error"):
+            raise RuntimeError(f"Bridge TTS failed: {state['error']}")
+        if result.get("sampleRate") != 24000 or result.get("channels") != 1:
+            raise RuntimeError(f"Bridge returned unexpected PCM format: {result}")
+        if int(result.get("sampleCount") or 0) <= 0:
+            raise RuntimeError(f"Bridge returned empty PCM: {result}")
+        if int(state.get("progressEvents") or 0) <= 0:
+            raise RuntimeError("Bridge did not emit TTS progress")
+        if "Could not play the synthesized audio." in body:
+            raise RuntimeError("The chat app reported an autoplay failure")
+
+        with tempfile.TemporaryDirectory(prefix="llamadart-web-tts-") as temp_dir:
+            with page.expect_download(timeout=120000) as download_info:
+                page.get_by_role("button", name="Save WAV").click()
+            download = download_info.value
+            wav_path = Path(temp_dir) / "llamadart-speech.wav"
+            download.save_as(str(wav_path))
+            wav_metadata = validate_wav(wav_path)
+
+        emit(
+            "result",
+            ok=True,
+            elapsedSeconds=round(time.monotonic() - started_at, 1),
+            variant="textToSpeech",
+            modelUrl=args.model_url,
+            mmprojUrl=args.mmproj_url,
+            promptCharacterCount=len(args.prompt),
+            speakerReference=(
+                {
+                    "filename": speaker_audio_path.name,
+                    "encodedByteLength": speaker_audio_path.stat().st_size,
+                }
+                if speaker_audio_path is not None
+                else None
+            ),
+            bridge=state,
+            wav=wav_metadata,
+            bodyTail=body[-1000:],
+            consoleTail=console_logs[-30:],
+            pageErrors=page_errors[-10:],
+            requestFailures=request_failures[-10:],
+        )
+        browser.close()
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tool/testing/run_local_e2e.dart
+++ b/tool/testing/run_local_e2e.dart
@@ -145,6 +145,10 @@ class LocalE2eRunContext {
       'https://huggingface.co/ggml-org/Qwen3-ASR-0.6B-GGUF/resolve/928ab958557df9aa2ef1c93e0e83c7ad0933fae2/Qwen3-ASR-0.6B-Q8_0.gguf';
   String get defaultQwen3AsrWebMmprojUrl =>
       'https://huggingface.co/ggml-org/Qwen3-ASR-0.6B-GGUF/resolve/928ab958557df9aa2ef1c93e0e83c7ad0933fae2/mmproj-Qwen3-ASR-0.6B-Q8_0.gguf';
+  String get defaultQwen3TtsWebModelUrl =>
+      'https://huggingface.co/ggml-org/Qwen3-TTS-12Hz-1.7B-Base-GGUF/resolve/ca27d74bc954b73dadab5b71ca265d87fc861a7c/Qwen3-TTS-12Hz-1.7B-Base-Q4_K_M.gguf';
+  String get defaultQwen3TtsWebMmprojUrl =>
+      'https://huggingface.co/ggml-org/Qwen3-TTS-12Hz-1.7B-Base-GGUF/resolve/ca27d74bc954b73dadab5b71ca265d87fc861a7c/mmproj-Qwen3-TTS-12Hz-1.7B-Base-Q8_0.gguf';
 }
 
 class LocalE2eScenario {
@@ -640,6 +644,51 @@ List<LocalE2eScenario> buildLocalE2eScenarios({String? projectRoot}) {
       },
     ),
     LocalE2eScenario(
+      name: 'chat-app-web-text-to-speech-smoke',
+      group: LocalE2eScenarioGroup.webSmoke,
+      description:
+          'Build chat_app web, synthesize Qwen3-TTS audio, autoplay it, and '
+          'export a validated WAV.',
+      requiresDevice: false,
+      stepsBuilder: (context) {
+        final steps = <LocalE2eCommandStep>[_prepareChatAppWebBuild(context)];
+        steps.addAll([
+          LocalE2eCommandStep(
+            workingDirectory: context.projectRoot,
+            executable: context.python,
+            arguments: [
+              'tool/testing/serve_static_with_headers.py',
+              '--directory',
+              '.',
+              '--port',
+              '${context.port}',
+            ],
+            description: 'Serve repo root with COOP/COEP headers',
+            background: true,
+            waitForPort: context.port,
+          ),
+          LocalE2eCommandStep(
+            workingDirectory: context.projectRoot,
+            executable: context.python,
+            arguments: [
+              'tool/testing/playwright_chat_app_text_to_speech_smoke.py',
+              context.webBuildUrl,
+              '--model-url',
+              context.modelUrl ?? context.defaultQwen3TtsWebModelUrl,
+              '--mmproj-url',
+              context.mmprojUrl ?? context.defaultQwen3TtsWebMmprojUrl,
+              if (context.audioPath != null) ...[
+                '--speaker-audio-path',
+                context.audioPath!,
+              ],
+            ],
+            description: 'Run Playwright Qwen3-TTS Web speech smoke',
+          ),
+        ]);
+        return steps;
+      },
+    ),
+    LocalE2eScenario(
       name: 'chat-app-web-mock-smoke',
       group: LocalE2eScenarioGroup.webSmoke,
       description:
@@ -882,6 +931,7 @@ Future<LocalE2eResult> runLocalE2e(
     'litert-lm-asr-smoke',
     'litert-lm-chat-features-smoke',
     'chat-app-web-speech-to-text-smoke',
+    'chat-app-web-text-to-speech-smoke',
   };
   if (parsed.audioPath != null && !audioPathScenarios.contains(scenario.name)) {
     return LocalE2eResult(

--- a/tool/testing/test_matrix.dart
+++ b/tool/testing/test_matrix.dart
@@ -240,6 +240,22 @@ const List<TestMatrixRow> testMatrixRows = <TestMatrixRow>[
         'chat-app synthesis changes.',
   ),
   TestMatrixRow(
+    id: 'web-text-to-speech-smoke',
+    tier: 'targeted',
+    mode: 'local-only',
+    covers:
+        'published WebGPU bridge, public typed TTS API, Qwen3-TTS catalog, '
+        'optional byte-backed speaker reference, progress, complete 24 kHz '
+        'PCM, chat-app autoplay, and downloaded WAV validation',
+    command:
+        'dart run tool/testing/run_local_e2e.dart --scenario '
+        'chat-app-web-text-to-speech-smoke '
+        '[--audio-path <speaker-reference.wav>]',
+    useWhen:
+        'Web bridge pins, Qwen3-TTS Web, typed speech synthesis, browser '
+        'playback, or WAV export changes.',
+  ),
+  TestMatrixRow(
     id: 'chat-app-microphone-transcription-smoke',
     tier: 'targeted',
     mode: 'manual/device',

--- a/website/docs/changelog/recent-releases.md
+++ b/website/docs/changelog/recent-releases.md
@@ -42,7 +42,8 @@ For canonical full release notes, use:
   capability discovery, cancellation, complete PCM/WAV output, and a dedicated
   synthesize workflow with file or microphone speaker references, automatic
   playback, replay, and WAV export in the Flutter chat example. Web accepts
-  byte-backed speaker references and complete PCM/WAV output; current LiteRT-LM
+  byte-backed speaker references and complete PCM/WAV output, with a bounded
+  example-app utterance length for browser stability; current LiteRT-LM
   artifacts remain unsupported.
 
 - Updated the native llama.cpp runtime to `b10453`, consuming the Granite

--- a/website/docs/changelog/recent-releases.md
+++ b/website/docs/changelog/recent-releases.md
@@ -37,11 +37,13 @@ For canonical full release notes, use:
   transient network failures, safe resume after truncated responses, and a
   distinct integrity-verification state after transfer reaches 100%.
 
-- Added experimental typed Qwen3-TTS synthesis on native llama.cpp, including
+- Added experimental typed Qwen3-TTS synthesis on native llama.cpp and WebGPU
+  bridge assets `v0.1.33+`, including
   capability discovery, cancellation, complete PCM/WAV output, and a dedicated
   synthesize workflow with file or microphone speaker references, automatic
-  playback, replay, and WAV export in the Flutter chat example. Web and the
-  current LiteRT-LM artifacts remain unsupported.
+  playback, replay, and WAV export in the Flutter chat example. Web accepts
+  byte-backed speaker references and complete PCM/WAV output; current LiteRT-LM
+  artifacts remain unsupported.
 
 - Updated the native llama.cpp runtime to `b10453`, consuming the Granite
   Speech heap-overflow, DOTS OCR out-of-bounds, and Step3VL divide-by-zero
@@ -51,7 +53,7 @@ For canonical full release notes, use:
 - Added an experimental typed Qwen3-ASR whole-file transcription workflow, a
   SHA-256-verified Qwen3-ASR 0.6B native-and-Web chat-app preset, and foreground
   microphone recording. WebGPU requires validated bridge assets `v0.1.30+`,
-  pins `v0.1.32` to recover short speech that would otherwise terminate empty,
+  pins `v0.1.33` with the `v0.1.32` short-speech recovery,
   and accepts WAV bytes only; native LiteRT-LM live dictation remains a
   separate implementation.
 

--- a/website/docs/changelog/recent-releases.md
+++ b/website/docs/changelog/recent-releases.md
@@ -43,8 +43,9 @@ For canonical full release notes, use:
   synthesize workflow with file or microphone speaker references, automatic
   playback, replay, and WAV export in the Flutter chat example. Web accepts
   byte-backed speaker references and complete PCM/WAV output, with a bounded
-  example-app utterance length for browser stability; current LiteRT-LM
-  artifacts remain unsupported.
+  example-app utterance length for browser stability. The example pins bridge
+  assets `v0.1.34`, which retry a failed worker WebGPU synthesis once on CPU;
+  current LiteRT-LM artifacts remain unsupported.
 
 - Updated the native llama.cpp runtime to `b10453`, consuming the Granite
   Speech heap-overflow, DOTS OCR out-of-bounds, and Step3VL divide-by-zero
@@ -54,7 +55,7 @@ For canonical full release notes, use:
 - Added an experimental typed Qwen3-ASR whole-file transcription workflow, a
   SHA-256-verified Qwen3-ASR 0.6B native-and-Web chat-app preset, and foreground
   microphone recording. WebGPU requires validated bridge assets `v0.1.30+`,
-  pins `v0.1.33` with the `v0.1.32` short-speech recovery,
+  pins `v0.1.34` with the `v0.1.32` short-speech recovery,
   and accepts WAV bytes only; native LiteRT-LM live dictation remains a
   separate implementation.
 

--- a/website/docs/examples/chat-app.md
+++ b/website/docs/examples/chat-app.md
@@ -103,7 +103,9 @@ flutter test
   completed 24 kHz mono output, replay it, or save it as a WAV file. This is
   separate from chat generation and does not automatically read assistant
   responses aloud. Web uses bridge assets `v0.1.33+`, accepts selected speaker
-  references as bytes, and does not record speaker references.
+  references as bytes, and does not record speaker references. The Web example
+  limits one utterance to 96 codec frames (about 7.7 seconds) to bound browser
+  memory and generation time, and labels output that reaches that limit.
 - The voice-question UI is code-supported on Android, iOS, macOS, and Windows
   when the selected native profile declares direct audio input or the loaded
   projector reports audio support; Linux recording and Web are excluded. That

--- a/website/docs/examples/chat-app.md
+++ b/website/docs/examples/chat-app.md
@@ -97,12 +97,13 @@ flutter test
   timestamp, confidence, or live-partial contract. Qwen3-ASR keeps the separate
   five-minute **Stop & transcribe** workflow and takes precedence for ASR
   profiles.
-- A dedicated native-desktop Qwen3-TTS mode backed by `TextToSpeechEngine`.
+- A dedicated cross-platform Qwen3-TTS mode backed by `TextToSpeechEngine`.
   Type an utterance, optionally choose a language and select or record
   speaker-reference audio, then cancel synthesis, automatically play the
   completed 24 kHz mono output, replay it, or save it as a WAV file. This is
   separate from chat generation and does not automatically read assistant
-  responses aloud.
+  responses aloud. Web uses bridge assets `v0.1.33+`, accepts selected speaker
+  references as bytes, and does not record speaker references.
 - The voice-question UI is code-supported on Android, iOS, macOS, and Windows
   when the selected native profile declares direct audio input or the loaded
   projector reports audio support; Linux recording and Web are excluded. That
@@ -134,8 +135,9 @@ flutter test
 The built-in library is intentionally small and Unsloth-first:
 
 - Cross-platform: FunctionGemma 270M, Qwen3.5 0.8B, Qwen3-ASR 0.6B,
+  Qwen3-TTS 1.7B Base,
   Gemma 4 E2B GGUF, Gemma 4 E2B LiteRT-LM, and Gemma 4 E4B GGUF.
-- Native desktop: Qwen3-TTS 1.7B Base, Gemma 4 12B, Gemma 4 26B A4B,
+- Native desktop: Gemma 4 12B, Gemma 4 26B A4B,
   Gemma 4 31B, and Qwen3.6 35B A3B.
 
 GGUF chat presets use [Unsloth distributions](https://huggingface.co/unsloth).
@@ -152,12 +154,11 @@ Model cards prioritize size, RAM, compatibility, capabilities, cache state, and
 the primary download/load action. Recommended context and output limits remain
 visible without repeating every sampling parameter on every card.
 
-Availability filters match each preset's platform restrictions. The Qwen3-ASR
-preset appears under native and **Web** with its validated platform-specific
-input contract, while Qwen3-TTS and the largest native models remain
-**Desktop** only. The first TTS
-catalog scope reflects macOS CPU/Metal real-model evidence; other native targets
-still require packaged-runtime validation.
+Availability filters match each preset's platform restrictions. Qwen3-ASR and
+Qwen3-TTS appear under native and **Web** with their validated platform-specific
+input contracts, while the largest native models remain **Desktop** only.
+Web Qwen3-TTS requires bridge assets `v0.1.33+`, memory64, and enough browser
+memory for the roughly 1.48 GB model/projector pair.
 
 The complete Qwen3-ASR model/projector, microphone, and final-transcript flow
 has passed on a physical Pixel using CPU inference and in the iOS Simulator.

--- a/website/docs/guides/text-to-speech.md
+++ b/website/docs/guides/text-to-speech.md
@@ -154,5 +154,8 @@ memory-constrained mobile devices.
 - Web requires published bridge assets `v0.1.33+`, WebAssembly memory64 for the
   pinned roughly 1.48 GB model/projector pair, and a browser/device with enough
   memory. Older bridge assets fail capability discovery clearly.
+- The chat example pins `v0.1.34`, which retries a worker WebGPU abort or device
+  failure once on CPU using the cached model and projector. Recovery is slower
+  and is not a substitute for sufficient browser memory.
 - Web speaker references are selected-file bytes only; microphone speaker
   recording remains a native chat-example feature.

--- a/website/docs/guides/text-to-speech.md
+++ b/website/docs/guides/text-to-speech.md
@@ -28,13 +28,26 @@ Use a matching model and projector pair. The chat example pins the Q4_K_M base
 model and Q8_0 projector from
 [`ggml-org/Qwen3-TTS-12Hz-1.7B-Base-GGUF`](https://huggingface.co/ggml-org/Qwen3-TTS-12Hz-1.7B-Base-GGUF).
 
+The structured model-source APIs keep the loading flow portable. Native
+runtimes download and cache remote sources before loading their local files;
+Web passes the same sources to the browser runtime and its cache.
+
 ```dart
 final engine = LlamaEngine(LlamaBackend());
-await engine.loadModel(
-  '/models/Qwen3-TTS-12Hz-1.7B-Base-Q4_K_M.gguf',
+const revision = 'ca27d74bc954b73dadab5b71ca265d87fc861a7c';
+await engine.loadModelSource(
+  ModelSource.huggingFace(
+    repoId: 'ggml-org/Qwen3-TTS-12Hz-1.7B-Base-GGUF',
+    revision: revision,
+    filePath: 'Qwen3-TTS-12Hz-1.7B-Base-Q4_K_M.gguf',
+  ),
 );
-await engine.loadMultimodalProjector(
-  '/models/mmproj-Qwen3-TTS-12Hz-1.7B-Base-Q8_0.gguf',
+await engine.loadMultimodalProjectorSource(
+  ModelSource.huggingFace(
+    repoId: 'ggml-org/Qwen3-TTS-12Hz-1.7B-Base-GGUF',
+    revision: revision,
+    filePath: 'mmproj-Qwen3-TTS-12Hz-1.7B-Base-Q8_0.gguf',
+  ),
 );
 
 final synthesizer = TextToSpeechEngine(
@@ -85,33 +98,38 @@ preflight fails before a task starts. After startup, failures are emitted as a
 stream error and also reported through `task.done`. The event stream is
 single-subscription.
 
-For models that advertise speaker-reference support, pass a complete encoded
-audio file or bytes. Browsers accept encoded bytes only:
+For models that advertise speaker-reference support, encoded bytes are the
+portable representation. In this example, `referenceWavBytes` is a
+`Uint8List` obtained through the host application's file picker or recorder:
 
 ```dart
 final task = await synthesizer.synthesize(
-  const TextToSpeechRequest(
+  TextToSpeechRequest(
     text: 'This utterance uses the supplied reference voice.',
     language: 'English',
-    speakerReference: SpeechAudioFileInput('/recordings/reference.wav'),
+    speakerReference: SpeechAudioBytesInput(referenceWavBytes),
   ),
 );
 ```
 
+Native applications may alternatively use
+`SpeechAudioFileInput('/recordings/reference.wav')`. Browser runtimes cannot
+read arbitrary local filesystem paths.
+
 For Qwen3-TTS, the canonical language codes are `zh`, `en`, `ja`, `ko`, `de`,
 `fr`, `ru`, `pt`, `es`, and `it`. Common English names are normalized to those
 codes, so `language: 'English'` is equivalent to `language: 'en'`. Other values
-fail during typed preflight instead of reaching the native model as an invalid
+fail during typed preflight instead of reaching the backend model as an invalid
 prompt.
 
 Treat reference recordings as sensitive input. The typed API does not retain
-them after the native request completes, but application code remains
+them after the backend request completes, but application code remains
 responsible for its own files, byte buffers, permissions, and disclosures.
 
 ## Cancellation, concurrency, and buffering
 
 Call `task.cancel()` to request cooperative cancellation. Cancelling only the
-event-stream subscription does not cancel native synthesis.
+event-stream subscription does not cancel synthesis.
 
 All typed STT and TTS wrappers over one `LlamaEngine` share a one-task speech
 lease. Do not run chat generation, transcription, or another synthesis on the

--- a/website/docs/guides/text-to-speech.md
+++ b/website/docs/guides/text-to-speech.md
@@ -1,6 +1,6 @@
 ---
 title: Text to Speech
-description: Generate complete PCM and WAV audio with the experimental typed native llama.cpp Qwen3-TTS API.
+description: Generate complete PCM and WAV audio with the experimental typed llama.cpp Qwen3-TTS API on native and WebGPU runtimes.
 ---
 
 `TextToSpeechEngine` is the typed API for speech synthesis. It is separate from
@@ -8,16 +8,17 @@ description: Generate complete PCM and WAV audio with the experimental typed nat
 progress, cancellation, and output buffering are not chat-token semantics.
 
 The first implementation is experimental and deliberately narrow. It supports
-Qwen3-TTS through the native llama.cpp runtime and its matching audio-generation
-projector. It reports prompt/frame progress, then returns one complete 24 kHz
-mono float32 PCM buffer. It does not stream playable audio chunks yet.
+Qwen3-TTS through native llama.cpp or WebGPU bridge assets `v0.1.33+` with the
+matching audio-generation projector. It reports prompt/frame progress, then
+returns one complete 24 kHz mono float32 PCM buffer. It does not stream playable
+audio chunks yet.
 
 ## Current support matrix
 
 | Runtime | Typed `TextToSpeechEngine` | Output |
 | --- | --- | --- |
 | Native llama.cpp / GGUF | Experimental Qwen3-TTS adapter | Complete float32 PCM; WAV helper |
-| WebGPU / GGUF | Unsupported by the published bridge ABI | None |
+| WebGPU / GGUF | Experimental Qwen3-TTS adapter with bridge assets `v0.1.33+` | Complete float32 PCM; WAV helper |
 | Native LiteRT-LM / `.litertlm` | Unsupported by the pinned native artifact | None |
 | LiteRT-LM Web | Unsupported | None |
 
@@ -47,8 +48,8 @@ if (!capabilities.isSupported) {
 ```
 
 Always probe capabilities after both artifacts are loaded. Loading a projector
-does not prove that the installed native runtime exports the required stable
-TTS ABI or that the projector matches the model.
+does not prove that the active native or Web runtime exports the required TTS
+ABI or that the projector matches the model.
 
 ## Synthesize and save WAV
 
@@ -85,7 +86,7 @@ stream error and also reported through `task.done`. The event stream is
 single-subscription.
 
 For models that advertise speaker-reference support, pass a complete encoded
-audio file or bytes:
+audio file or bytes. Browsers accept encoded bytes only:
 
 ```dart
 final task = await synthesizer.synthesize(
@@ -116,14 +117,14 @@ All typed STT and TTS wrappers over one `LlamaEngine` share a one-task speech
 lease. Do not run chat generation, transcription, or another synthesis on the
 same engine until the active speech task completes.
 
-The current native wrapper produces PCM only after all requested audio-codec
+The current native and Web wrappers produce PCM only after all requested audio-codec
 frames have been generated. `supportsIncrementalAudio` and
 `supportsOutputBackpressure` are therefore false. Progress events are useful
 for status and cancellation, but are not playable audio chunks.
 
 ## Chat example
 
-The native-desktop catalog contains a checksum-pinned **Qwen3-TTS 1.7B Base**
+The cross-platform catalog contains a checksum-pinned **Qwen3-TTS 1.7B Base**
 model/projector pair. Selecting it switches the composer into a dedicated TTS
 mode:
 
@@ -132,7 +133,8 @@ mode:
 - cancel while frames are being generated;
 - automatically play the completed output, replay it, or save it as a WAV file.
 
-Native microphone references are capped at 30 seconds. The example reads the
+Native microphone references are capped at 30 seconds. Web users can select an
+existing audio file, which is read as encoded bytes. The example reads the
 completed WAV into memory for synthesis and best-effort deletes the temporary
 recording. Selecting an existing audio file remains available as a separate
 option.
@@ -149,8 +151,8 @@ memory-constrained mobile devices.
 - Qwen3-TTS and llama.cpp audio generation are experimental. Voice quality,
   latency, supported reference formats, and accelerator behavior remain
   model/device dependent.
-- The initial catalog is native-desktop only because current real-model
-  validation covers macOS CPU and Metal. Other native targets require packaged
-  artifact and real-model validation before the catalog is broadened.
-- Web enablement requires a published bridge ABI and real-model browser gates;
-  merely loading a GGUF model on WebGPU does not establish TTS support.
+- Web requires published bridge assets `v0.1.33+`, WebAssembly memory64 for the
+  pinned roughly 1.48 GB model/projector pair, and a browser/device with enough
+  memory. Older bridge assets fail capability discovery clearly.
+- Web speaker references are selected-file bytes only; microphone speaker
+  recording remains a native chat-example feature.

--- a/website/docs/platforms/support-matrix.md
+++ b/website/docs/platforms/support-matrix.md
@@ -22,8 +22,8 @@ explicitly selects the Qwen3-ASR profile and the loaded projector reports audio
 capability. Native accepts WAV, MP3, and FLAC file or byte inputs. WebGPU bridge
 assets `v0.1.30+` opt into the validated Qwen3-ASR path with WAV bytes only;
 older or custom runtimes stay unsupported unless the host explicitly declares
-the capability. Native llama.cpp
-also exposes experimental Qwen3-TTS synthesis through the separate typed
+the capability. Native llama.cpp and WebGPU bridge assets `v0.1.33+` also expose
+experimental Qwen3-TTS synthesis through the separate typed
 [`TextToSpeechEngine`](../guides/text-to-speech). Native LiteRT-LM v0.16 also
 supports experimental CPU-only streaming ASR through
 `SpeechToTextEngine.liteRtLm`, with the native session owned by a worker

--- a/website/docs/platforms/webgpu-bridge.md
+++ b/website/docs/platforms/webgpu-bridge.md
@@ -146,13 +146,13 @@ development validation, and CDN-first loading for normal hosted deployments:
 1. On localhost: local asset first, then CDN fallback.
 2. On hosted deployments: CDN asset first, then local fallback.
 
-The example currently pins bridge assets to `v0.1.33`, with local vendored assets
-identified as `v0.1.33-local-b10453`.
+The example currently pins bridge assets to `v0.1.34`, with local vendored assets
+identified as `v0.1.34-local-b10453`.
 
 Fetch pinned local assets with:
 
 ```bash
-WEBGPU_BRIDGE_ASSETS_TAG=v0.1.33 ./scripts/fetch_webgpu_bridge_assets.sh
+WEBGPU_BRIDGE_ASSETS_TAG=v0.1.34 ./scripts/fetch_webgpu_bridge_assets.sh
 ```
 
 To verify the loaded runtime in a browser console, inspect:
@@ -191,6 +191,9 @@ cannot report success before the bridge exposes `prefetchModelToCache(...)`.
   complete float32 PCM generation, byte-backed speaker references, progress,
   and cancellation through direct and worker runtimes. The pinned roughly
   1.48 GB pair requires memory64 in the browser.
+- `v0.1.34+` bridge assets retry a failed worker WebGPU TTS synthesis once in a
+  CPU main-thread runtime using the already cached model and projector. This
+  recovery is slower than healthy WebGPU synthesis and does not loop.
 - `v0.1.12+` bridge assets forward native-compatible `ModelParams` load
   tuning fields, including multi-sequence slots, KV cache type, flash attention,
   RoPE overrides, split mode, and main GPU.
@@ -321,7 +324,7 @@ You can override bridge asset source/version before loader startup:
 ```html
 <script>
   window.__llamadartBridgeAssetsRepo = 'leehack/llama-web-bridge-assets';
-  window.__llamadartBridgeAssetsTag = 'v0.1.33';
+  window.__llamadartBridgeAssetsTag = 'v0.1.34';
   // Custom assets stay speech-disabled unless the host has validated them:
   // window.__llamadartBridgeSpeechToTextSupported = true;
   // Prefer local runtime even off localhost:

--- a/website/docs/platforms/webgpu-bridge.md
+++ b/website/docs/platforms/webgpu-bridge.md
@@ -146,13 +146,13 @@ development validation, and CDN-first loading for normal hosted deployments:
 1. On localhost: local asset first, then CDN fallback.
 2. On hosted deployments: CDN asset first, then local fallback.
 
-The example currently pins bridge assets to `v0.1.32`, with local vendored assets
-identified as `v0.1.32-local-b10453`.
+The example currently pins bridge assets to `v0.1.33`, with local vendored assets
+identified as `v0.1.33-local-b10453`.
 
 Fetch pinned local assets with:
 
 ```bash
-WEBGPU_BRIDGE_ASSETS_TAG=v0.1.32 ./scripts/fetch_webgpu_bridge_assets.sh
+WEBGPU_BRIDGE_ASSETS_TAG=v0.1.33 ./scripts/fetch_webgpu_bridge_assets.sh
 ```
 
 To verify the loaded runtime in a browser console, inspect:
@@ -187,6 +187,10 @@ cannot report success before the bridge exposes `prefetchModelToCache(...)`.
 - `v0.1.32+` bridge assets recover valid short Qwen3-ASR speech when the model
   initially emits only its end token, while preserving an empty transcript for
   silence.
+- `v0.1.33+` bridge assets expose versioned Qwen3-TTS capability discovery,
+  complete float32 PCM generation, byte-backed speaker references, progress,
+  and cancellation through direct and worker runtimes. The pinned roughly
+  1.48 GB pair requires memory64 in the browser.
 - `v0.1.12+` bridge assets forward native-compatible `ModelParams` load
   tuning fields, including multi-sequence slots, KV cache type, flash attention,
   RoPE overrides, split mode, and main GPU.
@@ -317,7 +321,7 @@ You can override bridge asset source/version before loader startup:
 ```html
 <script>
   window.__llamadartBridgeAssetsRepo = 'leehack/llama-web-bridge-assets';
-  window.__llamadartBridgeAssetsTag = 'v0.1.32';
+  window.__llamadartBridgeAssetsTag = 'v0.1.33';
   // Custom assets stay speech-disabled unless the host has validated them:
   // window.__llamadartBridgeSpeechToTextSupported = true;
   // Prefer local runtime even off localhost:


### PR DESCRIPTION
## Summary

- enable typed Qwen3-TTS synthesis through the WebGPU backend and the Web auto-router
- pin the chat app to published `llama-web-bridge-assets@v0.1.34` and expose the immutable Qwen3-TTS model/projector pair on Web
- recover a worker WebGPU TTS abort or device failure by retrying once in a CPU main-thread runtime with cached model/projector data
- support browser-selected speaker-reference bytes while keeping local file paths and Web microphone reference recording disabled
- add accessible speaker-reference controls, autoplay plus WAV export, capability/version-skew coverage, and a durable real-browser smoke

## Runtime provenance

- bridge source: `llama-web-bridge` merge [`20374be984827b5bb5bbcb334dc8041860d2ecd0`](https://github.com/leehack/llama-web-bridge/commit/20374be984827b5bb5bbcb334dc8041860d2ecd0)
- published assets: [`v0.1.34`](https://github.com/leehack/llama-web-bridge-assets/releases/tag/v0.1.34), manifest/checksums verified
- llama.cpp: `b10453`
- Qwen3-TTS model/projector URLs are revision-pinned with exact sizes and SHA-256 values

## Validation

- bridge PR #39 exact-head and merged-main CI: passed; wasm32/memory64 artifacts and browser state/multimodal smokes passed
- bridge real-model Qwen3-TTS: WebGPU direct and worker paths produced 24 kHz WAV; CPU recovery destination produced 24 kHz WAV after the simulated GPU failure path
- focused Chrome Web backend/WebGPU/public TTS tests after the `v0.1.34` pin: 84 passed
- focused VM TTS/tooling tests before the pin-only update: 50 passed
- chat input tests after the final picker/accessibility fixes: 56 passed
- chat app full VM suite before the pin-only update: 333 passed; `flutter analyze`: clean
- docs build/link validation, release-doc version check, deployable Web build, and pinned `v0.1.34` asset checksum validation: passed
- real headed Chrome WebGPU smoke without a reference on `v0.1.33`: 32,640 samples, 24 kHz mono, autoplay attempted, exported 1.36 s WAV
- real headed Chrome WebGPU smoke with a selected 2.17 MB WAV reference on `v0.1.33`: 40,320 samples, 24 kHz mono, autoplay attempted, exported 1.68 s WAV
- hosted `v0.1.34` preview smoke on exact head `fe10650f8`: cached Qwen3-TTS loaded under the published runtime and synthesized a 2.4 s, 24 kHz mono WAV

## Limits

- Web support currently targets compatible Chromium WebGPU with memory64 and requires roughly 1.48 GB of model/projector downloads plus runtime memory
- the CPU recovery is a single slower retry after a worker WebGPU abort/device failure; it does not make an otherwise memory-incompatible browser reliable
- synthesis returns one complete PCM buffer; this is not streaming TTS
- Web speaker references use selected-file bytes; browser microphone reference recording remains disabled
- browser autoplay policy may still require the user to press Play; WAV export remains available
- Qwen3-TTS audio generation remains experimental upstream, and LiteRT-LM Web TTS is not enabled
