### PR TITLE
refactor: drop an unused parameter and stop retyping the PEG tag names

### DIFF
--- a/lib/src/core/template/jinja/jinja_analyzer.dart
+++ b/lib/src/core/template/jinja/jinja_analyzer.dart
@@ -27,7 +27,7 @@ class JinjaAnalyzer {
       final parser = Parser(result.tokens, source);
       final program = parser.parse();
 
-      final astCaps = _analyzeAST(program, source);
+      final astCaps = _analyzeAST(program);
       return _probeWithExecution(source, astCaps);
     } catch (e) {
       // Fallback to regex if parsing fails (e.g. invalid syntax)
@@ -193,7 +193,7 @@ class JinjaAnalyzer {
     }
   }
 
-  static TemplateCaps _analyzeAST(Program template, String source) {
+  static TemplateCaps _analyzeAST(Program template) {
     bool supportsSystemRole = false;
     bool supportsToolCalls = false;
     bool supportsTools = false;

--- a/lib/src/core/template/peg_chat_parser.dart
+++ b/lib/src/core/template/peg_chat_parser.dart
@@ -3,6 +3,7 @@ import 'dart:convert';
 import '../models/chat/completion_chunk.dart';
 import 'chat_format.dart';
 import 'chat_parse_result.dart';
+import 'peg_parser_builder.dart';
 
 /// Runtime PEG parser for llama.cpp `parser.save()` payloads.
 ///
@@ -92,11 +93,11 @@ class _PegBaseMapper {
   }
 
   void map(_PegAstNode node) {
-    if (node.tag == 'reasoning') {
+    if (node.tag == ChatPegBuilder.reasoningTag) {
       message.reasoningContent = _trimTrailingWhitespace(node.text);
       return;
     }
-    if (node.tag == 'content') {
+    if (node.tag == ChatPegBuilder.contentTag) {
       message.content = _trimTrailingWhitespace(node.text);
     }
   }
@@ -111,24 +112,24 @@ class _PegNativeMapper extends _PegBaseMapper {
   void map(_PegAstNode node) {
     super.map(node);
 
-    if (node.tag == 'tool-open') {
+    if (node.tag == ChatPegNativeBuilder.toolOpenTag) {
       final tool = _PegToolCall();
       message.toolCalls.add(tool);
       _currentTool = tool;
       return;
     }
 
-    if (node.tag == 'tool-id' && _currentTool != null) {
+    if (node.tag == ChatPegNativeBuilder.toolIdTag && _currentTool != null) {
       _currentTool!.id = _trimTrailingWhitespace(node.text);
       return;
     }
 
-    if (node.tag == 'tool-name' && _currentTool != null) {
+    if (node.tag == ChatPegNativeBuilder.toolNameTag && _currentTool != null) {
       _currentTool!.name = _trimTrailingWhitespace(node.text);
       return;
     }
 
-    if (node.tag == 'tool-args' && _currentTool != null) {
+    if (node.tag == ChatPegNativeBuilder.toolArgsTag && _currentTool != null) {
       _currentTool!.arguments = _trimTrailingWhitespace(node.text);
     }
   }
@@ -145,7 +146,7 @@ class _PegConstructedMapper extends _PegBaseMapper {
   void map(_PegAstNode node) {
     super.map(node);
 
-    if (node.tag == 'tool-open') {
+    if (node.tag == ChatPegNativeBuilder.toolOpenTag) {
       final tool = _PegToolCall();
       message.toolCalls.add(tool);
       _currentTool = tool;
@@ -153,18 +154,19 @@ class _PegConstructedMapper extends _PegBaseMapper {
       return;
     }
 
-    if (node.tag == 'tool-name' && _currentTool != null) {
+    if (node.tag == ChatPegNativeBuilder.toolNameTag && _currentTool != null) {
       _currentTool!.name = node.text;
       _currentTool!.arguments = '{';
       return;
     }
 
-    if (node.tag == 'tool-arg-open') {
+    if (node.tag == ChatPegConstructedBuilder.toolArgOpenTag) {
       _needsClosingQuote = false;
       return;
     }
 
-    if (node.tag == 'tool-arg-name' && _currentTool != null) {
+    if (node.tag == ChatPegConstructedBuilder.toolArgNameTag &&
+        _currentTool != null) {
       if (_argCount > 0) {
         _currentTool!.arguments += ',';
       }
@@ -174,7 +176,8 @@ class _PegConstructedMapper extends _PegBaseMapper {
       return;
     }
 
-    if (node.tag == 'tool-arg-string-value' && _currentTool != null) {
+    if (node.tag == ChatPegConstructedBuilder.toolArgStringValueTag &&
+        _currentTool != null) {
       final dumped = jsonEncode(_trimTrailingWhitespace(node.text));
       if (dumped.isNotEmpty) {
         _currentTool!.arguments += dumped.substring(0, dumped.length - 1);
@@ -183,7 +186,8 @@ class _PegConstructedMapper extends _PegBaseMapper {
       return;
     }
 
-    if (node.tag == 'tool-arg-close' && _currentTool != null) {
+    if (node.tag == ChatPegConstructedBuilder.toolArgCloseTag &&
+        _currentTool != null) {
       if (_needsClosingQuote) {
         _currentTool!.arguments += '"';
         _needsClosingQuote = false;
@@ -191,12 +195,13 @@ class _PegConstructedMapper extends _PegBaseMapper {
       return;
     }
 
-    if (node.tag == 'tool-arg-json-value' && _currentTool != null) {
+    if (node.tag == ChatPegConstructedBuilder.toolArgJsonValueTag &&
+        _currentTool != null) {
       _currentTool!.arguments += _trimTrailingWhitespace(node.text);
       return;
     }
 
-    if (node.tag == 'tool-close' && _currentTool != null) {
+    if (node.tag == ChatPegNativeBuilder.toolCloseTag && _currentTool != null) {
       if (_needsClosingQuote) {
         _currentTool!.arguments += '"';
         _needsClosingQuote = false;


### PR DESCRIPTION
Two mechanical items from #363. The third item I proposed for this batch turned out to be unsafe — see the correction posted on that issue.

## 1. `_analyzeAST` took a parameter it never read

`lib/src/core/template/jinja/jinja_analyzer.dart:196`

```dart
static TemplateCaps _analyzeAST(Program template, String source) {
```

`source` appears exactly once across the method's 105 lines — in the signature. Removed, along with the argument at its single call site (`:30`). Private method, one caller, no API impact.

## 2. The PEG parser retyped every tag name

`peg_chat_parser.dart` compared `node.tag` against **fourteen** string literals that duplicate constants the builder already declares. Renaming a tag in the builder compiled cleanly and silently stopped the parser matching that node — a failure with no compile-time signal.

The comparisons now reference the constants.

**One thing worth a reviewer's eye:** the constants are spread across three classes in the same hierarchy, and Dart does not inherit static members, so each reference is qualified with its *declaring* class rather than the base:

| Tags | Declared on |
|---|---|
| `reasoning`, `content` | `ChatPegBuilder` |
| `tool`, `tool-open`, `tool-close`, `tool-id`, `tool-name`, `tool-args` | `ChatPegNativeBuilder` |
| `tool-arg-open`, `tool-arg-close`, `tool-arg-name`, `tool-arg-string-value`, `tool-arg-json-value` | `ChatPegConstructedBuilder` |

My first attempt qualified everything with `ChatPegBuilder` and produced 12 `undefined_getter` errors, which is what surfaced the split. If you would rather these thirteen names lived in one place, say so and I will consolidate them — nothing outside `peg_parser_builder.dart` referenced them before this PR, so moving them is still cheap.

## Behaviour

Every replacement was generated from the constant's own declared value, so each comparison keeps the exact string it had. The mapping is printed in the commit's working notes and is derived, not hand-written.

## Verification

- `dart analyze lib test tool hook` — No issues found
- `dart test -p vm` — 1407 passed (unchanged)
- `dart test -p chrome` — 765 passed (unchanged)
- `dart format` — both touched files clean
- `check_platform_boundaries.dart` — OK

No changelog entry: internal refactor, no user-facing behaviour change.