### PR TITLE
fix: make native video capability truthful

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,14 @@
 ## Unreleased
 
+* Made native video-input capability truthful without claiming end-to-end
+  support. `LlamaVideoContent` requests now fail with an actionable
+  `LlamaUnsupportedException`, `LlamaEngine.supportsVideo` reports public
+  consumability as false, and the llama.cpp worker uses the behavioral
+  `mtmd_helper_support_video` result instead of exported helper symbols. The
+  tested b10545 macOS arm64 artifact reports video compiled out; full path/byte
+  input remains blocked on cross-platform FFmpeg/ffprobe packaging and Dart
+  frame lifecycle wiring.
+
 * Fixed Web/native backend API parity. `WebAutoBackend` now forwards grammar
   constraint support from its active runtime, so strict structured output fails
   early with an actionable error on unsupported Web backends, and the Web-safe

--- a/example/chat_app/README.md
+++ b/example/chat_app/README.md
@@ -33,7 +33,7 @@ A Flutter chat application demonstrating real-world usage of llamadart with UI.
 - ⚙️ Model configuration (path, runtime-detected backend selection, GPU layers,
   context size, logical batch size, and micro-batch size; LiteRT-LM does not
   expose the llama.cpp/WebGPU batch controls)
-- 🧩 Capability badges per model (Tools / Thinking / Vision / Audio / Video)
+- 🧩 Capability badges per model (Tools / Thinking / Vision / Audio)
 - 🧪 GGUF and LiteRT-LM model routing through the same high-level engine APIs
 - 🎯 Per-model presets for temperature, Top-K, Top-P, context, and max tokens
 - 🛠️ Tool-calling toggles with template support checks
@@ -190,8 +190,10 @@ flutter test --run-skipped -t local-only \
      Gemma 4 E2B bundle, GPU text/vision with CPU audio is the resolved path;
      this is not a universal LiteRT-LM CPU-audio limitation.
    - Gemma 4 E2B is included as a GGUF + `mmproj` bundle. In the current native
-     `llama.cpp` mtmd path used here, that projector exposes image, audio, and
-     video input, so it uses the same **Ask with voice** interaction. Audio
+     `llama.cpp` mtmd path used here, that projector exposes image and audio
+     input, so it uses the same **Ask with voice** interaction. Video is not
+     consumable: the packaged native runtime reports it compiled out and Dart
+     does not yet own frame/timestamp ingestion or video-context cleanup. Audio
      remains experimental upstream; start with short mono clips for the most
      reliable results. The GGUF audio-answer path has current engine-level
      real-model evidence on macOS; microphone UI/device validation on Android,

--- a/example/chat_app/lib/models/downloadable_model.dart
+++ b/example/chat_app/lib/models/downloadable_model.dart
@@ -564,8 +564,7 @@ class DownloadableModel {
     ),
     DownloadableModel.fromSources(
       name: 'Gemma 4 E2B it',
-      description:
-          'Compact multimodal assistant for image, audio, and video input.',
+      description: 'Compact multimodal assistant for image and audio input.',
       modelSource: const RemoteModelAssetSource(
         url:
             'https://huggingface.co/unsloth/gemma-4-E2B-it-GGUF/resolve/90f9618340396838ee7ff5b0ba2da27da62953d3/gemma-4-E2B-it-Q4_K_S.gguf?download=true',
@@ -601,7 +600,6 @@ class DownloadableModel {
       supportsVision: true,
       supportsAudio: true,
       webSupportsAudio: false,
-      supportsVideo: true,
       supportsToolCalling: true,
       supportsThinking: true,
       preset: ModelPreset(
@@ -667,7 +665,6 @@ class DownloadableModel {
       supportsVision: true,
       supportsAudio: true,
       webSupportsAudio: false,
-      supportsVideo: true,
       supportsToolCalling: true,
       supportsThinking: true,
       preset: ModelPreset(
@@ -696,7 +693,6 @@ class DownloadableModel {
       minRamGb: 16,
       supportsVision: true,
       supportsAudio: true,
-      supportsVideo: true,
       supportsToolCalling: true,
       supportsThinking: true,
       preset: ModelPreset(
@@ -724,7 +720,6 @@ class DownloadableModel {
       availability: ModelAvailability.nativeDesktop,
       minRamGb: 24,
       supportsVision: true,
-      supportsVideo: true,
       supportsToolCalling: true,
       supportsThinking: true,
       preset: ModelPreset(
@@ -752,7 +747,6 @@ class DownloadableModel {
       availability: ModelAvailability.nativeDesktop,
       minRamGb: 32,
       supportsVision: true,
-      supportsVideo: true,
       supportsToolCalling: true,
       supportsThinking: true,
       preset: ModelPreset(

--- a/example/chat_app/lib/screens/manage_models_screen.dart
+++ b/example/chat_app/lib/screens/manage_models_screen.dart
@@ -217,7 +217,6 @@ class _ManageModelsScreenState extends State<ManageModelsScreen>
         'speech-to-text speech to text transcription asr stt',
       if (model.supportsTextToSpeechFor(web: useWebCapabilities))
         'text-to-speech text to speech synthesis tts voice output',
-      if (model.supportsVideoFor(web: useWebCapabilities)) 'video',
     ].join(' ').toLowerCase();
     return query.split(RegExp(r'\s+')).every(searchable.contains);
   }

--- a/example/chat_app/lib/widgets/model_card.dart
+++ b/example/chat_app/lib/widgets/model_card.dart
@@ -285,13 +285,6 @@ class ModelCard extends StatelessWidget {
                             label: 'Text-to-speech',
                             supported: true,
                           ),
-                        if (model.supportsVideoFor(web: isWeb))
-                          _buildCapabilityChip(
-                            context,
-                            icon: Icons.videocam_outlined,
-                            label: 'Video',
-                            supported: true,
-                          ),
                       ],
                     ),
                   ],

--- a/example/chat_app/test/model_card_test.dart
+++ b/example/chat_app/test/model_card_test.dart
@@ -77,6 +77,30 @@ void main() {
     expect(find.text('Audio'), findsNothing);
   });
 
+  testWidgets('does not advertise stale video capability metadata', (
+    tester,
+  ) async {
+    await _pumpCard(
+      tester,
+      model: const DownloadableModel(
+        name: 'Legacy video metadata',
+        description:
+            'A model entry saved before video capability was corrected.',
+        url: 'https://example.com/model.gguf',
+        filename: 'model.gguf',
+        sizeBytes: 10,
+        supportsVideo: true,
+      ),
+      isWeb: false,
+      isDownloaded: true,
+      onSelect: () {},
+      onDownload: () {},
+    );
+
+    expect(find.text('Video'), findsNothing);
+    expect(find.byIcon(Icons.videocam_outlined), findsNothing);
+  });
+
   testWidgets('ASR card distinguishes STT and requires its projector', (
     tester,
   ) async {

--- a/lib/src/backends/backend.dart
+++ b/lib/src/backends/backend.dart
@@ -197,7 +197,10 @@ abstract class BackendPromptSpeechToTextSupport {
 /// Dart frame-ingestion and lifetime contract is implemented.
 abstract class BackendVideoRuntimeSupport {
   /// Whether the loaded native mtmd context reports compiled video support.
-  Future<bool> supportsVideoRuntime(int mmContextHandle);
+  ///
+  /// Returns null when the selected delegate does not expose a native mtmd
+  /// video probe.
+  Future<bool?> supportsVideoRuntime(int mmContextHandle);
 }
 
 /// Model family reported by a backend text-to-speech implementation.

--- a/lib/src/backends/backend.dart
+++ b/lib/src/backends/backend.dart
@@ -190,6 +190,16 @@ abstract class BackendPromptSpeechToTextSupport {
   String? get promptSpeechToTextUnsupportedReason;
 }
 
+/// Internal backend probe for the loaded projector's native video runtime.
+///
+/// A true result only establishes that the native mtmd build and projector
+/// report video support. It does not make video publicly consumable until the
+/// Dart frame-ingestion and lifetime contract is implemented.
+abstract class BackendVideoRuntimeSupport {
+  /// Whether the loaded native mtmd context reports compiled video support.
+  Future<bool> supportsVideoRuntime(int mmContextHandle);
+}
+
 /// Model family reported by a backend text-to-speech implementation.
 enum BackendTextToSpeechModel {
   /// Qwen3-TTS audio generation through llama.cpp mtmd.

--- a/lib/src/backends/litert_lm/litert_lm_backend_web.dart
+++ b/lib/src/backends/litert_lm/litert_lm_backend_web.dart
@@ -198,6 +198,12 @@ class LiteRtLmBackend
     List<LlamaContentPart>? parts,
   }) async* {
     final engine = _requireContextHandle(contextHandle);
+    if (parts?.any((part) => part is LlamaVideoContent) ?? false) {
+      throw UnsupportedError(
+        'LiteRT-LM Web video input is not supported through llamadart. '
+        'Extract and send image frames instead.',
+      );
+    }
     if (_hasMediaParts(parts)) {
       throw UnsupportedError(
         'LiteRtLmBackend web does not support media parts.',
@@ -746,7 +752,10 @@ class LiteRtLmBackend
       return false;
     }
     return parts.any(
-      (part) => part is LlamaImageContent || part is LlamaAudioContent,
+      (part) =>
+          part is LlamaImageContent ||
+          part is LlamaAudioContent ||
+          part is LlamaVideoContent,
     );
   }
 

--- a/lib/src/backends/litert_lm/litert_lm_service.dart
+++ b/lib/src/backends/litert_lm/litert_lm_service.dart
@@ -734,7 +734,10 @@ class LiteRtLmService {
       return false;
     }
     return parts.any(
-      (part) => part is LlamaImageContent || part is LlamaAudioContent,
+      (part) =>
+          part is LlamaImageContent ||
+          part is LlamaAudioContent ||
+          part is LlamaVideoContent,
     );
   }
 
@@ -1184,6 +1187,11 @@ class LiteRtLmService {
           content.add(_nativeImageContent(part));
         case LlamaAudioContent():
           content.add(_nativeAudioContent(part));
+        case LlamaVideoContent():
+          throw UnsupportedError(
+            'LiteRT-LM video input is not supported through llamadart. '
+            'Extract and send image frames instead.',
+          );
         case LlamaThinkingContent():
           throw UnsupportedError(
             'LiteRtLmBackend native chat generation does not support thinking '

--- a/lib/src/backends/litert_lm/litert_lm_service.dart
+++ b/lib/src/backends/litert_lm/litert_lm_service.dart
@@ -20,6 +20,9 @@ import 'litert_lm_platform.dart';
 import 'litert_lm_runtime.dart';
 
 const int _gemma4DefaultVisualTokenBudget = 280;
+const String _liteRtLmVideoUnsupportedMessage =
+    'LiteRT-LM video input is not supported through llamadart. '
+    'Extract and send image frames instead.';
 
 /// Worker-owned service for the LiteRT-LM backend.
 ///
@@ -146,6 +149,9 @@ class LiteRtLmService {
     List<LlamaContentPart>? parts,
   }) async* {
     _checkContextHandle(contextHandle);
+    if (parts?.any((part) => part is LlamaVideoContent) ?? false) {
+      throw UnsupportedError(_liteRtLmVideoUnsupportedMessage);
+    }
     if (_hasMediaParts(parts)) {
       throw UnsupportedError('LiteRtLmBackend does not support media parts.');
     }
@@ -1188,10 +1194,7 @@ class LiteRtLmService {
         case LlamaAudioContent():
           content.add(_nativeAudioContent(part));
         case LlamaVideoContent():
-          throw UnsupportedError(
-            'LiteRT-LM video input is not supported through llamadart. '
-            'Extract and send image frames instead.',
-          );
+          throw UnsupportedError(_liteRtLmVideoUnsupportedMessage);
         case LlamaThinkingContent():
           throw UnsupportedError(
             'LiteRtLmBackend native chat generation does not support thinking '

--- a/lib/src/backends/llama_cpp/llama_cpp_backend.dart
+++ b/lib/src/backends/llama_cpp/llama_cpp_backend.dart
@@ -28,7 +28,8 @@ class NativeLlamaBackend
         BackendEmbeddings,
         BackendBatchEmbeddings,
         BackendStatePersistence,
-        BackendTextToSpeech {
+        BackendTextToSpeech,
+        BackendVideoRuntimeSupport {
   Isolate? _isolate;
   SendPort? _sendPort;
   Future<void>? _isolateStart;
@@ -664,6 +665,16 @@ class NativeLlamaBackend
     _sendPort!.send(SupportsAudioRequest(mmContextHandle, rp.sendPort));
     final res = await rp.first;
     rp.close();
+    return res as bool;
+  }
+
+  @override
+  Future<bool> supportsVideoRuntime(int mmContextHandle) async {
+    final rp = ReceivePort();
+    _sendPort!.send(SupportsVideoRequest(mmContextHandle, rp.sendPort));
+    final res = await rp.first;
+    rp.close();
+    if (res is ErrorResponse) throw _workerError(res);
     return res as bool;
   }
 

--- a/lib/src/backends/llama_cpp/llama_cpp_backend.dart
+++ b/lib/src/backends/llama_cpp/llama_cpp_backend.dart
@@ -669,7 +669,7 @@ class NativeLlamaBackend
   }
 
   @override
-  Future<bool> supportsVideoRuntime(int mmContextHandle) async {
+  Future<bool?> supportsVideoRuntime(int mmContextHandle) async {
     final rp = ReceivePort();
     _sendPort!.send(SupportsVideoRequest(mmContextHandle, rp.sendPort));
     final res = await rp.first;

--- a/lib/src/backends/llama_cpp/llama_cpp_service.dart
+++ b/lib/src/backends/llama_cpp/llama_cpp_service.dart
@@ -4028,8 +4028,15 @@ class LlamaCppService {
           parts?.any((part) => part is LlamaVideoContent) ?? false;
       if (hasVideoParts) {
         final mmHandle = _modelToMtmd[modelHandle];
-        final nativeRuntimeSupportsVideo =
-            mmHandle != null && supportsVideo(mmHandle);
+        if (mmHandle == null) {
+          throw LlamaUnsupportedException(
+            'Video input is unavailable because no multimodal projector is '
+            'loaded to inspect native runtime capability. Loading a compatible '
+            'projector enables inspection only; it does not enable public video '
+            'ingestion. Extract and send image frames instead.',
+          );
+        }
+        final nativeRuntimeSupportsVideo = supportsVideo(mmHandle);
         if (!nativeRuntimeSupportsVideo) {
           throw LlamaUnsupportedException(
             'Video input is unavailable because the loaded native mtmd '

--- a/lib/src/backends/llama_cpp/llama_cpp_service.dart
+++ b/lib/src/backends/llama_cpp/llama_cpp_service.dart
@@ -4036,7 +4036,8 @@ class LlamaCppService {
             'runtime/projector does not report compiled video support. Current '
             'llamadart artifacts build mtmd video support out; a future native '
             'package must enable LLAMA_SUBPROCESS/MTMD_VIDEO and provide '
-            'FFmpeg/ffprobe before video can be consumed.',
+            'FFmpeg/ffprobe before video can be consumed. Extract and send '
+            'image frames instead.',
           );
         }
         throw LlamaUnsupportedException(

--- a/lib/src/backends/llama_cpp/llama_cpp_service.dart
+++ b/lib/src/backends/llama_cpp/llama_cpp_service.dart
@@ -296,6 +296,8 @@ typedef _MtmdSupportVisionNative = Bool Function(Pointer<mtmd_context>);
 typedef _MtmdSupportVisionDart = bool Function(Pointer<mtmd_context>);
 typedef _MtmdSupportAudioNative = Bool Function(Pointer<mtmd_context>);
 typedef _MtmdSupportAudioDart = bool Function(Pointer<mtmd_context>);
+typedef _MtmdSupportVideoNative = Bool Function(Pointer<mtmd_context>);
+typedef _MtmdSupportVideoDart = bool Function(Pointer<mtmd_context>);
 typedef _MtmdBitmapFreeNative = Void Function(Pointer<mtmd_bitmap>);
 typedef _MtmdBitmapFreeDart = void Function(Pointer<mtmd_bitmap>);
 typedef _MtmdTokenizeNative =
@@ -648,6 +650,7 @@ class LlamaCppService {
   int _activeResolvedGpuLayers = 0;
   bool _mtmdFallbackLookupAttempted = false;
   bool _mtmdPrimarySymbolsUnavailable = false;
+  bool _mtmdVideoPrimarySymbolUnavailable = false;
   _MtmdApi? _mtmdFallbackApi;
   bool _reasoningBudgetApiLookupAttempted = false;
   _ReasoningBudgetApi? _reasoningBudgetApi;
@@ -4021,6 +4024,27 @@ class LlamaCppService {
       final hasMediaParts =
           parts?.any((p) => p is LlamaImageContent || p is LlamaAudioContent) ??
           false;
+      final hasVideoParts =
+          parts?.any((part) => part is LlamaVideoContent) ?? false;
+      if (hasVideoParts) {
+        final mmHandle = _modelToMtmd[modelHandle];
+        final nativeRuntimeSupportsVideo =
+            mmHandle != null && supportsVideo(mmHandle);
+        if (!nativeRuntimeSupportsVideo) {
+          throw LlamaUnsupportedException(
+            'Video input is unavailable because the loaded native mtmd '
+            'runtime/projector does not report compiled video support. Current '
+            'llamadart artifacts build mtmd video support out; a future native '
+            'package must enable LLAMA_SUBPROCESS/MTMD_VIDEO and provide '
+            'FFmpeg/ffprobe before video can be consumed.',
+          );
+        }
+        throw LlamaUnsupportedException(
+          'The loaded native runtime reports mtmd video support, but the Dart '
+          'frame-ingestion and video-context lifetime contract is not wired. '
+          'Extract and send image frames instead.',
+        );
+      }
       final thinkingBudgetConfig = _resolveLlamaCppThinkingBudgetConfig(
         params,
         hasMediaParts: hasMediaParts,
@@ -7252,6 +7276,32 @@ class LlamaCppService {
     return fallback?.supportsAudio(mmCtx) ?? false;
   }
 
+  /// Returns whether the active native mtmd build and projector report video.
+  ///
+  /// This is a behavioral probe. The helper symbol is present even when
+  /// `MTMD_VIDEO` was compiled out, so symbol lookup alone is not sufficient.
+  bool supportsVideo(int mmContextHandle) {
+    final mmCtx = _mtmdContexts[mmContextHandle];
+    if (mmCtx == null) {
+      return false;
+    }
+
+    if (!_mtmdPrimarySymbolsUnavailable &&
+        !_mtmdVideoPrimarySymbolUnavailable) {
+      try {
+        return mtmd_helper_support_video(mmCtx);
+      } on ArgumentError {
+        // Video helpers were added after the core mtmd surface. Do not mark
+        // working vision/audio symbols unavailable when only this optional
+        // probe is absent from an older library.
+        _mtmdVideoPrimarySymbolUnavailable = true;
+      }
+    }
+
+    final fallback = _resolveMtmdFallbackApi();
+    return fallback?.supportsVideo(mmCtx) ?? false;
+  }
+
   /// Discovers dedicated native text-to-speech support.
   BackendTextToSpeechCapabilities textToSpeechCapabilities(
     int contextHandle,
@@ -7992,6 +8042,7 @@ class _MtmdApi {
   final _MtmdBitmapInitFromAudioDart bitmapInitFromAudio;
   final _MtmdSupportVisionDart supportsVision;
   final _MtmdSupportAudioDart supportsAudio;
+  final _MtmdSupportVideoDart supportsVideo;
   final _MtmdBitmapFreeDart bitmapFree;
   final _MtmdTokenizeDart tokenize;
   final _MtmdHelperEvalChunksDart helperEvalChunks;
@@ -8010,6 +8061,7 @@ class _MtmdApi {
     required this.bitmapInitFromAudio,
     required this.supportsVision,
     required this.supportsAudio,
+    required this.supportsVideo,
     required this.bitmapFree,
     required this.tokenize,
     required this.helperEvalChunks,
@@ -8021,6 +8073,7 @@ class _MtmdApi {
     try {
       _MtmdLogSetDart? logSet;
       _MtmdLogSetDart? helperLogSet;
+      _MtmdSupportVideoDart supportsVideo = (_) => false;
       try {
         logSet = library.lookupFunction<_MtmdLogSetNative, _MtmdLogSetDart>(
           'mtmd_log_set',
@@ -8030,6 +8083,12 @@ class _MtmdApi {
         helperLogSet = library
             .lookupFunction<_MtmdLogSetNative, _MtmdLogSetDart>(
               'mtmd_helper_log_set',
+            );
+      } catch (_) {}
+      try {
+        supportsVideo = library
+            .lookupFunction<_MtmdSupportVideoNative, _MtmdSupportVideoDart>(
+              'mtmd_helper_support_video',
             );
       } catch (_) {}
 
@@ -8083,6 +8142,7 @@ class _MtmdApi {
             .lookupFunction<_MtmdSupportAudioNative, _MtmdSupportAudioDart>(
               'mtmd_support_audio',
             ),
+        supportsVideo: supportsVideo,
         bitmapFree: library
             .lookupFunction<_MtmdBitmapFreeNative, _MtmdBitmapFreeDart>(
               'mtmd_bitmap_free',

--- a/lib/src/backends/llama_cpp/worker.dart
+++ b/lib/src/backends/llama_cpp/worker.dart
@@ -385,6 +385,10 @@ void runLlamaWorkerForTesting(
             final supported = service.supportsAudio(message.mmContextHandle);
             message.sendPort.send(supported);
 
+          case SupportsVideoRequest():
+            final supported = service.supportsVideo(message.mmContextHandle);
+            message.sendPort.send(supported);
+
           case SystemInfoRequest():
             final info = service.getVramInfo();
             message.sendPort.send(SystemInfoResponse(info.total, info.free));

--- a/lib/src/backends/llama_cpp/worker_messages.dart
+++ b/lib/src/backends/llama_cpp/worker_messages.dart
@@ -301,6 +301,15 @@ class SupportsAudioRequest extends WorkerRequest {
   SupportsAudioRequest(this.mmContextHandle, super.sendPort);
 }
 
+/// Request to probe compiled native video support for a projector.
+class SupportsVideoRequest extends WorkerRequest {
+  /// The handle of the multimodal context.
+  final int mmContextHandle;
+
+  /// Creates a native video capability request.
+  SupportsVideoRequest(this.mmContextHandle, super.sendPort);
+}
+
 /// Request to discover dedicated native text-to-speech support.
 class TextToSpeechCapabilitiesRequest extends WorkerRequest {
   /// Handle of the loaded llama context.

--- a/lib/src/backends/native/native_backend.dart
+++ b/lib/src/backends/native/native_backend.dart
@@ -328,14 +328,14 @@ class NativeAutoBackend
   }
 
   @override
-  Future<bool> supportsVideoRuntime(int mmContextHandle) {
+  Future<bool?> supportsVideoRuntime(int mmContextHandle) {
     final delegate = _requireDelegate();
     if (delegate is BackendVideoRuntimeSupport) {
       return (delegate as BackendVideoRuntimeSupport).supportsVideoRuntime(
         mmContextHandle,
       );
     }
-    return Future<bool>.value(false);
+    return Future<bool?>.value();
   }
 
   @override

--- a/lib/src/backends/native/native_backend.dart
+++ b/lib/src/backends/native/native_backend.dart
@@ -35,7 +35,8 @@ class NativeAutoBackend
         BackendStatePersistenceSupport,
         BackendGrammarConstraintsSupport,
         BackendNativeChatGeneration,
-        BackendTextToSpeech {
+        BackendTextToSpeech,
+        BackendVideoRuntimeSupport {
   final LlamaBackend Function() _llamaCppFactory;
   final LlamaBackend Function() _liteRtLmFactory;
 
@@ -324,6 +325,17 @@ class NativeAutoBackend
   @override
   Future<bool> supportsAudio(int mmContextHandle) {
     return _requireDelegate().supportsAudio(mmContextHandle);
+  }
+
+  @override
+  Future<bool> supportsVideoRuntime(int mmContextHandle) {
+    final delegate = _requireDelegate();
+    if (delegate is BackendVideoRuntimeSupport) {
+      return (delegate as BackendVideoRuntimeSupport).supportsVideoRuntime(
+        mmContextHandle,
+      );
+    }
+    return Future<bool>.value(false);
   }
 
   @override

--- a/lib/src/backends/webgpu/webgpu_backend.dart
+++ b/lib/src/backends/webgpu/webgpu_backend.dart
@@ -1519,6 +1519,13 @@ class WebGpuLlamaBackend
     var index = 0;
 
     for (final part in parts) {
+      if (part is LlamaVideoContent) {
+        throw LlamaUnsupportedException(
+          'WebGPU video input is not supported through llamadart. Extract '
+          'and send image frames instead.',
+        );
+      }
+
       if (part is LlamaImageContent) {
         final jsPart = JSObject();
         jsPart.setProperty('type'.toJS, 'image'.toJS);

--- a/lib/src/core/engine/engine.dart
+++ b/lib/src/core/engine/engine.dart
@@ -621,6 +621,9 @@ class LlamaEngine {
     DateTime? templateNow,
   }) async* {
     _ensureReady();
+    await _rejectUnsupportedVideoInput(
+      messages.expand((message) => message.parts),
+    );
 
     // Keep tools available to template routing even with toolChoice.none,
     // matching llama.cpp behavior.
@@ -809,6 +812,7 @@ class LlamaEngine {
     List<LlamaContentPart>? parts,
   }) async* {
     _ensureReady();
+    await _rejectUnsupportedVideoInput(parts ?? const <LlamaContentPart>[]);
 
     try {
       final stream = backend.generate(
@@ -1164,6 +1168,53 @@ class LlamaEngine {
   Future<bool> get supportsAudio async =>
       _mmContextHandle != null &&
       await backend.supportsAudio(_mmContextHandle!);
+
+  /// Whether video input is consumable through the public Dart generation API.
+  ///
+  /// This remains false even if a custom native library was compiled with mtmd
+  /// video helpers: Dart does not yet own frame iteration, timestamp insertion,
+  /// cancellation, or lazy video-context cleanup. Use image frames explicitly
+  /// until that full contract is implemented.
+  Future<bool> get supportsVideo async => false;
+
+  Future<void> _rejectUnsupportedVideoInput(
+    Iterable<LlamaContentPart> parts,
+  ) async {
+    if (!parts.any((part) => part is LlamaVideoContent)) {
+      return;
+    }
+
+    var nativeRuntimeSupportsVideo = false;
+    final mmContextHandle = _mmContextHandle;
+    final candidate = backend;
+    if (mmContextHandle != null && candidate is BackendVideoRuntimeSupport) {
+      try {
+        nativeRuntimeSupportsVideo =
+            await (candidate as BackendVideoRuntimeSupport)
+                .supportsVideoRuntime(mmContextHandle);
+      } catch (_) {
+        // A failed optional capability probe is an unsupported result. The
+        // generation request below still receives the typed public error.
+      }
+    }
+
+    if (!nativeRuntimeSupportsVideo) {
+      throw LlamaUnsupportedException(
+        'Video input is not supported by the active backend/runtime. Current '
+        'llamadart native artifacts compile mtmd video support out; enabling '
+        'it requires LLAMA_SUBPROCESS plus FFmpeg/ffprobe packaging. Extract '
+        'and send image frames instead until companion-native packaging and '
+        'the Dart video-ingestion contract are implemented.',
+      );
+    }
+
+    throw LlamaUnsupportedException(
+      'The loaded native runtime reports mtmd video support, but video is not '
+      'yet consumable through llamadart. Dart frame iteration, timestamps, '
+      'cancellation, and video-context cleanup must be wired before path or '
+      'byte input can be accepted. Extract and send image frames instead.',
+    );
+  }
 
   /// Returns backend-native text-to-speech capabilities for the loaded model.
   ///

--- a/lib/src/core/engine/engine.dart
+++ b/lib/src/core/engine/engine.dart
@@ -1186,8 +1186,17 @@ class LlamaEngine {
 
     bool? nativeRuntimeSupportsVideo;
     final mmContextHandle = _mmContextHandle;
+    if (mmContextHandle == null) {
+      throw LlamaUnsupportedException(
+        'Video input is not consumable through llamadart, and no multimodal '
+        'projector is loaded to inspect native runtime capability. Loading a '
+        'compatible projector is required for that inspection but does not '
+        'enable public video ingestion. Extract and send image frames instead.',
+      );
+    }
+
     final candidate = backend;
-    if (mmContextHandle != null && candidate is BackendVideoRuntimeSupport) {
+    if (candidate is BackendVideoRuntimeSupport) {
       try {
         nativeRuntimeSupportsVideo =
             await (candidate as BackendVideoRuntimeSupport)

--- a/lib/src/core/engine/engine.dart
+++ b/lib/src/core/engine/engine.dart
@@ -1188,10 +1188,12 @@ class LlamaEngine {
     final mmContextHandle = _mmContextHandle;
     if (mmContextHandle == null) {
       throw LlamaUnsupportedException(
-        'Video input is not consumable through llamadart, and no multimodal '
-        'projector is loaded to inspect native runtime capability. Loading a '
-        'compatible projector is required for that inspection but does not '
-        'enable public video ingestion. Extract and send image frames instead.',
+        'Video input is not consumable through llamadart. Without an active '
+        'multimodal context, or on a backend that does not expose one, native '
+        'video capability cannot be inspected. Loading a compatible projector '
+        'on a supported native backend only enables that inspection; it does '
+        'not enable public video ingestion. Extract and send image frames '
+        'instead.',
       );
     }
 

--- a/lib/src/core/engine/engine.dart
+++ b/lib/src/core/engine/engine.dart
@@ -1184,7 +1184,7 @@ class LlamaEngine {
       return;
     }
 
-    var nativeRuntimeSupportsVideo = false;
+    bool? nativeRuntimeSupportsVideo;
     final mmContextHandle = _mmContextHandle;
     final candidate = backend;
     if (mmContextHandle != null && candidate is BackendVideoRuntimeSupport) {
@@ -1196,6 +1196,14 @@ class LlamaEngine {
         // A failed optional capability probe is an unsupported result. The
         // generation request below still receives the typed public error.
       }
+    }
+
+    if (nativeRuntimeSupportsVideo == null) {
+      throw LlamaUnsupportedException(
+        'Video input is not supported by the active backend. It does not '
+        'expose a consumable video transport or runtime capability probe. '
+        'Extract and send image frames instead.',
+      );
     }
 
     if (!nativeRuntimeSupportsVideo) {

--- a/lib/src/core/models/chat/content_part.dart
+++ b/lib/src/core/models/chat/content_part.dart
@@ -4,7 +4,7 @@ import 'dart:typed_data';
 /// Base class for all content types in a message.
 ///
 /// Multi-modality allows a single message to contain different types of data,
-/// such as text, images, or audio.
+/// such as text, images, audio, or video.
 sealed class LlamaContentPart {
   /// Base constructor for content parts.
   const LlamaContentPart();
@@ -105,6 +105,37 @@ class LlamaAudioContent extends LlamaContentPart {
             ? base64Encode(samples!.buffer.asUint8List())
             : (bytes != null ? base64Encode(bytes!) : ''),
         'format': samples != null ? 'pcm' : 'audio',
+      },
+    };
+  }
+}
+
+/// A part of a message containing encoded video input.
+///
+/// Video is represented explicitly so unsupported requests fail with a typed,
+/// actionable error instead of being flattened into text or treated as an
+/// image. The current packaged runtimes do not expose a consumable video-input
+/// pipeline; check [LlamaEngine.supportsVideo] before generation.
+class LlamaVideoContent extends LlamaContentPart {
+  /// Encoded video bytes, such as MP4 or WebM data.
+  final Uint8List? bytes;
+
+  /// Local filesystem path to an encoded video file.
+  final String? path;
+
+  /// Creates a video content part.
+  ///
+  /// Either [path] or [bytes] should be provided. Current runtimes reject both
+  /// forms until native video packaging and Dart frame ingestion are complete.
+  const LlamaVideoContent({this.bytes, this.path});
+
+  @override
+  Map<String, dynamic> toJson() {
+    return {
+      'type': 'input_video',
+      'input_video': {
+        'data': bytes == null ? '' : base64Encode(bytes!),
+        if (path != null) 'path': path,
       },
     };
   }

--- a/lib/src/core/models/chat/content_part.dart
+++ b/lib/src/core/models/chat/content_part.dart
@@ -128,11 +128,16 @@ class LlamaVideoContent extends LlamaContentPart {
   /// At least one of [path] or [bytes] must be provided. Current runtimes reject
   /// both forms until native video packaging and Dart frame ingestion are
   /// complete.
-  const LlamaVideoContent({this.bytes, this.path})
-    : assert(
-        bytes != null || path != null,
-        'LlamaVideoContent requires bytes or a path.',
-      );
+  ///
+  /// Throws [ArgumentError] when neither source is provided.
+  factory LlamaVideoContent({Uint8List? bytes, String? path}) {
+    if (bytes == null && path == null) {
+      throw ArgumentError('LlamaVideoContent requires bytes or a path.');
+    }
+    return LlamaVideoContent._(bytes: bytes, path: path);
+  }
+
+  const LlamaVideoContent._({this.bytes, this.path});
 
   @override
   Map<String, dynamic> toJson() {

--- a/lib/src/core/models/chat/content_part.dart
+++ b/lib/src/core/models/chat/content_part.dart
@@ -125,12 +125,20 @@ class LlamaVideoContent extends LlamaContentPart {
 
   /// Creates a video content part.
   ///
-  /// Either [path] or [bytes] should be provided. Current runtimes reject both
-  /// forms until native video packaging and Dart frame ingestion are complete.
-  const LlamaVideoContent({this.bytes, this.path});
+  /// At least one of [path] or [bytes] must be provided. Current runtimes reject
+  /// both forms until native video packaging and Dart frame ingestion are
+  /// complete.
+  const LlamaVideoContent({this.bytes, this.path})
+    : assert(
+        bytes != null || path != null,
+        'LlamaVideoContent requires bytes or a path.',
+      );
 
   @override
   Map<String, dynamic> toJson() {
+    if (bytes == null && path == null) {
+      throw ArgumentError('LlamaVideoContent requires bytes or a path.');
+    }
     return {
       'type': 'input_video',
       'input_video': {

--- a/test/integration/backends/llama_cpp/native_symbol_integration_test.dart
+++ b/test/integration/backends/llama_cpp/native_symbol_integration_test.dart
@@ -143,6 +143,8 @@ typedef _MtmdHelperBitmapInitFromBufDart =
     );
 typedef _MtmdBitmapFreeNative = ffi.Void Function(ffi.Pointer<mtmd_bitmap>);
 typedef _MtmdBitmapFreeDart = void Function(ffi.Pointer<mtmd_bitmap>);
+typedef _MtmdSupportVideoNative = ffi.Bool Function(ffi.Pointer<mtmd_context>);
+typedef _MtmdSupportVideoDart = bool Function(ffi.Pointer<mtmd_context>);
 
 @ffi.Native<ffi.Void Function(ffi.Pointer<llama_dart_mtp>)>(
   assetId: _llamadartWrapperAssetId,
@@ -850,6 +852,25 @@ void main() {
         reason: 'Expected a native library exporting mtmd symbols.',
       );
       _expectDynamicLibraryExports(libraryFile!, _b10514MtmdSymbols);
+    });
+
+    test('pinned b10545 artifact behavior reports video compiled out', () {
+      final libraryFile =
+          _mtmdFallbackLibraryFile() ?? _llamadartWrapperLibraryFileOrNull();
+      expect(
+        libraryFile,
+        isNotNull,
+        reason: 'Expected a native library exporting mtmd symbols.',
+      );
+      final library = ffi.DynamicLibrary.open(libraryFile!.path);
+      final supportsVideo = library
+          .lookupFunction<_MtmdSupportVideoNative, _MtmdSupportVideoDart>(
+            'mtmd_helper_support_video',
+          );
+
+      // The helper symbol is exported even when MTMD_VIDEO is off. Calling it
+      // is the behavioral compile-capability probe; symbol presence is not.
+      expect(supportsVideo(ffi.nullptr.cast<mtmd_context>()), isFalse);
     });
 
     test('Verify core llama symbols are resolvable', () {

--- a/test/unit/backends/litert_lm/litert_lm_backend_web_test.dart
+++ b/test/unit/backends/litert_lm/litert_lm_backend_web_test.dart
@@ -465,7 +465,7 @@ void main() {
           contextHandle,
           'describe',
           const GenerationParams(),
-          parts: const [LlamaVideoContent(path: '/tmp/clip.mp4')],
+          parts: [LlamaVideoContent(path: '/tmp/clip.mp4')],
         ),
         emitsError(
           isA<UnsupportedError>().having(

--- a/test/unit/backends/litert_lm/litert_lm_backend_web_test.dart
+++ b/test/unit/backends/litert_lm/litert_lm_backend_web_test.dart
@@ -9,6 +9,7 @@ import 'package:llamadart/src/backends/litert_lm/litert_lm_backend_web.dart';
 import 'package:llamadart/src/core/engine/engine.dart';
 import 'package:llamadart/src/core/models/chat/chat_message.dart';
 import 'package:llamadart/src/core/models/chat/chat_role.dart';
+import 'package:llamadart/src/core/models/chat/content_part.dart';
 import 'package:llamadart/src/core/models/config/gpu_backend.dart';
 import 'package:llamadart/src/core/models/config/log_level.dart';
 import 'package:llamadart/src/core/models/inference/generation_params.dart';
@@ -437,6 +438,40 @@ void main() {
             (error) => error.message.toString(),
             'message',
             contains('thinkingBudget'),
+          ),
+        ),
+      );
+    } finally {
+      await backend.dispose();
+    }
+  });
+
+  test('rejects video media with actionable fallback guidance', () async {
+    _installFakeEngine(chunks: <JSAny?>[]);
+
+    final backend = LiteRtLmBackend();
+    try {
+      final modelHandle = await backend.modelLoadFromUrl(
+        'https://example.com/model.litertlm',
+        const ModelParams(),
+      );
+      final contextHandle = await backend.contextCreate(
+        modelHandle,
+        const ModelParams(),
+      );
+
+      await expectLater(
+        backend.generate(
+          contextHandle,
+          'describe',
+          const GenerationParams(),
+          parts: const [LlamaVideoContent(path: '/tmp/clip.mp4')],
+        ),
+        emitsError(
+          isA<UnsupportedError>().having(
+            (error) => error.message.toString(),
+            'message',
+            contains('image frames'),
           ),
         ),
       );

--- a/test/unit/backends/litert_lm/litert_lm_service_test.dart
+++ b/test/unit/backends/litert_lm/litert_lm_service_test.dart
@@ -1269,6 +1269,15 @@ void main() {
           ),
         );
 
+        await expectMediaError(
+          const [LlamaVideoContent(path: '/tmp/clip.mp4')],
+          isA<UnsupportedError>().having(
+            (error) => error.message.toString(),
+            'message',
+            contains('Extract and send image frames'),
+          ),
+        );
+
         expect(fakeClient.initializeStarted.isCompleted, isFalse);
         expect(fakeClient.createConversationCount, 0);
         expect(fakeClient.generateCount, 0);

--- a/test/unit/backends/litert_lm/litert_lm_service_test.dart
+++ b/test/unit/backends/litert_lm/litert_lm_service_test.dart
@@ -686,6 +686,22 @@ void main() {
         ),
       );
 
+      await expectLater(
+        service.generate(
+          contextHandle,
+          'describe',
+          const GenerationParams(),
+          parts: const [LlamaVideoContent(path: '/tmp/clip.mp4')],
+        ),
+        emitsError(
+          isA<UnsupportedError>().having(
+            (error) => error.message.toString(),
+            'message',
+            contains('Extract and send image frames'),
+          ),
+        ),
+      );
+
       expect(fakeClient.initializeStarted.isCompleted, isFalse);
       expect(fakeClient.createConversationCount, 0);
       expect(fakeClient.generateCount, 0);

--- a/test/unit/backends/litert_lm/litert_lm_service_test.dart
+++ b/test/unit/backends/litert_lm/litert_lm_service_test.dart
@@ -691,7 +691,7 @@ void main() {
           contextHandle,
           'describe',
           const GenerationParams(),
-          parts: const [LlamaVideoContent(path: '/tmp/clip.mp4')],
+          parts: [LlamaVideoContent(path: '/tmp/clip.mp4')],
         ),
         emitsError(
           isA<UnsupportedError>().having(
@@ -1286,7 +1286,7 @@ void main() {
         );
 
         await expectMediaError(
-          const [LlamaVideoContent(path: '/tmp/clip.mp4')],
+          [LlamaVideoContent(path: '/tmp/clip.mp4')],
           isA<UnsupportedError>().having(
             (error) => error.message.toString(),
             'message',

--- a/test/unit/backends/llama_cpp/llama_cpp_backend_test.dart
+++ b/test/unit/backends/llama_cpp/llama_cpp_backend_test.dart
@@ -293,6 +293,7 @@ void main() {
       expect(mmHandle, 33);
       expect(await backend.supportsAudio(mmHandle!), isTrue);
       expect(await backend.supportsVision(mmHandle), isFalse);
+      expect(await backend.supportsVideoRuntime(mmHandle), isFalse);
       await backend.multimodalContextFree(mmHandle);
       expect(
         () => backend.multimodalContextCreate(-1, 'mmproj.gguf'),
@@ -635,6 +636,8 @@ class _FakeWorkerHarness {
         case SupportsAudioRequest():
           message.sendPort.send(true);
         case SupportsVisionRequest():
+          message.sendPort.send(false);
+        case SupportsVideoRequest():
           message.sendPort.send(false);
         case TextToSpeechCapabilitiesRequest():
           message.sendPort.send(

--- a/test/unit/backends/native/native_backend_test.dart
+++ b/test/unit/backends/native/native_backend_test.dart
@@ -402,7 +402,8 @@ void main() {
     () async {
       final litert = _FakeBackend(handle: 22)
         ..vramInfo = (total: 2048, free: 1024)
-        ..chatTemplateResponse = 'templated';
+        ..chatTemplateResponse = 'templated'
+        ..videoRuntimeSupport = null;
       final backend = NativeAutoBackend(
         llamaCppFactory: () => _FakeBackend(handle: 11),
         liteRtLmFactory: () => litert,
@@ -419,7 +420,7 @@ void main() {
         await backend.multimodalContextFree(222);
         expect(await backend.supportsVision(222), isTrue);
         expect(await backend.supportsAudio(222), isFalse);
-        expect(await backend.supportsVideoRuntime(222), isFalse);
+        expect(await backend.supportsVideoRuntime(222), isNull);
         expect(
           await backend.applyChatTemplate(
             22,
@@ -921,6 +922,7 @@ class _FakeBackend
   int? lastSupportsVisionHandle;
   int? lastSupportsAudioHandle;
   int? lastSupportsVideoHandle;
+  bool? videoRuntimeSupport = false;
   String chatTemplateResponse = '';
   List<Map<String, dynamic>>? lastChatTemplateMessages;
   String? lastChatTemplateCustomTemplate;
@@ -1028,9 +1030,9 @@ class _FakeBackend
   }
 
   @override
-  Future<bool> supportsVideoRuntime(int mmContextHandle) async {
+  Future<bool?> supportsVideoRuntime(int mmContextHandle) async {
     lastSupportsVideoHandle = mmContextHandle;
-    return false;
+    return videoRuntimeSupport;
   }
 
   @override

--- a/test/unit/backends/native/native_backend_test.dart
+++ b/test/unit/backends/native/native_backend_test.dart
@@ -419,6 +419,7 @@ void main() {
         await backend.multimodalContextFree(222);
         expect(await backend.supportsVision(222), isTrue);
         expect(await backend.supportsAudio(222), isFalse);
+        expect(await backend.supportsVideoRuntime(222), isFalse);
         expect(
           await backend.applyChatTemplate(
             22,
@@ -894,7 +895,8 @@ class _FakeBackend
     implements
         LlamaBackend,
         BackendGrammarConstraintsSupport,
-        BackendGpuEnumeration {
+        BackendGpuEnumeration,
+        BackendVideoRuntimeSupport {
   final int handle;
   bool grammarConstraintsSupported = true;
   final List<String> loadedPaths = <String>[];
@@ -918,6 +920,7 @@ class _FakeBackend
   int? lastMultimodalFreeHandle;
   int? lastSupportsVisionHandle;
   int? lastSupportsAudioHandle;
+  int? lastSupportsVideoHandle;
   String chatTemplateResponse = '';
   List<Map<String, dynamic>>? lastChatTemplateMessages;
   String? lastChatTemplateCustomTemplate;
@@ -1021,6 +1024,12 @@ class _FakeBackend
   @override
   Future<bool> supportsAudio(int mmContextHandle) async {
     lastSupportsAudioHandle = mmContextHandle;
+    return false;
+  }
+
+  @override
+  Future<bool> supportsVideoRuntime(int mmContextHandle) async {
+    lastSupportsVideoHandle = mmContextHandle;
     return false;
   }
 

--- a/test/unit/backends/webgpu/webgpu_backend_test.dart
+++ b/test/unit/backends/webgpu/webgpu_backend_test.dart
@@ -1902,7 +1902,7 @@ void main() {
           1,
           'Describe this video',
           const GenerationParams(),
-          parts: const <LlamaContentPart>[
+          parts: <LlamaContentPart>[
             LlamaVideoContent(path: '/tmp/clip.mp4'),
           ],
         ),

--- a/test/unit/backends/webgpu/webgpu_backend_test.dart
+++ b/test/unit/backends/webgpu/webgpu_backend_test.dart
@@ -1891,6 +1891,31 @@ void main() {
       );
     });
 
+    test('rejects video parts instead of silently dropping them', () async {
+      await backend.modelLoadFromUrl(
+        'https://example.com/model.gguf',
+        const ModelParams(),
+      );
+
+      expect(
+        () => backend.generate(
+          1,
+          'Describe this video',
+          const GenerationParams(),
+          parts: const <LlamaContentPart>[
+            LlamaVideoContent(path: '/tmp/clip.mp4'),
+          ],
+        ),
+        throwsA(
+          isA<LlamaUnsupportedException>().having(
+            (error) => error.message,
+            'message',
+            contains('image frames'),
+          ),
+        ),
+      );
+    });
+
     test('creates and uses multimodal context with media parts', () async {
       await backend.modelLoadFromUrl(
         'https://example.com/model.gguf',

--- a/test/unit/backends/webgpu/webgpu_backend_test.dart
+++ b/test/unit/backends/webgpu/webgpu_backend_test.dart
@@ -1902,9 +1902,7 @@ void main() {
           1,
           'Describe this video',
           const GenerationParams(),
-          parts: <LlamaContentPart>[
-            LlamaVideoContent(path: '/tmp/clip.mp4'),
-          ],
+          parts: <LlamaContentPart>[LlamaVideoContent(path: '/tmp/clip.mp4')],
         ),
         throwsA(
           isA<LlamaUnsupportedException>().having(

--- a/test/unit/core/engine/engine_test.dart
+++ b/test/unit/core/engine/engine_test.dart
@@ -1491,6 +1491,37 @@ void main() {
       expect(backend.lastGenerationPrompt, isNull);
     });
 
+    test(
+      'video input without projector explains inspection boundary',
+      () async {
+        await engine.loadModel('qwen-test.gguf');
+
+        await expectLater(
+          engine
+              .generate(
+                'describe',
+                parts: const [LlamaVideoContent(path: '/tmp/clip.mp4')],
+              )
+              .drain<void>(),
+          throwsA(
+            isA<LlamaUnsupportedException>()
+                .having(
+                  (error) => error.message,
+                  'message',
+                  contains('no multimodal projector'),
+                )
+                .having(
+                  (error) => error.message,
+                  'message',
+                  contains('does not enable public video ingestion'),
+                ),
+          ),
+        );
+        expect(backend.lastVideoProbeHandle, isNull);
+        expect(backend.lastGenerationPrompt, isNull);
+      },
+    );
+
     test('video input remains unavailable when native probe is true', () async {
       final videoBackend = MockLlamaBackend(nativeVideoRuntimeSupported: true);
       final videoEngine = LlamaEngine(videoBackend);

--- a/test/unit/core/engine/engine_test.dart
+++ b/test/unit/core/engine/engine_test.dart
@@ -62,7 +62,7 @@ class MockLlamaBackend
   Future<void>? modelLoadDelay;
   Future<void>? modelLoadFromUrlDelay;
   Future<void>? contextFreeDelay;
-  final bool nativeVideoRuntimeSupported;
+  final bool? nativeVideoRuntimeSupported;
   final Object? videoProbeError;
   int? lastVideoProbeHandle;
 
@@ -245,7 +245,7 @@ class MockLlamaBackend
   Future<bool> supportsAudio(int mmContextHandle) async => false;
 
   @override
-  Future<bool> supportsVideoRuntime(int mmContextHandle) async {
+  Future<bool?> supportsVideoRuntime(int mmContextHandle) async {
     lastVideoProbeHandle = mmContextHandle;
     if (videoProbeError case final error?) {
       throw error;
@@ -1521,38 +1521,68 @@ void main() {
       }
     });
 
-    test(
-      'video probe failure still produces typed unsupported error',
-      () async {
-        final videoBackend = MockLlamaBackend(
-          videoProbeError: StateError('missing optional probe'),
-        );
-        final videoEngine = LlamaEngine(videoBackend);
-        try {
-          await videoEngine.loadModel('qwen-test.gguf');
-          await videoEngine.loadMultimodalProjector('proj.gguf');
+    test('backend without native probe receives generic guidance', () async {
+      final videoBackend = MockLlamaBackend(nativeVideoRuntimeSupported: null);
+      final videoEngine = LlamaEngine(videoBackend);
+      try {
+        await videoEngine.loadModel('qwen-test.gguf');
+        await videoEngine.loadMultimodalProjector('proj.gguf');
 
-          await expectLater(
-            videoEngine
-                .generate(
-                  'describe',
-                  parts: const [LlamaVideoContent(path: '/tmp/clip.mp4')],
+        await expectLater(
+          videoEngine
+              .generate(
+                'describe',
+                parts: const [LlamaVideoContent(path: '/tmp/clip.mp4')],
+              )
+              .drain<void>(),
+          throwsA(
+            isA<LlamaUnsupportedException>()
+                .having(
+                  (error) => error.message,
+                  'message',
+                  contains('active backend'),
                 )
-                .drain<void>(),
-            throwsA(
-              isA<LlamaUnsupportedException>().having(
-                (error) => error.message,
-                'message',
-                contains('FFmpeg'),
-              ),
+                .having(
+                  (error) => error.message,
+                  'message',
+                  isNot(contains('FFmpeg')),
+                ),
+          ),
+        );
+      } finally {
+        await videoEngine.dispose();
+      }
+    });
+
+    test('video probe failure still produces generic typed error', () async {
+      final videoBackend = MockLlamaBackend(
+        videoProbeError: StateError('missing optional probe'),
+      );
+      final videoEngine = LlamaEngine(videoBackend);
+      try {
+        await videoEngine.loadModel('qwen-test.gguf');
+        await videoEngine.loadMultimodalProjector('proj.gguf');
+
+        await expectLater(
+          videoEngine
+              .generate(
+                'describe',
+                parts: const [LlamaVideoContent(path: '/tmp/clip.mp4')],
+              )
+              .drain<void>(),
+          throwsA(
+            isA<LlamaUnsupportedException>().having(
+              (error) => error.message,
+              'message',
+              contains('active backend'),
             ),
-          );
-          expect(videoBackend.lastGenerationPrompt, isNull);
-        } finally {
-          await videoEngine.dispose();
-        }
-      },
-    );
+          ),
+        );
+        expect(videoBackend.lastGenerationPrompt, isNull);
+      } finally {
+        await videoEngine.dispose();
+      }
+    });
 
     test(
       'multimodal projector can be unloaded without unloading model',

--- a/test/unit/core/engine/engine_test.dart
+++ b/test/unit/core/engine/engine_test.dart
@@ -1024,11 +1024,10 @@ void main() {
             reason: testCase.label,
           );
           expect(downloadManager.ensureModelCalls, 2, reason: testCase.label);
-          expect(
-            downloadManager.sources.map((source) => source.cacheKey),
-            [testCase.modelSource.cacheKey, testCase.projectorSource.cacheKey],
-            reason: testCase.label,
-          );
+          expect(downloadManager.sources.map((source) => source.cacheKey), [
+            testCase.modelSource.cacheKey,
+            testCase.projectorSource.cacheKey,
+          ], reason: testCase.label);
         }
       },
     );

--- a/test/unit/core/engine/engine_test.dart
+++ b/test/unit/core/engine/engine_test.dart
@@ -1508,7 +1508,12 @@ void main() {
                 .having(
                   (error) => error.message,
                   'message',
-                  contains('no multimodal projector'),
+                  contains('Without an active multimodal context'),
+                )
+                .having(
+                  (error) => error.message,
+                  'message',
+                  contains('backend that does not expose one'),
                 )
                 .having(
                   (error) => error.message,

--- a/test/unit/core/engine/engine_test.dart
+++ b/test/unit/core/engine/engine_test.dart
@@ -3,9 +3,15 @@ import 'dart:convert';
 import 'dart:math' as math;
 import 'package:test/test.dart';
 import 'package:llamadart/llamadart.dart';
+import 'package:llamadart/src/backends/backend.dart'
+    show BackendVideoRuntimeSupport;
 
 class MockLlamaBackend
-    implements LlamaBackend, BackendAvailability, BackendRuntimeDiagnostics {
+    implements
+        LlamaBackend,
+        BackendAvailability,
+        BackendRuntimeDiagnostics,
+        BackendVideoRuntimeSupport {
   MockLlamaBackend({
     this.backendName = 'Mock',
     this.urlLoadingSupported = false,
@@ -19,6 +25,8 @@ class MockLlamaBackend
     this.modelLoadDelay,
     this.modelLoadFromUrlDelay,
     this.contextFreeDelay,
+    this.nativeVideoRuntimeSupported = false,
+    this.videoProbeError,
   });
 
   bool _isReady = false;
@@ -54,6 +62,9 @@ class MockLlamaBackend
   Future<void>? modelLoadDelay;
   Future<void>? modelLoadFromUrlDelay;
   Future<void>? contextFreeDelay;
+  final bool nativeVideoRuntimeSupported;
+  final Object? videoProbeError;
+  int? lastVideoProbeHandle;
 
   @override
   bool get isReady => _isReady;
@@ -232,6 +243,15 @@ class MockLlamaBackend
 
   @override
   Future<bool> supportsAudio(int mmContextHandle) async => false;
+
+  @override
+  Future<bool> supportsVideoRuntime(int mmContextHandle) async {
+    lastVideoProbeHandle = mmContextHandle;
+    if (videoProbeError case final error?) {
+      throw error;
+    }
+    return nativeVideoRuntimeSupported;
+  }
 
   @override
   Future<({int total, int free})> getVramInfo() async =>
@@ -1004,10 +1024,11 @@ void main() {
             reason: testCase.label,
           );
           expect(downloadManager.ensureModelCalls, 2, reason: testCase.label);
-          expect(downloadManager.sources.map((source) => source.cacheKey), [
-            testCase.modelSource.cacheKey,
-            testCase.projectorSource.cacheKey,
-          ], reason: testCase.label);
+          expect(
+            downloadManager.sources.map((source) => source.cacheKey),
+            [testCase.modelSource.cacheKey, testCase.projectorSource.cacheKey],
+            reason: testCase.label,
+          );
         }
       },
     );
@@ -1443,7 +1464,96 @@ void main() {
       await engine.loadMultimodalProjector('proj.gguf');
       expect(await engine.supportsVision, true);
       expect(await engine.supportsAudio, false);
+      expect(await engine.supportsVideo, false);
     });
+
+    test('video input fails with compiled-runtime guidance', () async {
+      await engine.loadModel('qwen-test.gguf');
+      await engine.loadMultimodalProjector('proj.gguf');
+
+      await expectLater(
+        engine.create(const [
+          LlamaChatMessage.withContent(
+            role: LlamaChatRole.user,
+            content: [LlamaVideoContent(path: '/tmp/clip.mp4')],
+          ),
+        ]).drain<void>(),
+        throwsA(
+          isA<LlamaUnsupportedException>()
+              .having((error) => error.message, 'message', contains('FFmpeg'))
+              .having(
+                (error) => error.message,
+                'message',
+                contains('image frames'),
+              ),
+        ),
+      );
+      expect(backend.lastVideoProbeHandle, 2);
+      expect(backend.lastGenerationPrompt, isNull);
+    });
+
+    test('video input remains unavailable when native probe is true', () async {
+      final videoBackend = MockLlamaBackend(nativeVideoRuntimeSupported: true);
+      final videoEngine = LlamaEngine(videoBackend);
+      try {
+        await videoEngine.loadModel('qwen-test.gguf');
+        await videoEngine.loadMultimodalProjector('proj.gguf');
+
+        expect(await videoEngine.supportsVideo, isFalse);
+        await expectLater(
+          videoEngine
+              .generate(
+                'describe',
+                parts: const [LlamaVideoContent(path: '/tmp/clip.mp4')],
+              )
+              .drain<void>(),
+          throwsA(
+            isA<LlamaUnsupportedException>().having(
+              (error) => error.message,
+              'message',
+              contains('frame iteration'),
+            ),
+          ),
+        );
+        expect(videoBackend.lastVideoProbeHandle, 2);
+        expect(videoBackend.lastGenerationPrompt, isNull);
+      } finally {
+        await videoEngine.dispose();
+      }
+    });
+
+    test(
+      'video probe failure still produces typed unsupported error',
+      () async {
+        final videoBackend = MockLlamaBackend(
+          videoProbeError: StateError('missing optional probe'),
+        );
+        final videoEngine = LlamaEngine(videoBackend);
+        try {
+          await videoEngine.loadModel('qwen-test.gguf');
+          await videoEngine.loadMultimodalProjector('proj.gguf');
+
+          await expectLater(
+            videoEngine
+                .generate(
+                  'describe',
+                  parts: const [LlamaVideoContent(path: '/tmp/clip.mp4')],
+                )
+                .drain<void>(),
+            throwsA(
+              isA<LlamaUnsupportedException>().having(
+                (error) => error.message,
+                'message',
+                contains('FFmpeg'),
+              ),
+            ),
+          );
+          expect(videoBackend.lastGenerationPrompt, isNull);
+        } finally {
+          await videoEngine.dispose();
+        }
+      },
+    );
 
     test(
       'multimodal projector can be unloaded without unloading model',

--- a/test/unit/core/engine/engine_test.dart
+++ b/test/unit/core/engine/engine_test.dart
@@ -1471,7 +1471,7 @@ void main() {
       await engine.loadMultimodalProjector('proj.gguf');
 
       await expectLater(
-        engine.create(const [
+        engine.create([
           LlamaChatMessage.withContent(
             role: LlamaChatRole.user,
             content: [LlamaVideoContent(path: '/tmp/clip.mp4')],
@@ -1500,7 +1500,7 @@ void main() {
           engine
               .generate(
                 'describe',
-                parts: const [LlamaVideoContent(path: '/tmp/clip.mp4')],
+                parts: [LlamaVideoContent(path: '/tmp/clip.mp4')],
               )
               .drain<void>(),
           throwsA(
@@ -1539,7 +1539,7 @@ void main() {
           videoEngine
               .generate(
                 'describe',
-                parts: const [LlamaVideoContent(path: '/tmp/clip.mp4')],
+                parts: [LlamaVideoContent(path: '/tmp/clip.mp4')],
               )
               .drain<void>(),
           throwsA(
@@ -1568,7 +1568,7 @@ void main() {
           videoEngine
               .generate(
                 'describe',
-                parts: const [LlamaVideoContent(path: '/tmp/clip.mp4')],
+                parts: [LlamaVideoContent(path: '/tmp/clip.mp4')],
               )
               .drain<void>(),
           throwsA(
@@ -1603,7 +1603,7 @@ void main() {
           videoEngine
               .generate(
                 'describe',
-                parts: const [LlamaVideoContent(path: '/tmp/clip.mp4')],
+                parts: [LlamaVideoContent(path: '/tmp/clip.mp4')],
               )
               .drain<void>(),
           throwsA(

--- a/test/unit/core/models/chat/content_part_test.dart
+++ b/test/unit/core/models/chat/content_part_test.dart
@@ -27,4 +27,8 @@ void main() {
       },
     );
   });
+
+  test('LlamaVideoContent requires a path or bytes', () {
+    expect(() => LlamaVideoContent(), throwsA(isA<AssertionError>()));
+  });
 }

--- a/test/unit/core/models/chat/content_part_test.dart
+++ b/test/unit/core/models/chat/content_part_test.dart
@@ -15,7 +15,7 @@ void main() {
   });
 
   test('LlamaVideoContent keeps path and bytes explicit', () {
-    expect(const LlamaVideoContent(path: '/tmp/clip.mp4').toJson(), {
+    expect(LlamaVideoContent(path: '/tmp/clip.mp4').toJson(), {
       'type': 'input_video',
       'input_video': {'data': '', 'path': '/tmp/clip.mp4'},
     });
@@ -29,6 +29,6 @@ void main() {
   });
 
   test('LlamaVideoContent requires a path or bytes', () {
-    expect(() => LlamaVideoContent(), throwsA(isA<AssertionError>()));
+    expect(() => LlamaVideoContent(), throwsArgumentError);
   });
 }

--- a/test/unit/core/models/chat/content_part_test.dart
+++ b/test/unit/core/models/chat/content_part_test.dart
@@ -1,3 +1,5 @@
+import 'dart:typed_data';
+
 import 'package:llamadart/src/core/models/chat/content_part.dart';
 import 'package:test/test.dart';
 
@@ -10,5 +12,19 @@ void main() {
   test('LlamaThinkingContent serializes to JSON', () {
     const part = LlamaThinkingContent('reasoning');
     expect(part.toJson(), {'type': 'thinking', 'thinking': 'reasoning'});
+  });
+
+  test('LlamaVideoContent keeps path and bytes explicit', () {
+    expect(const LlamaVideoContent(path: '/tmp/clip.mp4').toJson(), {
+      'type': 'input_video',
+      'input_video': {'data': '', 'path': '/tmp/clip.mp4'},
+    });
+    expect(
+      LlamaVideoContent(bytes: Uint8List.fromList(<int>[1, 2, 3])).toJson(),
+      {
+        'type': 'input_video',
+        'input_video': {'data': 'AQID'},
+      },
+    );
   });
 }

--- a/website/docs/changelog/recent-releases.md
+++ b/website/docs/changelog/recent-releases.md
@@ -9,6 +9,13 @@ For canonical full release notes, use:
 
 ## Unreleased
 
+- Made native video-input capability truthful without claiming end-to-end
+  support. Explicit video content now receives a typed actionable rejection,
+  public capability remains false, and the native probe calls
+  `mtmd_helper_support_video` because helper symbols are exported even when
+  video is compiled out. Full support still requires companion FFmpeg/ffprobe
+  packaging and Dart frame-lifecycle wiring.
+
 - Fixed Web/native backend API parity. `WebAutoBackend` now forwards grammar
   constraint support from its active runtime, so strict structured output fails
   early with an actionable error on unsupported Web backends, and the Web-safe

--- a/website/docs/examples/chat-app.md
+++ b/website/docs/examples/chat-app.md
@@ -182,9 +182,11 @@ confirmation dialog offers both choices when cached assets exist.
 ## Gemma 4 note
 
 The download library includes Gemma 4 E2B, E4B, 12B, 26B A4B, and 31B GGUF
-tiers. E2B, E4B, and 12B expose image, audio, and video input on the current
-native `llama.cpp` mtmd path; 26B A4B and 31B expose image/video input but do
-not support audio. The native Gemma 4 E2B LiteRT-LM bundle accepts audio
+tiers. E2B, E4B, and 12B expose image and audio input on the current native
+`llama.cpp` mtmd path; 26B A4B and 31B expose image input but do not support
+audio. Video is not advertised because the packaged native runtime reports it
+compiled out and the public Dart API has no frame-ingestion contract. The
+native Gemma 4 E2B LiteRT-LM bundle accepts audio
 directly without an external projector. On code-supported native recorder
 targets, **Ask with voice** can send a recording to that bundle or to an
 audio-capable E2B, E4B, or 12B GGUF projector. This is generic audio-input chat,

--- a/website/docs/guides/multimodal.md
+++ b/website/docs/guides/multimodal.md
@@ -87,6 +87,7 @@ await for (final chunk in engine.create([message])) {
 ```dart
 final supportsVision = await engine.supportsVision;
 final supportsAudio = await engine.supportsAudio;
+final supportsVideo = await engine.supportsVideo; // false in current releases
 ```
 
 Always prefer these runtime checks over model-card assumptions. A loaded
@@ -94,6 +95,17 @@ projector can expose only a subset of the family-level modalities. The current
 Gemma 4 E2B GGUF projector path in native `llama.cpp` mtmd reports both vision
 and audio support; audio remains experimental upstream. Web continues to rely
 on the loaded bridge's runtime capability report.
+
+Video is not currently consumable through the public Dart generation API.
+`LlamaVideoContent` makes an attempted path/byte request explicit, but
+generation rejects it with `LlamaUnsupportedException`. The tested native
+b10545 macOS arm64 artifact exports upstream video helper symbols while the
+behavioral `mtmd_helper_support_video` probe reports video compiled out; symbol
+presence is not a capability check. A complete implementation still needs
+companion native builds with `LLAMA_SUBPROCESS`/`MTMD_VIDEO`, a cross-platform
+FFmpeg/ffprobe packaging policy, Dart frame and timestamp ingestion,
+cancellation, and lazy video-context cleanup. Extract representative image
+frames and send `LlamaImageContent` parts in the meantime.
 
 `LlamaAudioContent` is generic audio input routed through normal generation; it
 does not by itself provide a transcript contract. For typed whole-file native

--- a/website/docs/platforms/support-matrix.md
+++ b/website/docs/platforms/support-matrix.md
@@ -112,6 +112,21 @@ LFM2 DSpark uses `SpeculativeDecodingConfig.draftDspark(...)`. No
 model-specific Dart preset is required, but representative target/draft and
 backend validation remains necessary before enabling DSpark in production.
 
+### Video input boundary
+
+| Runtime path | Public video input | Current evidence |
+| --- | --- | --- |
+| Native llama.cpp / GGUF | Not consumable | The tested b10545 macOS arm64 artifact exports upstream video helper symbols, but the behavioral `mtmd_helper_support_video` probe reports false because video is compiled out. The companion build does not opt into `LLAMA_SUBPROCESS`/`MTMD_VIDEO` or package FFmpeg/ffprobe; Linux and Windows still require artifact-level validation before support can be claimed. |
+| Native LiteRT-LM | Not consumable | The public direct-media path accepts image/audio content only. |
+| WebGPU / Web LiteRT-LM | Not consumable | No validated public Dart video transport or frame-lifetime contract exists. |
+| Android / iOS | Not consumable | Explicitly unsupported pending native packaging and device validation. |
+
+`LlamaEngine.supportsVideo` therefore returns false. Passing
+`LlamaVideoContent` throws `LlamaUnsupportedException` with either the native
+compile/dependency blocker or, for a custom video-enabled native build, the
+remaining Dart frame-ingestion/lifetime blocker. Do not infer support from
+exported `mtmd_helper_video_*` symbols.
+
 Unset or empty config means all runtime families available for the target. Apps
 that only ship one model format can trim package size:
 


### PR DESCRIPTION
## Summary

- add an explicit `LlamaVideoContent` sentinel and keep `LlamaEngine.supportsVideo` false until video is actually consumable end to end
- behaviorally probe `mtmd_helper_support_video` through the llama.cpp worker while preserving older-library vision/audio compatibility
- reject video before generation with typed, actionable native-build versus Dart-ingestion diagnostics, with direct-backend safeguards for LiteRT-LM and WebGPU
- remove incorrect Gemma 4 video advertising and align the support matrix, guide, example docs, and changelog

This is the strongest safely addressable slice related to issue #320. It intentionally leaves that issue open and does **not** implement video decoding/frame ingestion.

## Current evidence

- `llamadart` currently pins `llamadart-native@b10545`.
- The published b10545 macOS arm64 library exports the upstream `mtmd_helper_video_*` and `mtmd_helper_support_video` symbols, but the behavioral helper call returns false and the binary contains the upstream compiled-out diagnostic.
- The companion build adds the upstream mtmd library but does not opt into `LLAMA_SUBPROCESS`/`MTMD_VIDEO` or package FFmpeg/ffprobe. Upstream forcibly disables `MTMD_VIDEO` when subprocess support is off.
- Linux and Windows have published artifacts, but they still require artifact-level behavioral validation before any support claim. Android and iOS remain explicitly unsupported.
- Even a custom native library reporting true is not publicly consumable yet: Dart does not own frame iteration, timestamps, cancellation, worker transport, or lazy video-context cleanup.

Symbol presence is therefore not treated as capability evidence.

## Scope and behavior

- `LlamaVideoContent` represents validated path/byte requests without silently flattening or dropping them; source-less construction fails immediately.
- `LlamaEngine.supportsVideo` reports the public consumability contract and remains false.
- Native llama.cpp uses the actual loaded mtmd context for the runtime probe.
- A backend without the optional native probe produces generic backend guidance rather than misleading FFmpeg details.
- A real native false probe produces `LlamaUnsupportedException` with the `LLAMA_SUBPROCESS` and FFmpeg/ffprobe blocker plus an image-frame fallback.
- A true native probe produces a different `LlamaUnsupportedException` naming the remaining Dart frame/timestamp/cancellation/lifetime work.
- LiteRT-LM and WebGPU direct paths reject video explicitly rather than dropping it or misclassifying it.
- Existing persisted chat-app video metadata remains readable for compatibility, but the app no longer advertises or searches on it.

## Proposed issue split

1. **Companion native desktop packaging:** define and implement macOS/Linux/Windows `LLAMA_SUBPROCESS`/`MTMD_VIDEO` policy; decide FFmpeg/ffprobe bundle-versus-discovery, licensing, update, missing-tool, and manifest-capability behavior; keep mobile off until separately validated.
2. **Dart end-to-end video ingestion:** wire path and byte transport, worker ownership, lazy native video-context lifetime, frame/timestamp semantics, cancellation, cleanup, and typed error mapping; only then allow public `supportsVideo` to become true.
3. **Cross-platform acceptance:** validate published macOS/Linux/Windows artifacts with FFmpeg present and missing, path/bytes/frame/timestamp/cancel/cleanup cases, representative Gemma 4 video smokes, and explicit Android/iOS unsupported behavior.

Issue #320 should remain the umbrella (or be replaced by those tracked follow-ups) until all three slices are complete.

## Validation

- `dart format --output=none --set-exit-if-changed` on all changed Dart files
- targeted `dart analyze` on all changed library and test files
- `dart test -p vm -j 1 --exclude-tags local-only` — 1,455 passed, 62 expected fixture-dependent skips
- `dart test -p chrome --exclude-tags local-only` — 779 passed
- focused VM capability/backend/native-symbol set — 198 passed
- focused WebGPU + LiteRT-LM Web Chrome set — 96 passed
- b10545 macOS arm64 native symbol/runtime integration — behavioral video probe false; native suite passed on Apple M4 Max
- changed chat-app Flutter files analyze clean
- chat-app widget and unit/model-management sets — 18 + 93 passed
- `./tool/docs/validate_links.sh` — Docusaurus build and link validation passed
- `git diff --check`

## Out of scope

- enabling or publishing companion-native video builds
- bundling or discovering FFmpeg/ffprobe
- accepting frames, timestamps, video paths, or video bytes for generation
- mobile video support
- release, tag, or publication changes
