### PR TITLE
ci: repair three quality gates that could never fail

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -17,5 +17,5 @@ website/docs/changelog/recent-releases.md @leehack
 website/docs/maintainers/native-and-web-sync.md @leehack
 website/docs/maintainers/release-workflow.md @leehack
 packages/*/CHANGELOG.md @leehack
-packages/*/Package.swift @leehack
+packages/*/darwin/*/Package.swift @leehack
 packages/*/pubspec.yaml @leehack

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,11 +1,31 @@
-# To get started with Dependabot version updates, you'll need to specify which
-# package ecosystems to update and where the package manifests are located.
-# Please see the documentation for all configuration options:
+# Dependabot version updates.
 # https://docs.github.com/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file
 
 version: 2
 updates:
-  - package-ecosystem: "" # See documentation for possible values
-    directory: "/" # Location of package manifests
+  # Root package.
+  - package-ecosystem: "pub"
+    directory: "/"
     schedule:
       interval: "weekly"
+    open-pull-requests-limit: 5
+
+  # Federated companion plugins, versioned and published separately.
+  - package-ecosystem: "pub"
+    directory: "/packages/llamadart_llama_cpp_flutter"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 5
+
+  - package-ecosystem: "pub"
+    directory: "/packages/llamadart_litert_lm_flutter"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 5
+
+  # Action pins in the workflows CODEOWNERS already protects.
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 5

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -51,8 +51,12 @@ jobs:
       - name: Install Pana
         run: flutter pub global activate pana
 
+      # pana exits non-zero when (max - granted) > threshold. pana's maximum is
+      # 160, so a threshold of 160 could only trip on a negative score. The
+      # package currently scores 160/160; 10 tolerates a single minor scoring
+      # change in a new pana release while still failing on any real regression.
       - name: Check Pana Score
-        run: flutter pub global run pana . --exit-code-threshold 160
+        run: flutter pub global run pana . --exit-code-threshold 10
 
   companion-packages:
     name: Companion Package (${{ matrix.package }})

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -54,9 +54,11 @@ jobs:
       # pana exits non-zero when (max - granted) > threshold, and pana's maximum
       # is 160 -- so the previous threshold of 160 could only trip on a negative
       # score. The package scores 160/160 today, so 0 costs no headroom and any
-      # point loss fails. Any non-zero tolerance would be enough to hide a whole
-      # check: pana's smallest buckets are 5-10 points, so even 10 would let
-      # "supports latest stable Dart and Flutter SDKs" (10/10) regress silently.
+      # point loss fails. pana's smallest buckets are 5-10 points, so any
+      # tolerance of 5 or more could hide a whole check regressing -- 10 would
+      # let "supports latest stable Dart and Flutter SDKs" (10/10) vanish
+      # silently. A tolerance of 1-4 would still catch every current bucket, but
+      # buys nothing that 0 does not.
       # A pana release that changes scoring fails here loudly, which is the
       # intended signal; raise this deliberately if slack is ever wanted.
       - name: Check Pana Score

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -51,16 +51,9 @@ jobs:
       - name: Install Pana
         run: flutter pub global activate pana
 
-      # pana exits non-zero when (max - granted) > threshold, and pana's maximum
-      # is 160 -- so the previous threshold of 160 could only trip on a negative
-      # score. The package scores 160/160 today, so 0 costs no headroom and any
-      # point loss fails. pana's smallest buckets are 5-10 points, so any
-      # tolerance of 5 or more could hide a whole check regressing -- 10 would
-      # let "supports latest stable Dart and Flutter SDKs" (10/10) vanish
-      # silently. A tolerance of 1-4 would still catch every current bucket, but
-      # buys nothing that 0 does not.
-      # A pana release that changes scoring fails here loudly, which is the
-      # intended signal; raise this deliberately if slack is ever wanted.
+      # pana fails when (max - granted) > threshold. Its max is 160, so the
+      # old value of 160 could never trip. Package scores 160/160; 0 keeps it
+      # there, and a tolerance of 5+ would hide a whole scoring bucket.
       - name: Check Pana Score
         run: flutter pub global run pana . --exit-code-threshold 0
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -51,12 +51,16 @@ jobs:
       - name: Install Pana
         run: flutter pub global activate pana
 
-      # pana exits non-zero when (max - granted) > threshold. pana's maximum is
-      # 160, so a threshold of 160 could only trip on a negative score. The
-      # package currently scores 160/160; 10 tolerates a single minor scoring
-      # change in a new pana release while still failing on any real regression.
+      # pana exits non-zero when (max - granted) > threshold, and pana's maximum
+      # is 160 -- so the previous threshold of 160 could only trip on a negative
+      # score. The package scores 160/160 today, so 0 costs no headroom and any
+      # point loss fails. Any non-zero tolerance would be enough to hide a whole
+      # check: pana's smallest buckets are 5-10 points, so even 10 would let
+      # "supports latest stable Dart and Flutter SDKs" (10/10) regress silently.
+      # A pana release that changes scoring fails here loudly, which is the
+      # intended signal; raise this deliberately if slack is ever wanted.
       - name: Check Pana Score
-        run: flutter pub global run pana . --exit-code-threshold 10
+        run: flutter pub global run pana . --exit-code-threshold 0
 
   companion-packages:
     name: Companion Package (${{ matrix.package }})


### PR DESCRIPTION
Fixes the three original items in #347. The runtime-pin-drift gate added in a comment there needs a new script plus CI wiring, so it is not here and #347 stays open.

**Pana threshold.** `pana` exits non-zero when `(max - granted) > threshold`, and its max is 160 — so `--exit-code-threshold 160` could only trip on a negative score. The package scores 160/160, so I set `0`. #347 proposed `10`, but pana's buckets are 5–10 points, so any tolerance of 5+ lets a whole check regress silently. Trade-off: a future pana scoring change fails the job even without a regression. Say so and I will use 5 or 10 instead.

**Dependabot.** `.github/dependabot.yml` was still the scaffold with `package-ecosystem: ""`, which matches nothing — no update PR has ever opened, despite two workflows special-casing `dependabot[bot]`. Now covers `pub` for `/` and for both companion packages (separately versioned, own pubspecs), plus `github-actions`.

**CODEOWNERS.** `packages/*/Package.swift` matched zero files: CODEOWNERS globs do not cross `/`, but the manifests sit at `packages/*/darwin/*/Package.swift`. Verified with `git ls-files ':(glob)…'` — plain `git ls-files` misleads here because its wildcards do cross `/`.

Verified: pana 160/160, both YAML files parse, corrected glob matches both manifests. No changelog entry — tooling only.
