### PR TITLE
fix: parse specialized llama.cpp chat templates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 ## Unreleased
 
+* Added template-aware parsing for Kimi K3, MiniMax M1/M3, DeepSeek V3.2/V4,
+  Muse Glimmer, and Poolside Laguna, preventing their native tool calls from
+  silently falling back to plain content.
+
 * Fixed Web/native backend API parity. `WebAutoBackend` now forwards grammar
   constraint support from its active runtime, so strict structured output fails
   early with an actionable error on unsupported Web backends, and the Web-safe

--- a/lib/src/core/template/chat_format.dart
+++ b/lib/src/core/template/chat_format.dart
@@ -123,6 +123,24 @@ enum ChatFormat {
 
   /// Hunyuan V3 — namespaced thinking and XML-like argument tool calls.
   hunyuanV3,
+
+  /// Kimi K3 — XTML response, reasoning, and typed tool-call sections.
+  kimiK3,
+
+  /// MiniMax M1 — newline-delimited JSON calls inside `<tool_calls>`.
+  minimaxM1,
+
+  /// MiniMax M3 — namespaced XML invokes with `<mm:think>` reasoning.
+  minimaxM3,
+
+  /// DeepSeek V3.2/V4 — DSML invokes with typed parameter values.
+  deepseekV4,
+
+  /// Muse Glimmer — recipient channels with ATEM function-call markup.
+  museGlimmer,
+
+  /// Poolside Laguna — tagged reasoning and arg-key/value tool calls.
+  laguna,
 }
 
 /// Detects the [ChatFormat] by scanning a Jinja template source string
@@ -133,6 +151,54 @@ enum ChatFormat {
 ChatFormat detectChatFormat(String? templateSource) {
   if (templateSource == null || templateSource.isEmpty) {
     return ChatFormat.contentOnly;
+  }
+
+  // Kimi K3. Keep this separate from Kimi K2: K3 uses XTML tags and typed
+  // arguments rather than K2's tool-call-section tokens.
+  if (templateSource.contains('<|open|>') &&
+      templateSource.contains('<|close|>') &&
+      templateSource.contains('<|end_of_msg|>')) {
+    return ChatFormat.kimiK3;
+  }
+
+  // Muse Glimmer recipient channels and ATEM calls.
+  if (templateSource.contains('<atem:function_calls>') &&
+      templateSource.contains('<|eom|>')) {
+    return ChatFormat.museGlimmer;
+  }
+
+  // MiniMax M3 must be checked before the generic Hermes signature because
+  // its namespaced envelope contains a literal <tool_call> marker.
+  if (templateSource.contains(']<]minimax[>[') &&
+      templateSource.contains('<tool_call>') &&
+      templateSource.contains('<invoke name=')) {
+    return ChatFormat.minimaxM3;
+  }
+
+  // DeepSeek V3.2/V4 DSML family. The marker is assembled from a Jinja
+  // variable, so detecting only literal rendered tags misses every variant.
+  if (templateSource.contains('dsml_token') &&
+      templateSource.contains('DSML') &&
+      (templateSource.contains('function_calls') ||
+          templateSource.contains('tool_calls'))) {
+    return ChatFormat.deepseekV4;
+  }
+
+  // MiniMax M1 newline-delimited JSON tool-call envelope.
+  if (templateSource.contains('<begin_of_document>') &&
+      templateSource.contains('<beginning_of_sentence>') &&
+      templateSource.contains('<tool_calls>')) {
+    return ChatFormat.minimaxM1;
+  }
+
+  // Poolside Laguna. These templates share GLM-style argument tags but use
+  // explicit assistant/tool-response turns and </assistant> as a stop.
+  if (templateSource.contains('<assistant>') &&
+      templateSource.contains('</assistant>') &&
+      templateSource.contains('<tool_response>') &&
+      templateSource.contains('<arg_key>') &&
+      templateSource.contains('<arg_value>')) {
+    return ChatFormat.laguna;
   }
 
   // DeepSeek V3.1

--- a/lib/src/core/template/chat_template_engine.dart
+++ b/lib/src/core/template/chat_template_engine.dart
@@ -34,6 +34,7 @@ import 'handlers/hunyuan_v3_handler.dart';
 import 'handlers/kimi_k2_handler.dart';
 import 'handlers/lfm2_handler.dart';
 import 'handlers/llama3_handler.dart';
+import 'handlers/llama_cpp_specialized_handlers.dart';
 import 'handlers/magistral_handler.dart';
 import 'handlers/minimax_m2_handler.dart';
 import 'handlers/ministral_handler.dart';
@@ -548,6 +549,18 @@ class ChatTemplateEngine {
         return MiniCpm5Handler();
       case ChatFormat.hunyuanV3:
         return HunyuanV3Handler();
+      case ChatFormat.kimiK3:
+        return KimiK3Handler();
+      case ChatFormat.minimaxM1:
+        return MinimaxM1Handler();
+      case ChatFormat.minimaxM3:
+        return MinimaxM3Handler();
+      case ChatFormat.deepseekV4:
+        return DeepseekV4Handler();
+      case ChatFormat.museGlimmer:
+        return MuseGlimmerHandler();
+      case ChatFormat.laguna:
+        return LagunaHandler();
       case ChatFormat.gptOss:
         return GptOssHandler();
       case ChatFormat.seedOss:

--- a/lib/src/core/template/handlers/llama_cpp_specialized_handlers.dart
+++ b/lib/src/core/template/handlers/llama_cpp_specialized_handlers.dart
@@ -476,7 +476,37 @@ class MinimaxM3Handler extends _DirectJinjaHandler {
         reasoningContent: thinking.reasoning,
       );
     }
-    final normalized = thinking.content.replaceAll(namespace, '');
+    final rawContent = thinking.content;
+    const namespacedScopeStart = '$namespace<tool_call>';
+    const namespacedScopeEnd = '$namespace</tool_call>';
+    final scopeStartIndex = rawContent.indexOf(namespacedScopeStart);
+    if (scopeStartIndex < 0) {
+      return ChatParseResult(
+        content: rawContent,
+        reasoningContent: thinking.reasoning,
+      );
+    }
+    final scopeEndIndex = rawContent.indexOf(
+      namespacedScopeEnd,
+      scopeStartIndex + namespacedScopeStart.length,
+    );
+    if (scopeEndIndex < 0 && !isPartial) {
+      return ChatParseResult(
+        content: rawContent,
+        reasoningContent: thinking.reasoning,
+      );
+    }
+    final scopeEndExclusive = scopeEndIndex < 0
+        ? rawContent.length
+        : scopeEndIndex + namespacedScopeEnd.length;
+    final normalizedScope = rawContent
+        .substring(scopeStartIndex, scopeEndExclusive)
+        .replaceAll('$namespace<', '<');
+    final normalized = rawContent.replaceRange(
+      scopeStartIndex,
+      scopeEndExclusive,
+      normalizedScope,
+    );
     final parsed = _parseInvokeScope(
       normalized,
       scopeStart: '<tool_call>',
@@ -487,7 +517,7 @@ class MinimaxM3Handler extends _DirectJinjaHandler {
       isPartial: isPartial,
     );
     return ChatParseResult(
-      content: parsed.success ? parsed.remaining.trim() : thinking.content,
+      content: parsed.success ? parsed.remaining.trim() : rawContent,
       reasoningContent: thinking.reasoning,
       toolCalls: parsed.success ? parsed.calls : const [],
     );

--- a/lib/src/core/template/handlers/llama_cpp_specialized_handlers.dart
+++ b/lib/src/core/template/handlers/llama_cpp_specialized_handlers.dart
@@ -1,5 +1,6 @@
 import 'package:dinja/dinja.dart';
 
+import '../../grammar/json_schema_converter.dart';
 import '../../models/chat/chat_message.dart';
 import '../../models/chat/chat_template_result.dart';
 import '../../models/chat/completion_chunk.dart';
@@ -373,16 +374,32 @@ class MinimaxM1Handler extends _DirectJinjaHandler {
     if (tools == null || tools.isEmpty) {
       return null;
     }
-    final names = tools
-        .map((tool) => ToolCallGrammarUtils.literal(tool.name))
-        .join(' | ');
-    return '''
-root ::= "<tool_calls>\\n" call+ "</tool_calls>"
-call ::= "{\\"name\\": \\"" tool-name "\\", \\"arguments\\": " object "}\\n"
-tool-name ::= $names
-object ::= "{" json-char* "}"
-json-char ::= [^{}] | object
-''';
+
+    final converter = JsonSchemaConverter();
+    final callRules = <String>[];
+    for (var i = 0; i < tools.length; i++) {
+      final tool = tools[i];
+      final schema = tool.toJsonSchema();
+      converter.resolveRefs(schema, schema);
+      final argumentsRule = converter.visit(schema, 'tool-$i-arguments');
+      final callRule = 'tool-$i-call';
+      converter.rules[callRule] =
+          '"{" space "\\"name\\"" space ":" space '
+          '${ToolCallGrammarUtils.literal(tool.name)} space "," space '
+          '"\\"arguments\\"" space ":" space $argumentsRule "}" space';
+      callRules.add(callRule);
+    }
+
+    final buffer = StringBuffer()
+      ..writeln('root ::= "<tool_calls>\\n" tool-call+ "</tool_calls>"')
+      ..writeln('tool-call ::= tool-choice "\\n"')
+      ..writeln('tool-choice ::= ${callRules.join(' | ')}');
+    final otherRules = converter.rules.entries.toList(growable: false)
+      ..sort((a, b) => a.key.compareTo(b.key));
+    for (final entry in otherRules) {
+      buffer.writeln('${entry.key} ::= ${entry.value}');
+    }
+    return buffer.toString();
   }
 }
 

--- a/lib/src/core/template/handlers/llama_cpp_specialized_handlers.dart
+++ b/lib/src/core/template/handlers/llama_cpp_specialized_handlers.dart
@@ -564,7 +564,7 @@ class MuseGlimmerHandler extends _DirectJinjaHandler {
   ];
 
   @override
-  List<String> get grammarTriggerValues => const [' to='];
+  List<String> get grammarTriggerValues => const ['<atem:function_calls>'];
 
   @override
   ChatParseResult parse(
@@ -623,7 +623,7 @@ class MuseGlimmerHandler extends _DirectJinjaHandler {
         .map((tool) => ToolCallGrammarUtils.literal(tool.name))
         .join(' | ');
     return '''
-root ::= " to=" tool-name "<|message|><atem:function_calls>\\n" invoke "</atem:function_calls>"
+root ::= "<atem:function_calls>\\n" invoke "</atem:function_calls>"
 invoke ::= "<atem:invoke name=\\"" tool-name "\\">\\n" parameter* "</atem:invoke>\\n"
 parameter ::= "<atem:parameter name=\\"" identifier "\\">" raw "</atem:parameter>\\n"
 tool-name ::= $names
@@ -748,38 +748,42 @@ _ParsedCalls _parseInvokeScope(
   }
   final bodyStart = scopeStartIndex + scopeStart.length;
   final scopeEndIndex = input.indexOf(scopeEnd, bodyStart);
-  if (scopeEndIndex < 0) {
-    return isPartial
-        ? _ParsedCalls(
-            calls: const [],
-            remaining: input.substring(0, scopeStartIndex),
-          )
-        : _ParsedCalls.failure();
+  if (scopeEndIndex < 0 && !isPartial) {
+    return _ParsedCalls.failure();
   }
-  final body = input.substring(bodyStart, scopeEndIndex);
+  final scopeComplete = scopeEndIndex >= 0;
+  final body = input.substring(
+    bodyStart,
+    scopeComplete ? scopeEndIndex : input.length,
+  );
   final calls = <LlamaCompletionChunkToolCall>[];
+  final allowPartial = isPartial && !scopeComplete;
+  _ParsedCalls partialResult() => _ParsedCalls(
+    calls: calls,
+    remaining: input.substring(0, scopeStartIndex),
+  );
   var cursor = 0;
   while (cursor < body.length) {
     final start = invokeStartPattern.firstMatch(body.substring(cursor));
     if (start == null) {
       if (body.substring(cursor).trim().isNotEmpty) {
-        return _ParsedCalls.failure();
+        return allowPartial ? partialResult() : _ParsedCalls.failure();
       }
       break;
     }
     final absoluteStart = cursor + start.start;
     if (body.substring(cursor, absoluteStart).trim().isNotEmpty) {
-      return _ParsedCalls.failure();
+      return allowPartial ? partialResult() : _ParsedCalls.failure();
     }
     final argumentsStart = cursor + start.end;
     final end = body.indexOf(invokeEnd, argumentsStart);
     if (end < 0) {
-      return _ParsedCalls.failure();
+      return allowPartial ? partialResult() : _ParsedCalls.failure();
     }
     final name = start.group(1) ?? '';
     final arguments = parseArguments(body.substring(argumentsStart, end));
     if (name.isEmpty || arguments == null) {
-      return _ParsedCalls.failure();
+      return allowPartial ? partialResult() : _ParsedCalls.failure();
     }
     calls.add(
       ToolCallParsingUtils.createFunctionToolCall(
@@ -791,7 +795,10 @@ _ParsedCalls _parseInvokeScope(
     cursor = end + invokeEnd.length;
   }
   if (calls.isEmpty) {
-    return _ParsedCalls.failure();
+    return allowPartial ? partialResult() : _ParsedCalls.failure();
+  }
+  if (!scopeComplete) {
+    return partialResult();
   }
   final remaining = input.replaceRange(
     scopeStartIndex,

--- a/lib/src/core/template/handlers/llama_cpp_specialized_handlers.dart
+++ b/lib/src/core/template/handlers/llama_cpp_specialized_handlers.dart
@@ -297,7 +297,9 @@ class KimiK3Handler extends _DirectJinjaHandler {
       return null;
     }
     final names = tools
-        .map((tool) => ToolCallGrammarUtils.literal(tool.name))
+        .map(
+          (tool) => ToolCallGrammarUtils.literal(_escapeAttribute(tool.name)),
+        )
         .join(' | ');
     final converter = JsonSchemaConverter();
     const objectSchema = <String, dynamic>{'type': 'object'};
@@ -1040,6 +1042,9 @@ List<LlamaCompletionChunkToolCall>? _parseAtemCalls(String body, int start) {
 
 String _unescapeAttribute(String value) =>
     value.replaceAll('&quot;', '"').replaceAll('&amp;', '&');
+
+String _escapeAttribute(String value) =>
+    value.replaceAll('&', '&amp;').replaceAll('"', '&quot;');
 
 String? _nullIfEmpty(String? value) {
   final trimmed = value?.trim();

--- a/lib/src/core/template/handlers/llama_cpp_specialized_handlers.dart
+++ b/lib/src/core/template/handlers/llama_cpp_specialized_handlers.dart
@@ -301,15 +301,42 @@ class KimiK3Handler extends _DirectJinjaHandler {
     final names = tools
         .map((tool) => ToolCallGrammarUtils.literal(tool.name))
         .join(' | ');
-    return '''
-root ::= "<|open|>tools<|sep|>" call+ "<|close|>tools<|sep|><|close|>message<|sep|>"
-call ::= "<|open|>call tool=\\"" tool-name "\\" index=\\"" [0-9]+ "\\"<|sep|>" argument* "<|close|>call<|sep|>"
-argument ::= "<|open|>argument key=\\"" identifier "\\" type=\\"" value-type "\\"<|sep|>" raw "<|close|>argument<|sep|>"
-tool-name ::= $names
-value-type ::= "string" | "number" | "boolean" | "null" | "object" | "array"
-identifier ::= [A-Za-z_] [A-Za-z0-9_.-]*
-raw ::= [^<]*
-''';
+    final converter = JsonSchemaConverter();
+    const objectSchema = <String, dynamic>{'type': 'object'};
+    converter.resolveRefs(objectSchema, objectSchema);
+    final objectRule = converter.visit(objectSchema, 'json-object');
+    final buffer = StringBuffer()
+      ..writeln(
+        'root ::= "<|open|>tools<|sep|>" call+ '
+        '"<|close|>tools<|sep|><|close|>message<|sep|>"',
+      )
+      ..writeln(
+        'call ::= "<|open|>call tool=\\"" tool-name '
+        '"\\" index=\\"" [0-9]+ "\\"<|sep|>" '
+        '(argument* | json-block) "<|close|>call<|sep|>"',
+      )
+      ..writeln(
+        'argument ::= "<|open|>argument key=\\"" identifier '
+        '"\\" type=\\"" value-type "\\"<|sep|>" raw '
+        '"<|close|>argument<|sep|>"',
+      )
+      ..writeln(
+        'json-block ::= "<|open|>json type=\\"object\\"<|sep|>" '
+        '$objectRule "<|close|>json<|sep|>"',
+      )
+      ..writeln('tool-name ::= $names')
+      ..writeln(
+        'value-type ::= "string" | "number" | "boolean" | "null" | '
+        '"object" | "array"',
+      )
+      ..writeln('identifier ::= [A-Za-z_] [A-Za-z0-9_.-]*')
+      ..writeln('raw ::= [^<]*');
+    final jsonRules = converter.rules.entries.toList(growable: false)
+      ..sort((a, b) => a.key.compareTo(b.key));
+    for (final entry in jsonRules) {
+      buffer.writeln('${entry.key} ::= ${entry.value}');
+    }
+    return buffer.toString();
   }
 }
 
@@ -613,8 +640,11 @@ class MuseGlimmerHandler extends _DirectJinjaHandler {
       } else if (parseToolCalls) {
         final parsed = _parseAtemCalls(body, calls.length);
         if (parsed == null) {
-          if (content.isNotEmpty) content.writeln();
-          content.write(body);
+          final terminator = match.group(3) ?? '';
+          if (!isPartial || terminator.isNotEmpty) {
+            if (content.isNotEmpty) content.writeln();
+            content.write(body);
+          }
         } else {
           calls.addAll(parsed);
         }

--- a/lib/src/core/template/handlers/llama_cpp_specialized_handlers.dart
+++ b/lib/src/core/template/handlers/llama_cpp_specialized_handlers.dart
@@ -312,7 +312,7 @@ class KimiK3Handler extends _DirectJinjaHandler {
       )
       ..writeln(
         'call ::= "<|open|>call tool=\\"" tool-name '
-        '"\\" index=\\"" [0-9]+ "\\"<|sep|>" '
+        '"\\"" (" index=\\"" [0-9]+ "\\"")? "<|sep|>" '
         '(argument* | json-block) "<|close|>call<|sep|>"',
       )
       ..writeln(

--- a/lib/src/core/template/handlers/llama_cpp_specialized_handlers.dart
+++ b/lib/src/core/template/handlers/llama_cpp_specialized_handlers.dart
@@ -1,0 +1,998 @@
+import 'package:dinja/dinja.dart';
+
+import '../../models/chat/chat_message.dart';
+import '../../models/chat/chat_template_result.dart';
+import '../../models/chat/completion_chunk.dart';
+import '../../models/tools/tool_definition.dart';
+import '../chat_format.dart';
+import '../chat_parse_result.dart';
+import '../chat_template_handler.dart';
+import '../thinking_utils.dart';
+import '../tool_call_grammar_utils.dart';
+import '../tool_call_parsing_utils.dart';
+import 'glm45_handler.dart';
+
+abstract class _DirectJinjaHandler extends ChatTemplateHandler {
+  @override
+  TemplateToolCallSerialization get toolCallSerialization =>
+      TemplateToolCallSerialization.normalizeOnly;
+
+  String get defaultBosToken => '';
+
+  String get defaultEosToken => '';
+
+  List<String> get grammarTriggerValues => const [];
+
+  @override
+  LlamaChatTemplateResult render({
+    required String templateSource,
+    required List<LlamaChatMessage> messages,
+    required Map<String, String> metadata,
+    bool addAssistant = true,
+    List<ToolDefinition>? tools,
+    bool enableThinking = true,
+  }) {
+    final template = Template(templateSource);
+    var prompt = renderTemplate(
+      template,
+      metadata: metadata,
+      context: <String, dynamic>{
+        'messages': templateMessages(messages),
+        'add_generation_prompt': addAssistant,
+        'tools': tools?.map((tool) => tool.toJson()).toList(),
+        'enable_thinking': enableThinking,
+        'thinking': enableThinking,
+        'thinking_mode': enableThinking ? 'enabled' : 'disabled',
+        'bos_token': metadata['tokenizer.ggml.bos_token'] ?? defaultBosToken,
+        'eos_token': metadata['tokenizer.ggml.eos_token'] ?? defaultEosToken,
+        'current_date': resolveTemplateNow(
+          metadata,
+        ).toIso8601String().substring(0, 10),
+      },
+    );
+
+    var thinkingForcedOpen = false;
+    if (isThinkingForcedOpen(prompt, startTag: thinkingStartTag)) {
+      if (enableThinking) {
+        thinkingForcedOpen = true;
+      } else {
+        prompt = '${prompt.trimRight()}$thinkingEndTag';
+      }
+    }
+
+    final hasTools = tools != null && tools.isNotEmpty;
+    return LlamaChatTemplateResult(
+      prompt: prompt,
+      format: format.index,
+      grammar: buildGrammar(tools),
+      grammarLazy: hasTools,
+      thinkingForcedOpen: thinkingForcedOpen,
+      additionalStops: getStops(
+        hasTools: hasTools,
+        enableThinking: enableThinking,
+      ),
+      preservedTokens: hasTools ? preservedTokens : const [],
+      grammarTriggers: hasTools
+          ? grammarTriggerValues
+                .map((value) => GrammarTrigger(type: 0, value: value))
+                .toList(growable: false)
+          : const [],
+    );
+  }
+}
+
+/// Handler for Kimi K3's XTML response and typed tool-call protocol.
+class KimiK3Handler extends _DirectJinjaHandler {
+  static const _open = '<|open|>';
+  static const _close = '<|close|>';
+  static const _sep = '<|sep|>';
+  static const _thinkClose =
+      '$_close'
+      'think$_sep';
+  static const _responseStart =
+      '$_open'
+      'response$_sep';
+  static const _responseEnd =
+      '$_close'
+      'response$_sep';
+  static const _toolsStart =
+      '$_open'
+      'tools$_sep';
+  static const _toolsEnd =
+      '$_close'
+      'tools$_sep';
+
+  @override
+  ChatFormat get format => ChatFormat.kimiK3;
+
+  @override
+  String get thinkingStartTag =>
+      '$_open'
+      'think$_sep';
+
+  @override
+  String get thinkingEndTag => _thinkClose;
+
+  @override
+  List<String> get additionalStops => const ['<|end_of_msg|>'];
+
+  @override
+  List<String> get preservedTokens => const [
+    '<|open|>',
+    '<|close|>',
+    '<|sep|>',
+    '<|end_of_msg|>',
+  ];
+
+  @override
+  List<String> get grammarTriggerValues => const [_toolsStart];
+
+  @override
+  ChatParseResult parse(
+    String output, {
+    bool isPartial = false,
+    bool parseToolCalls = true,
+    bool thinkingForcedOpen = false,
+  }) {
+    var remaining = output;
+    String? reasoning;
+    final thinkEnd = remaining.indexOf(_thinkClose);
+    if (thinkEnd >= 0) {
+      reasoning = remaining.substring(0, thinkEnd).trim();
+      remaining = remaining.substring(thinkEnd + _thinkClose.length);
+    } else if (thinkingForcedOpen) {
+      final responseIndex = remaining.indexOf(_responseStart);
+      if (responseIndex < 0) {
+        return ChatParseResult(
+          content: '',
+          reasoningContent: remaining.trim().isEmpty ? null : remaining.trim(),
+        );
+      }
+      reasoning = remaining.substring(0, responseIndex).trim();
+      remaining = remaining.substring(responseIndex);
+    }
+
+    var content = '';
+    final responseStart = remaining.indexOf(_responseStart);
+    if (responseStart >= 0) {
+      final bodyStart = responseStart + _responseStart.length;
+      final responseEnd = remaining.indexOf(_responseEnd, bodyStart);
+      if (responseEnd < 0) {
+        if (isPartial) {
+          return ChatParseResult(
+            content: remaining.substring(bodyStart),
+            reasoningContent: _nullIfEmpty(reasoning),
+          );
+        }
+        return ChatParseResult(
+          content: output.trim(),
+          reasoningContent: _nullIfEmpty(reasoning),
+        );
+      }
+      content = remaining.substring(bodyStart, responseEnd);
+      remaining = remaining.substring(responseEnd + _responseEnd.length);
+    }
+
+    if (!parseToolCalls) {
+      return ChatParseResult(
+        content: content.isEmpty
+            ? _stripKimiTurnEnd(remaining)
+            : content.trim(),
+        reasoningContent: _nullIfEmpty(reasoning),
+      );
+    }
+
+    final parsed = _parseKimiTools(remaining, isPartial: isPartial);
+    if (!parsed.success) {
+      final preserved = '$content${_stripKimiTurnEnd(remaining)}'.trim();
+      return ChatParseResult(
+        content: preserved,
+        reasoningContent: _nullIfEmpty(reasoning),
+      );
+    }
+    return ChatParseResult(
+      content: '$content${parsed.remaining}'.trim(),
+      reasoningContent: _nullIfEmpty(reasoning),
+      toolCalls: parsed.calls,
+    );
+  }
+
+  _ParsedCalls _parseKimiTools(String input, {required bool isPartial}) {
+    final scopeStart = input.indexOf(_toolsStart);
+    if (scopeStart < 0) {
+      return _ParsedCalls(calls: const [], remaining: _stripKimiTurnEnd(input));
+    }
+    final bodyStart = scopeStart + _toolsStart.length;
+    final scopeEnd = input.indexOf(_toolsEnd, bodyStart);
+    if (scopeEnd < 0) {
+      return isPartial
+          ? _ParsedCalls(
+              calls: const [],
+              remaining: input.substring(0, scopeStart),
+            )
+          : _ParsedCalls.failure();
+    }
+
+    final body = input.substring(bodyStart, scopeEnd);
+    final callPattern = RegExp(
+      r'<\|open\|>call\s+tool="([^"]+)"(?:\s+index="[^"]+")?<\|sep\|>([\s\S]*?)<\|close\|>call<\|sep\|>',
+    );
+    final matches = callPattern.allMatches(body).toList(growable: false);
+    if (matches.isEmpty || body.replaceAll(callPattern, '').trim().isNotEmpty) {
+      return _ParsedCalls.failure();
+    }
+
+    final calls = <LlamaCompletionChunkToolCall>[];
+    for (final match in matches) {
+      final name = _unescapeAttribute(match.group(1) ?? '');
+      final callBody = match.group(2) ?? '';
+      final arguments = _parseKimiArguments(callBody);
+      if (name.isEmpty || arguments == null) {
+        return _ParsedCalls.failure();
+      }
+      calls.add(
+        ToolCallParsingUtils.createFunctionToolCall(
+          index: calls.length,
+          name: name,
+          arguments: arguments,
+        ),
+      );
+    }
+
+    final removeEnd = scopeEnd + _toolsEnd.length;
+    final remaining = input.replaceRange(scopeStart, removeEnd, '');
+    return _ParsedCalls(calls: calls, remaining: _stripKimiTurnEnd(remaining));
+  }
+
+  Map<String, dynamic>? _parseKimiArguments(String body) {
+    final jsonPattern = RegExp(
+      r'<\|open\|>json\s+type="object"<\|sep\|>([\s\S]*?)<\|close\|>json<\|sep\|>',
+    );
+    final jsonMatch = jsonPattern.firstMatch(body);
+    if (jsonMatch != null) {
+      if (body.replaceFirst(jsonPattern, '').trim().isNotEmpty) {
+        return null;
+      }
+      return ToolCallParsingUtils.decodeJsonObject(jsonMatch.group(1) ?? '');
+    }
+
+    final argumentPattern = RegExp(
+      r'<\|open\|>argument\s+key="([^"]+)"\s+type="([^"]+)"<\|sep\|>([\s\S]*?)<\|close\|>argument<\|sep\|>',
+    );
+    if (body.replaceAll(argumentPattern, '').trim().isNotEmpty) {
+      return null;
+    }
+    final result = <String, dynamic>{};
+    for (final match in argumentPattern.allMatches(body)) {
+      final key = _unescapeAttribute(match.group(1) ?? '');
+      final type = match.group(2) ?? '';
+      final raw = match.group(3) ?? '';
+      if (key.isEmpty) {
+        return null;
+      }
+      if (type == 'string') {
+        result[key] = raw;
+      } else {
+        final decoded = ToolCallParsingUtils.decodeJsonValue(raw);
+        if (decoded == null && raw.trim() != 'null') {
+          return null;
+        }
+        result[key] = decoded;
+      }
+    }
+    return result;
+  }
+
+  String _stripKimiTurnEnd(String input) => input
+      .replaceAll(
+        '$_close'
+            'message$_sep',
+        '',
+      )
+      .replaceAll('<|end_of_msg|>', '')
+      .trim();
+
+  @override
+  String? buildGrammar(List<ToolDefinition>? tools) {
+    if (tools == null || tools.isEmpty) {
+      return null;
+    }
+    final names = tools
+        .map((tool) => ToolCallGrammarUtils.literal(tool.name))
+        .join(' | ');
+    return '''
+root ::= "<|open|>tools<|sep|>" call+ "<|close|>tools<|sep|><|close|>message<|sep|>"
+call ::= "<|open|>call tool=\\"" tool-name "\\" index=\\"" [0-9]+ "\\"<|sep|>" argument* "<|close|>call<|sep|>"
+argument ::= "<|open|>argument key=\\"" identifier "\\" type=\\"" value-type "\\"<|sep|>" raw "<|close|>argument<|sep|>"
+tool-name ::= $names
+value-type ::= "string" | "number" | "boolean" | "null" | "object" | "array"
+identifier ::= [A-Za-z_] [A-Za-z0-9_.-]*
+raw ::= [^<]*
+''';
+  }
+}
+
+/// Handler for MiniMax M1 newline-delimited JSON tool calls.
+class MinimaxM1Handler extends _DirectJinjaHandler {
+  @override
+  ChatFormat get format => ChatFormat.minimaxM1;
+
+  @override
+  List<String> get additionalStops => const ['<end_of_sentence>'];
+
+  @override
+  List<String> get preservedTokens => const [
+    '<tool_calls>',
+    '</tool_calls>',
+    '<end_of_sentence>',
+  ];
+
+  @override
+  List<String> get grammarTriggerValues => const ['<tool_calls>'];
+
+  @override
+  ChatParseResult parse(
+    String output, {
+    bool isPartial = false,
+    bool parseToolCalls = true,
+    bool thinkingForcedOpen = false,
+  }) {
+    if (!parseToolCalls) {
+      return ChatParseResult(content: output.trim());
+    }
+    const start = '<tool_calls>';
+    const end = '</tool_calls>';
+    final startIndex = output.indexOf(start);
+    if (startIndex < 0) {
+      return ChatParseResult(content: output.trim());
+    }
+    final endIndex = output.indexOf(end, startIndex + start.length);
+    if (endIndex < 0) {
+      return ChatParseResult(
+        content: isPartial
+            ? output.substring(0, startIndex).trim()
+            : output.trim(),
+      );
+    }
+
+    final body = output.substring(startIndex + start.length, endIndex);
+    final calls = _parseJsonObjectSequence(body);
+    if (calls == null) {
+      return ChatParseResult(content: output.trim());
+    }
+    final remaining = output.replaceRange(
+      startIndex,
+      endIndex + end.length,
+      '',
+    );
+    return ChatParseResult(content: remaining.trim(), toolCalls: calls);
+  }
+
+  @override
+  String? buildGrammar(List<ToolDefinition>? tools) {
+    if (tools == null || tools.isEmpty) {
+      return null;
+    }
+    final names = tools
+        .map((tool) => ToolCallGrammarUtils.literal(tool.name))
+        .join(' | ');
+    return '''
+root ::= "<tool_calls>\\n" call+ "</tool_calls>"
+call ::= "{\\"name\\": \\"" tool-name "\\", \\"arguments\\": " object "}\\n"
+tool-name ::= $names
+object ::= "{" json-char* "}"
+json-char ::= [^{}] | object
+''';
+  }
+}
+
+/// Handler for MiniMax M3 namespaced XML tool calls.
+class MinimaxM3Handler extends _DirectJinjaHandler {
+  /// Namespace prefix emitted before every MiniMax M3 tool tag.
+  static const namespace = ']<]minimax[>[';
+
+  @override
+  ChatFormat get format => ChatFormat.minimaxM3;
+
+  @override
+  String get thinkingStartTag => '<mm:think>';
+
+  @override
+  String get thinkingEndTag => '</mm:think>';
+
+  @override
+  List<String> get additionalStops => const ['[e~['];
+
+  @override
+  List<String> get preservedTokens => const [
+    '<mm:think>',
+    '</mm:think>',
+    namespace,
+  ];
+
+  @override
+  List<String> get grammarTriggerValues => const ['$namespace<tool_call>'];
+
+  @override
+  ChatParseResult parse(
+    String output, {
+    bool isPartial = false,
+    bool parseToolCalls = true,
+    bool thinkingForcedOpen = false,
+  }) {
+    final thinking = extractThinking(
+      output,
+      startTag: thinkingStartTag,
+      endTag: thinkingEndTag,
+      thinkingForcedOpen: thinkingForcedOpen,
+    );
+    if (!parseToolCalls) {
+      return ChatParseResult(
+        content: thinking.content,
+        reasoningContent: thinking.reasoning,
+      );
+    }
+    final normalized = thinking.content.replaceAll(namespace, '');
+    final parsed = _parseInvokeScope(
+      normalized,
+      scopeStart: '<tool_call>',
+      scopeEnd: '</tool_call>',
+      invokeStartPattern: RegExp(r'<invoke name="([^"]+)">'),
+      invokeEnd: '</invoke>',
+      parseArguments: _parseDynamicTagArguments,
+      isPartial: isPartial,
+    );
+    return ChatParseResult(
+      content: parsed.success ? parsed.remaining.trim() : thinking.content,
+      reasoningContent: thinking.reasoning,
+      toolCalls: parsed.success ? parsed.calls : const [],
+    );
+  }
+
+  @override
+  String? buildGrammar(List<ToolDefinition>? tools) {
+    if (tools == null || tools.isEmpty) {
+      return null;
+    }
+    final names = tools
+        .map((tool) => ToolCallGrammarUtils.literal(tool.name))
+        .join(' | ');
+    return '''
+root ::= "$namespace<tool_call>\\n" invoke+ "$namespace</tool_call>"
+invoke ::= "$namespace<invoke name=\\"" tool-name "\\">" parameter* "$namespace</invoke>\\n"
+parameter ::= "$namespace<" identifier ">" m3-value "$namespace</" identifier ">"
+tool-name ::= $names
+identifier ::= [A-Za-z_] [A-Za-z0-9_.-]*
+m3-value ::= raw | parameter+
+raw ::= [^]]*
+''';
+  }
+}
+
+/// Handler for DeepSeek V3.2/V4 DSML tool calls.
+class DeepseekV4Handler extends _DirectJinjaHandler {
+  static const _prefix = '<｜DSML｜';
+
+  @override
+  ChatFormat get format => ChatFormat.deepseekV4;
+
+  @override
+  List<String> get additionalStops => const ['<｜end▁of▁sentence｜>'];
+
+  @override
+  List<String> get preservedTokens => const [
+    '<think>',
+    '</think>',
+    '<｜DSML｜tool_calls>',
+    '</｜DSML｜tool_calls>',
+  ];
+
+  @override
+  List<String> get grammarTriggerValues => const ['<｜DSML｜tool_calls>'];
+
+  @override
+  ChatParseResult parse(
+    String output, {
+    bool isPartial = false,
+    bool parseToolCalls = true,
+    bool thinkingForcedOpen = false,
+  }) {
+    final thinking = extractThinking(
+      output,
+      thinkingForcedOpen: thinkingForcedOpen,
+    );
+    if (!parseToolCalls) {
+      return ChatParseResult(
+        content: thinking.content,
+        reasoningContent: thinking.reasoning,
+      );
+    }
+    final parsed = _parseInvokeScope(
+      thinking.content,
+      scopeStart:
+          '$_prefix'
+          'tool_calls>',
+      scopeEnd: '</｜DSML｜tool_calls>',
+      invokeStartPattern: RegExp(r'<｜DSML｜invoke name="([^"]+)">'),
+      invokeEnd: '</｜DSML｜invoke>',
+      parseArguments: _parseDsmlArguments,
+      isPartial: isPartial,
+    );
+    return ChatParseResult(
+      content: parsed.success ? parsed.remaining.trim() : thinking.content,
+      reasoningContent: thinking.reasoning,
+      toolCalls: parsed.success ? parsed.calls : const [],
+    );
+  }
+
+  @override
+  String? buildGrammar(List<ToolDefinition>? tools) {
+    if (tools == null || tools.isEmpty) {
+      return null;
+    }
+    final names = tools
+        .map((tool) => ToolCallGrammarUtils.literal(tool.name))
+        .join(' | ');
+    return '''
+root ::= "<｜DSML｜tool_calls>\\n" invoke+ "</｜DSML｜tool_calls>"
+invoke ::= "<｜DSML｜invoke name=\\"" tool-name "\\">\\n" parameter* "</｜DSML｜invoke>\\n"
+parameter ::= "<｜DSML｜parameter name=\\"" identifier "\\" string=\\"" boolean "\\">" raw "</｜DSML｜parameter>\\n"
+tool-name ::= $names
+identifier ::= [A-Za-z_] [A-Za-z0-9_.-]*
+boolean ::= "true" | "false"
+raw ::= [^<]*
+''';
+  }
+}
+
+/// Handler for Muse Glimmer recipient channels and ATEM tool calls.
+class MuseGlimmerHandler extends _DirectJinjaHandler {
+  @override
+  ChatFormat get format => ChatFormat.museGlimmer;
+
+  @override
+  List<String> get additionalStops => const ['<|eot|>'];
+
+  @override
+  List<String> get preservedTokens => const [
+    '<|start|>',
+    '<|message|>',
+    '<|eom|>',
+    '<|eot|>',
+    '<atem:function_calls>',
+    '</atem:function_calls>',
+  ];
+
+  @override
+  List<String> get grammarTriggerValues => const [' to='];
+
+  @override
+  ChatParseResult parse(
+    String output, {
+    bool isPartial = false,
+    bool parseToolCalls = true,
+    bool thinkingForcedOpen = false,
+  }) {
+    final channelPattern = RegExp(
+      r'(?:<\|start\|>assistant)?\s+to=([^<]+)<\|message\|>([\s\S]*?)(<\|eom\|>|<\|eot\|>|$)',
+    );
+    final matches = channelPattern.allMatches(output).toList(growable: false);
+    if (matches.isEmpty) {
+      return ChatParseResult(content: output.trim());
+    }
+
+    final content = StringBuffer();
+    final reasoning = StringBuffer();
+    final calls = <LlamaCompletionChunkToolCall>[];
+    for (final match in matches) {
+      final recipient = (match.group(1) ?? '').trim();
+      final body = match.group(2) ?? '';
+      if (recipient == 'self') {
+        if (reasoning.isNotEmpty) reasoning.writeln();
+        reasoning.write(body);
+      } else if (recipient == 'user') {
+        if (content.isNotEmpty) content.writeln();
+        content.write(body);
+      } else if (parseToolCalls) {
+        final parsed = _parseAtemCalls(body, calls.length);
+        if (parsed == null) {
+          if (content.isNotEmpty) content.writeln();
+          content.write(body);
+        } else {
+          calls.addAll(parsed);
+        }
+      } else {
+        if (content.isNotEmpty) content.writeln();
+        content.write(body);
+      }
+    }
+
+    return ChatParseResult(
+      content: content.toString().trim(),
+      reasoningContent: _nullIfEmpty(reasoning.toString()),
+      toolCalls: calls,
+    );
+  }
+
+  @override
+  String? buildGrammar(List<ToolDefinition>? tools) {
+    if (tools == null || tools.isEmpty) {
+      return null;
+    }
+    final names = tools
+        .map((tool) => ToolCallGrammarUtils.literal(tool.name))
+        .join(' | ');
+    return '''
+root ::= " to=" tool-name "<|message|><atem:function_calls>\\n" invoke "</atem:function_calls>"
+invoke ::= "<atem:invoke name=\\"" tool-name "\\">\\n" parameter* "</atem:invoke>\\n"
+parameter ::= "<atem:parameter name=\\"" identifier "\\">" raw "</atem:parameter>\\n"
+tool-name ::= $names
+identifier ::= [A-Za-z_] [A-Za-z0-9_.-]*
+raw ::= [^<]*
+''';
+  }
+}
+
+/// Poolside Laguna uses GLM-style argument tags with a distinct turn stop.
+class LagunaHandler extends _DirectJinjaHandler {
+  @override
+  ChatFormat get format => ChatFormat.laguna;
+
+  @override
+  List<String> get additionalStops => const ['</assistant>'];
+
+  @override
+  List<String> get preservedTokens => const [
+    '<think>',
+    '</think>',
+    '<tool_call>',
+    '</tool_call>',
+    '<arg_key>',
+    '</arg_key>',
+    '<arg_value>',
+    '</arg_value>',
+    '</assistant>',
+  ];
+
+  @override
+  List<String> get grammarTriggerValues => const ['<tool_call>'];
+
+  @override
+  ChatParseResult parse(
+    String output, {
+    bool isPartial = false,
+    bool parseToolCalls = true,
+    bool thinkingForcedOpen = false,
+  }) {
+    if (parseToolCalls && _hasMalformedLagunaToolBlock(output)) {
+      final thinking = extractThinking(
+        output,
+        thinkingForcedOpen: thinkingForcedOpen,
+      );
+      return ChatParseResult(
+        content: thinking.content,
+        reasoningContent: thinking.reasoning,
+      );
+    }
+    return Glm45Handler().parse(
+      output,
+      isPartial: isPartial,
+      parseToolCalls: parseToolCalls,
+      thinkingForcedOpen: thinkingForcedOpen,
+    );
+  }
+
+  bool _hasMalformedLagunaToolBlock(String output) {
+    final blockPattern = RegExp(r'<tool_call>\s*([\s\S]*?)</tool_call>');
+    final pairPattern = RegExp(
+      r'<arg_key>\s*[\s\S]*?\s*</arg_key>\s*<arg_value>\s*[\s\S]*?\s*</arg_value>',
+    );
+    for (final block in blockPattern.allMatches(output)) {
+      final body = block.group(1) ?? '';
+      final firstArgument = body.indexOf('<arg_key>');
+      if (firstArgument < 0) {
+        continue;
+      }
+      final argumentBody = body.substring(firstArgument);
+      if (argumentBody.replaceAll(pairPattern, '').trim().isNotEmpty) {
+        return true;
+      }
+    }
+    return false;
+  }
+
+  @override
+  String? buildGrammar(List<ToolDefinition>? tools) {
+    return Glm45Handler().buildGrammar(tools);
+  }
+}
+
+List<LlamaCompletionChunkToolCall>? _parseJsonObjectSequence(String body) {
+  final calls = <LlamaCompletionChunkToolCall>[];
+  var cursor = 0;
+  while (cursor < body.length) {
+    while (cursor < body.length && _isWhitespace(body.codeUnitAt(cursor))) {
+      cursor++;
+    }
+    if (cursor == body.length) {
+      break;
+    }
+    final slice = ToolCallParsingUtils.extractLeadingJsonValue(body, cursor);
+    if (slice == null || slice.value is! Map) {
+      return null;
+    }
+    final parsed = ToolCallParsingUtils.parseToolCallArray(<Object?>[
+      slice.value,
+    ], startIndex: calls.length);
+    if (parsed == null || parsed.length != 1) {
+      return null;
+    }
+    calls.add(parsed.single);
+    cursor = slice.end;
+  }
+  return calls.isEmpty ? null : calls;
+}
+
+_ParsedCalls _parseInvokeScope(
+  String input, {
+  required String scopeStart,
+  required String scopeEnd,
+  required RegExp invokeStartPattern,
+  required String invokeEnd,
+  required Map<String, dynamic>? Function(String) parseArguments,
+  required bool isPartial,
+}) {
+  final scopeStartIndex = input.indexOf(scopeStart);
+  if (scopeStartIndex < 0) {
+    return _ParsedCalls(calls: const [], remaining: input);
+  }
+  final bodyStart = scopeStartIndex + scopeStart.length;
+  final scopeEndIndex = input.indexOf(scopeEnd, bodyStart);
+  if (scopeEndIndex < 0) {
+    return isPartial
+        ? _ParsedCalls(
+            calls: const [],
+            remaining: input.substring(0, scopeStartIndex),
+          )
+        : _ParsedCalls.failure();
+  }
+  final body = input.substring(bodyStart, scopeEndIndex);
+  final calls = <LlamaCompletionChunkToolCall>[];
+  var cursor = 0;
+  while (cursor < body.length) {
+    final start = invokeStartPattern.firstMatch(body.substring(cursor));
+    if (start == null) {
+      if (body.substring(cursor).trim().isNotEmpty) {
+        return _ParsedCalls.failure();
+      }
+      break;
+    }
+    final absoluteStart = cursor + start.start;
+    if (body.substring(cursor, absoluteStart).trim().isNotEmpty) {
+      return _ParsedCalls.failure();
+    }
+    final argumentsStart = cursor + start.end;
+    final end = body.indexOf(invokeEnd, argumentsStart);
+    if (end < 0) {
+      return _ParsedCalls.failure();
+    }
+    final name = start.group(1) ?? '';
+    final arguments = parseArguments(body.substring(argumentsStart, end));
+    if (name.isEmpty || arguments == null) {
+      return _ParsedCalls.failure();
+    }
+    calls.add(
+      ToolCallParsingUtils.createFunctionToolCall(
+        index: calls.length,
+        name: name,
+        arguments: arguments,
+      ),
+    );
+    cursor = end + invokeEnd.length;
+  }
+  if (calls.isEmpty) {
+    return _ParsedCalls.failure();
+  }
+  final remaining = input.replaceRange(
+    scopeStartIndex,
+    scopeEndIndex + scopeEnd.length,
+    '',
+  );
+  return _ParsedCalls(calls: calls, remaining: remaining);
+}
+
+Map<String, dynamic>? _parseDynamicTagArguments(String body) {
+  final parsed = _parseDynamicElements(body);
+  if (parsed == null || parsed.elements.isEmpty) {
+    return null;
+  }
+  final result = <String, dynamic>{};
+  for (final element in parsed.elements) {
+    result[element.name] = element.value;
+  }
+  return result;
+}
+
+_DynamicElements? _parseDynamicElements(String input) {
+  final elements = <_DynamicElement>[];
+  var cursor = 0;
+  while (cursor < input.length) {
+    while (cursor < input.length && _isWhitespace(input.codeUnitAt(cursor))) {
+      cursor++;
+    }
+    if (cursor == input.length) {
+      break;
+    }
+    final opening = RegExp(
+      r'<([A-Za-z_][A-Za-z0-9_.-]*)>',
+    ).matchAsPrefix(input, cursor);
+    if (opening == null) {
+      return null;
+    }
+    final name = opening.group(1)!;
+    final close = _findMatchingDynamicClose(input, name, opening.end);
+    if (close == null) {
+      return null;
+    }
+    final raw = input.substring(opening.end, close.start);
+    final children = _parseDynamicElements(raw);
+    Object? value;
+    if (children != null && children.elements.isNotEmpty) {
+      if (children.elements.every((element) => element.name == 'item')) {
+        value = children.elements
+            .map((element) => element.value)
+            .toList(growable: false);
+      } else {
+        value = <String, dynamic>{
+          for (final element in children.elements) element.name: element.value,
+        };
+      }
+    } else {
+      value = ToolCallParsingUtils.decodeJsonValueOrString(raw);
+    }
+    elements.add(_DynamicElement(name: name, value: value));
+    cursor = close.end;
+  }
+  return _DynamicElements(elements);
+}
+
+({int start, int end})? _findMatchingDynamicClose(
+  String input,
+  String name,
+  int start,
+) {
+  final tagPattern = RegExp('<(/?)${RegExp.escape(name)}>');
+  var depth = 1;
+  for (final match in tagPattern.allMatches(input, start)) {
+    if (match.group(1) == '/') {
+      depth--;
+      if (depth == 0) {
+        return (start: match.start, end: match.end);
+      }
+    } else {
+      depth++;
+    }
+  }
+  return null;
+}
+
+Map<String, dynamic>? _parseDsmlArguments(String body) {
+  final pattern = RegExp(
+    r'<｜DSML｜parameter name="([^"]+)" string="(true|false)">([\s\S]*?)</｜DSML｜parameter>',
+  );
+  if (body.replaceAll(pattern, '').trim().isNotEmpty) {
+    return null;
+  }
+  final result = <String, dynamic>{};
+  for (final match in pattern.allMatches(body)) {
+    final key = match.group(1) ?? '';
+    final raw = match.group(3) ?? '';
+    if (key.isEmpty) {
+      return null;
+    }
+    if (match.group(2) == 'true') {
+      result[key] = raw;
+    } else {
+      final decoded = ToolCallParsingUtils.decodeJsonValue(raw);
+      if (decoded == null && raw.trim() != 'null') {
+        return null;
+      }
+      result[key] = decoded;
+    }
+  }
+  return result;
+}
+
+List<LlamaCompletionChunkToolCall>? _parseAtemCalls(String body, int start) {
+  const scopeStart = '<atem:function_calls>';
+  const scopeEnd = '</atem:function_calls>';
+  final scopeStartIndex = body.indexOf(scopeStart);
+  final scopeEndIndex = body.indexOf(scopeEnd);
+  if (scopeStartIndex < 0 || scopeEndIndex < scopeStartIndex) {
+    return null;
+  }
+  if (body.substring(0, scopeStartIndex).trim().isNotEmpty ||
+      body.substring(scopeEndIndex + scopeEnd.length).trim().isNotEmpty) {
+    return null;
+  }
+  final scope = body.substring(
+    scopeStartIndex + scopeStart.length,
+    scopeEndIndex,
+  );
+  final invokePattern = RegExp(
+    r'<atem:invoke name="([^"]+)">([\s\S]*?)</atem:invoke>',
+  );
+  if (scope.replaceAll(invokePattern, '').trim().isNotEmpty) {
+    return null;
+  }
+  final calls = <LlamaCompletionChunkToolCall>[];
+  for (final invoke in invokePattern.allMatches(scope)) {
+    final name = invoke.group(1) ?? '';
+    final params = invoke.group(2) ?? '';
+    final parameterPattern = RegExp(
+      r'<atem:parameter name="([^"]+)">([\s\S]*?)</atem:parameter>',
+    );
+    if (name.isEmpty ||
+        params.replaceAll(parameterPattern, '').trim().isNotEmpty) {
+      return null;
+    }
+    final arguments = <String, dynamic>{};
+    for (final parameter in parameterPattern.allMatches(params)) {
+      final key = parameter.group(1) ?? '';
+      final raw = parameter.group(2) ?? '';
+      if (key.isEmpty) {
+        return null;
+      }
+      arguments[key] = ToolCallParsingUtils.decodeJsonValueOrString(raw);
+    }
+    calls.add(
+      ToolCallParsingUtils.createFunctionToolCall(
+        index: start + calls.length,
+        name: name,
+        arguments: arguments,
+      ),
+    );
+  }
+  return calls.isEmpty ? null : calls;
+}
+
+String _unescapeAttribute(String value) =>
+    value.replaceAll('&quot;', '"').replaceAll('&amp;', '&');
+
+String? _nullIfEmpty(String? value) {
+  final trimmed = value?.trim();
+  return trimmed == null || trimmed.isEmpty ? null : trimmed;
+}
+
+bool _isWhitespace(int codeUnit) =>
+    codeUnit == 0x20 ||
+    codeUnit == 0x0A ||
+    codeUnit == 0x0D ||
+    codeUnit == 0x09;
+
+class _ParsedCalls {
+  final bool success;
+  final List<LlamaCompletionChunkToolCall> calls;
+  final String remaining;
+
+  const _ParsedCalls({required this.calls, required this.remaining})
+    : success = true;
+
+  const _ParsedCalls.failure()
+    : success = false,
+      calls = const [],
+      remaining = '';
+}
+
+class _DynamicElements {
+  final List<_DynamicElement> elements;
+
+  const _DynamicElements(this.elements);
+}
+
+class _DynamicElement {
+  final String name;
+  final Object? value;
+
+  const _DynamicElement({required this.name, required this.value});
+}

--- a/lib/src/core/template/handlers/llama_cpp_specialized_handlers.dart
+++ b/lib/src/core/template/handlers/llama_cpp_specialized_handlers.dart
@@ -176,9 +176,7 @@ class KimiK3Handler extends _DirectJinjaHandler {
 
     if (!parseToolCalls) {
       return ChatParseResult(
-        content: content.isEmpty
-            ? _stripKimiTurnEnd(remaining)
-            : content.trim(),
+        content: '$content${_stripKimiTurnEnd(remaining)}'.trim(),
         reasoningContent: _nullIfEmpty(reasoning),
       );
     }

--- a/test/integration/core/template/llama_cpp_template_detection_integration_test.dart
+++ b/test/integration/core/template/llama_cpp_template_detection_integration_test.dart
@@ -154,129 +154,117 @@ void main() {
       );
     }, skip: fixtureSkipReason);
 
-    test(
-      'renders and parses every vendored llama.cpp template',
-      () {
-        expect(templatesDir.existsSync(), isTrue);
+    test('renders and parses every vendored llama.cpp template', () {
+      expect(templatesDir.existsSync(), isTrue);
 
-        final files =
-            templatesDir
-                .listSync()
-                .whereType<File>()
-                .where((f) => f.path.endsWith('.jinja'))
-                .toList()
-              ..sort((a, b) => a.path.compareTo(b.path));
+      final files =
+          templatesDir
+              .listSync()
+              .whereType<File>()
+              .where((f) => f.path.endsWith('.jinja'))
+              .toList()
+            ..sort((a, b) => a.path.compareTo(b.path));
 
-        for (final file in files) {
-          final source = file.readAsStringSync();
-          final detected = detectChatFormat(source);
+      for (final file in files) {
+        final source = file.readAsStringSync();
+        final detected = detectChatFormat(source);
 
-          final rendered = ChatTemplateEngine.render(
-            templateSource: source,
-            messages: messages,
-            metadata: metadata,
-            tools: [tool],
-            parallelToolCalls: true,
-          );
+        final rendered = ChatTemplateEngine.render(
+          templateSource: source,
+          messages: messages,
+          metadata: metadata,
+          tools: [tool],
+          parallelToolCalls: true,
+        );
 
+        expect(
+          rendered.prompt.trim(),
+          isNotEmpty,
+          reason: 'Empty prompt for ${file.uri.pathSegments.last}',
+        );
+
+        final parseInput = sampleOutputForFormat(detected);
+        final parsed = ChatTemplateEngine.parse(
+          rendered.format,
+          parseInput,
+          parser: rendered.parser,
+          thinkingForcedOpen: rendered.thinkingForcedOpen,
+        );
+
+        final hasAnyPayload =
+            parsed.content.isNotEmpty ||
+            parsed.toolCalls.isNotEmpty ||
+            (parsed.reasoningContent?.isNotEmpty ?? false);
+        expect(
+          hasAnyPayload,
+          isTrue,
+          reason:
+              'Parse produced empty payload for ${file.uri.pathSegments.last}',
+        );
+
+        if (parseInput.contains('get_weather')) {
+          final parsedToolName = parsed.toolCalls.isNotEmpty
+              ? parsed.toolCalls.first.function?.name
+              : null;
+          final preservedInContent = parsed.content.contains('get_weather');
           expect(
-            rendered.prompt.trim(),
-            isNotEmpty,
-            reason: 'Empty prompt for ${file.uri.pathSegments.last}',
-          );
-
-          final parseInput = sampleOutputForFormat(detected);
-          final parsed = ChatTemplateEngine.parse(
-            rendered.format,
-            parseInput,
-            parser: rendered.parser,
-            thinkingForcedOpen: rendered.thinkingForcedOpen,
-          );
-
-          final hasAnyPayload =
-              parsed.content.isNotEmpty ||
-              parsed.toolCalls.isNotEmpty ||
-              (parsed.reasoningContent?.isNotEmpty ?? false);
-          expect(
-            hasAnyPayload,
+            parsedToolName == 'get_weather' || preservedInContent,
             isTrue,
             reason:
-                'Parse produced empty payload for ${file.uri.pathSegments.last}',
-          );
-
-          if (parseInput.contains('get_weather')) {
-            final parsedToolName = parsed.toolCalls.isNotEmpty
-                ? parsed.toolCalls.first.function?.name
-                : null;
-            final preservedInContent = parsed.content.contains('get_weather');
-            expect(
-              parsedToolName == 'get_weather' || preservedInContent,
-              isTrue,
-              reason:
-                  'Tool payload was neither parsed nor preserved for ${file.uri.pathSegments.last}',
-            );
-          }
-        }
-      },
-      skip: fixtureSkipReason,
-    );
-
-    test(
-      'preserves classified tool-call shapes through render and parse',
-      () {
-        const expectedMarkers = <String, String>{
-          'Kimi-K3.jinja': '<|open|>call tool="get_weather"',
-          'MiniMax-M1.jinja': '<tool_calls>\n{"name": "get_weather"',
-          'MiniMax-M3.jinja': ']<]minimax[>[<invoke name="get_weather">',
-          'deepseek-ai-DeepSeek-V3.2.jinja':
-              '<｜DSML｜invoke name="get_weather">',
-          'deepseek-ai-DeepSeek-V4.jinja': '<｜DSML｜invoke name="get_weather">',
-          'deepseek-ai-DeepSeek-V4-Flash-0731.jinja':
-              '<｜DSML｜invoke name="get_weather">',
-          'muse-glimmer.jinja': '<atem:invoke name="get_weather">',
-          'poolside-Laguna-S-2.1.jinja': '<tool_call>get_weather',
-          'poolside-Laguna-XS-2.1.jinja': '<tool_call>get_weather',
-          'poolside-Laguna-XS.2.jinja': '<tool_call>get_weather',
-        };
-
-        for (final entry in expectedMarkers.entries) {
-          final source = File(
-            '${templatesDir.path}/${entry.key}',
-          ).readAsStringSync();
-          final rendered = ChatTemplateEngine.render(
-            templateSource: source,
-            messages: toolCallHistory,
-            metadata: metadata,
-            addAssistant: false,
-            tools: [tool],
-            parallelToolCalls: true,
-          );
-
-          expect(
-            rendered.prompt,
-            contains(entry.value),
-            reason: 'Tool-call history shape drifted for ${entry.key}',
-          );
-
-          final parsed = ChatTemplateEngine.parse(
-            rendered.format,
-            sampleOutputForFormat(ChatFormat.values[rendered.format]),
-            thinkingForcedOpen: rendered.thinkingForcedOpen,
-          );
-          expect(
-            parsed.toolCalls,
-            hasLength(1),
-            reason: 'Generated tool-call shape was not parsed for ${entry.key}',
-          );
-          expect(parsed.toolCalls.single.function?.name, 'get_weather');
-          expect(
-            parsed.toolCalls.single.function?.arguments,
-            contains('Seoul'),
+                'Tool payload was neither parsed nor preserved for ${file.uri.pathSegments.last}',
           );
         }
-      },
-      skip: fixtureSkipReason,
-    );
+      }
+    }, skip: fixtureSkipReason);
+
+    test('preserves classified tool-call shapes through render and parse', () {
+      const expectedMarkers = <String, String>{
+        'Kimi-K3.jinja': '<|open|>call tool="get_weather"',
+        'MiniMax-M1.jinja': '<tool_calls>\n{"name": "get_weather"',
+        'MiniMax-M3.jinja': ']<]minimax[>[<invoke name="get_weather">',
+        'deepseek-ai-DeepSeek-V3.2.jinja': '<｜DSML｜invoke name="get_weather">',
+        'deepseek-ai-DeepSeek-V4.jinja': '<｜DSML｜invoke name="get_weather">',
+        'deepseek-ai-DeepSeek-V4-Flash-0731.jinja':
+            '<｜DSML｜invoke name="get_weather">',
+        'muse-glimmer.jinja': '<atem:invoke name="get_weather">',
+        'poolside-Laguna-S-2.1.jinja': '<tool_call>get_weather',
+        'poolside-Laguna-XS-2.1.jinja': '<tool_call>get_weather',
+        'poolside-Laguna-XS.2.jinja': '<tool_call>get_weather',
+      };
+
+      for (final entry in expectedMarkers.entries) {
+        final source = File(
+          '${templatesDir.path}/${entry.key}',
+        ).readAsStringSync();
+        final rendered = ChatTemplateEngine.render(
+          templateSource: source,
+          messages: toolCallHistory,
+          metadata: metadata,
+          addAssistant: false,
+          tools: [tool],
+          parallelToolCalls: true,
+        );
+
+        expect(
+          rendered.prompt,
+          contains(entry.value),
+          reason: 'Tool-call history shape drifted for ${entry.key}',
+        );
+
+        final parsed = ChatTemplateEngine.parse(
+          rendered.format,
+          sampleOutputForFormat(ChatFormat.values[rendered.format]),
+          thinkingForcedOpen: rendered.thinkingForcedOpen,
+        );
+        expect(
+          parsed.toolCalls,
+          hasLength(1),
+          reason: 'Generated tool-call shape was not parsed for ${entry.key}',
+        );
+        expect(parsed.toolCalls.single.function?.name, 'get_weather');
+        expect(parsed.toolCalls.single.function?.arguments, contains('Seoul'));
+      }
+    }, skip: fixtureSkipReason);
   });
 }
 

--- a/test/integration/core/template/llama_cpp_template_detection_integration_test.dart
+++ b/test/integration/core/template/llama_cpp_template_detection_integration_test.dart
@@ -5,6 +5,7 @@ import 'dart:io';
 
 import 'package:llamadart/src/core/models/chat/chat_message.dart';
 import 'package:llamadart/src/core/models/chat/chat_role.dart';
+import 'package:llamadart/src/core/models/chat/content_part.dart';
 import 'package:llamadart/src/core/models/tools/tool_definition.dart';
 import 'package:llamadart/src/core/models/tools/tool_param.dart';
 import 'package:llamadart/src/core/template/chat_format.dart';
@@ -29,6 +30,19 @@ void main() {
   const messages = <LlamaChatMessage>[
     LlamaChatMessage.fromText(role: LlamaChatRole.user, text: 'hello'),
   ];
+  const toolCallHistory = <LlamaChatMessage>[
+    LlamaChatMessage.fromText(role: LlamaChatRole.user, text: 'weather?'),
+    LlamaChatMessage.withContent(
+      role: LlamaChatRole.assistant,
+      content: <LlamaContentPart>[
+        LlamaToolCallContent(
+          name: 'get_weather',
+          arguments: <String, dynamic>{'location': 'Seoul'},
+          rawJson: '{"location":"Seoul"}',
+        ),
+      ],
+    ),
+  ];
 
   group('llama.cpp template detection parity', () {
     final expected = <String, ChatFormat>{
@@ -47,11 +61,14 @@ void main() {
       'HuggingFaceTB-SmolLM3-3B.jinja': ChatFormat.contentOnly,
       'Kimi-K2-Instruct.jinja': ChatFormat.kimiK2,
       'Kimi-K2-Thinking.jinja': ChatFormat.kimiK2,
+      'Kimi-K3.jinja': ChatFormat.kimiK3,
       'LFM2-8B-A1B.jinja': ChatFormat.lfm2,
       'LFM2.5-8B-A1B.jinja': ChatFormat.lfm2,
       'LFM2.5-Instruct.jinja': ChatFormat.contentOnly,
       'MiMo-VL.jinja': ChatFormat.hermes,
       'MiniMax-M2.jinja': ChatFormat.minimaxM2,
+      'MiniMax-M1.jinja': ChatFormat.minimaxM1,
+      'MiniMax-M3.jinja': ChatFormat.minimaxM3,
       'Mistral-Small-3.2-24B-Instruct-2506.jinja': ChatFormat.ministral,
       'NVIDIA-Nemotron-3-Nano-30B-A3B-BF16.jinja': ChatFormat.qwen3CoderXml,
       'NVIDIA-Nemotron-Nano-v2.jinja': ChatFormat.nemotronV2,
@@ -66,8 +83,9 @@ void main() {
       'deepseek-ai-DeepSeek-R1-Distill-Llama-8B.jinja': ChatFormat.deepseekR1,
       'deepseek-ai-DeepSeek-R1-Distill-Qwen-32B.jinja': ChatFormat.deepseekR1,
       'deepseek-ai-DeepSeek-V3.1.jinja': ChatFormat.deepseekV3,
-      'deepseek-ai-DeepSeek-V3.2.jinja': ChatFormat.contentOnly,
-      'deepseek-ai-DeepSeek-V4.jinja': ChatFormat.contentOnly,
+      'deepseek-ai-DeepSeek-V3.2.jinja': ChatFormat.deepseekV4,
+      'deepseek-ai-DeepSeek-V4.jinja': ChatFormat.deepseekV4,
+      'deepseek-ai-DeepSeek-V4-Flash-0731.jinja': ChatFormat.deepseekV4,
       'fireworks-ai-llama-3-firefunction-v2.jinja': ChatFormat.firefunctionV2,
       'google-gemma-2-2b-it.jinja': ChatFormat.gemma,
       'google-gemma-4-31B-it-interleaved.jinja': ChatFormat.gemma4,
@@ -86,8 +104,12 @@ void main() {
       'mistralai-Ministral-3-14B-Reasoning-2512.jinja': ChatFormat.ministral,
       'mistralai-Mistral-Nemo-Instruct-2407.jinja': ChatFormat.mistralNemo,
       'moonshotai-Kimi-K2.jinja': ChatFormat.kimiK2,
+      'muse-glimmer.jinja': ChatFormat.museGlimmer,
       'openai-gpt-oss-120b.jinja': ChatFormat.gptOss,
       'openbmb-MiniCPM5-1B.jinja': ChatFormat.minicpm5,
+      'poolside-Laguna-S-2.1.jinja': ChatFormat.laguna,
+      'poolside-Laguna-XS-2.1.jinja': ChatFormat.laguna,
+      'poolside-Laguna-XS.2.jinja': ChatFormat.laguna,
       'StepFun3.5-Flash.jinja': ChatFormat.qwen3CoderXml,
       'tencent-Hy3.jinja': ChatFormat.hunyuanV3,
       'unsloth-Apriel-1.5.jinja': ChatFormat.hermes,
@@ -122,7 +144,6 @@ void main() {
 
       final missing = files
           .where((name) => !expected.containsKey(name))
-          .where((name) => !unclassifiedTemplates.contains(name))
           .toList();
       missing.sort();
       expect(
@@ -131,107 +152,133 @@ void main() {
         reason:
             'Unmapped llama.cpp templates detected. Add expectations for: ${missing.join(', ')}',
       );
-
-      final absent = unclassifiedTemplates
-          .where((name) => !files.contains(name))
-          .toList();
-      absent.sort();
-      expect(
-        absent,
-        isEmpty,
-        reason:
-            'These are no longer in the fixture set; drop them from unclassifiedTemplates: ${absent.join(', ')}',
-      );
-
-      final classified = unclassifiedTemplates
-          .where(expected.containsKey)
-          .toList();
-      classified.sort();
-      expect(
-        classified,
-        isEmpty,
-        reason:
-            'These now have expectations; drop them from unclassifiedTemplates: ${classified.join(', ')}',
-      );
     }, skip: fixtureSkipReason);
 
-    test('renders and parses every vendored llama.cpp template', () {
-      expect(templatesDir.existsSync(), isTrue);
+    test(
+      'renders and parses every vendored llama.cpp template',
+      () {
+        expect(templatesDir.existsSync(), isTrue);
 
-      final files =
-          templatesDir
-              .listSync()
-              .whereType<File>()
-              .where((f) => f.path.endsWith('.jinja'))
-              .toList()
-            ..sort((a, b) => a.path.compareTo(b.path));
+        final files =
+            templatesDir
+                .listSync()
+                .whereType<File>()
+                .where((f) => f.path.endsWith('.jinja'))
+                .toList()
+              ..sort((a, b) => a.path.compareTo(b.path));
 
-      for (final file in files) {
-        final source = file.readAsStringSync();
-        final detected = detectChatFormat(source);
+        for (final file in files) {
+          final source = file.readAsStringSync();
+          final detected = detectChatFormat(source);
 
-        final rendered = ChatTemplateEngine.render(
-          templateSource: source,
-          messages: messages,
-          metadata: metadata,
-          tools: [tool],
-          parallelToolCalls: true,
-        );
+          final rendered = ChatTemplateEngine.render(
+            templateSource: source,
+            messages: messages,
+            metadata: metadata,
+            tools: [tool],
+            parallelToolCalls: true,
+          );
 
-        expect(
-          rendered.prompt.trim(),
-          isNotEmpty,
-          reason: 'Empty prompt for ${file.uri.pathSegments.last}',
-        );
-
-        final parseInput = sampleOutputForFormat(detected);
-        final parsed = ChatTemplateEngine.parse(
-          rendered.format,
-          parseInput,
-          parser: rendered.parser,
-          thinkingForcedOpen: rendered.thinkingForcedOpen,
-        );
-
-        final hasAnyPayload =
-            parsed.content.isNotEmpty ||
-            parsed.toolCalls.isNotEmpty ||
-            (parsed.reasoningContent?.isNotEmpty ?? false);
-        expect(
-          hasAnyPayload,
-          isTrue,
-          reason:
-              'Parse produced empty payload for ${file.uri.pathSegments.last}',
-        );
-
-        if (parseInput.contains('get_weather')) {
-          final parsedToolName = parsed.toolCalls.isNotEmpty
-              ? parsed.toolCalls.first.function?.name
-              : null;
-          final preservedInContent = parsed.content.contains('get_weather');
           expect(
-            parsedToolName == 'get_weather' || preservedInContent,
+            rendered.prompt.trim(),
+            isNotEmpty,
+            reason: 'Empty prompt for ${file.uri.pathSegments.last}',
+          );
+
+          final parseInput = sampleOutputForFormat(detected);
+          final parsed = ChatTemplateEngine.parse(
+            rendered.format,
+            parseInput,
+            parser: rendered.parser,
+            thinkingForcedOpen: rendered.thinkingForcedOpen,
+          );
+
+          final hasAnyPayload =
+              parsed.content.isNotEmpty ||
+              parsed.toolCalls.isNotEmpty ||
+              (parsed.reasoningContent?.isNotEmpty ?? false);
+          expect(
+            hasAnyPayload,
             isTrue,
             reason:
-                'Tool payload was neither parsed nor preserved for ${file.uri.pathSegments.last}',
+                'Parse produced empty payload for ${file.uri.pathSegments.last}',
+          );
+
+          if (parseInput.contains('get_weather')) {
+            final parsedToolName = parsed.toolCalls.isNotEmpty
+                ? parsed.toolCalls.first.function?.name
+                : null;
+            final preservedInContent = parsed.content.contains('get_weather');
+            expect(
+              parsedToolName == 'get_weather' || preservedInContent,
+              isTrue,
+              reason:
+                  'Tool payload was neither parsed nor preserved for ${file.uri.pathSegments.last}',
+            );
+          }
+        }
+      },
+      skip: fixtureSkipReason,
+    );
+
+    test(
+      'preserves classified tool-call shapes through render and parse',
+      () {
+        const expectedMarkers = <String, String>{
+          'Kimi-K3.jinja': '<|open|>call tool="get_weather"',
+          'MiniMax-M1.jinja': '<tool_calls>\n{"name": "get_weather"',
+          'MiniMax-M3.jinja': ']<]minimax[>[<invoke name="get_weather">',
+          'deepseek-ai-DeepSeek-V3.2.jinja':
+              '<｜DSML｜invoke name="get_weather">',
+          'deepseek-ai-DeepSeek-V4.jinja': '<｜DSML｜invoke name="get_weather">',
+          'deepseek-ai-DeepSeek-V4-Flash-0731.jinja':
+              '<｜DSML｜invoke name="get_weather">',
+          'muse-glimmer.jinja': '<atem:invoke name="get_weather">',
+          'poolside-Laguna-S-2.1.jinja': '<tool_call>get_weather',
+          'poolside-Laguna-XS-2.1.jinja': '<tool_call>get_weather',
+          'poolside-Laguna-XS.2.jinja': '<tool_call>get_weather',
+        };
+
+        for (final entry in expectedMarkers.entries) {
+          final source = File(
+            '${templatesDir.path}/${entry.key}',
+          ).readAsStringSync();
+          final rendered = ChatTemplateEngine.render(
+            templateSource: source,
+            messages: toolCallHistory,
+            metadata: metadata,
+            addAssistant: false,
+            tools: [tool],
+            parallelToolCalls: true,
+          );
+
+          expect(
+            rendered.prompt,
+            contains(entry.value),
+            reason: 'Tool-call history shape drifted for ${entry.key}',
+          );
+
+          final parsed = ChatTemplateEngine.parse(
+            rendered.format,
+            sampleOutputForFormat(ChatFormat.values[rendered.format]),
+            thinkingForcedOpen: rendered.thinkingForcedOpen,
+          );
+          expect(
+            parsed.toolCalls,
+            hasLength(1),
+            reason: 'Generated tool-call shape was not parsed for ${entry.key}',
+          );
+          expect(parsed.toolCalls.single.function?.name, 'get_weather');
+          expect(
+            parsed.toolCalls.single.function?.arguments,
+            contains('Seoul'),
           );
         }
-      }
-    }, skip: fixtureSkipReason);
+      },
+      skip: fixtureSkipReason,
+    );
   });
 }
-
-/// Templates at the pinned ref whose detected format is still an open
-/// question, so no expectation is asserted for them. See llamadart#380.
-const unclassifiedTemplates = <String>{
-  'Kimi-K3.jinja',
-  'MiniMax-M1.jinja',
-  'MiniMax-M3.jinja',
-  'deepseek-ai-DeepSeek-V4-Flash-0731.jinja',
-  'muse-glimmer.jinja',
-  'poolside-Laguna-S-2.1.jinja',
-  'poolside-Laguna-XS-2.1.jinja',
-  'poolside-Laguna-XS.2.jinja',
-};
 
 /// Returns null when the suite must run: either the fixtures are present, or
 /// `REQUIRE_LLAMA_CPP_TEMPLATES=1` demands they be, so a missing directory

--- a/test/integration/core/template/llama_cpp_template_parse_samples.dart
+++ b/test/integration/core/template/llama_cpp_template_parse_samples.dart
@@ -38,6 +38,44 @@ const Map<ChatFormat, String> _sampleOutputsByFormat = <ChatFormat, String>{
       '<arg_value:opensource>Seoul</arg_value:opensource>\n'
       '</tool_call:opensource>\n'
       '</tool_calls:opensource>',
+  ChatFormat.kimiK3:
+      '<|open|>response<|sep|><|close|>response<|sep|>'
+      '<|open|>tools<|sep|>'
+      '<|open|>call tool="get_weather" index="1"<|sep|>'
+      '<|open|>argument key="location" type="string"<|sep|>'
+      'Seoul<|close|>argument<|sep|>'
+      '<|close|>call<|sep|><|close|>tools<|sep|>'
+      '<|close|>message<|sep|>',
+  ChatFormat.minimaxM1:
+      '<tool_calls>\n'
+      '{"name":"get_weather","arguments":{"location":"Seoul"}}\n'
+      '</tool_calls>',
+  ChatFormat.minimaxM3:
+      '</mm:think>'
+      ']<]minimax[>[<tool_call>\n'
+      ']<]minimax[>[<invoke name="get_weather">'
+      ']<]minimax[>[<location>Seoul]<]minimax[>[</location>'
+      ']<]minimax[>[</invoke>\n'
+      ']<]minimax[>[</tool_call>',
+  ChatFormat.deepseekV4:
+      '</think>\n\n'
+      '<｜DSML｜tool_calls>\n'
+      '<｜DSML｜invoke name="get_weather">\n'
+      '<｜DSML｜parameter name="location" string="true">Seoul'
+      '</｜DSML｜parameter>\n'
+      '</｜DSML｜invoke>\n'
+      '</｜DSML｜tool_calls>',
+  ChatFormat.museGlimmer:
+      ' to=get_weather<|message|><atem:function_calls>\n'
+      '<atem:invoke name="get_weather">\n'
+      '<atem:parameter name="location">Seoul</atem:parameter>\n'
+      '</atem:invoke>\n'
+      '</atem:function_calls>',
+  ChatFormat.laguna:
+      '</think><tool_call>get_weather\n'
+      '<arg_key>location</arg_key>\n'
+      '<arg_value>Seoul</arg_value>\n'
+      '</tool_call>',
 };
 
 String sampleOutputForFormat(ChatFormat format) {

--- a/test/unit/core/template/chat_format_test.dart
+++ b/test/unit/core/template/chat_format_test.dart
@@ -48,18 +48,15 @@ void main() {
       expect(format, equals(ChatFormat.contentOnly));
     });
 
-    test(
-      'keeps DeepSeek V4 DSML tool_calls template content-only in b9860',
-      () {
-        const source =
-            "{%- set dsml_token = '｜DSML｜' -%}"
-            "<' + dsml_token + 'tool_calls>"
-            "<' + dsml_token + 'invoke name=\"\$TOOL_NAME\">"
-            "</' + dsml_token + 'tool_calls>";
-        final format = detectChatFormat(source);
-        expect(format, equals(ChatFormat.contentOnly));
-      },
-    );
+    test('detects DeepSeek V4 DSML tool_calls template', () {
+      const source =
+          "{%- set dsml_token = '｜DSML｜' -%}"
+          "<' + dsml_token + 'tool_calls>"
+          "<' + dsml_token + 'invoke name=\"\$TOOL_NAME\">"
+          "</' + dsml_token + 'tool_calls>";
+      final format = detectChatFormat(source);
+      expect(format, equals(ChatFormat.deepseekV4));
+    });
 
     test('detects Cohere2 MoE / North Code before older Command-R', () {
       const source =

--- a/test/unit/core/template/chat_template_engine_test.dart
+++ b/test/unit/core/template/chat_template_engine_test.dart
@@ -215,6 +215,12 @@ void main() {
         ChatFormat.minicpm5: TemplateToolCallSerialization.normalizeOnly,
         ChatFormat.qwen3CoderXml: TemplateToolCallSerialization.normalizeOnly,
         ChatFormat.seedOss: TemplateToolCallSerialization.normalizeOnly,
+        ChatFormat.kimiK3: TemplateToolCallSerialization.normalizeOnly,
+        ChatFormat.minimaxM1: TemplateToolCallSerialization.normalizeOnly,
+        ChatFormat.minimaxM3: TemplateToolCallSerialization.normalizeOnly,
+        ChatFormat.deepseekV4: TemplateToolCallSerialization.normalizeOnly,
+        ChatFormat.museGlimmer: TemplateToolCallSerialization.normalizeOnly,
+        ChatFormat.laguna: TemplateToolCallSerialization.normalizeOnly,
       };
 
       for (final MapEntry(key: format, value: expected)

--- a/test/unit/core/template/handlers/llama_cpp_specialized_handlers_test.dart
+++ b/test/unit/core/template/handlers/llama_cpp_specialized_handlers_test.dart
@@ -152,6 +152,18 @@ void main() {
       expect(parsed.content, output);
     });
 
+    test('preserves literal namespace tokens outside a parsed tool scope', () {
+      const output =
+          'Before $ns literal\n'
+          '$ns<tool_call>$ns<invoke name="weather">'
+          '$ns<city>Seoul$ns</city>$ns</invoke>$ns</tool_call>'
+          '\nAfter $ns literal';
+      final parsed = MinimaxM3Handler().parse(output);
+
+      expect(parsed.content, 'Before $ns literal\n\nAfter $ns literal');
+      expect(_arguments(parsed), {'city': 'Seoul'});
+    });
+
     test('keeps non-tool content after a disabled-thinking prefix', () {
       expect(MinimaxM3Handler().parse('</mm:think>Hello').content, 'Hello');
     });

--- a/test/unit/core/template/handlers/llama_cpp_specialized_handlers_test.dart
+++ b/test/unit/core/template/handlers/llama_cpp_specialized_handlers_test.dart
@@ -1,5 +1,6 @@
 import 'dart:convert';
 
+import 'package:llamadart/src/core/models/tools/tool_definition.dart';
 import 'package:llamadart/src/core/template/chat_format.dart';
 import 'package:llamadart/src/core/template/chat_template_engine.dart';
 import 'package:llamadart/src/core/template/handlers/llama_cpp_specialized_handlers.dart';
@@ -85,6 +86,17 @@ void main() {
       const output = 'Example: {"name":"weather"}';
       expect(MinimaxM1Handler().parse(output).content, output);
     });
+
+    test('grammar references the object rule instead of quoting it', () {
+      final grammar = MinimaxM1Handler().buildGrammar([_weatherTool])!;
+      final callRule = grammar
+          .split('\n')
+          .singleWhere((line) => line.startsWith('call ::='));
+
+      expect(callRule, contains(' tool-name '));
+      expect(callRule, contains(' object '));
+      expect(callRule, isNot(contains(r'\"object\"')));
+    });
   });
 
   group('MiniMax M3', () {
@@ -124,6 +136,30 @@ void main() {
 
     test('keeps non-tool content after a disabled-thinking prefix', () {
       expect(MinimaxM3Handler().parse('</mm:think>Hello').content, 'Hello');
+    });
+
+    test('hides an incomplete invoke while streaming', () {
+      const output =
+          'Prelude$ns<tool_call>\n'
+          '$ns<invoke name="weather">$ns<city>Seo';
+      final parsed = MinimaxM3Handler().parse(output, isPartial: true);
+
+      expect(parsed.content, 'Prelude');
+      expect(parsed.toolCalls, isEmpty);
+    });
+
+    test('keeps completed calls before a partial invoke', () {
+      const output =
+          'Prelude$ns<tool_call>\n'
+          '$ns<invoke name="weather">$ns<city>Seoul$ns</city>'
+          '$ns</invoke>\n'
+          '$ns<invoke name="clock">$ns<tz>UT';
+      final parsed = MinimaxM3Handler().parse(output, isPartial: true);
+
+      expect(parsed.content, 'Prelude');
+      expect(parsed.toolCalls, hasLength(1));
+      expect(parsed.toolCalls.single.function?.name, 'weather');
+      expect(_arguments(parsed), {'city': 'Seoul'});
     });
   });
 
@@ -194,6 +230,18 @@ void main() {
       expect(parsed.toolCalls, isEmpty);
       expect(parsed.content, contains('broken'));
     });
+
+    test('lazy grammar activates only at the ATEM tool-call envelope', () {
+      final handler = MuseGlimmerHandler();
+      final grammar = handler.buildGrammar([_weatherTool])!;
+
+      expect(handler.grammarTriggerValues, ['<atem:function_calls>']);
+      expect(
+        grammar.split('\n').first,
+        r'root ::= "<atem:function_calls>\n" invoke "</atem:function_calls>"',
+      );
+      expect(grammar.split('\n').first, isNot(contains(' to=')));
+    });
   });
 
   group('Poolside Laguna', () {
@@ -221,6 +269,13 @@ void main() {
     });
   });
 }
+
+final _weatherTool = ToolDefinition(
+  name: 'weather',
+  description: 'Weather',
+  parameters: const [],
+  handler: (_) async => null,
+);
 
 Map<String, dynamic> _arguments(dynamic parsed) {
   return jsonDecode(parsed.toolCalls.first.function!.arguments!)

--- a/test/unit/core/template/handlers/llama_cpp_specialized_handlers_test.dart
+++ b/test/unit/core/template/handlers/llama_cpp_specialized_handlers_test.dart
@@ -50,12 +50,31 @@ void main() {
       final grammar = KimiK3Handler().buildGrammar([_weatherTool])!;
 
       expect(grammar, contains('(argument* | json-block)'));
+      expect(grammar, contains(r'(" index=\"" [0-9]+ "\"")? "<|sep|>"'));
       expect(
         grammar,
         contains(r'"<|open|>json type=\"object\"<|sep|>" json-object'),
       );
       expect(grammar, contains('char ::= '));
     });
+
+    test(
+      'parses a tool call without the optional upstream index attribute',
+      () {
+        const output =
+            '<|open|>tools<|sep|>'
+            '<|open|>call tool="weather"<|sep|>'
+            '<|open|>argument key="city" type="string"<|sep|>Seoul'
+            '<|close|>argument<|sep|><|close|>call<|sep|>'
+            '<|close|>tools<|sep|><|close|>message<|sep|>';
+
+        final parsed = KimiK3Handler().parse(output);
+
+        expect(parsed.content, isEmpty);
+        expect(parsed.toolCalls.single.function?.name, 'weather');
+        expect(_arguments(parsed), {'city': 'Seoul'});
+      },
+    );
 
     test('preserves malformed tool markup instead of silently dropping it', () {
       const malformed =

--- a/test/unit/core/template/handlers/llama_cpp_specialized_handlers_test.dart
+++ b/test/unit/core/template/handlers/llama_cpp_specialized_handlers_test.dart
@@ -46,6 +46,17 @@ void main() {
       expect(_arguments(parsed), {'city': 'Seoul'});
     });
 
+    test('grammar permits the upstream raw JSON argument block', () {
+      final grammar = KimiK3Handler().buildGrammar([_weatherTool])!;
+
+      expect(grammar, contains('(argument* | json-block)'));
+      expect(
+        grammar,
+        contains(r'"<|open|>json type=\"object\"<|sep|>" json-object'),
+      );
+      expect(grammar, contains('char ::= '));
+    });
+
     test('preserves malformed tool markup instead of silently dropping it', () {
       const malformed =
           '<|open|>response<|sep|>On it.<|close|>response<|sep|>'
@@ -236,6 +247,18 @@ void main() {
       final parsed = MuseGlimmerHandler().parse(output);
       expect(parsed.toolCalls, isEmpty);
       expect(parsed.content, contains('broken'));
+    });
+
+    test('hides an incomplete tool channel while streaming', () {
+      const output =
+          ' to=user<|message|>On it.<|eom|>'
+          '<|start|>assistant to=weather<|message|>'
+          '<atem:function_calls>\n<atem:invoke name="weather">\n'
+          '<atem:parameter name="city">Seo';
+      final parsed = MuseGlimmerHandler().parse(output, isPartial: true);
+
+      expect(parsed.content, 'On it.');
+      expect(parsed.toolCalls, isEmpty);
     });
 
     test('lazy grammar activates only at the ATEM tool-call envelope', () {

--- a/test/unit/core/template/handlers/llama_cpp_specialized_handlers_test.dart
+++ b/test/unit/core/template/handlers/llama_cpp_specialized_handlers_test.dart
@@ -76,6 +76,18 @@ void main() {
       },
     );
 
+    test('preserves trailing output when tool parsing is disabled', () {
+      final parsed = KimiK3Handler().parse(call, parseToolCalls: false);
+
+      expect(parsed.toolCalls, isEmpty);
+      expect(parsed.content, startsWith('On it.'));
+      expect(parsed.content, contains('<|open|>tools<|sep|>'));
+      expect(
+        parsed.content,
+        contains('<|open|>call tool="weather&amp;alerts"'),
+      );
+    });
+
     test('preserves malformed tool markup instead of silently dropping it', () {
       const malformed =
           '<|open|>response<|sep|>On it.<|close|>response<|sep|>'

--- a/test/unit/core/template/handlers/llama_cpp_specialized_handlers_test.dart
+++ b/test/unit/core/template/handlers/llama_cpp_specialized_handlers_test.dart
@@ -58,6 +58,13 @@ void main() {
       expect(grammar, contains('char ::= '));
     });
 
+    test('grammar HTML-escapes tool names like the upstream XTML macro', () {
+      final grammar = KimiK3Handler().buildGrammar([_attributeTool])!;
+
+      expect(grammar, contains(r'tool-name ::= "weather&amp;&quot;alerts"'));
+      expect(grammar, isNot(contains(r'tool-name ::= "weather&\"alerts"')));
+    });
+
     test(
       'parses a tool call without the optional upstream index attribute',
       () {
@@ -354,6 +361,13 @@ final _weatherWithCityTool = ToolDefinition(
   name: 'weather',
   description: 'Weather',
   parameters: [ToolParam.string('city', required: true)],
+  handler: (_) async => null,
+);
+
+final _attributeTool = ToolDefinition(
+  name: 'weather&"alerts',
+  description: 'Weather alerts',
+  parameters: const [],
   handler: (_) async => null,
 );
 

--- a/test/unit/core/template/handlers/llama_cpp_specialized_handlers_test.dart
+++ b/test/unit/core/template/handlers/llama_cpp_specialized_handlers_test.dart
@@ -1,6 +1,7 @@
 import 'dart:convert';
 
 import 'package:llamadart/src/core/models/tools/tool_definition.dart';
+import 'package:llamadart/src/core/models/tools/tool_param.dart';
 import 'package:llamadart/src/core/template/chat_format.dart';
 import 'package:llamadart/src/core/template/chat_template_engine.dart';
 import 'package:llamadart/src/core/template/handlers/llama_cpp_specialized_handlers.dart';
@@ -87,15 +88,21 @@ void main() {
       expect(MinimaxM1Handler().parse(output).content, output);
     });
 
-    test('grammar references the object rule instead of quoting it', () {
-      final grammar = MinimaxM1Handler().buildGrammar([_weatherTool])!;
+    test('grammar uses schema-aware JSON string and escape rules', () {
+      final grammar = MinimaxM1Handler().buildGrammar([_weatherWithCityTool])!;
+      final rootRule = grammar
+          .split('\n')
+          .singleWhere((line) => line.startsWith('root ::='));
       final callRule = grammar
           .split('\n')
-          .singleWhere((line) => line.startsWith('call ::='));
+          .singleWhere((line) => line.startsWith('tool-0-call ::='));
 
-      expect(callRule, contains(' tool-name '));
-      expect(callRule, contains(' object '));
-      expect(callRule, isNot(contains(r'\"object\"')));
+      expect(rootRule, contains('tool-call+'));
+      expect(callRule, contains(' tool-0-arguments '));
+      expect(grammar, contains('char ::= '));
+      expect(grammar, contains(r'[^"\\\x7F\x00-\x1F]'));
+      expect(grammar, contains(r'[\\] (["\\bfnrt] | "u"'));
+      expect(grammar, isNot(contains('json-char ::=')));
     });
   });
 
@@ -274,6 +281,13 @@ final _weatherTool = ToolDefinition(
   name: 'weather',
   description: 'Weather',
   parameters: const [],
+  handler: (_) async => null,
+);
+
+final _weatherWithCityTool = ToolDefinition(
+  name: 'weather',
+  description: 'Weather',
+  parameters: [ToolParam.string('city', required: true)],
   handler: (_) async => null,
 );
 

--- a/test/unit/core/template/handlers/llama_cpp_specialized_handlers_test.dart
+++ b/test/unit/core/template/handlers/llama_cpp_specialized_handlers_test.dart
@@ -1,0 +1,228 @@
+import 'dart:convert';
+
+import 'package:llamadart/src/core/template/chat_format.dart';
+import 'package:llamadart/src/core/template/chat_template_engine.dart';
+import 'package:llamadart/src/core/template/handlers/llama_cpp_specialized_handlers.dart';
+import 'package:test/test.dart';
+
+void main() {
+  group('Kimi K3', () {
+    const call =
+        '<|open|>response<|sep|>On it.<|close|>response<|sep|>'
+        '<|open|>tools<|sep|>'
+        '<|open|>call tool="weather&amp;alerts" index="1"<|sep|>'
+        '<|open|>argument key="city" type="string"<|sep|>'
+        ' New York <|close|>argument<|sep|>'
+        '<|open|>argument key="days" type="number"<|sep|>'
+        '2<|close|>argument<|sep|>'
+        '<|close|>call<|sep|><|close|>tools<|sep|>'
+        '<|close|>message<|sep|>';
+
+    test('parses forced-open reasoning, content, and typed raw arguments', () {
+      final parsed = ChatTemplateEngine.parse(
+        ChatFormat.kimiK3.index,
+        'check first<|close|>think<|sep|>$call',
+        thinkingForcedOpen: true,
+      );
+
+      expect(parsed.reasoningContent, 'check first');
+      expect(parsed.content, 'On it.');
+      expect(parsed.toolCalls, hasLength(1));
+      expect(parsed.toolCalls.single.function?.name, 'weather&alerts');
+      expect(_arguments(parsed), {'city': ' New York ', 'days': 2});
+    });
+
+    test('parses a raw JSON argument block', () {
+      const output =
+          '<|open|>response<|sep|><|close|>response<|sep|>'
+          '<|open|>tools<|sep|>'
+          '<|open|>call tool="weather" index="1"<|sep|>'
+          '<|open|>json type="object"<|sep|>{"city":"Seoul"}'
+          '<|close|>json<|sep|><|close|>call<|sep|>'
+          '<|close|>tools<|sep|><|close|>message<|sep|>';
+      final parsed = KimiK3Handler().parse(output);
+      expect(_arguments(parsed), {'city': 'Seoul'});
+    });
+
+    test('preserves malformed tool markup instead of silently dropping it', () {
+      const malformed =
+          '<|open|>response<|sep|>On it.<|close|>response<|sep|>'
+          '<|open|>tools<|sep|><|open|>call tool="weather" index="1"'
+          '<|sep|><|open|>argument key="days" type="number"<|sep|>oops'
+          '<|close|>argument<|sep|><|close|>call<|sep|>'
+          '<|close|>tools<|sep|>';
+      final parsed = KimiK3Handler().parse(malformed);
+      expect(parsed.toolCalls, isEmpty);
+      expect(parsed.content, contains('<|open|>tools<|sep|>'));
+      expect(parsed.content, contains('On it.'));
+    });
+  });
+
+  group('MiniMax M1', () {
+    test('parses parallel newline-delimited calls and surrounding content', () {
+      const output =
+          'Checking.\n<tool_calls>\n'
+          '{"name":"weather","arguments":{"city":"Seoul"}}\n'
+          '{"name":"clock","arguments":{"tz":"UTC"}}\n'
+          '</tool_calls>';
+      final parsed = MinimaxM1Handler().parse(output);
+      expect(parsed.content, 'Checking.');
+      expect(parsed.toolCalls.map((call) => call.function?.name), [
+        'weather',
+        'clock',
+      ]);
+      expect(_arguments(parsed), {'city': 'Seoul'});
+    });
+
+    test('preserves malformed completed call envelopes', () {
+      const output = '<tool_calls>\n{"name":"weather"\n</tool_calls>';
+      final parsed = MinimaxM1Handler().parse(output);
+      expect(parsed.toolCalls, isEmpty);
+      expect(parsed.content, output);
+    });
+
+    test('keeps ordinary JSON-looking prose as content', () {
+      const output = 'Example: {"name":"weather"}';
+      expect(MinimaxM1Handler().parse(output).content, output);
+    });
+  });
+
+  group('MiniMax M3', () {
+    const ns = MinimaxM3Handler.namespace;
+
+    test('parses reasoning and namespaced raw arguments', () {
+      const output =
+          '<mm:think>check</mm:think>'
+          '$ns<tool_call>\n'
+          '$ns<invoke name="weather">'
+          '$ns<city> New York $ns</city>'
+          '$ns<days>2$ns</days>'
+          '$ns<options>$ns<units>metric$ns</units>'
+          '$ns<alerts>$ns<item>true$ns</item>$ns<item>false$ns</item>'
+          '$ns</alerts>$ns</options>'
+          '$ns</invoke>\n$ns</tool_call>';
+      final parsed = MinimaxM3Handler().parse(output);
+      expect(parsed.reasoningContent, 'check');
+      expect(parsed.content, isEmpty);
+      expect(parsed.toolCalls.single.function?.name, 'weather');
+      expect(_arguments(parsed), {
+        'city': ' New York ',
+        'days': 2,
+        'options': {
+          'units': 'metric',
+          'alerts': [true, false],
+        },
+      });
+    });
+
+    test('preserves malformed namespace scopes', () {
+      const output = '$ns<tool_call>$ns<invoke name="weather">broken';
+      final parsed = MinimaxM3Handler().parse(output);
+      expect(parsed.toolCalls, isEmpty);
+      expect(parsed.content, output);
+    });
+
+    test('keeps non-tool content after a disabled-thinking prefix', () {
+      expect(MinimaxM3Handler().parse('</mm:think>Hello').content, 'Hello');
+    });
+  });
+
+  group('DeepSeek V4 DSML', () {
+    test('parses reasoning, raw strings, and JSON-typed values', () {
+      const output =
+          'reasoning</think>Done.\n\n'
+          '<｜DSML｜tool_calls>\n'
+          '<｜DSML｜invoke name="weather">\n'
+          '<｜DSML｜parameter name="city" string="true"> New York '
+          '</｜DSML｜parameter>\n'
+          '<｜DSML｜parameter name="days" string="false">2'
+          '</｜DSML｜parameter>\n'
+          '</｜DSML｜invoke>\n'
+          '</｜DSML｜tool_calls>';
+      final parsed = DeepseekV4Handler().parse(
+        output,
+        thinkingForcedOpen: true,
+      );
+      expect(parsed.reasoningContent, 'reasoning');
+      expect(parsed.content, 'Done.');
+      expect(_arguments(parsed), {'city': ' New York ', 'days': 2});
+    });
+
+    test('preserves malformed non-string values', () {
+      const output =
+          '<｜DSML｜tool_calls>\n'
+          '<｜DSML｜invoke name="weather">\n'
+          '<｜DSML｜parameter name="days" string="false">two'
+          '</｜DSML｜parameter>\n'
+          '</｜DSML｜invoke>\n</｜DSML｜tool_calls>';
+      final parsed = DeepseekV4Handler().parse(output);
+      expect(parsed.toolCalls, isEmpty);
+      expect(parsed.content, output);
+    });
+  });
+
+  group('Muse Glimmer', () {
+    const atem =
+        '<atem:function_calls>\n'
+        '<atem:invoke name="weather">\n'
+        '<atem:parameter name="city"> New York </atem:parameter>\n'
+        '</atem:invoke>\n'
+        '</atem:function_calls>';
+
+    test('separates reasoning, user content, and recipient tool channels', () {
+      const output =
+          ' to=self<|message|>check first<|eom|>'
+          '<|start|>assistant to=user<|message|>On it.<|eom|>'
+          '<|start|>assistant to=weather<|message|>$atem';
+      final parsed = MuseGlimmerHandler().parse(output);
+      expect(parsed.reasoningContent, 'check first');
+      expect(parsed.content, 'On it.');
+      expect(parsed.toolCalls.single.function?.name, 'weather');
+      expect(_arguments(parsed), {'city': ' New York '});
+    });
+
+    test('does not parse quoted ATEM markup in the user channel', () {
+      const output = ' to=user<|message|>Use this example:\n$atem<|eot|>';
+      final parsed = MuseGlimmerHandler().parse(output);
+      expect(parsed.toolCalls, isEmpty);
+      expect(parsed.content, contains('<atem:function_calls>'));
+    });
+
+    test('preserves malformed tool-channel markup as content', () {
+      const output = ' to=weather<|message|><atem:function_calls>broken<|eot|>';
+      final parsed = MuseGlimmerHandler().parse(output);
+      expect(parsed.toolCalls, isEmpty);
+      expect(parsed.content, contains('broken'));
+    });
+  });
+
+  group('Poolside Laguna', () {
+    test('parses reasoning and GLM-style tool calls with raw strings', () {
+      const output =
+          '<think>check</think>On it.\n'
+          '<tool_call>weather\n'
+          '<arg_key>city</arg_key>\n'
+          '<arg_value> New York </arg_value>\n'
+          '</tool_call>';
+      final handler = LagunaHandler();
+      final parsed = handler.parse(output);
+      expect(parsed.reasoningContent, 'check');
+      expect(parsed.content, 'On it.');
+      expect(_arguments(parsed), {'city': 'New York'});
+      expect(handler.additionalStops, contains('</assistant>'));
+    });
+
+    test('preserves malformed tool blocks as non-tool content', () {
+      const output =
+          '<tool_call>weather<arg_key>city</arg_key>Seoul</tool_call>';
+      final parsed = LagunaHandler().parse(output);
+      expect(parsed.toolCalls, isEmpty);
+      expect(parsed.content, output);
+    });
+  });
+}
+
+Map<String, dynamic> _arguments(dynamic parsed) {
+  return jsonDecode(parsed.toolCalls.first.function!.arguments!)
+      as Map<String, dynamic>;
+}


### PR DESCRIPTION
## Summary

- classify every template reported in #380 as a detector/parser gap rather than accepting the previous `contentOnly` or `hermes` fallback
- add format-specific rendering and parsing for Kimi K3 XTML, MiniMax M1 JSON sequences, MiniMax M3 namespaced XML, DeepSeek DSML, Muse Glimmer recipient/ATEM channels, and Poolside Laguna tags
- preserve reasoning/content boundaries and raw arguments, support parallel/nested/typed calls where the protocol allows them, and keep malformed or non-tool output visible as content
- extend the same DSML correction to the adjacent DeepSeek V3.2 and V4 templates, which share the affected upstream protocol

Closes #380.

## Template classification

| Issue template | Previous fallback | Classification | Implemented format |
| --- | --- | --- | --- |
| Kimi-K3 | `contentOnly` | detector gap | `kimiK3` (XTML) |
| MiniMax-M1 | `contentOnly` | detector gap | `minimaxM1` (newline JSON objects) |
| MiniMax-M3 | `hermes` | detector gap | `minimaxM3` (namespaced XML) |
| DeepSeek-V4-Flash-0731 | `contentOnly` | detector gap | `deepseekV4` (DSML) |
| muse-glimmer | `contentOnly` | detector gap | `museGlimmer` (recipient/ATEM channels) |
| Laguna-S-2.1 | `hermes` | detector gap | `laguna` (GLM-like argument tags) |
| Laguna-XS-2.1 | `hermes` | detector gap | `laguna` (GLM-like argument tags) |
| Laguna-XS.2 | `hermes` | detector gap | `laguna` (GLM-like argument tags) |

No reported template remains an implicit fallback.

## Upstream evidence

- repository pin: llama.cpp `b10549`
- prepared pinned source: `b2e5e9b28b2484fbf94b543432ece638996a8b97`
- current upstream source checked: `d775b8967a46d8beb110d444aa3b8938179e0dd8`
- all eight template files are byte-identical between the pin and current upstream
- llama.cpp's primary chat implementation has specialized Kimi K3, MiniMax M3, DeepSeek DSML, and Muse Glimmer parsers plus Laguna auto-parser coverage; MiniMax M1's template directly defines its `<tool_calls>` JSON-object sequence

## Validation

- `tool/testing/run_template_parity_suites.sh` (71 detection/parity tests, 78 diagnostic fixtures, 390 template unit tests, and both selected/full upstream llama.cpp chat suites)
- `dart analyze`
- `dart test -p vm -j 1 --exclude-tags local-only` (1,584 tests)
- `dart test -p chrome test/unit/core/template/handlers/llama_cpp_specialized_handlers_test.dart` (23 tests)
- coverage: 77.34% overall (11,988/15,501; required 70%); 89.84% for the new specialized handler
- `dart format --output=none --set-exit-if-changed` on changed Dart files
- `git diff --check`

### Real-model smoke

- `gguf-chat-features-smoke` passed on macOS arm64 / Metal with
  `Qwen3.5-0.8B-Q4_K_M.gguf` (SHA-256
  `bd258782e35f7f458f8aced1adc053e6e92e89bc735ba3be89d38a06121dc517`).
  It produced four structured `get_weather` calls with raw
  `{"location":"Seoul"}` arguments across no-thinking, thinking,
  four-token thinking-budget, and zero-thinking-budget paths.
- `llama-cpp-chat-template-smoke` passed with the same real GGUF, covering
  native default/custom template application and unsupported multimodal
  diagnostics.
- This Qwen model validates the real native generation, grammar, streaming,
  and parser path, but does not emit any newly added wire protocol. No matching
  local GGUF was available for `Kimi-K3`, `MiniMax-M1`, `MiniMax-M3`,
  `DeepSeek-V4-Flash-0731`, `muse-glimmer`, `Laguna-S-2.1`,
  `Laguna-XS-2.1`, or `Laguna-XS.2`; format-specific evidence therefore
  remains the pinned/current upstream templates, llama.cpp parser behavior,
  emitted tool-call fixtures, and the durable parity/behavioral suites above.

## Scope

- public runtime behavior changes only for the newly classified template families and the adjacent DSML variants
- no native/web bridge source, asset pin, release, or publication changes
