### PR TITLE
chore: mechanical cleanup follow-ups

### DIFF
--- a/doc/litert_lm_structured_output.md
+++ b/doc/litert_lm_structured_output.md
@@ -51,8 +51,10 @@ llamadart can honestly report grammar support:
 3. A higher-level LiteRT-LM conversation option that directly models
    OpenAI-style `response_format`.
 
-Until that exists, `LiteRtLmBackend.supportsGrammarConstraints` and
-`LiteRtLmBackendWeb.supportsGrammarConstraints` remain `false`.
+Until that exists, `LiteRtLmBackend.supportsGrammarConstraints` stays `false`
+on both the native and web implementations (`litert_lm_backend.dart` and
+`litert_lm_backend_web.dart` each declare `LiteRtLmBackend` as conditional
+import twins).
 
 Relevant upstream files:
 

--- a/lib/src/backends/llama_cpp/llama_cpp_service.dart
+++ b/lib/src/backends/llama_cpp/llama_cpp_service.dart
@@ -4251,7 +4251,6 @@ class LlamaCppService {
           nCtx,
           cancelTokenAddress,
           pieceBuf,
-          grammarPtr,
           preservedTokenIds,
           effectiveStopSequences,
         );
@@ -5371,7 +5370,6 @@ class LlamaCppService {
     int nCtx,
     int cancelTokenAddress,
     Pointer<Uint8> pieceBuf,
-    Pointer<Utf8> grammarPtr,
     Set<int> preservedTokenIds,
     List<String> stopSequences,
   ) async* {

--- a/lib/src/core/engine/chat_session.dart
+++ b/lib/src/core/engine/chat_session.dart
@@ -1,5 +1,6 @@
 import 'dart:async';
 import 'dart:convert';
+
 import 'engine.dart';
 import '../llama_logger.dart';
 import '../models/chat/chat_message.dart';

--- a/lib/src/core/engine/engine.dart
+++ b/lib/src/core/engine/engine.dart
@@ -15,7 +15,6 @@ import '../models/chat/completion_chunk.dart';
 import '../models/chat/content_part.dart';
 import '../models/chat/chat_template_result.dart';
 import '../llama_logger.dart';
-
 import '../models/inference/model_params.dart';
 import '../models/inference/generation_params.dart';
 import '../models/inference/structured_output.dart';

--- a/lib/src/core/models/chat/chat_message.dart
+++ b/lib/src/core/models/chat/chat_message.dart
@@ -1,4 +1,5 @@
 import 'dart:convert';
+
 import 'chat_role.dart';
 import 'content_part.dart';
 

--- a/lib/src/core/template/chat_parse_result.dart
+++ b/lib/src/core/template/chat_parse_result.dart
@@ -1,4 +1,5 @@
 import 'dart:convert';
+
 import '../models/chat/chat_message.dart';
 import '../models/chat/chat_role.dart';
 import '../models/chat/completion_chunk.dart';

--- a/lib/src/experimental/litert_lm/litert_lm_benchmark.dart
+++ b/lib/src/experimental/litert_lm/litert_lm_benchmark.dart
@@ -1,9 +1,9 @@
-// ignore_for_file: public_member_api_docs
-
 import '../../backends/litert_lm/litert_lm_runtime.dart';
 
+/// Deprecated compatibility name for [LiteRtLmRuntimeMetrics].
 @Deprecated('Use LiteRtLmRuntimeMetrics from the LiteRT-LM runtime API.')
 class LiteRtLmBenchmarkMetrics extends LiteRtLmRuntimeMetrics {
+  /// Creates benchmark metrics.
   const LiteRtLmBenchmarkMetrics({
     required super.inputTokens,
     required super.outputTokens,
@@ -14,6 +14,7 @@ class LiteRtLmBenchmarkMetrics extends LiteRtLmRuntimeMetrics {
     required super.wallMilliseconds,
   });
 
+  /// Converts stable runtime metrics to the deprecated compatibility type.
   factory LiteRtLmBenchmarkMetrics.fromRuntime(LiteRtLmRuntimeMetrics metrics) {
     return LiteRtLmBenchmarkMetrics(
       inputTokens: metrics.inputTokens,
@@ -27,13 +28,16 @@ class LiteRtLmBenchmarkMetrics extends LiteRtLmRuntimeMetrics {
   }
 }
 
+/// Deprecated compatibility name for [LiteRtLmRuntimeResult].
 @Deprecated('Use LiteRtLmRuntimeResult from the LiteRT-LM runtime API.')
 class LiteRtLmBenchmarkResult extends LiteRtLmRuntimeResult {
+  /// Creates a benchmark result.
   const LiteRtLmBenchmarkResult({
     required super.text,
     required LiteRtLmBenchmarkMetrics metrics,
   }) : super(metrics: metrics);
 
+  /// Converts a stable runtime result to the deprecated compatibility type.
   factory LiteRtLmBenchmarkResult.fromRuntime(LiteRtLmRuntimeResult result) {
     return LiteRtLmBenchmarkResult(
       text: result.text,
@@ -46,8 +50,10 @@ class LiteRtLmBenchmarkResult extends LiteRtLmRuntimeResult {
       super.metrics as LiteRtLmBenchmarkMetrics;
 }
 
+/// Deprecated compatibility name for [LiteRtLmRuntimeClient].
 @Deprecated('Use LiteRtLmRuntimeClient from the LiteRT-LM runtime API.')
 class LiteRtLmBenchmarkClient extends LiteRtLmRuntimeClient {
+  /// Runs the benchmark.
   @override
   Future<LiteRtLmBenchmarkResult> run({
     required String prompt,
@@ -63,6 +69,7 @@ class LiteRtLmBenchmarkClient extends LiteRtLmRuntimeClient {
     );
   }
 
+  /// Reads benchmark metrics for the active conversation.
   @override
   LiteRtLmBenchmarkMetrics readMetrics({required int wallMilliseconds}) {
     return LiteRtLmBenchmarkMetrics.fromRuntime(

--- a/lib/src/hook/native_bundle_config.dart
+++ b/lib/src/hook/native_bundle_config.dart
@@ -378,7 +378,7 @@ List<String> selectNativeRuntimesForBundle({
     rawUserConfig: rawUserConfig,
   );
   if (parsed == null) {
-    return defaultNativeRuntimesForBundle(bundle);
+    return defaultNativeRuntimes;
   }
 
   final invalid = parsed.invalid;
@@ -408,10 +408,6 @@ bool nativeRuntimeExplicitlySelectedForBundle({
     rawUserConfig: rawUserConfig,
   );
   return parsed?.explicit.contains(normalizedRuntime) ?? false;
-}
-
-List<String> defaultNativeRuntimesForBundle(String bundle) {
-  return defaultNativeRuntimes;
 }
 
 List<String> selectBackendsForBundle({
@@ -487,7 +483,7 @@ _parseNativeRuntimeConfigForBundle({
   final root = _toStringMap(rawUserConfig);
   if (root == null) {
     return (
-      runtimes: defaultNativeRuntimesForBundle(bundle),
+      runtimes: defaultNativeRuntimes,
       invalid: [rawUserConfig.toString()],
       explicit: const <String>{},
     );
@@ -526,7 +522,7 @@ _parseNativeRuntimeConfigForBundle({
   }
 
   return (
-    runtimes: defaultNativeRuntimesForBundle(bundle),
+    runtimes: defaultNativeRuntimes,
     invalid: [rawUserConfig.toString()],
     explicit: const <String>{},
   );


### PR DESCRIPTION
Stacked on #352 — review that one first; this diff is only the 8 files above it.

Behaviour-neutral tidy-ups that were too small to justify their own PRs.

## Changes

| Change | Why it is safe |
|---|---|
| Group `dart:` imports separately in `chat_session.dart`, `chat_message.dart`, `chat_parse_result.dart`; drop a stray blank line in `engine.dart` | Import order only |
| Fix stale class name in `doc/litert_lm_structured_output.md` | The web backend declares `LiteRtLmBackend` too (conditional-import twin); `LiteRtLmBackendWeb` never existed. The doc's substantive claim still holds — both `litert_lm_backend.dart:67` and `litert_lm_backend_web.dart:99` have `supportsGrammarConstraints => false` |
| Remove ignored `grammarPtr` parameter from `_runInferenceLoop` | Private method, one call site. The pointer is consumed when the sampler is built; the loop never reads it. Its allocate/free lifetime at the call scope is untouched |
| Inline `defaultNativeRuntimesForBundle` | It ignored its `bundle` argument and returned the `defaultNativeRuntimes` constant. All three call sites are in the same file; neither `hook/build.dart` nor the unit test referenced it |
| Document `litert_lm_benchmark.dart`, drop `// ignore_for_file: public_member_api_docs` | Dartdoc copied verbatim from the members of its stub twin, which already carries it |

## Verification

- `dart analyze lib test tool hook` — No issues found
- `dart test -p vm` — 1407 passed
- `dart test -p chrome` — 765 passed
- `dart format` — clean
- `check_platform_boundaries.dart` — OK
- `verify_release_docs_versions.dart` — OK
- Public API: `native_bundle_config.dart` is outside the export closure of `lib/llamadart.dart` (51 files). The five closure files touched here are byte-identical once comments and imports are stripped.

No changelog entry: nothing here changes user-facing behaviour or public capability.

## Not included

A sixth mechanical item — dropping the unreachable `master` branch trigger from `ci.yml`, `chat_app_hf_static_deploy.yml`, `chat_app_hf_pr_preview.yml` and `litert_lm_smoke.yml` (the repo has no `master` branch) — is **not** in this PR. Pushing `.github/workflows/**` requires a token with `workflow` scope, which I do not have. Tracked separately.