### PR TITLE
fix: reject aLoRA adapters instead of applying them eagerly

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,8 @@
   being applied like ordinary LoRA adapters. An aLoRA adapter must activate only
   after its invocation tokens appear in the prompt, so applying it from the
   start of generation silently changed output. LoRA errors from the worker also
-  keep their typed exception instead of arriving as a bare `Exception`.
+  keep their typed exception instead of arriving as a bare `Exception`, and a
+  failed adapter load now throws `LlamaModelException`.
 
 * Deprecated `LiteRtLmRuntimeClient.conversationTokenCount()` and
   `replaceConversationWithClone()`. Both are unused and are scheduled for

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,12 @@
   layer rendered the prompt. MiniMax-M2 and MiniCPM-5 also now detect a
   forced-open thinking block using the same rule as every other handler.
 
+* aLoRA adapters are now rejected with `LlamaUnsupportedException` instead of
+  being applied like ordinary LoRA adapters. An aLoRA adapter must activate only
+  after its invocation tokens appear in the prompt, so applying it from the
+  start of generation silently changed output. LoRA errors from the worker also
+  keep their typed exception instead of arriving as a bare `Exception`.
+
 * Deprecated `LiteRtLmRuntimeClient.conversationTokenCount()` and
   `replaceConversationWithClone()`. Both are unused and are scheduled for
   removal in the next major release; open an issue if you depend on either.

--- a/lib/src/backends/llama_cpp/llama_cpp_backend.dart
+++ b/lib/src/backends/llama_cpp/llama_cpp_backend.dart
@@ -487,6 +487,7 @@ class NativeLlamaBackend
     String path,
     double scale,
   ) async {
+    await _ensureIsolate();
     final rp = ReceivePort();
     _sendPort!.send(
       LoraRequest(
@@ -499,27 +500,29 @@ class NativeLlamaBackend
     );
     final res = await rp.first;
     rp.close();
-    if (res is ErrorResponse) throw _workerError(res);
+    _expectDoneResponse(res, 'set LoRA adapter');
   }
 
   @override
   Future<void> removeLoraAdapter(int contextHandle, String path) async {
+    await _ensureIsolate();
     final rp = ReceivePort();
     _sendPort!.send(
       LoraRequest(contextHandle, 'remove', path: path, sendPort: rp.sendPort),
     );
     final res = await rp.first;
     rp.close();
-    if (res is ErrorResponse) throw _workerError(res);
+    _expectDoneResponse(res, 'remove LoRA adapter');
   }
 
   @override
   Future<void> clearLoraAdapters(int contextHandle) async {
+    await _ensureIsolate();
     final rp = ReceivePort();
     _sendPort!.send(LoraRequest(contextHandle, 'clear', sendPort: rp.sendPort));
     final res = await rp.first;
     rp.close();
-    if (res is ErrorResponse) throw _workerError(res);
+    _expectDoneResponse(res, 'clear LoRA adapters');
   }
 
   @override

--- a/lib/src/backends/llama_cpp/llama_cpp_backend.dart
+++ b/lib/src/backends/llama_cpp/llama_cpp_backend.dart
@@ -499,7 +499,7 @@ class NativeLlamaBackend
     );
     final res = await rp.first;
     rp.close();
-    if (res is ErrorResponse) throw Exception(res.message);
+    if (res is ErrorResponse) throw _workerError(res);
   }
 
   @override
@@ -510,7 +510,7 @@ class NativeLlamaBackend
     );
     final res = await rp.first;
     rp.close();
-    if (res is ErrorResponse) throw Exception(res.message);
+    if (res is ErrorResponse) throw _workerError(res);
   }
 
   @override
@@ -519,7 +519,7 @@ class NativeLlamaBackend
     _sendPort!.send(LoraRequest(contextHandle, 'clear', sendPort: rp.sendPort));
     final res = await rp.first;
     rp.close();
-    if (res is ErrorResponse) throw Exception(res.message);
+    if (res is ErrorResponse) throw _workerError(res);
   }
 
   @override

--- a/lib/src/backends/llama_cpp/llama_cpp_service.dart
+++ b/lib/src/backends/llama_cpp/llama_cpp_service.dart
@@ -6302,10 +6302,8 @@ class LlamaCppService {
           if (adapterPtr == nullptr) {
             throw Exception("Failed to load LoRA at $path");
           }
-          // aLoRA adapters carry invocation tokens and must activate only once
-          // that sequence appears in the prompt. This backend applies every
-          // adapter from the start of generation, which for an aLoRA adapter
-          // silently produces wrong output, so refuse it rather than guess.
+          // aLoRA must activate only after its invocation tokens appear, but
+          // adapters here apply from the start of generation.
           final invocationTokens = llama_adapter_get_alora_n_invocation_tokens(
             adapterPtr,
           );

--- a/lib/src/backends/llama_cpp/llama_cpp_service.dart
+++ b/lib/src/backends/llama_cpp/llama_cpp_service.dart
@@ -6302,6 +6302,25 @@ class LlamaCppService {
           if (adapterPtr == nullptr) {
             throw Exception("Failed to load LoRA at $path");
           }
+          // aLoRA adapters carry invocation tokens and must activate only once
+          // that sequence appears in the prompt. This backend applies every
+          // adapter from the start of generation, which for an aLoRA adapter
+          // silently produces wrong output, so refuse it rather than guess.
+          final invocationTokens = llama_adapter_get_alora_n_invocation_tokens(
+            adapterPtr,
+          );
+          if (invocationTokens > 0) {
+            llama_adapter_lora_free(adapterPtr);
+            throw LlamaUnsupportedException(
+              'The adapter at $path is an aLoRA adapter ($invocationTokens '
+              'invocation token(s)). llamadart applies LoRA adapters from the '
+              'start of generation, but an aLoRA adapter must activate only '
+              'after its invocation sequence appears in the prompt, so '
+              'applying it eagerly would silently change output. Use a '
+              'standard LoRA adapter until invocation-aware activation is '
+              'implemented.',
+            );
+          }
           adapter = _LlamaLoraWrapper(adapterPtr);
           modelAdapters[path] = adapter;
         }

--- a/lib/src/backends/llama_cpp/llama_cpp_service.dart
+++ b/lib/src/backends/llama_cpp/llama_cpp_service.dart
@@ -6300,7 +6300,7 @@ class LlamaCppService {
           );
           malloc.free(pathPtr);
           if (adapterPtr == nullptr) {
-            throw Exception("Failed to load LoRA at $path");
+            throw LlamaModelException('Failed to load LoRA at $path');
           }
           // aLoRA must activate only after its invocation tokens appear, but
           // adapters here apply from the start of generation.

--- a/test/unit/backends/llama_cpp/llama_cpp_backend_test.dart
+++ b/test/unit/backends/llama_cpp/llama_cpp_backend_test.dart
@@ -382,9 +382,7 @@ void main() {
     });
 
     test('LoRA errors keep the worker error kind', () async {
-      // setLoraAdapter previously threw a bare Exception, discarding the
-      // kind the worker had already classified. An aLoRA rejection has to
-      // reach callers as LlamaUnsupportedException to be actionable.
+      // The worker's error kind must survive the isolate boundary.
       await expectLater(
         backend.setLoraAdapter(1, 'alora.gguf', 1.0),
         throwsA(

--- a/test/unit/backends/llama_cpp/llama_cpp_backend_test.dart
+++ b/test/unit/backends/llama_cpp/llama_cpp_backend_test.dart
@@ -381,6 +381,32 @@ void main() {
       );
     });
 
+    test('LoRA errors keep the worker error kind', () async {
+      // setLoraAdapter previously threw a bare Exception, discarding the
+      // kind the worker had already classified. An aLoRA rejection has to
+      // reach callers as LlamaUnsupportedException to be actionable.
+      await expectLater(
+        backend.setLoraAdapter(1, 'alora.gguf', 1.0),
+        throwsA(
+          isA<LlamaUnsupportedException>().having(
+            (error) => error.message,
+            'message',
+            contains('aLoRA adapter'),
+          ),
+        ),
+      );
+    });
+
+    test('ordinary LoRA operations still succeed', () async {
+      await backend.setLoraAdapter(1, 'ordinary.gguf', 0.8);
+      await backend.removeLoraAdapter(1, 'ordinary.gguf');
+      await backend.clearLoraAdapters(1);
+      expect(
+        harness.received.whereType<LoraRequest>().map((r) => r.op),
+        containsAll(<String>['set', 'remove', 'clear']),
+      );
+    });
+
     test('modelLoadFromUrl remains unsupported on native backend', () {
       expect(
         () => backend.modelLoadFromUrl(
@@ -608,7 +634,16 @@ class _FakeWorkerHarness {
             message.sendPort.send(ChatTemplateResponse('templated'));
           }
         case LoraRequest():
-          message.sendPort.send(DoneResponse());
+          if (message.path == 'alora.gguf') {
+            message.sendPort.send(
+              ErrorResponse(
+                'The adapter at alora.gguf is an aLoRA adapter',
+                kind: WorkerErrorKind.unsupported,
+              ),
+            );
+          } else {
+            message.sendPort.send(DoneResponse());
+          }
         case DisposeRequest():
           message.sendPort.send(DoneResponse());
         case WorkerHandshake():

--- a/test/unit/backends/llama_cpp/llama_cpp_backend_test.dart
+++ b/test/unit/backends/llama_cpp/llama_cpp_backend_test.dart
@@ -395,6 +395,19 @@ void main() {
       );
     });
 
+    test('a failed adapter load surfaces as a model error', () async {
+      await expectLater(
+        backend.setLoraAdapter(1, 'missing.gguf', 1.0),
+        throwsA(
+          isA<LlamaModelException>().having(
+            (error) => error.message,
+            'message',
+            'Failed to load LoRA at missing.gguf',
+          ),
+        ),
+      );
+    });
+
     test('ordinary LoRA operations still succeed', () async {
       await backend.setLoraAdapter(1, 'ordinary.gguf', 0.8);
       await backend.removeLoraAdapter(1, 'ordinary.gguf');
@@ -637,6 +650,13 @@ class _FakeWorkerHarness {
               ErrorResponse(
                 'The adapter at alora.gguf is an aLoRA adapter',
                 kind: WorkerErrorKind.unsupported,
+              ),
+            );
+          } else if (message.path == 'missing.gguf') {
+            message.sendPort.send(
+              ErrorResponse(
+                'Failed to load LoRA at missing.gguf',
+                kind: WorkerErrorKind.model,
               ),
             );
           } else {

--- a/test/unit/backends/llama_cpp/worker_test.dart
+++ b/test/unit/backends/llama_cpp/worker_test.dart
@@ -280,6 +280,42 @@ void main() {
       }
     });
 
+    test('preserves LoRA error categories', () async {
+      final cases = <(Object, WorkerErrorKind)>[
+        (
+          LlamaModelException('Failed to load LoRA at bad.gguf'),
+          WorkerErrorKind.model,
+        ),
+        (
+          LlamaUnsupportedException('The adapter is an aLoRA adapter'),
+          WorkerErrorKind.unsupported,
+        ),
+        (Exception('boom'), WorkerErrorKind.generic),
+      ];
+
+      for (final (exception, expectedKind) in cases) {
+        final worker = await _startWorkerInCurrentIsolate(
+          _ThrowingLoraService(exception),
+        );
+        try {
+          final response = await _sendRequest(
+            worker.sendPort,
+            (sendPort) => LoraRequest(
+              1,
+              'set',
+              path: 'bad.gguf',
+              scale: 1.0,
+              sendPort: sendPort,
+            ),
+          );
+          expect(response, isA<ErrorResponse>());
+          expect((response as ErrorResponse).kind, expectedKind);
+        } finally {
+          await _disposeWorker(worker);
+        }
+      }
+    });
+
     test('waits for active generation before freeing native handles', () async {
       final service = _BlockingLlamaCppService();
       final worker = await _startWorkerInCurrentIsolate(service);
@@ -666,6 +702,26 @@ class _InferenceGenerationLlamaCppService extends LlamaCppService {
       'grammar sampler failed in this test runtime',
       'native grammar stack exhausted',
     );
+  }
+
+  @override
+  void dispose() {}
+}
+
+class _ThrowingLoraService extends LlamaCppService {
+  _ThrowingLoraService(this.error);
+
+  final Object error;
+
+  @override
+  void initializeBackend() {}
+
+  @override
+  void setLogLevel(LlamaLogLevel level) {}
+
+  @override
+  void handleLora(int contextHandle, String? path, double? scale, String op) {
+    throw error;
   }
 
   @override

--- a/website/docs/changelog/recent-releases.md
+++ b/website/docs/changelog/recent-releases.md
@@ -19,7 +19,8 @@ For canonical full release notes, use:
   being applied like ordinary LoRA adapters. An aLoRA adapter must activate only
   after its invocation tokens appear in the prompt, so applying it from the
   start of generation silently changed output. LoRA errors from the worker also
-  keep their typed exception instead of arriving as a bare `Exception`.
+  keep their typed exception instead of arriving as a bare `Exception`, and a
+  failed adapter load now throws `LlamaModelException`.
 
 - Deprecated `LiteRtLmRuntimeClient.conversationTokenCount()` and
   `replaceConversationWithClone()`. Both are unused and are scheduled for

--- a/website/docs/changelog/recent-releases.md
+++ b/website/docs/changelog/recent-releases.md
@@ -15,6 +15,12 @@ For canonical full release notes, use:
   layer rendered the prompt. MiniMax-M2 and MiniCPM-5 also now detect a
   forced-open thinking block using the same rule as every other handler.
 
+- aLoRA adapters are now rejected with `LlamaUnsupportedException` instead of
+  being applied like ordinary LoRA adapters. An aLoRA adapter must activate only
+  after its invocation tokens appear in the prompt, so applying it from the
+  start of generation silently changed output. LoRA errors from the worker also
+  keep their typed exception instead of arriving as a bare `Exception`.
+
 - Deprecated `LiteRtLmRuntimeClient.conversationTokenCount()` and
   `replaceConversationWithClone()`. Both are unused and are scheduled for
   removal in the next major release; open an issue if you depend on either.

--- a/website/docs/guides/lora-adapters.md
+++ b/website/docs/guides/lora-adapters.md
@@ -87,6 +87,29 @@ Practical compatibility checks:
 - Lower scales (`0.1` to `0.3`) help preserve base-model behavior.
 - Higher scales can over-steer outputs; validate with representative prompts.
 
+## aLoRA adapters are not supported
+
+Activated LoRA (aLoRA) adapters carry a sequence of invocation tokens and must
+take effect only once that sequence appears in the prompt. llamadart applies
+every adapter from the start of generation, so an aLoRA adapter used this way
+would change output without any error — the failure is silent and looks like a
+badly behaved LoRA.
+
+Rather than guess, `setLoraAdapter` inspects the adapter after loading it and
+rejects an aLoRA adapter with `LlamaUnsupportedException`:
+
+```
+The adapter at <path> is an aLoRA adapter (N invocation token(s)). llamadart
+applies LoRA adapters from the start of generation, but an aLoRA adapter must
+activate only after its invocation sequence appears in the prompt, so applying
+it eagerly would silently change output. Use a standard LoRA adapter until
+invocation-aware activation is implemented.
+```
+
+Native LoRA support should not be read as aLoRA support. Invocation-aware
+activation is tracked in
+[issue #321](https://github.com/leehack/llamadart/issues/321).
+
 ## Lifecycle notes
 
 - LoRA activation is tied to the active context.


### PR DESCRIPTION
The detect-and-reject slice of #321, not invocation-aware execution.

**The failure.** An aLoRA adapter must take effect only once its invocation tokens appear in the prompt. This backend applies every adapter from the start of generation via `llama_set_adapters_lora`, so loading an aLoRA adapter through `setLoraAdapter` changed output with no error — silently wrong output that looks like a badly behaved LoRA.

**The fix.** The pinned bindings already expose `llama_adapter_get_alora_n_invocation_tokens` and nothing called it. `handleLora` now checks it right after `llama_adapter_lora_init` succeeds, frees the adapter, and throws `LlamaUnsupportedException` naming the condition and the way forward. Nothing is inserted into `_loraAdapters` and the native handle is not leaked.

**Found on the way: the kind did not survive the isolate.** The worker already classified `LlamaUnsupportedException` as `WorkerErrorKind.unsupported` and `_workerError` already maps it back, but the three LoRA backend methods did `throw Exception(res.message)`, discarding it — so the rejection would have arrived indistinguishable from "adapter file missing". They now use `_expectDoneResponse`, and also `await _ensureIsolate()`, which they were missing.

Also typed the adjacent `Failed to load LoRA at $path` as `LlamaModelException` (reviewer catch). Note the file's own idiom is bare `Exception` at the service layer with the engine wrapping — but `LlamaEngine.setLora` does no wrapping, unlike `loadModel`, so this closes the gap without touching every backend.

**Seven further sites in `llama_cpp_backend.dart` still flatten the kind** (`:373`, `:400`, `:437`, `:460`, `:480`, `:646`, `:826`) — that is #348, deliberately left alone.

Tests: aLoRA rejection and ordinary set/remove/clear through the fake-worker harness, plus both legs of the model-error round trip (worker classification and backend reconstruction). Each verified non-vacuous by breaking its own leg. Native aLoRA detection itself would need a real `.gguf` fixture the repo does not carry.

Docs: new "aLoRA adapters are not supported" section in the LoRA guide.

Verified: analyze clean, 1411 VM tests (was 1407), 765 chrome unchanged, format clean, both repo gates OK, changelog in both files.

Does not implement invocation-aware activation — prefix decoding, prompt-cache safety and multi-aLoRA rejection remain open in #321.
