### PR TITLE
fix: fail closed on aLoRA metadata version skew

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,9 +27,11 @@
 * aLoRA adapters are now rejected with `LlamaUnsupportedException` instead of
   being applied like ordinary LoRA adapters. An aLoRA adapter must activate only
   after its invocation tokens appear in the prompt, so applying it from the
-  start of generation silently changed output. LoRA errors from the worker also
-  keep their typed exception instead of arriving as a bare `Exception`, and a
-  failed adapter load now throws `LlamaModelException`.
+  start of generation silently changed output. Missing metadata-inspection
+  symbols in custom native runtimes also fail closed with the same typed error,
+  and rejected adapters are released. LoRA errors from the worker keep their
+  typed exception instead of arriving as a bare `Exception`, and a failed
+  adapter load now throws `LlamaModelException`.
 
 * Deprecated `LiteRtLmRuntimeClient.conversationTokenCount()` and
   `replaceConversationWithClone()`. Both are unused and are scheduled for

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,9 +29,10 @@
   after its invocation tokens appear in the prompt, so applying it from the
   start of generation silently changed output. Missing metadata-inspection
   symbols in custom native runtimes also fail closed with the same typed error,
-  and rejected adapters are released. LoRA errors from the worker keep their
-  typed exception instead of arriving as a bare `Exception`, and a failed
-  adapter load now throws `LlamaModelException`.
+  and rejected adapters are released when the cleanup ABI is available. LoRA
+  errors from the worker keep their typed exception instead of arriving as a
+  bare `Exception`, and a failed adapter load now throws
+  `LlamaModelException`.
 
 * Deprecated `LiteRtLmRuntimeClient.conversationTokenCount()` and
   `replaceConversationWithClone()`. Both are unused and are scheduled for

--- a/lib/src/backends/llama_cpp/llama_cpp_service.dart
+++ b/lib/src/backends/llama_cpp/llama_cpp_service.dart
@@ -6316,6 +6316,7 @@ class LlamaCppService {
             adapterPtr,
             path,
             invocationTokenCount: llama_adapter_get_alora_n_invocation_tokens,
+            invocationTokenData: llama_adapter_get_alora_invocation_tokens,
             freeAdapter: llama_adapter_lora_free,
           );
           adapter = _LlamaLoraWrapper(adapterPtr);
@@ -6347,20 +6348,29 @@ class LlamaCppService {
     Pointer<llama_adapter_lora> adapter,
     String adapterPath, {
     required int Function(Pointer<llama_adapter_lora>) invocationTokenCount,
+    required Pointer<llama_token> Function(Pointer<llama_adapter_lora>)
+    invocationTokenData,
     required void Function(Pointer<llama_adapter_lora>) freeAdapter,
   }) {
     final int invocationTokens;
     try {
       invocationTokens = invocationTokenCount(adapter);
+      final tokenData = invocationTokenData(adapter);
+      if (invocationTokens > 0 && tokenData == nullptr) {
+        throw StateError(
+          'aLoRA metadata reports invocation tokens without token data',
+        );
+      }
     } catch (_) {
       _freeRejectedLoraAdapter(adapter, freeAdapter);
       throw LlamaUnsupportedException(
         'Cannot safely load the LoRA adapter at $adapterPath because the '
         'loaded native runtime cannot inspect aLoRA invocation-token metadata '
         '(missing or incompatible '
-        'llama_adapter_get_alora_n_invocation_tokens). Use a native runtime '
+        'llama_adapter_get_alora_n_invocation_tokens / '
+        'llama_adapter_get_alora_invocation_tokens ABI). Use a native runtime '
         'artifact that matches this package\'s bindings or another '
-        'ABI-compatible build that exports this symbol.',
+        'ABI-compatible build that exports both symbols.',
       );
     }
 
@@ -6400,12 +6410,15 @@ class LlamaCppService {
     Pointer<llama_adapter_lora> adapter,
     String adapterPath, {
     required int Function(Pointer<llama_adapter_lora>) invocationTokenCount,
+    required Pointer<llama_token> Function(Pointer<llama_adapter_lora>)
+    invocationTokenData,
     required void Function(Pointer<llama_adapter_lora>) freeAdapter,
   }) {
     _validateLoraForEagerActivation(
       adapter,
       adapterPath,
       invocationTokenCount: invocationTokenCount,
+      invocationTokenData: invocationTokenData,
       freeAdapter: freeAdapter,
     );
   }

--- a/lib/src/backends/llama_cpp/llama_cpp_service.dart
+++ b/lib/src/backends/llama_cpp/llama_cpp_service.dart
@@ -6358,8 +6358,9 @@ class LlamaCppService {
         'Cannot safely load the LoRA adapter at $adapterPath because the '
         'loaded native runtime cannot inspect aLoRA invocation-token metadata '
         '(missing or incompatible '
-        'llama_adapter_get_alora_n_invocation_tokens). Use the package-pinned '
-        'native runtime or an ABI-compatible build that exports this symbol.',
+        'llama_adapter_get_alora_n_invocation_tokens). Use a native runtime '
+        'artifact that matches this package\'s bindings or another '
+        'ABI-compatible build that exports this symbol.',
       );
     }
 

--- a/lib/src/backends/llama_cpp/llama_cpp_service.dart
+++ b/lib/src/backends/llama_cpp/llama_cpp_service.dart
@@ -6300,31 +6300,24 @@ class LlamaCppService {
         var adapter = modelAdapters[path];
         if (adapter == null) {
           final pathPtr = path.toNativeUtf8();
-          final adapterPtr = llama_adapter_lora_init(
-            _models[modelHandle]!.pointer,
-            pathPtr.cast(),
-          );
-          malloc.free(pathPtr);
+          final Pointer<llama_adapter_lora> adapterPtr;
+          try {
+            adapterPtr = llama_adapter_lora_init(
+              _models[modelHandle]!.pointer,
+              pathPtr.cast(),
+            );
+          } finally {
+            malloc.free(pathPtr);
+          }
           if (adapterPtr == nullptr) {
             throw LlamaModelException('Failed to load LoRA at $path');
           }
-          // aLoRA must activate only after its invocation tokens appear, but
-          // adapters here apply from the start of generation.
-          final invocationTokens = llama_adapter_get_alora_n_invocation_tokens(
+          _validateLoraForEagerActivation(
             adapterPtr,
+            path,
+            invocationTokenCount: llama_adapter_get_alora_n_invocation_tokens,
+            freeAdapter: llama_adapter_lora_free,
           );
-          if (invocationTokens > 0) {
-            llama_adapter_lora_free(adapterPtr);
-            throw LlamaUnsupportedException(
-              'The adapter at $path is an aLoRA adapter ($invocationTokens '
-              'invocation token(s)). llamadart applies LoRA adapters from the '
-              'start of generation, but an aLoRA adapter must activate only '
-              'after its invocation sequence appears in the prompt, so '
-              'applying it eagerly would silently change output. Use a '
-              'standard LoRA adapter until invocation-aware activation is '
-              'implemented.',
-            );
-          }
           adapter = _LlamaLoraWrapper(adapterPtr);
           modelAdapters[path] = adapter;
         }
@@ -6348,6 +6341,72 @@ class LlamaCppService {
     } catch (e) {
       rethrow;
     }
+  }
+
+  static void _validateLoraForEagerActivation(
+    Pointer<llama_adapter_lora> adapter,
+    String adapterPath, {
+    required int Function(Pointer<llama_adapter_lora>) invocationTokenCount,
+    required void Function(Pointer<llama_adapter_lora>) freeAdapter,
+  }) {
+    final int invocationTokens;
+    try {
+      invocationTokens = invocationTokenCount(adapter);
+    } catch (_) {
+      _freeRejectedLoraAdapter(adapter, freeAdapter);
+      throw LlamaUnsupportedException(
+        'Cannot safely load the LoRA adapter at $adapterPath because the '
+        'loaded native runtime cannot inspect aLoRA invocation-token metadata '
+        '(missing or incompatible '
+        'llama_adapter_get_alora_n_invocation_tokens). Use the package-pinned '
+        'native runtime or an ABI-compatible build that exports this symbol.',
+      );
+    }
+
+    // aLoRA must activate only after its invocation tokens appear, but
+    // adapters here apply from the start of generation.
+    if (invocationTokens > 0) {
+      _freeRejectedLoraAdapter(adapter, freeAdapter);
+      throw LlamaUnsupportedException(
+        'The adapter at $adapterPath is an aLoRA adapter ($invocationTokens '
+        'invocation token(s)). llamadart applies LoRA adapters from the start '
+        'of generation, but an aLoRA adapter must activate only after its '
+        'invocation sequence appears in the prompt, so applying it eagerly '
+        'would silently change output. Use a standard LoRA adapter until '
+        'invocation-aware activation is implemented.',
+      );
+    }
+  }
+
+  static void _freeRejectedLoraAdapter(
+    Pointer<llama_adapter_lora> adapter,
+    void Function(Pointer<llama_adapter_lora>) freeAdapter,
+  ) {
+    try {
+      freeAdapter(adapter);
+    } catch (_) {
+      // Keep the safety failure typed and actionable even for a severely
+      // version-skewed runtime whose cleanup symbol is also unavailable.
+    }
+  }
+
+  /// Exercises the production aLoRA safety guard with injected native calls.
+  ///
+  /// This is public only for VM unit tests, which use inert pointer values and
+  /// callbacks to cover ordinary LoRA, aLoRA, version-skew, and cleanup paths
+  /// without requiring a large model/adapter fixture.
+  static void debugValidateLoraForEagerActivationForTesting(
+    Pointer<llama_adapter_lora> adapter,
+    String adapterPath, {
+    required int Function(Pointer<llama_adapter_lora>) invocationTokenCount,
+    required void Function(Pointer<llama_adapter_lora>) freeAdapter,
+  }) {
+    _validateLoraForEagerActivation(
+      adapter,
+      adapterPath,
+      invocationTokenCount: invocationTokenCount,
+      freeAdapter: freeAdapter,
+    );
   }
 
   void _applyActiveLoras(

--- a/test/integration/backends/llama_cpp/native_symbol_integration_test.dart
+++ b/test/integration/backends/llama_cpp/native_symbol_integration_test.dart
@@ -57,6 +57,11 @@ const _b10514MtmdSymbols = [
   'mtmd_input_chunk_get_placeholder',
 ];
 
+const _aloraMetadataSymbols = [
+  'llama_adapter_get_alora_n_invocation_tokens',
+  'llama_adapter_get_alora_invocation_tokens',
+];
+
 const _transparentPngBytes = <int>[
   0x89,
   0x50,
@@ -470,6 +475,20 @@ void main() {
       }
     });
 
+    test('Verify aLoRA metadata symbols are declared in bindings', () {
+      final bindingsSource = File(
+        'lib/src/backends/llama_cpp/bindings.dart',
+      ).readAsStringSync();
+
+      for (final symbol in _aloraMetadataSymbols) {
+        expect(
+          _declaresExternalFunction(bindingsSource, symbol),
+          isTrue,
+          reason: symbol,
+        );
+      }
+    });
+
     test('Verify b10545 mtmd context parameter layout in bindings', () {
       final bindingsSource = File(
         'lib/src/backends/llama_cpp/bindings.dart',
@@ -869,6 +888,16 @@ void main() {
         () => llama_numa_init(ggml_numa_strategy.GGML_NUMA_STRATEGY_DISABLED),
         returnsNormally,
       );
+    });
+
+    test('Verify pinned runtime exports aLoRA metadata inspection', () {
+      final libraryFile = _llamadartWrapperLibraryFileOrNull();
+      expect(
+        libraryFile,
+        isNotNull,
+        reason: 'Expected a native library exporting llama.cpp symbols.',
+      );
+      _expectDynamicLibraryExports(libraryFile!, _aloraMetadataSymbols);
     });
   });
 }

--- a/test/integration/backends/llama_cpp/native_symbol_integration_test.dart
+++ b/test/integration/backends/llama_cpp/native_symbol_integration_test.dart
@@ -295,6 +295,17 @@ void _expectDynamicLibraryExports(File libraryFile, Iterable<String> symbols) {
   }
 }
 
+List<String> _missingDynamicLibraryExports(
+  File libraryFile,
+  Iterable<String> symbols,
+) {
+  final library = ffi.DynamicLibrary.open(libraryFile.path);
+  return [
+    for (final symbol in symbols)
+      if (!library.providesSymbol(symbol)) symbol,
+  ];
+}
+
 String? _nativeAssetFilePath(String assetId) {
   final configFile = File('.dart_tool/native_assets.yaml');
   if (!configFile.existsSync()) {
@@ -890,14 +901,25 @@ void main() {
       );
     });
 
-    test('Verify pinned runtime exports aLoRA metadata inspection', () {
+    test('Verify runtime aLoRA metadata inspection ABI is complete', () {
       final libraryFile = _llamadartWrapperLibraryFileOrNull();
       expect(
         libraryFile,
         isNotNull,
         reason: 'Expected a native library exporting llama.cpp symbols.',
       );
-      _expectDynamicLibraryExports(libraryFile!, _aloraMetadataSymbols);
+      final missingSymbols = _missingDynamicLibraryExports(
+        libraryFile!,
+        _aloraMetadataSymbols,
+      );
+      expect(
+        missingSymbols,
+        anyOf(isEmpty, unorderedEquals(_aloraMetadataSymbols)),
+        reason:
+            'A partially exported aLoRA inspection ABI cannot be used '
+            'safely. A runtime without either symbol is handled by the typed '
+            'version-skew guard.',
+      );
     });
   });
 }

--- a/test/integration/backends/llama_cpp/native_symbol_integration_test.dart
+++ b/test/integration/backends/llama_cpp/native_symbol_integration_test.dart
@@ -174,6 +174,15 @@ File? _llamadartWrapperLibraryFileOrNull() {
   return file.existsSync() ? file : null;
 }
 
+File? _llamadartPrimaryLibraryFileOrNull() {
+  final nativeAssetPath = _nativeAssetFilePath(_llamadartPrimaryAssetId);
+  if (nativeAssetPath == null) {
+    return null;
+  }
+  final file = File(nativeAssetPath);
+  return file.existsSync() ? file : null;
+}
+
 File _windowsMtpWrapperLibraryFile() {
   final dartToolLibPath = [
     Directory.current.path,
@@ -902,7 +911,7 @@ void main() {
     });
 
     test('Verify runtime aLoRA metadata inspection ABI is complete', () {
-      final libraryFile = _llamadartWrapperLibraryFileOrNull();
+      final libraryFile = _llamadartPrimaryLibraryFileOrNull();
       expect(
         libraryFile,
         isNotNull,

--- a/test/integration/backends/llama_cpp/native_symbol_integration_test.dart
+++ b/test/integration/backends/llama_cpp/native_symbol_integration_test.dart
@@ -304,17 +304,6 @@ void _expectDynamicLibraryExports(File libraryFile, Iterable<String> symbols) {
   }
 }
 
-List<String> _missingDynamicLibraryExports(
-  File libraryFile,
-  Iterable<String> symbols,
-) {
-  final library = ffi.DynamicLibrary.open(libraryFile.path);
-  return [
-    for (final symbol in symbols)
-      if (!library.providesSymbol(symbol)) symbol,
-  ];
-}
-
 String? _nativeAssetFilePath(String assetId) {
   final configFile = File('.dart_tool/native_assets.yaml');
   if (!configFile.existsSync()) {
@@ -910,25 +899,14 @@ void main() {
       );
     });
 
-    test('Verify runtime aLoRA metadata inspection ABI is complete', () {
+    test('Verify pinned primary runtime exports aLoRA metadata ABI', () {
       final libraryFile = _llamadartPrimaryLibraryFileOrNull();
       expect(
         libraryFile,
         isNotNull,
         reason: 'Expected a native library exporting llama.cpp symbols.',
       );
-      final missingSymbols = _missingDynamicLibraryExports(
-        libraryFile!,
-        _aloraMetadataSymbols,
-      );
-      expect(
-        missingSymbols,
-        anyOf(isEmpty, unorderedEquals(_aloraMetadataSymbols)),
-        reason:
-            'A partially exported aLoRA inspection ABI cannot be used '
-            'safely. A runtime without either symbol is handled by the typed '
-            'version-skew guard.',
-      );
+      _expectDynamicLibraryExports(libraryFile!, _aloraMetadataSymbols);
     });
   });
 }

--- a/test/unit/backends/llama_cpp/llama_cpp_backend_test.dart
+++ b/test/unit/backends/llama_cpp/llama_cpp_backend_test.dart
@@ -395,6 +395,19 @@ void main() {
       );
     });
 
+    test('LoRA metadata version skew stays typed across the worker', () async {
+      await expectLater(
+        backend.setLoraAdapter(1, 'old-runtime.gguf', 1.0),
+        throwsA(
+          isA<LlamaUnsupportedException>().having(
+            (error) => error.message,
+            'message',
+            contains('llama_adapter_get_alora_n_invocation_tokens'),
+          ),
+        ),
+      );
+    });
+
     test('worker errors keep their kind through every request', () async {
       await expectLater(
         backend.tokenize(1, 'boom'),
@@ -693,6 +706,15 @@ class _FakeWorkerHarness {
             message.sendPort.send(
               ErrorResponse(
                 'The adapter at alora.gguf is an aLoRA adapter',
+                kind: WorkerErrorKind.unsupported,
+              ),
+            );
+          } else if (message.path == 'old-runtime.gguf') {
+            message.sendPort.send(
+              ErrorResponse(
+                'Cannot safely load the LoRA adapter because the native '
+                'runtime is missing '
+                'llama_adapter_get_alora_n_invocation_tokens',
                 kind: WorkerErrorKind.unsupported,
               ),
             );

--- a/test/unit/backends/llama_cpp/llama_cpp_service_test.dart
+++ b/test/unit/backends/llama_cpp/llama_cpp_service_test.dart
@@ -31,6 +31,7 @@ void main() {
         adapter,
         'ordinary.gguf',
         invocationTokenCount: (_) => 0,
+        invocationTokenData: (_) => nullptr,
         freeAdapter: (_) => freed++,
       );
 
@@ -45,6 +46,7 @@ void main() {
           adapter,
           'activated.gguf',
           invocationTokenCount: (_) => 3,
+          invocationTokenData: (_) => Pointer<llama_token>.fromAddress(2),
           freeAdapter: (_) => freed++,
         ),
         throwsA(
@@ -75,6 +77,7 @@ void main() {
             'Could not resolve '
             'llama_adapter_get_alora_n_invocation_tokens',
           ),
+          invocationTokenData: (_) => nullptr,
           freeAdapter: (_) => freed++,
         ),
         throwsA(
@@ -99,12 +102,37 @@ void main() {
       expect(freed, 1);
     });
 
+    test('fails closed and frees on a partial metadata ABI', () {
+      var freed = 0;
+
+      expect(
+        () => LlamaCppService.debugValidateLoraForEagerActivationForTesting(
+          adapter,
+          'partial-abi.gguf',
+          invocationTokenCount: (_) => 0,
+          invocationTokenData: (_) => throw ArgumentError(
+            'Could not resolve llama_adapter_get_alora_invocation_tokens',
+          ),
+          freeAdapter: (_) => freed++,
+        ),
+        throwsA(
+          isA<LlamaUnsupportedException>().having(
+            (error) => error.message,
+            'message',
+            contains('llama_adapter_get_alora_invocation_tokens'),
+          ),
+        ),
+      );
+      expect(freed, 1);
+    });
+
     test('keeps version-skew failure typed if cleanup also fails', () {
       expect(
         () => LlamaCppService.debugValidateLoraForEagerActivationForTesting(
           adapter,
           'severely-skewed.gguf',
           invocationTokenCount: (_) => throw ArgumentError('missing getter'),
+          invocationTokenData: (_) => nullptr,
           freeAdapter: (_) => throw ArgumentError('missing free'),
         ),
         throwsA(isA<LlamaUnsupportedException>()),

--- a/test/unit/backends/llama_cpp/llama_cpp_service_test.dart
+++ b/test/unit/backends/llama_cpp/llama_cpp_service_test.dart
@@ -5,6 +5,7 @@ import 'dart:ffi';
 import 'dart:io';
 
 import 'package:ffi/ffi.dart';
+import 'package:llamadart/src/backends/llama_cpp/bindings.dart';
 import 'package:llamadart/src/backends/llama_cpp/llama_cpp_service.dart';
 import 'package:llamadart/src/core/exceptions.dart';
 import 'package:llamadart/src/core/models/config/gpu_backend.dart';
@@ -18,6 +19,97 @@ void main() {
   test('LlamaCppService can be instantiated', () {
     final service = LlamaCppService();
     expect(service, isA<LlamaCppService>());
+  });
+
+  group('aLoRA eager-activation guard', () {
+    final adapter = Pointer<llama_adapter_lora>.fromAddress(1);
+
+    test('preserves an ordinary LoRA adapter', () {
+      var freed = 0;
+
+      LlamaCppService.debugValidateLoraForEagerActivationForTesting(
+        adapter,
+        'ordinary.gguf',
+        invocationTokenCount: (_) => 0,
+        freeAdapter: (_) => freed++,
+      );
+
+      expect(freed, 0);
+    });
+
+    test('rejects and frees an aLoRA adapter', () {
+      var freed = 0;
+
+      expect(
+        () => LlamaCppService.debugValidateLoraForEagerActivationForTesting(
+          adapter,
+          'activated.gguf',
+          invocationTokenCount: (_) => 3,
+          freeAdapter: (_) => freed++,
+        ),
+        throwsA(
+          isA<LlamaUnsupportedException>()
+              .having(
+                (error) => error.message,
+                'message',
+                contains('activated.gguf is an aLoRA adapter'),
+              )
+              .having(
+                (error) => error.message,
+                'message',
+                contains('3 invocation token(s)'),
+              ),
+        ),
+      );
+      expect(freed, 1);
+    });
+
+    test('fails closed and frees on missing metadata symbol', () {
+      var freed = 0;
+
+      expect(
+        () => LlamaCppService.debugValidateLoraForEagerActivationForTesting(
+          adapter,
+          'unknown.gguf',
+          invocationTokenCount: (_) => throw ArgumentError(
+            'Could not resolve '
+            'llama_adapter_get_alora_n_invocation_tokens',
+          ),
+          freeAdapter: (_) => freed++,
+        ),
+        throwsA(
+          isA<LlamaUnsupportedException>()
+              .having(
+                (error) => error.message,
+                'message',
+                contains('Cannot safely load the LoRA adapter'),
+              )
+              .having(
+                (error) => error.message,
+                'message',
+                contains('llama_adapter_get_alora_n_invocation_tokens'),
+              )
+              .having(
+                (error) => error.message,
+                'message',
+                contains('package-pinned native runtime'),
+              ),
+        ),
+      );
+      expect(freed, 1);
+    });
+
+    test('keeps version-skew failure typed if cleanup also fails', () {
+      expect(
+        () => LlamaCppService.debugValidateLoraForEagerActivationForTesting(
+          adapter,
+          'severely-skewed.gguf',
+          invocationTokenCount: (_) => throw ArgumentError('missing getter'),
+          freeAdapter: (_) => throw ArgumentError('missing free'),
+        ),
+        throwsA(isA<LlamaUnsupportedException>()),
+      );
+    });
   });
 
   group('getVramInfo', () {

--- a/test/unit/backends/llama_cpp/llama_cpp_service_test.dart
+++ b/test/unit/backends/llama_cpp/llama_cpp_service_test.dart
@@ -92,7 +92,7 @@ void main() {
               .having(
                 (error) => error.message,
                 'message',
-                contains('package-pinned native runtime'),
+                contains("matches this package's bindings"),
               ),
         ),
       );

--- a/test/unit/backends/llama_cpp/llama_cpp_service_test.dart
+++ b/test/unit/backends/llama_cpp/llama_cpp_service_test.dart
@@ -126,6 +126,28 @@ void main() {
       expect(freed, 1);
     });
 
+    test('fails closed and frees on inconsistent aLoRA metadata', () {
+      var freed = 0;
+
+      expect(
+        () => LlamaCppService.debugValidateLoraForEagerActivationForTesting(
+          adapter,
+          'inconsistent-metadata.gguf',
+          invocationTokenCount: (_) => 1,
+          invocationTokenData: (_) => nullptr,
+          freeAdapter: (_) => freed++,
+        ),
+        throwsA(
+          isA<LlamaUnsupportedException>().having(
+            (error) => error.message,
+            'message',
+            contains('Cannot safely load the LoRA adapter'),
+          ),
+        ),
+      );
+      expect(freed, 1);
+    });
+
     test('keeps version-skew failure typed if cleanup also fails', () {
       expect(
         () => LlamaCppService.debugValidateLoraForEagerActivationForTesting(

--- a/website/docs/changelog/recent-releases.md
+++ b/website/docs/changelog/recent-releases.md
@@ -38,9 +38,10 @@ For canonical full release notes, use:
   after its invocation tokens appear in the prompt, so applying it from the
   start of generation silently changed output. Missing metadata-inspection
   symbols in custom native runtimes also fail closed with the same typed error,
-  and rejected adapters are released. LoRA errors from the worker keep their
-  typed exception instead of arriving as a bare `Exception`, and a failed
-  adapter load now throws `LlamaModelException`.
+  and rejected adapters are released when the cleanup ABI is available. LoRA
+  errors from the worker keep their typed exception instead of arriving as a
+  bare `Exception`, and a failed adapter load now throws
+  `LlamaModelException`.
 
 - Deprecated `LiteRtLmRuntimeClient.conversationTokenCount()` and
   `replaceConversationWithClone()`. Both are unused and are scheduled for

--- a/website/docs/changelog/recent-releases.md
+++ b/website/docs/changelog/recent-releases.md
@@ -36,9 +36,11 @@ For canonical full release notes, use:
 - aLoRA adapters are now rejected with `LlamaUnsupportedException` instead of
   being applied like ordinary LoRA adapters. An aLoRA adapter must activate only
   after its invocation tokens appear in the prompt, so applying it from the
-  start of generation silently changed output. LoRA errors from the worker also
-  keep their typed exception instead of arriving as a bare `Exception`, and a
-  failed adapter load now throws `LlamaModelException`.
+  start of generation silently changed output. Missing metadata-inspection
+  symbols in custom native runtimes also fail closed with the same typed error,
+  and rejected adapters are released. LoRA errors from the worker keep their
+  typed exception instead of arriving as a bare `Exception`, and a failed
+  adapter load now throws `LlamaModelException`.
 
 - Deprecated `LiteRtLmRuntimeClient.conversationTokenCount()` and
   `replaceConversationWithClone()`. Both are unused and are scheduled for

--- a/website/docs/guides/lora-adapters.md
+++ b/website/docs/guides/lora-adapters.md
@@ -107,8 +107,15 @@ invocation-aware activation is implemented.
 ```
 
 Native LoRA support should not be read as aLoRA support. Invocation-aware
-activation is tracked in
-[issue #321](https://github.com/leehack/llamadart/issues/321).
+activation, prompt-cache safety, and multiple-aLoRA behavior are not yet
+implemented.
+
+Custom native runtime overrides must also export
+`llama_adapter_get_alora_n_invocation_tokens`. If that metadata inspection is
+missing or ABI-incompatible, llamadart fails closed with
+`LlamaUnsupportedException` and asks you to use the package-pinned runtime or
+an ABI-compatible build. It does not activate an adapter whose type cannot be
+checked safely.
 
 ## Lifecycle notes
 

--- a/website/docs/guides/lora-adapters.md
+++ b/website/docs/guides/lora-adapters.md
@@ -113,9 +113,9 @@ implemented.
 Custom native runtime overrides must also export
 `llama_adapter_get_alora_n_invocation_tokens`. If that metadata inspection is
 missing or ABI-incompatible, llamadart fails closed with
-`LlamaUnsupportedException` and asks you to use the package-pinned runtime or
-an ABI-compatible build. It does not activate an adapter whose type cannot be
-checked safely.
+`LlamaUnsupportedException` and asks you to use a runtime artifact matching the
+package bindings or another ABI-compatible build. It does not activate an
+adapter whose type cannot be checked safely.
 
 ## Lifecycle notes
 

--- a/website/docs/guides/lora-adapters.md
+++ b/website/docs/guides/lora-adapters.md
@@ -110,9 +110,10 @@ Native LoRA support should not be read as aLoRA support. Invocation-aware
 activation, prompt-cache safety, and multiple-aLoRA behavior are not yet
 implemented.
 
-Custom native runtime overrides must also export
-`llama_adapter_get_alora_n_invocation_tokens`. If that metadata inspection is
-missing or ABI-incompatible, llamadart fails closed with
+Custom native runtime overrides must also export both
+`llama_adapter_get_alora_n_invocation_tokens` and
+`llama_adapter_get_alora_invocation_tokens`. If that metadata inspection ABI is
+missing, partial, or incompatible, llamadart fails closed with
 `LlamaUnsupportedException` and asks you to use a runtime artifact matching the
 package bindings or another ABI-compatible build. It does not activate an
 adapter whose type cannot be checked safely.

--- a/website/docs/platforms/support-matrix.md
+++ b/website/docs/platforms/support-matrix.md
@@ -204,10 +204,11 @@ device/model bundle, use `cpu` or `gpu` for that artifact.
 
 - **LoRA adapters** are supported at runtime on native llama.cpp/GGUF. Activated
   LoRA (aLoRA) is not yet supported: llamadart detects invocation-token metadata
-  and rejects the adapter before activation. Native overrides must export
-  `llama_adapter_get_alora_n_invocation_tokens`; runtimes without compatible
-  metadata inspection fail closed with `LlamaUnsupportedException` rather than
-  risk applying aLoRA eagerly.
+  and rejects the adapter before activation. Native overrides must export both
+  `llama_adapter_get_alora_n_invocation_tokens` and
+  `llama_adapter_get_alora_invocation_tokens`; runtimes without the complete,
+  compatible metadata inspection ABI fail closed with
+  `LlamaUnsupportedException` rather than risk applying aLoRA eagerly.
 - **Thinking budgets** (`GenerationParams.thinkingBudget`) use llama.cpp's
   reasoning-budget sampler on native text-only GGUF generation. `engine.create`
   resolves known template delimiters automatically; raw generation requires

--- a/website/docs/platforms/support-matrix.md
+++ b/website/docs/platforms/support-matrix.md
@@ -202,9 +202,10 @@ device/model bundle, use `cpu` or `gpu` for that artifact.
 
 ## Runtime capability notes
 
-- **LoRA adapters** are supported at runtime on native llama.cpp/GGUF. Activated
-  LoRA (aLoRA) is not yet supported: llamadart detects invocation-token metadata
-  and rejects the adapter before activation. Native overrides must export both
+- **LoRA adapters** are supported on native llama.cpp/GGUF runtimes with the
+  complete metadata inspection ABI below. Activated LoRA (aLoRA) is not yet
+  supported: llamadart detects invocation-token metadata and rejects the
+  adapter before activation. Native overrides must export both
   `llama_adapter_get_alora_n_invocation_tokens` and
   `llama_adapter_get_alora_invocation_tokens`; runtimes without the complete,
   compatible metadata inspection ABI fail closed with

--- a/website/docs/platforms/support-matrix.md
+++ b/website/docs/platforms/support-matrix.md
@@ -202,6 +202,12 @@ device/model bundle, use `cpu` or `gpu` for that artifact.
 
 ## Runtime capability notes
 
+- **LoRA adapters** are supported at runtime on native llama.cpp/GGUF. Activated
+  LoRA (aLoRA) is not yet supported: llamadart detects invocation-token metadata
+  and rejects the adapter before activation. Native overrides must export
+  `llama_adapter_get_alora_n_invocation_tokens`; runtimes without compatible
+  metadata inspection fail closed with `LlamaUnsupportedException` rather than
+  risk applying aLoRA eagerly.
 - **Thinking budgets** (`GenerationParams.thinkingBudget`) use llama.cpp's
   reasoning-budget sampler on native text-only GGUF generation. `engine.create`
   resolves known template delimiters automatically; raw generation requires


### PR DESCRIPTION
## Summary

- complete the immediate aLoRA safety slice from #321 on top of merged PR #372
- fail closed with `LlamaUnsupportedException` when a custom or older native runtime cannot inspect invocation-token metadata
- release rejected adapter handles when the cleanup ABI is available, preserve ordinary LoRA behavior on compatible runtimes, and keep the typed failure across the worker boundary
- verify the generated metadata bindings and require package-pinned primary runtime artifacts to expose both upstream aLoRA metadata functions
- document the aLoRA and native-override limits in the guide, support matrix, and changelogs

Closes #321.

## Scope

This closes the issue's immediate detect-and-reject acceptance criteria. It does **not** implement invocation-aware execution: prompt boundary detection, pre-invocation decoding with scale zero, prompt-cache policy, and multiple-aLoRA rules remain out of scope.

The key version-skew case is a native runtime that still loads LoRA adapters but lacks `llama_adapter_get_alora_n_invocation_tokens`. Previously the direct `@Native` call escaped as an untyped resolution error after adapter creation. The guard now catches metadata-inspection failure, releases the handle when the cleanup ABI is available, and rejects activation with instructions to use a runtime artifact matching the package bindings or another ABI-compatible build.

## Validation

| Matrix row / check | Result | Evidence |
| --- | --- | --- |
| Changed scopes analyze | PASS | `dart analyze lib test tool hook`; focused four-file analyze also clean |
| Touched-file format / diff | PASS | changed Dart files formatted; `git diff --check` clean |
| Platform boundaries | PASS | `dart run tool/testing/check_platform_boundaries.dart` |
| Focused native/worker tests | PASS | 165 tests on integrated head `6d73f4fe3`: service guard, backend worker propagation, worker classification, native symbol integration |
| `root-vm` | PASS | exact-head VM tests and 70% coverage gate |
| `root-chrome` | PASS | exact-head Chrome tests |
| `docs-site` | PASS | local and exact-head Docusaurus build/link validation |
| Native ABI evidence | PASS | generated declarations cover both getters; integration requires both exports from the package-pinned primary/core runtime asset on macOS and Windows |

### Real aLoRA smoke

PASS on exact integrated head `6d73f4fe3`. A Granite 4.1 3B Q2_K base and pinned tool-selector aLoRA converted with llama.cpp b10514 exercised the public `LlamaEngine` and native-worker path. The runtime loaded the real adapter metadata, rejected the aLoRA before generation with the typed actionable unsupported behavior, and then unloaded cleanly.

The exact production guard is also exercised deterministically with injected native callbacks for ordinary LoRA (`0` tokens), aLoRA (`3` tokens), positive-count/null-token inconsistency, either missing getter/partial ABI, cleanup, and cleanup-symbol skew. The native integration test separately proves the generated declarations and requires both exports from the package-pinned primary/core runtime asset on each desktop platform; missing-symbol behavior is covered by the typed injected version-skew path. Output parity belongs to the follow-up invocation-aware implementation, not this detect-and-reject change.

Repository-wide local coverage collection hit a Dart `test_core` loader failure (`VMPlatform.load`, null check) before suites executed, both default and serial. The focused service coverage run passed all 109 tests and produced LCOV; the required CI coverage job remains the authoritative full threshold gate.

## Follow-up

Full aLoRA support needs a separate design/implementation issue before any adapter can be activated: define invocation-boundary matching, cache invalidation/reuse, per-batch scale transitions, multiple-adapter rules, and real-adapter parity against upstream `llama-server`.
