### PR TITLE
fix: harden startup diagnostic failures

### DIFF
--- a/lib/src/backends/llama_cpp/llama_cpp_service.dart
+++ b/lib/src/backends/llama_cpp/llama_cpp_service.dart
@@ -8196,6 +8196,9 @@ String formatStartupDiagnostics(List<String> entries, {int maxLength = 4096}) {
   if (maxLength < 0) {
     throw RangeError.range(maxLength, 0, null, 'maxLength');
   }
+  if (maxLength == 0) {
+    return '';
+  }
   final sanitizedEntries = entries
       .map(_sanitizeStartupDiagnostic)
       .where((entry) => entry.isNotEmpty)
@@ -8215,8 +8218,19 @@ String formatStartupDiagnostics(List<String> entries, {int maxLength = 4096}) {
 }
 
 String _sanitizeStartupDiagnostic(String entry) {
-  final redactedUrls = entry.replaceAllMapped(
-    RegExp(r'https?://\S+', caseSensitive: false),
+  final controlCharacters = RegExp(
+    r'[\u0000-\u001f\u007f-\u009f\u2028\u2029]+',
+  );
+  final flattenedEntry = entry
+      .replaceAllMapped(
+        RegExp(r'https?://(?:(?!https?://)[^ /?#])*@', caseSensitive: false),
+        (match) => match.group(0)!.replaceAll(controlCharacters, ''),
+      )
+      .replaceAll(controlCharacters, ' ')
+      .replaceAll(RegExp(r' {2,}'), ' ')
+      .trim();
+  final redactedUrls = flattenedEntry.replaceAllMapped(
+    RegExp(r'https?://(?:(?!https?://)\S)+', caseSensitive: false),
     (match) {
       final uri = Uri.tryParse(match.group(0)!);
       final scheme = uri?.scheme.toLowerCase();
@@ -8231,10 +8245,7 @@ String _sanitizeStartupDiagnostic(String entry) {
       ).toString();
     },
   );
-  return redactedUrls
-      .replaceAll(RegExp(r'[\u0000-\u001f\u007f-\u009f\u2028\u2029]+'), ' ')
-      .replaceAll(RegExp(r' {2,}'), ' ')
-      .trim();
+  return redactedUrls.replaceAll(RegExp(r' {2,}'), ' ').trim();
 }
 
 /// The message thrown when `llama_model_load_from_file` returns null.

--- a/lib/src/backends/llama_cpp/llama_cpp_service.dart
+++ b/lib/src/backends/llama_cpp/llama_cpp_service.dart
@@ -8189,16 +8189,51 @@ class _LlamaContextWrapper {
 /// Returns an empty string when nothing was recorded, so platforms that never
 /// populate the buffer keep their existing message byte for byte. The tail is
 /// kept when truncating: the buffer caps entries, not bytes, and the newest
-/// entries are the ones describing the failure at hand.
+/// entries are the ones describing the failure at hand. Control characters are
+/// flattened and credential-bearing HTTP URL components are redacted before the
+/// diagnostics are included in an exception.
 String formatStartupDiagnostics(List<String> entries, {int maxLength = 4096}) {
-  if (entries.isEmpty) {
+  if (maxLength < 0) {
+    throw RangeError.range(maxLength, 0, null, 'maxLength');
+  }
+  final sanitizedEntries = entries
+      .map(_sanitizeStartupDiagnostic)
+      .where((entry) => entry.isNotEmpty)
+      .toList(growable: false);
+  if (sanitizedEntries.isEmpty) {
     return '';
   }
-  var joined = entries.join('; ');
+  var joined = sanitizedEntries.join('; ');
   if (joined.length > maxLength) {
-    joined = '...${joined.substring(joined.length - maxLength)}';
+    final ellipsisLength = math.min(3, maxLength);
+    final tailLength = maxLength - ellipsisLength;
+    joined =
+        '${'.' * ellipsisLength}'
+        '${joined.substring(joined.length - tailLength)}';
   }
   return ', startupDiagnostics=[$joined]';
+}
+
+String _sanitizeStartupDiagnostic(String entry) {
+  final redactedUrls = entry.replaceAllMapped(
+    RegExp(r'https?://[^\s\]\[(){}<>]+'),
+    (match) {
+      final uri = Uri.tryParse(match.group(0)!);
+      if (uri == null || (uri.scheme != 'http' && uri.scheme != 'https')) {
+        return '<redacted-url>';
+      }
+      return Uri(
+        scheme: uri.scheme,
+        host: uri.host,
+        port: uri.hasPort ? uri.port : null,
+        path: uri.path,
+      ).toString();
+    },
+  );
+  return redactedUrls
+      .replaceAll(RegExp(r'[\u0000-\u001f\u007f]+'), ' ')
+      .replaceAll(RegExp(r' {2,}'), ' ')
+      .trim();
 }
 
 /// The message thrown when `llama_model_load_from_file` returns null.

--- a/lib/src/backends/llama_cpp/llama_cpp_service.dart
+++ b/lib/src/backends/llama_cpp/llama_cpp_service.dart
@@ -8216,14 +8216,15 @@ String formatStartupDiagnostics(List<String> entries, {int maxLength = 4096}) {
 
 String _sanitizeStartupDiagnostic(String entry) {
   final redactedUrls = entry.replaceAllMapped(
-    RegExp(r'https?://[^\s\]\[(){}<>]+'),
+    RegExp(r'https?://\S+', caseSensitive: false),
     (match) {
       final uri = Uri.tryParse(match.group(0)!);
-      if (uri == null || (uri.scheme != 'http' && uri.scheme != 'https')) {
+      final scheme = uri?.scheme.toLowerCase();
+      if (uri == null || (scheme != 'http' && scheme != 'https')) {
         return '<redacted-url>';
       }
       return Uri(
-        scheme: uri.scheme,
+        scheme: scheme,
         host: uri.host,
         port: uri.hasPort ? uri.port : null,
         path: uri.path,
@@ -8231,7 +8232,7 @@ String _sanitizeStartupDiagnostic(String entry) {
     },
   );
   return redactedUrls
-      .replaceAll(RegExp(r'[\u0000-\u001f\u007f]+'), ' ')
+      .replaceAll(RegExp(r'[\u0000-\u001f\u007f-\u009f\u2028\u2029]+'), ' ')
       .replaceAll(RegExp(r' {2,}'), ' ')
       .trim();
 }

--- a/lib/src/backends/llama_cpp/llama_cpp_service.dart
+++ b/lib/src/backends/llama_cpp/llama_cpp_service.dart
@@ -8218,14 +8218,22 @@ String formatStartupDiagnostics(List<String> entries, {int maxLength = 4096}) {
 }
 
 String _sanitizeStartupDiagnostic(String entry) {
-  final controlCharacters = RegExp(
-    r'[\u0000-\u001f\u007f-\u009f\u2028\u2029]+',
+  const controlCharacterClass = r'[\u0000-\u001f\u007f-\u009f\u2028\u2029]';
+  final controlCharacters = RegExp('$controlCharacterClass+');
+  final fragmentedHttpPrefix =
+      'h$controlCharacterClass*'
+      't$controlCharacterClass*'
+      't$controlCharacterClass*'
+      'p$controlCharacterClass*'
+      's?$controlCharacterClass*'
+      ':$controlCharacterClass*'
+      '/$controlCharacterClass*'
+      '/';
+  final normalizedUrlCandidates = entry.replaceAllMapped(
+    RegExp('$fragmentedHttpPrefix[^ ]*', caseSensitive: false),
+    (match) => match.group(0)!.replaceAll(controlCharacters, ''),
   );
-  final flattenedEntry = entry
-      .replaceAllMapped(
-        RegExp(r'https?://(?:(?!https?://)[^ /?#])*@', caseSensitive: false),
-        (match) => match.group(0)!.replaceAll(controlCharacters, ''),
-      )
+  final flattenedEntry = normalizedUrlCandidates
       .replaceAll(controlCharacters, ' ')
       .replaceAll(RegExp(r' {2,}'), ' ')
       .trim();

--- a/lib/src/backends/llama_cpp/llama_cpp_service.dart
+++ b/lib/src/backends/llama_cpp/llama_cpp_service.dart
@@ -8229,11 +8229,15 @@ String _sanitizeStartupDiagnostic(String entry) {
       ':$controlCharacterClass*'
       '/$controlCharacterClass*'
       '/';
-  final normalizedUrlCandidates = entry.replaceAllMapped(
-    RegExp('$fragmentedHttpPrefix[^ ]*', caseSensitive: false),
+  final normalizedUrlPrefixes = entry.replaceAllMapped(
+    RegExp(fragmentedHttpPrefix, caseSensitive: false),
     (match) => match.group(0)!.replaceAll(controlCharacters, ''),
   );
-  final flattenedEntry = normalizedUrlCandidates
+  final normalizedUrlUserInfo = normalizedUrlPrefixes.replaceAllMapped(
+    RegExp(r'https?://(?:(?!https?://)[^ /?#])*@', caseSensitive: false),
+    (match) => match.group(0)!.replaceAll(controlCharacters, ''),
+  );
+  final flattenedEntry = normalizedUrlUserInfo
       .replaceAll(controlCharacters, ' ')
       .replaceAll(RegExp(r' {2,}'), ' ')
       .trim();

--- a/lib/src/backends/llama_cpp/llama_cpp_service.dart
+++ b/lib/src/backends/llama_cpp/llama_cpp_service.dart
@@ -8191,7 +8191,9 @@ class _LlamaContextWrapper {
 /// kept when truncating: the buffer caps entries, not bytes, and the newest
 /// entries are the ones describing the failure at hand. Control characters are
 /// flattened and credential-bearing HTTP URL components are redacted before the
-/// diagnostics are included in an exception.
+/// diagnostics are included in an exception. An entry with a control-split
+/// credentialed URL is replaced entirely rather than guessing whether the
+/// control was part of the URL or a diagnostic boundary.
 String formatStartupDiagnostics(List<String> entries, {int maxLength = 4096}) {
   if (maxLength < 0) {
     throw RangeError.range(maxLength, 0, null, 'maxLength');
@@ -8218,26 +8220,13 @@ String formatStartupDiagnostics(List<String> entries, {int maxLength = 4096}) {
 }
 
 String _sanitizeStartupDiagnostic(String entry) {
-  const controlCharacterClass = r'[\u0000-\u001f\u007f-\u009f\u2028\u2029]';
-  final controlCharacters = RegExp('$controlCharacterClass+');
-  final fragmentedHttpPrefix =
-      'h$controlCharacterClass*'
-      't$controlCharacterClass*'
-      't$controlCharacterClass*'
-      'p$controlCharacterClass*'
-      's?$controlCharacterClass*'
-      ':$controlCharacterClass*'
-      '/$controlCharacterClass*'
-      '/';
-  final normalizedUrlPrefixes = entry.replaceAllMapped(
-    RegExp(fragmentedHttpPrefix, caseSensitive: false),
-    (match) => match.group(0)!.replaceAll(controlCharacters, ''),
+  final controlCharacters = RegExp(
+    r'[\u0000-\u001f\u007f-\u009f\u2028\u2029]+',
   );
-  final normalizedUrlUserInfo = normalizedUrlPrefixes.replaceAllMapped(
-    RegExp(r'https?://(?:(?!https?://)[^ /?#])*@', caseSensitive: false),
-    (match) => match.group(0)!.replaceAll(controlCharacters, ''),
-  );
-  final flattenedEntry = normalizedUrlUserInfo
+  if (_hasControlSplitSensitiveHttpUrl(entry, controlCharacters)) {
+    return '<redacted-startup-diagnostic>';
+  }
+  final flattenedEntry = entry
       .replaceAll(controlCharacters, ' ')
       .replaceAll(RegExp(r' {2,}'), ' ')
       .trim();
@@ -8258,6 +8247,33 @@ String _sanitizeStartupDiagnostic(String entry) {
     },
   );
   return redactedUrls.replaceAll(RegExp(r' {2,}'), ' ').trim();
+}
+
+bool _hasControlSplitSensitiveHttpUrl(String entry, RegExp controlCharacters) {
+  if (!controlCharacters.hasMatch(entry)) {
+    return false;
+  }
+  final compacted = entry.replaceAll(controlCharacters, '');
+  final candidates = RegExp(
+    r'https?://(?:(?!https?://)\S)+',
+    caseSensitive: false,
+  ).allMatches(compacted);
+  for (final candidate in candidates) {
+    final text = candidate.group(0)!;
+    final uri = Uri.tryParse(text);
+    if (uri == null) {
+      if (text.contains('@') || text.contains('?') || text.contains('#')) {
+        return true;
+      }
+      continue;
+    }
+    final scheme = uri.scheme.toLowerCase();
+    if ((scheme == 'http' || scheme == 'https') &&
+        (uri.userInfo.isNotEmpty || uri.hasQuery || uri.hasFragment)) {
+      return true;
+    }
+  }
+  return false;
 }
 
 /// The message thrown when `llama_model_load_from_file` returns null.

--- a/test/unit/backends/llama_cpp/llama_cpp_service_test.dart
+++ b/test/unit/backends/llama_cpp/llama_cpp_service_test.dart
@@ -674,11 +674,12 @@ void main() {
     test('diagnostics are single-line and redact credentialed URLs', () {
       expect(
         formatStartupDiagnostics(const <String>[
-          'failed at HTTPS://user:pass@example.com/lib.so?token=secret#part'
-              '\r\nnext\u0000line\u0085more\u2028last\u2029line',
+          'failed at HTTPS:\n//user\u0085:pass@\u2028example.com/lib.so'
+              '?token=secret#part',
+          'next\u0000line\u0085more\u2028last\u2029line',
         ]),
         ', startupDiagnostics=['
-        'failed at https://example.com/lib.so next line more last line]',
+        'failed at https://example.com/lib.so; next line more last line]',
       );
       expect(
         formatStartupDiagnostics(const <String>[
@@ -688,7 +689,7 @@ void main() {
       );
       expect(
         formatStartupDiagnostics(const <String>[
-          'https://safe.example/a,HTTPS://user\n:pass@evil.example/b'
+          'https://safe.example/a,HTTPS:\n//user\n:pass@evil.example/b'
               '?token=secret',
         ]),
         ', startupDiagnostics=['
@@ -779,9 +780,12 @@ void main() {
           service,
           'failed at '
           'https://safe.example/a,'
-          'HTTPS://user\n:pass@example.com/libggml.so'
-          '?token=secret#fragment'
-          '\r\nnext\u0000line\u0085more\u2028last\u2029line',
+          'HTTPS:\n//user\n:pass@\u2028example.com/libggml.so'
+          '?token=secret#fragment',
+        );
+        _recordStartupDiagnosticForTesting(
+          service,
+          'next\u0000line\u0085more\u2028last\u2029line',
         );
 
         expect(
@@ -795,7 +799,7 @@ void main() {
                 contains(
                   'startupDiagnostics=[failed at '
                   'https://safe.example/a,'
-                  'https://example.com/libggml.so '
+                  'https://example.com/libggml.so; '
                   'next line more last line]',
                 ),
                 isNot(contains('user:pass')),

--- a/test/unit/backends/llama_cpp/llama_cpp_service_test.dart
+++ b/test/unit/backends/llama_cpp/llama_cpp_service_test.dart
@@ -679,7 +679,7 @@ void main() {
           'next\u0000line\u0085more\u2028last\u2029line',
         ]),
         ', startupDiagnostics=['
-        'failed at https://example.com/lib.so; next line more last line]',
+        '<redacted-startup-diagnostic>; next line more last line]',
       );
       expect(
         formatStartupDiagnostics(const <String>[
@@ -689,7 +689,7 @@ void main() {
       );
       expect(
         formatStartupDiagnostics(const <String>[
-          'https://safe.example/a,HTTPS:\n//user\n:pass@evil.example/b'
+          'https://safe.example/a,HTTPS://user:pass@evil.example/b'
               '?token=secret',
         ]),
         ', startupDiagnostics=['
@@ -698,6 +698,15 @@ void main() {
       expect(
         formatStartupDiagnostics(const <String>['https://example.com\nfailed']),
         ', startupDiagnostics=[https://example.com failed]',
+      );
+      expect(
+        formatStartupDiagnostics(const <String>[
+          'https://example.com\nfailed@evil.example',
+          'https://example.com/path?\ntoken=secret',
+        ]),
+        ', startupDiagnostics=['
+        '<redacted-startup-diagnostic>; '
+        '<redacted-startup-diagnostic>]',
       );
     });
 
@@ -801,9 +810,7 @@ void main() {
               allOf(
                 contains('Failed to load model (size=4 bytes,'),
                 contains(
-                  'startupDiagnostics=[failed at '
-                  'https://safe.example/a,'
-                  'https://example.com/libggml.so; '
+                  'startupDiagnostics=[<redacted-startup-diagnostic>; '
                   'next line more last line]',
                 ),
                 isNot(contains('user:pass')),

--- a/test/unit/backends/llama_cpp/llama_cpp_service_test.dart
+++ b/test/unit/backends/llama_cpp/llama_cpp_service_test.dart
@@ -674,7 +674,7 @@ void main() {
     test('diagnostics are single-line and redact credentialed URLs', () {
       expect(
         formatStartupDiagnostics(const <String>[
-          'failed at HTTPS:\n//user\u0085:pass@\u2028example.com/lib.so'
+          'failed at HTTPS:\n//user\u0085:pass@example.com/lib.so'
               '?token=secret#part',
           'next\u0000line\u0085more\u2028last\u2029line',
         ]),
@@ -694,6 +694,10 @@ void main() {
         ]),
         ', startupDiagnostics=['
         'https://safe.example/a,https://evil.example/b]',
+      );
+      expect(
+        formatStartupDiagnostics(const <String>['https://example.com\nfailed']),
+        ', startupDiagnostics=[https://example.com failed]',
       );
     });
 
@@ -780,7 +784,7 @@ void main() {
           service,
           'failed at '
           'https://safe.example/a,'
-          'HTTPS:\n//user\n:pass@\u2028example.com/libggml.so'
+          'HTTPS:\n//user\n:pass@example.com/libggml.so'
           '?token=secret#fragment',
         );
         _recordStartupDiagnosticForTesting(

--- a/test/unit/backends/llama_cpp/llama_cpp_service_test.dart
+++ b/test/unit/backends/llama_cpp/llama_cpp_service_test.dart
@@ -3,6 +3,7 @@ library;
 
 import 'dart:ffi';
 import 'dart:io';
+import 'dart:mirrors';
 
 import 'package:ffi/ffi.dart';
 import 'package:llamadart/src/backends/llama_cpp/llama_cpp_service.dart';
@@ -656,11 +657,21 @@ void main() {
 
       expect(formatted, startsWith(', startupDiagnostics=[...'));
       expect(formatted, endsWith('that actually matters]'));
+      final contentLength =
+          formatted.length - ', startupDiagnostics=['.length - ']'.length;
+      expect(contentLength, 40);
       // The oldest entry is dropped, not the newest.
       expect(formatted, isNot(contains('a' * 50)));
+    });
+
+    test('diagnostics are single-line and redact credentialed URLs', () {
       expect(
-        formatted.length,
-        lessThan(', startupDiagnostics=[...]'.length + 41),
+        formatStartupDiagnostics(const <String>[
+          'failed at https://user:pass@example.com/lib.so?token=secret#part'
+              '\r\nnext\u0000line',
+        ]),
+        ', startupDiagnostics=['
+        'failed at https://example.com/lib.so next line]',
       );
     });
 
@@ -719,6 +730,129 @@ void main() {
 
     test('a fresh service has nothing recorded', () {
       expect(LlamaCppService().getStartupDiagnostics(), isEmpty);
+    });
+
+    group('native null-return branches', () {
+      late Directory tempDir;
+      late String corruptGgufPath;
+
+      setUp(() {
+        tempDir = Directory.systemTemp.createTempSync(
+          'llamadart-load-failure-',
+        );
+        corruptGgufPath = path.join(tempDir.path, 'corrupt.gguf');
+        File(
+          corruptGgufPath,
+        ).writeAsBytesSync(const <int>[0x47, 0x47, 0x55, 0x46]);
+      });
+
+      tearDown(() {
+        if (tempDir.existsSync()) {
+          tempDir.deleteSync(recursive: true);
+        }
+      });
+
+      test('main-model failure uses the service diagnostics buffer', () {
+        final service = _warmedLoadFailureService(corruptGgufPath);
+        _recordStartupDiagnosticForTesting(
+          service,
+          'failed at '
+          'https://user:pass@example.com/libggml.so?token=secret#fragment'
+          '\r\nnext\u0000line',
+        );
+
+        expect(
+          () => service.loadModel(corruptGgufPath, const ModelParams()),
+          throwsA(
+            isA<Exception>().having(
+              (error) => error.toString(),
+              'message',
+              allOf(
+                contains('Failed to load model (size=4 bytes,'),
+                contains(
+                  'startupDiagnostics=[failed at '
+                  'https://example.com/libggml.so next line]',
+                ),
+                isNot(contains('user:pass')),
+                isNot(contains('token=secret')),
+                isNot(contains('\n')),
+                isNot(contains('\u0000')),
+              ),
+            ),
+          ),
+        );
+      });
+
+      test('main-model failure omits the suffix for an empty buffer', () {
+        final service = _warmedLoadFailureService(corruptGgufPath);
+
+        expect(
+          () => service.loadModel(corruptGgufPath, const ModelParams()),
+          throwsA(
+            isA<Exception>().having(
+              (error) => error.toString(),
+              'message',
+              isNot(contains('startupDiagnostics=')),
+            ),
+          ),
+        );
+      });
+
+      test('draft-model failure uses its label and bounded newest tail', () {
+        final service = _warmedLoadFailureService(corruptGgufPath);
+        _recordStartupDiagnosticForTesting(service, 'oldest:${'a' * 5000}');
+        _recordStartupDiagnosticForTesting(service, 'newest failure');
+
+        expect(
+          () => _loadDraftModelForTesting(
+            service,
+            corruptGgufPath,
+            'speculative draft model',
+          ),
+          throwsA(
+            isA<Exception>().having(
+              (error) => error.toString(),
+              'message',
+              allOf(
+                contains(
+                  'Failed to load speculative draft model '
+                  '(size=4 bytes, path=$corruptGgufPath,',
+                ),
+                contains('startupDiagnostics=[...'),
+                endsWith('newest failure]'),
+                isNot(contains('oldest:')),
+                predicate<String>((message) {
+                  final marker = 'startupDiagnostics=[';
+                  final start = message.indexOf(marker);
+                  final content = message.substring(
+                    start + marker.length,
+                    message.length - 1,
+                  );
+                  return content.length == 4096;
+                }, 'caps rendered diagnostic content at 4096 characters'),
+              ),
+            ),
+          ),
+        );
+      });
+
+      test('draft-model failure omits the suffix for an empty buffer', () {
+        final service = _warmedLoadFailureService(corruptGgufPath);
+
+        expect(
+          () => _loadDraftModelForTesting(service, corruptGgufPath, 'draft'),
+          throwsA(
+            isA<Exception>().having(
+              (error) => error.toString(),
+              'message',
+              allOf(
+                contains('Failed to load draft (size=4 bytes,'),
+                isNot(contains('startupDiagnostics=')),
+              ),
+            ),
+          ),
+        );
+      });
     });
   });
 
@@ -1761,6 +1895,64 @@ void main() {
       contains(endsWith(path.join('llama.framework', 'llama'))),
     );
   });
+}
+
+LlamaCppService _warmedLoadFailureService(String corruptGgufPath) {
+  final service = LlamaCppService();
+  try {
+    service.loadModel(corruptGgufPath, const ModelParams());
+  } on Exception {
+    // The first controlled failure initializes platform backend discovery.
+  }
+  _startupDiagnosticsForTesting(service).clear();
+  return service;
+}
+
+void _recordStartupDiagnosticForTesting(
+  LlamaCppService service,
+  String diagnostic,
+) {
+  _invokePrivateForTesting<void>(service, '_recordStartupDiagnostic', <Object?>[
+    diagnostic,
+  ]);
+}
+
+void _loadDraftModelForTesting(
+  LlamaCppService service,
+  String path,
+  String label,
+) {
+  _invokePrivateForTesting<Object?>(
+    service,
+    '_loadSpeculativeDraftModel',
+    <Object?>[-1, path, label],
+    <Symbol, Object?>{#loadMtp: false},
+  );
+}
+
+List<String> _startupDiagnosticsForTesting(LlamaCppService service) {
+  final owner = reflectClass(LlamaCppService).owner as LibraryMirror;
+  return reflect(
+        service,
+      ).getField(MirrorSystem.getSymbol('_startupDiagnostics', owner)).reflectee
+      as List<String>;
+}
+
+T _invokePrivateForTesting<T>(
+  LlamaCppService service,
+  String member,
+  List<Object?> positionalArguments, [
+  Map<Symbol, Object?> namedArguments = const <Symbol, Object?>{},
+]) {
+  final owner = reflectClass(LlamaCppService).owner as LibraryMirror;
+  return reflect(service)
+          .invoke(
+            MirrorSystem.getSymbol(member, owner),
+            positionalArguments,
+            namedArguments,
+          )
+          .reflectee
+      as T;
 }
 
 void _createWindowsBundleMarkerFiles(

--- a/test/unit/backends/llama_cpp/llama_cpp_service_test.dart
+++ b/test/unit/backends/llama_cpp/llama_cpp_service_test.dart
@@ -664,6 +664,13 @@ void main() {
       expect(formatted, isNot(contains('a' * 50)));
     });
 
+    test('a zero content limit omits the diagnostic suffix', () {
+      expect(
+        formatStartupDiagnostics(const <String>['failure'], maxLength: 0),
+        isEmpty,
+      );
+    });
+
     test('diagnostics are single-line and redact credentialed URLs', () {
       expect(
         formatStartupDiagnostics(const <String>[
@@ -678,6 +685,14 @@ void main() {
           'failed at https://user:pass@[2001:db8::1]/lib.so?token=secret',
         ]),
         ', startupDiagnostics=[failed at https://[2001:db8::1]/lib.so]',
+      );
+      expect(
+        formatStartupDiagnostics(const <String>[
+          'https://safe.example/a,HTTPS://user\n:pass@evil.example/b'
+              '?token=secret',
+        ]),
+        ', startupDiagnostics=['
+        'https://safe.example/a,https://evil.example/b]',
       );
     });
 
@@ -763,7 +778,9 @@ void main() {
         _recordStartupDiagnosticForTesting(
           service,
           'failed at '
-          'HTTPS://user:pass@example.com/libggml.so?token=secret#fragment'
+          'https://safe.example/a,'
+          'HTTPS://user\n:pass@example.com/libggml.so'
+          '?token=secret#fragment'
           '\r\nnext\u0000line\u0085more\u2028last\u2029line',
         );
 
@@ -777,6 +794,7 @@ void main() {
                 contains('Failed to load model (size=4 bytes,'),
                 contains(
                   'startupDiagnostics=[failed at '
+                  'https://safe.example/a,'
                   'https://example.com/libggml.so '
                   'next line more last line]',
                 ),

--- a/test/unit/backends/llama_cpp/llama_cpp_service_test.dart
+++ b/test/unit/backends/llama_cpp/llama_cpp_service_test.dart
@@ -667,11 +667,17 @@ void main() {
     test('diagnostics are single-line and redact credentialed URLs', () {
       expect(
         formatStartupDiagnostics(const <String>[
-          'failed at https://user:pass@example.com/lib.so?token=secret#part'
-              '\r\nnext\u0000line',
+          'failed at HTTPS://user:pass@example.com/lib.so?token=secret#part'
+              '\r\nnext\u0000line\u0085more\u2028last\u2029line',
         ]),
         ', startupDiagnostics=['
-        'failed at https://example.com/lib.so next line]',
+        'failed at https://example.com/lib.so next line more last line]',
+      );
+      expect(
+        formatStartupDiagnostics(const <String>[
+          'failed at https://user:pass@[2001:db8::1]/lib.so?token=secret',
+        ]),
+        ', startupDiagnostics=[failed at https://[2001:db8::1]/lib.so]',
       );
     });
 
@@ -757,8 +763,8 @@ void main() {
         _recordStartupDiagnosticForTesting(
           service,
           'failed at '
-          'https://user:pass@example.com/libggml.so?token=secret#fragment'
-          '\r\nnext\u0000line',
+          'HTTPS://user:pass@example.com/libggml.so?token=secret#fragment'
+          '\r\nnext\u0000line\u0085more\u2028last\u2029line',
         );
 
         expect(
@@ -771,7 +777,8 @@ void main() {
                 contains('Failed to load model (size=4 bytes,'),
                 contains(
                   'startupDiagnostics=[failed at '
-                  'https://example.com/libggml.so next line]',
+                  'https://example.com/libggml.so '
+                  'next line more last line]',
                 ),
                 isNot(contains('user:pass')),
                 isNot(contains('token=secret')),


### PR DESCRIPTION
## Summary
- Exercise the real main-model and draft-model `modelPtr == nullptr` branches with controlled corrupt-GGUF failures and service-owned diagnostics.
- Keep startup diagnostic payloads single-line, redact credential-bearing HTTP URL components, fail closed on ambiguous control-split sensitive URLs, and make the documented 4 KiB content cap exact.
- Preserve byte-identical load-failure messages when the diagnostic buffer is empty.

This is a recovery follow-up to #348 and #383. PR #383 merged before its two suppressed branch-coverage concerns could be validated. This PR references that already-closed work and does not close #348 again.

## Production-readiness scope
- **User-facing scope:** Failed llama.cpp model loads keep the #383 startup diagnostic suffix, now bounded to exactly 4,096 content characters and sanitized before surfacing.
- **Supported platforms/paths:** Native llama.cpp main-model and speculative draft-model null-return failures on Dart VM platforms.
- **Unsupported or intentionally unavailable paths:** Web is unaffected; the native service is VM-only. Preflight failures before native loading remain unchanged and intentionally omit startup diagnostics.
- **Out of scope / follow-ups:** The separate startup worker-handshake hang and diagnostic-producer gaps documented in #383 remain out of scope.

## Completeness checklist
- [x] Declared scope is fully implemented, or explicitly reduced above.
- [x] Unsupported platform/option combinations fail loudly with actionable diagnostics or are clearly documented as unavailable.
- [x] Public API docs, README/website docs, examples, support matrices, and changelog entries are updated where relevant. No public API or capability matrix changed; the existing Unreleased #383 note remains accurate.
- [x] Regression coverage covers the original issue plus key negative/version-skew paths where relevant.
- [x] Security/privacy review completed: credentialed HTTP URL components and control characters are removed before diagnostics enter exception text; ambiguous control-split sensitive URL entries use a fixed redaction marker.
- [x] Follow-up work that is useful but not required for this PR is tracked in GitHub Issues, or explicitly marked above.

## PR type guidance
- **Bugfix PR:** #383 formatted helpers in isolation, so removing either production call site left all tests green. The same formatter also retained raw URL credentials/control characters and produced 4,099 characters after its claimed 4,096-character cap. Controlled native failures now prove both call sites and the corrected bounds/sanitization.

## Test Plan
- [x] `dart format --output=none --set-exit-if-changed` on both touched files
- [x] Touched-file `dart analyze` — no issues
- [x] `dart test -p vm -j 1 --exclude-tags local-only --coverage=/private/tmp/llamadart-pr383-recovery-coverage` — 1,456 passed, 62 expected fixture skips
- [x] Full-repository analysis — exact-head CI `Analyze & Lint` passed
- [ ] `dart test -p chrome --exclude-tags local-only` — feature-specific N/A locally: the changed service and `dart:mirrors` failure harness are native VM-only; exact-head CI Chrome and Web Chat Contract passed as regression gates
- [x] `dart test -p vm -j 1 test/unit/backends/llama_cpp/llama_cpp_service_test.dart` — 111 passed on the final head, including all four direct corrupt-GGUF failure assertions
- [x] `LLAMADART_TEST_MODELS_DIR=$PWD/models dart test -p vm -j 1 test/integration/inference_smoke_test.dart` — real GGUF load/generation PASS
- [x] `dart run tool/testing/run_local_e2e.dart --scenario llama-cpp-speculative-benchmark --model-path models/stories15M.gguf --draft-model-path models/stories15M.gguf --backend cpu --speculative-cases baseline,draft-simple --benchmark-gpu-layers 0 --benchmark-max-tokens 8 --benchmark-runs 1 --draft-token-max 1 --benchmark-warmups 0` — real target and external draft-model load/generation PASS; baseline and draft output hash `2eed00e8`
- [x] LCOV threshold — 76.87% (11,614/15,109), required 70%
- [x] `git diff --check`

## Matrix Evidence
| Matrix row | Scope covered | Platform / model / backend | Result | Evidence / notes |
| --- | --- | --- | --- | --- |
| static-format-analyze | touched Dart files | macOS arm64 / Dart VM | PASS | Format and targeted analyzer clean; exact-head CI full analyzer/lint passed. |
| root-vm | unit + integration, including direct failure branches | macOS arm64 / Dart VM / bundled llama.cpp | PASS | 1,456 passed; 62 expected fixture skips. Final focused suite: 111 passed. Four direct assertions reach main/draft `modelPtr == nullptr` with diagnostic and empty-buffer variants. |
| coverage-lib | changed `lib/` behavior | macOS arm64 / Dart VM | PASS | 76.87% line coverage, threshold 70%; exact-head Linux coverage job passed. |
| native inference smoke | valid main-model load/generate | Apple M4 Max / `stories15M.gguf` / CPU | PASS | Repository integration smoke loaded the 94 MiB GGUF, generated output, tokenized, and read metadata. Model SHA-256: `61b50d457809a5194818fd22e6724b456cd7bb9a6264c52c8110684c53f3704a`. |
| llama-cpp-speculative-benchmark | valid target + external draft-model load/generate | Apple M4 Max / same compatible `stories15M.gguf` for target and draft / CPU | PASS | Durable local E2E runner completed baseline and `draft-simple`; both generated 8 tokens with output hash `2eed00e8`, and the draft path reported 4 drafted / 3 accepted tokens. This is call-path evidence, not a performance claim. |
| root-chrome | browser regression paths | Web | PASS (CI) | Exact-head Chrome and Web Chat Contract jobs passed; the changed native failure path is feature-specific N/A on Web. |

## Feature-specific N/A
- A valid real model cannot directly produce the null-return diagnostic failure under test. The real-model smokes therefore validate successful main/draft load integration only; the controlled four-byte corrupt GGUF remains the direct, deterministic proof for diagnostic composition, bounding, sanitization, and empty-buffer omission.
- The same compatible tiny GGUF was intentionally used for target and external draft roles to exercise both load call sites. Dedicated draft-model quality or performance comparison is N/A for this diagnostics-only PR.
- Metal was detected on the Apple M4 Max host, but the real-model commands used CPU (`gpuLayers: 0`) to keep the smoke deterministic. GPU-specific inference behavior is N/A because this change only formats native startup diagnostics after a backend-independent null model pointer.
- Android, iOS, Windows, and Linux device-specific real-model reruns are N/A for this focused test-hardening change. Exact-head CI covers Linux real prompt-reuse plus macOS/Windows native regression jobs; no bundle, ABI, platform routing, or native artifact changed.

## Review Notes
- Independent review: final Copilot review on `4e555daad357834f0f9b617d70807f1956d33763` recommends approval with zero new comments.
- Review threads: 6 total, 0 unresolved; every addressed thread includes the concrete fix rationale.
- CI: all populated CI and preview checks passed on exact head `4e555daad357834f0f9b617d70807f1956d33763`.
- Base: current with `main` at `0344dbb352e01fb219a06016b97349a85c7460d2` (0 commits behind).

## Current readiness refresh (2026-08-22)
- **Current-main integration:** PASS — exact head `4e555daad357834f0f9b617d70807f1956d33763` is based on current `main` `0344dbb352e01fb219a06016b97349a85c7460d2` (0 behind / 6 ahead), so no merge commit or push was necessary.
- **Controlled failure proof:** PASS — the focused VM suite passed 111/111 and directly executed both main-model and speculative draft-model corrupt-GGUF null-return branches, including empty-buffer behavior, exact 4,096-character bounds, single-line sanitization, and sensitive URL redaction.
- **Feasible real-model smoke:** PASS — the durable `gguf-chat-features-smoke` scenario loaded `Qwen3.5-0.8B-Q4_K_M.gguf` on Metal and completed normal generation, thinking, and tool-call paths.
- **Feature-specific N/A:** A successful external speculative-draft model run is not evidence for the changed null-return diagnostic suffix; the controlled corrupt draft GGUF is the direct branch proof. Browser/Web real-model testing is also N/A to this VM-only `dart:ffi` service change; the exact-head Chrome and Web Chat Contract checks remain green as regression gates.
- **Sequencing:** The PR remains draft and unmerged pending the explicit sequential-merge go-ahead. No release, publication, tagging, or workflow dispatch is part of this refresh.
