### PR TITLE
fix(template): honor XML tool argument semantics

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 ## Unreleased
 
+* Fixed XML-style tool-call parsing to honor raw-versus-JSON argument values
+  and final-value delimiters. Apriel 1.5 and Xiaomi MiMo now parse nested JSON
+  values without splitting on inner commas, while malformed payloads remain
+  ordinary assistant content.
+
 * Fixed Web/native backend API parity. `WebAutoBackend` now forwards grammar
   constraint support from its active runtime, so strict structured output fails
   early with an actionable error on unsupported Web backends, and the Web-safe

--- a/lib/src/core/template/tool_call_parsing_utils.dart
+++ b/lib/src/core/template/tool_call_parsing_utils.dart
@@ -264,8 +264,10 @@ class ToolCallParsingUtils {
       return null;
     }
 
-    final decoded = decodeJsonValue(input.substring(offset, end));
-    if (decoded == null) {
+    Object? decoded;
+    try {
+      decoded = jsonDecode(input.substring(offset, end));
+    } catch (_) {
       return null;
     }
 

--- a/lib/src/core/template/tool_call_parsing_utils.dart
+++ b/lib/src/core/template/tool_call_parsing_utils.dart
@@ -179,9 +179,20 @@ class ToolCallParsingUtils {
   }
 
   /// Decodes [text] as JSON and falls back to the original string on failure.
-  static Object decodeJsonValueOrString(String text, {bool trimInput = false}) {
+  static Object? decodeJsonValueOrString(
+    String text, {
+    bool trimInput = false,
+  }) {
     final normalizedInput = trimInput ? text.trim() : text;
-    return decodeJsonValue(normalizedInput) ?? normalizedInput;
+    if (normalizedInput.isEmpty) {
+      return normalizedInput;
+    }
+
+    try {
+      return jsonDecode(normalizedInput);
+    } catch (_) {
+      return normalizedInput;
+    }
   }
 
   /// Encodes parsed tool-call arguments to the chunk wire format.

--- a/lib/src/core/template/xml_tool_call_format.dart
+++ b/lib/src/core/template/xml_tool_call_format.dart
@@ -6,8 +6,9 @@ import 'tool_call_parsing_utils.dart';
 
 /// Describes the XML-style tool call format used by several models.
 ///
-/// Matches llama.cpp's `xml_tool_call_format` struct. Shared by:
-/// MiniMax M2, Qwen3 Coder XML, Kimi K2, Apriel, Seed OSS.
+/// Retains the semantics of llama.cpp's former `xml_tool_call_format` struct.
+/// Shared by MiniMax M2, Qwen3 Coder XML, Apriel, Seed OSS, and legacy
+/// format definitions.
 class XmlToolCallFormat {
   /// Opening scope tag (e.g., `<minimax:tool_call>`).
   final String scopeStart;
@@ -33,13 +34,20 @@ class XmlToolCallFormat {
   /// Closing scope tag (e.g., `</minimax:tool_call>`).
   final String scopeEnd;
 
-  /// Whether argument values are raw strings (true) or JSON (false).
-  final bool rawArgval;
+  /// How argument values are decoded.
+  ///
+  /// `true` preserves raw strings, `false` requires JSON, and `null` accepts
+  /// either form. This matches the three-state upstream field that preceded
+  /// llama.cpp's format-specific PEG parsers.
+  final bool? rawArgval;
 
   /// Whether to trim whitespace from raw argument values.
   final bool trimRawArgval;
 
   /// Override for the last value's end marker.
+  ///
+  /// An empty string means the tool-end marker immediately follows the final
+  /// value.
   final String? lastValEnd;
 
   /// Override for the last tool's end marker.
@@ -58,7 +66,7 @@ class XmlToolCallFormat {
     required this.valEnd,
     required this.toolEnd,
     required this.scopeEnd,
-    this.rawArgval = true,
+    this.rawArgval,
     this.trimRawArgval = false,
     this.lastValEnd,
     this.lastToolEnd,
@@ -140,7 +148,7 @@ class XmlToolCallFormat {
     toolEnd: '}, ',
     scopeEnd: ']</tool_calls>',
     rawArgval: false,
-    lastValEnd: '',
+    lastValEnd: '}',
     lastToolEnd: '}',
   );
 
@@ -245,12 +253,27 @@ $jsonValueRules
 ''';
   }
 
+  final argumentValueRule = format.rawArgval == true ? 'raw-text' : 'value';
+  final argumentsRule = format.lastValEnd == null
+      ? '(param ${_literal(format.valEnd)})*'
+      : '(param (${_literal(format.valEnd)} param)*)? ${_literal(format.lastValEnd!)}';
+  final toolCallRule =
+      '${_literal(format.toolStart)} tool-name ${_literal(format.toolSep)} arguments ${_literal(format.toolEnd)}';
+  final rootRule = format.lastToolEnd == null
+      ? '${scopeStart}tool-call+$scopeEnd'
+      : '${scopeStart}tool-call* last-tool-call$scopeEnd';
+  final lastToolCallRule = format.lastToolEnd == null
+      ? ''
+      : '\nlast-tool-call ::= ${_literal(format.toolStart)} tool-name ${_literal(format.toolSep)} arguments ${_literal(format.lastToolEnd!)}';
+  final rawTextRule = format.rawArgval == true ? '\nraw-text ::= ([^<])*' : '';
+
   return '''
-root ::= ${scopeStart}tool-call+$scopeEnd
-tool-call ::= ${_literal(format.toolStart)} tool-name ${_literal(format.toolSep)} param* ${_literal(format.toolEnd)}
-param ::= ${_literal(format.keyStart)} param-name ${_literal(format.keyValSep)} value ${_literal(format.valEnd)}
+root ::= $rootRule
+tool-call ::= $toolCallRule$lastToolCallRule
+arguments ::= $argumentsRule
+param ::= ${_literal(format.keyStart)} param-name ${_literal(format.keyValSep)} $argumentValueRule
 tool-name ::= $toolNameRule
-param-name ::= $paramNameRule
+param-name ::= $paramNameRule$rawTextRule
 $jsonValueRules
 ''';
 }
@@ -519,29 +542,12 @@ _ParsedXmlArguments? _parseXmlArguments(
     }
     pos = keyNameEnd + format.keyValSep.length;
 
-    final valEndIdx = format.valEnd.isEmpty
-        ? pos
-        : content.indexOf(format.valEnd, pos);
-    final cdataValue = _parseCdataValue(content, pos, format);
-    if (cdataValue != null) {
-      _setArgValue(args, key, cdataValue.value, format);
-      pos = cdataValue.nextPos;
-      continue;
+    final argumentValue = _parseXmlArgumentValue(content, pos, format);
+    if (argumentValue == null) {
+      return null;
     }
-
-    final toolEndIdx = _findNextToolEndIndex(content, pos, format);
-    if (valEndIdx == -1 || (toolEndIdx != -1 && toolEndIdx < valEndIdx)) {
-      if (toolEndIdx != -1) {
-        _setArgValue(args, key, content.substring(pos, toolEndIdx), format);
-        pos = toolEndIdx;
-      } else if (strictScope) {
-        return null;
-      }
-      break;
-    }
-
-    _setArgValue(args, key, content.substring(pos, valEndIdx), format);
-    pos = valEndIdx + format.valEnd.length;
+    args[key] = argumentValue.value;
+    pos = argumentValue.nextPos;
   }
 
   pos = _consumeXmlWhitespace(content, pos);
@@ -645,18 +651,115 @@ int _consumeXmlWhitespace(String text, int from) {
   return pos;
 }
 
-void _setArgValue(
-  Map<String, dynamic> args,
-  String key,
-  String rawValue,
+_ParsedXmlArgumentValue? _parseXmlArgumentValue(
+  String content,
+  int start,
   XmlToolCallFormat format,
 ) {
-  var value = rawValue;
+  if (format.rawArgval == false) {
+    final valueStart = _consumeXmlWhitespace(content, start);
+    final parsed = ToolCallParsingUtils.extractLeadingJsonValue(
+      content,
+      valueStart,
+    );
+    if (parsed == null) {
+      return null;
+    }
+    final nextPos = _consumeValueEnd(content, parsed.end, format);
+    if (nextPos == null) {
+      return null;
+    }
+    return _ParsedXmlArgumentValue(value: parsed.value, nextPos: nextPos);
+  }
+
+  final cdataValue = _parseCdataValue(content, start, format);
+  if (cdataValue != null) {
+    return _ParsedXmlArgumentValue(
+      value: cdataValue.value,
+      nextPos: cdataValue.nextPos,
+    );
+  }
+
+  final valueEnd = _findValueEnd(content, start, format);
+  if (valueEnd == null) {
+    return null;
+  }
+
+  var value = content.substring(start, valueEnd.valueEnd);
   if (format.trimRawArgval) {
     value = value.trim();
   }
+  return _ParsedXmlArgumentValue(
+    value: format.rawArgval == true
+        ? value
+        : ToolCallParsingUtils.decodeJsonValueOrString(value),
+    nextPos: valueEnd.nextPos,
+  );
+}
 
-  args[key] = ToolCallParsingUtils.decodeJsonValueOrString(value);
+int? _consumeValueEnd(String content, int start, XmlToolCallFormat format) {
+  final markerStart = _consumeXmlWhitespace(content, start);
+  if (format.valEnd.isNotEmpty &&
+      content.startsWith(format.valEnd, markerStart)) {
+    return markerStart + format.valEnd.length;
+  }
+
+  final lastValEnd = format.lastValEnd;
+  if (lastValEnd == null ||
+      (lastValEnd.isNotEmpty && !content.startsWith(lastValEnd, markerStart))) {
+    return null;
+  }
+  final afterMarker = markerStart + lastValEnd.length;
+  final toolEndStart = _consumeXmlWhitespace(content, afterMarker);
+  return _matchToolEnd(content, toolEndStart, format) == null
+      ? null
+      : afterMarker;
+}
+
+_ValueEndMatch? _findValueEnd(
+  String content,
+  int start,
+  XmlToolCallFormat format,
+) {
+  _ValueEndMatch? best;
+  if (format.valEnd.isNotEmpty) {
+    final index = content.indexOf(format.valEnd, start);
+    if (index != -1) {
+      best = _ValueEndMatch(
+        valueEnd: index,
+        nextPos: index + format.valEnd.length,
+      );
+    }
+  }
+
+  final lastValEnd = format.lastValEnd;
+  if (lastValEnd != null) {
+    if (lastValEnd.isEmpty) {
+      final toolEndIndex = _findNextToolEndIndex(content, start, format);
+      if (toolEndIndex != -1 &&
+          (best == null || toolEndIndex < best.valueEnd)) {
+        best = _ValueEndMatch(valueEnd: toolEndIndex, nextPos: toolEndIndex);
+      }
+    } else {
+      var searchFrom = start;
+      while (searchFrom <= content.length - lastValEnd.length) {
+        final index = content.indexOf(lastValEnd, searchFrom);
+        if (index == -1) {
+          break;
+        }
+        final afterMarker = index + lastValEnd.length;
+        final toolEndStart = _consumeXmlWhitespace(content, afterMarker);
+        if (_matchToolEnd(content, toolEndStart, format) != null) {
+          if (best == null || index < best.valueEnd) {
+            best = _ValueEndMatch(valueEnd: index, nextPos: afterMarker);
+          }
+          break;
+        }
+        searchFrom = index + lastValEnd.length;
+      }
+    }
+  }
+  return best;
 }
 
 final class _ParsedCdataValue {
@@ -683,4 +786,18 @@ final class _ParsedXmlArguments {
   final int nextPos;
 
   const _ParsedXmlArguments({required this.arguments, required this.nextPos});
+}
+
+final class _ParsedXmlArgumentValue {
+  final Object? value;
+  final int nextPos;
+
+  const _ParsedXmlArgumentValue({required this.value, required this.nextPos});
+}
+
+final class _ValueEndMatch {
+  final int valueEnd;
+  final int nextPos;
+
+  const _ValueEndMatch({required this.valueEnd, required this.nextPos});
 }

--- a/lib/src/core/template/xml_tool_call_format.dart
+++ b/lib/src/core/template/xml_tool_call_format.dart
@@ -253,9 +253,15 @@ $jsonValueRules
 ''';
   }
 
-  final argumentValueRule = format.rawArgval == true ? 'raw-text' : 'value';
+  final argumentValueRule = switch (format.rawArgval) {
+    true => 'raw-text',
+    false => 'value',
+    null => 'argument-value',
+  };
   final argumentsRule = format.lastValEnd == null
       ? '(param ${_literal(format.valEnd)})*'
+      : format.lastValEnd!.isEmpty
+      ? '(param (${_literal(format.valEnd)} param)*)?'
       : '(param (${_literal(format.valEnd)} param)*)? ${_literal(format.lastValEnd!)}';
   final toolCallRule =
       '${_literal(format.toolStart)} tool-name ${_literal(format.toolSep)} arguments ${_literal(format.toolEnd)}';
@@ -265,7 +271,10 @@ $jsonValueRules
   final lastToolCallRule = format.lastToolEnd == null
       ? ''
       : '\nlast-tool-call ::= ${_literal(format.toolStart)} tool-name ${_literal(format.toolSep)} arguments ${_literal(format.lastToolEnd!)}';
-  final rawTextRule = format.rawArgval == true ? '\nraw-text ::= ([^<])*' : '';
+  final rawTextRule = format.rawArgval == false ? '' : '\nraw-text ::= ([^<])*';
+  final eitherValueRule = format.rawArgval == null
+      ? '\nargument-value ::= raw-text | value'
+      : '';
 
   return '''
 root ::= $rootRule
@@ -273,7 +282,7 @@ tool-call ::= $toolCallRule$lastToolCallRule
 arguments ::= $argumentsRule
 param ::= ${_literal(format.keyStart)} param-name ${_literal(format.keyValSep)} $argumentValueRule
 tool-name ::= $toolNameRule
-param-name ::= $paramNameRule$rawTextRule
+param-name ::= $paramNameRule$rawTextRule$eitherValueRule
 $jsonValueRules
 ''';
 }
@@ -579,15 +588,18 @@ _ParsedCdataValue? _parseCdataValue(
     return null;
   }
 
-  final valEndStart = cdataEndIdx + cdataEnd.length;
-  if (format.valEnd.isNotEmpty &&
-      !content.startsWith(format.valEnd, valEndStart)) {
+  final valueEnd = _consumeValueEnd(
+    content,
+    cdataEndIdx + cdataEnd.length,
+    format,
+  );
+  if (valueEnd == null) {
     return null;
   }
 
   return _ParsedCdataValue(
     value: content.substring(start + cdataStart.length, cdataEndIdx),
-    nextPos: valEndStart + format.valEnd.length,
+    nextPos: valueEnd,
   );
 }
 

--- a/test/unit/core/template/handlers/apriel15_handler_test.dart
+++ b/test/unit/core/template/handlers/apriel15_handler_test.dart
@@ -1,7 +1,9 @@
-import 'package:llamadart/src/core/template/chat_format.dart';
+import 'dart:convert';
+
 import 'package:llamadart/src/core/template/handlers/apriel15_handler.dart';
 import 'package:llamadart/src/core/models/tools/tool_definition.dart';
 import 'package:llamadart/src/core/models/tools/tool_param.dart';
+import 'package:llamadart/src/core/template/chat_format.dart';
 import 'package:test/test.dart';
 
 void main() {
@@ -26,6 +28,55 @@ void main() {
     expect(grammar, contains('root ::='));
     expect(grammar, contains('"<tool_calls>["'));
     expect(grammar, contains('"]</tool_calls>"'));
+    expect(grammar, contains('last-tool-call ::='));
+    expect(grammar, contains('arguments ::= (param (", " param)*)? "}"'));
+  });
+
+  test('parses nested JSON values and multiple tool calls', () {
+    final handler = Apriel15Handler();
+    const output =
+        '<thinking>checking</thinking>'
+        '<tool_calls>['
+        '{"name": "first", "arguments": {'
+        '"payload": {"items": [1, 2], "label": "a, b"}, '
+        '"enabled": true}}, '
+        '{"name": "second", "arguments": {"nothing": null}}'
+        ']</tool_calls>';
+
+    final parsed = handler.parse(output);
+
+    expect(parsed.reasoningContent, 'checking');
+    expect(parsed.content, isEmpty);
+    expect(parsed.toolCalls, hasLength(2));
+    expect(jsonDecode(parsed.toolCalls[0].function!.arguments!), {
+      'payload': {
+        'items': [1, 2],
+        'label': 'a, b',
+      },
+      'enabled': true,
+    });
+    expect(jsonDecode(parsed.toolCalls[1].function!.arguments!), {
+      'nothing': null,
+    });
+  });
+
+  test('keeps malformed or truncated legacy payloads as content', () {
+    final handler = Apriel15Handler();
+    const rawValue =
+        '<tool_calls>['
+        '{"name": "weather", "arguments": {"city": Seoul}}'
+        ']</tool_calls>';
+    const truncated =
+        '<tool_calls>['
+        '{"name": "weather", "arguments": {"city": "Seoul"}';
+
+    final malformed = handler.parse(rawValue);
+    final partial = handler.parse(truncated);
+
+    expect(malformed.content, rawValue);
+    expect(malformed.toolCalls, isEmpty);
+    expect(partial.content, truncated);
+    expect(partial.toolCalls, isEmpty);
   });
 }
 

--- a/test/unit/core/template/handlers/kimi_k2_handler_test.dart
+++ b/test/unit/core/template/handlers/kimi_k2_handler_test.dart
@@ -117,6 +117,27 @@ void main() {
       );
     });
 
+    test('preserves nested JSON argument semantics', () {
+      const output =
+          '<|tool_calls_section_begin|>'
+          '<|tool_call_begin|>functions.search:0'
+          '<|tool_call_argument_begin|>'
+          '{"filters":{"tags":["a, b","c"]},"limit":null}'
+          '<|tool_call_end|>'
+          '<|tool_calls_section_end|>';
+
+      final result = ChatTemplateEngine.parse(ChatFormat.kimiK2.index, output);
+
+      expect(result.content, isEmpty);
+      expect(result.toolCalls, hasLength(1));
+      expect(jsonDecode(result.toolCalls.single.function!.arguments!), {
+        'filters': {
+          'tags': ['a, b', 'c'],
+        },
+        'limit': null,
+      });
+    });
+
     test('parses partial stream without call end token', () {
       const output =
           '<|tool_calls_section_begin|><|tool_call_begin|>functions.weather:0<|tool_call_argument_begin|>{"city":"Seoul"}';

--- a/test/unit/core/template/handlers/xiaomi_mimo_handler_test.dart
+++ b/test/unit/core/template/handlers/xiaomi_mimo_handler_test.dart
@@ -50,6 +50,47 @@ void main() {
       containsPair('city', 'Seoul'),
     );
   });
+
+  test('parses nested JSON argument values without splitting on commas', () {
+    final handler = XiaomiMimoHandler();
+    const output =
+        '<tool_call>\n'
+        '{"name": "weather", "arguments": {'
+        '"options": {"units": "c", "days": [1, 2]}, '
+        '"active": true}\n'
+        '</tool_call>';
+
+    final parsed = handler.parse(output);
+
+    expect(parsed.content, isEmpty);
+    expect(parsed.toolCalls, hasLength(1));
+    expect(jsonDecode(parsed.toolCalls.single.function!.arguments!), {
+      'options': {
+        'units': 'c',
+        'days': [1, 2],
+      },
+      'active': true,
+    });
+  });
+
+  test('keeps raw or truncated arguments as content', () {
+    final handler = XiaomiMimoHandler();
+    const rawValue =
+        '<tool_call>\n'
+        '{"name": "weather", "arguments": {"city": Seoul}\n'
+        '</tool_call>';
+    const truncated =
+        '<tool_call>\n'
+        '{"name": "weather", "arguments": {"city": "Seoul"';
+
+    final malformed = handler.parse(rawValue);
+    final partial = handler.parse(truncated);
+
+    expect(malformed.content, rawValue);
+    expect(malformed.toolCalls, isEmpty);
+    expect(partial.content, truncated);
+    expect(partial.toolCalls, isEmpty);
+  });
 }
 
 Future<Object?> _noop(_) async {

--- a/test/unit/core/template/tool_call_parsing_utils_test.dart
+++ b/test/unit/core/template/tool_call_parsing_utils_test.dart
@@ -120,6 +120,14 @@ void main() {
       expect(ToolCallParsingUtils.extractLeadingJsonValue('oops', 0), isNull);
     });
 
+    test('extracts a leading JSON null value', () {
+      final parsed = ToolCallParsingUtils.extractLeadingJsonValue('null,', 0);
+
+      expect(parsed, isNotNull);
+      expect(parsed!.value, isNull);
+      expect(parsed.end, 4);
+    });
+
     test('extracts the first embedded JSON object', () {
       final object = ToolCallParsingUtils.extractFirstJsonObject(
         'before {"city":"Seoul"} after',

--- a/test/unit/core/template/tool_call_parsing_utils_test.dart
+++ b/test/unit/core/template/tool_call_parsing_utils_test.dart
@@ -53,6 +53,7 @@ void main() {
 
     test('falls back to strings when JSON decoding fails', () {
       expect(ToolCallParsingUtils.decodeJsonValueOrString('42'), 42);
+      expect(ToolCallParsingUtils.decodeJsonValueOrString('null'), isNull);
       expect(ToolCallParsingUtils.decodeJsonValueOrString('Seoul'), 'Seoul');
       expect(
         ToolCallParsingUtils.decodeJsonValueOrString(

--- a/test/unit/core/template/xml_tool_call_format_test.dart
+++ b/test/unit/core/template/xml_tool_call_format_test.dart
@@ -116,6 +116,31 @@ void main() {
     expect(grammar, contains('argument-value ::= raw-text | value'));
   });
 
+  test('accept-either parsing preserves a JSON null value', () {
+    const format = XmlToolCallFormat(
+      scopeStart: '<calls>',
+      toolStart: '<call=',
+      toolSep: '>',
+      keyStart: '<arg=',
+      keyValSep: '>',
+      valEnd: '</arg>',
+      toolEnd: '</call>',
+      scopeEnd: '</calls>',
+    );
+    const output =
+        '<calls><call=sample>'
+        '<arg=value>null</arg>'
+        '</call></calls>';
+
+    final parsed = parseXmlToolCalls(output, format);
+
+    expect(parsed.content, isEmpty);
+    expect(parsed.toolCalls, hasLength(1));
+    expect(jsonDecode(parsed.toolCalls.single.function!.arguments!), {
+      'value': null,
+    });
+  });
+
   test('CDATA values honor the configured final delimiter', () {
     const format = XmlToolCallFormat(
       scopeStart: '<calls>',

--- a/test/unit/core/template/xml_tool_call_format_test.dart
+++ b/test/unit/core/template/xml_tool_call_format_test.dart
@@ -38,6 +38,56 @@ void main() {
     });
   });
 
+  test('honors raw-only values and the final value delimiter', () {
+    const format = XmlToolCallFormat(
+      scopeStart: '<calls>',
+      toolStart: '<call=',
+      toolSep: '>',
+      keyStart: '<arg=',
+      keyValSep: '>',
+      valEnd: '</arg>',
+      lastValEnd: '</last>',
+      toolEnd: '</call>',
+      scopeEnd: '</calls>',
+      rawArgval: true,
+    );
+    const output =
+        '<calls><call=sample>'
+        '<arg=count>42</arg>'
+        '<arg=enabled>false</last>'
+        '</call></calls>';
+
+    final parsed = parseXmlToolCalls(output, format);
+
+    expect(parsed.content, isEmpty);
+    expect(parsed.toolCalls, hasLength(1));
+    expect(jsonDecode(parsed.toolCalls.single.function!.arguments!), {
+      'count': '42',
+      'enabled': 'false',
+    });
+  });
+
+  test('rejects raw values when a format requires JSON', () {
+    const format = XmlToolCallFormat(
+      scopeStart: '<calls>',
+      toolStart: '<call=',
+      toolSep: '>{',
+      keyStart: '"',
+      keyValSep: '":',
+      valEnd: ',',
+      lastValEnd: '}',
+      toolEnd: '</call>',
+      scopeEnd: '</calls>',
+      rawArgval: false,
+    );
+    const output = '<calls><call=sample>{"city":Seoul}</call></calls>';
+
+    final parsed = parseXmlToolCalls(output, format);
+
+    expect(parsed.toolCalls, isEmpty);
+    expect(parsed.content, output);
+  });
+
   test('Qwen3 Coder grammar accepts raw XML parameter values', () {
     final grammar = buildXmlToolCallGrammar(<ToolDefinition>[
       ToolDefinition(
@@ -142,5 +192,34 @@ void main() {
 
     expect(parsed.toolCalls, isEmpty);
     expect(parsed.content, output);
+  });
+
+  test('raw-only grammar uses the configured final delimiter', () {
+    const format = XmlToolCallFormat(
+      scopeStart: '<calls>',
+      toolStart: '<call=',
+      toolSep: '>',
+      keyStart: '<arg=',
+      keyValSep: '>',
+      valEnd: '</arg>',
+      lastValEnd: '</last>',
+      toolEnd: '</call>',
+      scopeEnd: '</calls>',
+      rawArgval: true,
+    );
+    final grammar = buildXmlToolCallGrammar(<ToolDefinition>[
+      ToolDefinition(
+        name: 'sample',
+        description: 'Samples values.',
+        parameters: <ToolParam>[ToolParam.string('value', required: true)],
+        handler: (_) async => null,
+      ),
+    ], format);
+
+    expect(grammar, contains('raw-text ::= ([^<])*'));
+    expect(
+      grammar,
+      contains('arguments ::= (param ("</arg>" param)*)? "</last>"'),
+    );
   });
 }

--- a/test/unit/core/template/xml_tool_call_format_test.dart
+++ b/test/unit/core/template/xml_tool_call_format_test.dart
@@ -88,6 +88,60 @@ void main() {
     expect(parsed.content, output);
   });
 
+  test('accept-either grammar permits raw and JSON values', () {
+    const format = XmlToolCallFormat(
+      scopeStart: '<calls>',
+      toolStart: '<call=',
+      toolSep: '>',
+      keyStart: '<arg=',
+      keyValSep: '>',
+      valEnd: '</arg>',
+      toolEnd: '</call>',
+      scopeEnd: '</calls>',
+    );
+    final grammar = buildXmlToolCallGrammar(<ToolDefinition>[
+      ToolDefinition(
+        name: 'sample',
+        description: 'Samples values.',
+        parameters: <ToolParam>[ToolParam.string('value', required: true)],
+        handler: (_) async => null,
+      ),
+    ], format);
+
+    expect(grammar, contains('param-name ::= "value"\nraw-text ::= ([^<])*'));
+    expect(
+      grammar,
+      contains('param ::= "<arg=" param-name ">" argument-value'),
+    );
+    expect(grammar, contains('argument-value ::= raw-text | value'));
+  });
+
+  test('CDATA values honor the configured final delimiter', () {
+    const format = XmlToolCallFormat(
+      scopeStart: '<calls>',
+      toolStart: '<call=',
+      toolSep: '>',
+      keyStart: '<arg=',
+      keyValSep: '>',
+      valEnd: '</arg>',
+      lastValEnd: '</last>',
+      toolEnd: '</call>',
+      scopeEnd: '</calls>',
+      rawArgval: true,
+    );
+    const output =
+        '<calls><call=sample>'
+        '<arg=value><![CDATA[raw <value>]]></last>'
+        '</call></calls>';
+
+    final parsed = parseXmlToolCalls(output, format);
+
+    expect(parsed.content, isEmpty);
+    expect(jsonDecode(parsed.toolCalls.single.function!.arguments!), {
+      'value': 'raw <value>',
+    });
+  });
+
   test('Qwen3 Coder grammar accepts raw XML parameter values', () {
     final grammar = buildXmlToolCallGrammar(<ToolDefinition>[
       ToolDefinition(
@@ -221,5 +275,19 @@ void main() {
       grammar,
       contains('arguments ::= (param ("</arg>" param)*)? "</last>"'),
     );
+  });
+
+  test('empty final delimiter ends directly at the tool delimiter', () {
+    final grammar = buildXmlToolCallGrammar(<ToolDefinition>[
+      ToolDefinition(
+        name: 'sample',
+        description: 'Samples values.',
+        parameters: <ToolParam>[ToolParam.string('value', required: true)],
+        handler: (_) async => null,
+      ),
+    ], XmlToolCallFormat.xiaomiMimo);
+
+    expect(grammar, contains('arguments ::= (param (", " param)*)?'));
+    expect(grammar, isNot(contains('arguments ::= (param (", " param)*)? ""')));
   });
 }


### PR DESCRIPTION
## Summary

- honor the former upstream `raw_argval` tri-state contract: raw-only, JSON-only, or accept either
- honor `last_val_end` in both parsing and generated grammars, including structural JSON values with nested objects, arrays, commas, booleans, and `null`
- keep malformed/truncated legacy Apriel and Xiaomi payloads as assistant content, while preserving the current dedicated Kimi parser and unrelated XML formats

## Upstream decision

These fields were compatibility behavior, not dead data:

- Immediately before llama.cpp's parser refactor, [`raw_argval` was explicitly optional (`true` raw, `false` JSON, unset either) and `last_val_end` was an optional final delimiter](https://github.com/ggml-org/llama.cpp/blob/34df42f7bef5a711b2b40f5d2b6b78254def99c3/common/chat-parser-xml-toolcall.h#L27-L34).
- The old grammar and parser [selected raw/schema JSON grammar from `raw_argval`](https://github.com/ggml-org/llama.cpp/blob/34df42f7bef5a711b2b40f5d2b6b78254def99c3/common/chat-parser-xml-toolcall.cpp#L235-L246) and [used `last_val_end` while locating and decoding arguments](https://github.com/ggml-org/llama.cpp/blob/34df42f7bef5a711b2b40f5d2b6b78254def99c3/common/chat-parser-xml-toolcall.cpp#L344-L380).
- llama.cpp then [replaced the generic XML parser with format-specific PEG parsers](https://github.com/ggml-org/llama.cpp/commit/566059a26b0ce8faec4ea053605719d399c64cc5). At llamadart's pinned `b10549`, the Kimi parser still requires schema-valid JSON structurally; the latest upstream release `v0.2.0` has no relevant parser/template changes from that pin.

Accordingly, this PR implements the fields rather than deleting them. Apriel and Xiaomi remain legacy/version-skew handlers because current vendored templates detect through the newer generic JSON/Hermes path. Kimi already uses its dedicated whole-object parser, so this PR adds a preservation regression without replacing it.

## Scope

- Public runtime behavior changes only for XML-style tool-call argument parsing/grammar semantics.
- No native, Web bridge, asset, release, or package-version changes.
- No change to unrelated tool-call formats.

## Validation

| Matrix | Result |
| --- | --- |
| Focused affected parser/handler tests | PASS, 51 tests |
| Full template unit suite | PASS, 363 tests |
| Pinned llama.cpp template parity (`run_template_parity_suites.sh`) | PASS, including full upstream C++ chat suites |
| `gguf-chat-features-smoke` | PASS, macOS Metal with Qwen3.5-0.8B-Q4_K_M; four `get_weather({"location":"Seoul"})` tool-call variants passed with thinking suppression/separation |
| `llama-cpp-chat-template-smoke` | PASS, same Qwen GGUF on native llama.cpp; default/custom/model-parameter/per-call template paths and unsupported multimodal rejection passed |
| `dart analyze` | PASS |
| Full VM suite | PASS, 1,522 tests |
| Full Chrome suite | PASS, 783 tests |
| LCOV threshold | PASS, 76.93% (11,642/15,133; floor 70%) |
| Docs/link production build | PASS |
| Touched-file format and `git diff --check` | PASS |

No local Apriel, MiMo, or Kimi GGUF/LiteRT-LM model is available. Those
legacy/version-skew output formats are therefore gated by the pinned upstream
template/parser parity suites and format-specific behavioral regressions; the
Qwen smoke validates the public real-model tool-call pipeline and preservation
of an unrelated format.

Closes #350
