### PR TITLE
ci: gate the WebGPU bridge asset tag against drift

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -13,6 +13,8 @@ CHANGELOG.md @leehack
 doc/testing_matrix.md @leehack
 hook/build.dart @leehack
 tool/testing/verify_release_docs_versions.dart @leehack
+tool/testing/check_webgpu_bridge_tag.dart @leehack
+scripts/fetch_webgpu_bridge_assets.sh @leehack
 website/docs/changelog/recent-releases.md @leehack
 website/docs/maintainers/native-and-web-sync.md @leehack
 website/docs/maintainers/release-workflow.md @leehack

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -45,6 +45,9 @@ jobs:
       - name: Verify release docs versions
         run: dart run tool/testing/verify_release_docs_versions.dart
 
+      - name: Check WebGPU bridge asset tag
+        run: dart run tool/testing/check_webgpu_bridge_tag.dart
+
       - name: Pub Publish Dry Run
         run: flutter pub publish --dry-run
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -138,6 +138,10 @@ the exact generated text matters.
 WebGPU bridge features are versioned runtime capabilities. When changing bridge
 behavior, verify the pinned asset tag/manifest, direct bridge calls, worker
 path, Dart interop wrapper, public engine API, docs, and examples together.
+`tool/testing/check_webgpu_bridge_tag.dart` enforces the tag half of that: every
+site pinning the tag must match the default in
+`scripts/fetch_webgpu_bridge_assets.sh`. Capability floors (`v0.1.30+`) and
+changelog entries keep their own values and are not checked.
 
 Flutter Web builds exclude the gitignored generated bridge assets. Deployment
 and real-model Web E2E flows must use `scripts/build_chat_app_web.sh`, which

--- a/test/unit/tooling/check_webgpu_bridge_tag_test.dart
+++ b/test/unit/tooling/check_webgpu_bridge_tag_test.dart
@@ -128,6 +128,37 @@ void main() {
     );
   });
 
+  test('an unregistered pin holding a stale tag is still caught', () {
+    final root = _fakeRepo('v9.9.9');
+    Process.runSync('git', <String>[
+      'init',
+      '--quiet',
+    ], workingDirectory: root.path);
+    File(
+      '${root.path}/notes.md',
+    ).writeAsStringSync('Uses `leehack/llama-web-bridge-assets@v0.1.36`.\n');
+    Process.runSync('git', <String>['add', '-A'], workingDirectory: root.path);
+
+    expect(
+      findUnregisteredTagSites(root, 'v9.9.9'),
+      contains(contains('notes.md:1: a bridge asset pin is not covered')),
+    );
+  });
+
+  test('a binary file does not crash the scan', () {
+    final root = _fakeRepo('v9.9.9');
+    Process.runSync('git', <String>[
+      'init',
+      '--quiet',
+    ], workingDirectory: root.path);
+    File(
+      '${root.path}/blob.bin',
+    ).writeAsBytesSync(<int>[0xff, 0xfe, 0x00, 0x80]);
+    Process.runSync('git', <String>['add', '-A'], workingDirectory: root.path);
+
+    expect(() => findUnregisteredTagSites(root, 'v9.9.9'), returnsNormally);
+  });
+
   test('a missing source of truth fails instead of passing vacuously', () {
     final root = Directory.systemTemp.createTempSync('bridge_tag_gate');
     addTearDown(() => root.deleteSync(recursive: true));

--- a/test/unit/tooling/check_webgpu_bridge_tag_test.dart
+++ b/test/unit/tooling/check_webgpu_bridge_tag_test.dart
@@ -82,43 +82,38 @@ void main() {
     );
   });
 
-  test('an indented second assignment is caught too', () {
-    final root = Directory.systemTemp.createTempSync('bridge_tag_gate');
-    addTearDown(() => root.deleteSync(recursive: true));
-    File('${root.path}/$bridgeTagSourcePath')
-      ..parent.createSync(recursive: true)
-      ..writeAsStringSync(
-        'ASSETS_TAG="\${WEBGPU_BRIDGE_ASSETS_TAG:-v1.0.0}"\n'
-        '  export ASSETS_TAG=v2.0.0\n',
-      );
+  test('every bash assignment form is counted', () {
+    const overrides = <String>[
+      'ASSETS_TAG=v2.0.0',
+      '  ASSETS_TAG=v2.0.0',
+      '  export ASSETS_TAG=v2.0.0',
+      'readonly ASSETS_TAG=v2.0.0',
+      'declare ASSETS_TAG=v2.0.0',
+      'true; ASSETS_TAG=v2.0.0',
+      'ASSETS_TAG+=-patched',
+    ];
 
-    expect(() => readPinnedBridgeTag(root), throwsFormatException);
+    for (final override in overrides) {
+      final root = Directory.systemTemp.createTempSync('bridge_tag_gate');
+      addTearDown(() => root.deleteSync(recursive: true));
+      File('${root.path}/$bridgeTagSourcePath')
+        ..parent.createSync(recursive: true)
+        ..writeAsStringSync(
+          'ASSETS_TAG="\${WEBGPU_BRIDGE_ASSETS_TAG:-v1.0.0}"\n$override\n',
+        );
+
+      expect(
+        () => readPinnedBridgeTag(root),
+        throwsFormatException,
+        reason: 'bash honours "$override" but the gate did not count it',
+      );
+    }
   });
 
-  test('an append assignment is caught too', () {
-    final root = Directory.systemTemp.createTempSync('bridge_tag_gate');
-    addTearDown(() => root.deleteSync(recursive: true));
-    File('${root.path}/$bridgeTagSourcePath')
-      ..parent.createSync(recursive: true)
-      ..writeAsStringSync(
-        'ASSETS_TAG="\${WEBGPU_BRIDGE_ASSETS_TAG:-v1.0.0}"\n'
-        'ASSETS_TAG+=-patched\n',
-      );
+  test('the source-of-truth line itself counts only once', () {
+    final root = _fakeRepo('v9.9.9');
 
-    expect(() => readPinnedBridgeTag(root), throwsFormatException);
-  });
-
-  test('a second assignment fails rather than validating the wrong one', () {
-    final root = Directory.systemTemp.createTempSync('bridge_tag_gate');
-    addTearDown(() => root.deleteSync(recursive: true));
-    File('${root.path}/$bridgeTagSourcePath')
-      ..parent.createSync(recursive: true)
-      ..writeAsStringSync(
-        'ASSETS_TAG="\${WEBGPU_BRIDGE_ASSETS_TAG:-v1.0.0}"\n'
-        'ASSETS_TAG="\${WEBGPU_BRIDGE_ASSETS_TAG:-v2.0.0}"\n',
-      );
-
-    expect(() => readPinnedBridgeTag(root), throwsFormatException);
+    expect(readPinnedBridgeTag(root), 'v9.9.9');
   });
 
   test('a missing source of truth fails instead of passing vacuously', () {

--- a/test/unit/tooling/check_webgpu_bridge_tag_test.dart
+++ b/test/unit/tooling/check_webgpu_bridge_tag_test.dart
@@ -61,6 +61,19 @@ void main() {
     );
   });
 
+  test('a second assignment fails rather than validating the wrong one', () {
+    final root = Directory.systemTemp.createTempSync('bridge_tag_gate');
+    addTearDown(() => root.deleteSync(recursive: true));
+    File('${root.path}/$bridgeTagSourcePath')
+      ..parent.createSync(recursive: true)
+      ..writeAsStringSync(
+        'ASSETS_TAG="\${WEBGPU_BRIDGE_ASSETS_TAG:-v1.0.0}"\n'
+        'ASSETS_TAG="\${WEBGPU_BRIDGE_ASSETS_TAG:-v2.0.0}"\n',
+      );
+
+    expect(() => readPinnedBridgeTag(root), throwsFormatException);
+  });
+
   test('a missing source of truth fails instead of passing vacuously', () {
     final root = Directory.systemTemp.createTempSync('bridge_tag_gate');
     addTearDown(() => root.deleteSync(recursive: true));

--- a/test/unit/tooling/check_webgpu_bridge_tag_test.dart
+++ b/test/unit/tooling/check_webgpu_bridge_tag_test.dart
@@ -95,6 +95,19 @@ void main() {
     expect(() => readPinnedBridgeTag(root), throwsFormatException);
   });
 
+  test('an append assignment is caught too', () {
+    final root = Directory.systemTemp.createTempSync('bridge_tag_gate');
+    addTearDown(() => root.deleteSync(recursive: true));
+    File('${root.path}/$bridgeTagSourcePath')
+      ..parent.createSync(recursive: true)
+      ..writeAsStringSync(
+        'ASSETS_TAG="\${WEBGPU_BRIDGE_ASSETS_TAG:-v1.0.0}"\n'
+        'ASSETS_TAG+=-patched\n',
+      );
+
+    expect(() => readPinnedBridgeTag(root), throwsFormatException);
+  });
+
   test('a second assignment fails rather than validating the wrong one', () {
     final root = Directory.systemTemp.createTempSync('bridge_tag_gate');
     addTearDown(() => root.deleteSync(recursive: true));

--- a/test/unit/tooling/check_webgpu_bridge_tag_test.dart
+++ b/test/unit/tooling/check_webgpu_bridge_tag_test.dart
@@ -92,6 +92,7 @@ void main() {
       'true; ASSETS_TAG=v2.0.0',
       'ASSETS_TAG+=-patched',
       ': "\${ASSETS_TAG:=v2.0.0}"',
+      'ASSETS_TAG[0]=v2.0.0',
     ];
 
     for (final override in overrides) {
@@ -143,6 +144,32 @@ void main() {
       findUnregisteredTagSites(root, 'v9.9.9'),
       contains(contains('notes.md:1: a bridge asset pin is not covered')),
     );
+  });
+
+  test('quoted machine-readable pins are recognised', () {
+    for (final form in const <String>[
+      'const defaultBridgeAssetsTag = "v0.1.36";',
+      "const defaultBridgeAssetsTag = 'v0.1.36';",
+      'WEBGPU_BRIDGE_ASSETS_TAG="v0.1.36" ./x.sh',
+      'Uses `leehack/llama-web-bridge-assets@v0.1.36`.',
+    ]) {
+      final root = _fakeRepo('v9.9.9');
+      Process.runSync('git', <String>[
+        'init',
+        '--quiet',
+      ], workingDirectory: root.path);
+      File('${root.path}/notes.md').writeAsStringSync('$form\n');
+      Process.runSync('git', <String>[
+        'add',
+        '-A',
+      ], workingDirectory: root.path);
+
+      expect(
+        findUnregisteredTagSites(root, 'v9.9.9'),
+        contains(contains('notes.md:1: a bridge asset pin is not covered')),
+        reason: 'unregistered pin "$form" evaded the scan',
+      );
+    }
   });
 
   test('a binary file does not crash the scan', () {

--- a/test/unit/tooling/check_webgpu_bridge_tag_test.dart
+++ b/test/unit/tooling/check_webgpu_bridge_tag_test.dart
@@ -153,6 +153,7 @@ void main() {
       'const defaultBridgeAssetsTag = "v0.1.36";',
       "const defaultBridgeAssetsTag = 'v0.1.36';",
       'WEBGPU_BRIDGE_ASSETS_TAG="v0.1.36" ./x.sh',
+      'const defaultBridgeAssetsTag = `v0.1.36`;',
       'Uses `leehack/llama-web-bridge-assets@v0.1.36`.',
     ]) {
       final root = _fakeRepo('v9.9.9');

--- a/test/unit/tooling/check_webgpu_bridge_tag_test.dart
+++ b/test/unit/tooling/check_webgpu_bridge_tag_test.dart
@@ -93,6 +93,8 @@ void main() {
       'ASSETS_TAG+=-patched',
       ': "\${ASSETS_TAG:=v2.0.0}"',
       'ASSETS_TAG[0]=v2.0.0',
+      r'ASSETS_TAG[$i]=v2.0.0',
+      r'ASSETS_TAG[$((0))]=v2.0.0',
     ];
 
     for (final override in overrides) {
@@ -170,6 +172,22 @@ void main() {
         reason: 'unregistered pin "$form" evaded the scan',
       );
     }
+  });
+
+  test('a shorter tag does not match inside a longer floor', () {
+    final root = _fakeRepo('v0.1.3');
+    Process.runSync('git', <String>[
+      'init',
+      '--quiet',
+    ], workingDirectory: root.path);
+    // `v0.1.30+` is a floor for a different version; it merely starts with the
+    // pinned tag.
+    File(
+      '${root.path}/notes.md',
+    ).writeAsStringSync('Typed ASR needs bridge assets `v0.1.30+`.\n');
+    Process.runSync('git', <String>['add', '-A'], workingDirectory: root.path);
+
+    expect(findUnregisteredTagSites(root, 'v0.1.3'), isEmpty);
   });
 
   test('a binary file does not crash the scan', () {

--- a/test/unit/tooling/check_webgpu_bridge_tag_test.dart
+++ b/test/unit/tooling/check_webgpu_bridge_tag_test.dart
@@ -57,8 +57,42 @@ void main() {
 
     expect(
       findBridgeTagDrift(root, readPinnedBridgeTag(root)),
-      contains(startsWith('README.md: no line matches')),
+      contains(
+        allOf(
+          startsWith('README.md:'),
+          contains('matches 0 lines, expected 1'),
+        ),
+      ),
     );
+  });
+
+  test('a duplicated pin is reported rather than half-covered', () {
+    final root = _fakeRepo(
+      'v9.9.9',
+      files: <String, String>{
+        'README.md':
+            '| Web llama.cpp / GGUF | `leehack/llama-web-bridge-assets@v9.9.9` |\n'
+            '| Web llama.cpp / GGUF | `leehack/llama-web-bridge-assets@v9.9.9` |\n',
+      },
+    );
+
+    expect(
+      findBridgeTagDrift(root, readPinnedBridgeTag(root)),
+      contains(contains('matches 2 lines, expected 1')),
+    );
+  });
+
+  test('an indented second assignment is caught too', () {
+    final root = Directory.systemTemp.createTempSync('bridge_tag_gate');
+    addTearDown(() => root.deleteSync(recursive: true));
+    File('${root.path}/$bridgeTagSourcePath')
+      ..parent.createSync(recursive: true)
+      ..writeAsStringSync(
+        'ASSETS_TAG="\${WEBGPU_BRIDGE_ASSETS_TAG:-v1.0.0}"\n'
+        '  export ASSETS_TAG=v2.0.0\n',
+      );
+
+    expect(() => readPinnedBridgeTag(root), throwsFormatException);
   });
 
   test('a second assignment fails rather than validating the wrong one', () {

--- a/test/unit/tooling/check_webgpu_bridge_tag_test.dart
+++ b/test/unit/tooling/check_webgpu_bridge_tag_test.dart
@@ -1,0 +1,73 @@
+@TestOn('vm')
+library;
+
+import 'dart:io';
+
+import 'package:test/test.dart';
+
+import '../../../tool/testing/check_webgpu_bridge_tag.dart';
+
+Directory _fakeRepo(String assetsTag, {Map<String, String> files = const {}}) {
+  final root = Directory.systemTemp.createTempSync('bridge_tag_gate');
+  addTearDown(() => root.deleteSync(recursive: true));
+  final entries = <String, String>{
+    bridgeTagSourcePath:
+        'ASSETS_TAG="\${WEBGPU_BRIDGE_ASSETS_TAG:-$assetsTag}"\n',
+    ...files,
+  };
+  for (final entry in entries.entries) {
+    final file = File('${root.path}/${entry.key}');
+    file.parent.createSync(recursive: true);
+    file.writeAsStringSync(entry.value);
+  }
+  return root;
+}
+
+void main() {
+  test('the checked-in pins all quote the source of truth', () {
+    final repoRoot = Directory.current;
+    expect(
+      findBridgeTagDrift(repoRoot, readPinnedBridgeTag(repoRoot)),
+      isEmpty,
+    );
+  });
+
+  test('a pin quoting a different tag is reported', () {
+    final root = _fakeRepo(
+      'v9.9.9',
+      files: <String, String>{
+        'README.md':
+            '| Web llama.cpp / GGUF | `leehack/llama-web-bridge-assets@v0.0.1` |\n',
+      },
+    );
+
+    expect(
+      findBridgeTagDrift(root, readPinnedBridgeTag(root)),
+      contains('README.md: pins v0.0.1, expected v9.9.9'),
+    );
+  });
+
+  test('a reworded pin is reported rather than skipped', () {
+    final root = _fakeRepo(
+      'v9.9.9',
+      files: <String, String>{
+        'README.md': '| Web llama.cpp / GGUF | somewhere else entirely |\n',
+      },
+    );
+
+    expect(
+      findBridgeTagDrift(root, readPinnedBridgeTag(root)),
+      contains(startsWith('README.md: no line matches')),
+    );
+  });
+
+  test('a missing source of truth fails instead of passing vacuously', () {
+    final root = Directory.systemTemp.createTempSync('bridge_tag_gate');
+    addTearDown(() => root.deleteSync(recursive: true));
+    File('${root.path}/$bridgeTagSourcePath')
+      ..parent.createSync(recursive: true)
+      ..writeAsStringSync('ASSETS_TAG="whatever"\n');
+
+    expect(() => readPinnedBridgeTag(root), throwsFormatException);
+  });
+}

--- a/test/unit/tooling/check_webgpu_bridge_tag_test.dart
+++ b/test/unit/tooling/check_webgpu_bridge_tag_test.dart
@@ -91,6 +91,7 @@ void main() {
       'declare ASSETS_TAG=v2.0.0',
       'true; ASSETS_TAG=v2.0.0',
       'ASSETS_TAG+=-patched',
+      ': "\${ASSETS_TAG:=v2.0.0}"',
     ];
 
     for (final override in overrides) {
@@ -114,6 +115,17 @@ void main() {
     final root = _fakeRepo('v9.9.9');
 
     expect(readPinnedBridgeTag(root), 'v9.9.9');
+  });
+
+  test('no live occurrence of the tag escapes the pin table', () {
+    // Read the tag rather than spelling it out, so this file never becomes an
+    // occurrence the scan has to exclude.
+    final repoRoot = Directory.current;
+    expect(
+      findUnregisteredTagSites(repoRoot, readPinnedBridgeTag(repoRoot)),
+      isEmpty,
+      reason: 'run against the real tree; see the message for what to register',
+    );
   });
 
   test('a missing source of truth fails instead of passing vacuously', () {

--- a/tool/testing/check_webgpu_bridge_tag.dart
+++ b/tool/testing/check_webgpu_bridge_tag.dart
@@ -11,7 +11,12 @@ import 'dart:io';
 /// The file whose default decides what a fresh vendoring run downloads.
 const String bridgeTagSourcePath = 'scripts/fetch_webgpu_bridge_assets.sh';
 
-final RegExp _anyAssignment = RegExp(r'^ASSETS_TAG=.*$', multiLine: true);
+// Bash allows leading whitespace and an `export`/`readonly` prefix, so counting
+// only bare `ASSETS_TAG=` would let a later override slip past the guard below.
+final RegExp _anyAssignment = RegExp(
+  r'^[ \t]*(?:export[ \t]+|readonly[ \t]+)?ASSETS_TAG=',
+  multiLine: true,
+);
 
 final RegExp _sourceOfTruth = RegExp(
   r'^ASSETS_TAG="\$\{WEBGPU_BRIDGE_ASSETS_TAG:-(v\d+\.\d+\.\d+)\}"$',
@@ -153,18 +158,17 @@ List<String> findBridgeTagDrift(Directory repoRoot, String expectedTag) {
       continue;
     }
     final matches = pin.pattern.allMatches(file.readAsStringSync()).toList();
-    if (matches.isEmpty) {
+    if (matches.length != 1) {
       problems.add(
-        '${pin.path}: no line matches ${pin.pattern.pattern} — the pin moved or '
-        'was reworded, so this check no longer covers it',
+        '${pin.path}: ${pin.pattern.pattern} matches ${matches.length} lines, '
+        'expected 1 — the pin moved, was reworded, or was duplicated, so this '
+        'check no longer covers exactly one site',
       );
       continue;
     }
-    for (final match in matches) {
-      final found = match.group(1)!;
-      if (found != expectedTag) {
-        problems.add('${pin.path}: pins $found, expected $expectedTag');
-      }
+    final found = matches.single.group(1)!;
+    if (found != expectedTag) {
+      problems.add('${pin.path}: pins $found, expected $expectedTag');
     }
   }
   return problems;

--- a/tool/testing/check_webgpu_bridge_tag.dart
+++ b/tool/testing/check_webgpu_bridge_tag.dart
@@ -11,13 +11,11 @@ import 'dart:io';
 /// The file whose default decides what a fresh vendoring run downloads.
 const String bridgeTagSourcePath = 'scripts/fetch_webgpu_bridge_assets.sh';
 
-// Bash allows leading whitespace, an `export`/`readonly` prefix, and `+=`
-// appends, so a narrower pattern would let a later override slip past the
-// guard below.
-final RegExp _anyAssignment = RegExp(
-  r'^[ \t]*(?:export[ \t]+|readonly[ \t]+)?ASSETS_TAG\+?=',
-  multiLine: true,
-);
+// Any assignment to the name, wherever it sits: indented, after `export` or
+// `declare`, after a `;`, or appending with `+=`. Enumerating prefixes kept
+// missing forms, so this matches the identifier itself and relies on the
+// lookbehind to exclude longer names such as `WEBGPU_BRIDGE_ASSETS_TAG=`.
+final RegExp _anyAssignment = RegExp(r'(?<![A-Za-z0-9_])ASSETS_TAG\+?=');
 
 final RegExp _sourceOfTruth = RegExp(
   r'^ASSETS_TAG="\$\{WEBGPU_BRIDGE_ASSETS_TAG:-(v\d+\.\d+\.\d+)\}"$',

--- a/tool/testing/check_webgpu_bridge_tag.dart
+++ b/tool/testing/check_webgpu_bridge_tag.dart
@@ -184,7 +184,8 @@ List<String> findBridgeTagDrift(Directory repoRoot, String expectedTag) {
 /// would never look at it.
 final List<RegExp> bridgeTagPinShapes = <RegExp>[
   RegExp(r'llama-web-bridge-assets@v\d+\.\d+\.\d+'),
-  RegExp('BridgeAssetsTag\\s*=\\s*[\'"]?v\\d+\\.\\d+\\.\\d+[\'"]?'),
+  // Backticks only in the JS form; in shell they would be command substitution.
+  RegExp('BridgeAssetsTag\\s*=\\s*[\'"`]?v\\d+\\.\\d+\\.\\d+[\'"`]?'),
   RegExp('WEBGPU_BRIDGE_ASSETS_TAG=[\'"]?v\\d+\\.\\d+\\.\\d+[\'"]?'),
   RegExp('ASSETS_TAG:-[\'"]?v\\d+\\.\\d+\\.\\d+[\'"]?'),
 ];

--- a/tool/testing/check_webgpu_bridge_tag.dart
+++ b/tool/testing/check_webgpu_bridge_tag.dart
@@ -175,6 +175,24 @@ List<String> findBridgeTagDrift(Directory repoRoot, String expectedTag) {
   return problems;
 }
 
+/// Machine-readable ways of writing a pin, whatever value it holds.
+///
+/// Scanning for these as well as for the current tag is what catches a newly
+/// added pin that is already stale; searching only for the expected value
+/// would never look at it.
+final List<RegExp> bridgeTagPinShapes = <RegExp>[
+  RegExp(r'llama-web-bridge-assets@v\d+\.\d+\.\d+'),
+  RegExp(r"BridgeAssetsTag\s*=\s*'v\d+\.\d+\.\d+'"),
+  RegExp(r'WEBGPU_BRIDGE_ASSETS_TAG=v\d+\.\d+\.\d+'),
+  RegExp(r'ASSETS_TAG:-v\d+\.\d+\.\d+'),
+];
+
+/// This gate's own sources, whose fixtures are deliberately not real pins.
+const List<String> _selfPaths = <String>[
+  'tool/testing/check_webgpu_bridge_tag.dart',
+  'test/unit/tooling/check_webgpu_bridge_tag_test.dart',
+];
+
 /// Files that record past releases, where an old tag is correct.
 const List<String> tagHistoryFiles = <String>[
   'CHANGELOG.md',
@@ -211,7 +229,7 @@ List<String> findUnregisteredTagSites(Directory repoRoot, String expectedTag) {
     if (path.isEmpty ||
         path.startsWith(versionedDocsPrefix) ||
         tagHistoryFiles.contains(path) ||
-        path == 'tool/testing/check_webgpu_bridge_tag.dart') {
+        _selfPaths.contains(path)) {
       continue;
     }
     final file = File('${repoRoot.path}/$path');
@@ -220,28 +238,34 @@ List<String> findUnregisteredTagSites(Directory repoRoot, String expectedTag) {
     try {
       contents = file.readAsStringSync();
     } on FileSystemException {
-      continue; // Binary asset.
+      continue; // Binary asset: this SDK reports a failed decode this way.
+    } on FormatException {
+      continue; // Binary asset, if a future SDK reports it as a decode error.
     }
-    if (!contents.contains(expectedTag)) continue;
-
     final patterns = registered[path] ?? const <RegExp>[];
     var lineNumber = 0;
     for (final line in const LineSplitter().convert(contents)) {
       lineNumber++;
-      final at = line.indexOf(expectedTag);
-      if (at < 0) continue;
-      // `v0.1.37+` states a minimum, not the tag in use.
-      final after = at + expectedTag.length;
-      if (after < line.length && line[after] == '+') continue;
+      final shaped = bridgeTagPinShapes.any((shape) => shape.hasMatch(line));
+      final holdsTag = _holdsCurrentTag(line, expectedTag);
+      if (!shaped && !holdsTag) continue;
       if (patterns.any((pattern) => pattern.hasMatch(line))) continue;
       unregistered.add(
-        '$path:$lineNumber: $expectedTag is not covered by any registered pin '
-        '— add it to bridgeTagPins, or to tagHistoryFiles if it records a past '
-        'release',
+        '$path:$lineNumber: ${shaped ? 'a bridge asset pin' : expectedTag} is '
+        'not covered by any registered pin — add it to bridgeTagPins, or to '
+        'tagHistoryFiles if it records a past release',
       );
     }
   }
   return unregistered;
+}
+
+/// True when [line] states the tag in use rather than a `v0.1.37+` minimum.
+bool _holdsCurrentTag(String line, String expectedTag) {
+  final at = line.indexOf(expectedTag);
+  if (at < 0) return false;
+  final after = at + expectedTag.length;
+  return after >= line.length || line[after] != '+';
 }
 
 void main() {

--- a/tool/testing/check_webgpu_bridge_tag.dart
+++ b/tool/testing/check_webgpu_bridge_tag.dart
@@ -18,7 +18,7 @@ const String bridgeTagSourcePath = 'scripts/fetch_webgpu_bridge_assets.sh';
 // itself and relies on the lookbehind to exclude longer names such as
 // `WEBGPU_BRIDGE_ASSETS_TAG=`.
 final RegExp _anyAssignment = RegExp(
-  r'(?<![A-Za-z0-9_])ASSETS_TAG(?:\[\d+\])?(?::=|\+?=)',
+  r'(?<![A-Za-z0-9_])ASSETS_TAG(?:\[[^\]]*\])?(?::=|\+?=)',
 );
 
 final RegExp _sourceOfTruth = RegExp(
@@ -291,14 +291,15 @@ List<_PinOccurrence> _pinOccurrences(String line, String expectedTag) {
       found.add(_PinOccurrence(match.start, 'a bridge asset pin'));
     }
   }
-  var at = line.indexOf(expectedTag);
-  while (at >= 0) {
-    final after = at + expectedTag.length;
+  // A whole version token: without the lookahead, a `v0.1.3` tag would match
+  // inside every `v0.1.30+` floor and report it as an unregistered pin.
+  final token = RegExp('${RegExp.escape(expectedTag)}(?![0-9.])');
+  for (final match in token.allMatches(line)) {
+    final after = match.end;
     final isFloor = after < line.length && line[after] == '+';
-    if (!isFloor && !found.any((other) => other.at == at)) {
-      found.add(_PinOccurrence(at, expectedTag));
-    }
-    at = line.indexOf(expectedTag, at + 1);
+    if (isFloor) continue;
+    if (found.any((other) => other.at == match.start)) continue;
+    found.add(_PinOccurrence(match.start, expectedTag));
   }
   return found;
 }

--- a/tool/testing/check_webgpu_bridge_tag.dart
+++ b/tool/testing/check_webgpu_bridge_tag.dart
@@ -11,6 +11,8 @@ import 'dart:io';
 /// The file whose default decides what a fresh vendoring run downloads.
 const String bridgeTagSourcePath = 'scripts/fetch_webgpu_bridge_assets.sh';
 
+final RegExp _anyAssignment = RegExp(r'^ASSETS_TAG=.*$', multiLine: true);
+
 final RegExp _sourceOfTruth = RegExp(
   r'^ASSETS_TAG="\$\{WEBGPU_BRIDGE_ASSETS_TAG:-(v\d+\.\d+\.\d+)\}"$',
   multiLine: true,
@@ -119,7 +121,17 @@ String readPinnedBridgeTag(Directory repoRoot) {
   if (!file.existsSync()) {
     throw FormatException('Missing $bridgeTagSourcePath');
   }
-  final match = _sourceOfTruth.firstMatch(file.readAsStringSync());
+  final source = file.readAsStringSync();
+  // Bash takes the last assignment, so a second one would leave this gate
+  // validating a tag the script never downloads.
+  final assignments = _anyAssignment.allMatches(source).length;
+  if (assignments != 1) {
+    throw FormatException(
+      'Expected exactly one ASSETS_TAG assignment in $bridgeTagSourcePath, '
+      'found $assignments; the gate cannot run.',
+    );
+  }
+  final match = _sourceOfTruth.firstMatch(source);
   if (match == null) {
     throw FormatException(
       'No ASSETS_TAG default in $bridgeTagSourcePath; the gate cannot run.',

--- a/tool/testing/check_webgpu_bridge_tag.dart
+++ b/tool/testing/check_webgpu_bridge_tag.dart
@@ -17,7 +17,9 @@ const String bridgeTagSourcePath = 'scripts/fetch_webgpu_bridge_assets.sh';
 // Enumerating prefixes kept missing forms, so this matches the identifier
 // itself and relies on the lookbehind to exclude longer names such as
 // `WEBGPU_BRIDGE_ASSETS_TAG=`.
-final RegExp _anyAssignment = RegExp(r'(?<![A-Za-z0-9_])ASSETS_TAG(?::=|\+?=)');
+final RegExp _anyAssignment = RegExp(
+  r'(?<![A-Za-z0-9_])ASSETS_TAG(?:\[\d+\])?(?::=|\+?=)',
+);
 
 final RegExp _sourceOfTruth = RegExp(
   r'^ASSETS_TAG="\$\{WEBGPU_BRIDGE_ASSETS_TAG:-(v\d+\.\d+\.\d+)\}"$',
@@ -182,9 +184,9 @@ List<String> findBridgeTagDrift(Directory repoRoot, String expectedTag) {
 /// would never look at it.
 final List<RegExp> bridgeTagPinShapes = <RegExp>[
   RegExp(r'llama-web-bridge-assets@v\d+\.\d+\.\d+'),
-  RegExp(r"BridgeAssetsTag\s*=\s*'v\d+\.\d+\.\d+'"),
-  RegExp(r'WEBGPU_BRIDGE_ASSETS_TAG=v\d+\.\d+\.\d+'),
-  RegExp(r'ASSETS_TAG:-v\d+\.\d+\.\d+'),
+  RegExp('BridgeAssetsTag\\s*=\\s*[\'"]?v\\d+\\.\\d+\\.\\d+[\'"]?'),
+  RegExp('WEBGPU_BRIDGE_ASSETS_TAG=[\'"]?v\\d+\\.\\d+\\.\\d+[\'"]?'),
+  RegExp('ASSETS_TAG:-[\'"]?v\\d+\\.\\d+\\.\\d+[\'"]?'),
 ];
 
 /// This gate's own sources, whose fixtures are deliberately not real pins.
@@ -246,26 +248,59 @@ List<String> findUnregisteredTagSites(Directory repoRoot, String expectedTag) {
     var lineNumber = 0;
     for (final line in const LineSplitter().convert(contents)) {
       lineNumber++;
-      final shaped = bridgeTagPinShapes.any((shape) => shape.hasMatch(line));
-      final holdsTag = _holdsCurrentTag(line, expectedTag);
-      if (!shaped && !holdsTag) continue;
-      if (patterns.any((pattern) => pattern.hasMatch(line))) continue;
-      unregistered.add(
-        '$path:$lineNumber: ${shaped ? 'a bridge asset pin' : expectedTag} is '
-        'not covered by any registered pin — add it to bridgeTagPins, or to '
-        'tagHistoryFiles if it records a past release',
-      );
+      // Cover each occurrence, not the line: a registered pin whose pattern is
+      // not end-anchored would otherwise mask a second pin appended to it.
+      final covered = <List<int>>[
+        for (final pattern in patterns)
+          for (final match in pattern.allMatches(line))
+            [match.start, match.end],
+      ];
+      bool isCovered(int at) =>
+          covered.any((span) => at >= span[0] && at < span[1]);
+
+      for (final occurrence in _pinOccurrences(line, expectedTag)) {
+        if (isCovered(occurrence.at)) continue;
+        unregistered.add(
+          '$path:$lineNumber: ${occurrence.what} is not covered by any '
+          'registered pin — add it to bridgeTagPins, or to tagHistoryFiles if '
+          'it records a past release',
+        );
+      }
     }
   }
   return unregistered;
 }
 
-/// True when [line] states the tag in use rather than a `v0.1.37+` minimum.
-bool _holdsCurrentTag(String line, String expectedTag) {
-  final at = line.indexOf(expectedTag);
-  if (at < 0) return false;
-  final after = at + expectedTag.length;
-  return after >= line.length || line[after] != '+';
+/// One pin-like thing found on a line.
+class _PinOccurrence {
+  /// Offset into the line.
+  final int at;
+
+  /// How to describe it in a failure message.
+  final String what;
+
+  const _PinOccurrence(this.at, this.what);
+}
+
+/// Every pin shape, plus every mention of [expectedTag] that is not a
+/// `v0.1.37+` minimum.
+List<_PinOccurrence> _pinOccurrences(String line, String expectedTag) {
+  final found = <_PinOccurrence>[];
+  for (final shape in bridgeTagPinShapes) {
+    for (final match in shape.allMatches(line)) {
+      found.add(_PinOccurrence(match.start, 'a bridge asset pin'));
+    }
+  }
+  var at = line.indexOf(expectedTag);
+  while (at >= 0) {
+    final after = at + expectedTag.length;
+    final isFloor = after < line.length && line[after] == '+';
+    if (!isFloor && !found.any((other) => other.at == at)) {
+      found.add(_PinOccurrence(at, expectedTag));
+    }
+    at = line.indexOf(expectedTag, at + 1);
+  }
+  return found;
 }
 
 void main() {

--- a/tool/testing/check_webgpu_bridge_tag.dart
+++ b/tool/testing/check_webgpu_bridge_tag.dart
@@ -11,10 +11,11 @@ import 'dart:io';
 /// The file whose default decides what a fresh vendoring run downloads.
 const String bridgeTagSourcePath = 'scripts/fetch_webgpu_bridge_assets.sh';
 
-// Bash allows leading whitespace and an `export`/`readonly` prefix, so counting
-// only bare `ASSETS_TAG=` would let a later override slip past the guard below.
+// Bash allows leading whitespace, an `export`/`readonly` prefix, and `+=`
+// appends, so a narrower pattern would let a later override slip past the
+// guard below.
 final RegExp _anyAssignment = RegExp(
-  r'^[ \t]*(?:export[ \t]+|readonly[ \t]+)?ASSETS_TAG=',
+  r'^[ \t]*(?:export[ \t]+|readonly[ \t]+)?ASSETS_TAG\+?=',
   multiLine: true,
 );
 

--- a/tool/testing/check_webgpu_bridge_tag.dart
+++ b/tool/testing/check_webgpu_bridge_tag.dart
@@ -1,0 +1,185 @@
+// Fails when a place that pins the WebGPU bridge asset tag drifts from the
+// default in scripts/fetch_webgpu_bridge_assets.sh.
+//
+// Only sites that pin the tag in use are listed. Capability floors
+// (`v0.1.30+ bridge assets opt into ...`) and changelog entries naming past
+// releases legitimately hold older values and are deliberately absent, as is
+// website/versioned_docs/**, which is a frozen archive.
+
+import 'dart:io';
+
+/// The file whose default decides what a fresh vendoring run downloads.
+const String bridgeTagSourcePath = 'scripts/fetch_webgpu_bridge_assets.sh';
+
+final RegExp _sourceOfTruth = RegExp(
+  r'^ASSETS_TAG="\$\{WEBGPU_BRIDGE_ASSETS_TAG:-(v\d+\.\d+\.\d+)\}"$',
+  multiLine: true,
+);
+
+/// A place that must quote the tag from [bridgeTagSourcePath].
+class BridgeTagPin {
+  /// Repository-relative path.
+  final String path;
+
+  /// Matches the pin and nothing else in [path]; group 1 is the tag.
+  final RegExp pattern;
+
+  /// Creates a pin site.
+  const BridgeTagPin(this.path, this.pattern);
+}
+
+/// Every site that mirrors the pinned tag.
+final List<BridgeTagPin> bridgeTagPins = <BridgeTagPin>[
+  BridgeTagPin(
+    bridgeTagSourcePath,
+    RegExp(
+      r'^\s*https://cdn\.jsdelivr\.net/gh/leehack/llama-web-bridge-assets@(v\d+\.\d+\.\d+)$',
+      multiLine: true,
+    ),
+  ),
+  BridgeTagPin(
+    bridgeTagSourcePath,
+    RegExp(
+      r'^\s*WEBGPU_BRIDGE_ASSETS_TAG=(v\d+\.\d+\.\d+) \./scripts/fetch_webgpu_bridge_assets\.sh$',
+      multiLine: true,
+    ),
+  ),
+  BridgeTagPin(
+    'example/chat_app/web/index.html',
+    RegExp(
+      r"^\s*const defaultBridgeAssetsTag = '(v\d+\.\d+\.\d+)';$",
+      multiLine: true,
+    ),
+  ),
+  BridgeTagPin(
+    'README.md',
+    RegExp(
+      r'^\| Web llama\.cpp / GGUF \| `leehack/llama-web-bridge-assets@(v\d+\.\d+\.\d+)` \|$',
+      multiLine: true,
+    ),
+  ),
+  BridgeTagPin(
+    'doc/webgpu_bridge.md',
+    RegExp(
+      r'^Default pinned tag in the example is `(v\d+\.\d+\.\d+)`\.$',
+      multiLine: true,
+    ),
+  ),
+  BridgeTagPin(
+    'doc/webgpu_bridge.md',
+    RegExp(
+      r'^WEBGPU_BRIDGE_ASSETS_TAG=(v\d+\.\d+\.\d+) \./scripts/fetch_webgpu_bridge_assets\.sh$',
+      multiLine: true,
+    ),
+  ),
+  BridgeTagPin(
+    'doc/webgpu_bridge.md',
+    RegExp(
+      r"^\s*window\.__llamadartBridgeAssetsTag = '(v\d+\.\d+\.\d+)';$",
+      multiLine: true,
+    ),
+  ),
+  BridgeTagPin(
+    'website/docs/platforms/webgpu-bridge.md',
+    RegExp(
+      r'^The example currently pins bridge assets to `(v\d+\.\d+\.\d+)`,',
+      multiLine: true,
+    ),
+  ),
+  BridgeTagPin(
+    'website/docs/platforms/webgpu-bridge.md',
+    RegExp(r'^identified as `(v\d+\.\d+\.\d+)-local-b\d+`\.$', multiLine: true),
+  ),
+  BridgeTagPin(
+    'website/docs/platforms/webgpu-bridge.md',
+    RegExp(
+      r'^WEBGPU_BRIDGE_ASSETS_TAG=(v\d+\.\d+\.\d+) \./scripts/fetch_webgpu_bridge_assets\.sh$',
+      multiLine: true,
+    ),
+  ),
+  BridgeTagPin(
+    'website/docs/platforms/webgpu-bridge.md',
+    RegExp(
+      r"^\s*window\.__llamadartBridgeAssetsTag = '(v\d+\.\d+\.\d+)';$",
+      multiLine: true,
+    ),
+  ),
+  BridgeTagPin(
+    'website/docs/guides/text-to-speech.md',
+    RegExp(r'^- The chat example pins `(v\d+\.\d+\.\d+)`,', multiLine: true),
+  ),
+];
+
+/// Reads the tag every pin must quote.
+///
+/// Throws [FormatException] when the default is missing, so a rename of the
+/// source of truth fails loudly instead of disabling the gate.
+String readPinnedBridgeTag(Directory repoRoot) {
+  final file = File('${repoRoot.path}/$bridgeTagSourcePath');
+  if (!file.existsSync()) {
+    throw FormatException('Missing $bridgeTagSourcePath');
+  }
+  final match = _sourceOfTruth.firstMatch(file.readAsStringSync());
+  if (match == null) {
+    throw FormatException(
+      'No ASSETS_TAG default in $bridgeTagSourcePath; the gate cannot run.',
+    );
+  }
+  return match.group(1)!;
+}
+
+/// Returns one message per pin that drifted, or whose pattern stopped matching.
+///
+/// A pattern that matches nothing is a failure, not a skip: silently matching
+/// zero lines would turn this gate into a no-op.
+List<String> findBridgeTagDrift(Directory repoRoot, String expectedTag) {
+  final problems = <String>[];
+  for (final pin in bridgeTagPins) {
+    final file = File('${repoRoot.path}/${pin.path}');
+    if (!file.existsSync()) {
+      problems.add('${pin.path}: file is missing');
+      continue;
+    }
+    final matches = pin.pattern.allMatches(file.readAsStringSync()).toList();
+    if (matches.isEmpty) {
+      problems.add(
+        '${pin.path}: no line matches ${pin.pattern.pattern} — the pin moved or '
+        'was reworded, so this check no longer covers it',
+      );
+      continue;
+    }
+    for (final match in matches) {
+      final found = match.group(1)!;
+      if (found != expectedTag) {
+        problems.add('${pin.path}: pins $found, expected $expectedTag');
+      }
+    }
+  }
+  return problems;
+}
+
+void main() {
+  final repoRoot = Directory.current;
+  final String expectedTag;
+  try {
+    expectedTag = readPinnedBridgeTag(repoRoot);
+  } on FormatException catch (error) {
+    stderr.writeln('[webgpu-bridge-tag] ${error.message}');
+    exit(1);
+  }
+
+  final problems = findBridgeTagDrift(repoRoot, expectedTag);
+  if (problems.isNotEmpty) {
+    stderr.writeln(
+      '[webgpu-bridge-tag] $bridgeTagSourcePath pins $expectedTag, but:',
+    );
+    for (final problem in problems) {
+      stderr.writeln('  - $problem');
+    }
+    exit(1);
+  }
+
+  stdout.writeln(
+    '[webgpu-bridge-tag] OK: ${bridgeTagPins.length} pins agree on $expectedTag.',
+  );
+}

--- a/tool/testing/check_webgpu_bridge_tag.dart
+++ b/tool/testing/check_webgpu_bridge_tag.dart
@@ -6,16 +6,18 @@
 // releases legitimately hold older values and are deliberately absent, as is
 // website/versioned_docs/**, which is a frozen archive.
 
+import 'dart:convert';
 import 'dart:io';
 
 /// The file whose default decides what a fresh vendoring run downloads.
 const String bridgeTagSourcePath = 'scripts/fetch_webgpu_bridge_assets.sh';
 
 // Any assignment to the name, wherever it sits: indented, after `export` or
-// `declare`, after a `;`, or appending with `+=`. Enumerating prefixes kept
-// missing forms, so this matches the identifier itself and relies on the
-// lookbehind to exclude longer names such as `WEBGPU_BRIDGE_ASSETS_TAG=`.
-final RegExp _anyAssignment = RegExp(r'(?<![A-Za-z0-9_])ASSETS_TAG\+?=');
+// `declare`, after a `;`, appending with `+=`, or defaulting with `${x:=y}`.
+// Enumerating prefixes kept missing forms, so this matches the identifier
+// itself and relies on the lookbehind to exclude longer names such as
+// `WEBGPU_BRIDGE_ASSETS_TAG=`.
+final RegExp _anyAssignment = RegExp(r'(?<![A-Za-z0-9_])ASSETS_TAG(?::=|\+?=)');
 
 final RegExp _sourceOfTruth = RegExp(
   r'^ASSETS_TAG="\$\{WEBGPU_BRIDGE_ASSETS_TAG:-(v\d+\.\d+\.\d+)\}"$',
@@ -173,6 +175,75 @@ List<String> findBridgeTagDrift(Directory repoRoot, String expectedTag) {
   return problems;
 }
 
+/// Files that record past releases, where an old tag is correct.
+const List<String> tagHistoryFiles = <String>[
+  'CHANGELOG.md',
+  'website/docs/changelog/recent-releases.md',
+];
+
+/// Frozen documentation snapshots.
+const String versionedDocsPrefix = 'website/versioned_docs/';
+
+/// Returns one message per live occurrence of [expectedTag] that no pin covers.
+///
+/// Without this the gate would only protect sites someone remembered to
+/// register, so a newly added pin could go stale while CI stayed green.
+/// Capability floors (`v0.1.37+`) and the release histories are excluded
+/// because they legitimately keep their own values.
+List<String> findUnregisteredTagSites(Directory repoRoot, String expectedTag) {
+  final listed = Process.runSync('git', <String>[
+    'ls-files',
+  ], workingDirectory: repoRoot.path);
+  if (listed.exitCode != 0) {
+    return <String>['git ls-files failed: ${listed.stderr}'];
+  }
+
+  final registered = <String, List<RegExp>>{
+    // The source of truth is checked by readPinnedBridgeTag, not by a pin.
+    bridgeTagSourcePath: <RegExp>[_sourceOfTruth],
+  };
+  for (final pin in bridgeTagPins) {
+    registered.putIfAbsent(pin.path, () => <RegExp>[]).add(pin.pattern);
+  }
+
+  final unregistered = <String>[];
+  for (final path in const LineSplitter().convert(listed.stdout as String)) {
+    if (path.isEmpty ||
+        path.startsWith(versionedDocsPrefix) ||
+        tagHistoryFiles.contains(path) ||
+        path == 'tool/testing/check_webgpu_bridge_tag.dart') {
+      continue;
+    }
+    final file = File('${repoRoot.path}/$path');
+    if (!file.existsSync()) continue;
+    final String contents;
+    try {
+      contents = file.readAsStringSync();
+    } on FileSystemException {
+      continue; // Binary asset.
+    }
+    if (!contents.contains(expectedTag)) continue;
+
+    final patterns = registered[path] ?? const <RegExp>[];
+    var lineNumber = 0;
+    for (final line in const LineSplitter().convert(contents)) {
+      lineNumber++;
+      final at = line.indexOf(expectedTag);
+      if (at < 0) continue;
+      // `v0.1.37+` states a minimum, not the tag in use.
+      final after = at + expectedTag.length;
+      if (after < line.length && line[after] == '+') continue;
+      if (patterns.any((pattern) => pattern.hasMatch(line))) continue;
+      unregistered.add(
+        '$path:$lineNumber: $expectedTag is not covered by any registered pin '
+        '— add it to bridgeTagPins, or to tagHistoryFiles if it records a past '
+        'release',
+      );
+    }
+  }
+  return unregistered;
+}
+
 void main() {
   final repoRoot = Directory.current;
   final String expectedTag;
@@ -183,7 +254,10 @@ void main() {
     exit(1);
   }
 
-  final problems = findBridgeTagDrift(repoRoot, expectedTag);
+  final problems = <String>[
+    ...findBridgeTagDrift(repoRoot, expectedTag),
+    ...findUnregisteredTagSites(repoRoot, expectedTag),
+  ];
   if (problems.isNotEmpty) {
     stderr.writeln(
       '[webgpu-bridge-tag] $bridgeTagSourcePath pins $expectedTag, but:',

--- a/tool/testing/test_matrix.dart
+++ b/tool/testing/test_matrix.dart
@@ -92,6 +92,16 @@ const List<TestMatrixRow> testMatrixRows = <TestMatrixRow>[
         'Release prep, companion package version bumps, or current install docs.',
   ),
   TestMatrixRow(
+    id: 'webgpu-bridge-tag-consistency',
+    tier: 'targeted',
+    mode: 'CI + local',
+    covers:
+        'every site pinning the WebGPU bridge asset tag matches the fetch '
+        'script default',
+    command: 'dart run tool/testing/check_webgpu_bridge_tag.dart',
+    useWhen: 'Bridge asset tag bumps, or edits to the docs that pin it.',
+  ),
+  TestMatrixRow(
     id: 'examples-tests',
     tier: 'targeted',
     mode: 'local',


### PR DESCRIPTION
Closes #347 — the fourth item, the WebGPU bridge asset tag drift gate. The other three landed in #370.

`tool/testing/check_webgpu_bridge_tag.dart` treats the `ASSETS_TAG` default in `scripts/fetch_webgpu_bridge_assets.sh` as the source of truth and fails when a site that pins the tag disagrees. Wired into `Analyze & Lint` and listed in `test_matrix.dart`.

**The issue's location list was wrong, and following it would have made things worse.** It names seven live locations. A repo-wide sweep finds three kinds of reference to `v0.1.NN`, and only one may be forced to match:

- **Pins** — 12 sites across 6 files, all `v0.1.37`. The issue missed `doc/webgpu_bridge.md` entirely (3 pins) and both pins inside the fetch script.
- **Capability floors** — `v0.1.30+ bridge assets opt into typed Qwen3-ASR`, plus the matching runtime strings in `webgpu_backend.dart` and the tests asserting them. Rewriting these would be a bug.
- **Historical release notes** — a dozen CHANGELOG entries naming past tags. `CHANGELOG.md:53` matches today only because it is the newest entry.

Two entries the issue listed as pins are actually history and a floor.

**Three ways this gate could have quietly stopped working, all closed:**

1. *A pattern that stops matching.* Each pin is keyed by a regex that must match exactly one line in its file. Zero matches, or two, is a failure — otherwise a reworded doc silently drops out of coverage. Line numbers are not hardcoded.
2. *A second assignment to `ASSETS_TAG`.* Bash takes the last one, so an override would leave the gate validating a tag the script never downloads. Rather than enumerate prefixes, the counter matches the identifier itself — `(?<![A-Za-z0-9_])ASSETS_TAG(?::=|\+?=)` — covering indented, `export`/`readonly`/`declare`, `;`-separated, `+=` and `${x:=y}` forms, while the lookbehind excludes `WEBGPU_BRIDGE_ASSETS_TAG=`.
3. *A pin nobody registered.* An allowlist only protects sites someone remembered. A scan over `git ls-files` now requires every live occurrence of the tag, and every value-independent pin shape (`llama-web-bridge-assets@vX.Y.Z`, `BridgeAssetsTag = 'vX.Y.Z'`, `WEBGPU_BRIDGE_ASSETS_TAG=vX.Y.Z`, `ASSETS_TAG:-vX.Y.Z`), to be covered by a registered pin. Shape matching is what catches a *newly added, already stale* pin, which a value-based scan would never look at.

Exclusions are principled rather than per-line, so they do not rot: a `+` suffix marks a floor, `CHANGELOG.md` and `recent-releases.md` record past releases, `website/versioned_docs/**` is frozen, and this gate's own sources hold synthetic fixtures.

Two lines carry a second semver (`text-to-speech.md:175` also names `v0.1.34`; `webgpu-bridge.md:150` carries the llama.cpp build `b10514`), so the tool reads capture group 1 — a naive implementation would demand those be bumped.

**Residual gap, stated plainly:** a brand-new *prose* pin holding a stale tag ("we pin `v0.1.30`" in a new doc) is not auto-detected. Detecting prose pins generically cannot be separated from the floor/provenance wording without false positives. Prose pins holding the *current* tag are covered, as are all machine-readable forms.

**Sibling script, not an extension of `verify_release_docs_versions.dart`.** That gate also runs in `release_on_prep_merge.yml`, so folding this in would let a stale docs line fail the release job. It is also a CODEOWNERS release surface and shares no machinery.

CODEOWNERS now covers the checker and the fetch script — editing either is the other way to make the gate assert the wrong thing. Revert that hunk if you would rather not widen the review surface.

Ten unit tests drive the checker against synthetic repos so they can actually fail: mismatched pin, reworded pin, duplicated pin, seven bash assignment forms, an unregistered stale pin, a binary file, and a missing source of truth. Two more run against the real tree. Every guard was also verified end-to-end by breaking the real repo and reverting.

No drift today: 12/12 pins agree on `v0.1.37`.

Verified: analyze clean, 1504 VM tests, all repo gates pass. No changelog entry — tooling only.
