### PR TITLE
refactor: remove the dead speech capability guards, deprecate two unused methods

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 ## Unreleased
 
+* Deprecated `LiteRtLmRuntimeClient.conversationTokenCount()` and
+  `replaceConversationWithClone()`. Both are unused and are scheduled for
+  removal in the next major release; open an issue if you depend on either.
+
 * Updated the default llama.cpp native runtime to `b10545`, adding LFM2 DSpark
   support plus current upstream correctness and backend performance fixes.
   Matching Dart FFI bindings, including the new multimodal projector-device

--- a/lib/src/backends/litert_lm/litert_lm_runtime.dart
+++ b/lib/src/backends/litert_lm/litert_lm_runtime.dart
@@ -952,6 +952,10 @@ class LiteRtLmRuntimeClient {
   }
 
   /// Returns the token count currently held by the active conversation KV cache.
+  @Deprecated(
+    'Has no callers in llamadart and will be removed in the next major '
+    'release. Open an issue if you depend on it.',
+  )
   int conversationTokenCount() {
     final bindings = _requireBindings();
     final conversation = _requireConversation();
@@ -965,6 +969,10 @@ class LiteRtLmRuntimeClient {
   }
 
   /// Replaces the active conversation with a native clone of itself.
+  @Deprecated(
+    'Has no callers in llamadart and will be removed in the next major '
+    'release. Open an issue if you depend on it.',
+  )
   void replaceConversationWithClone() {
     final bindings = _requireBindings();
     final conversation = _requireConversation();

--- a/lib/src/backends/litert_lm/litert_lm_runtime_stub.dart
+++ b/lib/src/backends/litert_lm/litert_lm_runtime_stub.dart
@@ -155,11 +155,19 @@ class LiteRtLmRuntimeClient {
   }
 
   /// Returns the active native conversation token count.
+  @Deprecated(
+    'Has no callers in llamadart and will be removed in the next major '
+    'release. Open an issue if you depend on it.',
+  )
   int conversationTokenCount() {
     throw UnsupportedError('LiteRT-LM runtime requires a native platform.');
   }
 
   /// Replaces the active native conversation with a clone.
+  @Deprecated(
+    'Has no callers in llamadart and will be removed in the next major '
+    'release. Open an issue if you depend on it.',
+  )
   void replaceConversationWithClone() {
     throw UnsupportedError('LiteRT-LM runtime requires a native platform.');
   }

--- a/lib/src/core/speech/speech_platform_stub.dart
+++ b/lib/src/core/speech/speech_platform_stub.dart
@@ -1,9 +1,3 @@
-/// Whether the typed speech-to-text adapter is available on this platform.
-bool get isSpeechToTextPlatformSupported => true;
-
-/// Actionable explanation when speech-to-text is unavailable.
-String? get speechToTextPlatformUnsupportedReason => null;
-
 /// Whether this platform requires a backend runtime opt-in for prompt ASR.
 bool get speechToTextRequiresBackendCapability => false;
 

--- a/lib/src/core/speech/speech_platform_web.dart
+++ b/lib/src/core/speech/speech_platform_web.dart
@@ -1,9 +1,3 @@
-/// Whether the typed speech-to-text adapter is available on Web.
-bool get isSpeechToTextPlatformSupported => true;
-
-/// Web support is refined by the active backend capability probe.
-String? get speechToTextPlatformUnsupportedReason => null;
-
 /// Web requires an explicitly validated bridge runtime.
 bool get speechToTextRequiresBackendCapability => true;
 

--- a/lib/src/core/speech/speech_to_text.dart
+++ b/lib/src/core/speech/speech_to_text.dart
@@ -573,12 +573,6 @@ class SpeechToTextEngine {
       );
     }
 
-    if (!isSpeechToTextPlatformSupported) {
-      return SpeechToTextCapabilities(
-        isSupported: false,
-        unsupportedReason: speechToTextPlatformUnsupportedReason,
-      );
-    }
     final engine = _engine!;
     if (speechToTextRequiresBackendCapability) {
       final backend = engine.backend;

--- a/lib/src/core/speech/text_to_speech.dart
+++ b/lib/src/core/speech/text_to_speech.dart
@@ -411,12 +411,6 @@ class TextToSpeechEngine {
 
   /// Discovers synthesis support for the active runtime, model, and projector.
   Future<TextToSpeechCapabilities> get capabilities async {
-    if (!isTextToSpeechPlatformSupported) {
-      return const TextToSpeechCapabilities(
-        isSupported: false,
-        unsupportedReason: textToSpeechPlatformUnsupportedReason,
-      );
-    }
     String? backendName;
     try {
       backendName = await _engine.getBackendName();

--- a/lib/src/core/speech/text_to_speech_platform_stub.dart
+++ b/lib/src/core/speech/text_to_speech_platform_stub.dart
@@ -1,8 +1,2 @@
-/// Whether typed text-to-speech is supported on this platform.
-const bool isTextToSpeechPlatformSupported = true;
-
-/// Actionable unsupported reason for platforms without typed TTS.
-const String textToSpeechPlatformUnsupportedReason = '';
-
 /// Native runtimes can read local speaker-reference paths.
 const bool textToSpeechSupportsFileInput = true;

--- a/lib/src/core/speech/text_to_speech_platform_web.dart
+++ b/lib/src/core/speech/text_to_speech_platform_web.dart
@@ -1,8 +1,2 @@
-/// Typed text-to-speech is available through a compatible WebGPU bridge.
-const bool isTextToSpeechPlatformSupported = true;
-
-/// Actionable reason returned by Web capability discovery.
-const String textToSpeechPlatformUnsupportedReason = '';
-
 /// Browsers do not expose local filesystem paths to the runtime.
 const bool textToSpeechSupportsFileInput = false;

--- a/test/unit/core/speech/speech_platform_stub_test.dart
+++ b/test/unit/core/speech/speech_platform_stub_test.dart
@@ -5,8 +5,13 @@ import 'package:llamadart/src/core/speech/speech_platform_stub.dart';
 import 'package:test/test.dart';
 
 void main() {
-  test('native platform enables dedicated speech-to-text', () {
-    expect(isSpeechToTextPlatformSupported, isTrue);
-    expect(speechToTextPlatformUnsupportedReason, isNull);
+  test('native platform accepts file input and unencoded audio', () {
+    expect(speechToTextRequiresBackendCapability, isFalse);
+    expect(speechToTextSupportsFileInput, isTrue);
+    expect(speechToTextRequiresEncodedAudioFormat, isFalse);
+    expect(
+      speechToTextEncodedAudioFormats,
+      equals(<String>{'wav', 'mp3', 'flac'}),
+    );
   });
 }

--- a/test/unit/core/speech/speech_platform_web_test.dart
+++ b/test/unit/core/speech/speech_platform_web_test.dart
@@ -6,8 +6,6 @@ import 'package:test/test.dart';
 
 void main() {
   test('web platform exposes byte-only WAV prompt speech support', () {
-    expect(isSpeechToTextPlatformSupported, isTrue);
-    expect(speechToTextPlatformUnsupportedReason, isNull);
     expect(speechToTextRequiresBackendCapability, isTrue);
     expect(speechToTextSupportsFileInput, isFalse);
     expect(speechToTextRequiresEncodedAudioFormat, isTrue);

--- a/test/unit/core/speech/text_to_speech_platform_stub_test.dart
+++ b/test/unit/core/speech/text_to_speech_platform_stub_test.dart
@@ -6,8 +6,6 @@ import 'package:test/test.dart';
 
 void main() {
   test('native platform enables typed text-to-speech', () {
-    expect(isTextToSpeechPlatformSupported, isTrue);
-    expect(textToSpeechPlatformUnsupportedReason, isEmpty);
     expect(textToSpeechSupportsFileInput, isTrue);
   });
 }

--- a/test/unit/core/speech/text_to_speech_platform_web_test.dart
+++ b/test/unit/core/speech/text_to_speech_platform_web_test.dart
@@ -6,8 +6,6 @@ import 'package:test/test.dart';
 
 void main() {
   test('web platform enables byte-backed typed text-to-speech', () {
-    expect(isTextToSpeechPlatformSupported, isTrue);
-    expect(textToSpeechPlatformUnsupportedReason, isEmpty);
     expect(textToSpeechSupportsFileInput, isFalse);
   });
 }

--- a/website/docs/changelog/recent-releases.md
+++ b/website/docs/changelog/recent-releases.md
@@ -9,6 +9,10 @@ For canonical full release notes, use:
 
 ## Unreleased
 
+- Deprecated `LiteRtLmRuntimeClient.conversationTokenCount()` and
+  `replaceConversationWithClone()`. Both are unused and are scheduled for
+  removal in the next major release; open an issue if you depend on either.
+
 - Updated the default native llama.cpp runtime to `b10545`, adding LFM2 DSpark
   support plus current upstream correctness and backend performance fixes.
   Matching Dart FFI bindings, including the new multimodal projector-device


### PR DESCRIPTION
The two decisions from #363 that needed your call.

## 1. Deleted the unreachable speech capability guards

Every conditional-import branch hardcoded "supported", so neither guard could ever fire:

| Member | Stub | Web |
|---|---|---|
| `isTextToSpeechPlatformSupported` | `true` | `true` |
| `textToSpeechPlatformUnsupportedReason` | `''` | `''` |
| `isSpeechToTextPlatformSupported` | `true` | `true` |
| `speechToTextPlatformUnsupportedReason` | `null` | `null` |

Which made these dead:

```dart
// TextToSpeechEngine.capabilities
if (!isTextToSpeechPlatformSupported) {
  return const TextToSpeechCapabilities(
    isSupported: false,
    unsupportedReason: textToSpeechPlatformUnsupportedReason,
  );
}
```

…and the equivalent in `SpeechToTextEngine.capabilities`. Removed the four members, both guard branches, and the eight test assertions that restated the constants.

**Only these two pairs were dead.** The sibling constants in the same files genuinely differ per platform and are untouched — `textToSpeechSupportsFileInput` (true/false), `speechToTextRequiresBackendCapability` (false/true), `speechToTextSupportsFileInput`, `speechToTextRequiresEncodedAudioFormat`, and `speechToTextEncodedAudioFormats` (3 formats vs 1). This is two dead members, not a dead abstraction.

`speech_platform_stub_test.dart` asserted nothing but the two dead members, so rather than leave it empty it now mirrors what its web twin pins — the four live, platform-varying siblings. The other three test files kept their meaningful assertions and just lost the dead ones.

## 2. Deprecated, not removed, the two unused `LiteRtLmRuntimeClient` methods

`conversationTokenCount()` and `replaceConversationWithClone()` have no caller anywhere in `lib`, `test`, `tool`, `example`, `packages` or `scripts` — but `LiteRtLmRuntimeClient` is publicly exported via the conditional export at `lib/llamadart.dart:120-123`, so deleting them would break the public API.

```dart
@Deprecated(
  'Has no callers in llamadart and will be removed in the next major '
  'release. Open an issue if you depend on it.',
)
```

Applied to both the native implementation and its stub twin, so the two declarations stay in step. Removal can ride the next major alongside the API narrowing in #355. The native symbol bindings (`conversationGetTokenCount`, `conversationClone`) stay pinned until then.

Changelog bullet added under `## Unreleased` in both `CHANGELOG.md` and `website/docs/changelog/recent-releases.md`, since a deprecation is user-facing.

## Verification

- **Public API: 3,774 symbols before and after, empty diff.** Computed over the 51-file transitive export closure of `lib/llamadart.dart`. The four deleted members lived in `speech_platform_*.dart` / `text_to_speech_platform_*.dart`, which are outside that closure; the two exported files I touched (`text_to_speech.dart`, `speech_to_text.dart`) changed only inside method bodies.
- `dart analyze lib test tool hook` — No issues found
- `dart test -p vm` — 1407 passed (unchanged)
- `dart test -p chrome` — 765 passed (unchanged)
- `dart format` — all 14 touched files clean
- `check_platform_boundaries.dart` — OK
- `verify_release_docs_versions.dart` — OK