### PR TITLE
Update native llama.cpp runtime to b10545

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+## Unreleased
+
+* Updated the default llama.cpp native runtime to `b10545`, adding LFM2 DSpark
+  support plus current upstream correctness and backend performance fixes.
+  Matching Dart FFI bindings, including the new multimodal projector-device
+  field, and the Apple SwiftPM artifact checksum were refreshed.
+
 ## 0.8.20
 
 * Added `code_assets` 2.x compatibility while retaining support for 1.x native

--- a/README.md
+++ b/README.md
@@ -143,7 +143,7 @@ Current default runtime pins:
 
 | Runtime | Pin |
 | --- | --- |
-| Native llama.cpp / GGUF | `leehack/llamadart-native@b10514` |
+| Native llama.cpp / GGUF | `leehack/llamadart-native@b10545` |
 | Native LiteRT-LM / `.litertlm` | `leehack/litert-lm-native@v0.16.0-native.2` |
 | Web llama.cpp / GGUF | `leehack/llama-web-bridge-assets@v0.1.37` |
 | Web LiteRT-LM / `.litertlm` | `@litert-lm/core@0.15.0` |

--- a/hook/build.dart
+++ b/hook/build.dart
@@ -13,7 +13,7 @@ import 'package:path/path.dart' as path;
 
 import 'package:llamadart/src/hook/native_bundle_config.dart';
 
-const _llamaCppTag = 'b10514';
+const _llamaCppTag = 'b10545';
 const _nativeRepoSlug = 'leehack/llamadart-native';
 
 const _packageName = 'llamadart';
@@ -1653,7 +1653,7 @@ List<String> _emittedFileNamesForLibrary({
     if (lowered.endsWith('.so') && !lowered.endsWith('.so.0')) {
       fileNames.add('${library.fileName}.0');
     }
-    // llamadart-native b10514 still publishes mtmd with the literal ELF SONAME
+    // llamadart-native b10545 still publishes mtmd with the literal ELF SONAME
     // `libmtmd.so.SOVERSION`. Keep the immutable release consumable until the
     // owning native artifact corrects that SONAME.
     if (lowered == 'libmtmd.so') {

--- a/lib/src/backends/llama_cpp/bindings.dart
+++ b/lib/src/backends/llama_cpp/bindings.dart
@@ -10813,6 +10813,8 @@ final class mtmd_context_params extends ffi.Struct {
   @ffi.Bool()
   external bool use_gpu;
 
+  external ggml_backend_dev_t device;
+
   @ffi.Bool()
   external bool print_timings;
 

--- a/packages/llamadart_llama_cpp_flutter/CHANGELOG.md
+++ b/packages/llamadart_llama_cpp_flutter/CHANGELOG.md
@@ -1,3 +1,7 @@
+## Unreleased
+
+* Updated Apple SwiftPM native pin to `leehack/llamadart-native@b10545`.
+
 ## 0.0.14
 
 * Updated Apple SwiftPM native pin to `leehack/llamadart-native@b10514`.

--- a/packages/llamadart_llama_cpp_flutter/README.md
+++ b/packages/llamadart_llama_cpp_flutter/README.md
@@ -16,7 +16,7 @@ dependencies:
 This package has no runtime Dart API of its own. Import `package:llamadart`
 normally from the core package and use `LlamaBackend()` / `LlamaEngine` there.
 
-The Apple SwiftPM manifest pins `leehack/llamadart-native@b10514`.
+The Apple SwiftPM manifest pins `leehack/llamadart-native@b10545`.
 
 Source for this package lives in
 `packages/llamadart_llama_cpp_flutter` in the

--- a/packages/llamadart_llama_cpp_flutter/darwin/llamadart_llama_cpp_flutter/Package.swift
+++ b/packages/llamadart_llama_cpp_flutter/darwin/llamadart_llama_cpp_flutter/Package.swift
@@ -4,7 +4,7 @@ import PackageDescription
 
 let packageRoot = URL(fileURLWithPath: #filePath).deletingLastPathComponent()
 let artifactsRoot = packageRoot.appendingPathComponent("Artifacts")
-let llamaCppTag = "b10514"
+let llamaCppTag = "b10545"
 
 func localArtifactPath(_ name: String) -> String? {
     let path = artifactsRoot.appendingPathComponent(name).path
@@ -47,7 +47,7 @@ let package = Package(
             repository: "leehack/llamadart-native",
             artifactName: "llamadart-native-apple-xcframework-\(llamaCppTag).zip",
             tag: llamaCppTag,
-            checksum: "d700be95bddd0255eb6e544a6f6760e0647e1e1819e7bc22638a097f976a7a8d"
+            checksum: "4169f2741ce9fe2a8f345e419c08fecf458ebe537c024d533e639c4639adf776"
         ),
         .target(
             name: "llamadart_llama_cpp_flutter",

--- a/test/integration/backends/llama_cpp/native_symbol_integration_test.dart
+++ b/test/integration/backends/llama_cpp/native_symbol_integration_test.dart
@@ -392,6 +392,13 @@ void _expectBitmapHelperDecodesTransparentPng(
   }
 }
 
+void _expectB10545MtmdContextDefaults(mtmd_context_params params) {
+  expect(params.use_gpu, isTrue);
+  expect(params.device.address, 0);
+  expect(params.print_timings, isTrue);
+  expect(params.n_threads, 4);
+}
+
 void main() {
   group('Native Symbol Availability', () {
     test('context batch constants match the pinned llama.cpp defaults', () {
@@ -438,6 +445,27 @@ void main() {
           reason: symbol,
         );
       }
+    });
+
+    test('Verify b10545 mtmd context parameter layout in bindings', () {
+      final bindingsSource = File(
+        'lib/src/backends/llama_cpp/bindings.dart',
+      ).readAsStringSync();
+      final section = _sourceSection(
+        bindingsSource,
+        'final class mtmd_context_params extends ffi.Struct {',
+        'typedef mtmd_bitmap_lazy_callbackFunction =',
+      );
+
+      final useGpuIndex = section.indexOf('external bool use_gpu;');
+      final deviceIndex = section.indexOf(
+        'external ggml_backend_dev_t device;',
+      );
+      final printTimingsIndex = section.indexOf('external bool print_timings;');
+
+      expect(useGpuIndex, isNot(-1));
+      expect(deviceIndex, greaterThan(useGpuIndex));
+      expect(printTimingsIndex, greaterThan(deviceIndex));
     });
 
     test('Verify MTP wrapper symbols are resolvable', () {
@@ -689,14 +717,15 @@ void main() {
       // it as a dedicated mtmd shared library loaded via runtime fallback.
       // So direct primary-asset lookup may legitimately fail.
       if (Platform.isWindows || Platform.isLinux || Platform.isAndroid) {
-        expect(
-          () => mtmd_context_params_default(),
-          anyOf(returnsNormally, throwsA(isA<ArgumentError>())),
-        );
+        try {
+          _expectB10545MtmdContextDefaults(mtmd_context_params_default());
+        } on ArgumentError {
+          // The service resolves the dedicated mtmd shared library instead.
+        }
         return;
       }
 
-      expect(() => mtmd_context_params_default(), returnsNormally);
+      _expectB10545MtmdContextDefaults(mtmd_context_params_default());
     });
 
     test('Verify mtmd fallback bitmap helper ABI mirrors bindings', () {

--- a/website/docs/changelog/recent-releases.md
+++ b/website/docs/changelog/recent-releases.md
@@ -7,6 +7,13 @@ For canonical full release notes, use:
 
 - [`CHANGELOG.md`](https://github.com/leehack/llamadart/blob/main/CHANGELOG.md)
 
+## Unreleased
+
+- Updated the default native llama.cpp runtime to `b10545`, adding LFM2 DSpark
+  support plus current upstream correctness and backend performance fixes.
+  Matching Dart FFI bindings, including the new multimodal projector-device
+  field, and the Apple SwiftPM artifact checksum were refreshed.
+
 ## 0.8.20
 
 - Updated WebGPU bridge assets to `v0.1.37` (llama.cpp `b10514`), restoring

--- a/website/docs/getting-started/installation.md
+++ b/website/docs/getting-started/installation.md
@@ -79,7 +79,7 @@ hooks:
     llamadart:
       # Optional. Defaults to llamadart's tested native runtime pin.
       # Use a leehack/llamadart-native release tag when testing another build.
-      llamadart_native_tag: b10514
+      llamadart_native_tag: b10545
 
       # Optional. GitHub repository slug or github.com URL.
       llamadart_native_repository: leehack/llamadart-native
@@ -106,7 +106,7 @@ per-target module list.
 Native source overrides are for compatibility testing. They do not regenerate
 Dart FFI bindings or symbol lookups, so the selected binary still must be ABI-
 and symbol-compatible with the default
-`leehack/llamadart-native@b10514` runtime.
+`leehack/llamadart-native@b10545` runtime.
 
 Available native tags are published on the
 [`leehack/llamadart-native` releases page](https://github.com/leehack/llamadart-native/releases).
@@ -118,7 +118,7 @@ gh release list --repo leehack/llamadart-native --limit 20
 
 Before overriding, confirm the release includes the asset for your target. The
 hook downloads files named `llamadart-native-<bundle>-<tag>.tar.gz`, for example
-`llamadart-native-windows-x64-b10514.tar.gz`.
+`llamadart-native-windows-x64-b10545.tar.gz`.
 For local testing, `llamadart_native_path` may point directly at a bundle
 archive, at an extracted bundle directory, or at a directory containing
 `<tag>/<bundle>/`, `<bundle>/`, or the expected archive file.

--- a/website/docs/guides/performance-tuning.md
+++ b/website/docs/guides/performance-tuning.md
@@ -148,9 +148,10 @@ Guidelines:
 - DSpark is an experimental, opt-in native llama.cpp external draft-model
   strategy. Use `SpeculativeDecodingConfig.draftDspark(draftModelPath: ...)`;
   it is never selected automatically, maps to upstream `draft-dspark`, requires
-  at least the `b10356-llamadart.1` wrapper fix; the package-pinned `b10514`
-  runtime satisfies that ABI and adds upstream speculators-format checkpoint
-  support. DSpark remains subject to target/draft/backend compatibility.
+  at least the `b10356-llamadart.1` wrapper fix; the package-pinned `b10545`
+  runtime satisfies that ABI, supports speculators-format checkpoints, and
+  adds LFM2 target/draft support. DSpark remains subject to
+  target/draft/backend compatibility.
   Compare deterministic output, acceptance, and warmed throughput against the
   same baseline before enabling it in production.
 - DFlash draft models must use upstream-compatible GGUF metadata:

--- a/website/docs/platforms/support-matrix.md
+++ b/website/docs/platforms/support-matrix.md
@@ -8,7 +8,7 @@ backend-module configuration for
 `llamadart`.
 
 The native-assets hook currently pins `llamadart-native` tag
-`b10514` and
+`b10545` and
 `litert-lm-native` release `v0.16.0-native.2` (`hook/build.dart`). Apps can
 override the llama.cpp native GitHub source with
 `hooks.user_defines.llamadart.llamadart_native_tag` and
@@ -105,10 +105,12 @@ bundled:
 - `llama_cpp`: GGUF model support through llama.cpp.
 - `litert_lm`: `.litertlm` model support through LiteRT-LM.
 
-The `b10514` native llama.cpp pin adds BailingMoE3 and
-GraniteSWA/GraniteMoeSWA model loading. These architectures use the existing
-GGUF APIs without a model-specific Dart configuration or preset; chat-template
-and tool-call behavior still depends on the metadata bundled with each model.
+The `b10545` native llama.cpp pin includes BailingMoE3 and
+GraniteSWA/GraniteMoeSWA model loading and adds LFM2 target/draft support for
+DSpark speculative decoding. These architectures use the existing GGUF APIs;
+LFM2 DSpark uses `SpeculativeDecodingConfig.draftDspark(...)`. No
+model-specific Dart preset is required, but representative target/draft and
+backend validation remains necessary before enabling DSpark in production.
 
 Unset or empty config means all runtime families available for the target. Apps
 that only ship one model format can trim package size:
@@ -227,7 +229,7 @@ device/model bundle, use `cpu` or `gpu` for that artifact.
   a web load failure as a package bug. The [WebGPU Bridge](./webgpu-bridge)
   page has the browser-console probe and Flutter Web smoke-test path.
 
-## Current llama.cpp module availability by bundle (`b10514`)
+## Current llama.cpp module availability by bundle (`b10545`)
 
 | Bundle key | Available backend modules in bundle |
 | --- | --- |
@@ -275,7 +277,7 @@ hooks:
   user_defines:
     llamadart:
       # Optional. Defaults to llamadart's tested native runtime pin.
-      llamadart_native_tag: b10514
+      llamadart_native_tag: b10545
 
       # Optional. GitHub repository slug or github.com URL.
       llamadart_native_repository: leehack/llamadart-native


### PR DESCRIPTION
## Summary

- update the default native llama.cpp runtime from `b10514` to published `llamadart-native@b10545`
- regenerate Dart FFI bindings for the new `mtmd_context_params.device` field and add source-layout plus runtime-default ABI regression coverage
- refresh the Apple SwiftPM artifact checksum and align README, changelog, installation, performance, and support-matrix documentation
- document automatic LFM2 target/draft support for the existing opt-in `SpeculativeDecodingConfig.draftDspark(...)` path

Upstream runtime: https://github.com/ggml-org/llama.cpp/releases/tag/b10545  
Published native artifacts: https://github.com/leehack/llamadart-native/releases/tag/b10545

## Production-readiness scope

- **User-facing scope:** Native GGUF consumers receive the b10545 correctness and backend performance updates, including LFM2 DSpark target/draft runtime support through the existing Dart speculative-decoding API.
- **Supported platforms/paths:** Existing `llamadart-native` bundle targets and Apple SwiftPM packaging. The generated MTMD layout is validated against the published macOS arm64 runtime, and a real Qwen3-ASR model/projector passes through the public typed speech-to-text API on CPU.
- **Unsupported or intentionally unavailable paths:** This PR does not claim that LFM2 DSpark is a universal speedup or production-validated model pair. Android Vulkan Qwen3-TTS remains blocked by open upstream correctness work tracked in #322. Linux continues to emit the compatibility alias for the published literal `libmtmd.so.SOVERSION` defect tracked in https://github.com/leehack/llamadart-native/issues/36.
- **Out of scope / follow-ups:** Web bridge/assets remain on their independently published pin. Representative LFM2 DSpark correctness and performance validation is tracked in #344. Publishing companion packages or a llamadart release is out of scope.

## Completeness checklist

- [x] Declared scope is fully implemented, or explicitly reduced above.
- [x] Unsupported platform/option combinations fail loudly with actionable diagnostics or are clearly documented as unavailable.
- [x] Public API docs, README/website docs, examples, support matrices, and changelog entries are updated where relevant.
- [x] Regression coverage covers the ABI change plus key runtime/version-skew paths where relevant.
- [x] Security/privacy review completed: no secrets, bearer tokens, signed URLs, or raw secret-bearing paths leak through logs, cache keys, metadata, errors, or snapshots.
- [x] Follow-up work that is useful but not required for this PR is tracked in GitHub Issues.

## PR type guidance

- **Bugfix/maintenance PR:** regenerates bindings for an upstream by-value struct layout change, adds targeted ABI/runtime regression coverage, and updates the tested native runtime pin.

## Test Plan

- [x] Changed Dart files pass `dart format --output=none --set-exit-if-changed`.
- [x] `dart analyze`
- [x] `dart test -p vm -j 1 --exclude-tags local-only` — 1,412 passed, 66 skipped
- [x] `dart test -p chrome --exclude-tags local-only` — 766 passed, 1 skipped
- [x] `dart test -p vm test/integration/backends/llama_cpp/native_symbol_integration_test.dart` — 13 passed
- [x] `dart test -p vm test/unit/tooling/sync_native_release_pins_script_test.dart`
- [x] `dart test -p vm test/unit/hook/build_hook_linux_integration_test.dart`
- [x] `python3 tool/native/sync_native_release_pins.py --llama-cpp-tag b10545 --litert-lm-tag keep --dry-run`
- [x] `dart run tool/testing/verify_release_docs_versions.dart`
- [x] `./tool/docs/validate_links.sh`
- [x] Maintained `speech-to-text-smoke` with Qwen3-ASR 0.6B Q8_0, matching projector, official English WAV, and the public typed API on macOS arm64 CPU
- [x] Published b10545 Linux arm64 ELF inspection; confirmed the existing SONAME workaround is still required and updated the owning issue

## Matrix Evidence

| Matrix row | Scope covered | Platform / model / backend | Result | Evidence / notes |
| --- | --- | --- | --- | --- |
| `static-format-analyze` | changed Dart format and full analyzer | macOS arm64 | PASS | zero analyzer issues; changed Dart files already formatted |
| `root-vm` | native-safe unit/integration coverage | macOS arm64 / b10545 CPU + Metal discovery | PASS | 1,412 passed, 66 expected fixture-dependent skips |
| `root-chrome` | browser-compatible regression coverage | Chromium | PASS | 766 passed, 1 expected skip; Web pins unchanged |
| `docs-site` | Docusaurus build and link validation | local Node toolchain | PASS | production site build completed with broken links set to throw |
| `release-doc-version-consistency` | install snippets and companion versions | local Dart toolchain | PASS | core 0.8.20 and current companion versions verified |
| `native-hook-bundles` | b10545 pin/checksum, Apple package, Linux aliases | macOS host plus published artifacts | PASS | live dry run was idempotent; focused pin and Linux hook tests passed |
| `macos-arm64-runtime-smoke` | generated ABI and native symbol/runtime defaults | Apple M4 Max / b10545 | PASS | MTMD device field order and null default verified; core native symbols loaded |
| `speech-to-text-smoke` | real projector creation and typed transcription | Qwen3-ASR 0.6B Q8_0 / CPU | PASS | official WAV matched the exact expected transcript |
| `llama-cpp-speculative-benchmark` | LFM2 DSpark correctness/performance | representative LFM2 pair | N/A | non-blocking model-backed validation tracked in #344 |

## Review Notes

- Independent review status: local readiness review found no blocking code, docs, test, packaging, or issue-tracking gap. GitHub review remains pending while this PR is draft.
- CI status / head SHA: pending on `0428af575952833c447820448552eaa5ffcafd8c`.
