### PR TITLE
feat(native): support semantic release tags

### DIFF
--- a/.github/workflows/sync_native_bindings.yml
+++ b/.github/workflows/sync_native_bindings.yml
@@ -4,7 +4,7 @@ on:
   workflow_dispatch:
     inputs:
       native_tag:
-        description: 'vM.m.p, vM.m.p-N, bNNNN, bNNNN-N, legacy bNNNN-llamadart.N, or latest'
+        description: 'vM.m.p; explicit vM.m.p-N, bNNNN[-N], or legacy bNNNN-llamadart.N; latest is unsuffixed v only'
         required: true
         default: 'latest'
       allow_nightly_channel:
@@ -53,14 +53,16 @@ jobs:
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           ALLOW_NIGHTLY_CHANNEL: ${{ inputs.allow_nightly_channel }}
+          NATIVE_TAG: ${{ inputs.native_tag }}
+          LITERT_LM_TAG: ${{ inputs.litert_lm_tag }}
         run: |
           transition_args=()
           if [[ "${ALLOW_NIGHTLY_CHANNEL}" == "true" ]]; then
             transition_args+=(--allow-legacy-tag)
           fi
           python3 tool/native/sync_native_release_pins.py \
-            --llama-cpp-tag "${{ github.event.inputs.native_tag }}" \
-            --litert-lm-tag "${{ github.event.inputs.litert_lm_tag }}" \
+            --llama-cpp-tag "${NATIVE_TAG}" \
+            --litert-lm-tag "${LITERT_LM_TAG}" \
             "${transition_args[@]}" \
             --dry-run
 
@@ -68,23 +70,26 @@ jobs:
         id: sync_headers
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          NATIVE_TAG: ${{ inputs.native_tag }}
         run: |
-          tool/native/sync_native_headers_and_bindings.sh --tag "${{ github.event.inputs.native_tag }}"
+          tool/native/sync_native_headers_and_bindings.sh --tag "${NATIVE_TAG}"
 
       - name: Sync native hook pins
         id: sync_pins
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           ALLOW_NIGHTLY_CHANNEL: ${{ inputs.allow_nightly_channel }}
+          RESOLVED_NATIVE_TAG: ${{ steps.sync_headers.outputs.resolved_tag }}
+          LITERT_LM_TAG: ${{ inputs.litert_lm_tag }}
         run: |
           transition_args=()
           if [[ "${ALLOW_NIGHTLY_CHANNEL}" == "true" ]]; then
             transition_args+=(--allow-legacy-tag)
           fi
           python3 tool/native/sync_native_release_pins.py \
-            --llama-cpp-tag "${{ steps.sync_headers.outputs.resolved_tag }}" \
+            --llama-cpp-tag "${RESOLVED_NATIVE_TAG}" \
             "${transition_args[@]}" \
-            --litert-lm-tag "${{ github.event.inputs.litert_lm_tag }}"
+            --litert-lm-tag "${LITERT_LM_TAG}"
 
       - name: Create pull request
         uses: peter-evans/create-pull-request@v8

--- a/.github/workflows/sync_native_bindings.yml
+++ b/.github/workflows/sync_native_bindings.yml
@@ -4,9 +4,14 @@ on:
   workflow_dispatch:
     inputs:
       native_tag:
-        description: 'llamadart-native release tag to sync (e.g., b8011 or latest)'
+        description: 'vM.m.p, vM.m.p-N, bNNNN, bNNNN-N, legacy bNNNN-llamadart.N, or latest'
         required: true
         default: 'latest'
+      allow_nightly_channel:
+        description: 'Allow an intentional stable-to-nightly native channel switch'
+        required: true
+        type: boolean
+        default: false
       litert_lm_tag:
         description: 'litert-lm-native release tag to sync (e.g., v0.13.1, latest, or keep)'
         required: true
@@ -44,6 +49,21 @@ jobs:
       - name: Install Dart/Flutter dependencies
         run: flutter pub get
 
+      - name: Validate native release contract
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          ALLOW_NIGHTLY_CHANNEL: ${{ inputs.allow_nightly_channel }}
+        run: |
+          transition_args=()
+          if [[ "${ALLOW_NIGHTLY_CHANNEL}" == "true" ]]; then
+            transition_args+=(--allow-legacy-tag)
+          fi
+          python3 tool/native/sync_native_release_pins.py \
+            --llama-cpp-tag "${{ github.event.inputs.native_tag }}" \
+            --litert-lm-tag "${{ github.event.inputs.litert_lm_tag }}" \
+            "${transition_args[@]}" \
+            --dry-run
+
       - name: Sync headers and regenerate bindings
         id: sync_headers
         env:
@@ -55,9 +75,15 @@ jobs:
         id: sync_pins
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          ALLOW_NIGHTLY_CHANNEL: ${{ inputs.allow_nightly_channel }}
         run: |
+          transition_args=()
+          if [[ "${ALLOW_NIGHTLY_CHANNEL}" == "true" ]]; then
+            transition_args+=(--allow-legacy-tag)
+          fi
           python3 tool/native/sync_native_release_pins.py \
             --llama-cpp-tag "${{ steps.sync_headers.outputs.resolved_tag }}" \
+            "${transition_args[@]}" \
             --litert-lm-tag "${{ github.event.inputs.litert_lm_tag }}"
 
       - name: Create pull request
@@ -79,6 +105,7 @@ jobs:
             - Updates current README/website native pin docs and the core changelog when the llama.cpp native pin changes.
 
             Native version checklist:
+            - [ ] If `allow_nightly_channel` was enabled, confirm the stable-to-nightly switch was intentional and record the compatibility reason.
             - [ ] Confirm `leehack/llamadart-native` release `${{ steps.sync_headers.outputs.resolved_tag }}` includes the required native-assets archives.
             - [ ] If LiteRT-LM sync was requested (`litert_lm_tag` is not `keep`), confirm `leehack/litert-lm-native` release `${{ steps.sync_pins.outputs.resolved_litert_lm_tag }}` includes the required runtime archives.
             - [ ] Confirm matching Apple SPM pins changed under `packages/` when Apple XCFramework releases changed.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -196,6 +196,10 @@ Stable `llamadart-native` distribution tags use strict
 `vMAJOR.MINOR.PATCH`. A wrapper-only rebuild of upstream `vM.m.p` uses
 `vM.m.p-N`, preserving the exact upstream prefix; native release ordering treats
 `-N` as a forward wrapper sequence despite generic SemVer prerelease ordering.
+Wrapper rebuilds are GitHub prereleases and must be selected explicitly;
+`latest` accepts only unsuffixed `vMAJOR.MINOR.PATCH`. Nightly cores use
+canonical decimal spelling (`b0` or a nonzero first digit), and rebuild counters
+start at 1 without leading zeros.
 New nightly wrapper rebuilds use `bNNNN-N`; existing
 `bNNNN-llamadart.N` artifacts remain explicit consumption-only compatibility
 inputs. New stable or nightly wrapper forms require manifests containing both

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -200,8 +200,10 @@ New wrapper and nightly releases are GitHub prereleases and must be selected
 explicitly. Historical `bNNNN` and `bNNNN-llamadart.N` artifacts may retain
 older `prerelease=false` metadata, but remain explicit compatibility inputs;
 `latest` accepts only unsuffixed `vMAJOR.MINOR.PATCH` regardless of GitHub
-metadata. Nightly cores use canonical decimal spelling (`b0` or a nonzero first
-digit), and rebuild counters start at 1 without leading zeros.
+metadata. Build-hook overrides must always name an explicit tag; only maintainer
+synchronization and header/binding regeneration accept `latest`. Nightly cores
+use canonical decimal spelling (`b0` or a nonzero first digit), and rebuild
+counters start at 1 without leading zeros.
 New nightly wrapper rebuilds use `bNNNN-N`; existing
 `bNNNN-llamadart.N` artifacts remain explicit consumption-only compatibility
 inputs. New stable or nightly wrapper forms require manifests containing both

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -192,6 +192,19 @@ flow in ownership order:
 Prefer the repository workflow for native version and binding updates:
 `.github/workflows/sync_native_bindings.yml`.
 
+Stable `llamadart-native` distribution tags use strict
+`vMAJOR.MINOR.PATCH`. A wrapper-only rebuild of upstream `vM.m.p` uses
+`vM.m.p-N`, preserving the exact upstream prefix; native release ordering treats
+`-N` as a forward wrapper sequence despite generic SemVer prerelease ordering.
+New nightly wrapper rebuilds use `bNNNN-N`; existing
+`bNNNN-llamadart.N` artifacts remain explicit consumption-only compatibility
+inputs. New stable or nightly wrapper forms require manifests containing both
+`native_release_tag` and the legacy `tag` alias. Stable syncs must validate
+manifest provenance, hook contract, bundle coverage, checksums, upstream/native
+tag separation, and forward version movement before changing the default pin.
+The manual workflow requires its explicit `allow_nightly_channel` input before
+moving a stable pin back to the nightly channel.
+
 For local native regeneration:
 
 ```bash

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -196,10 +196,12 @@ Stable `llamadart-native` distribution tags use strict
 `vMAJOR.MINOR.PATCH`. A wrapper-only rebuild of upstream `vM.m.p` uses
 `vM.m.p-N`, preserving the exact upstream prefix; native release ordering treats
 `-N` as a forward wrapper sequence despite generic SemVer prerelease ordering.
-Wrapper rebuilds are GitHub prereleases and must be selected explicitly;
-`latest` accepts only unsuffixed `vMAJOR.MINOR.PATCH`. Nightly cores use
-canonical decimal spelling (`b0` or a nonzero first digit), and rebuild counters
-start at 1 without leading zeros.
+New wrapper and nightly releases are GitHub prereleases and must be selected
+explicitly. Historical `bNNNN` and `bNNNN-llamadart.N` artifacts may retain
+older `prerelease=false` metadata, but remain explicit compatibility inputs;
+`latest` accepts only unsuffixed `vMAJOR.MINOR.PATCH` regardless of GitHub
+metadata. Nightly cores use canonical decimal spelling (`b0` or a nonzero first
+digit), and rebuild counters start at 1 without leading zeros.
 New nightly wrapper rebuilds use `bNNNN-N`; existing
 `bNNNN-llamadart.N` artifacts remain explicit consumption-only compatibility
 inputs. New stable or nightly wrapper forms require manifests containing both

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,9 +23,8 @@
   rebuilds plus nightly `bNNNN-N` rebuilds, while preserving historical
   `bNNNN` and `bNNNN-llamadart.N` artifacts. Sync rejects invalid tags,
   leading-zero nightly versions, rollback, wrapper/nightly `latest` results,
-  incompatible manifest contracts,
-  missing bundles, and release/manifest checksum or version skew without
-  changing the default pin.
+  incompatible manifest contracts, missing bundles, and release/manifest
+  checksum or version skew without changing the default pin.
 
 * Fixed Web/native backend API parity. `WebAutoBackend` now forwards grammar
   constraint support from its active runtime, so strict structured output fails

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,7 +22,8 @@
   `vMAJOR.MINOR.PATCH` artifacts and ordered `vMAJOR.MINOR.PATCH-N` wrapper
   rebuilds plus nightly `bNNNN-N` rebuilds, while preserving historical
   `bNNNN` and `bNNNN-llamadart.N` artifacts. Sync rejects invalid tags,
-  rollback, unstable `latest` results, incompatible manifest contracts,
+  leading-zero nightly versions, rollback, wrapper/nightly `latest` results,
+  incompatible manifest contracts,
   missing bundles, and release/manifest checksum or version skew without
   changing the default pin.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,14 @@
   input remains blocked on cross-platform FFmpeg/ffprobe packaging and Dart
   frame lifecycle wiring.
 
+* Native release synchronization and build-hook overrides now accept stable
+  `vMAJOR.MINOR.PATCH` artifacts and ordered `vMAJOR.MINOR.PATCH-N` wrapper
+  rebuilds plus nightly `bNNNN-N` rebuilds, while preserving historical
+  `bNNNN` and `bNNNN-llamadart.N` artifacts. Sync rejects invalid tags,
+  rollback, unstable `latest` results, incompatible manifest contracts,
+  missing bundles, and release/manifest checksum or version skew without
+  changing the default pin.
+
 * Fixed Web/native backend API parity. `WebAutoBackend` now forwards grammar
   constraint support from its active runtime, so strict structured output fails
   early with an actionable error on unsupported Web backends, and the Web-safe

--- a/README.md
+++ b/README.md
@@ -154,8 +154,12 @@ rebuilds use `bNNNN-N`; existing `bNNNN-llamadart.N` artifacts remain valid
 consumption-only overrides. Stable wrapper-only rebuilds of upstream `vM.m.p`
 use `vM.m.p-N`, preserving the exact upstream prefix. Native release policy
 treats each `-N` suffix as a forward wrapper rebuild even where generic SemVer
-ordering differs. The default pin above changes only after the matching
-artifacts, bindings, runtime behavior, and docs have been validated together.
+ordering differs. Wrapper rebuilds are GitHub prereleases and must be selected
+explicitly; `latest` accepts only an unsuffixed stable tag. Nightly cores use
+canonical decimal spelling (`b0` or a nonzero first digit), and rebuild counters
+start at 1 without leading zeros. The default pin above changes only after the
+matching artifacts, bindings, runtime behavior, and docs have been validated
+together.
 
 ## Common Tasks
 

--- a/README.md
+++ b/README.md
@@ -148,6 +148,15 @@ Current default runtime pins:
 | Web llama.cpp / GGUF | `leehack/llama-web-bridge-assets@v0.1.37` |
 | Web LiteRT-LM / `.litertlm` | `@litert-lm/core@0.15.0` |
 
+Native overrides accept stable `vMAJOR.MINOR.PATCH` releases and preserve
+explicit access to historical/nightly `bNNNN` artifacts. New nightly wrapper
+rebuilds use `bNNNN-N`; existing `bNNNN-llamadart.N` artifacts remain valid
+consumption-only overrides. Stable wrapper-only rebuilds of upstream `vM.m.p`
+use `vM.m.p-N`, preserving the exact upstream prefix. Native release policy
+treats each `-N` suffix as a forward wrapper rebuild even where generic SemVer
+ordering differs. The default pin above changes only after the matching
+artifacts, bindings, runtime behavior, and docs have been validated together.
+
 ## Common Tasks
 
 | Task | Docs |

--- a/README.md
+++ b/README.md
@@ -157,11 +157,13 @@ treats each `-N` suffix as a forward wrapper rebuild even where generic SemVer
 ordering differs. New wrapper and nightly releases are GitHub prereleases and
 must be selected explicitly. Immutable historical `bNNNN` and
 `bNNNN-llamadart.N` artifacts may retain older `prerelease=false` metadata, but
-remain explicit compatibility inputs; `latest` accepts only an unsuffixed
-stable tag regardless of GitHub metadata. Nightly cores use canonical decimal
-spelling (`b0` or a nonzero first digit), and rebuild counters start at 1
-without leading zeros. The default pin above changes only after the matching
-artifacts, bindings, runtime behavior, and docs have been validated together.
+remain explicit compatibility inputs. Build-hook overrides must always name an
+explicit tag; `latest` is limited to maintainer synchronization and
+header/binding regeneration, where it accepts only an unsuffixed stable tag
+regardless of GitHub metadata. Nightly cores use canonical decimal spelling
+(`b0` or a nonzero first digit), and rebuild counters start at 1 without leading
+zeros. The default pin above changes only after the matching artifacts,
+bindings, runtime behavior, and docs have been validated together.
 
 ## Common Tasks
 

--- a/README.md
+++ b/README.md
@@ -154,12 +154,14 @@ rebuilds use `bNNNN-N`; existing `bNNNN-llamadart.N` artifacts remain valid
 consumption-only overrides. Stable wrapper-only rebuilds of upstream `vM.m.p`
 use `vM.m.p-N`, preserving the exact upstream prefix. Native release policy
 treats each `-N` suffix as a forward wrapper rebuild even where generic SemVer
-ordering differs. Wrapper rebuilds are GitHub prereleases and must be selected
-explicitly; `latest` accepts only an unsuffixed stable tag. Nightly cores use
-canonical decimal spelling (`b0` or a nonzero first digit), and rebuild counters
-start at 1 without leading zeros. The default pin above changes only after the
-matching artifacts, bindings, runtime behavior, and docs have been validated
-together.
+ordering differs. New wrapper and nightly releases are GitHub prereleases and
+must be selected explicitly. Immutable historical `bNNNN` and
+`bNNNN-llamadart.N` artifacts may retain older `prerelease=false` metadata, but
+remain explicit compatibility inputs; `latest` accepts only an unsuffixed
+stable tag regardless of GitHub metadata. Nightly cores use canonical decimal
+spelling (`b0` or a nonzero first digit), and rebuild counters start at 1
+without leading zeros. The default pin above changes only after the matching
+artifacts, bindings, runtime behavior, and docs have been validated together.
 
 ## Common Tasks
 

--- a/hook/build.dart
+++ b/hook/build.dart
@@ -159,7 +159,7 @@ final _windowsCublasPattern = RegExp(r'^cublas64(?:[_-]?\d+)?\.dll$');
 final _linuxVersionedSoPattern = RegExp(r'\.so\.\d+$');
 final _nativeTagPattern = RegExp(
   r'^(?:v(?:0|[1-9][0-9]*)\.(?:0|[1-9][0-9]*)\.(?:0|[1-9][0-9]*)(?:-[1-9][0-9]*)?|'
-  r'b[0-9]+(?:-[1-9][0-9]*|-llamadart\.[1-9][0-9]*)?)$',
+  r'b(?:0|[1-9][0-9]*)(?:-[1-9][0-9]*|-llamadart\.[1-9][0-9]*)?)$',
 );
 final _githubRepoSegmentPattern = RegExp(r'^[A-Za-z0-9_.-]+$');
 
@@ -1146,7 +1146,8 @@ String _resolveNativeTag(Object? rawUserConfig) {
     throw FormatException(
       'hooks.user_defines.$_packageName.$nativeTagUserDefineKey must be a '
       'stable vMAJOR.MINOR.PATCH tag, stable wrapper rebuild '
-      'vMAJOR.MINOR.PATCH-N, historical/nightly bNNNN tag, nightly wrapper '
+      'vMAJOR.MINOR.PATCH-N, canonical historical/nightly bNNNN tag without '
+      'leading zeros, nightly wrapper '
       'rebuild bNNNN-N, or legacy wrapper artifact bNNNN-llamadart.N '
       '(for example $_llamaCppTag).',
     );

--- a/hook/build.dart
+++ b/hook/build.dart
@@ -157,7 +157,10 @@ const _dynamicLibraryExtensions = {'.so', '.dylib', '.dll'};
 final _windowsCudartPattern = RegExp(r'^cudart64(?:[_-]?\d+)?\.dll$');
 final _windowsCublasPattern = RegExp(r'^cublas64(?:[_-]?\d+)?\.dll$');
 final _linuxVersionedSoPattern = RegExp(r'\.so\.\d+$');
-final _nativeTagPattern = RegExp(r'^[A-Za-z0-9][A-Za-z0-9._-]*$');
+final _nativeTagPattern = RegExp(
+  r'^(?:v(?:0|[1-9][0-9]*)\.(?:0|[1-9][0-9]*)\.(?:0|[1-9][0-9]*)(?:-[1-9][0-9]*)?|'
+  r'b[0-9]+(?:-[1-9][0-9]*|-llamadart\.[1-9][0-9]*)?)$',
+);
 final _githubRepoSegmentPattern = RegExp(r'^[A-Za-z0-9_.-]+$');
 
 class _NativeBundleConfig {
@@ -1142,7 +1145,10 @@ String _resolveNativeTag(Object? rawUserConfig) {
   if (!_nativeTagPattern.hasMatch(tag)) {
     throw FormatException(
       'hooks.user_defines.$_packageName.$nativeTagUserDefineKey must be a '
-      'path-safe release tag such as $_llamaCppTag.',
+      'stable vMAJOR.MINOR.PATCH tag, stable wrapper rebuild '
+      'vMAJOR.MINOR.PATCH-N, historical/nightly bNNNN tag, nightly wrapper '
+      'rebuild bNNNN-N, or legacy wrapper artifact bNNNN-llamadart.N '
+      '(for example $_llamaCppTag).',
     );
   }
 

--- a/test/unit/hook/build_hook_integration_test.dart
+++ b/test/unit/hook/build_hook_integration_test.dart
@@ -341,6 +341,8 @@ void main() {
   test('build hook uses accepted wrapper native tag overrides', () async {
     for (final overrideTag in const [
       'v9.8.8-1',
+      'b0-1',
+      'b0-llamadart.1',
       'b10514-1',
       'b10514-llamadart.1',
     ]) {
@@ -419,7 +421,7 @@ void main() {
   });
 
   test('build hook uses custom GitHub repository cache namespace', () async {
-    const overrideTag = 'b0000';
+    const overrideTag = 'b0';
     const customRepository = 'example/native-fork';
     final repoCacheRoot = Directory(
       '.dart_tool/llamadart/native_bundles/github/example/native-fork',
@@ -539,7 +541,7 @@ void main() {
   });
 
   test('build hook uses local native path archive', () async {
-    const overrideTag = 'b0000-llamadart.1';
+    const overrideTag = 'b0-llamadart.1';
     const localRootPath = '.dart_tool/llamadart_hook_test_local_archive';
     final localRoot = Directory(localRootPath);
     final archiveFile = File(
@@ -618,11 +620,20 @@ void main() {
       '../bad',
       'v1.2',
       'v01.2.3',
+      'b00',
+      'b0000',
+      'b0001',
+      'b0001-1',
+      'b0001-llamadart.1',
+      'b1-01',
+      'b1-llamadart.01',
       'b10514-custom',
       'b10514-0',
       'v0.2.0-0',
       'v0.2.0-llamadart.1',
       'v0.2.0-custom.1',
+      r'b1; touch "$RUNNER_TEMP/llamadart-pwned"',
+      r'b1$(touch "$RUNNER_TEMP/llamadart-pwned")',
     ]) {
       final userDefines = PackageUserDefines(
         workspacePubspec: PackageUserDefinesSource(

--- a/test/unit/hook/build_hook_integration_test.dart
+++ b/test/unit/hook/build_hook_integration_test.dart
@@ -338,80 +338,88 @@ void main() {
     );
   });
 
-  test('build hook uses pubspec native tag override', () async {
-    const overrideTag = 'b0000-hook-test';
-    final overrideCacheDir = Directory(
-      '.dart_tool/llamadart/native_bundles/$overrideTag/windows-x64',
-    );
-    final overrideBundleDir = Directory(
-      path.join(overrideCacheDir.path, 'extracted'),
-    );
-    final overrideBackupDir = Directory(
-      '${overrideCacheDir.path}.__hook_test_backup',
-    );
+  test('build hook uses accepted wrapper native tag overrides', () async {
+    for (final overrideTag in const [
+      'v9.8.8-1',
+      'b10514-1',
+      'b10514-llamadart.1',
+    ]) {
+      final overrideCacheDir = Directory(
+        '.dart_tool/llamadart/native_bundles/$overrideTag/windows-x64',
+      );
+      final overrideBundleDir = Directory(
+        path.join(overrideCacheDir.path, 'extracted'),
+      );
+      final overrideBackupDir = Directory(
+        '${overrideCacheDir.path}.__hook_test_backup',
+      );
 
-    if (overrideBackupDir.existsSync()) {
-      await overrideBackupDir.delete(recursive: true);
-    }
-    if (overrideCacheDir.existsSync()) {
-      await overrideCacheDir.rename(overrideBackupDir.path);
-    }
+      if (overrideBackupDir.existsSync()) {
+        await overrideBackupDir.delete(recursive: true);
+      }
+      if (overrideCacheDir.existsSync()) {
+        await overrideCacheDir.rename(overrideBackupDir.path);
+      }
 
-    try {
-      await _writeBundleLibraries(overrideBundleDir, const [
-        'llamadart-windows-x64.dll',
-        'llama-windows-x64.dll',
-        'ggml-windows-x64.dll',
-        'ggml-base-windows-x64.dll',
-        'ggml-cpu-windows-x64.dll',
-        'ggml-opencl-windows-x64.dll',
-      ]);
+      try {
+        await _writeBundleLibraries(overrideBundleDir, const [
+          'llamadart-windows-x64.dll',
+          'llama-windows-x64.dll',
+          'ggml-windows-x64.dll',
+          'ggml-base-windows-x64.dll',
+          'ggml-cpu-windows-x64.dll',
+          'ggml-opencl-windows-x64.dll',
+        ]);
 
-      final userDefines = PackageUserDefines(
-        workspacePubspec: PackageUserDefinesSource(
-          defines: {
-            'llamadart_native_tag': overrideTag,
-            'llamadart_native_backends': {
-              'platforms': {
-                'windows-x64': ['opencl'],
+        final userDefines = PackageUserDefines(
+          workspacePubspec: PackageUserDefinesSource(
+            defines: {
+              'llamadart_native_tag': overrideTag,
+              'llamadart_native_backends': {
+                'platforms': {
+                  'windows-x64': ['opencl'],
+                },
               },
             },
+            basePath: Directory.current.uri,
+          ),
+        );
+
+        await testCodeBuildHook(
+          mainMethod: build_hook.main,
+          targetOS: OS.windows,
+          targetArchitecture: Architecture.x64,
+          userDefines: userDefines,
+          check: (input, output) {
+            final codeAssets = output.assets.encodedAssets
+                .where((asset) => asset.isCodeAsset)
+                .map((asset) => asset.asCodeAsset)
+                .toList(growable: false);
+
+            final emittedNames = codeAssets
+                .map((asset) => path.basename(asset.file!.toFilePath()))
+                .toSet();
+
+            expect(emittedNames, contains('ggml-opencl-windows-x64.dll'));
+            expect(
+              emittedNames,
+              isNot(contains('ggml-vulkan-windows-x64.dll')),
+            );
           },
-          basePath: Directory.current.uri,
-        ),
-      );
-
-      await testCodeBuildHook(
-        mainMethod: build_hook.main,
-        targetOS: OS.windows,
-        targetArchitecture: Architecture.x64,
-        userDefines: userDefines,
-        check: (input, output) {
-          final codeAssets = output.assets.encodedAssets
-              .where((asset) => asset.isCodeAsset)
-              .map((asset) => asset.asCodeAsset)
-              .toList(growable: false);
-
-          final emittedNames = codeAssets
-              .map((asset) => path.basename(asset.file!.toFilePath()))
-              .toSet();
-
-          expect(emittedNames, contains('ggml-opencl-windows-x64.dll'));
-          expect(emittedNames, isNot(contains('ggml-vulkan-windows-x64.dll')));
-        },
-      );
-    } finally {
-      if (overrideCacheDir.existsSync()) {
-        await overrideCacheDir.delete(recursive: true);
-      }
-      if (overrideBackupDir.existsSync()) {
-        await overrideBackupDir.rename(overrideCacheDir.path);
+        );
+      } finally {
+        if (overrideCacheDir.existsSync()) {
+          await overrideCacheDir.delete(recursive: true);
+        }
+        if (overrideBackupDir.existsSync()) {
+          await overrideBackupDir.rename(overrideCacheDir.path);
+        }
       }
     }
   });
 
   test('build hook uses custom GitHub repository cache namespace', () async {
-    const overrideTag = 'b0000-repo-test';
+    const overrideTag = 'b0000';
     const customRepository = 'example/native-fork';
     final repoCacheRoot = Directory(
       '.dart_tool/llamadart/native_bundles/github/example/native-fork',
@@ -531,7 +539,7 @@ void main() {
   });
 
   test('build hook uses local native path archive', () async {
-    const overrideTag = 'b0000-local-archive';
+    const overrideTag = 'b0000-llamadart.1';
     const localRootPath = '.dart_tool/llamadart_hook_test_local_archive';
     final localRoot = Directory(localRootPath);
     final archiveFile = File(
@@ -605,30 +613,41 @@ void main() {
     }
   });
 
-  test('build hook rejects path-unsafe native tag override', () async {
-    final userDefines = PackageUserDefines(
-      workspacePubspec: PackageUserDefinesSource(
-        defines: const {'llamadart_native_tag': '../bad'},
-        basePath: Directory.current.uri,
-      ),
-    );
-
-    await expectLater(
-      testCodeBuildHook(
-        mainMethod: build_hook.main,
-        targetOS: OS.windows,
-        targetArchitecture: Architecture.x64,
-        userDefines: userDefines,
-        check: (input, output) {},
-      ),
-      throwsA(
-        isA<FormatException>().having(
-          (error) => error.message,
-          'message',
-          contains('path-safe release tag'),
+  test('build hook rejects unsupported native tag forms', () async {
+    for (final invalidTag in const [
+      '../bad',
+      'v1.2',
+      'v01.2.3',
+      'b10514-custom',
+      'b10514-0',
+      'v0.2.0-0',
+      'v0.2.0-llamadart.1',
+      'v0.2.0-custom.1',
+    ]) {
+      final userDefines = PackageUserDefines(
+        workspacePubspec: PackageUserDefinesSource(
+          defines: {'llamadart_native_tag': invalidTag},
+          basePath: Directory.current.uri,
         ),
-      ),
-    );
+      );
+
+      await expectLater(
+        testCodeBuildHook(
+          mainMethod: build_hook.main,
+          targetOS: OS.windows,
+          targetArchitecture: Architecture.x64,
+          userDefines: userDefines,
+          check: (input, output) {},
+        ),
+        throwsA(
+          isA<FormatException>().having(
+            (error) => error.message,
+            'message for $invalidTag',
+            contains('stable vMAJOR.MINOR.PATCH tag'),
+          ),
+        ),
+      );
+    }
   });
 
   test('build hook rejects invalid native repository override', () async {

--- a/test/unit/tooling/sync_native_release_pins_script_test.dart
+++ b/test/unit/tooling/sync_native_release_pins_script_test.dart
@@ -20,7 +20,7 @@ void main() {
       ..createSync(recursive: true);
 
     await File(path.join(root.path, 'hook', 'build.dart')).writeAsString('''
-const _llamaCppTag = 'old';
+const _llamaCppTag = 'b9998';
 const _litertLmVersion = '1.0.0';
 
 const _litertLmBundleSpecs = <_LiteRtLmBundleSpec>[
@@ -494,6 +494,650 @@ paths=(
       contains('llamadart_llama_cpp_flutter: ^0.0.2'),
     );
   });
+
+  test(
+    'transitions b10514 to stable tags and upgrades semantic versions',
+    () async {
+      final setup = await _writeLlamaOnlyRepo('b10514');
+      addTearDown(() => setup.root.delete(recursive: true));
+      await _writeStableNativeReleaseFixture(
+        setup.releaseDir,
+        'v0.2.0',
+        includeNativeReleaseTag: false,
+      );
+
+      final transition = await _runLlamaSync(setup, 'v0.2.0');
+      expect(
+        transition.exitCode,
+        0,
+        reason: '${transition.stdout}\n${transition.stderr}',
+      );
+      expect(
+        await File(
+          path.join(setup.root.path, 'hook', 'build.dart'),
+        ).readAsString(),
+        contains("const _llamaCppTag = 'v0.2.0';"),
+      );
+      expect(
+        await File(path.join(setup.root.path, 'README.md')).readAsString(),
+        contains('leehack/llamadart-native@v0.2.0'),
+      );
+
+      await _writeStableNativeReleaseFixture(setup.releaseDir, 'v0.2.1');
+      final upgrade = await _runLlamaSync(setup, 'v0.2.1');
+      expect(
+        upgrade.exitCode,
+        0,
+        reason: '${upgrade.stdout}\n${upgrade.stderr}',
+      );
+      expect(
+        await File(
+          path.join(setup.root.path, 'hook', 'build.dart'),
+        ).readAsString(),
+        contains("const _llamaCppTag = 'v0.2.1';"),
+      );
+
+      final latestSetup = await _writeLlamaOnlyRepo('b10514');
+      addTearDown(() => latestSetup.root.delete(recursive: true));
+      await _writeStableNativeReleaseFixture(
+        latestSetup.releaseDir,
+        'latest',
+        resolvedTag: 'v0.2.0',
+      );
+      final latest = await _runLlamaSync(latestSetup, 'latest');
+      expect(latest.exitCode, 0, reason: '${latest.stdout}\n${latest.stderr}');
+    },
+  );
+
+  test('requires explicit opt-in for stable to historical channel', () async {
+    final setup = await _writeLlamaOnlyRepo('v0.2.0');
+    addTearDown(() => setup.root.delete(recursive: true));
+    await _writeReleaseFixture(
+      setup.releaseDir,
+      'leehack/llamadart-native',
+      'b10514',
+      {'llamadart-native-apple-xcframework-b10514.zip': _hex('a')},
+    );
+
+    final rejected = await _runLlamaSync(setup, 'b10514');
+    expect(rejected.exitCode, 1);
+    expect(
+      rejected.stderr,
+      contains('stable-to-historical/nightly native channel'),
+    );
+    expect(rejected.stderr, contains('--allow-legacy-tag'));
+
+    final accepted = await _runLlamaSync(
+      setup,
+      'b10514',
+      extraArguments: const ['--allow-legacy-tag'],
+    );
+    expect(
+      accepted.exitCode,
+      0,
+      reason: '${accepted.stdout}\n${accepted.stderr}',
+    );
+  });
+
+  test(
+    'accepts nightly rebuild progression and legacy wrapper artifacts',
+    () async {
+      final setup = await _writeLlamaOnlyRepo('b10514');
+      addTearDown(() => setup.root.delete(recursive: true));
+      for (final tag in const ['b10514-1', 'b10514-2']) {
+        await _writeNightlyNativeReleaseFixture(setup.releaseDir, tag);
+        final result = await _runLlamaSync(setup, tag);
+        expect(
+          result.exitCode,
+          0,
+          reason: '$tag\n${result.stdout}\n${result.stderr}',
+        );
+      }
+
+      final legacySetup = await _writeLlamaOnlyRepo('b10514');
+      addTearDown(() => legacySetup.root.delete(recursive: true));
+      const legacyTag = 'b10514-llamadart.1';
+      await _writeReleaseFixture(
+        legacySetup.releaseDir,
+        'leehack/llamadart-native',
+        legacyTag,
+        {'llamadart-native-apple-xcframework-$legacyTag.zip': _hex('b')},
+      );
+      final legacy = await _runLlamaSync(legacySetup, legacyTag);
+      expect(legacy.exitCode, 0, reason: '${legacy.stdout}\n${legacy.stderr}');
+    },
+  );
+
+  test('requires provenance manifests for new wrapper release forms', () async {
+    final missingManifestSetup = await _writeLlamaOnlyRepo('b10514');
+    addTearDown(() => missingManifestSetup.root.delete(recursive: true));
+    await _writeNightlyNativeReleaseFixture(
+      missingManifestSetup.releaseDir,
+      'b10514-1',
+      includeManifest: false,
+    );
+    final missingManifest = await _runLlamaSync(
+      missingManifestSetup,
+      'b10514-1',
+    );
+    expect(missingManifest.exitCode, 1);
+    expect(missingManifest.stderr, contains('missing required assets.json'));
+
+    final missingNativeTagSetup = await _writeLlamaOnlyRepo('b10514');
+    addTearDown(() => missingNativeTagSetup.root.delete(recursive: true));
+    await _writeNightlyNativeReleaseFixture(
+      missingNativeTagSetup.releaseDir,
+      'b10514-1',
+      includeNativeReleaseTag: false,
+    );
+    final missingNativeTag = await _runLlamaSync(
+      missingNativeTagSetup,
+      'b10514-1',
+    );
+    expect(missingNativeTag.exitCode, 1);
+    expect(missingNativeTag.stderr, contains('native_release_tag'));
+
+    final missingLegacyAliasSetup = await _writeLlamaOnlyRepo('b10514');
+    addTearDown(() => missingLegacyAliasSetup.root.delete(recursive: true));
+    await _writeNightlyNativeReleaseFixture(
+      missingLegacyAliasSetup.releaseDir,
+      'b10514-1',
+      includeLegacyTag: false,
+    );
+    final missingLegacyAlias = await _runLlamaSync(
+      missingLegacyAliasSetup,
+      'b10514-1',
+    );
+    expect(missingLegacyAlias.exitCode, 1);
+    expect(missingLegacyAlias.stderr, contains('tag field(s): tag'));
+
+    final stableWrapperSetup = await _writeLlamaOnlyRepo('v0.2.0');
+    addTearDown(() => stableWrapperSetup.root.delete(recursive: true));
+    await _writeStableNativeReleaseFixture(
+      stableWrapperSetup.releaseDir,
+      'v0.2.0-1',
+      includeNativeReleaseTag: false,
+    );
+    final stableWrapper = await _runLlamaSync(stableWrapperSetup, 'v0.2.0-1');
+    expect(stableWrapper.exitCode, 1);
+    expect(stableWrapper.stderr, contains('native_release_tag'));
+  });
+
+  test(
+    'workflow exposes and forwards explicit nightly channel opt-in',
+    () async {
+      final workflow = await File(
+        path.join(
+          Directory.current.path,
+          '.github',
+          'workflows',
+          'sync_native_bindings.yml',
+        ),
+      ).readAsString();
+
+      expect(workflow, contains('allow_nightly_channel:'));
+      expect(
+        _occurrences(workflow, 'transition_args+=(--allow-legacy-tag)'),
+        2,
+      );
+      expect(_occurrences(workflow, r'"${transition_args[@]}"'), 2);
+    },
+  );
+
+  test('orders stable wrapper rebuilds between upstream stable tags', () async {
+    final setup = await _writeLlamaOnlyRepo('v0.2.0');
+    addTearDown(() => setup.root.delete(recursive: true));
+    for (final tag in const ['v0.2.0-1', 'v0.2.0-2', 'v0.2.1']) {
+      await _writeStableNativeReleaseFixture(setup.releaseDir, tag);
+      final result = await _runLlamaSync(setup, tag);
+      expect(
+        result.exitCode,
+        0,
+        reason: '$tag\n${result.stdout}\n${result.stderr}',
+      );
+    }
+  });
+
+  test('rejects invalid native release tags before release lookup', () async {
+    final setup = await _writeLlamaOnlyRepo('b10514');
+    addTearDown(() => setup.root.delete(recursive: true));
+
+    for (final tag in const [
+      'v1.2',
+      'v01.2.3',
+      'b10514-custom',
+      'b10514-0',
+      'v0.2.0-0',
+      'v0.2.0-llamadart.1',
+      'v0.2.0-custom.1',
+      '../v0.2.0',
+    ]) {
+      final result = await _runLlamaSync(setup, tag);
+      expect(result.exitCode, 1, reason: tag);
+      expect(
+        result.stderr,
+        contains('Invalid llamadart-native release tag'),
+        reason: tag,
+      );
+    }
+  });
+
+  test(
+    'header sync rejects invalid native tags before network lookup',
+    () async {
+      for (final tag in const ['v1.2', 'b10514-0', 'v0.2.0-llamadart.1']) {
+        final result = await Process.run('bash', [
+          'tool/native/sync_native_headers_and_bindings.sh',
+          '--tag',
+          tag,
+          '--skip-ffigen',
+        ]);
+        expect(result.exitCode, 1, reason: tag);
+        expect(
+          result.stderr,
+          contains('Invalid llamadart-native tag'),
+          reason: tag,
+        );
+        expect(
+          result.stderr,
+          contains('stable vMAJOR.MINOR.PATCH'),
+          reason: tag,
+        );
+      }
+    },
+  );
+
+  test('rejects semantic, nightly, and legacy wrapper rollbacks', () async {
+    final semanticSetup = await _writeLlamaOnlyRepo('v0.2.1');
+    addTearDown(() => semanticSetup.root.delete(recursive: true));
+    await _writeStableNativeReleaseFixture(semanticSetup.releaseDir, 'v0.2.0');
+    final semanticRollback = await _runLlamaSync(semanticSetup, 'v0.2.0');
+    expect(semanticRollback.exitCode, 1);
+    expect(semanticRollback.stderr, contains('native release rollback'));
+
+    final wrapperSetup = await _writeLlamaOnlyRepo('b10514-2');
+    addTearDown(() => wrapperSetup.root.delete(recursive: true));
+    await _writeReleaseFixture(
+      wrapperSetup.releaseDir,
+      'leehack/llamadart-native',
+      'b10514-1',
+      {'llamadart-native-apple-xcframework-b10514-1.zip': _hex('c')},
+    );
+    final wrapperRollback = await _runLlamaSync(wrapperSetup, 'b10514-1');
+    expect(wrapperRollback.exitCode, 1);
+    expect(wrapperRollback.stderr, contains('native release rollback'));
+
+    final legacyWrapperSetup = await _writeLlamaOnlyRepo('b10514-llamadart.2');
+    addTearDown(() => legacyWrapperSetup.root.delete(recursive: true));
+    await _writeReleaseFixture(
+      legacyWrapperSetup.releaseDir,
+      'leehack/llamadart-native',
+      'b10514-llamadart.1',
+      {'llamadart-native-apple-xcframework-b10514-llamadart.1.zip': _hex('c')},
+    );
+    final legacyWrapperRollback = await _runLlamaSync(
+      legacyWrapperSetup,
+      'b10514-llamadart.1',
+    );
+    expect(legacyWrapperRollback.exitCode, 1);
+    expect(legacyWrapperRollback.stderr, contains('native release rollback'));
+
+    final aliasSetup = await _writeLlamaOnlyRepo('b10514-llamadart.1');
+    addTearDown(() => aliasSetup.root.delete(recursive: true));
+    await _writeReleaseFixture(
+      aliasSetup.releaseDir,
+      'leehack/llamadart-native',
+      'b10514-1',
+      {'llamadart-native-apple-xcframework-b10514-1.zip': _hex('c')},
+    );
+    final aliasCollision = await _runLlamaSync(aliasSetup, 'b10514-1');
+    expect(aliasCollision.exitCode, 1);
+    expect(
+      aliasCollision.stderr,
+      contains('equivalent native release sequence aliases'),
+    );
+
+    final stableWrapperSetup = await _writeLlamaOnlyRepo('v0.2.0-2');
+    addTearDown(() => stableWrapperSetup.root.delete(recursive: true));
+    await _writeStableNativeReleaseFixture(
+      stableWrapperSetup.releaseDir,
+      'v0.2.0-1',
+    );
+    final stableWrapperRollback = await _runLlamaSync(
+      stableWrapperSetup,
+      'v0.2.0-1',
+    );
+    expect(stableWrapperRollback.exitCode, 1);
+    expect(stableWrapperRollback.stderr, contains('native release rollback'));
+
+    final alignedSetup = await _writeLlamaOnlyRepo('v0.2.1');
+    addTearDown(() => alignedSetup.root.delete(recursive: true));
+    await _writeStableNativeReleaseFixture(alignedSetup.releaseDir, 'v0.2.0-3');
+    final alignedRollback = await _runLlamaSync(alignedSetup, 'v0.2.0-3');
+    expect(alignedRollback.exitCode, 1);
+    expect(alignedRollback.stderr, contains('native release rollback'));
+  });
+
+  test(
+    'accepts latest stable wrappers and rejects nightly or manifest skew',
+    () async {
+      final latestSetup = await _writeLlamaOnlyRepo('b10514');
+      addTearDown(() => latestSetup.root.delete(recursive: true));
+      await _writeReleaseFixture(
+        latestSetup.releaseDir,
+        'leehack/llamadart-native',
+        'latest',
+        {'llamadart-native-apple-xcframework-b10515-1.zip': _hex('d')},
+        resolvedTag: 'b10515-1',
+      );
+      final latest = await _runLlamaSync(latestSetup, 'latest');
+      expect(latest.exitCode, 1);
+      expect(latest.stderr, contains('latest resolved to nightly tag'));
+
+      final latestWrapperSetup = await _writeLlamaOnlyRepo('v0.2.0');
+      addTearDown(() => latestWrapperSetup.root.delete(recursive: true));
+      await _writeStableNativeReleaseFixture(
+        latestWrapperSetup.releaseDir,
+        'latest',
+        resolvedTag: 'v0.2.0-1',
+      );
+      final latestWrapper = await _runLlamaSync(latestWrapperSetup, 'latest');
+      expect(
+        latestWrapper.exitCode,
+        0,
+        reason: '${latestWrapper.stdout}\n${latestWrapper.stderr}',
+      );
+
+      final releaseSetup = await _writeLlamaOnlyRepo('b10514');
+      addTearDown(() => releaseSetup.root.delete(recursive: true));
+      await _writeStableNativeReleaseFixture(
+        releaseSetup.releaseDir,
+        'v0.2.0',
+        resolvedTag: 'v0.2.1',
+      );
+      final releaseSkew = await _runLlamaSync(releaseSetup, 'v0.2.0');
+      expect(releaseSkew.exitCode, 1);
+      expect(releaseSkew.stderr, contains('metadata resolved v0.2.1'));
+
+      final manifestSetup = await _writeLlamaOnlyRepo('b10514');
+      addTearDown(() => manifestSetup.root.delete(recursive: true));
+      await _writeStableNativeReleaseFixture(
+        manifestSetup.releaseDir,
+        'v0.2.0',
+        manifestTag: 'v0.2.1',
+      );
+      final manifestSkew = await _runLlamaSync(manifestSetup, 'v0.2.0');
+      expect(manifestSkew.exitCode, 1);
+      expect(
+        manifestSkew.stderr,
+        contains('Refusing version-skewed native assets'),
+      );
+
+      final abiSetup = await _writeLlamaOnlyRepo('b10514');
+      addTearDown(() => abiSetup.root.delete(recursive: true));
+      await _writeStableNativeReleaseFixture(
+        abiSetup.releaseDir,
+        'v0.2.0',
+        llamaCppTag: 'v0.1.9',
+      );
+      final abiSkew = await _runLlamaSync(abiSetup, 'v0.2.0');
+      expect(abiSkew.exitCode, 1);
+      expect(abiSkew.stderr, contains('version-skewed native ABI metadata'));
+
+      final aliasSetup = await _writeLlamaOnlyRepo('b10514');
+      addTearDown(() => aliasSetup.root.delete(recursive: true));
+      await _writeStableNativeReleaseFixture(
+        aliasSetup.releaseDir,
+        'v0.2.0',
+        legacyManifestTag: 'v0.2.1',
+      );
+      final aliasSkew = await _runLlamaSync(aliasSetup, 'v0.2.0');
+      expect(aliasSkew.exitCode, 1);
+      expect(aliasSkew.stderr, contains('disagrees with legacy tag alias'));
+
+      final wrapperRefSetup = await _writeLlamaOnlyRepo('v0.2.0');
+      addTearDown(() => wrapperRefSetup.root.delete(recursive: true));
+      await _writeStableNativeReleaseFixture(
+        wrapperRefSetup.releaseDir,
+        'v0.2.0-1',
+        llamaCppTag: 'v0.2.0-1',
+      );
+      final wrapperRefSkew = await _runLlamaSync(wrapperRefSetup, 'v0.2.0-1');
+      expect(wrapperRefSkew.exitCode, 1);
+      expect(
+        wrapperRefSkew.stderr,
+        contains('version-skewed native ABI metadata'),
+      );
+
+      final nightlyWrapperRefSetup = await _writeLlamaOnlyRepo('b10514');
+      addTearDown(() => nightlyWrapperRefSetup.root.delete(recursive: true));
+      await _writeNightlyNativeReleaseFixture(
+        nightlyWrapperRefSetup.releaseDir,
+        'b10514-1',
+        llamaCppTag: 'b10514-1',
+      );
+      final nightlyWrapperRefSkew = await _runLlamaSync(
+        nightlyWrapperRefSetup,
+        'b10514-1',
+      );
+      expect(nightlyWrapperRefSkew.exitCode, 1);
+      expect(
+        nightlyWrapperRefSkew.stderr,
+        contains('version-skewed native ABI metadata'),
+      );
+    },
+  );
+
+  test(
+    'rejects unsupported contracts, unavailable bundles, and checksum skew',
+    () async {
+      final contractSetup = await _writeLlamaOnlyRepo('b10514');
+      addTearDown(() => contractSetup.root.delete(recursive: true));
+      await _writeStableNativeReleaseFixture(
+        contractSetup.releaseDir,
+        'v0.2.0',
+        hookContractVersion: 2,
+      );
+      final contract = await _runLlamaSync(contractSetup, 'v0.2.0');
+      expect(contract.exitCode, 1);
+      expect(contract.stderr, contains('requires native hook contract 2'));
+
+      final bundleSetup = await _writeLlamaOnlyRepo('b10514');
+      addTearDown(() => bundleSetup.root.delete(recursive: true));
+      await _writeStableNativeReleaseFixture(
+        bundleSetup.releaseDir,
+        'v0.2.0',
+        omittedBundle: 'windows-arm64',
+      );
+      final bundle = await _runLlamaSync(bundleSetup, 'v0.2.0');
+      expect(bundle.exitCode, 1);
+      expect(bundle.stderr, contains('missing required bundle(s)'));
+      expect(bundle.stderr, contains('windows-arm64'));
+
+      final digestSetup = await _writeLlamaOnlyRepo('b10514');
+      addTearDown(() => digestSetup.root.delete(recursive: true));
+      await _writeStableNativeReleaseFixture(
+        digestSetup.releaseDir,
+        'v0.2.0',
+        missingDigestFile: 'llamadart-native-linux-x64-v0.2.0.tar.gz',
+      );
+      final digest = await _runLlamaSync(digestSetup, 'v0.2.0');
+      expect(digest.exitCode, 1);
+      expect(digest.stderr, contains('does not publish a GitHub SHA-256'));
+
+      final sumsSetup = await _writeLlamaOnlyRepo('b10514');
+      addTearDown(() => sumsSetup.root.delete(recursive: true));
+      await _writeStableNativeReleaseFixture(
+        sumsSetup.releaseDir,
+        'v0.2.0',
+        checksumSumsMismatchFile: 'llamadart-native-headers-v0.2.0.tar.gz',
+      );
+      final sums = await _runLlamaSync(sumsSetup, 'v0.2.0');
+      expect(sums.exitCode, 1);
+      expect(sums.stderr, contains('SHA256SUMS checksum'));
+    },
+  );
+}
+
+Future<_LlamaSyncSetup> _writeLlamaOnlyRepo(String currentTag) async {
+  final root = await Directory.systemTemp.createTemp('native_semver_sync_');
+  await Directory(path.join(root.path, 'hook')).create(recursive: true);
+  await File(path.join(root.path, 'hook', 'build.dart')).writeAsString('''
+const _llamaCppTag = '$currentTag';
+''');
+  final releaseDir = Directory(path.join(root.path, 'releases'))
+    ..createSync(recursive: true);
+  await _writePackageSwift(
+    root,
+    'packages/llamadart_llama_cpp_flutter/darwin/'
+        'llamadart_llama_cpp_flutter/Package.swift',
+    'llamaCppTag',
+    const ['llama'],
+    const {'llama': 'llamadart-native-apple-xcframework-\\(llamaCppTag).zip'},
+  );
+  await _writeCompanionDocs(
+    root,
+    'packages/llamadart_llama_cpp_flutter',
+    'leehack/llamadart-native',
+  );
+  await _writeProjectDocs(root);
+  return _LlamaSyncSetup(root, releaseDir);
+}
+
+Future<ProcessResult> _runLlamaSync(
+  _LlamaSyncSetup setup,
+  String tag, {
+  List<String> extraArguments = const [],
+}) {
+  return _runPython([
+    'tool/native/sync_native_release_pins.py',
+    '--repo-root',
+    setup.root.path,
+    '--release-json-dir',
+    setup.releaseDir.path,
+    '--llama-cpp-tag',
+    tag,
+    '--litert-lm-tag',
+    'keep',
+    ...extraArguments,
+  ]);
+}
+
+Future<void> _writeStableNativeReleaseFixture(
+  Directory dir,
+  String fixtureTag, {
+  String? resolvedTag,
+  String? manifestTag,
+  String? legacyManifestTag,
+  String? llamaCppTag,
+  bool includeNativeReleaseTag = true,
+  int hookContractVersion = 1,
+  String? omittedBundle,
+  String? missingDigestFile,
+  String? checksumSumsMismatchFile,
+}) {
+  final releaseTag = resolvedTag ?? fixtureTag;
+  final bundleNames = _stableNativeBundles
+      .where((bundle) => bundle != omittedBundle)
+      .toList(growable: false);
+  final artifactFiles = <String>[
+    for (final bundle in bundleNames)
+      'llamadart-native-$bundle-$releaseTag.tar.gz',
+    'llamadart-native-apple-xcframework-$releaseTag.zip',
+    'llamadart-native-headers-$releaseTag.tar.gz',
+  ];
+  final artifacts = [
+    for (var index = 0; index < artifactFiles.length; index++)
+      {
+        'file': artifactFiles[index],
+        'sha256': _hex(_fixtureHexCharacters[index]),
+      },
+  ];
+  final manifest = {
+    if (includeNativeReleaseTag)
+      'native_release_tag': manifestTag ?? releaseTag,
+    'tag': legacyManifestTag ?? manifestTag ?? releaseTag,
+    'llama_cpp_tag': llamaCppTag ?? _upstreamTagForNativeTag(releaseTag),
+    'llama_cpp_commit': _hex('a').substring(0, 40),
+    'native_commit': _hex('b').substring(0, 40),
+    'hook_contract_version': hookContractVersion,
+    'artifacts': artifacts,
+  };
+  final payload = {
+    'tag_name': releaseTag,
+    'assets': [
+      for (final artifact in artifacts)
+        {
+          'name': artifact['file'],
+          if (artifact['file'] != missingDigestFile)
+            'digest': 'sha256:${artifact['sha256']}',
+        },
+      {
+        'name': 'assets.json',
+        'digest': 'sha256:${_hex('c')}',
+        'fixture_json': manifest,
+      },
+      {
+        'name': 'SHA256SUMS',
+        'digest': 'sha256:${_hex('d')}',
+        'fixture_text': [
+          for (final artifact in artifacts)
+            '${artifact['file'] == checksumSumsMismatchFile ? _hex('f') : artifact['sha256']}  ${artifact['file']}',
+        ].join('\n'),
+      },
+    ],
+  };
+  final file = File(
+    path.join(dir.path, 'leehack__llamadart-native__$fixtureTag.json'),
+  );
+  return file.writeAsString(jsonEncode(payload));
+}
+
+Future<void> _writeNightlyNativeReleaseFixture(
+  Directory dir,
+  String tag, {
+  bool includeManifest = true,
+  bool includeNativeReleaseTag = true,
+  bool includeLegacyTag = true,
+  String? llamaCppTag,
+}) {
+  final artifactFile = 'llamadart-native-apple-xcframework-$tag.zip';
+  final artifactChecksum = _hex('b');
+  final manifest = {
+    if (includeNativeReleaseTag) 'native_release_tag': tag,
+    if (includeLegacyTag) 'tag': tag,
+    'llama_cpp_tag':
+        llamaCppTag ?? tag.replaceFirst(RegExp(r'-[1-9][0-9]*$'), ''),
+    'llama_cpp_commit': _hex('a').substring(0, 40),
+    'native_commit': _hex('b').substring(0, 40),
+    'hook_contract_version': 1,
+    'artifacts': [
+      {'file': artifactFile, 'sha256': artifactChecksum},
+    ],
+  };
+  final payload = {
+    'tag_name': tag,
+    'assets': [
+      {'name': artifactFile, 'digest': 'sha256:$artifactChecksum'},
+      if (includeManifest)
+        {
+          'name': 'assets.json',
+          'digest': 'sha256:${_hex('c')}',
+          'fixture_json': manifest,
+        },
+    ],
+  };
+  final file = File(
+    path.join(dir.path, 'leehack__llamadart-native__$tag.json'),
+  );
+  return file.writeAsString(jsonEncode(payload));
+}
+
+String _upstreamTagForNativeTag(String tag) {
+  if (tag.startsWith('v')) {
+    return tag.replaceFirst(RegExp(r'-[1-9][0-9]*$'), '');
+  }
+  return tag.split('-llamadart.').first;
 }
 
 int _occurrences(String text, String needle) => needle.allMatches(text).length;
@@ -663,13 +1307,14 @@ Future<void> _writeReleaseFixture(
   Directory dir,
   String repo,
   String tag,
-  Map<String, String> assets,
-) {
+  Map<String, String> assets, {
+  String? resolvedTag,
+}) {
   final file = File(
     path.join(dir.path, '${repo.replaceAll('/', '__')}__$tag.json'),
   );
   final payload = {
-    'tag_name': tag,
+    'tag_name': resolvedTag ?? tag,
     'assets': [
       for (final entry in assets.entries)
         {'name': entry.key, 'digest': 'sha256:${entry.value}'},
@@ -688,3 +1333,40 @@ const Map<String, (String, String)> _litertAppleTargets = {
     '8',
   ),
 };
+
+const _stableNativeBundles = <String>[
+  'android-arm64',
+  'android-x64',
+  'ios-arm64',
+  'ios-arm64-sim',
+  'ios-x86_64-sim',
+  'linux-arm64',
+  'linux-x64',
+  'macos-arm64',
+  'macos-x86_64',
+  'windows-arm64',
+  'windows-x64',
+];
+
+const _fixtureHexCharacters = <String>[
+  '0',
+  '1',
+  '2',
+  '3',
+  '4',
+  '5',
+  '6',
+  '7',
+  '8',
+  '9',
+  'a',
+  'b',
+  'c',
+];
+
+final class _LlamaSyncSetup {
+  const _LlamaSyncSetup(this.root, this.releaseDir);
+
+  final Directory root;
+  final Directory releaseDir;
+}

--- a/test/unit/tooling/sync_native_release_pins_script_test.dart
+++ b/test/unit/tooling/sync_native_release_pins_script_test.dart
@@ -1154,6 +1154,28 @@ printf '%s\\n' '{"tag_name":"v0.2.0-1","assets":[]}'
       expect(sums.stderr, contains('SHA256SUMS checksum'));
     },
   );
+
+  test('rejects non-object release assets without a traceback', () async {
+    final setup = await _writeLlamaOnlyRepo('b10514');
+    addTearDown(() => setup.root.delete(recursive: true));
+    await _writeStableNativeReleaseFixture(setup.releaseDir, 'v0.2.0');
+    final fixture = File(
+      path.join(
+        setup.releaseDir.path,
+        'leehack__llamadart-native__v0.2.0.json',
+      ),
+    );
+    final payload =
+        jsonDecode(await fixture.readAsString()) as Map<String, Object?>;
+    (payload['assets'] as List<Object?>).add('not-an-object');
+    await fixture.writeAsString(jsonEncode(payload));
+
+    final result = await _runLlamaSync(setup, 'v0.2.0');
+    expect(result.exitCode, 1);
+    expect(result.stderr, contains('asset list contains a non-object entry'));
+    expect(result.stderr, isNot(contains('Traceback')));
+    expect(result.stderr, isNot(contains('AttributeError')));
+  });
 }
 
 Future<_LlamaSyncSetup> _writeLlamaOnlyRepo(String currentTag) async {

--- a/test/unit/tooling/sync_native_release_pins_script_test.dart
+++ b/test/unit/tooling/sync_native_release_pins_script_test.dart
@@ -663,6 +663,41 @@ paths=(
     expect(stableWrapper.stderr, contains('native_release_tag'));
   });
 
+  test('reports non-UTF-8 release manifests without a traceback', () async {
+    final setup = await _writeLlamaOnlyRepo('b10514');
+    addTearDown(() => setup.root.delete(recursive: true));
+    final server = await HttpServer.bind(InternetAddress.loopbackIPv4, 0);
+    addTearDown(() => server.close(force: true));
+    server.listen((request) async {
+      request.response.add(const [0xff]);
+      await request.response.close();
+    });
+
+    const tag = 'v0.2.0';
+    await _writeStableNativeReleaseFixture(setup.releaseDir, tag);
+    final fixture = File(
+      path.join(setup.releaseDir.path, 'leehack__llamadart-native__$tag.json'),
+    );
+    final release = jsonDecode(await fixture.readAsString()) as Map;
+    final assets = release['assets'] as List;
+    final manifestAsset = assets.cast<Map>().singleWhere(
+      (asset) => asset['name'] == 'assets.json',
+    );
+    manifestAsset.remove('fixture_json');
+    manifestAsset['browser_download_url'] =
+        'http://${server.address.address}:${server.port}/assets.json';
+    await fixture.writeAsString(jsonEncode(release));
+
+    final result = await _runLlamaSync(setup, tag);
+
+    expect(result.exitCode, 1);
+    expect(
+      result.stderr,
+      contains('Failed to read release manifest assets.json'),
+    );
+    expect(result.stderr, isNot(contains('Traceback')));
+  });
+
   test(
     'workflow exposes and forwards explicit nightly channel opt-in',
     () async {

--- a/test/unit/tooling/sync_native_release_pins_script_test.dart
+++ b/test/unit/tooling/sync_native_release_pins_script_test.dart
@@ -1120,6 +1120,28 @@ printf '%s\\n' '{"tag_name":"v0.2.0-1","assets":[]}'
       expect(digest.exitCode, 1);
       expect(digest.stderr, contains('does not publish a GitHub SHA-256'));
 
+      for (final metadataFile in const ['assets.json', 'SHA256SUMS']) {
+        final metadataDigestSetup = await _writeLlamaOnlyRepo('b10514');
+        addTearDown(() => metadataDigestSetup.root.delete(recursive: true));
+        await _writeStableNativeReleaseFixture(
+          metadataDigestSetup.releaseDir,
+          'v0.2.0',
+          missingDigestFile: metadataFile,
+        );
+        final metadataDigest = await _runLlamaSync(
+          metadataDigestSetup,
+          'v0.2.0',
+        );
+        expect(metadataDigest.exitCode, 1, reason: metadataFile);
+        expect(
+          metadataDigest.stderr,
+          contains(
+            'does not publish a GitHub SHA-256 digest for $metadataFile',
+          ),
+          reason: metadataFile,
+        );
+      }
+
       final sumsSetup = await _writeLlamaOnlyRepo('b10514');
       addTearDown(() => sumsSetup.root.delete(recursive: true));
       await _writeStableNativeReleaseFixture(
@@ -1229,12 +1251,12 @@ Future<void> _writeStableNativeReleaseFixture(
         },
       {
         'name': 'assets.json',
-        'digest': 'sha256:${_hex('c')}',
+        if (missingDigestFile != 'assets.json') 'digest': 'sha256:${_hex('c')}',
         'fixture_json': manifest,
       },
       {
         'name': 'SHA256SUMS',
-        'digest': 'sha256:${_hex('d')}',
+        if (missingDigestFile != 'SHA256SUMS') 'digest': 'sha256:${_hex('d')}',
         'fixture_text': [
           for (final artifact in artifacts)
             '${artifact['file'] == checksumSumsMismatchFile ? _hex('f') : artifact['sha256']}  ${artifact['file']}',

--- a/test/unit/tooling/sync_native_release_pins_script_test.dart
+++ b/test/unit/tooling/sync_native_release_pins_script_test.dart
@@ -1000,7 +1000,7 @@ printf '%s\\n' '{"tag_name":"v0.2.0-1","assets":[]}'
       expect(latestWrapper.stderr, contains('latest resolved to v0.2.0-1'));
       expect(
         latestWrapper.stderr,
-        contains('select GitHub-prerelease wrapper rebuilds'),
+        contains('select wrapper rebuilds and historical or nightly tags'),
       );
 
       final releaseSetup = await _writeLlamaOnlyRepo('b10514');

--- a/test/unit/tooling/sync_native_release_pins_script_test.dart
+++ b/test/unit/tooling/sync_native_release_pins_script_test.dart
@@ -745,6 +745,7 @@ paths=(
         );
       }
     },
+    skip: Platform.isWindows ? 'requires a POSIX Bash runtime' : false,
   );
 
   test('rejects semantic, nightly, and legacy wrapper rollbacks', () async {

--- a/test/unit/tooling/sync_native_release_pins_script_test.dart
+++ b/test/unit/tooling/sync_native_release_pins_script_test.dart
@@ -699,7 +699,7 @@ paths=(
   });
 
   test(
-    'workflow exposes and forwards explicit nightly channel opt-in',
+    'workflow passes dispatch inputs through quoted environment variables',
     () async {
       final workflow = await File(
         path.join(
@@ -716,8 +716,70 @@ paths=(
         2,
       );
       expect(_occurrences(workflow, r'"${transition_args[@]}"'), 2);
+      expect(workflow, contains(r'NATIVE_TAG: ${{ inputs.native_tag }}'));
+      expect(
+        _occurrences(workflow, r'LITERT_LM_TAG: ${{ inputs.litert_lm_tag }}'),
+        2,
+      );
+      expect(
+        workflow,
+        contains(
+          r'RESOLVED_NATIVE_TAG: ${{ steps.sync_headers.outputs.resolved_tag }}',
+        ),
+      );
+      expect(_occurrences(workflow, r'--llama-cpp-tag "${NATIVE_TAG}"'), 1);
+      expect(_occurrences(workflow, r'--tag "${NATIVE_TAG}"'), 1);
+      expect(
+        _occurrences(workflow, r'--llama-cpp-tag "${RESOLVED_NATIVE_TAG}"'),
+        1,
+      );
+      expect(_occurrences(workflow, r'--litert-lm-tag "${LITERT_LM_TAG}"'), 2);
+      expect(
+        workflow,
+        isNot(contains(r'${{ github.event.inputs.native_tag }}')),
+      );
+      expect(
+        workflow,
+        isNot(contains(r'${{ github.event.inputs.litert_lm_tag }}')),
+      );
+      expect(
+        workflow,
+        isNot(contains(r'--llama-cpp-tag "${{ inputs.native_tag }}"')),
+      );
+      expect(
+        workflow,
+        isNot(contains(r'--litert-lm-tag "${{ inputs.litert_lm_tag }}"')),
+      );
     },
   );
+
+  test('native tag consumers use canonical nightly core grammar', () async {
+    final sources = <String, String>{
+      'Python synchronizer': await File(
+        'tool/native/sync_native_release_pins.py',
+      ).readAsString(),
+      'Bash header sync': await File(
+        'tool/native/sync_native_headers_and_bindings.sh',
+      ).readAsString(),
+      'Dart build hook': await File('hook/build.dart').readAsString(),
+      'release-doc verifier': await File(
+        'tool/testing/verify_release_docs_versions.dart',
+      ).readAsString(),
+    };
+
+    expect(sources['Python synchronizer'], contains(r'r"^b(0|[1-9][0-9]*)$"'));
+    expect(
+      sources['Bash header sync'],
+      contains("nightly_tag_pattern='^b(0|[1-9][0-9]*)\$'"),
+    );
+    for (final entry in sources.entries.where(
+      (entry) =>
+          entry.key.startsWith('Dart') || entry.key.startsWith('release'),
+    )) {
+      expect(entry.value, contains(r'b(?:0|[1-9][0-9]*)'), reason: entry.key);
+      expect(entry.value, isNot(contains(r'b[0-9]+')), reason: entry.key);
+    }
+  });
 
   test('orders stable wrapper rebuilds between upstream stable tags', () async {
     final setup = await _writeLlamaOnlyRepo('v0.2.0');
@@ -740,12 +802,21 @@ paths=(
     for (final tag in const [
       'v1.2',
       'v01.2.3',
+      'b00',
+      'b0000',
+      'b0001',
+      'b0001-1',
+      'b0001-llamadart.1',
+      'b1-01',
+      'b1-llamadart.01',
       'b10514-custom',
       'b10514-0',
       'v0.2.0-0',
       'v0.2.0-llamadart.1',
       'v0.2.0-custom.1',
       '../v0.2.0',
+      r'b1; touch "$RUNNER_TEMP/llamadart-pwned"',
+      r'b1$(touch "$RUNNER_TEMP/llamadart-pwned")',
     ]) {
       final result = await _runLlamaSync(setup, tag);
       expect(result.exitCode, 1, reason: tag);
@@ -760,7 +831,17 @@ paths=(
   test(
     'header sync rejects invalid native tags before network lookup',
     () async {
-      for (final tag in const ['v1.2', 'b10514-0', 'v0.2.0-llamadart.1']) {
+      for (final tag in const [
+        'v1.2',
+        'b0000',
+        'b0001-1',
+        'b0001-llamadart.1',
+        'b1-01',
+        'b1-llamadart.01',
+        'b10514-0',
+        'v0.2.0-llamadart.1',
+        r'b1; touch "$RUNNER_TEMP/llamadart-pwned"',
+      ]) {
         final result = await Process.run('bash', [
           'tool/native/sync_native_headers_and_bindings.sh',
           '--tag',
@@ -779,6 +860,42 @@ paths=(
           reason: tag,
         );
       }
+    },
+    skip: Platform.isWindows ? 'requires a POSIX Bash runtime' : false,
+  );
+
+  test(
+    'header sync rejects wrapper prereleases resolved through latest',
+    () async {
+      final root = await Directory.systemTemp.createTemp(
+        'native_latest_wrapper_',
+      );
+      addTearDown(() => root.delete(recursive: true));
+      final fakeBin = Directory(path.join(root.path, 'bin'))
+        ..createSync(recursive: true);
+      final curl = File(path.join(fakeBin.path, 'curl'));
+      await curl.writeAsString('''#!/usr/bin/env bash
+printf '%s\\n' '{"tag_name":"v0.2.0-1","assets":[]}'
+''');
+      await Process.run('chmod', ['+x', curl.path]);
+
+      final result = await Process.run(
+        'bash',
+        [
+          'tool/native/sync_native_headers_and_bindings.sh',
+          '--tag',
+          'latest',
+          '--skip-ffigen',
+        ],
+        environment: {
+          ...Platform.environment,
+          'PATH': '${fakeBin.path}:${Platform.environment['PATH']}',
+        },
+      );
+
+      expect(result.exitCode, 1);
+      expect(result.stderr, contains('latest resolved to v0.2.0-1'));
+      expect(result.stderr, contains('only unsuffixed vMAJOR.MINOR.PATCH'));
     },
     skip: Platform.isWindows ? 'requires a POSIX Bash runtime' : false,
   );
@@ -855,7 +972,7 @@ paths=(
   });
 
   test(
-    'accepts latest stable wrappers and rejects nightly or manifest skew',
+    'latest accepts only unsuffixed stable tags and rejects release skew',
     () async {
       final latestSetup = await _writeLlamaOnlyRepo('b10514');
       addTearDown(() => latestSetup.root.delete(recursive: true));
@@ -868,7 +985,8 @@ paths=(
       );
       final latest = await _runLlamaSync(latestSetup, 'latest');
       expect(latest.exitCode, 1);
-      expect(latest.stderr, contains('latest resolved to nightly tag'));
+      expect(latest.stderr, contains('latest resolved to b10515-1'));
+      expect(latest.stderr, contains('only unsuffixed vMAJOR.MINOR.PATCH'));
 
       final latestWrapperSetup = await _writeLlamaOnlyRepo('v0.2.0');
       addTearDown(() => latestWrapperSetup.root.delete(recursive: true));
@@ -878,10 +996,11 @@ paths=(
         resolvedTag: 'v0.2.0-1',
       );
       final latestWrapper = await _runLlamaSync(latestWrapperSetup, 'latest');
+      expect(latestWrapper.exitCode, 1);
+      expect(latestWrapper.stderr, contains('latest resolved to v0.2.0-1'));
       expect(
-        latestWrapper.exitCode,
-        0,
-        reason: '${latestWrapper.stdout}\n${latestWrapper.stderr}',
+        latestWrapper.stderr,
+        contains('select GitHub-prerelease wrapper rebuilds'),
       );
 
       final releaseSetup = await _writeLlamaOnlyRepo('b10514');
@@ -1275,21 +1394,21 @@ The Apple SwiftPM manifest pins
 
 Future<void> _writeProjectDocs(Directory root) async {
   await File(path.join(root.path, 'README.md')).writeAsString('''
-llamadart_native_tag: b0001-llamadart.1
+llamadart_native_tag: b1-llamadart.1
 
-ABI-compatible with the default `leehack/llamadart-native@b0001-llamadart.1` runtime.
+ABI-compatible with the default `leehack/llamadart-native@b1-llamadart.1` runtime.
 
 dependencies:
   llamadart: ^0.1.0
   llamadart_llama_cpp_flutter: ^0.0.1
   llamadart_litert_lm_flutter: ^0.0.1
 
-`llamadart-native-windows-x64-b0001-llamadart.1.tar.gz`
+`llamadart-native-windows-x64-b1-llamadart.1.tar.gz`
 
-Available llama.cpp module matrix from the default native tag `b0001-llamadart.1`:
+Available llama.cpp module matrix from the default native tag `b1-llamadart.1`:
 
-| Native llama.cpp / GGUF | `leehack/llamadart-native@b0001-llamadart.1` |
-| Apple SPM llama.cpp / GGUF | `llamadart_llama_cpp_flutter` pins `leehack/llamadart-native@b0001-llamadart.1` Apple XCFramework |
+| Native llama.cpp / GGUF | `leehack/llamadart-native@b1-llamadart.1` |
+| Apple SPM llama.cpp / GGUF | `llamadart_llama_cpp_flutter` pins `leehack/llamadart-native@b1-llamadart.1` Apple XCFramework |
 ''');
 
   final installDoc = File(
@@ -1297,16 +1416,16 @@ Available llama.cpp module matrix from the default native tag `b0001-llamadart.1
   );
   await installDoc.parent.create(recursive: true);
   await installDoc.writeAsString('''
-llamadart_native_tag: b0001-llamadart.1
+llamadart_native_tag: b1-llamadart.1
 
-ABI-compatible with the default `leehack/llamadart-native@b0001-llamadart.1` runtime.
+ABI-compatible with the default `leehack/llamadart-native@b1-llamadart.1` runtime.
 
 dependencies:
   llamadart: ^0.1.0
   llamadart_llama_cpp_flutter: ^0.0.1
   llamadart_litert_lm_flutter: ^0.0.1
 
-`llamadart-native-windows-x64-b0001-llamadart.1.tar.gz`
+`llamadart-native-windows-x64-b1-llamadart.1.tar.gz`
 ''');
 
   final supportMatrix = File(
@@ -1315,19 +1434,19 @@ dependencies:
   await supportMatrix.parent.create(recursive: true);
   await supportMatrix.writeAsString('''
 The native-assets hook currently pins `llamadart-native` tag
-`b0001-llamadart.1` and
+`b1-llamadart.1` and
 `litert-lm-native` release `v0.13.1-native.1`.
 
-## Current llama.cpp module availability by bundle (`b0001-llamadart.1`)
+## Current llama.cpp module availability by bundle (`b1-llamadart.1`)
 
-llamadart_native_tag: b0001-llamadart.1
+llamadart_native_tag: b1-llamadart.1
 ''');
 
   await File(path.join(root.path, 'CHANGELOG.md')).writeAsString('''
 ## Unreleased
 
 * Updated the default llama.cpp native runtime pin to
-  `leehack/llamadart-native@b0001`, regenerated matching Dart FFI bindings,
+  `leehack/llamadart-native@b1`, regenerated matching Dart FFI bindings,
   refreshed the `llamadart_llama_cpp_flutter` Apple SwiftPM checksum, and
   aligned current README/website native override docs.
 

--- a/test/unit/tooling/sync_native_release_pins_script_test.dart
+++ b/test/unit/tooling/sync_native_release_pins_script_test.dart
@@ -781,6 +781,23 @@ paths=(
     }
   });
 
+  test('override docs limit latest to maintainer tooling', () async {
+    const contract =
+        'Build-hook overrides must always name an explicit tag; `latest` is '
+        'limited to maintainer synchronization and header/binding '
+        'regeneration';
+    for (final path in <String>[
+      'README.md',
+      'website/docs/getting-started/installation.md',
+      'website/docs/platforms/support-matrix.md',
+    ]) {
+      final normalized = (await File(
+        path,
+      ).readAsString()).replaceAll(RegExp(r'\s+'), ' ');
+      expect(normalized, contains(contract), reason: path);
+    }
+  });
+
   test('orders stable wrapper rebuilds between upstream stable tags', () async {
     final setup = await _writeLlamaOnlyRepo('v0.2.0');
     addTearDown(() => setup.root.delete(recursive: true));

--- a/tool/native/sync_native_headers_and_bindings.sh
+++ b/tool/native/sync_native_headers_and_bindings.sh
@@ -17,7 +17,7 @@ Downloads llamadart-native release header bundle for a tag and regenerates
 bindings using ffigen.
 
 Options:
-  --tag <tag|latest>      Stable/nightly tag or wrapper rebuild (default: latest)
+  --tag <tag|latest>      Explicit tag, or latest unsuffixed stable (default: latest)
   --repo <owner/name>     Native repository slug (default: leehack/llamadart-native)
   --header-root <path>    Header staging path (default: .dart_tool/llamadart/ffigen_headers)
   --skip-ffigen           Only sync headers, do not run ffigen
@@ -57,9 +57,9 @@ done
 
 stable_tag_pattern='^v(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)$'
 stable_wrapper_tag_pattern='^v(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)-[1-9][0-9]*$'
-nightly_tag_pattern='^b[0-9]+$'
-nightly_wrapper_tag_pattern='^b[0-9]+-[1-9][0-9]*$'
-legacy_wrapper_tag_pattern='^b[0-9]+-llamadart\.[1-9][0-9]*$'
+nightly_tag_pattern='^b(0|[1-9][0-9]*)$'
+nightly_wrapper_tag_pattern='^b(0|[1-9][0-9]*)-[1-9][0-9]*$'
+legacy_wrapper_tag_pattern='^b(0|[1-9][0-9]*)-llamadart\.[1-9][0-9]*$'
 
 is_supported_native_tag() {
   [[ "$1" =~ ${stable_tag_pattern} ]] ||
@@ -69,7 +69,11 @@ is_supported_native_tag() {
     [[ "$1" =~ ${legacy_wrapper_tag_pattern} ]]
 }
 
-is_stable_channel_tag() {
+is_latest_eligible_tag() {
+  [[ "$1" =~ ${stable_tag_pattern} ]]
+}
+
+is_stable_upstream_tag() {
   [[ "$1" =~ ${stable_tag_pattern} || "$1" =~ ${stable_wrapper_tag_pattern} ]]
 }
 
@@ -77,7 +81,8 @@ if [[ "${tag_input}" != "latest" && -n "${tag_input}" ]] &&
   ! is_supported_native_tag "${tag_input}"; then
   echo "Invalid llamadart-native tag: ${tag_input}" >&2
   echo "Expected stable vMAJOR.MINOR.PATCH, stable wrapper" \
-    "vMAJOR.MINOR.PATCH-N, historical/nightly bNNNN, nightly wrapper" \
+    "vMAJOR.MINOR.PATCH-N, canonical historical/nightly bNNNN without" \
+    "leading zeros, nightly wrapper" \
     "bNNNN-N, or legacy wrapper artifact bNNNN-llamadart.N." >&2
   exit 1
 fi
@@ -108,9 +113,10 @@ if ! is_supported_native_tag "${resolved_tag}"; then
   echo "Release metadata resolved unsupported tag: ${resolved_tag}" >&2
   exit 1
 fi
-if [[ "${tag_input}" == "latest" ]] && ! is_stable_channel_tag "${resolved_tag}"; then
-  echo "llamadart-native latest resolved nightly tag ${resolved_tag};" \
-    "select historical tags explicitly." >&2
+if [[ "${tag_input}" == "latest" ]] && ! is_latest_eligible_tag "${resolved_tag}"; then
+  echo "llamadart-native latest resolved to ${resolved_tag};" \
+    "automatic discovery accepts only unsuffixed vMAJOR.MINOR.PATCH releases;" \
+    "select GitHub-prerelease wrapper rebuilds and nightly tags explicitly." >&2
   exit 1
 fi
 if [[ "${tag_input}" != "latest" && -n "${tag_input}" ]] &&
@@ -159,7 +165,7 @@ if [[ "${asset_digest}" == sha256:* ]]; then
       "${expected_sha256}, got ${actual_sha256}." >&2
     exit 1
   fi
-elif is_stable_channel_tag "${resolved_tag}"; then
+elif is_stable_upstream_tag "${resolved_tag}"; then
   echo "Stable release ${resolved_tag} does not publish a SHA-256 digest for ${asset_name}." >&2
   exit 1
 else

--- a/tool/native/sync_native_headers_and_bindings.sh
+++ b/tool/native/sync_native_headers_and_bindings.sh
@@ -116,7 +116,7 @@ fi
 if [[ "${tag_input}" == "latest" ]] && ! is_latest_eligible_tag "${resolved_tag}"; then
   echo "llamadart-native latest resolved to ${resolved_tag};" \
     "automatic discovery accepts only unsuffixed vMAJOR.MINOR.PATCH releases;" \
-    "select GitHub-prerelease wrapper rebuilds and nightly tags explicitly." >&2
+    "select wrapper rebuilds and historical or nightly tags explicitly." >&2
   exit 1
 fi
 if [[ "${tag_input}" != "latest" && -n "${tag_input}" ]] &&

--- a/tool/native/sync_native_headers_and_bindings.sh
+++ b/tool/native/sync_native_headers_and_bindings.sh
@@ -17,7 +17,7 @@ Downloads llamadart-native release header bundle for a tag and regenerates
 bindings using ffigen.
 
 Options:
-  --tag <tag|latest>      Release tag to use (default: latest)
+  --tag <tag|latest>      Stable/nightly tag or wrapper rebuild (default: latest)
   --repo <owner/name>     Native repository slug (default: leehack/llamadart-native)
   --header-root <path>    Header staging path (default: .dart_tool/llamadart/ffigen_headers)
   --skip-ffigen           Only sync headers, do not run ffigen
@@ -55,6 +55,33 @@ while [[ $# -gt 0 ]]; do
   esac
 done
 
+stable_tag_pattern='^v(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)$'
+stable_wrapper_tag_pattern='^v(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)-[1-9][0-9]*$'
+nightly_tag_pattern='^b[0-9]+$'
+nightly_wrapper_tag_pattern='^b[0-9]+-[1-9][0-9]*$'
+legacy_wrapper_tag_pattern='^b[0-9]+-llamadart\.[1-9][0-9]*$'
+
+is_supported_native_tag() {
+  [[ "$1" =~ ${stable_tag_pattern} ]] ||
+    [[ "$1" =~ ${stable_wrapper_tag_pattern} ]] ||
+    [[ "$1" =~ ${nightly_tag_pattern} ]] ||
+    [[ "$1" =~ ${nightly_wrapper_tag_pattern} ]] ||
+    [[ "$1" =~ ${legacy_wrapper_tag_pattern} ]]
+}
+
+is_stable_channel_tag() {
+  [[ "$1" =~ ${stable_tag_pattern} || "$1" =~ ${stable_wrapper_tag_pattern} ]]
+}
+
+if [[ "${tag_input}" != "latest" && -n "${tag_input}" ]] &&
+  ! is_supported_native_tag "${tag_input}"; then
+  echo "Invalid llamadart-native tag: ${tag_input}" >&2
+  echo "Expected stable vMAJOR.MINOR.PATCH, stable wrapper" \
+    "vMAJOR.MINOR.PATCH-N, historical/nightly bNNNN, nightly wrapper" \
+    "bNNNN-N, or legacy wrapper artifact bNNNN-llamadart.N." >&2
+  exit 1
+fi
+
 curl_headers=(
   -H "Accept: application/vnd.github+json"
   -H "X-GitHub-Api-Version: 2022-11-28"
@@ -77,6 +104,22 @@ resolved_tag="$(
   python3 -c "import json,sys; print(json.load(sys.stdin)['tag_name'])" <<<"${release_json}"
 )"
 
+if ! is_supported_native_tag "${resolved_tag}"; then
+  echo "Release metadata resolved unsupported tag: ${resolved_tag}" >&2
+  exit 1
+fi
+if [[ "${tag_input}" == "latest" ]] && ! is_stable_channel_tag "${resolved_tag}"; then
+  echo "llamadart-native latest resolved nightly tag ${resolved_tag};" \
+    "select historical tags explicitly." >&2
+  exit 1
+fi
+if [[ "${tag_input}" != "latest" && -n "${tag_input}" ]] &&
+  [[ "${resolved_tag}" != "${tag_input}" ]]; then
+  echo "Requested ${tag_input}, but release metadata resolved" \
+    "${resolved_tag}; refusing version skew." >&2
+  exit 1
+fi
+
 asset_name="llamadart-native-headers-${resolved_tag}.tar.gz"
 asset_url="$(
   python3 -c "import json,sys; name=sys.argv[1]; data=json.load(sys.stdin); print(next((a.get('browser_download_url','') for a in data.get('assets',[]) if a.get('name')==name),''))" \
@@ -88,6 +131,11 @@ if [[ -z "${asset_url}" ]]; then
   exit 1
 fi
 
+asset_digest="$(
+  python3 -c "import json,sys; name=sys.argv[1]; data=json.load(sys.stdin); print(next((a.get('digest','') for a in data.get('assets',[]) if a.get('name')==name),''))" \
+    "${asset_name}" <<<"${release_json}"
+)"
+
 tmp_dir="${TMPDIR:-/tmp}/llamadart-native-headers-${resolved_tag}-$$"
 archive_path="${tmp_dir}/${asset_name}"
 extract_dir="${tmp_dir}/extract"
@@ -96,6 +144,28 @@ trap 'rm -rf "${tmp_dir}"' EXIT
 mkdir -p "${extract_dir}"
 echo "Downloading ${asset_name} from ${native_repo} (${resolved_tag})..."
 curl -fsSL "${curl_headers[@]}" "${asset_url}" -o "${archive_path}"
+if [[ "${asset_digest}" == sha256:* ]]; then
+  expected_sha256="${asset_digest#sha256:}"
+  if command -v shasum >/dev/null 2>&1; then
+    actual_sha256="$(shasum -a 256 "${archive_path}" | awk '{print $1}')"
+  elif command -v sha256sum >/dev/null 2>&1; then
+    actual_sha256="$(sha256sum "${archive_path}" | awk '{print $1}')"
+  else
+    echo "No SHA-256 tool available to verify ${asset_name}" >&2
+    exit 1
+  fi
+  if [[ "${actual_sha256}" != "${expected_sha256}" ]]; then
+    echo "Header archive checksum mismatch for ${asset_name}: expected" \
+      "${expected_sha256}, got ${actual_sha256}." >&2
+    exit 1
+  fi
+elif is_stable_channel_tag "${resolved_tag}"; then
+  echo "Stable release ${resolved_tag} does not publish a SHA-256 digest for ${asset_name}." >&2
+  exit 1
+else
+  echo "Warning: historical release ${resolved_tag} has no GitHub SHA-256" \
+    "digest for ${asset_name}." >&2
+fi
 tar -xzf "${archive_path}" -C "${extract_dir}"
 
 llama_include_src=""

--- a/tool/native/sync_native_release_pins.py
+++ b/tool/native/sync_native_release_pins.py
@@ -634,6 +634,20 @@ def find_release_asset(
     return None
 
 
+def require_github_sha256_digest(
+    asset: dict[str, Any], release_tag: str, asset_name: str
+) -> str:
+    digest = asset.get("digest")
+    if not isinstance(digest, str) or re.fullmatch(
+        r"sha256:[0-9a-f]{64}", digest
+    ) is None:
+        raise ReleaseError(
+            f"Stable release {release_tag} does not publish a GitHub "
+            f"SHA-256 digest for {asset_name}"
+        )
+    return digest.removeprefix("sha256:")
+
+
 def release_asset_json(
     release: dict[str, Any], asset_name: str
 ) -> dict[str, Any]:
@@ -730,6 +744,12 @@ def validate_native_release_manifest(
                 "provenance and hook-contract metadata."
             )
         return
+    if release_version.channel == "stable":
+        require_github_sha256_digest(
+            manifest_asset,
+            release_tag,
+            "assets.json",
+        )
 
     manifest = release_asset_json(release, "assets.json")
     native_release_tag = manifest.get("native_release_tag")
@@ -843,10 +863,14 @@ def validate_native_release_manifest(
                 f"{file_name}"
             )
         digest = release_asset.get("digest") or ""
-        if release_version.channel == "stable" and not digest.startswith("sha256:"):
-            raise ReleaseError(
-                f"Stable release {release_tag} does not publish a GitHub "
-                f"SHA-256 digest for {file_name}"
+        if release_version.channel == "stable":
+            digest = (
+                "sha256:"
+                + require_github_sha256_digest(
+                    release_asset,
+                    release_tag,
+                    file_name,
+                )
             )
         if (
             digest.startswith("sha256:")
@@ -872,10 +896,16 @@ def validate_native_release_manifest(
                 f"Stable release {release_tag} manifest is missing required "
                 f"bundle(s): {', '.join(missing)}"
             )
-        if find_release_asset(release, "SHA256SUMS") is None:
+        checksum_asset = find_release_asset(release, "SHA256SUMS")
+        if checksum_asset is None:
             raise ReleaseError(
                 f"Stable release {release_tag} is missing required SHA256SUMS"
             )
+        require_github_sha256_digest(
+            checksum_asset,
+            release_tag,
+            "SHA256SUMS",
+        )
         published_checksums = parse_sha256_sums(
             release_asset_text(release, "SHA256SUMS"),
             release_tag,

--- a/tool/native/sync_native_release_pins.py
+++ b/tool/native/sync_native_release_pins.py
@@ -562,8 +562,8 @@ def validate_resolved_native_release(
             raise ReleaseError(
                 f"llamadart-native latest resolved to {resolved_tag}. "
                 "Automatic discovery accepts only unsuffixed "
-                "vMAJOR.MINOR.PATCH releases; select GitHub-prerelease "
-                "wrapper rebuilds and nightly tags explicitly."
+                "vMAJOR.MINOR.PATCH releases; select wrapper rebuilds and "
+                "historical or nightly tags explicitly."
             )
     elif resolved_tag != requested_tag:
         raise ReleaseError(

--- a/tool/native/sync_native_release_pins.py
+++ b/tool/native/sync_native_release_pins.py
@@ -658,6 +658,7 @@ def release_asset_json(
         urllib.error.HTTPError,
         urllib.error.URLError,
         json.JSONDecodeError,
+        UnicodeDecodeError,
     ) as error:
         raise ReleaseError(
             f"Failed to read release manifest {asset_name}: {error}"

--- a/tool/native/sync_native_release_pins.py
+++ b/tool/native/sync_native_release_pins.py
@@ -43,17 +43,17 @@ _STABLE_WRAPPER_TAG_PATTERN = re.compile(
     r"^v(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)\."
     r"(0|[1-9][0-9]*)-([1-9][0-9]*)$"
 )
-_LEGACY_NATIVE_TAG_PATTERN = re.compile(r"^b([0-9]+)$")
+_LEGACY_NATIVE_TAG_PATTERN = re.compile(r"^b(0|[1-9][0-9]*)$")
 _NIGHTLY_WRAPPER_TAG_PATTERN = re.compile(
-    r"^b([0-9]+)-([1-9][0-9]*)$"
+    r"^b(0|[1-9][0-9]*)-([1-9][0-9]*)$"
 )
 _LEGACY_WRAPPER_TAG_PATTERN = re.compile(
-    r"^b([0-9]+)-llamadart\.([1-9][0-9]*)$"
+    r"^b(0|[1-9][0-9]*)-llamadart\.([1-9][0-9]*)$"
 )
 _NATIVE_DOC_TAG_PATTERN = (
     r"(?:v(?:0|[1-9][0-9]*)\.(?:0|[1-9][0-9]*)\."
     r"(?:0|[1-9][0-9]*)(?:-[1-9][0-9]*)?|"
-    r"b[0-9]+(?:-[1-9][0-9]*|-llamadart\.[1-9][0-9]*)?)"
+    r"b(?:0|[1-9][0-9]*)(?:-[1-9][0-9]*|-llamadart\.[1-9][0-9]*)?)"
 )
 _COMMIT_PATTERN = re.compile(r"^[0-9a-f]{40}$")
 _STABLE_NATIVE_BUNDLES = (
@@ -355,8 +355,8 @@ def parse_args() -> argparse.Namespace:
         "--llama-cpp-tag",
         default="keep",
         help=(
-            "llamadart-native stable, wrapper-rebuild, or historical/nightly "
-            "tag; latest; or keep."
+            "Explicit llamadart-native stable, wrapper-rebuild, or "
+            "historical/nightly tag; latest unsuffixed stable; or keep."
         ),
     )
     parser.add_argument(
@@ -365,7 +365,7 @@ def parse_args() -> argparse.Namespace:
         help=(
             "Allow an explicit stable-to-historical/nightly bNNNN channel "
             "switch. This does not permit version rollback or make latest "
-            "accept a nightly release."
+            "accept a wrapper rebuild or nightly release."
         ),
     )
     parser.add_argument(
@@ -530,7 +530,8 @@ def parse_native_release_tag(tag: str) -> NativeReleaseVersion:
     raise ReleaseError(
         f"Invalid llamadart-native release tag {tag!r}. Expected stable "
         "vMAJOR.MINOR.PATCH, stable wrapper rebuild "
-        "vMAJOR.MINOR.PATCH-N, historical/nightly bNNNN, nightly wrapper "
+        "vMAJOR.MINOR.PATCH-N, canonical historical/nightly bNNNN without "
+        "leading zeros, nightly wrapper "
         "rebuild bNNNN-N, or legacy wrapper artifact bNNNN-llamadart.N."
     )
 
@@ -554,15 +555,15 @@ def validate_resolved_native_release(
     resolved_tag = release.get("tag_name")
     if not isinstance(resolved_tag, str) or not resolved_tag:
         raise ReleaseError("Native release metadata has no non-empty tag_name")
-    resolved_version = parse_native_release_tag(resolved_tag)
+    parse_native_release_tag(resolved_tag)
 
     if requested_tag == "latest":
-        if resolved_version.channel != "stable":
+        if _STABLE_NATIVE_TAG_PATTERN.fullmatch(resolved_tag) is None:
             raise ReleaseError(
-                f"llamadart-native latest resolved to nightly tag "
-                f"{resolved_tag}. Automatic discovery accepts GitHub stable-channel "
-                "vMAJOR.MINOR.PATCH and vMAJOR.MINOR.PATCH-N releases only; "
-                "select a historical bNNNN tag explicitly when needed."
+                f"llamadart-native latest resolved to {resolved_tag}. "
+                "Automatic discovery accepts only unsuffixed "
+                "vMAJOR.MINOR.PATCH releases; select GitHub-prerelease "
+                "wrapper rebuilds and nightly tags explicitly."
             )
     elif resolved_tag != requested_tag:
         raise ReleaseError(

--- a/tool/native/sync_native_release_pins.py
+++ b/tool/native/sync_native_release_pins.py
@@ -12,7 +12,7 @@ import sys
 import urllib.error
 import urllib.request
 from pathlib import Path
-from typing import Any
+from typing import Any, NamedTuple
 
 
 DEFAULT_LLAMADART_NATIVE_REPO = "leehack/llamadart-native"
@@ -35,10 +35,51 @@ DEFAULT_LLAMA_CPP_PROJECT_DOCS = (
     "website/docs/platforms/support-matrix.md",
 )
 DEFAULT_CHANGELOG = "CHANGELOG.md"
+SUPPORTED_NATIVE_HOOK_CONTRACT_VERSION = 1
+_STABLE_NATIVE_TAG_PATTERN = re.compile(
+    r"^v(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)$"
+)
+_STABLE_WRAPPER_TAG_PATTERN = re.compile(
+    r"^v(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)\."
+    r"(0|[1-9][0-9]*)-([1-9][0-9]*)$"
+)
+_LEGACY_NATIVE_TAG_PATTERN = re.compile(r"^b([0-9]+)$")
+_NIGHTLY_WRAPPER_TAG_PATTERN = re.compile(
+    r"^b([0-9]+)-([1-9][0-9]*)$"
+)
+_LEGACY_WRAPPER_TAG_PATTERN = re.compile(
+    r"^b([0-9]+)-llamadart\.([1-9][0-9]*)$"
+)
+_NATIVE_DOC_TAG_PATTERN = (
+    r"(?:v(?:0|[1-9][0-9]*)\.(?:0|[1-9][0-9]*)\."
+    r"(?:0|[1-9][0-9]*)(?:-[1-9][0-9]*)?|"
+    r"b[0-9]+(?:-[1-9][0-9]*|-llamadart\.[1-9][0-9]*)?)"
+)
+_COMMIT_PATTERN = re.compile(r"^[0-9a-f]{40}$")
+_STABLE_NATIVE_BUNDLES = (
+    "android-arm64",
+    "android-x64",
+    "ios-arm64",
+    "ios-arm64-sim",
+    "ios-x86_64-sim",
+    "linux-arm64",
+    "linux-x64",
+    "macos-arm64",
+    "macos-x86_64",
+    "windows-arm64",
+    "windows-x64",
+)
 
 
 class ReleaseError(RuntimeError):
     pass
+
+
+class NativeReleaseVersion(NamedTuple):
+    channel: str
+    version: tuple[int, ...]
+    wrapper_revision: int
+    upstream_tag: str
 
 
 def main() -> int:
@@ -71,7 +112,13 @@ def main() -> int:
             llama_cpp_tag_input,
             args.release_json_dir,
         )
-        resolved_llama_cpp_tag = release["tag_name"]
+        resolved_llama_cpp_tag = validate_resolved_native_release(
+            release,
+            requested_tag=llama_cpp_tag_input,
+            current_tag=read_hook_native_tag(hook_text),
+            allow_legacy_tag=args.allow_legacy_tag,
+        )
+        validate_native_release_manifest(release, resolved_llama_cpp_tag)
         hook_text = replace_one(
             hook_text,
             r"const _llamaCppTag = '[^']+';",
@@ -307,7 +354,19 @@ def parse_args() -> argparse.Namespace:
     parser.add_argument(
         "--llama-cpp-tag",
         default="keep",
-        help="llamadart-native release tag, latest, or keep.",
+        help=(
+            "llamadart-native stable, wrapper-rebuild, or historical/nightly "
+            "tag; latest; or keep."
+        ),
+    )
+    parser.add_argument(
+        "--allow-legacy-tag",
+        action="store_true",
+        help=(
+            "Allow an explicit stable-to-historical/nightly bNNNN channel "
+            "switch. This does not permit version rollback or make latest "
+            "accept a nightly release."
+        ),
     )
     parser.add_argument(
         "--litert-lm-tag",
@@ -383,9 +442,8 @@ def github_auth_header() -> dict[str, str]:
 
 
 def release_asset_checksum(release: dict[str, Any], asset_name: str) -> str:
-    for asset in release.get("assets", []):
-        if asset.get("name") != asset_name:
-            continue
+    asset = find_release_asset(release, asset_name)
+    if asset is not None:
         digest = asset.get("digest") or ""
         if digest.startswith("sha256:"):
             return digest.removeprefix("sha256:")
@@ -419,11 +477,421 @@ def normalize_release_tag(tag: str) -> str:
     tag = tag.strip()
     if not tag:
         return "keep"
+    if tag not in {"keep", "latest"}:
+        parse_native_release_tag(tag)
     return tag
 
 
+def parse_native_release_tag(tag: str) -> NativeReleaseVersion:
+    stable_match = _STABLE_NATIVE_TAG_PATTERN.fullmatch(tag)
+    if stable_match:
+        version = tuple(int(value) for value in stable_match.groups())
+        return NativeReleaseVersion("stable", version, 0, tag)
+
+    stable_wrapper_match = _STABLE_WRAPPER_TAG_PATTERN.fullmatch(tag)
+    if stable_wrapper_match:
+        major, minor, patch, wrapper_revision = (
+            int(value) for value in stable_wrapper_match.groups()
+        )
+        return NativeReleaseVersion(
+            "stable",
+            (major, minor, patch),
+            wrapper_revision,
+            f"v{major}.{minor}.{patch}",
+        )
+
+    legacy_match = _LEGACY_NATIVE_TAG_PATTERN.fullmatch(tag)
+    if legacy_match:
+        build = int(legacy_match.group(1))
+        return NativeReleaseVersion("nightly", (build,), 0, tag)
+
+    nightly_wrapper_match = _NIGHTLY_WRAPPER_TAG_PATTERN.fullmatch(tag)
+    if nightly_wrapper_match:
+        build = int(nightly_wrapper_match.group(1))
+        wrapper_revision = int(nightly_wrapper_match.group(2))
+        return NativeReleaseVersion(
+            "nightly",
+            (build,),
+            wrapper_revision,
+            f"b{nightly_wrapper_match.group(1)}",
+        )
+
+    wrapper_match = _LEGACY_WRAPPER_TAG_PATTERN.fullmatch(tag)
+    if wrapper_match:
+        build = int(wrapper_match.group(1))
+        wrapper_revision = int(wrapper_match.group(2))
+        return NativeReleaseVersion(
+            "nightly",
+            (build,),
+            wrapper_revision,
+            f"b{wrapper_match.group(1)}",
+        )
+
+    raise ReleaseError(
+        f"Invalid llamadart-native release tag {tag!r}. Expected stable "
+        "vMAJOR.MINOR.PATCH, stable wrapper rebuild "
+        "vMAJOR.MINOR.PATCH-N, historical/nightly bNNNN, nightly wrapper "
+        "rebuild bNNNN-N, or legacy wrapper artifact bNNNN-llamadart.N."
+    )
+
+
+def read_hook_native_tag(hook_text: str) -> str:
+    match = re.search(r"const _llamaCppTag = '([^']+)';", hook_text)
+    if not match:
+        raise ReleaseError("Could not read hook llama.cpp tag")
+    tag = match.group(1)
+    parse_native_release_tag(tag)
+    return tag
+
+
+def validate_resolved_native_release(
+    release: dict[str, Any],
+    *,
+    requested_tag: str,
+    current_tag: str,
+    allow_legacy_tag: bool,
+) -> str:
+    resolved_tag = release.get("tag_name")
+    if not isinstance(resolved_tag, str) or not resolved_tag:
+        raise ReleaseError("Native release metadata has no non-empty tag_name")
+    resolved_version = parse_native_release_tag(resolved_tag)
+
+    if requested_tag == "latest":
+        if resolved_version.channel != "stable":
+            raise ReleaseError(
+                f"llamadart-native latest resolved to nightly tag "
+                f"{resolved_tag}. Automatic discovery accepts GitHub stable-channel "
+                "vMAJOR.MINOR.PATCH and vMAJOR.MINOR.PATCH-N releases only; "
+                "select a historical bNNNN tag explicitly when needed."
+            )
+    elif resolved_tag != requested_tag:
+        raise ReleaseError(
+            f"Requested llamadart-native tag {requested_tag}, but release "
+            f"metadata resolved {resolved_tag}. Refusing version-skewed pins."
+        )
+
+    validate_native_release_transition(
+        current_tag,
+        resolved_tag,
+        allow_legacy_tag=allow_legacy_tag,
+    )
+    return resolved_tag
+
+
+def validate_native_release_transition(
+    current_tag: str,
+    target_tag: str,
+    *,
+    allow_legacy_tag: bool,
+) -> None:
+    current = parse_native_release_tag(current_tag)
+    target = parse_native_release_tag(target_tag)
+    if current_tag == target_tag:
+        return
+
+    if current.channel == "nightly" and target.channel == "stable":
+        return
+
+    if current.channel == "stable" and target.channel == "nightly":
+        if allow_legacy_tag:
+            return
+        raise ReleaseError(
+            f"Refusing stable-to-historical/nightly native channel switch "
+            f"{current_tag} -> {target_tag}. Pass --allow-legacy-tag only for "
+            "an intentional compatibility override."
+        )
+
+    current_key = native_release_order_key(current)
+    target_key = native_release_order_key(target)
+    if target_key == current_key:
+        raise ReleaseError(
+            f"Refusing equivalent native release sequence aliases "
+            f"{current_tag} -> {target_tag}. Keep the current artifact or "
+            "move to a higher wrapper revision."
+        )
+    if target_key < current_key:
+        raise ReleaseError(
+            f"Refusing native release rollback {current_tag} -> {target_tag}. "
+            "Use a forward release and regenerate bindings for its exact "
+            "header manifest."
+        )
+
+
+def native_release_order_key(version: NativeReleaseVersion) -> tuple[int, ...]:
+    return (*version.version, version.wrapper_revision)
+
+
+def find_release_asset(
+    release: dict[str, Any], asset_name: str
+) -> dict[str, Any] | None:
+    assets = release.get("assets", [])
+    if not isinstance(assets, list):
+        raise ReleaseError("Native release metadata assets must be a list")
+    for asset in assets:
+        if isinstance(asset, dict) and asset.get("name") == asset_name:
+            return asset
+    return None
+
+
+def release_asset_json(
+    release: dict[str, Any], asset_name: str
+) -> dict[str, Any]:
+    asset = find_release_asset(release, asset_name)
+    if asset is None:
+        tag = release.get("tag_name", "<unknown>")
+        raise ReleaseError(
+            f"Release {tag} does not contain required asset {asset_name}"
+        )
+
+    fixture_json = asset.get("fixture_json")
+    if isinstance(fixture_json, dict):
+        return fixture_json
+
+    download_url = asset.get("browser_download_url")
+    if not isinstance(download_url, str) or not download_url:
+        raise ReleaseError(f"Asset {asset_name} has no download URL")
+    request = urllib.request.Request(download_url, headers=github_auth_header())
+    try:
+        with urllib.request.urlopen(request) as response:
+            payload = json.loads(response.read().decode("utf-8"))
+    except (
+        urllib.error.HTTPError,
+        urllib.error.URLError,
+        json.JSONDecodeError,
+    ) as error:
+        raise ReleaseError(
+            f"Failed to read release manifest {asset_name}: {error}"
+        ) from error
+    if not isinstance(payload, dict):
+        raise ReleaseError(f"Release manifest {asset_name} must be a JSON object")
+    return payload
+
+
+def release_asset_text(release: dict[str, Any], asset_name: str) -> str:
+    asset = find_release_asset(release, asset_name)
+    if asset is None:
+        tag = release.get("tag_name", "<unknown>")
+        raise ReleaseError(
+            f"Release {tag} does not contain required asset {asset_name}"
+        )
+
+    fixture_text = asset.get("fixture_text")
+    if isinstance(fixture_text, str):
+        return fixture_text
+
+    download_url = asset.get("browser_download_url")
+    if not isinstance(download_url, str) or not download_url:
+        raise ReleaseError(f"Asset {asset_name} has no download URL")
+    request = urllib.request.Request(download_url, headers=github_auth_header())
+    try:
+        with urllib.request.urlopen(request) as response:
+            return response.read().decode("utf-8")
+    except (urllib.error.HTTPError, urllib.error.URLError, UnicodeDecodeError) as error:
+        raise ReleaseError(
+            f"Failed to read release checksum file {asset_name}: {error}"
+        ) from error
+
+
+def parse_sha256_sums(checksum_text: str, release_tag: str) -> dict[str, str]:
+    checksums: dict[str, str] = {}
+    for line_number, line in enumerate(checksum_text.splitlines(), start=1):
+        if not line.strip():
+            continue
+        match = re.fullmatch(r"([0-9a-f]{64})  (\S+)", line)
+        if match is None:
+            raise ReleaseError(
+                f"Release {release_tag} SHA256SUMS has invalid line "
+                f"{line_number}: {line!r}"
+            )
+        checksum, file_name = match.groups()
+        if file_name in checksums:
+            raise ReleaseError(
+                f"Release {release_tag} SHA256SUMS duplicates {file_name}"
+            )
+        checksums[file_name] = checksum
+    return checksums
+
+
+def validate_native_release_manifest(
+    release: dict[str, Any], release_tag: str
+) -> None:
+    release_version = parse_native_release_tag(release_tag)
+    is_new_wrapper_form = bool(
+        _STABLE_WRAPPER_TAG_PATTERN.fullmatch(release_tag)
+        or _NIGHTLY_WRAPPER_TAG_PATTERN.fullmatch(release_tag)
+    )
+    manifest_asset = find_release_asset(release, "assets.json")
+    if manifest_asset is None:
+        if release_version.channel == "stable" or is_new_wrapper_form:
+            raise ReleaseError(
+                f"Release {release_tag} is missing required assets.json "
+                "provenance and hook-contract metadata."
+            )
+        return
+
+    manifest = release_asset_json(release, "assets.json")
+    native_release_tag = manifest.get("native_release_tag")
+    legacy_release_tag = manifest.get("tag")
+    for field_name, value in (
+        ("native_release_tag", native_release_tag),
+        ("tag", legacy_release_tag),
+    ):
+        if value is not None and (not isinstance(value, str) or not value):
+            raise ReleaseError(
+                f"Release {release_tag} manifest has invalid {field_name}: "
+                f"{value!r}"
+            )
+    if is_new_wrapper_form:
+        missing_tag_fields = [
+            field_name
+            for field_name, value in (
+                ("native_release_tag", native_release_tag),
+                ("tag", legacy_release_tag),
+            )
+            if value is None
+        ]
+        if missing_tag_fields:
+            raise ReleaseError(
+                f"Release {release_tag} manifest is missing required "
+                f"tag field(s): {', '.join(missing_tag_fields)}"
+            )
+    if native_release_tag is not None and legacy_release_tag is not None:
+        if native_release_tag != legacy_release_tag:
+            raise ReleaseError(
+                f"Release {release_tag} manifest native_release_tag "
+                f"{native_release_tag!r} disagrees with legacy tag alias "
+                f"{legacy_release_tag!r}."
+            )
+    manifest_release_tag = (
+        native_release_tag
+        if native_release_tag is not None
+        else legacy_release_tag
+    )
+    if manifest_release_tag != release_tag:
+        raise ReleaseError(
+            f"Release manifest tag {manifest_release_tag!r} does not match "
+            f"release {release_tag}. Refusing version-skewed native assets."
+        )
+
+    hook_contract_version = manifest.get("hook_contract_version")
+    if hook_contract_version != SUPPORTED_NATIVE_HOOK_CONTRACT_VERSION:
+        raise ReleaseError(
+            f"Release {release_tag} requires native hook contract "
+            f"{hook_contract_version!r}; this checkout supports "
+            f"{SUPPORTED_NATIVE_HOOK_CONTRACT_VERSION}."
+        )
+
+    for field in ("llama_cpp_commit", "native_commit"):
+        value = manifest.get(field)
+        if not isinstance(value, str) or not _COMMIT_PATTERN.fullmatch(value):
+            raise ReleaseError(
+                f"Release {release_tag} manifest has invalid {field}: {value!r}"
+            )
+
+    llama_cpp_tag = manifest.get("llama_cpp_tag")
+    llama_cpp_ref = manifest.get("llama_cpp_ref")
+    if llama_cpp_tag is not None and llama_cpp_ref is not None:
+        if llama_cpp_tag != llama_cpp_ref:
+            raise ReleaseError(
+                f"Release {release_tag} manifest llama_cpp_tag "
+                f"{llama_cpp_tag!r} disagrees with llama_cpp_ref "
+                f"{llama_cpp_ref!r}."
+            )
+    upstream_ref = llama_cpp_tag if llama_cpp_tag is not None else llama_cpp_ref
+    if upstream_ref != release_version.upstream_tag:
+        raise ReleaseError(
+            f"Release {release_tag} manifest resolves llama.cpp tag "
+            f"{upstream_ref!r}, expected {release_version.upstream_tag!r}. "
+            "Refusing version-skewed native ABI metadata."
+        )
+
+    artifacts = manifest.get("artifacts")
+    if not isinstance(artifacts, list):
+        raise ReleaseError(
+            f"Release {release_tag} manifest artifacts must be a list"
+        )
+
+    manifest_checksums: dict[str, str] = {}
+    for artifact in artifacts:
+        if not isinstance(artifact, dict):
+            raise ReleaseError(
+                f"Release {release_tag} manifest contains a non-object artifact"
+            )
+        file_name = artifact.get("file")
+        checksum = artifact.get("sha256")
+        if not isinstance(file_name, str) or not file_name:
+            raise ReleaseError(
+                f"Release {release_tag} manifest artifact has no file name"
+            )
+        if not isinstance(checksum, str) or not re.fullmatch(r"[0-9a-f]{64}", checksum):
+            raise ReleaseError(
+                f"Release {release_tag} manifest has invalid checksum for "
+                f"{file_name}"
+            )
+        if file_name in manifest_checksums:
+            raise ReleaseError(
+                f"Release {release_tag} manifest duplicates artifact {file_name}"
+            )
+        manifest_checksums[file_name] = checksum
+
+        release_asset = find_release_asset(release, file_name)
+        if release_asset is None:
+            raise ReleaseError(
+                f"Release {release_tag} manifest lists unavailable bundle "
+                f"{file_name}"
+            )
+        digest = release_asset.get("digest") or ""
+        if release_version.channel == "stable" and not digest.startswith("sha256:"):
+            raise ReleaseError(
+                f"Stable release {release_tag} does not publish a GitHub "
+                f"SHA-256 digest for {file_name}"
+            )
+        if (
+            digest.startswith("sha256:")
+            and digest.removeprefix("sha256:") != checksum
+        ):
+            raise ReleaseError(
+                f"Release {release_tag} checksum mismatch for {file_name}: "
+                "manifest and GitHub release metadata disagree."
+            )
+
+    if release_version.channel == "stable":
+        required_assets = {
+            *(
+                f"llamadart-native-{bundle}-{release_tag}.tar.gz"
+                for bundle in _STABLE_NATIVE_BUNDLES
+            ),
+            f"llamadart-native-apple-xcframework-{release_tag}.zip",
+            f"llamadart-native-headers-{release_tag}.tar.gz",
+        }
+        missing = sorted(required_assets.difference(manifest_checksums))
+        if missing:
+            raise ReleaseError(
+                f"Stable release {release_tag} manifest is missing required "
+                f"bundle(s): {', '.join(missing)}"
+            )
+        if find_release_asset(release, "SHA256SUMS") is None:
+            raise ReleaseError(
+                f"Stable release {release_tag} is missing required SHA256SUMS"
+            )
+        published_checksums = parse_sha256_sums(
+            release_asset_text(release, "SHA256SUMS"),
+            release_tag,
+        )
+        for file_name, checksum in manifest_checksums.items():
+            published_checksum = published_checksums.get(file_name)
+            if published_checksum != checksum:
+                raise ReleaseError(
+                    f"Stable release {release_tag} SHA256SUMS checksum for "
+                    f"{file_name} is {published_checksum!r}, expected "
+                    f"{checksum!r} from assets.json"
+                )
+
+
 def normalize_litert_lm_release_tag(tag: str) -> str:
-    tag = normalize_release_tag(tag)
+    tag = tag.strip()
+    if not tag:
+        return "keep"
     if tag in {"keep", "latest"} or tag.startswith("v"):
         return tag
     return f"v{tag}"
@@ -642,28 +1110,30 @@ def replace_llama_cpp_native_doc_references(
     repo: str,
     tag: str,
 ) -> str:
-    native_tag_pattern = r"b[0-9]+(?:-[A-Za-z0-9._-]+)?"
     replacements = (
-        (rf"(llamadart_native_tag:\s*){native_tag_pattern}", rf"\g<1>{tag}"),
         (
-            rf"({re.escape(repo)}@){native_tag_pattern}",
+            rf"(llamadart_native_tag:\s*){_NATIVE_DOC_TAG_PATTERN}",
+            rf"\g<1>{tag}",
+        ),
+        (
+            rf"({re.escape(repo)}@){_NATIVE_DOC_TAG_PATTERN}",
             rf"\g<1>{tag}",
         ),
         (
             rf"(llamadart-native-[a-z0-9_-]+-)"
-            rf"{native_tag_pattern}(?=\.tar\.gz`)",
+            rf"{_NATIVE_DOC_TAG_PATTERN}(?=\.tar\.gz`)",
             rf"\g<1>{tag}",
         ),
         (
-            rf"(default native tag `){native_tag_pattern}(`)",
+            rf"(default native tag `){_NATIVE_DOC_TAG_PATTERN}(`)",
             rf"\g<1>{tag}\2",
         ),
         (
-            rf"(llamadart-native` tag\s+`){native_tag_pattern}(`)",
+            rf"(llamadart-native` tag\s+`){_NATIVE_DOC_TAG_PATTERN}(`)",
             rf"\g<1>{tag}\2",
         ),
         (
-            rf"(module availability by bundle \(`){native_tag_pattern}(`\))",
+            rf"(module availability by bundle \(`){_NATIVE_DOC_TAG_PATTERN}(`\))",
             rf"\g<1>{tag}\2",
         ),
     )
@@ -712,15 +1182,15 @@ def update_core_changelog_native_pin(
     repo: str,
     tag: str,
 ) -> str:
-    if re.fullmatch(r"b[0-9]+-llamadart\.[0-9]+", tag):
-        base_tag = tag.split("-", maxsplit=1)[0]
+    native_version = parse_native_release_tag(tag)
+    if native_version.wrapper_revision > 0:
+        base_tag = native_version.upstream_tag
         entry = (
             "* Updated the default llama.cpp native runtime pin to\n"
             f"  `{repo}@{tag}`, keeping the `{base_tag}` llama.cpp\n"
-            "  ABI/bindings while picking up wrapper fixes for native release\n"
-            "  provenance and backend-selected speculative sampler acceptance. Refreshed\n"
-            "  the `llamadart_llama_cpp_flutter` Apple SwiftPM checksum and aligned current\n"
-            "  README/website native override docs."
+            "  ABI/bindings while picking up wrapper-only native fixes. Refreshed\n"
+            "  the `llamadart_llama_cpp_flutter` Apple SwiftPM checksum and\n"
+            "  aligned current README/website native override docs."
         )
     else:
         entry = (

--- a/tool/native/sync_native_release_pins.py
+++ b/tool/native/sync_native_release_pins.py
@@ -453,7 +453,7 @@ def release_asset_checksum(release: dict[str, Any], asset_name: str) -> str:
         return sha256_url(download_url)
     tag = release.get("tag_name", "<unknown>")
     names = ", ".join(
-        sorted(str(asset.get("name", "")) for asset in release.get("assets", []))
+        sorted(str(asset.get("name", "")) for asset in release_assets(release))
     )
     raise ReleaseError(
         f"Release {tag} does not contain required asset {asset_name}. "
@@ -625,13 +625,23 @@ def native_release_order_key(version: NativeReleaseVersion) -> tuple[int, ...]:
 def find_release_asset(
     release: dict[str, Any], asset_name: str
 ) -> dict[str, Any] | None:
+    for asset in release_assets(release):
+        if asset.get("name") == asset_name:
+            return asset
+    return None
+
+
+def release_assets(release: dict[str, Any]) -> list[dict[str, Any]]:
     assets = release.get("assets", [])
     if not isinstance(assets, list):
         raise ReleaseError("Native release metadata assets must be a list")
-    for asset in assets:
-        if isinstance(asset, dict) and asset.get("name") == asset_name:
-            return asset
-    return None
+    for index, asset in enumerate(assets):
+        if not isinstance(asset, dict):
+            raise ReleaseError(
+                "Native release metadata asset list contains a non-object "
+                f"entry at index {index}"
+            )
+    return assets
 
 
 def require_github_sha256_digest(

--- a/tool/testing/verify_release_docs_versions.dart
+++ b/tool/testing/verify_release_docs_versions.dart
@@ -40,15 +40,40 @@ const Map<String, List<String>> _currentDocDependencies =
       ],
     };
 
+final Map<String, RegExp> _currentNativePins = <String, RegExp>{
+  'hook/build.dart': RegExp(r"const _llamaCppTag = '([^']+)';"),
+  'packages/llamadart_llama_cpp_flutter/darwin/'
+      'llamadart_llama_cpp_flutter/Package.swift': RegExp(
+    r'let llamaCppTag = "([^"]+)"',
+  ),
+  'packages/llamadart_llama_cpp_flutter/README.md': RegExp(
+    r'The Apple SwiftPM manifest pins\s+`leehack/llamadart-native@([^`]+)`\.',
+  ),
+  'README.md': RegExp(
+    r'\| Native llama\.cpp / GGUF \| `leehack/llamadart-native@([^`]+)` \|',
+  ),
+  'website/docs/getting-started/installation.md': RegExp(
+    r'llamadart_native_tag:\s*([^\s#]+)',
+  ),
+  'website/docs/platforms/support-matrix.md': RegExp(
+    r'The native-assets hook currently pins `llamadart-native` tag\s+`([^`]+)`',
+  ),
+};
+
 final RegExp _dependencyLine = RegExp(
   r'^\s+(llamadart(?:_[a-z0-9_]+)?):\s+\^([0-9]+\.[0-9]+\.[0-9]+(?:[-+][^\s#]+)?)',
 );
 final RegExp _fenceLine = RegExp(r'^\s*```\s*([^\s`]*)?\s*$');
 final RegExp _versionLine = RegExp(r'^version:\s*(\S+)\s*$');
+final RegExp _nativeReleaseTag = RegExp(
+  r'^(?:v(?:0|[1-9][0-9]*)\.(?:0|[1-9][0-9]*)\.(?:0|[1-9][0-9]*)(?:-[1-9][0-9]*)?|'
+  r'b[0-9]+(?:-[1-9][0-9]*|-llamadart\.[1-9][0-9]*)?)$',
+);
 
 void main() {
   final errors = <String>[];
   final versions = <String, String>{};
+  String? nativePin;
   for (final entry in _packagePubspecs.entries) {
     final version = _readPubspecVersion(entry.value, errors);
     if (version != null) {
@@ -65,6 +90,7 @@ void main() {
         errors: errors,
       );
     }
+    nativePin = _checkCurrentNativePins(errors);
   }
 
   if (errors.isNotEmpty) {
@@ -78,8 +104,59 @@ void main() {
 
   stdout.writeln(
     'Release docs versions verified: '
-    '${versions.entries.map((entry) => '${entry.key} ${entry.value}').join(', ')}.',
+    '${versions.entries.map((entry) => '${entry.key} ${entry.value}').join(', ')}; '
+    'llamadart-native $nativePin.',
   );
+}
+
+String? _checkCurrentNativePins(List<String> errors) {
+  final pins = <String, String>{};
+  for (final entry in _currentNativePins.entries) {
+    final file = File(entry.key);
+    if (!file.existsSync()) {
+      errors.add('${entry.key} does not exist.');
+      continue;
+    }
+
+    String text;
+    try {
+      text = file.readAsStringSync();
+    } on FileSystemException catch (error) {
+      errors.add('Could not read ${entry.key}: ${error.message}.');
+      continue;
+    }
+
+    final match = entry.value.firstMatch(text);
+    if (match == null) {
+      errors.add('${entry.key} does not contain its current native pin.');
+      continue;
+    }
+    final pin = match.group(1)!;
+    if (!_nativeReleaseTag.hasMatch(pin)) {
+      errors.add(
+        '${entry.key} uses unsupported native tag $pin; expected stable '
+        'vMAJOR.MINOR.PATCH, stable wrapper rebuild '
+        'vMAJOR.MINOR.PATCH-N, historical/nightly bNNNN, nightly wrapper '
+        'rebuild bNNNN-N, or legacy wrapper artifact bNNNN-llamadart.N.',
+      );
+      continue;
+    }
+    pins[entry.key] = pin;
+  }
+
+  if (pins.isEmpty) {
+    return null;
+  }
+  final expectedPin = pins['hook/build.dart'] ?? pins.values.first;
+  for (final entry in pins.entries) {
+    if (entry.value != expectedPin) {
+      errors.add(
+        '${entry.key} pins native tag ${entry.value}, but hook/build.dart '
+        'pins $expectedPin.',
+      );
+    }
+  }
+  return expectedPin;
 }
 
 String? _readPubspecVersion(String path, List<String> errors) {

--- a/tool/testing/verify_release_docs_versions.dart
+++ b/tool/testing/verify_release_docs_versions.dart
@@ -67,7 +67,7 @@ final RegExp _fenceLine = RegExp(r'^\s*```\s*([^\s`]*)?\s*$');
 final RegExp _versionLine = RegExp(r'^version:\s*(\S+)\s*$');
 final RegExp _nativeReleaseTag = RegExp(
   r'^(?:v(?:0|[1-9][0-9]*)\.(?:0|[1-9][0-9]*)\.(?:0|[1-9][0-9]*)(?:-[1-9][0-9]*)?|'
-  r'b[0-9]+(?:-[1-9][0-9]*|-llamadart\.[1-9][0-9]*)?)$',
+  r'b(?:0|[1-9][0-9]*)(?:-[1-9][0-9]*|-llamadart\.[1-9][0-9]*)?)$',
 );
 
 void main() {
@@ -136,7 +136,8 @@ String? _checkCurrentNativePins(List<String> errors) {
       errors.add(
         '${entry.key} uses unsupported native tag $pin; expected stable '
         'vMAJOR.MINOR.PATCH, stable wrapper rebuild '
-        'vMAJOR.MINOR.PATCH-N, historical/nightly bNNNN, nightly wrapper '
+        'vMAJOR.MINOR.PATCH-N, canonical historical/nightly bNNNN without '
+        'leading zeros, nightly wrapper '
         'rebuild bNNNN-N, or legacy wrapper artifact bNNNN-llamadart.N.',
       );
       continue;

--- a/website/docs/changelog/recent-releases.md
+++ b/website/docs/changelog/recent-releases.md
@@ -19,9 +19,10 @@ For canonical full release notes, use:
 - Native release synchronization and build-hook overrides now accept stable
   `vMAJOR.MINOR.PATCH` artifacts and ordered `vMAJOR.MINOR.PATCH-N` wrapper
   rebuilds plus nightly `bNNNN-N` rebuilds, while preserving historical
-  `bNNNN` and `bNNNN-llamadart.N` artifacts. Invalid tags, rollback, unstable
-  `latest` results, missing bundles, and manifest/checksum/version skew fail
-  closed; the default native pin is unchanged.
+  `bNNNN` and `bNNNN-llamadart.N` artifacts. Leading-zero nightly tags,
+  rollback, wrapper/nightly `latest` results, missing bundles, and
+  manifest/checksum/version skew fail closed; the default native pin is
+  unchanged.
 
 - Fixed Web/native backend API parity. `WebAutoBackend` now forwards grammar
   constraint support from its active runtime, so strict structured output fails

--- a/website/docs/changelog/recent-releases.md
+++ b/website/docs/changelog/recent-releases.md
@@ -16,6 +16,13 @@ For canonical full release notes, use:
   video is compiled out. Full support still requires companion FFmpeg/ffprobe
   packaging and Dart frame-lifecycle wiring.
 
+- Native release synchronization and build-hook overrides now accept stable
+  `vMAJOR.MINOR.PATCH` artifacts and ordered `vMAJOR.MINOR.PATCH-N` wrapper
+  rebuilds plus nightly `bNNNN-N` rebuilds, while preserving historical
+  `bNNNN` and `bNNNN-llamadart.N` artifacts. Invalid tags, rollback, unstable
+  `latest` results, missing bundles, and manifest/checksum/version skew fail
+  closed; the default native pin is unchanged.
+
 - Fixed Web/native backend API parity. `WebAutoBackend` now forwards grammar
   constraint support from its active runtime, so strict structured output fails
   early with an actionable error on unsupported Web backends, and the Web-safe

--- a/website/docs/getting-started/installation.md
+++ b/website/docs/getting-started/installation.md
@@ -119,11 +119,13 @@ advances the native sequence while the manifest's upstream ref remains
 `v0.2.0`. New wrapper and nightly releases are GitHub prereleases and must be
 named explicitly. Immutable historical `bNNNN` and `bNNNN-llamadart.N`
 artifacts may retain older `prerelease=false` metadata, but remain explicit
-compatibility inputs; `latest` accepts only an unsuffixed stable tag regardless
-of GitHub metadata. Nightly cores use canonical decimal spelling (`b0` or a
-nonzero first digit), and rebuild counters start at 1 without leading zeros.
-Other suffixes are rejected so a typo cannot select an unreviewed or
-version-skewed archive.
+compatibility inputs. Build-hook overrides must always name an explicit tag;
+`latest` is limited to maintainer synchronization and header/binding
+regeneration, where it accepts only an unsuffixed stable tag regardless of
+GitHub metadata. Nightly cores use canonical decimal spelling (`b0` or a nonzero
+first digit), and rebuild counters start at 1 without leading zeros. Other
+suffixes are rejected so a typo cannot select an unreviewed or version-skewed
+archive.
 You can also list them with the GitHub CLI:
 
 ```bash

--- a/website/docs/getting-started/installation.md
+++ b/website/docs/getting-started/installation.md
@@ -115,8 +115,11 @@ releases remain valid explicit overrides. New nightly wrapper rebuilds use
 `bNNNN-N`; existing `bNNNN-llamadart.N` artifacts remain valid
 consumption-only overrides. A stable wrapper-only rebuild of upstream `vM.m.p`
 uses `vM.m.p-N`, such as native `v0.2.0-1` for upstream `v0.2.0`. The suffix
-advances the GitHub stable native release sequence while the manifest's upstream
-ref remains `v0.2.0`. Other suffixes are rejected so a typo cannot select an
+advances the native sequence while the manifest's upstream ref remains
+`v0.2.0`. Wrapper rebuilds are GitHub prereleases and must be named explicitly;
+`latest` accepts only an unsuffixed stable tag. Nightly cores use canonical
+decimal spelling (`b0` or a nonzero first digit), and rebuild counters start at
+1 without leading zeros. Other suffixes are rejected so a typo cannot select an
 unreviewed or version-skewed archive.
 You can also list them with the GitHub CLI:
 

--- a/website/docs/getting-started/installation.md
+++ b/website/docs/getting-started/installation.md
@@ -116,11 +116,14 @@ releases remain valid explicit overrides. New nightly wrapper rebuilds use
 consumption-only overrides. A stable wrapper-only rebuild of upstream `vM.m.p`
 uses `vM.m.p-N`, such as native `v0.2.0-1` for upstream `v0.2.0`. The suffix
 advances the native sequence while the manifest's upstream ref remains
-`v0.2.0`. Wrapper rebuilds are GitHub prereleases and must be named explicitly;
-`latest` accepts only an unsuffixed stable tag. Nightly cores use canonical
-decimal spelling (`b0` or a nonzero first digit), and rebuild counters start at
-1 without leading zeros. Other suffixes are rejected so a typo cannot select an
-unreviewed or version-skewed archive.
+`v0.2.0`. New wrapper and nightly releases are GitHub prereleases and must be
+named explicitly. Immutable historical `bNNNN` and `bNNNN-llamadart.N`
+artifacts may retain older `prerelease=false` metadata, but remain explicit
+compatibility inputs; `latest` accepts only an unsuffixed stable tag regardless
+of GitHub metadata. Nightly cores use canonical decimal spelling (`b0` or a
+nonzero first digit), and rebuild counters start at 1 without leading zeros.
+Other suffixes are rejected so a typo cannot select an unreviewed or
+version-skewed archive.
 You can also list them with the GitHub CLI:
 
 ```bash

--- a/website/docs/getting-started/installation.md
+++ b/website/docs/getting-started/installation.md
@@ -110,6 +110,14 @@ and symbol-compatible with the default
 
 Available native tags are published on the
 [`leehack/llamadart-native` releases page](https://github.com/leehack/llamadart-native/releases).
+Stable distributions use `vMAJOR.MINOR.PATCH`. Historical/nightly `bNNNN`
+releases remain valid explicit overrides. New nightly wrapper rebuilds use
+`bNNNN-N`; existing `bNNNN-llamadart.N` artifacts remain valid
+consumption-only overrides. A stable wrapper-only rebuild of upstream `vM.m.p`
+uses `vM.m.p-N`, such as native `v0.2.0-1` for upstream `v0.2.0`. The suffix
+advances the GitHub stable native release sequence while the manifest's upstream
+ref remains `v0.2.0`. Other suffixes are rejected so a typo cannot select an
+unreviewed or version-skewed archive.
 You can also list them with the GitHub CLI:
 
 ```bash

--- a/website/docs/maintainers/native-and-web-sync.md
+++ b/website/docs/maintainers/native-and-web-sync.md
@@ -37,8 +37,10 @@ prepares companion package releases. The `native_tag` input controls the
 `vMAJOR.MINOR.PATCH`; historical/nightly artifacts remain consumable through an
 explicit `bNNNN` tag. New nightly wrapper releases use `bNNNN-N`; existing
 `bNNNN-llamadart.N` artifacts remain explicit consumption-only inputs. `latest`
-may resolve to an upstream-aligned tag or wrapper rebuild when GitHub exposes it
-through the stable release channel; all nightly forms remain explicit inputs.
+accepts only an unsuffixed `vMAJOR.MINOR.PATCH`; every wrapper rebuild is a
+GitHub prerelease and must be named explicitly. Nightly cores use canonical
+decimal spelling (`b0` or a nonzero first digit), and rebuild counters start at
+1 without leading zeros.
 The `litert_lm_tag` input defaults to `keep`; set it to a
 `litert-lm-native` tag or `latest` only when the LiteRT-LM native release should
 move in the same PR.
@@ -48,7 +50,8 @@ For a wrapper-only rebuild of upstream stable `vM.m.p`, the native release uses
 `v0.2.0-2`. The native release policy orders that sequence after `v0.2.0` and
 before upstream `v0.2.1`, despite generic SemVer prerelease ordering. The suffix
 belongs only to `native_release_tag`; `llama_cpp_tag`/`llama_cpp_ref` in
-`assets.json` must remain the exact unsuffixed upstream prefix.
+`assets.json` must remain the exact unsuffixed upstream prefix. GitHub classifies
+the rebuild as a prerelease, so automatic `latest` discovery must not select it.
 
 Local fallback:
 
@@ -93,7 +96,7 @@ Use this checklist in native sync PRs:
 - Confirm `llamadart-native` or `litert-lm-native` has published the target
   release and the required per-platform native-assets archives.
 - For a stable-channel llama.cpp native sync, confirm the release tag is an
-  upstream-aligned `vMAJOR.MINOR.PATCH` or an explicit wrapper rebuild,
+  upstream-aligned `vMAJOR.MINOR.PATCH` or an explicitly selected wrapper rebuild,
   `assets.json` records the correct distinct native/upstream tags and hook
   contract version 1, and its artifact checksums match the release assets.
 - Confirm the same release provides Apple SPM-compatible XCFramework zip

--- a/website/docs/maintainers/native-and-web-sync.md
+++ b/website/docs/maintainers/native-and-web-sync.md
@@ -33,18 +33,52 @@ README/website native pin docs, and opens a PR. It does not bump companion
 package versions by default. Use the sync script's explicit
 `--bump-companion-versions` option only when the same change intentionally
 prepares companion package releases. The `native_tag` input controls the
-`llamadart-native` release. The `litert_lm_tag` input defaults to `keep`; set it
-to a `litert-lm-native` tag or `latest` only when the LiteRT-LM native release
-should move in the same PR.
+`llamadart-native` release. Stable distribution tags use strict
+`vMAJOR.MINOR.PATCH`; historical/nightly artifacts remain consumable through an
+explicit `bNNNN` tag. New nightly wrapper releases use `bNNNN-N`; existing
+`bNNNN-llamadart.N` artifacts remain explicit consumption-only inputs. `latest`
+may resolve to an upstream-aligned tag or wrapper rebuild when GitHub exposes it
+through the stable release channel; all nightly forms remain explicit inputs.
+The `litert_lm_tag` input defaults to `keep`; set it to a
+`litert-lm-native` tag or `latest` only when the LiteRT-LM native release should
+move in the same PR.
+
+For a wrapper-only rebuild of upstream stable `vM.m.p`, the native release uses
+`vM.m.p-N`: for example upstream `v0.2.0` maps to native `v0.2.0-1`, then
+`v0.2.0-2`. The native release policy orders that sequence after `v0.2.0` and
+before upstream `v0.2.1`, despite generic SemVer prerelease ordering. The suffix
+belongs only to `native_release_tag`; `llama_cpp_tag`/`llama_cpp_ref` in
+`assets.json` must remain the exact unsuffixed upstream prefix.
 
 Local fallback:
 
 ```bash
+python3 tool/native/sync_native_release_pins.py \
+  --llama-cpp-tag latest \
+  --litert-lm-tag keep \
+  --dry-run
 tool/native/sync_native_headers_and_bindings.sh --tag latest
 python3 tool/native/sync_native_release_pins.py \
   --llama-cpp-tag latest \
   --litert-lm-tag keep
 ```
+
+The pin sync rejects same-channel rollback and release/manifest version skew.
+After the default pin moves to the stable channel, an intentional compatibility
+test against a `bNNNN`, `bNNNN-N`, or legacy `bNNNN-llamadart.N` artifact must
+name that tag and pass `--allow-legacy-tag`; the compatibility-named flag does
+not allow rollback within either channel. The manual sync workflow exposes the
+same gate as its `allow_nightly_channel` checkbox and leaves it disabled by
+default.
+Stable releases must provide `assets.json`, `SHA256SUMS`, every supported bundle,
+and hook contract version 1. New stable or nightly wrapper forms require
+`assets.json`, `native_release_tag`, and the retained `tag` compatibility alias;
+older base or legacy-wrapper manifests with only `tag` remain valid.
+Manifest checksums must agree with both `SHA256SUMS` and GitHub release asset
+digests before any pin files are written.
+Re-syncing the exact current tag remains idempotent for recovery and validation;
+the owning native release workflow is responsible for rejecting publication
+collisions.
 
 After sync, run analyze/tests/docs checks before merge. For Apple SPM pin
 changes, verify the companion package changes under `packages/`, then run at
@@ -58,6 +92,10 @@ Use this checklist in native sync PRs:
 
 - Confirm `llamadart-native` or `litert-lm-native` has published the target
   release and the required per-platform native-assets archives.
+- For a stable-channel llama.cpp native sync, confirm the release tag is an
+  upstream-aligned `vMAJOR.MINOR.PATCH` or an explicit wrapper rebuild,
+  `assets.json` records the correct distinct native/upstream tags and hook
+  contract version 1, and its artifact checksums match the release assets.
 - Confirm the same release provides Apple SPM-compatible XCFramework zip
   artifacts when companion package pins should move.
 - Update `hook/build.dart` native pins with

--- a/website/docs/maintainers/native-and-web-sync.md
+++ b/website/docs/maintainers/native-and-web-sync.md
@@ -37,10 +37,12 @@ prepares companion package releases. The `native_tag` input controls the
 `vMAJOR.MINOR.PATCH`; historical/nightly artifacts remain consumable through an
 explicit `bNNNN` tag. New nightly wrapper releases use `bNNNN-N`; existing
 `bNNNN-llamadart.N` artifacts remain explicit consumption-only inputs. `latest`
-accepts only an unsuffixed `vMAJOR.MINOR.PATCH`; every wrapper rebuild is a
-GitHub prerelease and must be named explicitly. Nightly cores use canonical
-decimal spelling (`b0` or a nonzero first digit), and rebuild counters start at
-1 without leading zeros.
+accepts only an unsuffixed `vMAJOR.MINOR.PATCH` regardless of GitHub metadata.
+New wrapper and nightly releases are GitHub prereleases and must be named
+explicitly. Immutable historical `bNNNN` and `bNNNN-llamadart.N` artifacts may
+retain older `prerelease=false` metadata, but remain explicit compatibility
+inputs. Nightly cores use canonical decimal spelling (`b0` or a nonzero first
+digit), and rebuild counters start at 1 without leading zeros.
 The `litert_lm_tag` input defaults to `keep`; set it to a
 `litert-lm-native` tag or `latest` only when the LiteRT-LM native release should
 move in the same PR.

--- a/website/docs/maintainers/release-workflow.md
+++ b/website/docs/maintainers/release-workflow.md
@@ -40,7 +40,10 @@ version alignment:
   checksum agreement before accepting a stable pin change. `SHA256SUMS`, the
   manifest, and GitHub asset digests must agree. Stable wrapper-only rebuilds
   use `vM.m.p-N` for upstream `vM.m.p`; the suffix advances the native sequence
-  but must never appear in the manifest's upstream llama.cpp ref.
+  but must never appear in the manifest's upstream llama.cpp ref. GitHub marks
+  every wrapper rebuild as a prerelease, so select it explicitly; `latest`
+  accepts only unsuffixed `vMAJOR.MINOR.PATCH`. Nightly cores and positive
+  rebuild counters must use canonical decimal spelling without leading zeros.
 
 ## 2. Version and docs updates
 

--- a/website/docs/maintainers/release-workflow.md
+++ b/website/docs/maintainers/release-workflow.md
@@ -41,9 +41,12 @@ version alignment:
   manifest, and GitHub asset digests must agree. Stable wrapper-only rebuilds
   use `vM.m.p-N` for upstream `vM.m.p`; the suffix advances the native sequence
   but must never appear in the manifest's upstream llama.cpp ref. GitHub marks
-  every wrapper rebuild as a prerelease, so select it explicitly; `latest`
-  accepts only unsuffixed `vMAJOR.MINOR.PATCH`. Nightly cores and positive
-  rebuild counters must use canonical decimal spelling without leading zeros.
+  newly published wrapper and nightly releases as prereleases, so select them
+  explicitly. Historical `bNNNN` and `bNNNN-llamadart.N` artifacts may retain
+  older `prerelease=false` metadata, but remain explicit compatibility inputs;
+  `latest` accepts only unsuffixed `vMAJOR.MINOR.PATCH` regardless of GitHub
+  metadata. Nightly cores and positive rebuild counters must use canonical
+  decimal spelling without leading zeros.
 
 ## 2. Version and docs updates
 

--- a/website/docs/maintainers/release-workflow.md
+++ b/website/docs/maintainers/release-workflow.md
@@ -34,6 +34,13 @@ version alignment:
 - If native versions changed, prefer the `Sync Native Version & Bindings`
   workflow PR over hand-editing core pins. It also updates Apple SPM companion
   package pins under `packages/` when Apple XCFramework releases changed.
+- Stable llama.cpp native pins use strict `vMAJOR.MINOR.PATCH`; historical
+  `bNNNN` pins remain explicit compatibility inputs. Verify `assets.json`,
+  `SHA256SUMS`, hook contract version, bundle coverage, and manifest/release
+  checksum agreement before accepting a stable pin change. `SHA256SUMS`, the
+  manifest, and GitHub asset digests must agree. Stable wrapper-only rebuilds
+  use `vM.m.p-N` for upstream `vM.m.p`; the suffix advances the native sequence
+  but must never appear in the manifest's upstream llama.cpp ref.
 
 ## 2. Version and docs updates
 

--- a/website/docs/platforms/support-matrix.md
+++ b/website/docs/platforms/support-matrix.md
@@ -37,7 +37,9 @@ Accepted tags are stable `vMAJOR.MINOR.PATCH`, historical `bNNNN`, and existing
 nightly artifacts. New nightly wrapper rebuilds use `bNNNN-N`; existing
 `bNNNN-llamadart.N` artifacts remain consumption-only overrides. A stable
 wrapper-only rebuild of upstream `vM.m.p` uses `vM.m.p-N` and preserves that
-upstream prefix in the release manifest.
+upstream prefix in the release manifest. All wrapper rebuilds are GitHub
+prereleases and require an explicit tag; `latest` accepts only an unsuffixed
+stable tag. Nightly cores and positive rebuild counters reject leading zeros.
 The selected release must include a bundle asset named
 `llamadart-native-<bundle>-<tag>.tar.gz` for the target being built.
 Native source overrides do not regenerate Dart FFI bindings or symbol lookups,

--- a/website/docs/platforms/support-matrix.md
+++ b/website/docs/platforms/support-matrix.md
@@ -40,9 +40,11 @@ wrapper-only rebuild of upstream `vM.m.p` uses `vM.m.p-N` and preserves that
 upstream prefix in the release manifest. New wrapper and nightly releases are
 GitHub prereleases and require an explicit tag. Historical `bNNNN` and
 `bNNNN-llamadart.N` artifacts may retain older `prerelease=false` metadata, but
-remain explicit compatibility inputs; `latest` accepts only an unsuffixed
-stable tag regardless of GitHub metadata. Nightly cores and positive rebuild
-counters reject leading zeros.
+remain explicit compatibility inputs. Build-hook overrides must always name an
+explicit tag; `latest` is limited to maintainer synchronization and
+header/binding regeneration, where it accepts only an unsuffixed stable tag
+regardless of GitHub metadata. Nightly cores and positive rebuild counters
+reject leading zeros.
 The selected release must include a bundle asset named
 `llamadart-native-<bundle>-<tag>.tar.gz` for the target being built.
 Native source overrides do not regenerate Dart FFI bindings or symbol lookups,

--- a/website/docs/platforms/support-matrix.md
+++ b/website/docs/platforms/support-matrix.md
@@ -37,9 +37,12 @@ Accepted tags are stable `vMAJOR.MINOR.PATCH`, historical `bNNNN`, and existing
 nightly artifacts. New nightly wrapper rebuilds use `bNNNN-N`; existing
 `bNNNN-llamadart.N` artifacts remain consumption-only overrides. A stable
 wrapper-only rebuild of upstream `vM.m.p` uses `vM.m.p-N` and preserves that
-upstream prefix in the release manifest. All wrapper rebuilds are GitHub
-prereleases and require an explicit tag; `latest` accepts only an unsuffixed
-stable tag. Nightly cores and positive rebuild counters reject leading zeros.
+upstream prefix in the release manifest. New wrapper and nightly releases are
+GitHub prereleases and require an explicit tag. Historical `bNNNN` and
+`bNNNN-llamadart.N` artifacts may retain older `prerelease=false` metadata, but
+remain explicit compatibility inputs; `latest` accepts only an unsuffixed
+stable tag regardless of GitHub metadata. Nightly cores and positive rebuild
+counters reject leading zeros.
 The selected release must include a bundle asset named
 `llamadart-native-<bundle>-<tag>.tar.gz` for the target being built.
 Native source overrides do not regenerate Dart FFI bindings or symbol lookups,

--- a/website/docs/platforms/support-matrix.md
+++ b/website/docs/platforms/support-matrix.md
@@ -33,6 +33,11 @@ isolate. LiteRT-LM Web does not expose typed speech. See the
 Available override tags are published on the
 [`leehack/llamadart-native` releases page](https://github.com/leehack/llamadart-native/releases)
 or via `gh release list --repo leehack/llamadart-native --limit 20`.
+Accepted tags are stable `vMAJOR.MINOR.PATCH`, historical `bNNNN`, and existing
+nightly artifacts. New nightly wrapper rebuilds use `bNNNN-N`; existing
+`bNNNN-llamadart.N` artifacts remain consumption-only overrides. A stable
+wrapper-only rebuild of upstream `vM.m.p` uses `vM.m.p-N` and preserves that
+upstream prefix in the release manifest.
 The selected release must include a bundle asset named
 `llamadart-native-<bundle>-<tag>.tar.gz` for the target being built.
 Native source overrides do not regenerate Dart FFI bindings or symbol lookups,


### PR DESCRIPTION
## Summary

- Accept stable `llamadart-native` tags and wrapper rebuilds throughout synchronization, header/binding regeneration, build-hook overrides, release checks, workflows, and maintained documentation.
- Preserve historical native artifact consumption while enforcing channel, ordering, manifest, provenance, bundle, and checksum contracts.
- Keep the checked-in default native pin unchanged at `b10545`.

Closes #393.

## Production-readiness scope

- **User-facing scope:** Native-runtime overrides can consume stable `vMAJOR.MINOR.PATCH`, stable wrapper `vMAJOR.MINOR.PATCH-N`, explicit nightly `bNNNN`, new nightly wrapper `bNNNN-N`, and historical compatibility-only `bNNNN-llamadart.N` releases.
- **Supported platforms/paths:** Native-assets build hook, Apple SwiftPM checksum sync, native header/ffigen path, manual sync workflow, release-doc pin verifier, and maintained native installation/support documentation.
- **Unsupported or intentionally unavailable paths:** Invalid/custom tag suffixes, leading-zero nightly cores or rebuilds, zero rebuilds, rollback, same-sequence alias collisions, version/provenance skew, incompatible hook contracts, missing stable bundles/checksums, and implicit stable-to-nightly movement fail closed with actionable errors. Build-hook overrides never accept `latest`; maintainer sync/header tooling resolves `latest` only to unsuffixed `vMAJOR.MINOR.PATCH`. Wrapper, historical, and nightly releases require an explicit tag.
- **Out of scope / follow-ups:** Central dependency publication orchestration and owner workflow contracts are tracked by #400, leehack/llamadart-native#57, leehack/llama-web-bridge#62, and leehack/litert-lm-native#22. Native sync network error handling is #401, atomic header staging is #403, cross-consumer grammar consolidation is #404, and the repository-wide root format/analyze baseline is #405.

## Exact native tag and provenance contract

- Stable upstream-aligned native release: `vMAJOR.MINOR.PATCH`.
- Stable wrapper-only rebuild: `vMAJOR.MINOR.PATCH-N`; the exact upstream version remains the unsuffixed prefix and `N` is the monotonically increasing native wrapper revision.
- Explicit nightly release: `bNNNN`, where the core is canonical `b(0|[1-9][0-9]*)`.
- New nightly wrapper-only rebuild: `bNNNN-N`, with a positive rebuild counter and no leading zeros.
- Historical `bNNNN-llamadart.N`: consumption-only compatibility input with the same canonical core/counter rules; new publication is owned/rejected by `llamadart-native` policy.
- Native policy marks newly published wrapper and nightly releases as GitHub prereleases. Immutable historical `bNNNN` and legacy `bNNNN-llamadart.N` artifacts may retain older `prerelease=false` metadata, but remain explicit compatibility inputs. Only maintainer synchronization and header/binding regeneration accept `latest`, which must resolve to an unsuffixed `vMAJOR.MINOR.PATCH` regardless of GitHub metadata; build-hook overrides require an explicit tag.
- `native_release_tag` identifies the native artifact/archive. New wrapper forms require it and the retained legacy `tag` alias to agree.
- `llama_cpp_tag`/`llama_cpp_ref` identify the exact unsuffixed upstream ref. Native wrapper suffixes are never treated as upstream llama.cpp refs.
- `llama_cpp_commit` and `native_commit` remain separate exact 40-hex provenance fields.
- Stable-to-nightly movement requires explicit `--allow-legacy-tag`; the manual workflow exposes the same default-false approval as `allow_nightly_channel`.
- Historical base/legacy-wrapper manifests remain readable, including the published `v0.2.0` manifest that contains only the legacy `tag` alias.

## Completeness checklist

- [x] Declared scope is fully implemented, or explicitly reduced above.
- [x] Unsupported platform/option combinations fail loudly with actionable diagnostics or are clearly documented as unavailable.
- [x] Public API docs, README/website docs, examples, support matrices, and changelog entries are updated where relevant.
- [x] Regression coverage covers the original issue plus key negative/version-skew paths.
- [x] Security/privacy review completed: errors and snapshots contain no secrets, bearer tokens, signed URLs, or raw secret-bearing paths.
- [x] Follow-up work is tracked in the issues linked above.

## Transition and regression coverage

- `b10514 -> v0.2.0` and normal semantic upgrades.
- `v0.2.0 -> v0.2.0-1 -> v0.2.0-2 -> v0.2.1` using native channel ordering rather than generic SemVer prerelease precedence.
- `b10514 -> b10514-1 -> b10514-2` and legacy `b10514-llamadart.1` consumption.
- Explicit stable-to-nightly override and default rejection.
- Invalid/custom/zero or leading-zero nightly/rebuild tags before lookup, consistently across Python, Bash, Dart, and release-doc validation.
- Stable, nightly, and legacy-wrapper rollback.
- Equivalent compact/legacy wrapper alias collision.
- Release tag, manifest tag/alias, upstream ref, hook contract, required bundle, GitHub digest, `SHA256SUMS`, and `assets.json` skew.
- New wrapper manifests missing `assets.json`, `native_release_tag`, or `tag`.
- Build-hook acceptance/rejection and manual-workflow override wiring.
- Adversarial dispatch/tag payloads with shell metacharacters, plus the static workflow contract requiring environment transport and quoted shell expansion.

## Zero-regression audit

The final local review found and fixed two #393 blockers before PR creation:

1. The workflow could not express the required explicit stable-to-nightly override. It now has a default-false `allow_nightly_channel` input forwarded to validation and synchronization, with a PR checklist disclosure.
2. New `bNNNN-N` releases could use the legacy missing-manifest path. New stable/nightly wrapper forms now require the full manifest tag/provenance contract.

No known #393 regression remains. Every unrelated concrete finding is tracked: #401, #403, #404, and #405.

The first hosted Windows run exposed one test-only portability regression: a POSIX Bash preflight test was executed where `bash` is unavailable. The test is now explicitly skipped on Windows while the cross-platform Dart/Python tag-contract coverage remains active; the focused VM test and analyzer pass after the fix.

Hosted review then exposed a malformed-manifest error-path regression: non-UTF-8 `assets.json` bytes could escape as a raw `UnicodeDecodeError`. Manifest decoding now wraps that failure in the synchronizer's actionable `ReleaseError`, with a loopback-server regression test that asserts no traceback leaks.

Independent QA at `3e747f8` found three additional direct #393 blockers, all fixed on the current head:

1. Python, Bash, Dart, and release-doc consumers now share native's canonical nightly core grammar `b(0|[1-9][0-9]*)`; leading-zero core, rebuild, and legacy forms fail before release lookup.
2. `latest` now accepts only unsuffixed `vMAJOR.MINOR.PATCH`; newly emitted stable wrappers are GitHub prereleases under native #56 and remain explicit-only inputs, while immutable historical nightly artifacts may retain older GitHub metadata without becoming `latest`-eligible.
3. Manual workflow dispatch strings are transported through step environment variables and expanded only as quoted shell variables. Static workflow assertions and adversarial metacharacter cases cover the injection boundary. This prerequisite security fix is included in #412; opening a separate public security issue remains a separate approval boundary.

Exact-head review then found that stable bundle digests were enforced while the stable `assets.json` and `SHA256SUMS` metadata assets did not have the same explicit GitHub-digest requirement. Stable validation now requires a well-formed `sha256:` digest for both metadata assets as well as every bundle; focused missing-digest fixtures and a repeat live `v0.2.0` dry-run cover the fix.

Fresh independent QA then exercised malformed GitHub release metadata and found that a non-object member of the `assets` array could escape as `AttributeError` while formatting an unavailable-asset diagnostic. Asset-list validation is now centralized and rejects non-object entries as an actionable `ReleaseError`, with an explicit no-traceback regression test.

Exact-head QA also identified inaccurate historical GitHub prerelease wording. Maintained diagnostics and documentation now distinguish the current publication policy (new wrapper/nightly releases are prereleases) from immutable historical `bNNNN` and `bNNNN-llamadart.N` releases that may retain `prerelease=false`; every historical/nightly form remains explicit-only, and `latest` remains limited to unsuffixed stable tags regardless of GitHub metadata.

Fresh Copilot review then found that two user-facing override sections could be read as accepting `latest` in the native-assets build hook. Consumer docs now state that build-hook overrides require an explicit tag and reserve `latest` for maintainer synchronization/header regeneration; a static documentation contract test prevents that distinction from regressing.

## Published artifact evidence

### `llamadart-native@v0.2.0`

- Normal synchronizer dry-run: PASS without writing files.
- Published legacy manifest compatibility: `tag: v0.2.0`; `llama_cpp_tag: v0.2.0`; hook contract 1.
- Upstream commit: `bb4caa7540188872173c44d161602d9271386413`.
- Native commit: `4750db4d36d73145a96aa5278451d15cf42caa0c`.
- Required platform/archive coverage: 13/13.
- GitHub `assets.json` digest: `59483172d120c9a5f28701f49c5f1d672c745b26a42957807c5ad03d2c9fe7ba`.
- GitHub `SHA256SUMS` digest: `429d2b3e42478fb971be4900a565d01941f1c27246aaf95698893563e79e6dde`.
- Header archive selection, checksum, ffigen generation path, and generated-binding byte comparison: PASS.

### Current historical `llamadart-native@b10545`

- Normal synchronizer dry-run: PASS without writing files.
- Existing cached runtime/build-hook/native symbol/inference coverage remains green.
- The checked-in default pin remains `b10545`; this PR does not upgrade any dependency or artifact.

## Test Plan

- [ ] `dart format --output=none --set-exit-if-changed .` — repository-wide baseline currently reports five untouched files and nested-example setup warnings; disclosed and tracked by #405. Touched Dart files are formatted.
- [ ] `dart analyze` — repository-wide baseline currently reports 9,224 predominantly unprepared nested-example dependency/override findings; disclosed and tracked by #405. Focused touched-file analysis passes.
- [x] `dart test -p vm -j 1 --exclude-tags local-only` — 1,527 passed, 71 fixture-dependent skips on exact local head.
- [ ] `dart test -p chrome --exclude-tags local-only` — N/A: no browser runtime, imports, Web assets, or Web API behavior changes.
- [x] `dart analyze hook/build.dart test/unit/hook/build_hook_integration_test.dart test/unit/tooling/sync_native_release_pins_script_test.dart tool/testing/verify_release_docs_versions.dart`
- [x] `dart test -p vm -j 1 test/unit/tooling/sync_native_release_pins_script_test.dart test/unit/hook/build_hook_integration_test.dart` — 28/28.
- [x] `actionlint .github/workflows/sync_native_bindings.yml`
- [x] `shellcheck tool/native/sync_native_headers_and_bindings.sh`
- [x] `bash -n tool/native/sync_native_headers_and_bindings.sh`
- [x] `python3 -m py_compile tool/native/sync_native_release_pins.py`
- [x] `dart run tool/testing/verify_release_docs_versions.dart`
- [x] `./tool/docs/validate_links.sh`
- [x] Live `v0.2.0` and `b10545` synchronizer dry-runs.
- [x] `git diff --check origin/main...HEAD`

## Matrix Evidence

| Matrix row | Scope covered | Platform / model / backend | Result | Evidence / notes |
| --- | --- | --- | --- | --- |
| `static-format-analyze` | touched Dart formatting/analyzer and workflow/shell static checks | macOS arm64 local | PASS (focused) / baseline disclosed | Focused analyze, actionlint, shellcheck, and diff check pass; root baseline is #405. |
| `root-vm` | native-safe unit/integration and real cached runtime coverage | macOS arm64, b10545, Metal/CPU | PASS | 1,527 passed; 71 fixture-dependent skips. |
| `docs-site` | maintained native docs and generated routes | Docusaurus local build | PASS | Link validation builds the site with broken links set to throw. |
| `release-doc-version-consistency` | native/default pins and current package snippets | local verifier | PASS | Default native pin verified as `b10545`. |
| `native-hook-bundles` | tag overrides, archive naming, bundle selection, runtime companions | cached native bundles plus deterministic release fixtures | PASS | Focused combined synchronization/build-hook contract suite 28/28. |
| `macos-arm64-runtime-smoke` | checked-in default runtime remains operational | macOS arm64, b10545, Metal/CPU | PASS | Full VM inference/native-symbol coverage passed; no pin/runtime binary changed. |

## Review Notes

- Independent review status: fresh independent QA passed at exact head `7b5e6e123eb0e90a375fc159e4fa5bfe8a32899a`; final human contract review remains appropriate while the PR is draft.
- CI status / head SHA: all 13 draft-PR checks pass for exact head `7b5e6e123eb0e90a375fc159e4fa5bfe8a32899a`.
- This PR must remain draft. It does not dispatch workflows, publish assets, create tags/releases, mark itself ready, merge, or change native/Web/LiteRT pins.
