### PR TITLE
chore: drop the unreachable master branch triggers

### DIFF
--- a/.github/workflows/chat_app_hf_pr_preview.yml
+++ b/.github/workflows/chat_app_hf_pr_preview.yml
@@ -2,7 +2,7 @@ name: Chat App HF PR Preview
 
 on:
   pull_request:
-    branches: [master, main]
+    branches: [main]
     types: [opened, reopened, synchronize, closed]
     paths:
       - "example/chat_app/**"

--- a/.github/workflows/chat_app_hf_static_deploy.yml
+++ b/.github/workflows/chat_app_hf_static_deploy.yml
@@ -2,7 +2,7 @@ name: Chat App HF Static Deploy
 
 on:
   push:
-    branches: [master, main]
+    branches: [main]
     paths:
       - "example/chat_app/**"
       - "lib/**"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,9 +2,9 @@ name: CI
 
 on:
   push:
-    branches: [ master, main ]
+    branches: [ main ]
   pull_request:
-    branches: [ master, main ]
+    branches: [ main ]
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}

--- a/.github/workflows/litert_lm_smoke.yml
+++ b/.github/workflows/litert_lm_smoke.yml
@@ -3,7 +3,7 @@ name: LiteRT-LM Smoke
 on:
   workflow_dispatch:
   push:
-    branches: [master, main]
+    branches: [main]
     paths:
       - ".github/workflows/litert_lm_smoke.yml"
       - "hook/**"
@@ -14,7 +14,7 @@ on:
       - "tool/litert_lm_engine_smoke.dart"
       - "tool/litert_lm_library_smoke.dart"
   pull_request:
-    branches: [master, main]
+    branches: [main]
     paths:
       - ".github/workflows/litert_lm_smoke.yml"
       - "hook/**"


### PR DESCRIPTION
Closes #359.

Four workflows trigger on a `master` branch that does not exist in this repository, so six trigger halves can never match. They are leftovers from the default-branch rename.

| File | Trigger |
|---|---|
| `.github/workflows/ci.yml` | `push` and `pull_request` |
| `.github/workflows/litert_lm_smoke.yml` | `push` and `pull_request` |
| `.github/workflows/chat_app_hf_static_deploy.yml` | `push` |
| `.github/workflows/chat_app_hf_pr_preview.yml` | `pull_request` |

Every change is the same shape:

```diff
-    branches: [master, main]
+    branches: [main]
```

No job, step, or condition changes. `git ls-remote --heads origin` confirms there is no `master` branch — only `main` and active feature branches.

This was filed as an issue rather than a PR because pushing anything under `.github/workflows/` requires a token with the `workflow` scope, which the session token did not have until now.