### PR TITLE
fix: report startup diagnostics when a model fails to load

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@
   `LiteRtLmRuntimeClient` stub now exposes the native client's thinking-tag
   configuration method.
 
+* A failed llama.cpp model load now reports the startup diagnostics collected
+  during native library discovery, so a missing or unloadable runtime library
+  explains itself instead of surfacing as a bare load failure. Platforms that
+  record no diagnostics keep their previous message unchanged.
+
 * llama.cpp worker errors now keep their type. Every backend method routes an
   `ErrorResponse` through the file's own error mapper instead of rebuilding a
   bare `Exception`, `tokenize` and `detokenize` no longer discard the worker's

--- a/lib/src/backends/llama_cpp/llama_cpp_service.dart
+++ b/lib/src/backends/llama_cpp/llama_cpp_service.dart
@@ -1745,11 +1745,12 @@ class LlamaCppService {
     }
 
     if (modelPtr == nullptr) {
-      final diagnostics = _backendDiagnostics();
       throw Exception(
-        "Failed to load model (size=$modelFileSize bytes, "
-        "diagnostics=$diagnostics)"
-        "${formatStartupDiagnostics(getStartupDiagnostics())}",
+        describeModelLoadFailure(
+          sizeBytes: modelFileSize,
+          backendDiagnostics: _backendDiagnostics(),
+          startupDiagnostics: getStartupDiagnostics(),
+        ),
       );
     }
 
@@ -1860,11 +1861,14 @@ class LlamaCppService {
     }
 
     if (modelPtr == nullptr) {
-      final diagnostics = _backendDiagnostics();
       throw Exception(
-        "Failed to load $label (size=$modelFileSize bytes, "
-        "path=$draftModelPath, diagnostics=$diagnostics)"
-        "${formatStartupDiagnostics(getStartupDiagnostics())}",
+        describeDraftModelLoadFailure(
+          label: label,
+          path: draftModelPath,
+          sizeBytes: modelFileSize,
+          backendDiagnostics: _backendDiagnostics(),
+          startupDiagnostics: getStartupDiagnostics(),
+        ),
       );
     }
 
@@ -8196,3 +8200,25 @@ String formatStartupDiagnostics(List<String> entries, {int maxLength = 4096}) {
   }
   return ', startupDiagnostics=[$joined]';
 }
+
+/// The message thrown when `llama_model_load_from_file` returns null.
+String describeModelLoadFailure({
+  required int sizeBytes,
+  required String backendDiagnostics,
+  required List<String> startupDiagnostics,
+}) =>
+    'Failed to load model (size=$sizeBytes bytes, '
+    'diagnostics=$backendDiagnostics)'
+    '${formatStartupDiagnostics(startupDiagnostics)}';
+
+/// The message thrown when a speculative draft model fails to load.
+String describeDraftModelLoadFailure({
+  required String label,
+  required String path,
+  required int sizeBytes,
+  required String backendDiagnostics,
+  required List<String> startupDiagnostics,
+}) =>
+    'Failed to load $label (size=$sizeBytes bytes, '
+    'path=$path, diagnostics=$backendDiagnostics)'
+    '${formatStartupDiagnostics(startupDiagnostics)}';

--- a/lib/src/backends/llama_cpp/llama_cpp_service.dart
+++ b/lib/src/backends/llama_cpp/llama_cpp_service.dart
@@ -1748,7 +1748,8 @@ class LlamaCppService {
       final diagnostics = _backendDiagnostics();
       throw Exception(
         "Failed to load model (size=$modelFileSize bytes, "
-        "diagnostics=$diagnostics)",
+        "diagnostics=$diagnostics)"
+        "${formatStartupDiagnostics(getStartupDiagnostics())}",
       );
     }
 
@@ -1862,7 +1863,8 @@ class LlamaCppService {
       final diagnostics = _backendDiagnostics();
       throw Exception(
         "Failed to load $label (size=$modelFileSize bytes, "
-        "path=$draftModelPath, diagnostics=$diagnostics)",
+        "path=$draftModelPath, diagnostics=$diagnostics)"
+        "${formatStartupDiagnostics(getStartupDiagnostics())}",
       );
     }
 
@@ -8176,4 +8178,21 @@ class _LlamaContextWrapper {
     kvFromStateLoad = false;
     llama_free(pointer);
   }
+}
+
+/// Renders startup diagnostics as a suffix for a load-failure message.
+///
+/// Returns an empty string when nothing was recorded, so platforms that never
+/// populate the buffer keep their existing message byte for byte. The tail is
+/// kept when truncating: the buffer caps entries, not bytes, and the newest
+/// entries are the ones describing the failure at hand.
+String formatStartupDiagnostics(List<String> entries, {int maxLength = 4096}) {
+  if (entries.isEmpty) {
+    return '';
+  }
+  var joined = entries.join('; ');
+  if (joined.length > maxLength) {
+    joined = '...${joined.substring(joined.length - maxLength)}';
+  }
+  return ', startupDiagnostics=[$joined]';
 }

--- a/test/unit/backends/llama_cpp/llama_cpp_service_test.dart
+++ b/test/unit/backends/llama_cpp/llama_cpp_service_test.dart
@@ -664,6 +664,59 @@ void main() {
       );
     });
 
+    test('the model-load message carries the diagnostics', () {
+      final message = describeModelLoadFailure(
+        sizeBytes: 4700000000,
+        backendDiagnostics: '{moduleDir=/x}',
+        startupDiagnostics: const <String>['libggml.so failed to load'],
+      );
+
+      expect(
+        message,
+        'Failed to load model (size=4700000000 bytes, '
+        'diagnostics={moduleDir=/x}), '
+        'startupDiagnostics=[libggml.so failed to load]',
+      );
+    });
+
+    test('the draft-model message carries the diagnostics', () {
+      final message = describeDraftModelLoadFailure(
+        label: 'speculative draft model',
+        path: '/draft.gguf',
+        sizeBytes: 120,
+        backendDiagnostics: '{moduleDir=/x}',
+        startupDiagnostics: const <String>['libggml.so failed to load'],
+      );
+
+      expect(
+        message,
+        'Failed to load speculative draft model (size=120 bytes, '
+        'path=/draft.gguf, diagnostics={moduleDir=/x}), '
+        'startupDiagnostics=[libggml.so failed to load]',
+      );
+    });
+
+    test('both messages are unchanged when nothing was recorded', () {
+      expect(
+        describeModelLoadFailure(
+          sizeBytes: 1,
+          backendDiagnostics: '{}',
+          startupDiagnostics: const <String>[],
+        ),
+        'Failed to load model (size=1 bytes, diagnostics={})',
+      );
+      expect(
+        describeDraftModelLoadFailure(
+          label: 'draft',
+          path: '/d.gguf',
+          sizeBytes: 1,
+          backendDiagnostics: '{}',
+          startupDiagnostics: const <String>[],
+        ),
+        'Failed to load draft (size=1 bytes, path=/d.gguf, diagnostics={})',
+      );
+    });
+
     test('a fresh service has nothing recorded', () {
       expect(LlamaCppService().getStartupDiagnostics(), isEmpty);
     });

--- a/test/unit/backends/llama_cpp/llama_cpp_service_test.dart
+++ b/test/unit/backends/llama_cpp/llama_cpp_service_test.dart
@@ -637,6 +637,38 @@ void main() {
     );
   });
 
+  group('startup diagnostics', () {
+    test('an empty buffer leaves the message unchanged', () {
+      expect(formatStartupDiagnostics(const <String>[]), isEmpty);
+    });
+
+    test('entries are joined into a labelled suffix', () {
+      expect(
+        formatStartupDiagnostics(const <String>['first failed', 'then this']),
+        ', startupDiagnostics=[first failed; then this]',
+      );
+    });
+
+    test('truncation keeps the newest text', () {
+      final entries = <String>['a' * 100, 'the failure that actually matters'];
+
+      final formatted = formatStartupDiagnostics(entries, maxLength: 40);
+
+      expect(formatted, startsWith(', startupDiagnostics=[...'));
+      expect(formatted, endsWith('that actually matters]'));
+      // The oldest entry is dropped, not the newest.
+      expect(formatted, isNot(contains('a' * 50)));
+      expect(
+        formatted.length,
+        lessThan(', startupDiagnostics=[...]'.length + 41),
+      );
+    });
+
+    test('a fresh service has nothing recorded', () {
+      expect(LlamaCppService().getStartupDiagnostics(), isEmpty);
+    });
+  });
+
   group('invalid-handle guard rails', () {
     late LlamaCppService service;
 

--- a/website/docs/changelog/recent-releases.md
+++ b/website/docs/changelog/recent-releases.md
@@ -15,6 +15,11 @@ For canonical full release notes, use:
   `LiteRtLmRuntimeClient` stub now exposes the native client's thinking-tag
   configuration method.
 
+- A failed llama.cpp model load now reports the startup diagnostics collected
+  during native library discovery, so a missing or unloadable runtime library
+  explains itself instead of surfacing as a bare load failure. Platforms that
+  record no diagnostics keep their previous message unchanged.
+
 - llama.cpp worker errors now keep their type. Every backend method routes an
   `ErrorResponse` through the file's own error mapper instead of rebuilding a
   bare `Exception`, `tokenize` and `detokenize` no longer discard the worker's


### PR DESCRIPTION
Closes #348 — the third item, "startup diagnostics are collected and discarded". Parts 1 and 2 landed in #379.

A failed model load now appends the startup diagnostics recorded during native library discovery, so a missing or unloadable runtime library explains itself:

```
Failed to load model (size=… bytes, diagnostics={…}), startupDiagnostics=[Failed to
preload Linux core library candidates `…/libggml.so.0`; last error from `…/libggml.so`:
Failed to load dynamic library]
```

`getStartupDiagnostics()` gains its first caller — it previously had exactly one occurrence repo-wide, its own declaration.

**I did not implement the fix the issue suggests, and the reason is worth reading.** It proposes putting the buffer in `LlamaException.details`. The diagnostics live in the worker isolate while the exception is rebuilt in the main isolate from only `(message, kind)`, so that needs a `details` field on `ErrorResponse`, threading through both mappers, and an additive `details` parameter on `LlamaUnsupportedException` — six files and the only public API change in the set. What it buys is a nested `dynamic` field: a caller would write `(e.details as LlamaModelException).details`. Appending at the throw site puts the same text in the same place the caller already reads, in one file, with no protocol or API change.

It is also more targeted. The wire version has to gate on request type, which would decorate "model file not found", "file is empty" and "does not appear to be GGUF" with library-discovery noise that has nothing to do with those failures.

**Empty stays byte-identical.** Every producer sits behind `Platform.isLinux`, `Platform.isWindows`, or `backend == 'cpu' && Platform.isAndroid`, so on macOS and iOS the buffer is provably always empty and the message does not change. The suffix is omitted entirely rather than rendered as `[]`.

**Truncation keeps the tail.** The cap is 32 *entries*, not bytes, and the dominant term is unbounded OS text — `dlerror` output and `FileSystemException` strings. The joined text is capped at 4 KiB from the end, because the newest entries describe the failure at hand.

Tests cover the empty case (the no-regression proof for two of four supported platforms), the joined form, and that truncation drops the oldest text rather than the newest.

Verified: analyze clean, 1510 VM tests, all three repo gates pass.

**Three things found and not fixed**, per the repo rule on reporting rather than fixing:

1. **`initializeBackend` is called outside the worker's try.** `worker.dart:156` invokes it from the handshake branch, above the `try` at `:167`. A throw there escapes as an uncaught isolate error; `Isolate.spawn` uses the default `errorsAreFatal`, so the worker dies after `_startIsolate` has already completed — and the next `modelLoad` hangs forever on `await rp.first`. That is the total-library-miss case, the most severe discovery failure, and it produces a hang with no diagnostics at all no matter what this PR does. Fixing it would deliver more of #348's stated goal than this attachment does.
2. **The ring buffer evicts oldest-first.** On a Windows auto-backend run the `FreeLibrary` teardown entries compete for the same 32 slots as the explanatory ones, so the most useful lines are evicted first. Dropping the two teardown producers, or evicting newest, would fix it.
3. **The wrapper-library probes never record anything.** The probes that would explain "unavailable in this native runtime bundle" all end in `catch (_) { continue; }`, so `LlamaUnsupportedException` failures stay un-diagnosable.

Happy to file 1 as its own issue — it is a hang, not a diagnostics gap.
