### PR TITLE
Fix worker backend initialization failure propagation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 ## Unreleased
 
+* llama.cpp backend initialization failures now complete the worker startup
+  handshake with a typed `LlamaBackendInitializationException` and collected
+  native-loader diagnostics. A failed or incompatible worker is torn down
+  instead of being reported ready and leaving later requests waiting forever.
+
 * Fixed Web/native backend API parity. `WebAutoBackend` now forwards grammar
   constraint support from its active runtime, so strict structured output fails
   early with an actionable error on unsupported Web backends, and the Web-safe

--- a/lib/src/backends/llama_cpp/llama_cpp_backend.dart
+++ b/lib/src/backends/llama_cpp/llama_cpp_backend.dart
@@ -16,6 +16,9 @@ import '../../core/models/inference/model_params.dart';
 import '../../core/models/inference/generation_params.dart';
 import 'worker.dart';
 
+/// Worker entry point used by [NativeLlamaBackend].
+typedef LlamaWorkerEntrypoint = void Function(SendPort initialSendPort);
+
 /// Native implementation of [LlamaBackend] using isolates and FFI.
 class NativeLlamaBackend
     implements
@@ -32,6 +35,7 @@ class NativeLlamaBackend
   Isolate? _isolate;
   SendPort? _sendPort;
   Future<void>? _isolateStart;
+  final LlamaWorkerEntrypoint _workerEntrypoint;
   final ReceivePort _responsesPort = ReceivePort();
   Pointer<Int8>? _activeCancelToken;
   void Function()? _activeGenerationCleanup;
@@ -42,7 +46,10 @@ class NativeLlamaBackend
   LlamaLogLevel _currentLogLevel = LlamaLogLevel.warn;
 
   /// Creates a new [NativeLlamaBackend] and initializes its ports.
-  NativeLlamaBackend({SendPort? initialSendPort}) {
+  NativeLlamaBackend({
+    SendPort? initialSendPort,
+    LlamaWorkerEntrypoint workerEntrypoint = llamaWorkerEntry,
+  }) : _workerEntrypoint = workerEntrypoint {
     _responsesPort.listen(_handleResponse);
     if (initialSendPort != null) {
       _sendPort = initialSendPort;
@@ -57,7 +64,11 @@ class NativeLlamaBackend
     if (message is SendPort) {
       _sendPort = message;
       // Complete handshake
-      _sendPort!.send(WorkerHandshake(_currentLogLevel));
+      final handshakePort = ReceivePort();
+      _sendPort!.send(
+        WorkerHandshake(_currentLogLevel, handshakePort.sendPort),
+      );
+      handshakePort.first.then((_) => handshakePort.close());
       // Sync log level, closing the reply port once acked so it does not leak
       // (mirrors _ensureIsolate).
       final logRp = ReceivePort();
@@ -100,6 +111,8 @@ class NativeLlamaBackend
             ? response.message.substring(exceptionPrefix.length)
             : response.message;
         return Exception(message);
+      case WorkerErrorKind.backendInitialization:
+        return LlamaBackendInitializationException(response.message);
     }
   }
 
@@ -129,26 +142,70 @@ class NativeLlamaBackend
   Future<void> _startIsolate() async {
     final completer = Completer<void>();
     final tempPort = ReceivePort();
+    var workerPortReceived = false;
     tempPort.listen((msg) {
-      if (msg is SendPort) {
+      if (msg is SendPort && !workerPortReceived) {
+        workerPortReceived = true;
         _sendPort = msg;
-        _sendPort!.send(WorkerHandshake(_currentLogLevel));
-        final logRp = ReceivePort();
-        _sendPort!.send(LogLevelRequest(_currentLogLevel, logRp.sendPort));
-        logRp.first.then((_) {
-          logRp.close();
-        });
-        tempPort.close();
-        completer.complete();
+        _sendPort!.send(WorkerHandshake(_currentLogLevel, tempPort.sendPort));
+        return;
       }
+      if (completer.isCompleted) {
+        return;
+      }
+      if (msg is DoneResponse && workerPortReceived) {
+        completer.complete();
+        return;
+      }
+      if (msg is ErrorResponse && workerPortReceived) {
+        completer.completeError(_workerError(msg));
+        return;
+      }
+      if (msg is List<Object?> && msg.isNotEmpty) {
+        completer.completeError(
+          LlamaBackendInitializationException(
+            'The llama.cpp worker exited during backend initialization: '
+            '${msg.first}',
+          ),
+        );
+        return;
+      }
+      final reason = workerPortReceived
+          ? 'before acknowledging the backend initialization handshake'
+          : 'before providing its request port';
+      completer.completeError(
+        LlamaBackendInitializationException(
+          msg == null
+              ? 'The llama.cpp worker exited $reason.'
+              : 'The llama.cpp worker returned an unexpected startup '
+                    'response (${msg.runtimeType}) $reason. The worker and '
+                    'Dart package may be incompatible.',
+        ),
+      );
     });
     try {
-      _isolate = await Isolate.spawn(llamaWorkerEntry, tempPort.sendPort);
+      _isolate = await Isolate.spawn(
+        _workerEntrypoint,
+        tempPort.sendPort,
+        onError: tempPort.sendPort,
+        onExit: tempPort.sendPort,
+        errorsAreFatal: true,
+      );
       await completer.future;
       _isReady = true;
-    } catch (_) {
+    } catch (error) {
+      _isReady = false;
+      _sendPort = null;
+      _isolate?.kill(priority: Isolate.immediate);
+      _isolate = null;
+      if (error is LlamaBackendInitializationException) {
+        rethrow;
+      }
+      throw LlamaBackendInitializationException(
+        'Failed to start the llama.cpp worker isolate: $error',
+      );
+    } finally {
       tempPort.close();
-      rethrow;
     }
   }
 

--- a/lib/src/backends/llama_cpp/llama_cpp_backend.dart
+++ b/lib/src/backends/llama_cpp/llama_cpp_backend.dart
@@ -146,10 +146,12 @@ class NativeLlamaBackend
         return;
       }
       if (msg is List<Object?> && msg.isNotEmpty) {
+        final phase = workerPortReceived
+            ? 'during backend initialization'
+            : 'before providing its request port';
         completer.completeError(
           LlamaBackendInitializationException(
-            'The llama.cpp worker exited during backend initialization: '
-            '${msg.first}',
+            'The llama.cpp worker exited $phase: ${msg.first}',
             msg.length > 1 ? msg[1] : null,
           ),
         );

--- a/lib/src/backends/llama_cpp/llama_cpp_backend.dart
+++ b/lib/src/backends/llama_cpp/llama_cpp_backend.dart
@@ -675,6 +675,9 @@ class NativeLlamaBackend
       rp.close();
     }
     _isolate?.kill();
+    _isolate = null;
+    _sendPort = null;
+    _isolateStart = null;
     // Worker is gone; free the token if a terminal response did not already.
     _activeFreeToken?.call();
     _activeCancelToken = null;

--- a/lib/src/backends/llama_cpp/llama_cpp_backend.dart
+++ b/lib/src/backends/llama_cpp/llama_cpp_backend.dart
@@ -98,14 +98,14 @@ class NativeLlamaBackend
   }
 
   Future<void> _ensureIsolate() async {
-    if (_sendPort != null) {
-      _isReady = true;
-      return;
-    }
     final existingStart = _isolateStart;
     if (existingStart != null) {
       await existingStart;
       _isReady = _sendPort != null;
+      return;
+    }
+    if (_sendPort != null) {
+      _isReady = true;
       return;
     }
 

--- a/lib/src/backends/llama_cpp/llama_cpp_backend.dart
+++ b/lib/src/backends/llama_cpp/llama_cpp_backend.dart
@@ -36,7 +36,6 @@ class NativeLlamaBackend
   SendPort? _sendPort;
   Future<void>? _isolateStart;
   final LlamaWorkerEntrypoint _workerEntrypoint;
-  final ReceivePort _responsesPort = ReceivePort();
   Pointer<Int8>? _activeCancelToken;
   void Function()? _activeGenerationCleanup;
   void Function()? _activeFreeToken;
@@ -50,7 +49,6 @@ class NativeLlamaBackend
     SendPort? initialSendPort,
     LlamaWorkerEntrypoint workerEntrypoint = llamaWorkerEntry,
   }) : _workerEntrypoint = workerEntrypoint {
-    _responsesPort.listen(_handleResponse);
     if (initialSendPort != null) {
       _sendPort = initialSendPort;
       _isReady = true;
@@ -59,23 +57,6 @@ class NativeLlamaBackend
 
   @override
   bool get isReady => _isReady;
-
-  void _handleResponse(dynamic message) {
-    if (message is SendPort) {
-      _sendPort = message;
-      // Complete handshake
-      final handshakePort = ReceivePort();
-      _sendPort!.send(
-        WorkerHandshake(_currentLogLevel, handshakePort.sendPort),
-      );
-      handshakePort.first.then((_) => handshakePort.close());
-      // Sync log level, closing the reply port once acked so it does not leak
-      // (mirrors _ensureIsolate).
-      final logRp = ReceivePort();
-      _sendPort!.send(LogLevelRequest(_currentLogLevel, logRp.sendPort));
-      logRp.first.then((_) => logRp.close());
-    }
-  }
 
   void _expectDoneResponse(Object? response, String operation) {
     if (response is DoneResponse) {
@@ -166,6 +147,7 @@ class NativeLlamaBackend
           LlamaBackendInitializationException(
             'The llama.cpp worker exited during backend initialization: '
             '${msg.first}',
+            msg.length > 1 ? msg[1] : null,
           ),
         );
         return;
@@ -681,7 +663,6 @@ class NativeLlamaBackend
       rp.close();
     }
     _isolate?.kill();
-    _responsesPort.close();
     // Worker is gone; free the token if a terminal response did not already.
     _activeFreeToken?.call();
     _activeCancelToken = null;

--- a/lib/src/backends/llama_cpp/llama_cpp_backend.dart
+++ b/lib/src/backends/llama_cpp/llama_cpp_backend.dart
@@ -36,6 +36,8 @@ class NativeLlamaBackend
   Isolate? _isolate;
   SendPort? _sendPort;
   Future<void>? _isolateStart;
+  Future<void>? _disposeStart;
+  int _lifecycleEpoch = 0;
   final LlamaWorkerEntrypoint _workerEntrypoint;
   final Duration _workerStartupTimeout;
   Pointer<Int8>? _activeCancelToken;
@@ -102,9 +104,15 @@ class NativeLlamaBackend
   }
 
   Future<void> _ensureIsolate() async {
+    final activeDispose = _disposeStart;
+    if (activeDispose != null) {
+      await activeDispose;
+    }
+    final lifecycleEpoch = _lifecycleEpoch;
     final existingStart = _isolateStart;
     if (existingStart != null) {
       await existingStart;
+      _throwIfDisposedDuringStartup(lifecycleEpoch);
       _isReady = _sendPort != null;
       return;
     }
@@ -117,6 +125,8 @@ class NativeLlamaBackend
     _isolateStart = start;
     try {
       await start;
+      _throwIfDisposedDuringStartup(lifecycleEpoch);
+      _isReady = _sendPort != null;
     } finally {
       if (_isolateStart == start) {
         _isolateStart = null;
@@ -127,27 +137,29 @@ class NativeLlamaBackend
   Future<void> _startIsolate() async {
     final completer = Completer<void>();
     final tempPort = ReceivePort();
-    var workerPortReceived = false;
+    SendPort? workerSendPort;
     tempPort.listen((msg) {
-      if (msg is SendPort && !workerPortReceived) {
-        workerPortReceived = true;
-        _sendPort = msg;
-        _sendPort!.send(WorkerHandshake(_currentLogLevel, tempPort.sendPort));
+      if (msg is SendPort && workerSendPort == null) {
+        workerSendPort = msg;
+        workerSendPort!.send(
+          WorkerHandshake(_currentLogLevel, tempPort.sendPort),
+        );
         return;
       }
       if (completer.isCompleted) {
         return;
       }
-      if (msg is DoneResponse && workerPortReceived) {
+      if (msg is DoneResponse && workerSendPort != null) {
+        _sendPort = workerSendPort;
         completer.complete();
         return;
       }
-      if (msg is ErrorResponse && workerPortReceived) {
+      if (msg is ErrorResponse && workerSendPort != null) {
         completer.completeError(_workerError(msg));
         return;
       }
       if (msg is List<Object?> && msg.isNotEmpty) {
-        final phase = workerPortReceived
+        final phase = workerSendPort != null
             ? 'during backend initialization'
             : 'before providing its request port';
         completer.completeError(
@@ -158,7 +170,7 @@ class NativeLlamaBackend
         );
         return;
       }
-      final reason = workerPortReceived
+      final reason = workerSendPort != null
           ? 'before acknowledging the backend initialization handshake'
           : 'before providing its request port';
       completer.completeError(
@@ -189,7 +201,6 @@ class NativeLlamaBackend
           );
         },
       );
-      _isReady = true;
     } catch (error) {
       _isReady = false;
       _sendPort = null;
@@ -206,6 +217,14 @@ class NativeLlamaBackend
     }
   }
 
+  void _throwIfDisposedDuringStartup(int lifecycleEpoch) {
+    if (lifecycleEpoch != _lifecycleEpoch) {
+      throw LlamaBackendInitializationException(
+        'The llama.cpp worker was disposed during backend initialization.',
+      );
+    }
+  }
+
   @override
   void cancelGeneration() {
     _activeCancelToken?.value = 1;
@@ -214,11 +233,25 @@ class NativeLlamaBackend
   @override
   Future<void> setLogLevel(LlamaLogLevel level) async {
     _currentLogLevel = level;
-    if (_sendPort != null) {
+    final activeDispose = _disposeStart;
+    if (activeDispose != null) {
+      await activeDispose;
+    }
+    final lifecycleEpoch = _lifecycleEpoch;
+    final startup = _isolateStart;
+    if (startup != null) {
+      await startup;
+      _throwIfDisposedDuringStartup(lifecycleEpoch);
+    }
+    final sendPort = _sendPort;
+    if (sendPort != null) {
       final rp = ReceivePort();
-      _sendPort!.send(LogLevelRequest(level, rp.sendPort));
-      await rp.first;
-      rp.close();
+      try {
+        sendPort.send(LogLevelRequest(level, rp.sendPort));
+        _expectDoneResponse(await rp.first, 'log-level update');
+      } finally {
+        rp.close();
+      }
     }
   }
 
@@ -661,6 +694,33 @@ class NativeLlamaBackend
 
   @override
   Future<void> dispose() async {
+    final existingDispose = _disposeStart;
+    if (existingDispose != null) {
+      await existingDispose;
+      return;
+    }
+    final dispose = _disposeWorker();
+    _disposeStart = dispose;
+    try {
+      await dispose;
+    } finally {
+      if (_disposeStart == dispose) {
+        _disposeStart = null;
+      }
+    }
+  }
+
+  Future<void> _disposeWorker() async {
+    _lifecycleEpoch += 1;
+    _isReady = false;
+    final startup = _isolateStart;
+    if (startup != null) {
+      try {
+        await startup;
+      } catch (_) {
+        // Startup already performed its own failure cleanup.
+      }
+    }
     // Signal any in-flight generation to stop and close the Dart side, but do
     // not free the shared cancel token yet: the worker may still poll it. The
     // worker awaits the in-flight generation before acking the dispose, so its

--- a/lib/src/backends/llama_cpp/llama_cpp_backend.dart
+++ b/lib/src/backends/llama_cpp/llama_cpp_backend.dart
@@ -36,6 +36,7 @@ class NativeLlamaBackend
   SendPort? _sendPort;
   Future<void>? _isolateStart;
   final LlamaWorkerEntrypoint _workerEntrypoint;
+  final Duration _workerStartupTimeout;
   Pointer<Int8>? _activeCancelToken;
   void Function()? _activeGenerationCleanup;
   void Function()? _activeFreeToken;
@@ -48,7 +49,9 @@ class NativeLlamaBackend
   NativeLlamaBackend({
     SendPort? initialSendPort,
     LlamaWorkerEntrypoint workerEntrypoint = llamaWorkerEntry,
-  }) : _workerEntrypoint = workerEntrypoint {
+    Duration workerStartupTimeout = const Duration(seconds: 5),
+  }) : _workerEntrypoint = workerEntrypoint,
+       _workerStartupTimeout = workerStartupTimeout {
     if (initialSendPort != null) {
       _sendPort = initialSendPort;
       _isReady = true;
@@ -173,7 +176,16 @@ class NativeLlamaBackend
         onExit: tempPort.sendPort,
         errorsAreFatal: true,
       );
-      await completer.future;
+      await completer.future.timeout(
+        _workerStartupTimeout,
+        onTimeout: () {
+          throw LlamaBackendInitializationException(
+            'Timed out after ${_workerStartupTimeout.inMilliseconds} ms '
+            'waiting for the llama.cpp worker to initialize its backend. '
+            'The native runtime may be unavailable or unresponsive.',
+          );
+        },
+      );
       _isReady = true;
     } catch (error) {
       _isReady = false;

--- a/lib/src/backends/llama_cpp/worker.dart
+++ b/lib/src/backends/llama_cpp/worker.dart
@@ -158,12 +158,12 @@ void runLlamaWorkerForTesting(
           isInitialized = true;
         }
         message.sendPort.send(DoneResponse());
-      } catch (error) {
+      } catch (error, stackTrace) {
         final diagnostics = service.getStartupDiagnostics();
         message.sendPort.send(
           ErrorResponse(
             'Failed to initialize the llama.cpp backend: '
-            '$error${formatStartupDiagnostics(diagnostics)}',
+            '$error\n$stackTrace${formatStartupDiagnostics(diagnostics)}',
             kind: WorkerErrorKind.backendInitialization,
           ),
         );

--- a/lib/src/backends/llama_cpp/worker.dart
+++ b/lib/src/backends/llama_cpp/worker.dart
@@ -151,10 +151,32 @@ void runLlamaWorkerForTesting(
 
     // Handshake
     if (message is WorkerHandshake) {
-      service.setLogLevel(message.initialLogLevel);
-      if (!isInitialized) {
-        service.initializeBackend();
-        isInitialized = true;
+      try {
+        service.setLogLevel(message.initialLogLevel);
+        if (!isInitialized) {
+          service.initializeBackend();
+          isInitialized = true;
+        }
+        message.sendPort.send(DoneResponse());
+      } catch (error) {
+        final diagnostics = service.getStartupDiagnostics();
+        message.sendPort.send(
+          ErrorResponse(
+            'Failed to initialize the llama.cpp backend: '
+            '$error${formatStartupDiagnostics(diagnostics)}',
+            kind: WorkerErrorKind.backendInitialization,
+          ),
+        );
+        shuttingDown = true;
+        try {
+          service.dispose();
+        } catch (_) {
+          // Initialization already failed; preserve the original error.
+        }
+        receivePort.close();
+        if (exitOnDispose) {
+          Isolate.exit();
+        }
       }
       return;
     }

--- a/lib/src/backends/llama_cpp/worker.dart
+++ b/lib/src/backends/llama_cpp/worker.dart
@@ -163,7 +163,7 @@ void runLlamaWorkerForTesting(
         final diagnosticsSuffix = formatStartupDiagnostics(diagnostics);
         final diagnosticsSection = diagnosticsSuffix.isEmpty
             ? ''
-            : '\n${diagnosticsSuffix.substring(2)}';
+            : '\n${diagnosticsSuffix.replaceFirst(RegExp(r'^,\s*'), '')}';
         message.sendPort.send(
           ErrorResponse(
             'Failed to initialize the llama.cpp backend: '

--- a/lib/src/backends/llama_cpp/worker.dart
+++ b/lib/src/backends/llama_cpp/worker.dart
@@ -160,10 +160,14 @@ void runLlamaWorkerForTesting(
         message.sendPort.send(DoneResponse());
       } catch (error, stackTrace) {
         final diagnostics = service.getStartupDiagnostics();
+        final diagnosticsSuffix = formatStartupDiagnostics(diagnostics);
+        final diagnosticsSection = diagnosticsSuffix.isEmpty
+            ? ''
+            : '\n${diagnosticsSuffix.substring(2)}';
         message.sendPort.send(
           ErrorResponse(
             'Failed to initialize the llama.cpp backend: '
-            '$error\n$stackTrace${formatStartupDiagnostics(diagnostics)}',
+            '$error\n$stackTrace$diagnosticsSection',
             kind: WorkerErrorKind.backendInitialization,
           ),
         );

--- a/lib/src/backends/llama_cpp/worker_messages.dart
+++ b/lib/src/backends/llama_cpp/worker_messages.dart
@@ -574,6 +574,9 @@ enum WorkerErrorKind {
   /// An unclassified worker error.
   generic,
 
+  /// The native backend failed during worker startup.
+  backendInitialization,
+
   /// Model loading or ownership failed.
   model,
 
@@ -747,6 +750,9 @@ class WorkerHandshake {
   /// The initial log level to set before backend initialization.
   final LlamaLogLevel initialLogLevel;
 
+  /// Port that receives [DoneResponse] or an initialization [ErrorResponse].
+  final SendPort sendPort;
+
   /// Creates a new [WorkerHandshake].
-  WorkerHandshake(this.initialLogLevel);
+  WorkerHandshake(this.initialLogLevel, this.sendPort);
 }

--- a/lib/src/core/exceptions.dart
+++ b/lib/src/core/exceptions.dart
@@ -32,6 +32,12 @@ class LlamaInferenceException extends LlamaException {
   LlamaInferenceException(super.message, [super.details]);
 }
 
+/// Exception thrown when a backend cannot initialize its runtime.
+class LlamaBackendInitializationException extends LlamaException {
+  /// Creates a new [LlamaBackendInitializationException].
+  LlamaBackendInitializationException(super.message, [super.details]);
+}
+
 /// Exception thrown when speech recognition fails.
 class LlamaSpeechException extends LlamaException {
   /// Creates a new [LlamaSpeechException].

--- a/test/unit/backends/llama_cpp/llama_cpp_backend_test.dart
+++ b/test/unit/backends/llama_cpp/llama_cpp_backend_test.dart
@@ -531,6 +531,15 @@ void main() {
                       (error) => error.message,
                       'startup diagnostics',
                       contains('libllamadart.dylib was not loadable'),
+                    )
+                    .having(
+                      (error) => error.message,
+                      'sanitized diagnostics',
+                      allOf(
+                        isNot(contains('user:pass')),
+                        isNot(contains('token=secret')),
+                        isNot(contains('\u0000')),
+                      ),
                     ),
               ),
               reason: 'attempt ${attempt + 1} must fail instead of hanging',
@@ -575,6 +584,74 @@ void main() {
         await backend.dispose().timeout(const Duration(seconds: 2));
       }
     });
+
+    test('log-level update joins a failing startup handshake', () async {
+      final backend = NativeLlamaBackend(
+        workerEntrypoint: _delayedFailingInitializationWorkerEntry,
+      );
+
+      try {
+        final modelLoad = backend.modelLoad('never.gguf', const ModelParams());
+        await Future<void>.delayed(const Duration(milliseconds: 10));
+        final logLevelUpdate = backend.setLogLevel(LlamaLogLevel.debug);
+
+        await Future.wait(<Future<void>>[
+          expectLater(
+            modelLoad.timeout(const Duration(seconds: 2)),
+            throwsA(isA<LlamaBackendInitializationException>()),
+          ),
+          expectLater(
+            logLevelUpdate.timeout(const Duration(seconds: 2)),
+            throwsA(isA<LlamaBackendInitializationException>()),
+          ),
+        ]);
+        expect(backend.isReady, isFalse);
+      } finally {
+        await backend.dispose().timeout(const Duration(seconds: 2));
+      }
+    });
+
+    test(
+      'concurrent dispose cancels the startup caller and permits restart',
+      () async {
+        final backend = NativeLlamaBackend(
+          workerEntrypoint: _delayedReusableWorkerEntry,
+        );
+
+        try {
+          final modelLoad = backend.modelLoad(
+            'before-dispose.gguf',
+            const ModelParams(),
+          );
+          await Future<void>.delayed(const Duration(milliseconds: 10));
+
+          await Future.wait(<Future<void>>[
+            expectLater(
+              modelLoad.timeout(const Duration(seconds: 2)),
+              throwsA(
+                isA<LlamaBackendInitializationException>().having(
+                  (error) => error.message,
+                  'message',
+                  contains('disposed during backend initialization'),
+                ),
+              ),
+            ),
+            backend.dispose().timeout(const Duration(seconds: 2)),
+            backend.dispose().timeout(const Duration(seconds: 2)),
+          ]);
+          expect(backend.isReady, isFalse);
+          expect(
+            await backend
+                .modelLoad('after-dispose.gguf', const ModelParams())
+                .timeout(const Duration(seconds: 2)),
+            42,
+          );
+          expect(backend.isReady, isTrue);
+        } finally {
+          await backend.dispose().timeout(const Duration(seconds: 2));
+        }
+      },
+    );
 
     test(
       'worker exit before handshake acknowledgement fails promptly',
@@ -770,6 +847,24 @@ void _delayedFailingInitializationWorkerEntry(SendPort initialSendPort) {
   });
 }
 
+void _delayedReusableWorkerEntry(SendPort initialSendPort) {
+  final receivePort = ReceivePort();
+  initialSendPort.send(receivePort.sendPort);
+  receivePort.listen((message) async {
+    switch (message) {
+      case WorkerHandshake():
+        await Future<void>.delayed(const Duration(milliseconds: 50));
+        message.sendPort.send(DoneResponse());
+      case ModelLoadRequest():
+        message.sendPort.send(HandleResponse(42));
+      case DisposeRequest():
+        message.sendPort.send(null);
+        receivePort.close();
+        Isolate.exit();
+    }
+  });
+}
+
 void _exitingBeforeHandshakeReplyWorkerEntry(SendPort initialSendPort) {
   final receivePort = ReceivePort();
   initialSendPort.send(receivePort.sendPort);
@@ -822,7 +917,10 @@ class _FailingInitializationLlamaCppService extends LlamaCppService {
 
   @override
   List<String> getStartupDiagnostics() {
-    return const <String>['libllamadart.dylib was not loadable'];
+    return const <String>[
+      'libllamadart.dylib was not loadable',
+      'failed at https://user:pass@example.com/lib.dylib?token=secret\u0000next',
+    ];
   }
 
   @override

--- a/test/unit/backends/llama_cpp/llama_cpp_backend_test.dart
+++ b/test/unit/backends/llama_cpp/llama_cpp_backend_test.dart
@@ -532,6 +532,36 @@ void main() {
       },
     );
 
+    test('uncaught worker startup error preserves its stack trace', () async {
+      final backend = NativeLlamaBackend(
+        workerEntrypoint: _crashingDuringHandshakeWorkerEntry,
+      );
+
+      try {
+        await expectLater(
+          backend
+              .modelLoad('never.gguf', const ModelParams())
+              .timeout(const Duration(seconds: 2)),
+          throwsA(
+            isA<LlamaBackendInitializationException>()
+                .having(
+                  (error) => error.message,
+                  'message',
+                  contains('synthetic handshake crash'),
+                )
+                .having(
+                  (error) => error.details,
+                  'stack trace',
+                  contains('_crashingDuringHandshakeWorkerEntry'),
+                ),
+          ),
+        );
+        expect(backend.isReady, isFalse);
+      } finally {
+        await backend.dispose().timeout(const Duration(seconds: 2));
+      }
+    });
+
     test('unexpected handshake response reports version skew', () async {
       final backend = NativeLlamaBackend(
         workerEntrypoint: _incompatibleHandshakeWorkerEntry,
@@ -578,6 +608,16 @@ void _exitingBeforeHandshakeReplyWorkerEntry(SendPort initialSendPort) {
     if (message is WorkerHandshake) {
       receivePort.close();
       Isolate.exit();
+    }
+  });
+}
+
+void _crashingDuringHandshakeWorkerEntry(SendPort initialSendPort) {
+  final receivePort = ReceivePort();
+  initialSendPort.send(receivePort.sendPort);
+  receivePort.listen((message) {
+    if (message is WorkerHandshake) {
+      throw StateError('synthetic handshake crash');
     }
   });
 }

--- a/test/unit/backends/llama_cpp/llama_cpp_backend_test.dart
+++ b/test/unit/backends/llama_cpp/llama_cpp_backend_test.dart
@@ -468,6 +468,30 @@ void main() {
     expect(backend.isReady, isFalse);
   });
 
+  test('a disposed backend starts a fresh worker instead of hanging', () async {
+    final backend = NativeLlamaBackend(workerEntrypoint: _reusableWorkerEntry);
+
+    try {
+      expect(
+        await backend
+            .modelLoad('first.gguf', const ModelParams())
+            .timeout(const Duration(seconds: 2)),
+        42,
+      );
+      await backend.dispose().timeout(const Duration(seconds: 2));
+      expect(backend.isReady, isFalse);
+      expect(
+        await backend
+            .modelLoad('second.gguf', const ModelParams())
+            .timeout(const Duration(seconds: 2)),
+        42,
+      );
+      expect(backend.isReady, isTrue);
+    } finally {
+      await backend.dispose().timeout(const Duration(seconds: 2));
+    }
+  });
+
   group('worker startup handshake', () {
     test(
       'init failure is typed, diagnostic, retryable, and cleaned up',
@@ -663,6 +687,23 @@ void _failingInitializationWorkerEntry(SendPort initialSendPort) {
     initialSendPort,
     _FailingInitializationLlamaCppService(),
   );
+}
+
+void _reusableWorkerEntry(SendPort initialSendPort) {
+  final receivePort = ReceivePort();
+  initialSendPort.send(receivePort.sendPort);
+  receivePort.listen((message) {
+    switch (message) {
+      case WorkerHandshake():
+        message.sendPort.send(DoneResponse());
+      case ModelLoadRequest():
+        message.sendPort.send(HandleResponse(42));
+      case DisposeRequest():
+        message.sendPort.send(null);
+        receivePort.close();
+        Isolate.exit();
+    }
+  });
 }
 
 void _delayedFailingInitializationWorkerEntry(SendPort initialSendPort) {

--- a/test/unit/backends/llama_cpp/llama_cpp_backend_test.dart
+++ b/test/unit/backends/llama_cpp/llama_cpp_backend_test.dart
@@ -505,6 +505,39 @@ void main() {
       },
     );
 
+    test('concurrent calls share the failing startup handshake', () async {
+      final backend = NativeLlamaBackend(
+        workerEntrypoint: _delayedFailingInitializationWorkerEntry,
+      );
+
+      try {
+        final startupFailure = throwsA(
+          isA<LlamaBackendInitializationException>().having(
+            (error) => error.message,
+            'message',
+            contains('delayed synthetic initialization failure'),
+          ),
+        );
+        await Future.wait(<Future<void>>[
+          expectLater(
+            backend
+                .modelLoad('first.gguf', const ModelParams())
+                .timeout(const Duration(seconds: 2)),
+            startupFailure,
+          ),
+          expectLater(
+            backend
+                .modelLoad('second.gguf', const ModelParams())
+                .timeout(const Duration(seconds: 2)),
+            startupFailure,
+          ),
+        ]);
+        expect(backend.isReady, isFalse);
+      } finally {
+        await backend.dispose().timeout(const Duration(seconds: 2));
+      }
+    });
+
     test(
       'worker exit before handshake acknowledgement fails promptly',
       () async {
@@ -599,6 +632,23 @@ void _failingInitializationWorkerEntry(SendPort initialSendPort) {
     initialSendPort,
     _FailingInitializationLlamaCppService(),
   );
+}
+
+void _delayedFailingInitializationWorkerEntry(SendPort initialSendPort) {
+  final receivePort = ReceivePort();
+  initialSendPort.send(receivePort.sendPort);
+  receivePort.listen((message) async {
+    if (message is WorkerHandshake) {
+      await Future<void>.delayed(const Duration(milliseconds: 50));
+      message.sendPort.send(
+        ErrorResponse(
+          'delayed synthetic initialization failure',
+          kind: WorkerErrorKind.backendInitialization,
+        ),
+      );
+      receivePort.close();
+    }
+  });
 }
 
 void _exitingBeforeHandshakeReplyWorkerEntry(SendPort initialSendPort) {

--- a/test/unit/backends/llama_cpp/llama_cpp_backend_test.dart
+++ b/test/unit/backends/llama_cpp/llama_cpp_backend_test.dart
@@ -595,6 +595,37 @@ void main() {
       }
     });
 
+    test('wedged worker initialization times out and is cleaned up', () async {
+      final backend = NativeLlamaBackend(
+        workerEntrypoint: _wedgedInitializationWorkerEntry,
+        workerStartupTimeout: const Duration(milliseconds: 50),
+      );
+
+      try {
+        await expectLater(
+          backend
+              .modelLoad('never.gguf', const ModelParams())
+              .timeout(const Duration(seconds: 2)),
+          throwsA(
+            isA<LlamaBackendInitializationException>()
+                .having(
+                  (error) => error.message,
+                  'timeout',
+                  contains('Timed out after 50 ms'),
+                )
+                .having(
+                  (error) => error.message,
+                  'diagnostic',
+                  contains('native runtime may be unavailable or unresponsive'),
+                ),
+          ),
+        );
+        expect(backend.isReady, isFalse);
+      } finally {
+        await backend.dispose().timeout(const Duration(seconds: 2));
+      }
+    });
+
     test('unexpected handshake response reports version skew', () async {
       final backend = NativeLlamaBackend(
         workerEntrypoint: _incompatibleHandshakeWorkerEntry,
@@ -669,6 +700,14 @@ void _crashingDuringHandshakeWorkerEntry(SendPort initialSendPort) {
     if (message is WorkerHandshake) {
       throw StateError('synthetic handshake crash');
     }
+  });
+}
+
+void _wedgedInitializationWorkerEntry(SendPort initialSendPort) {
+  final receivePort = ReceivePort();
+  initialSendPort.send(receivePort.sendPort);
+  receivePort.listen((_) {
+    // Keep the worker alive without acknowledging its startup handshake.
   });
 }
 

--- a/test/unit/backends/llama_cpp/llama_cpp_backend_test.dart
+++ b/test/unit/backends/llama_cpp/llama_cpp_backend_test.dart
@@ -7,7 +7,8 @@ import 'dart:typed_data';
 
 import 'package:llamadart/src/backends/backend.dart';
 import 'package:llamadart/src/backends/llama_cpp/llama_cpp_backend.dart';
-import 'package:llamadart/src/backends/llama_cpp/worker_messages.dart';
+import 'package:llamadart/src/backends/llama_cpp/llama_cpp_service.dart';
+import 'package:llamadart/src/backends/llama_cpp/worker.dart';
 import 'package:llamadart/src/core/exceptions.dart';
 import 'package:llamadart/src/core/models/inference/generation_params.dart';
 import 'package:llamadart/src/core/models/inference/model_params.dart';
@@ -466,6 +467,148 @@ void main() {
     await backend.dispose();
     expect(backend.isReady, isFalse);
   });
+
+  group('worker startup handshake', () {
+    test(
+      'init failure is typed, diagnostic, retryable, and cleaned up',
+      () async {
+        final backend = NativeLlamaBackend(
+          workerEntrypoint: _failingInitializationWorkerEntry,
+        );
+
+        try {
+          for (var attempt = 0; attempt < 2; attempt += 1) {
+            await expectLater(
+              backend
+                  .modelLoad('never.gguf', const ModelParams())
+                  .timeout(const Duration(seconds: 2)),
+              throwsA(
+                isA<LlamaBackendInitializationException>()
+                    .having(
+                      (error) => error.message,
+                      'message',
+                      contains('synthetic native loader failure'),
+                    )
+                    .having(
+                      (error) => error.message,
+                      'startup diagnostics',
+                      contains('libllamadart.dylib was not loadable'),
+                    ),
+              ),
+              reason: 'attempt ${attempt + 1} must fail instead of hanging',
+            );
+            expect(backend.isReady, isFalse);
+          }
+        } finally {
+          await backend.dispose().timeout(const Duration(seconds: 2));
+        }
+      },
+    );
+
+    test(
+      'worker exit before handshake acknowledgement fails promptly',
+      () async {
+        final backend = NativeLlamaBackend(
+          workerEntrypoint: _exitingBeforeHandshakeReplyWorkerEntry,
+        );
+
+        try {
+          await expectLater(
+            backend
+                .modelLoad('never.gguf', const ModelParams())
+                .timeout(const Duration(seconds: 2)),
+            throwsA(
+              isA<LlamaBackendInitializationException>().having(
+                (error) => error.message,
+                'message',
+                contains('before acknowledging'),
+              ),
+            ),
+          );
+          expect(backend.isReady, isFalse);
+        } finally {
+          await backend.dispose().timeout(const Duration(seconds: 2));
+        }
+      },
+    );
+
+    test('unexpected handshake response reports version skew', () async {
+      final backend = NativeLlamaBackend(
+        workerEntrypoint: _incompatibleHandshakeWorkerEntry,
+      );
+
+      try {
+        await expectLater(
+          backend
+              .modelLoad('never.gguf', const ModelParams())
+              .timeout(const Duration(seconds: 2)),
+          throwsA(
+            isA<LlamaBackendInitializationException>()
+                .having(
+                  (error) => error.message,
+                  'response type',
+                  contains('String'),
+                )
+                .having(
+                  (error) => error.message,
+                  'compatibility hint',
+                  contains('may be incompatible'),
+                ),
+          ),
+        );
+        expect(backend.isReady, isFalse);
+      } finally {
+        await backend.dispose().timeout(const Duration(seconds: 2));
+      }
+    });
+  });
+}
+
+void _failingInitializationWorkerEntry(SendPort initialSendPort) {
+  runLlamaWorkerForTesting(
+    initialSendPort,
+    _FailingInitializationLlamaCppService(),
+  );
+}
+
+void _exitingBeforeHandshakeReplyWorkerEntry(SendPort initialSendPort) {
+  final receivePort = ReceivePort();
+  initialSendPort.send(receivePort.sendPort);
+  receivePort.listen((message) {
+    if (message is WorkerHandshake) {
+      receivePort.close();
+      Isolate.exit();
+    }
+  });
+}
+
+void _incompatibleHandshakeWorkerEntry(SendPort initialSendPort) {
+  final receivePort = ReceivePort();
+  initialSendPort.send(receivePort.sendPort);
+  receivePort.listen((message) {
+    if (message is WorkerHandshake) {
+      message.sendPort.send('legacy-ready');
+      receivePort.close();
+    }
+  });
+}
+
+class _FailingInitializationLlamaCppService extends LlamaCppService {
+  @override
+  void initializeBackend() {
+    throw ArgumentError('synthetic native loader failure');
+  }
+
+  @override
+  List<String> getStartupDiagnostics() {
+    return const <String>['libllamadart.dylib was not loadable'];
+  }
+
+  @override
+  void setLogLevel(LlamaLogLevel level) {}
+
+  @override
+  void dispose() {}
 }
 
 class _TrackingNativeLlamaBackend extends NativeLlamaBackend {

--- a/test/unit/backends/llama_cpp/llama_cpp_backend_test.dart
+++ b/test/unit/backends/llama_cpp/llama_cpp_backend_test.dart
@@ -589,6 +589,39 @@ void main() {
       },
     );
 
+    test(
+      'uncaught worker error before request port identifies stage',
+      () async {
+        final backend = NativeLlamaBackend(
+          workerEntrypoint: _crashingBeforeRequestPortWorkerEntry,
+        );
+
+        try {
+          await expectLater(
+            backend
+                .modelLoad('never.gguf', const ModelParams())
+                .timeout(const Duration(seconds: 2)),
+            throwsA(
+              isA<LlamaBackendInitializationException>()
+                  .having(
+                    (error) => error.message,
+                    'startup stage',
+                    contains('before providing its request port'),
+                  )
+                  .having(
+                    (error) => error.message,
+                    'message',
+                    contains('synthetic pre-port crash'),
+                  ),
+            ),
+          );
+          expect(backend.isReady, isFalse);
+        } finally {
+          await backend.dispose().timeout(const Duration(seconds: 2));
+        }
+      },
+    );
+
     test('uncaught worker startup error preserves its stack trace', () async {
       final backend = NativeLlamaBackend(
         workerEntrypoint: _crashingDuringHandshakeWorkerEntry,
@@ -732,6 +765,10 @@ void _exitingBeforeHandshakeReplyWorkerEntry(SendPort initialSendPort) {
       Isolate.exit();
     }
   });
+}
+
+void _crashingBeforeRequestPortWorkerEntry(SendPort initialSendPort) {
+  throw StateError('synthetic pre-port crash');
 }
 
 void _crashingDuringHandshakeWorkerEntry(SendPort initialSendPort) {

--- a/test/unit/backends/llama_cpp/worker_messages_test.dart
+++ b/test/unit/backends/llama_cpp/worker_messages_test.dart
@@ -168,9 +168,10 @@ void main() {
       expect(BackendInfoResponse('n').name, 'n');
       expect(GpuSupportResponse(true).support, true);
       expect(
-        WorkerHandshake(LlamaLogLevel.debug).initialLogLevel,
+        WorkerHandshake(LlamaLogLevel.debug, sp).initialLogLevel,
         LlamaLogLevel.debug,
       );
+      expect(WorkerHandshake(LlamaLogLevel.debug, sp).sendPort, sp);
       expect(DoneResponse(), isNotNull);
     });
 

--- a/test/unit/backends/llama_cpp/worker_test.dart
+++ b/test/unit/backends/llama_cpp/worker_test.dart
@@ -21,6 +21,32 @@ void main() {
   });
 
   group('llamaWorkerEntry isolate routing', () {
+    test('reports and cleans up backend initialization failure', () async {
+      final service = _FailingInitializationLlamaCppService();
+      final receivePort = ReceivePort();
+      runLlamaWorkerForTesting(
+        receivePort.sendPort,
+        service,
+        exitOnDispose: false,
+      );
+      final sendPort = await receivePort.first as SendPort;
+      receivePort.close();
+      final handshakePort = ReceivePort();
+
+      sendPort.send(
+        WorkerHandshake(LlamaLogLevel.warn, handshakePort.sendPort),
+      );
+      final response = await handshakePort.first;
+      handshakePort.close();
+
+      expect(response, isA<ErrorResponse>());
+      final error = response as ErrorResponse;
+      expect(error.kind, WorkerErrorKind.backendInitialization);
+      expect(error.message, contains('synthetic initialization failure'));
+      expect(error.message, contains('libllamadart.so could not be opened'));
+      expect(service.disposeCalls, 1);
+    });
+
     test('handles control and info requests', () async {
       final worker = await _spawnWorker();
 
@@ -451,7 +477,7 @@ Future<({Isolate isolate, SendPort sendPort})> _spawnWorker() async {
   final receivePort = ReceivePort();
   final isolate = await Isolate.spawn(llamaWorkerEntry, receivePort.sendPort);
   final sendPort = await receivePort.first as SendPort;
-  sendPort.send(WorkerHandshake(LlamaLogLevel.warn));
+  await _performHandshake(sendPort);
   return (isolate: isolate, sendPort: sendPort);
 }
 
@@ -468,8 +494,18 @@ Future<({Isolate? isolate, SendPort sendPort})> _startWorkerInCurrentIsolate(
   );
   final sendPort = await receivePort.first as SendPort;
   receivePort.close();
-  sendPort.send(WorkerHandshake(LlamaLogLevel.warn));
+  await _performHandshake(sendPort);
   return (isolate: null, sendPort: sendPort);
+}
+
+Future<void> _performHandshake(SendPort workerSendPort) async {
+  final responsePort = ReceivePort();
+  workerSendPort.send(
+    WorkerHandshake(LlamaLogLevel.warn, responsePort.sendPort),
+  );
+  final response = await responsePort.first;
+  responsePort.close();
+  expect(response, isA<DoneResponse>());
 }
 
 Future<dynamic> _sendRequest(
@@ -577,6 +613,28 @@ class _BlockingLlamaCppService extends LlamaCppService {
   void freeMultimodalContext(int mmContextHandle) {
     freeMultimodalContextCalls += 1;
   }
+
+  @override
+  void dispose() {
+    disposeCalls += 1;
+  }
+}
+
+class _FailingInitializationLlamaCppService extends LlamaCppService {
+  int disposeCalls = 0;
+
+  @override
+  void initializeBackend() {
+    throw ArgumentError('synthetic initialization failure');
+  }
+
+  @override
+  List<String> getStartupDiagnostics() {
+    return const <String>['libllamadart.so could not be opened'];
+  }
+
+  @override
+  void setLogLevel(LlamaLogLevel level) {}
 
   @override
   void dispose() {

--- a/test/unit/backends/llama_cpp/worker_test.dart
+++ b/test/unit/backends/llama_cpp/worker_test.dart
@@ -48,6 +48,11 @@ void main() {
         contains('_FailingInitializationLlamaCppService.initializeBackend'),
       );
       expect(error.message, contains('libllamadart.so could not be opened'));
+      expect(
+        error.message,
+        contains('\nstartupDiagnostics=[libllamadart.so could not be opened]'),
+      );
+      expect(error.message, isNot(contains(', startupDiagnostics=')));
       expect(service.disposeCalls, 1);
     });
 

--- a/test/unit/backends/llama_cpp/worker_test.dart
+++ b/test/unit/backends/llama_cpp/worker_test.dart
@@ -43,6 +43,10 @@ void main() {
       final error = response as ErrorResponse;
       expect(error.kind, WorkerErrorKind.backendInitialization);
       expect(error.message, contains('synthetic initialization failure'));
+      expect(
+        error.message,
+        contains('_FailingInitializationLlamaCppService.initializeBackend'),
+      );
       expect(error.message, contains('libllamadart.so could not be opened'));
       expect(service.disposeCalls, 1);
     });

--- a/test/unit/core/exceptions_test.dart
+++ b/test/unit/core/exceptions_test.dart
@@ -13,6 +13,17 @@ void main() {
       );
     });
 
+    test('LlamaBackendInitializationException properties', () {
+      final ex = LlamaBackendInitializationException(
+        'Backend initialization failed',
+        'libllamadart missing',
+      );
+
+      expect(ex.message, 'Backend initialization failed');
+      expect(ex.details, 'libllamadart missing');
+      expect(ex, isA<LlamaException>());
+    });
+
     test('LlamaContextException properties', () {
       final ex = LlamaContextException('Context full');
       expect(ex.message, 'Context full');


### PR DESCRIPTION
## Summary

- Make the llama.cpp worker handshake acknowledge backend initialization before the parent marks the isolate ready.
- Surface initialization, timeout, isolate-exit, disposal-race, and incompatible-handshake failures as `LlamaBackendInitializationException`; include sanitized collected startup diagnostics and tear down failed workers.
- Serialize concurrent callers, log-level updates, and disposal around the in-flight handshake; clear dead worker state so retries and post-dispose restart cannot target a dead isolate.

Closes #386.

## Production-readiness scope

- **User-facing scope:** Native llama.cpp startup failures now fail callers promptly with a typed, actionable exception instead of reporting ready and hanging a later or concurrent request. A live but unresponsive initialization is bounded to five seconds.
- **Supported platforms/paths:** Native llama.cpp worker startup on Dart VM platforms. The new exception is exported from the existing Web-safe core exception library.
- **Unsupported or intentionally unavailable paths:** A worker that exits before acknowledgement or returns an unknown handshake response fails loudly; the latter includes a worker/package incompatibility hint.
- **Out of scope / tracked follow-ups:** #415 tracks priority-aware retention when the bounded diagnostic buffer fills. #416 tracks aggregated, redacted summaries for candidate probe failures. Both are non-blocking to the acknowledged handshake and are kept separate to avoid replacing root-cause entries with teardown/noise or logging every expected candidate miss.

## Completeness checklist

- [x] Declared scope is fully implemented, or explicitly reduced above.
- [x] Unsupported platform/option combinations fail loudly with actionable diagnostics or are clearly documented as unavailable.
- [x] Public API docs, README/website docs, examples, support matrices, and changelog entries are updated where relevant.
- [x] Regression coverage covers the original issue plus key negative/version-skew paths where relevant.
- [x] Security/privacy review completed: collected startup diagnostics remain bounded and redact credentials, signed URL components, and control characters through the worker exception path.
- [x] Follow-up work that is useful but not required for this PR is tracked in GitHub Issues.

## PR type guidance

- **Bugfix PR:** `NativeLlamaBackend._startIsolate` previously completed when it received the worker `SendPort`, while `initializeBackend()` ran later outside the request `try`/`catch`. The acknowledged, bounded handshake now makes initialization part of startup, publishes the request port only after acknowledgement, and listens for isolate errors/exits until startup settles.
- **Lifecycle hardening:** Disposal shares one in-flight future, invalidates startup callers with a lifecycle epoch, waits for startup settlement, and then tears down. `setLogLevel` joins startup/disposal instead of sending into a pre-ready or dead worker.

## Test Plan

- [x] Touched Dart format check.
- [x] `dart analyze lib test tool hook`
- [x] Focused VM: 191 passed across exception, protocol, worker, backend, and service suites.
- [x] Full VM with coverage: 1,541 passed / 71 skipped fixtures.
- [x] Full Chrome: 823 passed.
- [x] Coverage: 76.99% (12,141/15,770), threshold 70%.
- [x] `dart run tool/testing/check_platform_boundaries.dart`
- [x] `./tool/docs/build_site.sh`
- [x] `./tool/docs/validate_links.sh`
- [x] `dart run tool/testing/verify_release_docs_versions.dart`
- [x] `git diff --check`

## Behavioral evidence

- Real spawned-isolate missing-native-library probe: temporarily withheld the packaged `libllamadart.dylib`; two sequential attempts both returned `LlamaBackendInitializationException` promptly with native resolver context, left `isReady == false`, and allowed cleanup. The exact library SHA-256 was verified unchanged before and after restoration.
- Full VM integration exercised real native library load, model load, generation, native symbols, expected multimodal/LoRA failure paths, and state persistence.
- Durable regressions cover typed init failure, sanitized diagnostics, retry/no-hang, concurrent startup, log-level/startup failure, duplicate concurrent disposal during startup, cleanup/restart, early exit, pre-port and post-port crashes, timeout, and incompatible/version-skew responses.
- Independent blocking-only QA at `5cfc964a2` is READY; its two lifecycle race findings were fixed and the dispose/start/restart regression passed 20/20 repeated runs.

## Matrix Evidence

| Matrix row | Scope covered | Platform / model / backend | Result | Evidence / notes |
| --- | --- | --- | --- | --- |
| static-format-analyze | formatting, analyzer, import boundaries | macOS arm64 | PASS | Touched format, root source analysis, platform boundaries, release-doc versions, and diff checks passed. |
| root-vm | native-safe unit/integration and real native smoke | macOS arm64 / llama.cpp | PASS | 1,541 passed / 71 skipped; real model load/generation and explicit missing-library spawned-isolate probe passed. |
| root-chrome | Web compatibility of shared/public API | Chrome | PASS | 823 passed. |
| coverage-lib | maintainable `lib/` line coverage | VM | PASS | 76.99% (12,141/15,770), required 70%. |
| docs-site | changelog and docs routes | Docusaurus | PASS | Production build, broken-link validation, and release-doc version verification passed. |

## Review Notes

- Current pushed head: `5cfc964a2191ba7dfdcaa0aa35324e9244ee0651`, merged with current `main` `8690243fd32d761773fd15b769619156bc3c1c85` without force-push.
- Independent blocking-only QA: READY, no blocking findings.
- Exact-head GitHub CI is green: [CI run 32595466435](https://github.com/leehack/llamadart/actions/runs/32595466435) plus the chat preview check passed. Copilot's current-head review recommends approval with 0 new comments; all 4 review threads are answered and resolved.
