### PR TITLE
fix: normalize media placeholders and thinking detection consistently

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 ## Unreleased
 
+* Fixed multimodal media placeholders being normalized inconsistently. `<img>`,
+  `<|img|>`, `<start_of_image>` and indexed markers such as `<|image_1|>` are now
+  rewritten to the mtmd marker on every path, rather than depending on which
+  layer rendered the prompt. MiniMax-M2 and MiniCPM-5 also now detect a
+  forced-open thinking block using the same rule as every other handler.
+
 * Deprecated `LiteRtLmRuntimeClient.conversationTokenCount()` and
   `replaceConversationWithClone()`. Both are unused and are scheduled for
   removal in the next major release; open an issue if you depend on either.

--- a/lib/src/backends/llama_cpp/llama_cpp_service.dart
+++ b/lib/src/backends/llama_cpp/llama_cpp_service.dart
@@ -19,6 +19,7 @@ import '../../core/models/config/gpu_device_info.dart';
 import '../../core/models/config/log_level.dart';
 import '../../core/models/diagnostics/model_file_type.dart';
 import '../../core/models/inference/generation_params.dart';
+import '../../core/template/media_placeholders.dart';
 import '../../core/models/inference/model_params.dart';
 import '../../core/template/chat_template_engine.dart';
 import 'load_param_helpers.dart';
@@ -4781,26 +4782,7 @@ class LlamaCppService {
         ? '<__media__>'
         : markerPtr.cast<Utf8>().toDartString();
 
-    var normalized = prompt;
-    const directPlaceholders = [
-      '<image>',
-      '[IMG]',
-      '<|image|>',
-      '<|audio|>',
-      '<|video|>',
-      '<img>',
-      '<|img|>',
-      '<image_soft_token>',
-      '<audio_soft_token>',
-      '<video_soft_token>',
-    ];
-
-    for (final placeholder in directPlaceholders) {
-      normalized = normalized.replaceAll(placeholder, marker);
-    }
-
-    // Some VLM templates index image placeholders (e.g. <|image_1|>).
-    normalized = normalized.replaceAll(RegExp(r'<\|image_\d+\|>'), marker);
+    var normalized = normalizeMediaPlaceholders(prompt, marker: marker);
 
     if (mediaPartCount <= 0) {
       return normalized;

--- a/lib/src/core/template/chat_template_handler.dart
+++ b/lib/src/core/template/chat_template_handler.dart
@@ -5,6 +5,7 @@ import '../models/chat/chat_message.dart';
 import '../models/chat/chat_template_result.dart';
 import '../models/tools/tool_definition.dart';
 import 'chat_format.dart';
+import 'media_placeholders.dart';
 import 'chat_parse_result.dart';
 import 'template_internal_metadata.dart';
 import 'template_render_context.dart';
@@ -184,20 +185,7 @@ abstract class ChatTemplateHandler {
 
     // Post-process: replace model-specific image placeholders with
     // the mtmd marker so the native tokenizer can match bitmaps to markers.
-    const mtmdMarker = '<__media__>';
-    const imagePlaceholders = [
-      '<image>', // SmolVLM, InternVL, etc.
-      '[IMG]', // Some CLIP-based models
-      '<|image|>', // Phi-3 vision
-      '<|audio|>',
-      '<|video|>',
-      '<image_soft_token>',
-      '<audio_soft_token>',
-      '<video_soft_token>',
-    ];
-    for (final placeholder in imagePlaceholders) {
-      prompt = prompt.replaceAll(placeholder, mtmdMarker);
-    }
+    prompt = normalizeMediaPlaceholders(prompt);
 
     final hasTools = tools != null && tools.isNotEmpty;
 

--- a/lib/src/core/template/handlers/function_gemma_handler.dart
+++ b/lib/src/core/template/handlers/function_gemma_handler.dart
@@ -7,6 +7,7 @@ import '../../models/chat/completion_chunk.dart';
 import '../../models/chat/content_part.dart';
 import '../../models/tools/tool_definition.dart';
 import '../chat_format.dart';
+import '../media_placeholders.dart';
 import '../chat_parse_result.dart';
 import '../chat_template_handler.dart';
 import '../tool_call_fallback_parser.dart';
@@ -91,7 +92,7 @@ class FunctionGemmaHandler extends ChatTemplateHandler {
     );
 
     if (multimodalContent) {
-      prompt = prompt.replaceAll('<start_of_image>', '<__media__>');
+      prompt = normalizeMediaPlaceholders(prompt);
     }
 
     final hasTools = tools != null && tools.isNotEmpty;

--- a/lib/src/core/template/handlers/minicpm5_handler.dart
+++ b/lib/src/core/template/handlers/minicpm5_handler.dart
@@ -4,6 +4,7 @@ import '../../models/chat/chat_message.dart';
 import '../../models/chat/chat_template_result.dart';
 import '../../models/tools/tool_definition.dart';
 import '../chat_format.dart';
+import '../thinking_utils.dart';
 import '../chat_parse_result.dart';
 import '../chat_template_handler.dart';
 import '../xml_tool_call_format.dart';
@@ -55,7 +56,7 @@ class MiniCpm5Handler extends ChatTemplateHandler {
     );
 
     var thinkingForcedOpen = false;
-    if (prompt.endsWith('<think>\n')) {
+    if (isThinkingForcedOpen(prompt)) {
       if (!enableThinking) {
         prompt = '$prompt</think>\n\n';
       } else {

--- a/lib/src/core/template/handlers/minimax_m2_handler.dart
+++ b/lib/src/core/template/handlers/minimax_m2_handler.dart
@@ -4,6 +4,7 @@ import '../../models/chat/chat_message.dart';
 import '../../models/chat/chat_template_result.dart';
 import '../../models/tools/tool_definition.dart';
 import '../chat_format.dart';
+import '../thinking_utils.dart';
 import '../chat_parse_result.dart';
 import '../chat_template_handler.dart';
 import '../xml_tool_call_format.dart';
@@ -54,7 +55,7 @@ class MinimaxM2Handler extends ChatTemplateHandler {
     );
 
     var thinkingForcedOpen = false;
-    if (prompt.endsWith('<think>\n')) {
+    if (isThinkingForcedOpen(prompt)) {
       if (!enableThinking) {
         prompt = '$prompt</think>\n\n';
       } else {

--- a/lib/src/core/template/media_placeholders.dart
+++ b/lib/src/core/template/media_placeholders.dart
@@ -1,0 +1,45 @@
+/// Shared media-placeholder normalization for multimodal prompts.
+///
+/// Model templates emit their own image/audio/video placeholders, which must be
+/// rewritten to the mtmd marker so the native tokenizer can bind bitmaps to
+/// positions in the prompt. Two layers do this — the chat-template handlers and
+/// the llama.cpp service — and a marker added to only one of them makes the
+/// result depend on which path rendered the prompt. Keep the table here so both
+/// stay in step.
+library;
+
+/// The mtmd marker the native tokenizer matches media parts against.
+///
+/// The llama.cpp service prefers the marker reported by the runtime and falls
+/// back to this value when the symbol is unavailable.
+const String mtmdMediaMarker = '<__media__>';
+
+/// Model-specific media placeholders rewritten to [mtmdMediaMarker].
+const List<String> mtmdMediaPlaceholders = <String>[
+  '<image>', // SmolVLM, InternVL, etc.
+  '[IMG]', // Some CLIP-based models
+  '<|image|>', // Phi-3 vision
+  '<|audio|>',
+  '<|video|>',
+  '<img>',
+  '<|img|>',
+  '<start_of_image>', // Gemma
+  '<image_soft_token>',
+  '<audio_soft_token>',
+  '<video_soft_token>',
+];
+
+/// Indexed image placeholders such as `<|image_1|>`, used by some VLM templates.
+final RegExp mtmdIndexedImagePlaceholder = RegExp(r'<\|image_\d+\|>');
+
+/// Rewrites every known media placeholder in [prompt] to [marker].
+String normalizeMediaPlaceholders(
+  String prompt, {
+  String marker = mtmdMediaMarker,
+}) {
+  var normalized = prompt;
+  for (final placeholder in mtmdMediaPlaceholders) {
+    normalized = normalized.replaceAll(placeholder, marker);
+  }
+  return normalized.replaceAll(mtmdIndexedImagePlaceholder, marker);
+}

--- a/lib/src/core/template/media_placeholders.dart
+++ b/lib/src/core/template/media_placeholders.dart
@@ -1,17 +1,13 @@
 /// Shared media-placeholder normalization for multimodal prompts.
 ///
-/// Model templates emit their own image/audio/video placeholders, which must be
-/// rewritten to the mtmd marker so the native tokenizer can bind bitmaps to
-/// positions in the prompt. Two layers do this — the chat-template handlers and
-/// the llama.cpp service — and a marker added to only one of them makes the
-/// result depend on which path rendered the prompt. Keep the table here so both
-/// stay in step.
+/// Both the chat-template handlers and the llama.cpp service normalize, so the
+/// table lives here to keep them in step.
 library;
 
 /// The mtmd marker the native tokenizer matches media parts against.
 ///
-/// The llama.cpp service prefers the marker reported by the runtime and falls
-/// back to this value when the symbol is unavailable.
+/// The llama.cpp service prefers the runtime-reported marker and falls back to
+/// this when the symbol is unavailable.
 const String mtmdMediaMarker = '<__media__>';
 
 /// Model-specific media placeholders rewritten to [mtmdMediaMarker].

--- a/test/unit/core/template/media_placeholders_test.dart
+++ b/test/unit/core/template/media_placeholders_test.dart
@@ -39,10 +39,13 @@ void main() {
       );
     });
 
-    // `<image>` is a prefix of `<image_soft_token>` up to the closing angle
-    // bracket. If the table were matched loosely, the soft-token placeholder
-    // would be corrupted into `<__media__>_soft_token>`.
-    test('does not corrupt placeholders that share a prefix', () {
+    // No table entry is a substring of another today, so exact matching keeps
+    // these distinct: `<image>` does not occur inside `<image_soft_token>`,
+    // because the character after `image` is `_` rather than `>`. That safety
+    // depends on matching the full literal — a looser match on `<image` would
+    // rewrite the soft-token placeholder into `<__media__>_soft_token>`, so pin
+    // the exact behaviour here.
+    test('matches full literals rather than shared prefixes', () {
       expect(normalizeMediaPlaceholders('<image_soft_token>'), mtmdMediaMarker);
       expect(normalizeMediaPlaceholders('<|image_1|>'), mtmdMediaMarker);
     });

--- a/test/unit/core/template/media_placeholders_test.dart
+++ b/test/unit/core/template/media_placeholders_test.dart
@@ -1,0 +1,97 @@
+@TestOn('vm')
+library;
+
+import 'dart:io';
+
+import 'package:llamadart/src/core/template/media_placeholders.dart';
+import 'package:test/test.dart';
+
+void main() {
+  group('normalizeMediaPlaceholders', () {
+    test('rewrites every placeholder in the shared table', () {
+      for (final placeholder in mtmdMediaPlaceholders) {
+        expect(
+          normalizeMediaPlaceholders('before $placeholder after'),
+          'before $mtmdMediaMarker after',
+          reason: '$placeholder should normalize to the mtmd marker',
+        );
+      }
+    });
+
+    test('rewrites indexed image placeholders', () {
+      expect(
+        normalizeMediaPlaceholders('a <|image_1|> b <|image_12|> c'),
+        'a $mtmdMediaMarker b $mtmdMediaMarker c',
+      );
+    });
+
+    test('honours a runtime-resolved marker', () {
+      expect(
+        normalizeMediaPlaceholders('<image>', marker: '<<media>>'),
+        '<<media>>',
+      );
+    });
+
+    test('rewrites every occurrence, not just the first', () {
+      expect(
+        normalizeMediaPlaceholders('<image><image>'),
+        '$mtmdMediaMarker$mtmdMediaMarker',
+      );
+    });
+
+    // `<image>` is a prefix of `<image_soft_token>` up to the closing angle
+    // bracket. If the table were matched loosely, the soft-token placeholder
+    // would be corrupted into `<__media__>_soft_token>`.
+    test('does not corrupt placeholders that share a prefix', () {
+      expect(normalizeMediaPlaceholders('<image_soft_token>'), mtmdMediaMarker);
+      expect(normalizeMediaPlaceholders('<|image_1|>'), mtmdMediaMarker);
+    });
+
+    test('leaves unrelated markup alone', () {
+      expect(
+        normalizeMediaPlaceholders('<think>text</think> <imagine>'),
+        '<think>text</think> <imagine>',
+      );
+    });
+
+    test('covers the markers that previously differed between layers', () {
+      // `<img>` and `<|img|>` existed only in the llama.cpp service table, and
+      // `<start_of_image>` only in the Gemma handler, so the same prompt
+      // normalized differently depending on which path rendered it.
+      for (final placeholder in <String>[
+        '<img>',
+        '<|img|>',
+        '<start_of_image>',
+      ]) {
+        expect(mtmdMediaPlaceholders, contains(placeholder));
+        expect(normalizeMediaPlaceholders(placeholder), mtmdMediaMarker);
+      }
+    });
+  });
+
+  group('shared table adoption', () {
+    // Guards the reason this module exists: a placeholder added to one consumer
+    // and not the other is exactly the drift this replaced.
+    const consumers = <String>[
+      'lib/src/core/template/chat_template_handler.dart',
+      'lib/src/core/template/handlers/function_gemma_handler.dart',
+      'lib/src/backends/llama_cpp/llama_cpp_service.dart',
+    ];
+
+    for (final path in consumers) {
+      test('$path normalizes through the shared helper', () {
+        final source = File(path).readAsStringSync();
+        expect(
+          source,
+          contains('normalizeMediaPlaceholders('),
+          reason: '$path should delegate to the shared helper',
+        );
+        expect(
+          source,
+          isNot(contains("'<image_soft_token>'")),
+          reason: '$path should not re-declare its own placeholder table',
+        );
+      });
+    }
+  });
+}

--- a/test/unit/core/template/media_placeholders_test.dart
+++ b/test/unit/core/template/media_placeholders_test.dart
@@ -39,12 +39,7 @@ void main() {
       );
     });
 
-    // No table entry is a substring of another today, so exact matching keeps
-    // these distinct: `<image>` does not occur inside `<image_soft_token>`,
-    // because the character after `image` is `_` rather than `>`. That safety
-    // depends on matching the full literal — a looser match on `<image` would
-    // rewrite the soft-token placeholder into `<__media__>_soft_token>`, so pin
-    // the exact behaviour here.
+    // A looser match on `<image` would corrupt `<image_soft_token>`.
     test('matches full literals rather than shared prefixes', () {
       expect(normalizeMediaPlaceholders('<image_soft_token>'), mtmdMediaMarker);
       expect(normalizeMediaPlaceholders('<|image_1|>'), mtmdMediaMarker);
@@ -58,9 +53,7 @@ void main() {
     });
 
     test('covers the markers that previously differed between layers', () {
-      // `<img>` and `<|img|>` existed only in the llama.cpp service table, and
-      // `<start_of_image>` only in the Gemma handler, so the same prompt
-      // normalized differently depending on which path rendered it.
+      // Each of these lived in only one of the tables before.
       for (final placeholder in <String>[
         '<img>',
         '<|img|>',
@@ -73,8 +66,8 @@ void main() {
   });
 
   group('shared table adoption', () {
-    // Guards the reason this module exists: a placeholder added to one consumer
-    // and not the other is exactly the drift this replaced.
+    // A placeholder added to one consumer and not the other is the drift
+    // this module replaced.
     const consumers = <String>[
       'lib/src/core/template/chat_template_handler.dart',
       'lib/src/core/template/handlers/function_gemma_handler.dart',

--- a/test/unit/core/template/media_placeholders_test.dart
+++ b/test/unit/core/template/media_placeholders_test.dart
@@ -82,10 +82,19 @@ void main() {
           contains('normalizeMediaPlaceholders('),
           reason: '$path should delegate to the shared helper',
         );
+        for (final placeholder in mtmdMediaPlaceholders) {
+          for (final literal in ["'$placeholder'", '"$placeholder"']) {
+            expect(
+              source,
+              isNot(contains(literal)),
+              reason: '$path should not re-declare $placeholder',
+            );
+          }
+        }
         expect(
           source,
-          isNot(contains("'<image_soft_token>'")),
-          reason: '$path should not re-declare its own placeholder table',
+          isNot(contains(mtmdIndexedImagePlaceholder.pattern)),
+          reason: '$path should not re-declare the indexed image pattern',
         );
       });
     }

--- a/website/docs/changelog/recent-releases.md
+++ b/website/docs/changelog/recent-releases.md
@@ -9,6 +9,12 @@ For canonical full release notes, use:
 
 ## Unreleased
 
+- Fixed multimodal media placeholders being normalized inconsistently. `<img>`,
+  `<|img|>`, `<start_of_image>` and indexed markers such as `<|image_1|>` are now
+  rewritten to the mtmd marker on every path, rather than depending on which
+  layer rendered the prompt. MiniMax-M2 and MiniCPM-5 also now detect a
+  forced-open thinking block using the same rule as every other handler.
+
 - Deprecated `LiteRtLmRuntimeClient.conversationTokenCount()` and
   `replaceConversationWithClone()`. Both are unused and are scheduled for
   removal in the next major release; open an issue if you depend on either.


### PR DESCRIPTION
Closes #356.

**Three media-placeholder tables had drifted.** `ChatTemplateHandler` knew 8 markers; `LlamaCppService` knew those 8 plus `<img>`, `<|img|>` and indexed `<|image_N|>`; `FunctionGemmaHandler` *overrides* the base method rather than extending it, so it knew only `<start_of_image>` and Gemma prompts lost the other 8. Which markers a prompt got depended on which path rendered it, and an unrecognised marker reaches the tokenizer as literal text instead of binding to a bitmap.

The table, the indexed pattern and the rewrite now live in `lib/src/core/template/media_placeholders.dart` — the union of all three, 11 markers plus the pattern — and all three sites call `normalizeMediaPlaceholders`. The service still resolves its marker from the runtime, so the helper takes the marker as a parameter.

**Two handlers bypassed the shared thinking check.** `minimax_m2_handler` and `minicpm5_handler` hand-rolled `prompt.endsWith('<think>\n')` while 19 others call `isThinkingForcedOpen`, which also tolerates trailing whitespace and escaped `\n`/`\r`. A prompt ending `<think>` or `<think>\n\n` was missed, so the `</think>` closer was not injected for those two families. Both now use the helper; each keeps its own closing string byte-identical, so previously-detected cases are unchanged.

Tests cover every marker, the indexed pattern, a runtime-supplied marker, and the overlap case where a loose match would corrupt `<image_soft_token>`. A second group asserts no consumer re-declares any placeholder from the table — verified non-vacuous by reintroducing one and watching it fail.

Verified: analyze clean, 1417 VM tests (was 1407), 765 chrome unchanged, format clean, both repo gates OK.

Caveat: end-to-end template rendering for these families is not meaningfully gated until #346 is fixed, since its 65 parity fixtures currently skip silently.
