### PR TITLE
Update native and Web llama.cpp pins to b10514

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,17 +1,21 @@
 ## Unreleased
 
+* Updated the default llama.cpp native runtime pin to
+  `leehack/llamadart-native@b10514`, adding BailingMoE3,
+  GraniteSWA/GraniteMoeSWA, speculators-format DSpark checkpoints, and current
+  upstream multimodal/backend fixes and performance improvements. Regenerated
+  matching Dart FFI bindings, refreshed the `llamadart_llama_cpp_flutter`
+  Apple SwiftPM checksum, and aligned current native-runtime documentation.
+
+* Updated the default WebGPU bridge assets to `v0.1.37`, embedding llama.cpp
+  `b10514` to restore native/Web parity. The bridge provisions an explicit 1 MiB
+  Wasm stack for both wasm32 and memory64, preventing the `b10514` graph
+  parameter growth from aborting Qwen3-ASR memory64 context construction.
+
 * Improved Web microphone transcription by warming up browser capture before
   showing the recording-ready state, trimming the warmup silence, and
   rejecting too-short, silent, or unsupported PCM WAV captures before
   inference.
-
-* Updated the default llama.cpp native runtime pin to
-  `leehack/llamadart-native@b10453`, picking up llama.cpp fixes for a Granite
-  Speech heap overflow, a DOTS OCR out-of-bounds write, and a Step3VL
-  divide-by-zero. The update preserves the existing speculative wrapper ABI,
-  regenerates bindings for the signed automatic load mode and current MTMD
-  layouts, and refreshes the `llamadart_llama_cpp_flutter` Apple SwiftPM
-  checksum.
 
 * Added logical batch-size (`n_batch`) and micro-batch-size (`n_ubatch`)
   controls for llama.cpp/WebGPU models in the Flutter chat example. Android
@@ -55,16 +59,17 @@
   with file or microphone speaker references, automatic playback, replay, and
   WAV save controls. Web accepts byte-backed speaker references and complete
   PCM/WAV output, with a bounded example-app utterance length for browser
-  stability. The example pins bridge assets `v0.1.34`, which retry a failed
-  worker WebGPU synthesis once on CPU; current LiteRT-LM artifacts fail
-  explicitly as unsupported.
+  stability. The example pins bridge assets `v0.1.37`, retaining the `v0.1.34`
+  recovery that retries a failed worker WebGPU synthesis once on CPU; current
+  LiteRT-LM artifacts fail explicitly as unsupported.
 
 * Added an experimental typed `SpeechToTextEngine` with an explicit Qwen3-ASR
   adapter profile for whole-file llama.cpp transcription. The Flutter chat
   example includes a SHA-256-verified Qwen3-ASR 0.6B preset plus separate
   **Transcribe Audio** and foreground microphone recording flows on native and
-  WebGPU. Web requires validated bridge assets `v0.1.30+`, pins `v0.1.34` (with
-  the short-speech recovery introduced in `v0.1.32`) to
+  WebGPU. Web requires validated bridge assets `v0.1.30+`, pins `v0.1.37` (with
+  the short-speech recovery introduced in `v0.1.32` and the `b10514` memory64
+  stack fix) to
   recover short speech that would otherwise terminate empty, accepts WAV bytes
   only, and remains separate from native LiteRT-LM live dictation. The native
   flow has been exercised on a physical Pixel with CPU inference and in the

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -61,7 +61,8 @@
   PCM/WAV output, with a bounded example-app utterance length for browser
   stability. The example pins bridge assets `v0.1.37`, retaining the `v0.1.34`
   recovery that retries a failed worker WebGPU synthesis once on CPU; current
-  LiteRT-LM artifacts fail explicitly as unsupported.
+  LiteRT-LM artifacts fail explicitly as unsupported. Apple companion builds
+  now discover the native TTS wrapper ABI from the embedded llama framework.
 
 * Added an experimental typed `SpeechToTextEngine` with an explicit Qwen3-ASR
   adapter profile for whole-file llama.cpp transcription. The Flutter chat

--- a/README.md
+++ b/README.md
@@ -143,9 +143,9 @@ Current default runtime pins:
 
 | Runtime | Pin |
 | --- | --- |
-| Native llama.cpp / GGUF | `leehack/llamadart-native@b10453` |
+| Native llama.cpp / GGUF | `leehack/llamadart-native@b10514` |
 | Native LiteRT-LM / `.litertlm` | `leehack/litert-lm-native@v0.16.0-native.2` |
-| Web llama.cpp / GGUF | `leehack/llama-web-bridge-assets@v0.1.30` |
+| Web llama.cpp / GGUF | `leehack/llama-web-bridge-assets@v0.1.37` |
 | Web LiteRT-LM / `.litertlm` | `@litert-lm/core@0.15.0` |
 
 ## Common Tasks

--- a/doc/webgpu_bridge.md
+++ b/doc/webgpu_bridge.md
@@ -19,12 +19,14 @@ pipelines.
    `https://cdn.jsdelivr.net/gh/leehack/llama-web-bridge-assets@<tag>/llama_webgpu_bridge.js`
 2. Local fallback: `./webgpu_bridge/llama_webgpu_bridge.js`
 
-Default pinned tag in the example is `v0.1.30`.
+Default pinned tag in the example is `v0.1.37`.
 
-That release embeds llama.cpp `b10448` and is the first published asset set
-validated for Qwen3-ASR typed speech-to-text in direct and worker modes. The
-chat bootstrap opts `SpeechToTextEngine` into that contract from the immutable
-tag; older or custom assets remain disabled unless the host explicitly sets
+That release embeds llama.cpp `b10514`, matching the default native runtime. It
+retains the Qwen3-ASR typed speech-to-text contract introduced in `v0.1.30` and
+provisions the explicit 1 MiB Wasm stack needed for `b10514` memory64 context
+construction in direct and worker modes. The chat bootstrap opts
+`SpeechToTextEngine` into that contract from the immutable tag; older or custom
+assets remain disabled unless the host explicitly sets
 `window.__llamadartBridgeSpeechToTextSupported = true` after equivalent
 validation.
 
@@ -39,7 +41,7 @@ model bytes.
 To vendor pinned assets into local app web files:
 
 ```bash
-WEBGPU_BRIDGE_ASSETS_TAG=v0.1.30 ./scripts/fetch_webgpu_bridge_assets.sh
+WEBGPU_BRIDGE_ASSETS_TAG=v0.1.37 ./scripts/fetch_webgpu_bridge_assets.sh
 ```
 
 Optional compatibility env vars:
@@ -120,7 +122,7 @@ You can override CDN source/version before the bridge loader runs:
 ```html
 <script>
   window.__llamadartBridgeAssetsRepo = 'leehack/llama-web-bridge-assets';
-  window.__llamadartBridgeAssetsTag = 'v0.1.30';
+  window.__llamadartBridgeAssetsTag = 'v0.1.37';
 </script>
 ```
 

--- a/example/chat_app/README.md
+++ b/example/chat_app/README.md
@@ -56,12 +56,13 @@ If you run this app on Apple platforms with the Flutter SwiftPM companion
 packages enabled, set the Xcode project deployment target to iOS `16.4` or
 macOS `14.0` or newer first.
 
-This app keeps the default all-runtime native-assets configuration so native
-`.litertlm` presets work on supported targets. If you copy this app and only
-ship GGUF models, set `llamadart_native_runtimes` to `[llama_cpp]` to reduce
-bundle size on hook-managed native-assets builds. Flutter iOS/macOS apps that
-want SwiftPM-linked Apple frameworks should add `llamadart_llama_cpp_flutter`,
-`llamadart_litert_lm_flutter`, or both beside `llamadart`.
+This app keeps the default all-runtime native-assets configuration and declares
+both Apple companion packages so GGUF and `.litertlm` presets work on supported
+targets. If you copy this app and only ship GGUF models, set
+`llamadart_native_runtimes` to `[llama_cpp]` and keep only
+`llamadart_llama_cpp_flutter` to reduce bundle size. Flutter iOS/macOS apps
+should declare the companion package for every runtime they ship beside
+`llamadart`.
 
 ### 1.1 Run Tests
 ```bash

--- a/example/chat_app/macos/Flutter/GeneratedPluginRegistrant.swift
+++ b/example/chat_app/macos/Flutter/GeneratedPluginRegistrant.swift
@@ -8,6 +8,7 @@ import Foundation
 import audioplayers_darwin
 import file_picker
 import llamadart_litert_lm_flutter
+import llamadart_llama_cpp_flutter
 import pasteboard
 import record_macos
 import shared_preferences_foundation
@@ -17,6 +18,7 @@ func RegisterGeneratedPlugins(registry: FlutterPluginRegistry) {
   AudioplayersDarwinPlugin.register(with: registry.registrar(forPlugin: "AudioplayersDarwinPlugin"))
   FilePickerPlugin.register(with: registry.registrar(forPlugin: "FilePickerPlugin"))
   LlamadartLiteRtLmPlugin.register(with: registry.registrar(forPlugin: "LlamadartLiteRtLmPlugin"))
+  LlamadartLlamaCppPlugin.register(with: registry.registrar(forPlugin: "LlamadartLlamaCppPlugin"))
   PasteboardPlugin.register(with: registry.registrar(forPlugin: "PasteboardPlugin"))
   RecordMacOsPlugin.register(with: registry.registrar(forPlugin: "RecordMacOsPlugin"))
   SharedPreferencesPlugin.register(with: registry.registrar(forPlugin: "SharedPreferencesPlugin"))

--- a/example/chat_app/pubspec.lock
+++ b/example/chat_app/pubspec.lock
@@ -421,6 +421,13 @@ packages:
       relative: true
     source: path
     version: "0.0.9"
+  llamadart_llama_cpp_flutter:
+    dependency: "direct main"
+    description:
+      path: "../../packages/llamadart_llama_cpp_flutter"
+      relative: true
+    source: path
+    version: "0.0.13"
   logging:
     dependency: transitive
     description:

--- a/example/chat_app/pubspec.yaml
+++ b/example/chat_app/pubspec.yaml
@@ -12,6 +12,8 @@ dependencies:
     sdk: flutter
   llamadart:
     path: ../..  # Use local version
+  llamadart_llama_cpp_flutter:
+    path: ../../packages/llamadart_llama_cpp_flutter
   llamadart_litert_lm_flutter:
     path: ../../packages/llamadart_litert_lm_flutter
   provider: ^6.0.5

--- a/example/chat_app/web/index.html
+++ b/example/chat_app/web/index.html
@@ -211,10 +211,12 @@
       typeof configuredRepo === 'string' && configuredRepo.length > 0
         ? configuredRepo
         : 'leehack/llama-web-bridge-assets';
+    const defaultBridgeAssetsTag = 'v0.1.37';
+    const defaultBridgeLlamaCppTag = 'b10514';
     const bridgeAssetsTag =
       typeof configuredTag === 'string' && configuredTag.length > 0
         ? configuredTag
-        : 'v0.1.34';
+        : defaultBridgeAssetsTag;
     function bridgeTagSupportsSpeechToText(tag) {
       const match = /^v(\d+)\.(\d+)\.(\d+)(?:$|-)/.exec(String(tag || ''));
       if (!match) return false;
@@ -235,7 +237,8 @@
       window.__llamadartLiteRtLmModuleUrl.length > 0
         ? window.__llamadartLiteRtLmModuleUrl
         : 'https://cdn.jsdelivr.net/npm/@litert-lm/core@0.15.0/+esm';
-    const localBridgeVersion = 'v0.1.34-local-b10453';
+    const localBridgeVersion =
+      `${defaultBridgeAssetsTag}-local-${defaultBridgeLlamaCppTag}`;
     window.__llamadartBridgeLocalVersion = localBridgeVersion;
 
     const localBridgeUrl = `./webgpu_bridge/llama_webgpu_bridge.js?v=${localBridgeVersion}`;

--- a/hook/build.dart
+++ b/hook/build.dart
@@ -13,7 +13,7 @@ import 'package:path/path.dart' as path;
 
 import 'package:llamadart/src/hook/native_bundle_config.dart';
 
-const _llamaCppTag = 'b10453';
+const _llamaCppTag = 'b10514';
 const _nativeRepoSlug = 'leehack/llamadart-native';
 
 const _packageName = 'llamadart';
@@ -1653,9 +1653,9 @@ List<String> _emittedFileNamesForLibrary({
     if (lowered.endsWith('.so') && !lowered.endsWith('.so.0')) {
       fileNames.add('${library.fileName}.0');
     }
-    // llama.cpp b10453 accidentally publishes mtmd with the literal ELF
-    // SONAME `libmtmd.so.SOVERSION`. Keep the immutable release consumable
-    // until the owning native artifact corrects that SONAME.
+    // llamadart-native b10514 still publishes mtmd with the literal ELF SONAME
+    // `libmtmd.so.SOVERSION`. Keep the immutable release consumable until the
+    // owning native artifact corrects that SONAME.
     if (lowered == 'libmtmd.so') {
       fileNames.add('${library.fileName}.SOVERSION');
     }

--- a/lib/src/backends/llama_cpp/bindings.dart
+++ b/lib/src/backends/llama_cpp/bindings.dart
@@ -4706,6 +4706,14 @@ external ffi.Pointer<ggml_tensor> ggml_rope_multi_back(
 );
 
 @ffi.Native<
+  ffi.Pointer<ggml_tensor> Function(ffi.Pointer<ggml_tensor>, ffi.Int)
+>()
+external ffi.Pointer<ggml_tensor> ggml_rope_set_offset(
+  ffi.Pointer<ggml_tensor> a,
+  int n_offs,
+);
+
+@ffi.Native<
   ffi.Pointer<ggml_tensor> Function(
     ffi.Pointer<ggml_context>,
     ffi.Pointer<ggml_tensor>,
@@ -7479,6 +7487,12 @@ external void mtmd_bitmap_set_id(
   ffi.Pointer<ffi.Char> id,
 );
 
+@ffi.Native<ffi.Void Function(ffi.Pointer<mtmd_bitmap>, ffi.Bool)>()
+external void mtmd_bitmap_set_mergeable(
+  ffi.Pointer<mtmd_bitmap> bitmap,
+  bool mergeable,
+);
+
 @ffi.Native<
   ffi.Pointer<mtmd_bitmap> Function(
     ffi.Pointer<mtmd_context>,
@@ -7561,6 +7575,13 @@ external ffi.Pointer<mtmd_input_chunk> mtmd_input_chunk_copy(
 
 @ffi.Native<ffi.Void Function(ffi.Pointer<mtmd_input_chunk>)>()
 external void mtmd_input_chunk_free(ffi.Pointer<mtmd_input_chunk> chunk);
+
+@ffi.Native<
+  ffi.Pointer<mtmd_input_chunk> Function(ffi.Pointer<mtmd_input_chunk>)
+>()
+external ffi.Pointer<mtmd_input_chunk> mtmd_input_chunk_get_placeholder(
+  ffi.Pointer<mtmd_input_chunk> chunk,
+);
 
 @ffi.Native<
   ffi.Int32 Function(

--- a/lib/src/backends/llama_cpp/llama_cpp_service.dart
+++ b/lib/src/backends/llama_cpp/llama_cpp_service.dart
@@ -3479,6 +3479,7 @@ class LlamaCppService {
       // as a bare libllamadart.dylib. Opening the framework binary directly
       // makes dynamically discovered wrapper ABIs visible to FFI.
       candidates.add(path.join('llamadart.framework', 'llamadart'));
+      candidates.add(path.join('llama.framework', 'llama'));
     }
     return candidates;
   }

--- a/packages/llamadart_llama_cpp_flutter/CHANGELOG.md
+++ b/packages/llamadart_llama_cpp_flutter/CHANGELOG.md
@@ -1,6 +1,6 @@
 ## Unreleased
 
-* Updated Apple SwiftPM native pin to `leehack/llamadart-native@b10453`.
+* Updated Apple SwiftPM native pin to `leehack/llamadart-native@b10514`.
 
 ## 0.0.13
 

--- a/packages/llamadart_llama_cpp_flutter/README.md
+++ b/packages/llamadart_llama_cpp_flutter/README.md
@@ -16,7 +16,7 @@ dependencies:
 This package has no runtime Dart API of its own. Import `package:llamadart`
 normally from the core package and use `LlamaBackend()` / `LlamaEngine` there.
 
-The Apple SwiftPM manifest pins `leehack/llamadart-native@b10453`.
+The Apple SwiftPM manifest pins `leehack/llamadart-native@b10514`.
 
 Source for this package lives in
 `packages/llamadart_llama_cpp_flutter` in the

--- a/packages/llamadart_llama_cpp_flutter/darwin/llamadart_llama_cpp_flutter/Package.swift
+++ b/packages/llamadart_llama_cpp_flutter/darwin/llamadart_llama_cpp_flutter/Package.swift
@@ -4,7 +4,7 @@ import PackageDescription
 
 let packageRoot = URL(fileURLWithPath: #filePath).deletingLastPathComponent()
 let artifactsRoot = packageRoot.appendingPathComponent("Artifacts")
-let llamaCppTag = "b10453"
+let llamaCppTag = "b10514"
 
 func localArtifactPath(_ name: String) -> String? {
     let path = artifactsRoot.appendingPathComponent(name).path
@@ -47,7 +47,7 @@ let package = Package(
             repository: "leehack/llamadart-native",
             artifactName: "llamadart-native-apple-xcframework-\(llamaCppTag).zip",
             tag: llamaCppTag,
-            checksum: "69c1e9b64d8e733fda97a75cbaf91dbe15aeaa9d5d1a9fc99080c8eed6fdf5fc"
+            checksum: "d700be95bddd0255eb6e544a6f6760e0647e1e1819e7bc22638a097f976a7a8d"
         ),
         .target(
             name: "llamadart_llama_cpp_flutter",

--- a/scripts/fetch_webgpu_bridge_assets.sh
+++ b/scripts/fetch_webgpu_bridge_assets.sh
@@ -4,7 +4,7 @@ set -euo pipefail
 ROOT_DIR="$(git rev-parse --show-toplevel)"
 OUT_DIR="${WEBGPU_BRIDGE_OUT_DIR:-$ROOT_DIR/example/chat_app/web/webgpu_bridge}"
 ASSETS_REPO="${WEBGPU_BRIDGE_ASSETS_REPO:-leehack/llama-web-bridge-assets}"
-ASSETS_TAG="${WEBGPU_BRIDGE_ASSETS_TAG:-v0.1.34}"
+ASSETS_TAG="${WEBGPU_BRIDGE_ASSETS_TAG:-v0.1.37}"
 CDN_BASE="${WEBGPU_BRIDGE_CDN_BASE:-https://cdn.jsdelivr.net/gh/${ASSETS_REPO}@${ASSETS_TAG}}"
 PATCH_SAFARI_COMPAT="${WEBGPU_BRIDGE_PATCH_SAFARI_COMPAT:-1}"
 MIN_SAFARI_VERSION="${WEBGPU_BRIDGE_MIN_SAFARI_VERSION:-170400}"
@@ -14,7 +14,7 @@ if [[ "${1:-}" == "--help" || "${1:-}" == "-h" ]]; then
 Downloads prebuilt WebGPU bridge assets into the chat_app web directory.
 
 Default source:
-  https://cdn.jsdelivr.net/gh/leehack/llama-web-bridge-assets@v0.1.34
+  https://cdn.jsdelivr.net/gh/leehack/llama-web-bridge-assets@v0.1.37
 
 Environment variables:
   WEBGPU_BRIDGE_ASSETS_REPO   Asset repo in owner/repo format
@@ -28,7 +28,7 @@ Usage:
   ./scripts/fetch_webgpu_bridge_assets.sh
 
 Examples:
-  WEBGPU_BRIDGE_ASSETS_TAG=v0.1.34 ./scripts/fetch_webgpu_bridge_assets.sh
+  WEBGPU_BRIDGE_ASSETS_TAG=v0.1.37 ./scripts/fetch_webgpu_bridge_assets.sh
   WEBGPU_BRIDGE_ASSETS_REPO=acme/llama-web-bridge-assets WEBGPU_BRIDGE_ASSETS_TAG=v2 ./scripts/fetch_webgpu_bridge_assets.sh
 USAGE
   exit 0

--- a/scripts/validate_chat_app_web_build.sh
+++ b/scripts/validate_chat_app_web_build.sh
@@ -36,12 +36,13 @@ for wasm_file in \
   fi
 done
 
+manifest_json="$(tr -d '\r\n' < "$BRIDGE_DIR/manifest.json")"
 manifest_tag="$(sed -nE \
-  's/^[[:space:]]*"bridge_assets_tag":[[:space:]]*"([^"]+)".*$/\1/p' \
-  "$BRIDGE_DIR/manifest.json")"
+  's/.*"bridge_assets_tag":[[:space:]]*"([^"]+)".*/\1/p' \
+  <<<"$manifest_json")"
 manifest_llama_cpp_tag="$(sed -nE \
-  's/^[[:space:]]*"llama_cpp_tag":[[:space:]]*"([^"]+)".*$/\1/p' \
-  "$BRIDGE_DIR/manifest.json")"
+  's/.*"llama_cpp_tag":[[:space:]]*"([^"]+)".*/\1/p' \
+  <<<"$manifest_json")"
 bootstrap_tag="$(sed -nE \
   "s/^[[:space:]]*const defaultBridgeAssetsTag = '([^']+)';.*$/\1/p" \
   "$BUILD_DIR/index.html")"

--- a/scripts/validate_chat_app_web_build.sh
+++ b/scripts/validate_chat_app_web_build.sh
@@ -36,6 +36,34 @@ for wasm_file in \
   fi
 done
 
+manifest_tag="$(sed -nE \
+  's/^[[:space:]]*"bridge_assets_tag":[[:space:]]*"([^"]+)".*$/\1/p' \
+  "$BRIDGE_DIR/manifest.json")"
+manifest_llama_cpp_tag="$(sed -nE \
+  's/^[[:space:]]*"llama_cpp_tag":[[:space:]]*"([^"]+)".*$/\1/p' \
+  "$BRIDGE_DIR/manifest.json")"
+bootstrap_tag="$(sed -nE \
+  "s/^[[:space:]]*const defaultBridgeAssetsTag = '([^']+)';.*$/\1/p" \
+  "$BUILD_DIR/index.html")"
+bootstrap_llama_cpp_tag="$(sed -nE \
+  "s/^[[:space:]]*const defaultBridgeLlamaCppTag = '([^']+)';.*$/\1/p" \
+  "$BUILD_DIR/index.html")"
+
+if [[ -z "$manifest_tag" || -z "$manifest_llama_cpp_tag" ]]; then
+  echo "[chat-app-web] error: bridge manifest is missing version provenance" >&2
+  exit 1
+fi
+
+if [[ "$bootstrap_tag" != "$manifest_tag" ]]; then
+  echo "[chat-app-web] error: bootstrap bridge tag '$bootstrap_tag' does not match manifest '$manifest_tag'" >&2
+  exit 1
+fi
+
+if [[ "$bootstrap_llama_cpp_tag" != "$manifest_llama_cpp_tag" ]]; then
+  echo "[chat-app-web] error: bootstrap llama.cpp tag '$bootstrap_llama_cpp_tag' does not match manifest '$manifest_llama_cpp_tag'" >&2
+  exit 1
+fi
+
 (
   cd "$BRIDGE_DIR"
   if command -v sha256sum >/dev/null 2>&1; then

--- a/scripts/validate_chat_app_web_build.sh
+++ b/scripts/validate_chat_app_web_build.sh
@@ -54,6 +54,11 @@ if [[ -z "$manifest_tag" || -z "$manifest_llama_cpp_tag" ]]; then
   exit 1
 fi
 
+if [[ -z "$bootstrap_tag" || -z "$bootstrap_llama_cpp_tag" ]]; then
+  echo "[chat-app-web] error: chat app bootstrap is missing bridge version provenance" >&2
+  exit 1
+fi
+
 if [[ "$bootstrap_tag" != "$manifest_tag" ]]; then
   echo "[chat-app-web] error: bootstrap bridge tag '$bootstrap_tag' does not match manifest '$manifest_tag'" >&2
   exit 1

--- a/test/integration/backends/llama_cpp/native_symbol_integration_test.dart
+++ b/test/integration/backends/llama_cpp/native_symbol_integration_test.dart
@@ -52,8 +52,6 @@ const _b10514BindingSymbols = [
   'mtmd_input_chunk_get_placeholder',
 ];
 
-const _b10514CoreSymbols = ['ggml_rope_set_offset'];
-
 const _b10514MtmdSymbols = [
   'mtmd_bitmap_set_mergeable',
   'mtmd_input_chunk_get_placeholder',
@@ -801,16 +799,6 @@ void main() {
         reason: 'Expected a native library exporting mtmd symbols.',
       );
       _expectDynamicLibraryExports(libraryFile!, _b10514MtmdSymbols);
-    });
-
-    test('Verify b10514 core symbols are resolvable', () {
-      final libraryFile = _llamadartWrapperLibraryFileOrNull();
-      expect(
-        libraryFile,
-        isNotNull,
-        reason: 'Expected a native library exporting llama.cpp symbols.',
-      );
-      _expectDynamicLibraryExports(libraryFile!, _b10514CoreSymbols);
     });
 
     test('Verify core llama symbols are resolvable', () {

--- a/test/integration/backends/llama_cpp/native_symbol_integration_test.dart
+++ b/test/integration/backends/llama_cpp/native_symbol_integration_test.dart
@@ -52,6 +52,8 @@ const _b10514BindingSymbols = [
   'mtmd_input_chunk_get_placeholder',
 ];
 
+const _b10514CoreSymbols = ['ggml_rope_set_offset'];
+
 const _b10514MtmdSymbols = [
   'mtmd_bitmap_set_mergeable',
   'mtmd_input_chunk_get_placeholder',
@@ -799,6 +801,16 @@ void main() {
         reason: 'Expected a native library exporting mtmd symbols.',
       );
       _expectDynamicLibraryExports(libraryFile!, _b10514MtmdSymbols);
+    });
+
+    test('Verify b10514 core symbols are resolvable', () {
+      final libraryFile = _llamadartWrapperLibraryFileOrNull();
+      expect(
+        libraryFile,
+        isNotNull,
+        reason: 'Expected a native library exporting llama.cpp symbols.',
+      );
+      _expectDynamicLibraryExports(libraryFile!, _b10514CoreSymbols);
     });
 
     test('Verify core llama symbols are resolvable', () {

--- a/test/integration/backends/llama_cpp/native_symbol_integration_test.dart
+++ b/test/integration/backends/llama_cpp/native_symbol_integration_test.dart
@@ -46,6 +46,17 @@ const _genericSpeculativeSymbols = [
   'llama_dart_speculative_accept',
 ];
 
+const _b10514BindingSymbols = [
+  'ggml_rope_set_offset',
+  'mtmd_bitmap_set_mergeable',
+  'mtmd_input_chunk_get_placeholder',
+];
+
+const _b10514MtmdSymbols = [
+  'mtmd_bitmap_set_mergeable',
+  'mtmd_input_chunk_get_placeholder',
+];
+
 const _transparentPngBytes = <int>[
   0x89,
   0x50,
@@ -415,6 +426,20 @@ void main() {
       }
     });
 
+    test('Verify b10514 symbols are declared in generated bindings', () {
+      final bindingsSource = File(
+        'lib/src/backends/llama_cpp/bindings.dart',
+      ).readAsStringSync();
+
+      for (final symbol in _b10514BindingSymbols) {
+        expect(
+          bindingsSource,
+          matches(RegExp(r'external\s+[\s\S]*?\b' + RegExp.escape(symbol))),
+          reason: symbol,
+        );
+      }
+    });
+
     test('Verify MTP wrapper symbols are resolvable', () {
       if (Platform.isWindows) {
         expect(() => llama_context_default_params(), returnsNormally);
@@ -763,6 +788,17 @@ void main() {
             'mtmd_bitmap_free',
           );
       _expectBitmapHelperDecodesTransparentPng(helper, bitmapFree);
+    });
+
+    test('Verify b10514 mtmd symbols are resolvable', () {
+      final libraryFile =
+          _mtmdFallbackLibraryFile() ?? _llamadartWrapperLibraryFileOrNull();
+      expect(
+        libraryFile,
+        isNotNull,
+        reason: 'Expected a native library exporting mtmd symbols.',
+      );
+      _expectDynamicLibraryExports(libraryFile!, _b10514MtmdSymbols);
     });
 
     test('Verify core llama symbols are resolvable', () {

--- a/test/integration/backends/llama_cpp/native_symbol_integration_test.dart
+++ b/test/integration/backends/llama_cpp/native_symbol_integration_test.dart
@@ -419,8 +419,8 @@ void main() {
         ..._genericSpeculativeSymbols,
       ]) {
         expect(
-          bindingsSource,
-          matches(RegExp(r'external\s+[\s\S]*?\b' + RegExp.escape(symbol))),
+          _declaresExternalFunction(bindingsSource, symbol),
+          isTrue,
           reason: symbol,
         );
       }
@@ -433,8 +433,8 @@ void main() {
 
       for (final symbol in _b10514BindingSymbols) {
         expect(
-          bindingsSource,
-          matches(RegExp(r'external\s+[\s\S]*?\b' + RegExp.escape(symbol))),
+          _declaresExternalFunction(bindingsSource, symbol),
+          isTrue,
           reason: symbol,
         );
       }
@@ -821,3 +821,7 @@ void main() {
     });
   });
 }
+
+bool _declaresExternalFunction(String source, String symbol) => RegExp(
+  r'external\s+[^;]*\b' + RegExp.escape(symbol) + r'\s*\(',
+).hasMatch(source);

--- a/test/unit/backends/llama_cpp/llama_cpp_service_test.dart
+++ b/test/unit/backends/llama_cpp/llama_cpp_service_test.dart
@@ -1657,7 +1657,7 @@ void main() {
     expect(LlamaCppService.resolveBackendModuleDirectory(), isNull);
   });
 
-  test('Apple wrapper lookup includes the embedded framework binary', () {
+  test('Apple wrapper lookup includes embedded framework binary names', () {
     if (!Platform.isMacOS) {
       return;
     }
@@ -1667,6 +1667,10 @@ void main() {
     expect(
       candidates,
       contains(endsWith(path.join('llamadart.framework', 'llamadart'))),
+    );
+    expect(
+      candidates,
+      contains(endsWith(path.join('llama.framework', 'llama'))),
     );
   });
 }

--- a/test/unit/tooling/run_local_e2e_test.dart
+++ b/test/unit/tooling/run_local_e2e_test.dart
@@ -925,47 +925,55 @@ void main() {
     });
 
     test('reports port conflicts before starting Web smoke servers', () async {
-      final socket = await ServerSocket.bind(InternetAddress.loopbackIPv4, 0);
-      addTearDown(socket.close);
       final tempDir = await _createBridgeSmokeFixture();
       addTearDown(() => tempDir.delete(recursive: true));
+      const port = 9123;
 
-      final result = await runLocalE2e([
-        '--scenario',
-        'bridge-smoke',
-        '--skip-build',
-        '--port',
-        '${socket.port}',
-      ], projectRoot: tempDir.path);
+      final result = await runLocalE2e(
+        ['--scenario', 'bridge-smoke', '--skip-build', '--port', '$port'],
+        projectRoot: tempDir.path,
+        portAvailabilityCheck: (actualPort) async {
+          throw StateError(
+            'Port $actualPort is already in use; stop the existing server or '
+            'choose a different --port.',
+          );
+        },
+      );
 
       expect(result.exitCode, isNot(0));
       expect(
         result.stdout,
         contains('Running local E2E scenario: bridge-smoke'),
       );
-      expect(result.stderr, contains('Port ${socket.port} is already in use'));
+      expect(result.stderr, contains('Port $port is already in use'));
     });
 
     test('reports background server startup failures', () async {
-      final socket = await ServerSocket.bind(InternetAddress.loopbackIPv4, 0);
-      final port = socket.port;
-      await socket.close();
-
       final tempDir = await Directory.systemTemp.createTemp(
         'run_local_e2e_test_',
       );
       addTearDown(() => tempDir.delete(recursive: true));
       await _writeBridgeSmokeValidator(tempDir);
+      const port = 9124;
 
-      final result = await runLocalE2e([
-        '--scenario',
-        'bridge-smoke',
-        '--skip-build',
-        '--python',
-        'dart',
-        '--port',
-        '$port',
-      ], projectRoot: tempDir.path);
+      final result = await runLocalE2e(
+        [
+          '--scenario',
+          'bridge-smoke',
+          '--skip-build',
+          '--python',
+          Platform.resolvedExecutable,
+          '--port',
+          '$port',
+        ],
+        projectRoot: tempDir.path,
+        portReadinessWait: (actualPort, _) async {
+          throw StateError(
+            'Background server exited before port $actualPort became ready '
+            '(exit code 1).',
+          );
+        },
+      );
 
       expect(result.exitCode, isNot(0));
       expect(result.stderr, contains('Background server exited'));

--- a/test/unit/tooling/run_local_e2e_test.dart
+++ b/test/unit/tooling/run_local_e2e_test.dart
@@ -932,6 +932,7 @@ void main() {
       final result = await runLocalE2e(
         ['--scenario', 'bridge-smoke', '--skip-build', '--port', '$port'],
         projectRoot: tempDir.path,
+        foregroundStepRun: _successfulForegroundStep,
         portAvailabilityCheck: (actualPort) async {
           throw StateError(
             'Port $actualPort is already in use; stop the existing server or '
@@ -953,7 +954,6 @@ void main() {
         'run_local_e2e_test_',
       );
       addTearDown(() => tempDir.delete(recursive: true));
-      await _writeBridgeSmokeValidator(tempDir);
       const port = 9124;
 
       final result = await runLocalE2e(
@@ -967,6 +967,8 @@ void main() {
           '$port',
         ],
         projectRoot: tempDir.path,
+        foregroundStepRun: _successfulForegroundStep,
+        portAvailabilityCheck: (_) async {},
         portReadinessWait: (actualPort, _) async {
           throw StateError(
             'Background server exited before port $actualPort became ready '
@@ -1017,17 +1019,8 @@ void main() {
 }
 
 Future<Directory> _createBridgeSmokeFixture() async {
-  final directory = await Directory.systemTemp.createTemp(
-    'run_local_e2e_bridge_test_',
-  );
-  await _writeBridgeSmokeValidator(directory);
-  return directory;
+  return Directory.systemTemp.createTemp('run_local_e2e_bridge_test_');
 }
 
-Future<void> _writeBridgeSmokeValidator(Directory directory) async {
-  final validator = File(
-    '${directory.path}/scripts/validate_chat_app_web_build.sh',
-  );
-  await validator.create(recursive: true);
-  await validator.writeAsString('#!/bin/sh\nexit 0\n');
-}
+Future<ProcessResult> _successfulForegroundStep(LocalE2eCommandStep _) async =>
+    ProcessResult(0, 0, '', '');

--- a/test/unit/tooling/run_local_e2e_test.dart
+++ b/test/unit/tooling/run_local_e2e_test.dart
@@ -242,6 +242,53 @@ void main() {
       },
     );
 
+    test('dry-runs packaged bridge smoke with build and serve steps', () async {
+      final result = await runLocalE2e(const [
+        '--scenario',
+        'bridge-smoke',
+        '--python',
+        '/custom/python',
+        '--dry-run',
+      ], projectRoot: '/repo');
+
+      expect(result.exitCode, 0);
+      expect(
+        result.stdout,
+        contains(
+          'CHAT_APP_BASE_HREF=/example/chat_app/build/web/ '
+          'bash scripts/build_chat_app_web.sh',
+        ),
+      );
+      expect(result.stdout, contains('serve_static_with_headers.py'));
+      expect(
+        result.stdout,
+        contains(
+          '/custom/python tool/testing/playwright_bridge_smoke.py '
+          'http://127.0.0.1:7358/example/chat_app/build/web/',
+        ),
+      );
+    });
+
+    test('validates an existing packaged bridge build when skipped', () async {
+      final result = await runLocalE2e(const [
+        '--scenario',
+        'bridge-smoke',
+        '--skip-build',
+        '--dry-run',
+      ], projectRoot: '/repo');
+
+      expect(result.exitCode, 0);
+      expect(
+        result.stdout,
+        contains('bash scripts/validate_chat_app_web_build.sh'),
+      );
+      expect(result.stdout, isNot(contains('scripts/build_chat_app_web.sh')));
+      expect(
+        result.stdout,
+        contains('http://127.0.0.1:7358/example/chat_app/build/web/'),
+      );
+    });
+
     test('prefers repo-local Playwright Python by default', () async {
       final tempDir = await Directory.systemTemp.createTemp(
         'run_local_e2e_python_test_',
@@ -880,13 +927,16 @@ void main() {
     test('reports port conflicts before starting Web smoke servers', () async {
       final socket = await ServerSocket.bind(InternetAddress.loopbackIPv4, 0);
       addTearDown(socket.close);
+      final tempDir = await _createBridgeSmokeFixture();
+      addTearDown(() => tempDir.delete(recursive: true));
 
       final result = await runLocalE2e([
         '--scenario',
         'bridge-smoke',
+        '--skip-build',
         '--port',
         '${socket.port}',
-      ], projectRoot: '/repo');
+      ], projectRoot: tempDir.path);
 
       expect(result.exitCode, isNot(0));
       expect(
@@ -905,13 +955,12 @@ void main() {
         'run_local_e2e_test_',
       );
       addTearDown(() => tempDir.delete(recursive: true));
-      await Directory(
-        '${tempDir.path}/example/chat_app/web',
-      ).create(recursive: true);
+      await _writeBridgeSmokeValidator(tempDir);
 
       final result = await runLocalE2e([
         '--scenario',
         'bridge-smoke',
+        '--skip-build',
         '--python',
         'dart',
         '--port',
@@ -957,4 +1006,20 @@ void main() {
       expect(metadata.toString(), isNot(contains(audioPath)));
     });
   });
+}
+
+Future<Directory> _createBridgeSmokeFixture() async {
+  final directory = await Directory.systemTemp.createTemp(
+    'run_local_e2e_bridge_test_',
+  );
+  await _writeBridgeSmokeValidator(directory);
+  return directory;
+}
+
+Future<void> _writeBridgeSmokeValidator(Directory directory) async {
+  final validator = File(
+    '${directory.path}/scripts/validate_chat_app_web_build.sh',
+  );
+  await validator.create(recursive: true);
+  await validator.writeAsString('#!/bin/sh\nexit 0\n');
 }

--- a/tool/testing/playwright_bridge_smoke.py
+++ b/tool/testing/playwright_bridge_smoke.py
@@ -136,7 +136,10 @@ def main() -> int:
               window.Worker = FakeWorker;
 
               try {
-                const moduleUrl = `/webgpu_bridge/llama_webgpu_bridge.js?v=${Date.now()}`;
+                const moduleUrl = new URL(
+                  `webgpu_bridge/llama_webgpu_bridge.js?v=${Date.now()}`,
+                  document.baseURI,
+                ).href;
                 const mod = await import(moduleUrl);
                 const Bridge = mod.LlamaWebGpuBridge;
                 const bridge = new Bridge({

--- a/tool/testing/run_local_e2e.dart
+++ b/tool/testing/run_local_e2e.dart
@@ -881,6 +881,8 @@ List<LocalE2eScenario> buildLocalE2eScenarios({String? projectRoot}) {
 Future<LocalE2eResult> runLocalE2e(
   List<String> args, {
   String? projectRoot,
+  Future<void> Function(int port)? portAvailabilityCheck,
+  Future<void> Function(int port, Process owner)? portReadinessWait,
 }) async {
   final parsed = _ParsedArgs.parse(args);
   if (parsed.help) {
@@ -1071,7 +1073,7 @@ Future<LocalE2eResult> runLocalE2e(
       if (step.background) {
         final port = step.waitForPort;
         if (port != null) {
-          await _ensurePortAvailable(port);
+          await (portAvailabilityCheck ?? _ensurePortAvailable)(port);
         }
         final process = await Process.start(
           step.executable,
@@ -1094,7 +1096,7 @@ Future<LocalE2eResult> runLocalE2e(
           ),
         );
         if (port != null) {
-          await _waitForPort(port, process);
+          await (portReadinessWait ?? _waitForPort)(port, process);
         }
         continue;
       }

--- a/tool/testing/run_local_e2e.dart
+++ b/tool/testing/run_local_e2e.dart
@@ -132,7 +132,6 @@ class LocalE2eRunContext {
   final bool skipBuild;
 
   String get chatAppDir => '$projectRoot/example/chat_app';
-  String get chatAppWebDir => '$chatAppDir/web';
   String get webBuildUrl =>
       'http://127.0.0.1:$port/example/chat_app/build/web/';
   String get defaultModelUrl =>
@@ -847,20 +846,21 @@ List<LocalE2eScenario> buildLocalE2eScenarios({String? projectRoot}) {
     LocalE2eScenario(
       name: 'bridge-smoke',
       group: LocalE2eScenarioGroup.webSmoke,
-      description: 'Run the cheap WebGPU bridge bootstrap smoke.',
+      description: 'Run the packaged WebGPU bridge bootstrap smoke.',
       requiresDevice: false,
       stepsBuilder: (context) => [
+        _prepareChatAppWebBuild(context),
         LocalE2eCommandStep(
-          workingDirectory: context.chatAppWebDir,
+          workingDirectory: context.projectRoot,
           executable: context.python,
           arguments: [
-            '-m',
-            'http.server',
+            'tool/testing/serve_static_with_headers.py',
+            '--directory',
+            '.',
+            '--port',
             '${context.port}',
-            '--bind',
-            '127.0.0.1',
           ],
-          description: 'Serve repo root for bridge smoke',
+          description: 'Serve repo root with COOP/COEP headers',
           background: true,
           waitForPort: context.port,
         ),
@@ -869,9 +869,9 @@ List<LocalE2eScenario> buildLocalE2eScenarios({String? projectRoot}) {
           executable: context.python,
           arguments: [
             'tool/testing/playwright_bridge_smoke.py',
-            'http://127.0.0.1:${context.port}',
+            context.webBuildUrl,
           ],
-          description: 'Run bridge smoke',
+          description: 'Run packaged bridge smoke',
         ),
       ],
     ),

--- a/tool/testing/run_local_e2e.dart
+++ b/tool/testing/run_local_e2e.dart
@@ -883,6 +883,7 @@ Future<LocalE2eResult> runLocalE2e(
   String? projectRoot,
   Future<void> Function(int port)? portAvailabilityCheck,
   Future<void> Function(int port, Process owner)? portReadinessWait,
+  Future<ProcessResult> Function(LocalE2eCommandStep step)? foregroundStepRun,
 }) async {
   final parsed = _ParsedArgs.parse(args);
   if (parsed.help) {
@@ -1101,13 +1102,15 @@ Future<LocalE2eResult> runLocalE2e(
         continue;
       }
 
-      final result = await Process.run(
-        step.executable,
-        step.arguments,
-        workingDirectory: step.workingDirectory,
-        environment: step.environment.isEmpty ? null : step.environment,
-        runInShell: false,
-      );
+      final result = await (foregroundStepRun == null
+          ? Process.run(
+              step.executable,
+              step.arguments,
+              workingDirectory: step.workingDirectory,
+              environment: step.environment.isEmpty ? null : step.environment,
+              runInShell: false,
+            )
+          : foregroundStepRun(step));
       buffer
         ..write(result.stdout)
         ..write(result.stderr);

--- a/website/docs/changelog/recent-releases.md
+++ b/website/docs/changelog/recent-releases.md
@@ -9,6 +9,11 @@ For canonical full release notes, use:
 
 ## Unreleased
 
+- Updated WebGPU bridge assets to `v0.1.37` (llama.cpp `b10514`), restoring
+  native/Web parity and provisioning an explicit 1 MiB Wasm stack for wasm32
+  and memory64 so `b10514` graph-parameter growth does not abort Qwen3-ASR
+  memory64 context construction.
+
 - Improved Web microphone transcription with browser-capture warmup trimming
   and early short, silent, and unsupported PCM WAV diagnostics.
 
@@ -44,18 +49,20 @@ For canonical full release notes, use:
   playback, replay, and WAV export in the Flutter chat example. Web accepts
   byte-backed speaker references and complete PCM/WAV output, with a bounded
   example-app utterance length for browser stability. The example pins bridge
-  assets `v0.1.34`, which retry a failed worker WebGPU synthesis once on CPU;
-  current LiteRT-LM artifacts remain unsupported.
+  assets `v0.1.37`, retaining the `v0.1.34` recovery that retries a failed
+  worker WebGPU synthesis once on CPU; current LiteRT-LM artifacts remain
+  unsupported.
 
-- Updated the native llama.cpp runtime to `b10453`, consuming the Granite
-  Speech heap-overflow, DOTS OCR out-of-bounds, and Step3VL divide-by-zero
-  fixes while preserving the speculative wrapper ABI. Matching Dart FFI
-  bindings and the Apple SwiftPM artifact checksum were refreshed.
+- Updated the native llama.cpp runtime to `b10514`, adding BailingMoE3,
+  GraniteSWA/GraniteMoeSWA, speculators-format DSpark checkpoints, and current
+  upstream multimodal/backend fixes and performance improvements. Matching Dart
+  FFI bindings and the Apple SwiftPM artifact checksum were refreshed.
 
 - Added an experimental typed Qwen3-ASR whole-file transcription workflow, a
   SHA-256-verified Qwen3-ASR 0.6B native-and-Web chat-app preset, and foreground
   microphone recording. WebGPU requires validated bridge assets `v0.1.30+`,
-  pins `v0.1.34` with the `v0.1.32` short-speech recovery,
+  pins `v0.1.37` with the `v0.1.32` short-speech recovery and the `b10514`
+  memory64 stack fix,
   and accepts WAV bytes only; native LiteRT-LM live dictation remains a
   separate implementation.
 

--- a/website/docs/changelog/recent-releases.md
+++ b/website/docs/changelog/recent-releases.md
@@ -50,8 +50,9 @@ For canonical full release notes, use:
   byte-backed speaker references and complete PCM/WAV output, with a bounded
   example-app utterance length for browser stability. The example pins bridge
   assets `v0.1.37`, retaining the `v0.1.34` recovery that retries a failed
-  worker WebGPU synthesis once on CPU; current LiteRT-LM artifacts remain
-  unsupported.
+  worker WebGPU synthesis once on CPU; Apple companion builds discover the
+  native TTS wrapper ABI from the embedded llama framework, while current
+  LiteRT-LM artifacts remain unsupported.
 
 - Updated the native llama.cpp runtime to `b10514`, adding BailingMoE3,
   GraniteSWA/GraniteMoeSWA, speculators-format DSpark checkpoints, and current

--- a/website/docs/getting-started/installation.md
+++ b/website/docs/getting-started/installation.md
@@ -79,7 +79,7 @@ hooks:
     llamadart:
       # Optional. Defaults to llamadart's tested native runtime pin.
       # Use a leehack/llamadart-native release tag when testing another build.
-      llamadart_native_tag: b10453
+      llamadart_native_tag: b10514
 
       # Optional. GitHub repository slug or github.com URL.
       llamadart_native_repository: leehack/llamadart-native
@@ -106,7 +106,7 @@ per-target module list.
 Native source overrides are for compatibility testing. They do not regenerate
 Dart FFI bindings or symbol lookups, so the selected binary still must be ABI-
 and symbol-compatible with the default
-`leehack/llamadart-native@b10453` runtime.
+`leehack/llamadart-native@b10514` runtime.
 
 Available native tags are published on the
 [`leehack/llamadart-native` releases page](https://github.com/leehack/llamadart-native/releases).
@@ -118,7 +118,7 @@ gh release list --repo leehack/llamadart-native --limit 20
 
 Before overriding, confirm the release includes the asset for your target. The
 hook downloads files named `llamadart-native-<bundle>-<tag>.tar.gz`, for example
-`llamadart-native-windows-x64-b10453.tar.gz`.
+`llamadart-native-windows-x64-b10514.tar.gz`.
 For local testing, `llamadart_native_path` may point directly at a bundle
 archive, at an extracted bundle directory, or at a directory containing
 `<tag>/<bundle>/`, `<bundle>/`, or the expected archive file.

--- a/website/docs/guides/performance-tuning.md
+++ b/website/docs/guides/performance-tuning.md
@@ -148,10 +148,11 @@ Guidelines:
 - DSpark is an experimental, opt-in native llama.cpp external draft-model
   strategy. Use `SpeculativeDecodingConfig.draftDspark(draftModelPath: ...)`;
   it is never selected automatically, maps to upstream `draft-dspark`, requires
-  at least the `b10356-llamadart.1` wrapper fix; the package-pinned `b10453`
-  runtime satisfies that ABI. It remains subject to target/draft/backend
-  compatibility. Compare deterministic output, acceptance, and warmed
-  throughput against the same baseline before enabling it in production.
+  at least the `b10356-llamadart.1` wrapper fix; the package-pinned `b10514`
+  runtime satisfies that ABI and adds upstream speculators-format checkpoint
+  support. DSpark remains subject to target/draft/backend compatibility.
+  Compare deterministic output, acceptance, and warmed throughput against the
+  same baseline before enabling it in production.
 - DFlash draft models must use upstream-compatible GGUF metadata:
   `general.architecture=dflash` plus the `dflash.*` metadata block, including
   `dflash.target_layers`. A known-good public pair is target

--- a/website/docs/guides/text-to-speech.md
+++ b/website/docs/guides/text-to-speech.md
@@ -172,8 +172,11 @@ memory-constrained mobile devices.
 - Web requires published bridge assets `v0.1.33+`, WebAssembly memory64 for the
   pinned roughly 1.48 GB model/projector pair, and a browser/device with enough
   memory. Older bridge assets fail capability discovery clearly.
-- The chat example pins `v0.1.34`, which retries a worker WebGPU abort or device
-  failure once on CPU using the cached model and projector. Recovery is slower
-  and is not a substitute for sufficient browser memory.
+- The chat example pins `v0.1.37`, which retains the `v0.1.34` recovery that
+  retries a worker WebGPU abort or device failure once on CPU using the cached
+  model and projector. Recovery is slower and is not a substitute for
+  sufficient browser memory. Qwen3-TTS accelerator behavior remains
+  device-dependent; validate the target browser and device for queue-watchdog
+  timeouts before relying on it in production.
 - Web speaker references are selected-file bytes only; microphone speaker
   recording remains a native chat-example feature.

--- a/website/docs/platforms/support-matrix.md
+++ b/website/docs/platforms/support-matrix.md
@@ -8,7 +8,7 @@ backend-module configuration for
 `llamadart`.
 
 The native-assets hook currently pins `llamadart-native` tag
-`b10453` and
+`b10514` and
 `litert-lm-native` release `v0.16.0-native.2` (`hook/build.dart`). Apps can
 override the llama.cpp native GitHub source with
 `hooks.user_defines.llamadart.llamadart_native_tag` and
@@ -104,6 +104,11 @@ bundled:
 
 - `llama_cpp`: GGUF model support through llama.cpp.
 - `litert_lm`: `.litertlm` model support through LiteRT-LM.
+
+The `b10514` native llama.cpp pin adds BailingMoE3 and
+GraniteSWA/GraniteMoeSWA model loading. These architectures use the existing
+GGUF APIs without a model-specific Dart configuration or preset; chat-template
+and tool-call behavior still depends on the metadata bundled with each model.
 
 Unset or empty config means all runtime families available for the target. Apps
 that only ship one model format can trim package size:
@@ -206,7 +211,7 @@ device/model bundle, use `cpu` or `gpu` for that artifact.
   It maps to upstream `draft-dspark`, requires a compatible external draft
   GGUF, and remains subject to target/draft/backend parity, acceptance, and
   throughput validation. It is an external non-MTP draft-context strategy and
-  requires at least the `b10356-llamadart.1` wrapper fix; the default `b10453`
+  requires at least the `b10356-llamadart.1` wrapper fix; the default `b10514`
   runtime satisfies that ABI. WebGPU and LiteRT-LM reject this llama.cpp-
   specific strategy explicitly.
 - **State persistence** (`LlamaEngine.stateSaveFile(...)` /
@@ -222,7 +227,7 @@ device/model bundle, use `cpu` or `gpu` for that artifact.
   a web load failure as a package bug. The [WebGPU Bridge](./webgpu-bridge)
   page has the browser-console probe and Flutter Web smoke-test path.
 
-## Current llama.cpp module availability by bundle (`b10453`)
+## Current llama.cpp module availability by bundle (`b10514`)
 
 | Bundle key | Available backend modules in bundle |
 | --- | --- |
@@ -270,7 +275,7 @@ hooks:
   user_defines:
     llamadart:
       # Optional. Defaults to llamadart's tested native runtime pin.
-      llamadart_native_tag: b10453
+      llamadart_native_tag: b10514
 
       # Optional. GitHub repository slug or github.com URL.
       llamadart_native_repository: leehack/llamadart-native

--- a/website/docs/platforms/webgpu-bridge.md
+++ b/website/docs/platforms/webgpu-bridge.md
@@ -146,13 +146,13 @@ development validation, and CDN-first loading for normal hosted deployments:
 1. On localhost: local asset first, then CDN fallback.
 2. On hosted deployments: CDN asset first, then local fallback.
 
-The example currently pins bridge assets to `v0.1.34`, with local vendored assets
-identified as `v0.1.34-local-b10453`.
+The example currently pins bridge assets to `v0.1.37`, with local vendored assets
+identified as `v0.1.37-local-b10514`.
 
 Fetch pinned local assets with:
 
 ```bash
-WEBGPU_BRIDGE_ASSETS_TAG=v0.1.34 ./scripts/fetch_webgpu_bridge_assets.sh
+WEBGPU_BRIDGE_ASSETS_TAG=v0.1.37 ./scripts/fetch_webgpu_bridge_assets.sh
 ```
 
 To verify the loaded runtime in a browser console, inspect:
@@ -194,6 +194,10 @@ cannot report success before the bridge exposes `prefetchModelToCache(...)`.
 - `v0.1.34+` bridge assets retry a failed worker WebGPU TTS synthesis once in a
   CPU main-thread runtime using the already cached model and projector. This
   recovery is slower than healthy WebGPU synthesis and does not loop.
+- `v0.1.37+` bridge assets embed llama.cpp `b10514`, matching the default native
+  runtime, and provision an explicit 1 MiB stack for both wasm32 and memory64.
+  This prevents `b10514` graph-parameter growth from overflowing Emscripten's
+  64 KiB default during memory64 Qwen3-ASR context construction.
 - `v0.1.12+` bridge assets forward native-compatible `ModelParams` load
   tuning fields, including multi-sequence slots, KV cache type, flash attention,
   RoPE overrides, split mode, and main GPU.
@@ -324,7 +328,7 @@ You can override bridge asset source/version before loader startup:
 ```html
 <script>
   window.__llamadartBridgeAssetsRepo = 'leehack/llama-web-bridge-assets';
-  window.__llamadartBridgeAssetsTag = 'v0.1.34';
+  window.__llamadartBridgeAssetsTag = 'v0.1.37';
   // Custom assets stay speech-disabled unless the host has validated them:
   // window.__llamadartBridgeSpeechToTextSupported = true;
   // Prefer local runtime even off localhost:


### PR DESCRIPTION
## Summary

- update the default native llama.cpp runtime from `b10453` to `b10514`, refresh the Apple SwiftPM checksum, regenerate additive GGML/MTMD bindings, and cover the new symbols
- update the default Web bridge from `v0.1.34` to published `llama-web-bridge-assets@v0.1.37`, which embeds the same llama.cpp `b10514` revision and carries the 1 MiB wasm32/memory64 stack fix for Qwen3-ASR
- make the deployable Web build reject bootstrap pins that disagree with the published bridge manifest's asset or llama.cpp tag, and make the durable bridge smoke exercise the packaged build
- package both Apple companion runtimes in the chat example and discover the native TTS wrapper ABI from the embedded `llama.framework/llama` binary
- align README, changelog, installation, performance, support-matrix, WebGPU, ASR, and TTS documentation

Upstream bridge source: leehack/llama-web-bridge#42. Published assets: `llama-web-bridge-assets@v0.1.37`.

## Production-readiness scope

- **User-facing scope:** Native and Web GGUF runtimes intentionally use llama.cpp `b10514`; Web Qwen3-ASR no longer hits the b10514 Emscripten default-stack abort; the Flutter Apple chat app now packages and discovers its llama.cpp runtime/TTS ABI correctly.
- **Supported platforms/paths:** Existing native bundle targets, Flutter Apple companion packaging, Flutter Web wasm32/memory64 assets, direct/worker bridge loading, typed speech-to-text and text-to-speech, and chat-app file/microphone transcription paths.
- **Unsupported or device-dependent paths:** Qwen3-TTS Web acceleration remains device-dependent and should be validated on target browsers/devices. The physical-iPad TTS gate used CPU (`gpuLayers=0`); Metal TTS, speaker-reference synthesis, autoplay, and physical-speaker playback were not exercised.
- **Out of scope:** Publishing or releasing llamadart and changing downstream release pins.

## Completeness checklist

- [x] Declared scope is fully implemented, or explicitly reduced above.
- [x] Unsupported platform/option combinations fail loudly with actionable diagnostics or are clearly documented as unavailable.
- [x] Public docs, README/website docs, examples, support matrices, and changelog entries match the final behavior.
- [x] Regression coverage covers the original issue plus relevant packaging, version-skew, worker, and capability paths.
- [x] Security/privacy review completed: no secrets, bearer tokens, signed URLs, or raw secret-bearing paths leak through logs, cache keys, metadata, errors, or snapshots.
- [x] No required follow-up issue remains for this parity pin.

## Test plan

- [x] Scoped changed Dart files pass `dart format --output=none --set-exit-if-changed`; the full-tree formatter still reports the same four untouched baseline files from clean `origin/main`.
- [x] `dart analyze`
- [x] `dart test -p vm -j 1 --exclude-tags local-only` — 1,409 passed, 66 skipped
- [x] `dart test -p chrome --exclude-tags local-only` — 766 passed, 1 skipped
- [x] `flutter test` in `example/chat_app` — 336 passed
- [x] `dart run tool/testing/verify_release_docs_versions.dart`
- [x] `./tool/docs/validate_links.sh`
- [x] Shell syntax and ShellCheck for Web fetch/build validation scripts
- [x] Packaged chat-app Web build and durable `bridge-smoke`
- [x] Real-model Web Qwen3.5, Gemma 4 memory64, Qwen3-ASR, and Qwen3-TTS smokes
- [x] Physical-iPad Qwen3.5, Gemma 4, Qwen3-ASR, and exact-head Qwen3-TTS smokes
- [x] Exact-head GitHub Actions — 14/14 successful

## Matrix evidence

| Matrix row | Platform / model / backend | Result | Evidence / notes |
| --- | --- | --- | --- |
| Native/static regression | macOS, Linux, Windows, Chrome | PASS | Analyzer, VM/Chrome suites, example tests, companion packages, docs, symbol checks, and exact-head CI passed. |
| Web bridge contract | Packaged Chromium / v0.1.37 | PASS | Published manifest/checksums and b10514 provenance validated; direct/worker load, dispose/reload, projector, and completion calls passed. |
| Web text | Qwen3.5 0.8B / worker | PASS | Returned `2+2 equals 4`; cross-origin isolation and no-fallback path verified. |
| Web memory64 text | Gemma 4 E2B / memory64 worker | PASS | Returned exact `4`; memory64 assets and `preferMemory64=true` verified. |
| Web speech-to-text | Qwen3-ASR 0.6B / selected WAV + synthetic microphone | PASS | Both paths produced the exact expected 186-character transcript; no wasm64 abort or worker fallback. |
| Web text-to-speech | Qwen3-TTS 1.7B / memory64 worker | PASS | Same-origin immutable model/projector staging loaded in 29.9 s; generated 38,400 samples and a validated 24 kHz mono 1.6 s WAV without watchdog/allocation failure. |
| Physical iPad text | Qwen3.5 0.8B + Gemma 4 E2B / Metal auto | PASS | Both immutable GGUF models loaded and returned deterministic exact `4`. |
| Physical iPad speech-to-text | Qwen3-ASR 0.6B / CPU | PASS | Model/projector loaded and the supplied PCM16 fixture matched the exact expected transcript. |
| Physical iPad text-to-speech | Qwen3-TTS 1.7B / CPU | PASS | Exact head `410e6fff`; model/projector SHA-256 verified on-device, native capability detected, 51,840 finite samples synthesized, and 24 kHz mono 2.16 s WAV independently validated. |
| Live chat preview | PR preview | PASS | `/llamadart-build.json` serves exact head `410e6fff127e43d09a0e19144119c77d94a790e2`; COOP/COEP deployment job passed. |

## Review notes

- Exact head: `410e6fff127e43d09a0e19144119c77d94a790e2`.
- GitHub Actions: 14/14 checks successful; merge state `MERGEABLE/CLEAN`.
- Review threads: zero unresolved; latest Copilot review generated no new comments.
- Independent cleanup/optimization reviews found no blocking code, docs, test, or performance issue. Further refactoring would add churn without evidence-backed benefit.
