### PR TITLE
fix: preserve typed worker errors across the llama.cpp boundary

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 ## Unreleased
 
+* llama.cpp worker errors now keep their type. Every backend method routes an
+  `ErrorResponse` through the file's own error mapper instead of rebuilding a
+  bare `Exception`, `tokenize` and `detokenize` no longer discard the worker's
+  error entirely, and a core `UnsupportedError` raised for an unavailable native
+  capability is classified rather than flattened. State-file failures now throw
+  `LlamaStateException`.
+
 * Fixed multimodal media placeholders being normalized inconsistently. `<img>`,
   `<|img|>`, `<start_of_image>` and indexed markers such as `<|image_1|>` are now
   rewritten to the mtmd marker on every path, rather than depending on which

--- a/lib/src/backends/llama_cpp/llama_cpp_backend.dart
+++ b/lib/src/backends/llama_cpp/llama_cpp_backend.dart
@@ -355,6 +355,7 @@ class NativeLlamaBackend
     final res = await rp.first;
     rp.close();
     if (res is TokenizeResponse) return res.tokens;
+    if (res is ErrorResponse) throw _workerError(res);
     throw Exception("Tokenization failed");
   }
 
@@ -370,7 +371,7 @@ class NativeLlamaBackend
     final res = await rp.first;
     rp.close();
     if (res is EmbedResponse) return res.embedding;
-    if (res is ErrorResponse) throw Exception(res.message);
+    if (res is ErrorResponse) throw _workerError(res);
     throw Exception('Embedding failed');
   }
 
@@ -397,7 +398,7 @@ class NativeLlamaBackend
     final res = await rp.first;
     rp.close();
     if (res is EmbedBatchResponse) return res.embeddings;
-    if (res is ErrorResponse) throw Exception(res.message);
+    if (res is ErrorResponse) throw _workerError(res);
     throw Exception('Batch embedding failed');
   }
 
@@ -414,6 +415,7 @@ class NativeLlamaBackend
     final res = await rp.first;
     rp.close();
     if (res is DetokenizeResponse) return res.text;
+    if (res is ErrorResponse) throw _workerError(res);
     throw Exception("Detokenization failed");
   }
 
@@ -434,7 +436,7 @@ class NativeLlamaBackend
     final res = await rp.first;
     rp.close();
     if (res is ModelFileTypeResponse) return res.modelFileType;
-    if (res is ErrorResponse) throw Exception(res.message);
+    if (res is ErrorResponse) throw _workerError(res);
     return null;
   }
 
@@ -457,7 +459,7 @@ class NativeLlamaBackend
     final res = await rp.first;
     rp.close();
     if (res is StateSaveFileResponse) return res.success;
-    if (res is ErrorResponse) throw Exception(res.message);
+    if (res is ErrorResponse) throw _workerError(res);
     throw Exception('State save failed');
   }
 
@@ -477,7 +479,7 @@ class NativeLlamaBackend
     if (res is StateLoadFileResponse) {
       return StateLoadResult(tokens: res.tokens);
     }
-    if (res is ErrorResponse) throw Exception(res.message);
+    if (res is ErrorResponse) throw _workerError(res);
     throw Exception('State load failed');
   }
 
@@ -585,7 +587,7 @@ class NativeLlamaBackend
       );
     }
     if (res is ErrorResponse) {
-      throw Exception(res.message);
+      throw _workerError(res);
     }
     return null;
   }
@@ -643,7 +645,7 @@ class NativeLlamaBackend
     final res = await rp.first;
     rp.close();
     if (res is HandleResponse) return res.handle;
-    if (res is ErrorResponse) throw Exception(res.message);
+    if (res is ErrorResponse) throw _workerError(res);
     return null;
   }
 
@@ -823,7 +825,7 @@ class NativeLlamaBackend
     final res = await rp.first;
     rp.close();
     if (res is ChatTemplateResponse) return res.result;
-    if (res is ErrorResponse) throw Exception(res.message);
+    if (res is ErrorResponse) throw _workerError(res);
     throw Exception("Unknown response during chat template application");
   }
 }

--- a/lib/src/backends/llama_cpp/llama_cpp_service.dart
+++ b/lib/src/backends/llama_cpp/llama_cpp_service.dart
@@ -5993,10 +5993,10 @@ class LlamaCppService {
   bool stateSaveFile(int contextHandle, String path, List<int> tokens) {
     final ctx = _contexts[contextHandle];
     if (ctx == null) {
-      throw StateError('Unknown context handle: $contextHandle');
+      throw LlamaStateException('Unknown context handle: $contextHandle');
     }
     if (_generatingContexts.containsKey(contextHandle)) {
-      throw StateError(
+      throw LlamaStateException(
         'Cannot save state while generation is active on context $contextHandle',
       );
     }
@@ -6027,10 +6027,10 @@ class LlamaCppService {
   List<int> stateLoadFile(int contextHandle, String path, int tokenCapacity) {
     final ctx = _contexts[contextHandle];
     if (ctx == null) {
-      throw StateError('Unknown context handle: $contextHandle');
+      throw LlamaStateException('Unknown context handle: $contextHandle');
     }
     if (_generatingContexts.containsKey(contextHandle)) {
-      throw StateError(
+      throw LlamaStateException(
         'Cannot load state while generation is active on context $contextHandle',
       );
     }
@@ -6063,14 +6063,14 @@ class LlamaCppService {
         countPtr,
       );
       if (!ok) {
-        throw StateError(
+        throw LlamaStateException(
           'llama_state_load_file failed for "$path" '
           '(corrupt file, version mismatch, or capacity too small)',
         );
       }
       final actual = countPtr.value;
       if (actual > tokenCapacity) {
-        throw StateError(
+        throw LlamaStateException(
           'llama_state_load_file returned actual=$actual '
           'exceeding capacity=$tokenCapacity',
         );

--- a/lib/src/backends/llama_cpp/worker.dart
+++ b/lib/src/backends/llama_cpp/worker.dart
@@ -38,6 +38,18 @@ ErrorResponse _toErrorResponse(Object error) {
   if (error is LlamaSpeechException) {
     return ErrorResponse(messageFor(error), kind: WorkerErrorKind.speech);
   }
+  // UnimplementedError is an unfinished code path, not a runtime capability
+  // limit, so it stays generic. It implements UnsupportedError, so it must be
+  // checked first.
+  if (error is UnimplementedError) {
+    return ErrorResponse(error.toString());
+  }
+  if (error is UnsupportedError) {
+    return ErrorResponse(
+      error.message ?? error.toString(),
+      kind: WorkerErrorKind.unsupported,
+    );
+  }
   return ErrorResponse(error.toString());
 }
 

--- a/test/e2e/backends/llama_cpp_chat_template_backend_e2e_test.dart
+++ b/test/e2e/backends/llama_cpp_chat_template_backend_e2e_test.dart
@@ -131,8 +131,8 @@ void main() {
               },
             ]),
             throwsA(
-              isA<Exception>().having(
-                (error) => error.toString(),
+              isA<LlamaUnsupportedException>().having(
+                (error) => error.message,
                 'message',
                 contains('multimodal chat-template content'),
               ),

--- a/test/unit/backends/llama_cpp/llama_cpp_backend_test.dart
+++ b/test/unit/backends/llama_cpp/llama_cpp_backend_test.dart
@@ -395,6 +395,25 @@ void main() {
       );
     });
 
+    test('worker errors keep their kind through every request', () async {
+      await expectLater(
+        backend.tokenize(1, 'boom'),
+        throwsA(isA<LlamaUnsupportedException>()),
+      );
+      await expectLater(
+        backend.detokenize(1, const <int>[]),
+        throwsA(isA<LlamaUnsupportedException>()),
+      );
+      await expectLater(
+        backend.applyChatTemplate(
+          1,
+          const <Map<String, dynamic>>[],
+          customTemplate: 'unsupported',
+        ),
+        throwsA(isA<LlamaUnsupportedException>()),
+      );
+    });
+
     test('a failed adapter load surfaces as a model error', () async {
       await expectLater(
         backend.setLoraAdapter(1, 'missing.gguf', 1.0),
@@ -503,9 +522,27 @@ class _FakeWorkerHarness {
             message.sendPort.send(DoneResponse());
           }
         case TokenizeRequest():
-          message.sendPort.send(TokenizeResponse(<int>[1, 2, 3]));
+          if (message.text == 'boom') {
+            message.sendPort.send(
+              ErrorResponse(
+                'tokenizer unavailable',
+                kind: WorkerErrorKind.unsupported,
+              ),
+            );
+          } else {
+            message.sendPort.send(TokenizeResponse(<int>[1, 2, 3]));
+          }
         case DetokenizeRequest():
-          message.sendPort.send(DetokenizeResponse('decoded'));
+          if (message.tokens.isEmpty) {
+            message.sendPort.send(
+              ErrorResponse(
+                'detokenizer unavailable',
+                kind: WorkerErrorKind.unsupported,
+              ),
+            );
+          } else {
+            message.sendPort.send(DetokenizeResponse('decoded'));
+          }
         case MetadataRequest():
           message.sendPort.send(MetadataResponse(<String, String>{'a': 'b'}));
         case EmbedRequest():
@@ -641,6 +678,13 @@ class _FakeWorkerHarness {
         case ChatTemplateRequest():
           if (message.customTemplate == 'error') {
             message.sendPort.send(ErrorResponse('chat template failed'));
+          } else if (message.customTemplate == 'unsupported') {
+            message.sendPort.send(
+              ErrorResponse(
+                'multimodal chat-template content is unavailable',
+                kind: WorkerErrorKind.unsupported,
+              ),
+            );
           } else {
             message.sendPort.send(ChatTemplateResponse('templated'));
           }

--- a/test/unit/backends/llama_cpp/llama_cpp_service_test.dart
+++ b/test/unit/backends/llama_cpp/llama_cpp_service_test.dart
@@ -704,10 +704,14 @@ void main() {
       );
     });
 
-    test('stateSaveFile throws for unknown context handle', () {
+    test('state file methods throw for unknown context handle', () {
       expect(
         () => service.stateSaveFile(-1, '/tmp/state.bin', const <int>[]),
-        throwsA(isA<StateError>()),
+        throwsA(isA<LlamaStateException>()),
+      );
+      expect(
+        () => service.stateLoadFile(-1, '/tmp/state.bin', 16),
+        throwsA(isA<LlamaStateException>()),
       );
     });
 

--- a/test/unit/backends/llama_cpp/worker_test.dart
+++ b/test/unit/backends/llama_cpp/worker_test.dart
@@ -280,7 +280,7 @@ void main() {
       }
     });
 
-    test('preserves LoRA error categories', () async {
+    test('preserves LoRA and capability error categories', () async {
       final cases = <(Object, WorkerErrorKind)>[
         (
           LlamaModelException('Failed to load LoRA at bad.gguf'),
@@ -290,6 +290,13 @@ void main() {
           LlamaUnsupportedException('The adapter is an aLoRA adapter'),
           WorkerErrorKind.unsupported,
         ),
+        (
+          UnsupportedError('native capability missing'),
+          WorkerErrorKind.unsupported,
+        ),
+        // UnimplementedError implements UnsupportedError, so it must not be
+        // reclassified as a runtime capability limit.
+        (UnimplementedError('not done yet'), WorkerErrorKind.generic),
         (Exception('boom'), WorkerErrorKind.generic),
       ];
 
@@ -310,6 +317,7 @@ void main() {
           );
           expect(response, isA<ErrorResponse>());
           expect((response as ErrorResponse).kind, expectedKind);
+          expect(response.message, isNot(contains('LlamaException:')));
         } finally {
           await _disposeWorker(worker);
         }

--- a/website/docs/changelog/recent-releases.md
+++ b/website/docs/changelog/recent-releases.md
@@ -9,6 +9,13 @@ For canonical full release notes, use:
 
 ## Unreleased
 
+- llama.cpp worker errors now keep their type. Every backend method routes an
+  `ErrorResponse` through the file's own error mapper instead of rebuilding a
+  bare `Exception`, `tokenize` and `detokenize` no longer discard the worker's
+  error entirely, and a core `UnsupportedError` raised for an unavailable native
+  capability is classified rather than flattened. State-file failures now throw
+  `LlamaStateException`.
+
 - Fixed multimodal media placeholders being normalized inconsistently. `<img>`,
   `<|img|>`, `<start_of_image>` and indexed markers such as `<|image_1|>` are now
   rewritten to the mtmd marker on every path, rather than depending on which


### PR DESCRIPTION
Parts 1 and 2 of #348. Part 3 (startup diagnostics) is deferred — see below.

**Every ErrorResponse now routes through `_workerError`.** Eight sites rebuilt a bare `Exception` from `res.message`, discarding the kind the worker had just assigned; `tokenize` and `detokenize` were worse, ignoring `ErrorResponse` entirely and throwing a two-word `Exception("Tokenization failed")` that dropped the real diagnostic.

**`UnsupportedError` is now classified.** `_toErrorResponse` handled every `LlamaException` subtype but not core `UnsupportedError`, which the service throws for genuinely unavailable native capabilities. It now maps to `WorkerErrorKind.unsupported`. `UnimplementedError` is checked first and deliberately stays generic — it is an unfinished code path, not a runtime capability limit, and classifying it as "unsupported" would disguise a bug as a hardware limitation.

**State-file failures throw `LlamaStateException`.** The issue asks for the state assertions to be tightened to typed subtypes, which was impossible as written: `stateSaveFile`/`stateLoadFile` threw core `StateError`, and `_toErrorResponse` maps `LlamaStateException` but not `StateError`. Rather than blanket-mapping `StateError` — which would misclassify internal errors like double-completing a `Completer` — the six throws in those two methods now use `LlamaStateException`, matching what the file already does elsewhere.

Two behavior changes worth naming:

- `LlamaEngine.renderChatTemplate` now returns `tokenCount: null` instead of failing when tokenization is unsupported. `chat_template_renderer.dart:92` already had an `on LlamaUnsupportedException` arm for exactly this, which could never fire while the error arrived untyped. This is the arm doing its job.
- Generic-kind errors lose a doubled prefix: the worker sends `error.toString()` (`"Exception: boom"`) and the old code wrapped it again into `"Exception: Exception: boom"`. `_workerError` strips one. Nothing asserts on the doubled form.

Tests: worker-side classification (`UnsupportedError` → unsupported, `UnimplementedError` → generic), backend-side reconstruction for tokenize/detokenize/applyChatTemplate, and the state guard rails. The e2e chat-template test was the one path that exercised the whole chain end-to-end while asserting only `isA<Exception>()` — it passed identically before and after, so Part 2 could have shipped broken. Now tightened to `isA<LlamaUnsupportedException>()` on `.message`, and it passes against real native code.

Each new test verified non-vacuous by breaking its own leg: removing the `UnsupportedError` branch fails the worker test and the e2e test; reverting the tokenize guard fails the backend test.

Verified: analyze clean, 1422 VM tests, both repo gates OK. No public API change — all three files are outside the export closure and no signature moved.

**Deferred: Part 3.** The diagnostics ring buffer lives in the worker isolate, but the exception the caller sees is rebuilt in the main isolate from only a message and a kind. Surfacing it in `LlamaException.details` as the issue suggests needs a `details` field on `ErrorResponse`, threading through both mappers this PR rewrites, and an additive `details` parameter on `LlamaUnsupportedException` — the one subtype whose constructor lacks it. That is a wire-format change, not a mechanical fix, so #348 stays open for it.
