### PR TITLE
fix: report URL loading as unsupported, not unimplemented

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,8 +5,9 @@
   removal in the next major release; open an issue if you depend on either.
 
 * `NativeLlamaBackend.modelLoadFromUrl` now throws `LlamaUnsupportedException`
-  instead of `UnimplementedError`, matching the error contract the rest of the
-  library uses and the message `LlamaEngine.loadModelFromUrl` already produced.
+  instead of `UnimplementedError`, bringing it into the `LlamaException`
+  hierarchy. It is the same exception type `LlamaEngine.loadModelFromUrl`
+  already throws for this condition; each keeps its own message.
 
 * Updated the default llama.cpp native runtime to `b10545`, adding LFM2 DSpark
   support plus current upstream correctness and backend performance fixes.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@
   `replaceConversationWithClone()`. Both are unused and are scheduled for
   removal in the next major release; open an issue if you depend on either.
 
+* `NativeLlamaBackend.modelLoadFromUrl` now throws `LlamaUnsupportedException`
+  instead of `UnimplementedError`, matching the error contract the rest of the
+  library uses and the message `LlamaEngine.loadModelFromUrl` already produced.
+
 * Updated the default llama.cpp native runtime to `b10545`, adding LFM2 DSpark
   support plus current upstream correctness and backend performance fixes.
   Matching Dart FFI bindings, including the new multimodal projector-device

--- a/lib/src/backends/llama_cpp/llama_cpp_backend.dart
+++ b/lib/src/backends/llama_cpp/llama_cpp_backend.dart
@@ -186,7 +186,11 @@ class NativeLlamaBackend
     ModelParams params, {
     Function(double progress)? onProgress,
   }) async {
-    throw UnimplementedError("Use modelLoad with a local path for now");
+    throw LlamaUnsupportedException(
+      'The native llama.cpp backend cannot load a model from a URL: '
+      'supportsUrlLoading is false. Download the model first, then call '
+      'modelLoad with a local path.',
+    );
   }
 
   @override

--- a/test/unit/backends/llama_cpp/llama_cpp_backend_test.dart
+++ b/test/unit/backends/llama_cpp/llama_cpp_backend_test.dart
@@ -389,7 +389,7 @@ void main() {
         ),
         throwsA(
           isA<LlamaUnsupportedException>().having(
-            (error) => error.toString(),
+            (error) => error.message,
             'message',
             contains('supportsUrlLoading is false'),
           ),

--- a/test/unit/backends/llama_cpp/llama_cpp_backend_test.dart
+++ b/test/unit/backends/llama_cpp/llama_cpp_backend_test.dart
@@ -387,7 +387,13 @@ void main() {
           'https://example.com/model.gguf',
           const ModelParams(),
         ),
-        throwsA(isA<UnimplementedError>()),
+        throwsA(
+          isA<LlamaUnsupportedException>().having(
+            (error) => error.toString(),
+            'message',
+            contains('supportsUrlLoading is false'),
+          ),
+        ),
       );
       expect(backend.supportsUrlLoading, isFalse);
       expect(backend.isReady, isTrue);

--- a/website/docs/changelog/recent-releases.md
+++ b/website/docs/changelog/recent-releases.md
@@ -14,8 +14,9 @@ For canonical full release notes, use:
   removal in the next major release; open an issue if you depend on either.
 
 - `NativeLlamaBackend.modelLoadFromUrl` now throws `LlamaUnsupportedException`
-  instead of `UnimplementedError`, matching the error contract the rest of the
-  library uses and the message `LlamaEngine.loadModelFromUrl` already produced.
+  instead of `UnimplementedError`, bringing it into the `LlamaException`
+  hierarchy. It is the same exception type `LlamaEngine.loadModelFromUrl`
+  already throws for this condition; each keeps its own message.
 
 - Updated the default native llama.cpp runtime to `b10545`, adding LFM2 DSpark
   support plus current upstream correctness and backend performance fixes.

--- a/website/docs/changelog/recent-releases.md
+++ b/website/docs/changelog/recent-releases.md
@@ -13,6 +13,10 @@ For canonical full release notes, use:
   `replaceConversationWithClone()`. Both are unused and are scheduled for
   removal in the next major release; open an issue if you depend on either.
 
+- `NativeLlamaBackend.modelLoadFromUrl` now throws `LlamaUnsupportedException`
+  instead of `UnimplementedError`, matching the error contract the rest of the
+  library uses and the message `LlamaEngine.loadModelFromUrl` already produced.
+
 - Updated the default native llama.cpp runtime to `b10545`, adding LFM2 DSpark
   support plus current upstream correctness and backend performance fixes.
   Matching Dart FFI bindings, including the new multimodal projector-device


### PR DESCRIPTION
Closes the last open item in #363.

## What

`NativeLlamaBackend.modelLoadFromUrl` (`llama_cpp_backend.dart:183-190`) threw:

```dart
throw UnimplementedError("Use modelLoad with a local path for now");
```

Two problems with that:

1. **Wrong type.** AGENTS.md requires `LlamaUnsupportedException` or a typed subtype for unsupported public paths, from the `LlamaException` hierarchy. `UnimplementedError` sits outside it, so a caller catching `LlamaException` broadly missed this one.
2. **Wrong tense.** "for now" frames a permanent capability boundary as a temporary gap. `supportsUrlLoading` is `false` for this backend by design — the llama.cpp path loads from local files.

Now:

```dart
throw LlamaUnsupportedException(
  'The native llama.cpp backend cannot load a model from a URL: '
  'supportsUrlLoading is false. Download the model first, then call '
  'modelLoad with a local path.',
);
```

That satisfies AGENTS.md's "include actionable diagnostics: missing capability, platform/runtime condition, and version requirement where known" — it names the capability, the condition, and the supported route.

## Consistency

`LlamaEngine.loadModelFromUrl` already guards the same condition at `engine.dart:294-298` and throws `LlamaUnsupportedException`. Going through the engine, you never reached the backend throw at all; going around it, you got a different exception type for the identical situation. The two now agree.

## Scope

`llama_cpp_backend.dart` is **not** in the export closure of `lib/llamadart.dart`, so no public symbol changes. The thrown type is still observable to anyone calling `engine.backend.modelLoadFromUrl(...)` directly, which is why there is a changelog bullet.

The existing test at `llama_cpp_backend_test.dart:384` pinned `UnimplementedError`; it now pins the typed exception and asserts the message stays actionable, so the diagnostic cannot silently regress to a bare string.

## Verification

- `dart analyze lib test tool hook` — No issues found
- `dart test -p vm` — 1407 passed (unchanged)
- `dart test -p chrome` — 765 passed (unchanged)
- `dart format` — both touched files clean
- `verify_release_docs_versions.dart` — OK
- Changelog bullet in `CHANGELOG.md` and `website/docs/changelog/recent-releases.md`