### PR TITLE
Fix web/native backend capability API parity

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 ## Unreleased
 
+* Fixed Web/native backend API parity. `WebAutoBackend` now forwards grammar
+  constraint support from its active runtime, so strict structured output fails
+  early with an actionable error on unsupported Web backends, and the Web-safe
+  `LiteRtLmRuntimeClient` stub now exposes the native client's thinking-tag
+  configuration method.
+
 * llama.cpp worker errors now keep their type. Every backend method routes an
   `ErrorResponse` through the file's own error mapper instead of rebuilding a
   bare `Exception`, `tokenize` and `detokenize` no longer discard the worker's

--- a/lib/src/backends/litert_lm/litert_lm_runtime_stub.dart
+++ b/lib/src/backends/litert_lm/litert_lm_runtime_stub.dart
@@ -70,6 +70,14 @@ class LiteRtLmRuntimeClient {
     throw UnsupportedError('LiteRT-LM runtime requires a native platform.');
   }
 
+  /// Configures how LiteRT-LM thought-channel chunks are exposed to parsers.
+  void configureResponseThinkingTags({
+    required String startTag,
+    required String endTag,
+  }) {
+    throw UnsupportedError('LiteRT-LM runtime requires a native platform.');
+  }
+
   /// Dedicated native ASR is unavailable without `dart:ffi`.
   bool get supportsAsrBridge => false;
 

--- a/lib/src/backends/web/web_backend.dart
+++ b/lib/src/backends/web/web_backend.dart
@@ -18,6 +18,7 @@ class WebAutoBackend
         BackendEmbeddingsSupport,
         BackendBatchEmbeddings,
         BackendPromptSpeechToTextSupport,
+        BackendGrammarConstraintsSupport,
         BackendTextToSpeech,
         BackendStatePersistence,
         BackendStatePersistenceSupport {
@@ -65,6 +66,16 @@ class WebAutoBackend
       return (delegate as BackendEmbeddingsSupport).supportsEmbeddings;
     }
     return delegate is BackendEmbeddings;
+  }
+
+  @override
+  bool get supportsGrammarConstraints {
+    final delegate = _delegate;
+    if (delegate is BackendGrammarConstraintsSupport) {
+      return (delegate as BackendGrammarConstraintsSupport)
+          .supportsGrammarConstraints;
+    }
+    return true;
   }
 
   @override

--- a/test/unit/backends/litert_lm/litert_lm_public_api_test.dart
+++ b/test/unit/backends/litert_lm/litert_lm_public_api_test.dart
@@ -23,6 +23,11 @@ void main() {
     expect(result.metrics, same(metrics));
     expect(client, isA<LiteRtLmRuntimeClient>());
 
+    client.configureResponseThinkingTags(
+      startTag: '<thought>',
+      endTag: '</thought>',
+    );
+
     client.dispose();
   });
 

--- a/test/unit/backends/litert_lm/litert_lm_web_public_api_test.dart
+++ b/test/unit/backends/litert_lm/litert_lm_web_public_api_test.dart
@@ -31,6 +31,14 @@ void main() {
   });
 
   test('reports native-only LiteRT-LM runtime APIs as unsupported on web', () {
+    void configureThinkingTags(LiteRtLmRuntimeClient client) {
+      client.configureResponseThinkingTags(
+        startTag: '<thought>',
+        endTag: '</thought>',
+      );
+    }
+
+    expect(configureThinkingTags, isA<void Function(LiteRtLmRuntimeClient)>());
     expect(LiteRtLmRuntimeClient.new, throwsUnsupportedError);
     expect(LiteRtLmBenchmarkClient.new, throwsUnsupportedError);
   });
@@ -42,6 +50,10 @@ void main() {
     );
 
     expect(backend.supportsUrlLoading, isTrue);
+    expect(
+      (backend as BackendGrammarConstraintsSupport).supportsGrammarConstraints,
+      isFalse,
+    );
     expect(await backend.getBackendName(), 'LiteRT-LM web cpu');
   });
 }

--- a/test/unit/backends/web/web_backend_test.dart
+++ b/test/unit/backends/web/web_backend_test.dart
@@ -5,10 +5,15 @@ import 'dart:typed_data';
 
 import 'package:llamadart/src/backends/backend.dart';
 import 'package:llamadart/src/backends/web/web_backend.dart';
+import 'package:llamadart/src/core/engine/chat_completion_request_planner.dart';
 import 'package:llamadart/src/core/engine/engine.dart';
 import 'package:llamadart/src/core/exceptions.dart';
+import 'package:llamadart/src/core/models/chat/chat_message.dart';
+import 'package:llamadart/src/core/models/chat/chat_role.dart';
+import 'package:llamadart/src/core/models/chat/chat_template_result.dart';
 import 'package:llamadart/src/core/models/config/log_level.dart';
 import 'package:llamadart/src/core/models/inference/model_params.dart';
+import 'package:llamadart/src/core/models/inference/tool_choice.dart';
 import 'package:test/test.dart';
 
 void main() {
@@ -26,6 +31,47 @@ void main() {
     expect(backend, isA<BackendTextToSpeech>());
     expect((backend as WebAutoBackend).supportsStatePersistence, isFalse);
     expect(backend.supportsEmbeddings, isFalse);
+  });
+
+  test('WebAutoBackend forwards grammar support from its delegate', () {
+    final unsupported = WebAutoBackend(
+      webBackend: _GrammarSupportBackend(supportsGrammarConstraints: false),
+    );
+    final supported = WebAutoBackend(
+      webBackend: _GrammarSupportBackend(supportsGrammarConstraints: true),
+    );
+    final legacy = WebAutoBackend(webBackend: _NoStateBackend());
+
+    expect(unsupported, isA<BackendGrammarConstraintsSupport>());
+    expect(unsupported.supportsGrammarConstraints, isFalse);
+    expect(supported.supportsGrammarConstraints, isTrue);
+    expect(legacy.supportsGrammarConstraints, isTrue);
+  });
+
+  test('WebAutoBackend rejects strict output for unsupported delegates', () {
+    final backend = WebAutoBackend(
+      webBackend: _GrammarSupportBackend(supportsGrammarConstraints: false),
+    );
+
+    expect(
+      () => ChatCompletionRequestPlanner.build(
+        backend: backend,
+        templateResult: const LlamaChatTemplateResult(prompt: 'prompt'),
+        messages: const [
+          LlamaChatMessage.fromText(role: LlamaChatRole.user, text: 'hello'),
+        ],
+        toolChoice: ToolChoice.auto,
+        parallelToolCalls: false,
+        responseFormat: const {'type': 'json_object'},
+      ),
+      throwsA(
+        isA<LlamaUnsupportedException>().having(
+          (error) => error.message,
+          'message',
+          contains('active backend does not support grammar constraints'),
+        ),
+      ),
+    );
   });
 
   test('WebAutoBackend forwards prompt speech runtime support', () async {
@@ -274,6 +320,14 @@ class _EmbeddingSupportBackend
 
   @override
   dynamic noSuchMethod(Invocation invocation) => super.noSuchMethod(invocation);
+}
+
+class _GrammarSupportBackend extends _NoStateBackend
+    implements BackendGrammarConstraintsSupport {
+  _GrammarSupportBackend({required this.supportsGrammarConstraints});
+
+  @override
+  final bool supportsGrammarConstraints;
 }
 
 class _TextToSpeechBackend extends _NoStateBackend

--- a/website/docs/changelog/recent-releases.md
+++ b/website/docs/changelog/recent-releases.md
@@ -9,6 +9,12 @@ For canonical full release notes, use:
 
 ## Unreleased
 
+- Fixed Web/native backend API parity. `WebAutoBackend` now forwards grammar
+  constraint support from its active runtime, so strict structured output fails
+  early with an actionable error on unsupported Web backends, and the Web-safe
+  `LiteRtLmRuntimeClient` stub now exposes the native client's thinking-tag
+  configuration method.
+
 - llama.cpp worker errors now keep their type. Every backend method routes an
   `ErrorResponse` through the file's own error mapper instead of rebuilding a
   bare `Exception`, `tokenize` and `detokenize` no longer discard the worker's


### PR DESCRIPTION
## Summary

- forward grammar-constraint capability through `WebAutoBackend`
- expose `configureResponseThinkingTags` on the Web-safe LiteRT-LM runtime stub
- add focused VM and Chrome coverage for supported, unsupported, and legacy/version-skew capability surfaces

Closes #349

## Scope

`WebAutoBackend` now implements `BackendGrammarConstraintsSupport` and reports the active delegate's value. This lets the existing chat planner reject strict `responseFormat` requests with `LlamaUnsupportedException` when LiteRT-LM Web is active instead of allowing an unsupported grammar path to proceed.

The Web-safe `LiteRtLmRuntimeClient` stub now declares the same `configureResponseThinkingTags({required startTag, required endTag})` method as the native implementation. Native-only use on Web continues to fail with the existing platform `UnsupportedError`.

The legacy fallback remains `true` when a delegate does not implement the capability interface, matching `NativeAutoBackend` and preserving compatibility with older or third-party delegates.

## Validation

- PASS: changed-file formatting and `git diff --check`
- PASS: `dart analyze lib test tool hook`
- PASS: focused VM tests (8 passed)
- PASS: focused Chrome tests (12 passed)
- PASS: root VM suite (1,444 passed; 62 fixture-dependent skips)
- PASS: root Chrome suite
- PASS: platform-boundary validation
- PASS: LCOV 76.44% (11,519/15,069; threshold 70%)
- PASS: Docusaurus site build and docs link validation
- N/A: real-model/device smoke; the change is capability routing and conditional public API parity and does not alter model runtime code

## Compatibility and docs

This is a backward-compatible parity fix. It does not remove or change native API signatures. LiteRT-LM strict structured output remains unsupported on native and Web; the Web auto-router now exposes that documented limitation so the existing typed pre-flight error is consistent across platforms.

The canonical and website Unreleased changelogs are updated. The existing generation guide already documents that LiteRT-LM native and Web fail early for strict structured output, so the support matrix did not need a behavior change.

## Baseline warnings and residual risk

- Full repository-wide `dart analyze` remains non-green because unresolved example subpackages produce 9,216 existing issues; analysis of `lib`, `test`, `tool`, and `hook` passes with no issues.
- Repository-wide format verification reports five existing untouched files; all changed Dart files pass formatting, and those five paths have no diff in this PR.
- The website declares Node `>=20 <21`, while this local host used Node 24.14.1. The locked install and production docs build passed. `npm audit` reports 22 existing findings (19 high, 3 moderate) from the unchanged website lockfile; GitHub also reported four existing default-branch Dependabot findings during push.
- Delegates that do not implement `BackendGrammarConstraintsSupport` retain the existing `true` compatibility fallback. Unsupported third-party delegates must implement the capability interface to opt into early rejection.
