### PR TITLE
Fix structured-output parser and grammar regressions

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -33,6 +33,13 @@ For docs and release-sensitive snippets:
 dart run tool/testing/verify_release_docs_versions.dart
 ```
 
+For chat-template handler, parser, or grammar changes, run the pinned upstream
+suite plus compiled specialized-grammar acceptance checks:
+
+```bash
+tool/testing/run_template_parity_suites.sh
+```
+
 For coverage when `lib/` behavior changes or coverage is in doubt:
 
 ```bash

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,24 @@
 ## Unreleased
 
+* Fixed DeepSeek V3.2 DSML tool calls using their upstream
+  `<｜DSML｜function_calls>` envelope while preserving DeepSeek V4's distinct
+  `<｜DSML｜tool_calls>` grammar and parser behavior.
+
+* Fixed partial GLM 4.5, Poolside Laguna, and Muse Glimmer tool envelopes
+  leaking into streamed assistant content, while preserving completed calls,
+  malformed final output, and ordinary text surrounding Muse recipient
+  channels.
+
+* Fixed schema-constrained tool calls for Kimi K3, MiniMax M1/M3, DeepSeek
+  V3.2/V4, and Muse Glimmer, including exact escaped names, required fields,
+  declared value types, matching MiniMax M3 element tags, zero-argument calls,
+  and strings containing delimiter characters. Required-tool mode now accepts
+  each format's reasoning/content prefix while still requiring a call.
+  MiniMax M3, DeepSeek DSML, Muse Glimmer, Poolside Laguna, and GLM 4.5 now
+  reconstruct argument values from the declared tool schema instead of
+  guessing from text. Added `ToolParam.nullType` for null-only JSON Schema
+  properties.
+
 * Added template-aware parsing for Kimi K3, MiniMax M1/M3, DeepSeek V3.2/V4,
   Muse Glimmer, and Poolside Laguna, preventing their native tool calls from
   silently falling back to plain content.

--- a/lib/llamadart.dart
+++ b/lib/llamadart.dart
@@ -94,7 +94,7 @@ export 'src/core/models/chat/completion_chunk.dart';
 
 // Tools
 export 'src/core/models/tools/tool_definition.dart';
-export 'src/core/models/tools/tool_param.dart';
+export 'src/core/models/tools/tool_param.dart' show ToolParam;
 export 'src/core/models/tools/tool_params.dart';
 
 // Models - Config

--- a/lib/src/core/engine/chat_completion_stream_parser.dart
+++ b/lib/src/core/engine/chat_completion_stream_parser.dart
@@ -420,6 +420,11 @@ class ChatCompletionStreamParser {
   }
 
   static bool _mayEmbedToolEnvelopeAfterContent(int formatIndex) =>
+      formatIndex == ChatFormat.kimiK3.index ||
+      formatIndex == ChatFormat.minimaxM1.index ||
+      formatIndex == ChatFormat.minimaxM3.index ||
+      formatIndex == ChatFormat.deepseekV32.index ||
+      formatIndex == ChatFormat.deepseekV4.index ||
       formatIndex == ChatFormat.museGlimmer.index ||
       formatIndex == ChatFormat.glm45.index ||
       formatIndex == ChatFormat.laguna.index;

--- a/lib/src/core/engine/chat_completion_stream_parser.dart
+++ b/lib/src/core/engine/chat_completion_stream_parser.dart
@@ -3,6 +3,8 @@ import 'dart:async';
 import '../llama_logger.dart';
 import '../models/chat/chat_template_result.dart';
 import '../models/chat/completion_chunk.dart';
+import '../models/tools/tool_definition.dart';
+import '../template/chat_format.dart';
 import '../template/chat_template_engine.dart';
 
 enum _ToolStreamingMode { undecided, raw, parsed }
@@ -42,6 +44,7 @@ class ChatCompletionStreamParser {
     required bool enableThinking,
     required String modelName,
     required String completionId,
+    List<ToolDefinition>? tools,
   }) async* {
     final buffer = StringBuffer();
     var streamedContent = '';
@@ -58,7 +61,9 @@ class ChatCompletionStreamParser {
     // A forced-open thought can transition straight into a tool envelope
     // without producing `</think>`. Start in parsed mode so that envelope is
     // never streamed as reasoning before the final structured parse.
-    var streamingMode = templateResult.thinkingForcedOpen
+    var streamingMode =
+        templateResult.thinkingForcedOpen ||
+            _mayEmbedToolEnvelopeAfterContent(templateResult.format)
         ? _ToolStreamingMode.parsed
         : _ToolStreamingMode.undecided;
     var undecidedPrefix = '';
@@ -167,6 +172,7 @@ class ChatCompletionStreamParser {
             parseToolCalls: true,
             thinkingForcedOpen: templateResult.thinkingForcedOpen,
             parser: templateResult.parser,
+            tools: tools,
           );
 
           final partialReasoning = partialParsed.reasoningContent ?? '';
@@ -286,6 +292,7 @@ class ChatCompletionStreamParser {
       parseToolCalls: parseToolCallsEnabled,
       thinkingForcedOpen: templateResult.thinkingForcedOpen,
       parser: templateResult.parser,
+      tools: tools,
     );
 
     if (parseToolCallsEnabled) {
@@ -411,6 +418,11 @@ class ChatCompletionStreamParser {
     }
     return false;
   }
+
+  static bool _mayEmbedToolEnvelopeAfterContent(int formatIndex) =>
+      formatIndex == ChatFormat.museGlimmer.index ||
+      formatIndex == ChatFormat.glm45.index ||
+      formatIndex == ChatFormat.laguna.index;
 
   static int? _firstNonWhitespaceIndex(String value) {
     for (var i = 0; i < value.length; i++) {

--- a/lib/src/core/engine/engine.dart
+++ b/lib/src/core/engine/engine.dart
@@ -686,6 +686,7 @@ class LlamaEngine {
       enableThinking: enableThinking,
       modelName: _modelPath ?? 'llama_model',
       completionId: completionId,
+      tools: effectiveTools,
     );
   }
 

--- a/lib/src/core/models/tools/tool_param.dart
+++ b/lib/src/core/models/tools/tool_param.dart
@@ -5,6 +5,7 @@
 /// - [ToolParam.integer] for integer parameters
 /// - [ToolParam.number] for floating-point parameters
 /// - [ToolParam.boolean] for boolean parameters
+/// - [ToolParam.nullType] for parameters whose only valid value is `null`
 /// - [ToolParam.enumType] for enum parameters with allowed values
 /// - [ToolParam.array] for array parameters
 /// - [ToolParam.object] for nested object parameters
@@ -51,6 +52,13 @@ sealed class ToolParam {
     String? description,
     bool required = false,
   }) => _BooleanParam(name: name, description: description, required: required);
+
+  /// Creates a parameter whose only valid JSON value is `null`.
+  static ToolParam nullType(
+    String name, {
+    String? description,
+    bool required = false,
+  }) => _NullParam(name: name, description: description, required: required);
 
   /// Creates an enum parameter with a list of allowed values.
   static ToolParam enumType(
@@ -135,6 +143,17 @@ final class _BooleanParam extends ToolParam {
   @override
   Map<String, dynamic> toJsonSchema() => {
     'type': 'boolean',
+    if (description != null) 'description': description,
+  };
+}
+
+final class _NullParam extends ToolParam {
+  const _NullParam({required super.name, super.description, super.required})
+    : super._();
+
+  @override
+  Map<String, dynamic> toJsonSchema() => {
+    'type': 'null',
     if (description != null) 'description': description,
   };
 }

--- a/lib/src/core/models/tools/tool_param.dart
+++ b/lib/src/core/models/tools/tool_param.dart
@@ -103,6 +103,47 @@ sealed class ToolParam {
   Map<String, dynamic> toJsonSchema();
 }
 
+/// Returns an actionable identity error for [parameters], or `null` when every
+/// object property name is non-empty and unique within its containing object.
+///
+/// Array item names are not represented in JSON Schema and are therefore not
+/// validated, but object properties nested inside array items are.
+String? toolParamIdentityError(
+  List<ToolParam> parameters, {
+  required String path,
+}) {
+  final names = <String>{};
+  for (final parameter in parameters) {
+    if (parameter.name.isEmpty) {
+      return 'Structured tool schemas require non-empty parameter names at '
+          '$path.';
+    }
+    if (!names.add(parameter.name)) {
+      return 'Structured tool schemas require unique parameter names at '
+          '$path; "${parameter.name}" is declared more than once.';
+    }
+  }
+
+  for (final parameter in parameters) {
+    final nestedPath = '$path.${parameter.name}';
+    final error = _nestedToolParamIdentityError(parameter, nestedPath);
+    if (error != null) {
+      return error;
+    }
+  }
+  return null;
+}
+
+String? _nestedToolParamIdentityError(ToolParam parameter, String path) {
+  if (parameter is _ObjectParam) {
+    return toolParamIdentityError(parameter.properties, path: path);
+  }
+  if (parameter is _ArrayParam) {
+    return _nestedToolParamIdentityError(parameter.itemType, '$path[]');
+  }
+  return null;
+}
+
 final class _StringParam extends ToolParam {
   const _StringParam({required super.name, super.description, super.required})
     : super._();

--- a/lib/src/core/template/chat_format.dart
+++ b/lib/src/core/template/chat_format.dart
@@ -133,7 +133,7 @@ enum ChatFormat {
   /// MiniMax M3 — namespaced XML invokes with `<mm:think>` reasoning.
   minimaxM3,
 
-  /// DeepSeek V3.2/V4 — DSML invokes with typed parameter values.
+  /// DeepSeek V4 — DSML `tool_calls` with typed parameter values.
   deepseekV4,
 
   /// Muse Glimmer — recipient channels with ATEM function-call markup.
@@ -141,6 +141,11 @@ enum ChatFormat {
 
   /// Poolside Laguna — tagged reasoning and arg-key/value tool calls.
   laguna,
+
+  /// DeepSeek V3.2 — DSML `function_calls` with typed parameter values.
+  ///
+  /// Appended to preserve the serialized indices of existing formats.
+  deepseekV32,
 }
 
 /// Detects the [ChatFormat] by scanning a Jinja template source string
@@ -179,8 +184,12 @@ ChatFormat detectChatFormat(String? templateSource) {
   // variable, so detecting only literal rendered tags misses every variant.
   if (templateSource.contains('dsml_token') &&
       templateSource.contains('DSML') &&
-      (templateSource.contains('function_calls') ||
-          templateSource.contains('tool_calls'))) {
+      templateSource.contains('function_calls')) {
+    return ChatFormat.deepseekV32;
+  }
+  if (templateSource.contains('dsml_token') &&
+      templateSource.contains('DSML') &&
+      templateSource.contains('tool_calls')) {
     return ChatFormat.deepseekV4;
   }
 

--- a/lib/src/core/template/chat_template_engine.dart
+++ b/lib/src/core/template/chat_template_engine.dart
@@ -444,6 +444,8 @@ class ChatTemplateEngine {
   /// Parses raw LLM output using the format's handler.
   ///
   /// The [formatIndex] should come from [LlamaChatTemplateResult.format].
+  /// [tools] supplies the schemas needed by formats whose wire representation
+  /// does not encode enough type information to reconstruct arguments safely.
   static ChatParseResult parse(
     int formatIndex,
     String output, {
@@ -451,6 +453,7 @@ class ChatTemplateEngine {
     bool parseToolCalls = true,
     bool thinkingForcedOpen = false,
     String? parser,
+    List<ToolDefinition>? tools,
   }) {
     final resolved = _resolveHandlerForParse(formatIndex: formatIndex);
     final handler = resolved.handler;
@@ -479,6 +482,79 @@ class ChatTemplateEngine {
         output: output,
         isPartial: isPartial,
         parseToolCalls: parseToolCalls,
+      );
+    }
+
+    if (format == ChatFormat.minimaxM3 && handler is MinimaxM3Handler) {
+      return handler.parseWithTools(
+        output,
+        tools: tools,
+        isPartial: isPartial,
+        parseToolCalls: parseToolCalls,
+        thinkingForcedOpen: thinkingForcedOpen,
+      );
+    }
+    if (format == ChatFormat.kimiK3 && handler is KimiK3Handler) {
+      return handler.parseWithTools(
+        output,
+        tools: tools,
+        isPartial: isPartial,
+        parseToolCalls: parseToolCalls,
+        thinkingForcedOpen: thinkingForcedOpen,
+      );
+    }
+    if (format == ChatFormat.minimaxM1 && handler is MinimaxM1Handler) {
+      return handler.parseWithTools(
+        output,
+        tools: tools,
+        isPartial: isPartial,
+        parseToolCalls: parseToolCalls,
+        thinkingForcedOpen: thinkingForcedOpen,
+      );
+    }
+    if (format == ChatFormat.deepseekV32 && handler is DeepseekV32Handler) {
+      return handler.parseWithTools(
+        output,
+        tools: tools,
+        isPartial: isPartial,
+        parseToolCalls: parseToolCalls,
+        thinkingForcedOpen: thinkingForcedOpen,
+      );
+    }
+    if (format == ChatFormat.deepseekV4 && handler is DeepseekV4Handler) {
+      return handler.parseWithTools(
+        output,
+        tools: tools,
+        isPartial: isPartial,
+        parseToolCalls: parseToolCalls,
+        thinkingForcedOpen: thinkingForcedOpen,
+      );
+    }
+    if (format == ChatFormat.museGlimmer && handler is MuseGlimmerHandler) {
+      return handler.parseWithTools(
+        output,
+        tools: tools,
+        isPartial: isPartial,
+        parseToolCalls: parseToolCalls,
+        thinkingForcedOpen: thinkingForcedOpen,
+      );
+    }
+    if (format == ChatFormat.laguna && handler is LagunaHandler) {
+      return handler.parseWithTools(
+        output,
+        tools: tools,
+        isPartial: isPartial,
+        parseToolCalls: parseToolCalls,
+        thinkingForcedOpen: thinkingForcedOpen,
+      );
+    }
+    if (format == ChatFormat.glm45 && handler is Glm45Handler) {
+      return handler.parseWithTools(
+        output,
+        tools: tools,
+        isPartial: isPartial,
+        parseToolCalls: parseToolCalls,
+        thinkingForcedOpen: thinkingForcedOpen,
       );
     }
 
@@ -557,6 +633,8 @@ class ChatTemplateEngine {
         return MinimaxM3Handler();
       case ChatFormat.deepseekV4:
         return DeepseekV4Handler();
+      case ChatFormat.deepseekV32:
+        return DeepseekV32Handler();
       case ChatFormat.museGlimmer:
         return MuseGlimmerHandler();
       case ChatFormat.laguna:

--- a/lib/src/core/template/chat_template_engine.dart
+++ b/lib/src/core/template/chat_template_engine.dart
@@ -413,7 +413,7 @@ class ChatTemplateEngine {
     LlamaChatTemplateResult result,
     ToolChoice toolChoice,
   ) {
-    if (toolChoice != ToolChoice.required || !result.grammarLazy) {
+    if (toolChoice != ToolChoice.required) {
       return result;
     }
     if (result.grammar == null || result.grammar!.isEmpty) {
@@ -423,7 +423,7 @@ class ChatTemplateEngine {
     final resultFormat = result.format < ChatFormat.values.length
         ? ChatFormat.values[result.format]
         : ChatFormat.generic;
-    if (_requiredKeepsLazyFormats.contains(resultFormat)) {
+    if (_requiredKeepsLazyFormats.contains(resultFormat) && result.grammarLazy) {
       return result;
     }
 
@@ -434,7 +434,7 @@ class ChatTemplateEngine {
       grammarLazy: false,
       additionalStops: result.additionalStops,
       preservedTokens: result.preservedTokens,
-      grammarTriggers: result.grammarTriggers,
+      grammarTriggers: const [],
       thinkingForcedOpen: result.thinkingForcedOpen,
       parser: result.parser,
       tokenCount: result.tokenCount,
@@ -485,71 +485,8 @@ class ChatTemplateEngine {
       );
     }
 
-    if (format == ChatFormat.minimaxM3 && handler is MinimaxM3Handler) {
-      return handler.parseWithTools(
-        output,
-        tools: tools,
-        isPartial: isPartial,
-        parseToolCalls: parseToolCalls,
-        thinkingForcedOpen: thinkingForcedOpen,
-      );
-    }
-    if (format == ChatFormat.kimiK3 && handler is KimiK3Handler) {
-      return handler.parseWithTools(
-        output,
-        tools: tools,
-        isPartial: isPartial,
-        parseToolCalls: parseToolCalls,
-        thinkingForcedOpen: thinkingForcedOpen,
-      );
-    }
-    if (format == ChatFormat.minimaxM1 && handler is MinimaxM1Handler) {
-      return handler.parseWithTools(
-        output,
-        tools: tools,
-        isPartial: isPartial,
-        parseToolCalls: parseToolCalls,
-        thinkingForcedOpen: thinkingForcedOpen,
-      );
-    }
-    if (format == ChatFormat.deepseekV32 && handler is DeepseekV32Handler) {
-      return handler.parseWithTools(
-        output,
-        tools: tools,
-        isPartial: isPartial,
-        parseToolCalls: parseToolCalls,
-        thinkingForcedOpen: thinkingForcedOpen,
-      );
-    }
-    if (format == ChatFormat.deepseekV4 && handler is DeepseekV4Handler) {
-      return handler.parseWithTools(
-        output,
-        tools: tools,
-        isPartial: isPartial,
-        parseToolCalls: parseToolCalls,
-        thinkingForcedOpen: thinkingForcedOpen,
-      );
-    }
-    if (format == ChatFormat.museGlimmer && handler is MuseGlimmerHandler) {
-      return handler.parseWithTools(
-        output,
-        tools: tools,
-        isPartial: isPartial,
-        parseToolCalls: parseToolCalls,
-        thinkingForcedOpen: thinkingForcedOpen,
-      );
-    }
-    if (format == ChatFormat.laguna && handler is LagunaHandler) {
-      return handler.parseWithTools(
-        output,
-        tools: tools,
-        isPartial: isPartial,
-        parseToolCalls: parseToolCalls,
-        thinkingForcedOpen: thinkingForcedOpen,
-      );
-    }
-    if (format == ChatFormat.glm45 && handler is Glm45Handler) {
-      return handler.parseWithTools(
+    if (handler is ToolSchemaAwareChatTemplateHandler) {
+      return (handler as ToolSchemaAwareChatTemplateHandler).parseWithTools(
         output,
         tools: tools,
         isPartial: isPartial,

--- a/lib/src/core/template/chat_template_engine.dart
+++ b/lib/src/core/template/chat_template_engine.dart
@@ -423,7 +423,8 @@ class ChatTemplateEngine {
     final resultFormat = result.format < ChatFormat.values.length
         ? ChatFormat.values[result.format]
         : ChatFormat.generic;
-    if (_requiredKeepsLazyFormats.contains(resultFormat) && result.grammarLazy) {
+    if (_requiredKeepsLazyFormats.contains(resultFormat) &&
+        result.grammarLazy) {
       return result;
     }
 

--- a/lib/src/core/template/chat_template_handler.dart
+++ b/lib/src/core/template/chat_template_handler.dart
@@ -236,3 +236,20 @@ abstract class ChatTemplateHandler {
     return DateTime.now();
   }
 }
+
+/// Optional handler contract for output formats whose argument decoding depends
+/// on the tool JSON schemas supplied for the completion request.
+///
+/// [ChatTemplateEngine] uses this contract when schemas are available while
+/// retaining [ChatTemplateHandler.parse] for callers that only have raw output.
+abstract interface class ToolSchemaAwareChatTemplateHandler {
+  /// Parses [output] using [tools] to validate names, required properties, and
+  /// schema-directed argument types.
+  ChatParseResult parseWithTools(
+    String output, {
+    List<ToolDefinition>? tools,
+    bool isPartial = false,
+    bool parseToolCalls = true,
+    bool thinkingForcedOpen = false,
+  });
+}

--- a/lib/src/core/template/handlers/glm45_handler.dart
+++ b/lib/src/core/template/handlers/glm45_handler.dart
@@ -189,6 +189,7 @@ class Glm45Handler extends ChatTemplateHandler
     if (tools == null || tools.isEmpty) {
       return null;
     }
+    toolSchemas(tools);
 
     final toolChoiceRules = <String>[];
     final toolRules = <String>[];
@@ -229,7 +230,7 @@ class Glm45Handler extends ChatTemplateHandler
 
     return [
       'root ::= tool-call+',
-      'tool-call ::= "\\n<tool_call>" tool-choice "</tool_call>\\n"',
+      'tool-call ::= "\\n"? "<tool_call>" tool-choice "</tool_call>\\n"',
       toolChoiceRule,
       ...toolRules,
       'space ::= " "?',
@@ -373,11 +374,39 @@ class Glm45Handler extends ChatTemplateHandler
       }
     }
 
+    if (toolCalls.isNotEmpty && _containsGlmProtocolMarker(remaining)) {
+      return null;
+    }
+
     return _ExtractedToolCalls(
       toolCalls: toolCalls,
       remainingContent: remaining,
     );
   }
+}
+
+bool _containsGlmProtocolMarker(String input) {
+  const markers = <String>[
+    '<tool_call>',
+    '</tool_call>',
+    '<arg_key>',
+    '</arg_key>',
+    '<arg_value>',
+    '</arg_value>',
+  ];
+  for (final marker in markers) {
+    if (input.contains(marker.substring(0, marker.length - 1))) {
+      return true;
+    }
+  }
+  for (final marker in markers) {
+    for (var length = marker.length - 1; length >= 5; length--) {
+      if (input.endsWith(marker.substring(0, length))) {
+        return true;
+      }
+    }
+  }
+  return false;
 }
 
 ToolSchemaValueResult _decodeGlmSchemaText(
@@ -450,15 +479,24 @@ String _escapeGlmLiteralCharacter(String character) {
 }
 
 String _hideIncompleteToolCallBlock(String input) {
-  const marker = '<tool_call>';
-  final open = input.lastIndexOf(marker);
+  const toolCallMarker = '<tool_call>';
+  final open = input.lastIndexOf(toolCallMarker);
   final close = input.lastIndexOf('</tool_call>');
   if (open > close) {
     return input.substring(0, open);
   }
-  for (var length = 1; length < marker.length; length++) {
-    if (input.endsWith(marker.substring(0, length))) {
-      return input.substring(0, input.length - length);
+  for (final marker in const [
+    toolCallMarker,
+    '</tool_call>',
+    '<arg_key>',
+    '</arg_key>',
+    '<arg_value>',
+    '</arg_value>',
+  ]) {
+    for (var length = 1; length < marker.length; length++) {
+      if (input.endsWith(marker.substring(0, length))) {
+        return input.substring(0, input.length - length);
+      }
     }
   }
   return input;

--- a/lib/src/core/template/handlers/glm45_handler.dart
+++ b/lib/src/core/template/handlers/glm45_handler.dart
@@ -233,6 +233,7 @@ class Glm45Handler extends ChatTemplateHandler
       'tool-call ::= "\\n"? "<tool_call>" tool-choice "</tool_call>\\n"',
       toolChoiceRule,
       ...toolRules,
+      ..._glmUntilAnyLiteralRules('glm-string-raw', _glmProtocolMarkers),
       'space ::= " "?',
       'string ::= "\\"" ([^"\\\\] | "\\\\" .)* "\\""',
       'number ::= "-"? ([0-9] | [1-9] [0-9]*) ("." [0-9]+)? ([eE] [+-]? [0-9]+)?',
@@ -263,10 +264,7 @@ class Glm45Handler extends ChatTemplateHandler
             .join(' | ');
         return ['$valueRuleName ::= $rawEnum | $jsonEnum'];
       }
-      return [
-        '$valueRuleName ::= $valueRuleName-raw-0',
-        ..._glmUntilLiteralRules('$valueRuleName-raw', '</arg_value>'),
-      ];
+      return ['$valueRuleName ::= glm-string-raw-0'];
     }
 
     if (type == 'integer' || type == 'number') {
@@ -334,7 +332,7 @@ class Glm45Handler extends ChatTemplateHandler
       for (final argMatch in _argPairPattern.allMatches(block)) {
         final key = (argMatch.group(1) ?? '').trim();
         final rawValue = (argMatch.group(2) ?? '').trim();
-        if (key.isEmpty) {
+        if (key.isEmpty || _containsGlmProtocolMarker(rawValue)) {
           return null;
         }
         if (args.containsKey(key)) {
@@ -385,21 +383,22 @@ class Glm45Handler extends ChatTemplateHandler
   }
 }
 
+const _glmProtocolMarkers = [
+  '<tool_call>',
+  '</tool_call>',
+  '<arg_key>',
+  '</arg_key>',
+  '<arg_value>',
+  '</arg_value>',
+];
+
 bool _containsGlmProtocolMarker(String input) {
-  const markers = <String>[
-    '<tool_call>',
-    '</tool_call>',
-    '<arg_key>',
-    '</arg_key>',
-    '<arg_value>',
-    '</arg_value>',
-  ];
-  for (final marker in markers) {
+  for (final marker in _glmProtocolMarkers) {
     if (input.contains(marker.substring(0, marker.length - 1))) {
       return true;
     }
   }
-  for (final marker in markers) {
+  for (final marker in _glmProtocolMarkers) {
     for (var length = marker.length - 1; length >= 5; length--) {
       if (input.endsWith(marker.substring(0, length))) {
         return true;
@@ -420,21 +419,52 @@ ToolSchemaValueResult _decodeGlmSchemaText(
   return decodeToolSchemaText(raw, schema);
 }
 
-List<String> _glmUntilLiteralRules(String ruleBase, String delimiter) {
-  final marker = delimiter.runes
-      .map(String.fromCharCode)
+List<String> _glmUntilAnyLiteralRules(
+  String ruleBase,
+  List<String> delimiters,
+) {
+  final markers = delimiters
+      .map(
+        (delimiter) =>
+            delimiter.runes.map(String.fromCharCode).toList(growable: false),
+      )
       .toList(growable: false);
-  final alphabet = marker.toSet().toList(growable: false);
+  final prefixes = <String>{''};
+  for (final delimiter in delimiters) {
+    for (var length = 1; length < delimiter.length; length++) {
+      prefixes.add(delimiter.substring(0, length));
+    }
+  }
+  final states = prefixes.toList(growable: false)
+    ..sort((left, right) {
+      final byLength = left.length.compareTo(right.length);
+      return byLength != 0 ? byLength : left.compareTo(right);
+    });
+  final stateIndexes = <String, int>{
+    for (var index = 0; index < states.length; index++) states[index]: index,
+  };
+  final alphabet = markers
+      .expand((marker) => marker)
+      .toSet()
+      .toList(growable: false);
   final lines = <String>[
     '$ruleBase-other ::= [^${alphabet.map(_escapeGlmCharacterClass).join()}]',
   ];
-  for (var state = 0; state < marker.length; state++) {
+  for (var state = 0; state < states.length; state++) {
     final alternatives = <String>['$ruleBase-other $ruleBase-0'];
     for (final character in alphabet) {
-      final next = _glmDelimiterTransition(marker, state, character);
-      if (next == marker.length) {
+      final candidate = '${states[state]}$character';
+      if (delimiters.any(candidate.endsWith)) {
         continue;
       }
+      final nextState = states
+          .where(candidate.endsWith)
+          .fold<String>(
+            '',
+            (longest, prefix) =>
+                prefix.length > longest.length ? prefix : longest,
+          );
+      final next = stateIndexes[nextState]!;
       alternatives.add(
         '"${_escapeGlmLiteralCharacter(character)}" $ruleBase-$next',
       );
@@ -442,26 +472,6 @@ List<String> _glmUntilLiteralRules(String ruleBase, String delimiter) {
     lines.add('$ruleBase-$state ::= (${alternatives.join(' | ')})?');
   }
   return lines;
-}
-
-int _glmDelimiterTransition(List<String> marker, int state, String character) {
-  final candidate = <String>[...marker.take(state), character];
-  final max = candidate.length < marker.length
-      ? candidate.length
-      : marker.length;
-  for (var length = max; length >= 0; length--) {
-    var matches = true;
-    for (var index = 0; index < length; index++) {
-      if (candidate[candidate.length - length + index] != marker[index]) {
-        matches = false;
-        break;
-      }
-    }
-    if (matches) {
-      return length;
-    }
-  }
-  return 0;
 }
 
 String _escapeGlmCharacterClass(String character) {

--- a/lib/src/core/template/handlers/glm45_handler.dart
+++ b/lib/src/core/template/handlers/glm45_handler.dart
@@ -332,7 +332,7 @@ class Glm45Handler extends ChatTemplateHandler
       for (final argMatch in _argPairPattern.allMatches(block)) {
         final key = (argMatch.group(1) ?? '').trim();
         final rawValue = (argMatch.group(2) ?? '').trim();
-        if (key.isEmpty || _containsGlmProtocolMarker(rawValue)) {
+        if (key.isEmpty || _containsExactGlmProtocolMarker(rawValue)) {
           return null;
         }
         if (args.containsKey(key)) {
@@ -372,7 +372,7 @@ class Glm45Handler extends ChatTemplateHandler
       }
     }
 
-    if (toolCalls.isNotEmpty && _containsGlmProtocolMarker(remaining)) {
+    if (toolCalls.isNotEmpty && _containsGlmProtocolRemainder(remaining)) {
       return null;
     }
 
@@ -392,7 +392,11 @@ const _glmProtocolMarkers = [
   '</arg_value>',
 ];
 
-bool _containsGlmProtocolMarker(String input) {
+bool _containsExactGlmProtocolMarker(String input) {
+  return _glmProtocolMarkers.any(input.contains);
+}
+
+bool _containsGlmProtocolRemainder(String input) {
   for (final marker in _glmProtocolMarkers) {
     if (input.contains(marker.substring(0, marker.length - 1))) {
       return true;

--- a/lib/src/core/template/handlers/glm45_handler.dart
+++ b/lib/src/core/template/handlers/glm45_handler.dart
@@ -9,6 +9,7 @@ import '../chat_parse_result.dart';
 import '../chat_template_handler.dart';
 import '../thinking_utils.dart';
 import '../tool_call_parsing_utils.dart';
+import '../tool_schema_utils.dart';
 
 /// Handler for GLM 4.5 format.
 ///
@@ -128,6 +129,22 @@ class Glm45Handler extends ChatTemplateHandler {
     bool parseToolCalls = true,
     bool thinkingForcedOpen = false,
   }) {
+    return parseWithTools(
+      output,
+      isPartial: isPartial,
+      parseToolCalls: parseToolCalls,
+      thinkingForcedOpen: thinkingForcedOpen,
+    );
+  }
+
+  /// Parses GLM output using [tools] for schema-directed argument types.
+  ChatParseResult parseWithTools(
+    String output, {
+    List<ToolDefinition>? tools,
+    bool isPartial = false,
+    bool parseToolCalls = true,
+    bool thinkingForcedOpen = false,
+  }) {
     final thinking = extractThinking(
       output,
       thinkingForcedOpen: thinkingForcedOpen,
@@ -141,7 +158,17 @@ class Glm45Handler extends ChatTemplateHandler {
       );
     }
 
-    final extractedFromContent = _extractToolCalls(text);
+    final parseText = isPartial ? _hideIncompleteToolCallBlock(text) : text;
+    final extractedFromContent = _extractToolCalls(
+      parseText,
+      schemas: toolSchemas(tools),
+    );
+    if (extractedFromContent == null) {
+      return ChatParseResult(
+        content: parseText.trim(),
+        reasoningContent: thinking.reasoning,
+      );
+    }
     final toolCalls = <LlamaCompletionChunkToolCall>[
       ...extractedFromContent.toolCalls,
     ];
@@ -271,7 +298,10 @@ class Glm45Handler extends ChatTemplateHandler {
     return ToolCallParsingUtils.decodeJsonValueOrString(value);
   }
 
-  _ExtractedToolCalls _extractToolCalls(String input) {
+  _ExtractedToolCalls? _extractToolCalls(
+    String input, {
+    required Map<String, Map<String, dynamic>> schemas,
+  }) {
     final toolCalls = <LlamaCompletionChunkToolCall>[];
     var remaining = input;
 
@@ -282,18 +312,49 @@ class Glm45Handler extends ChatTemplateHandler {
       final toolName = firstArgIdx == -1
           ? block.trim()
           : block.substring(0, firstArgIdx).trim();
+      if (firstArgIdx >= 0 &&
+          block
+              .substring(firstArgIdx)
+              .replaceAll(_argPairPattern, '')
+              .trim()
+              .isNotEmpty) {
+        return null;
+      }
+      final schema = schemas[toolName];
+      if (schemas.isNotEmpty && schema == null) {
+        return null;
+      }
+      final properties = schema == null ? null : schemaProperties(schema);
+      final required = schema == null
+          ? const <String>{}
+          : schemaRequired(schema);
       final args = <String, dynamic>{};
       for (final argMatch in _argPairPattern.allMatches(block)) {
         final key = (argMatch.group(1) ?? '').trim();
         final rawValue = (argMatch.group(2) ?? '').trim();
         if (key.isEmpty) {
-          continue;
+          return null;
         }
-        args[key] = _decodeArgValue(rawValue);
+        if (args.containsKey(key)) {
+          return null;
+        }
+        final propertySchema = properties?[key];
+        if (properties != null && propertySchema == null) {
+          return null;
+        }
+        if (propertySchema == null) {
+          args[key] = _decodeArgValue(rawValue);
+        } else {
+          final decoded = decodeToolSchemaText(rawValue, propertySchema);
+          if (!decoded.valid) {
+            return null;
+          }
+          args[key] = decoded.value;
+        }
       }
 
-      if (toolName.isEmpty) {
-        continue;
+      if (toolName.isEmpty || !args.keys.toSet().containsAll(required)) {
+        return null;
       }
 
       final index = toolCalls.length;
@@ -316,6 +377,21 @@ class Glm45Handler extends ChatTemplateHandler {
       remainingContent: remaining,
     );
   }
+}
+
+String _hideIncompleteToolCallBlock(String input) {
+  const marker = '<tool_call>';
+  final open = input.lastIndexOf(marker);
+  final close = input.lastIndexOf('</tool_call>');
+  if (open > close) {
+    return input.substring(0, open);
+  }
+  for (var length = 1; length < marker.length; length++) {
+    if (input.endsWith(marker.substring(0, length))) {
+      return input.substring(0, input.length - length);
+    }
+  }
+  return input;
 }
 
 class _ExtractedToolCalls {

--- a/lib/src/core/template/handlers/glm45_handler.dart
+++ b/lib/src/core/template/handlers/glm45_handler.dart
@@ -8,6 +8,7 @@ import '../chat_format.dart';
 import '../chat_parse_result.dart';
 import '../chat_template_handler.dart';
 import '../thinking_utils.dart';
+import '../tool_call_grammar_utils.dart';
 import '../tool_call_parsing_utils.dart';
 import '../tool_schema_utils.dart';
 
@@ -18,7 +19,8 @@ import '../tool_schema_utils.dart';
 /// `<tool_call>func_name<arg_key>key</arg_key><arg_value>value</arg_value></tool_call>`
 ///
 /// Supports `<think>`/`</think>` for reasoning.
-class Glm45Handler extends ChatTemplateHandler {
+class Glm45Handler extends ChatTemplateHandler
+    implements ToolSchemaAwareChatTemplateHandler {
   static final RegExp _toolCallBlockPattern = RegExp(
     r'<tool_call>\s*([\s\S]*?)</tool_call>',
   );
@@ -138,6 +140,7 @@ class Glm45Handler extends ChatTemplateHandler {
   }
 
   /// Parses GLM output using [tools] for schema-directed argument types.
+  @override
   ChatParseResult parseWithTools(
     String output, {
     List<ToolDefinition>? tools,
@@ -191,23 +194,25 @@ class Glm45Handler extends ChatTemplateHandler {
     final toolRules = <String>[];
 
     for (final tool in tools) {
-      final toolRuleName = '${_sanitizeRuleName(tool.name)}-call';
+      final toolRuleName = '${ToolCallGrammarUtils.ruleName(tool.name)}-call';
       toolChoiceRules.add(toolRuleName);
 
       final argParts = <String>[];
       for (final parameter in tool.parameters) {
         final paramSchema = parameter.toJsonSchema();
         final paramRuleName =
-            '${_sanitizeRuleName(tool.name)}-arg-${_sanitizeRuleName(parameter.name)}';
+            '${ToolCallGrammarUtils.ruleName(tool.name)}-arg-'
+            '${ToolCallGrammarUtils.ruleName(parameter.name)}';
         final valueRuleName =
-            '${_sanitizeRuleName(tool.name)}-arg-${_sanitizeRuleName(parameter.name)}-value';
+            '${ToolCallGrammarUtils.ruleName(tool.name)}-arg-'
+            '${ToolCallGrammarUtils.ruleName(parameter.name)}-value';
 
-        final valueRule = _buildValueRule(
+        final valueRules = _buildValueRules(
           valueRuleName: valueRuleName,
           schema: paramSchema,
         );
 
-        toolRules.add(valueRule);
+        toolRules.addAll(valueRules);
         toolRules.add(
           '$paramRuleName ::= "<arg_key>${_escapeLiteral(parameter.name)}</arg_key>\\n<arg_value>" $valueRuleName "</arg_value>\\n"',
         );
@@ -227,9 +232,6 @@ class Glm45Handler extends ChatTemplateHandler {
       'tool-call ::= "\\n<tool_call>" tool-choice "</tool_call>\\n"',
       toolChoiceRule,
       ...toolRules,
-      'raw-alpha ::= [A-Za-z]',
-      'raw-tail ::= [A-Za-z0-9_ ./:-]',
-      'raw-string ::= raw-alpha raw-tail*',
       'space ::= " "?',
       'string ::= "\\"" ([^"\\\\] | "\\\\" .)* "\\""',
       'number ::= "-"? ([0-9] | [1-9] [0-9]*) ("." [0-9]+)? ([eE] [+-]? [0-9]+)?',
@@ -241,7 +243,7 @@ class Glm45Handler extends ChatTemplateHandler {
     ].join('\n');
   }
 
-  String _buildValueRule({
+  List<String> _buildValueRules({
     required String valueRuleName,
     required Map<String, dynamic> schema,
   }) {
@@ -258,32 +260,31 @@ class Glm45Handler extends ChatTemplateHandler {
             .whereType<String>()
             .map((value) => '"\\"${_escapeLiteral(value)}\\""')
             .join(' | ');
-        return '$valueRuleName ::= $rawEnum | $jsonEnum';
+        return ['$valueRuleName ::= $rawEnum | $jsonEnum'];
       }
-      return '$valueRuleName ::= raw-string | string';
+      return [
+        '$valueRuleName ::= $valueRuleName-raw-0',
+        ..._glmUntilLiteralRules('$valueRuleName-raw', '</arg_value>'),
+      ];
     }
 
     if (type == 'integer' || type == 'number') {
-      return '$valueRuleName ::= number';
+      return ['$valueRuleName ::= number'];
     }
 
     if (type == 'boolean') {
-      return '$valueRuleName ::= boolean';
+      return ['$valueRuleName ::= boolean'];
     }
 
     if (type == 'array') {
-      return '$valueRuleName ::= arr';
+      return ['$valueRuleName ::= arr'];
     }
 
     if (type == 'object') {
-      return '$valueRuleName ::= obj';
+      return ['$valueRuleName ::= obj'];
     }
 
-    return '$valueRuleName ::= value';
-  }
-
-  String _sanitizeRuleName(String input) {
-    return input.replaceAll(RegExp(r'[^a-zA-Z0-9]'), '-').toLowerCase();
+    return ['$valueRuleName ::= value'];
   }
 
   String _escapeLiteral(String input) {
@@ -345,7 +346,7 @@ class Glm45Handler extends ChatTemplateHandler {
         if (propertySchema == null) {
           args[key] = _decodeArgValue(rawValue);
         } else {
-          final decoded = decodeToolSchemaText(rawValue, propertySchema);
+          final decoded = _decodeGlmSchemaText(rawValue, propertySchema);
           if (!decoded.valid) {
             return null;
           }
@@ -377,6 +378,75 @@ class Glm45Handler extends ChatTemplateHandler {
       remainingContent: remaining,
     );
   }
+}
+
+ToolSchemaValueResult _decodeGlmSchemaText(
+  String raw,
+  Map<String, dynamic> schema,
+) {
+  if (schemaResolvesToString(schema)) {
+    final decoded = ToolCallParsingUtils.decodeJsonValue(raw);
+    return validateToolSchemaValue(decoded is String ? decoded : raw, schema);
+  }
+  return decodeToolSchemaText(raw, schema);
+}
+
+List<String> _glmUntilLiteralRules(String ruleBase, String delimiter) {
+  final marker = delimiter.runes
+      .map(String.fromCharCode)
+      .toList(growable: false);
+  final alphabet = marker.toSet().toList(growable: false);
+  final lines = <String>[
+    '$ruleBase-other ::= [^${alphabet.map(_escapeGlmCharacterClass).join()}]',
+  ];
+  for (var state = 0; state < marker.length; state++) {
+    final alternatives = <String>['$ruleBase-other $ruleBase-0'];
+    for (final character in alphabet) {
+      final next = _glmDelimiterTransition(marker, state, character);
+      if (next == marker.length) {
+        continue;
+      }
+      alternatives.add(
+        '"${_escapeGlmLiteralCharacter(character)}" $ruleBase-$next',
+      );
+    }
+    lines.add('$ruleBase-$state ::= (${alternatives.join(' | ')})?');
+  }
+  return lines;
+}
+
+int _glmDelimiterTransition(List<String> marker, int state, String character) {
+  final candidate = <String>[...marker.take(state), character];
+  final max = candidate.length < marker.length
+      ? candidate.length
+      : marker.length;
+  for (var length = max; length >= 0; length--) {
+    var matches = true;
+    for (var index = 0; index < length; index++) {
+      if (candidate[candidate.length - length + index] != marker[index]) {
+        matches = false;
+        break;
+      }
+    }
+    if (matches) {
+      return length;
+    }
+  }
+  return 0;
+}
+
+String _escapeGlmCharacterClass(String character) {
+  return switch (character) {
+    r'\' => r'\\',
+    ']' => r'\]',
+    '-' => r'\-',
+    '^' => r'\^',
+    _ => character,
+  };
+}
+
+String _escapeGlmLiteralCharacter(String character) {
+  return character.replaceAll(r'\', r'\\').replaceAll('"', r'\"');
 }
 
 String _hideIncompleteToolCallBlock(String input) {

--- a/lib/src/core/template/handlers/glm45_handler.dart
+++ b/lib/src/core/template/handlers/glm45_handler.dart
@@ -398,7 +398,7 @@ bool _containsExactGlmProtocolMarker(String input) {
 
 bool _containsGlmProtocolRemainder(String input) {
   for (final marker in _glmProtocolMarkers) {
-    if (input.contains(marker.substring(0, marker.length - 1))) {
+    if (input.contains(marker)) {
       return true;
     }
   }

--- a/lib/src/core/template/handlers/llama_cpp_specialized_handlers.dart
+++ b/lib/src/core/template/handlers/llama_cpp_specialized_handlers.dart
@@ -805,7 +805,11 @@ class MuseGlimmerHandler extends _DirectJinjaHandler {
         );
       } else if (parseToolCalls) {
         final parsed = _parseAtemCalls(body, calls.length, schemas: schemas);
-        if (parsed == null) {
+        final routeMatchesCall =
+            parsed != null &&
+            parsed.length == 1 &&
+            parsed.single.function?.name == recipient;
+        if (!routeMatchesCall) {
           final terminator = match.group(3) ?? '';
           if (!isPartial || terminator.isNotEmpty) {
             lastContentCodeUnit = _appendMuseContent(
@@ -1558,7 +1562,7 @@ List<LlamaCompletionChunkToolCall>? _parseJsonObjectSequence(
       }
       final name = call['name'];
       final arguments = call['arguments'];
-      final schema = name is String ? schemas[name] : null;
+      final schema = name is String && name.isNotEmpty ? schemas[name] : null;
       if (schema == null || arguments is! Map) {
         return null;
       }

--- a/lib/src/core/template/handlers/llama_cpp_specialized_handlers.dart
+++ b/lib/src/core/template/handlers/llama_cpp_specialized_handlers.dart
@@ -767,23 +767,34 @@ class MuseGlimmerHandler extends _DirectJinjaHandler {
     final content = StringBuffer();
     final reasoning = StringBuffer();
     final calls = <LlamaCompletionChunkToolCall>[];
+    int? lastContentCodeUnit;
     var cursor = 0;
     for (final match in matches) {
-      _appendMuseContent(content, output.substring(cursor, match.start));
+      lastContentCodeUnit = _appendMuseContent(
+        content,
+        lastContentCodeUnit,
+        output.substring(cursor, match.start),
+      );
       final recipient = (match.group(1) ?? '').trim();
       final body = match.group(2) ?? '';
       if (recipient == 'self') {
         if (reasoning.isNotEmpty) reasoning.writeln();
         reasoning.write(body);
       } else if (recipient == 'user') {
-        _appendMuseContent(content, body, channelBody: true);
+        lastContentCodeUnit = _appendMuseContent(
+          content,
+          lastContentCodeUnit,
+          body,
+          channelBody: true,
+        );
       } else if (parseToolCalls) {
         final parsed = _parseAtemCalls(body, calls.length, schemas: schemas);
         if (parsed == null) {
           final terminator = match.group(3) ?? '';
           if (!isPartial || terminator.isNotEmpty) {
-            _appendMuseContent(
+            lastContentCodeUnit = _appendMuseContent(
               content,
+              lastContentCodeUnit,
               match.group(0) ?? body,
               channelBody: true,
             );
@@ -792,13 +803,19 @@ class MuseGlimmerHandler extends _DirectJinjaHandler {
           calls.addAll(parsed);
         }
       } else {
-        _appendMuseContent(content, body, channelBody: true);
+        lastContentCodeUnit = _appendMuseContent(
+          content,
+          lastContentCodeUnit,
+          body,
+          channelBody: true,
+        );
       }
       cursor = match.end;
     }
     final trailing = output.substring(cursor);
     _appendMuseContent(
       content,
+      lastContentCodeUnit,
       isPartial ? _hideIncompleteMuseRoute(trailing) : trailing,
     );
 
@@ -923,21 +940,23 @@ class LagunaHandler extends _DirectJinjaHandler {
   }
 }
 
-void _appendMuseContent(
+int? _appendMuseContent(
   StringBuffer content,
+  int? lastCodeUnit,
   String value, {
   bool channelBody = false,
 }) {
   if (value.isEmpty) {
-    return;
+    return lastCodeUnit;
   }
   if (channelBody &&
-      content.isNotEmpty &&
-      !_isWhitespace(content.toString().codeUnitAt(content.length - 1)) &&
+      lastCodeUnit != null &&
+      !_isWhitespace(lastCodeUnit) &&
       !_isWhitespace(value.codeUnitAt(0))) {
     content.writeln();
   }
   content.write(value);
+  return value.codeUnitAt(value.length - 1);
 }
 
 String _hideIncompleteMuseRoute(String input) {
@@ -1013,11 +1032,12 @@ class _KimiK3GrammarBuilder {
         ...requiredRules,
         ...optionalRules.map((rule) => '($rule)?'),
       ].join(' ');
+      final rawArgumentsRule = rawArguments.isEmpty ? '""' : rawArguments;
       final arguments = properties.isEmpty
           ? '(kimi-empty-arguments | kimi-json-$toolIndex)'
           : '(kimi-raw-$toolIndex | kimi-json-$toolIndex)';
       _rules
-        ..add('kimi-raw-$toolIndex ::= $rawArguments')
+        ..add('kimi-raw-$toolIndex ::= $rawArgumentsRule')
         ..add(
           'kimi-json-$toolIndex ::= '
           '${ToolCallGrammarUtils.literal('<|open|>json type="object"<|sep|>')} '

--- a/lib/src/core/template/handlers/llama_cpp_specialized_handlers.dart
+++ b/lib/src/core/template/handlers/llama_cpp_specialized_handlers.dart
@@ -1011,7 +1011,7 @@ class _KimiK3GrammarBuilder {
       final jsonRule = _converter.visit(schema, 'kimi-tool-$toolIndex-json');
       final rawArguments = <String>[
         ...requiredRules,
-        if (optionalRules.isNotEmpty) '(${optionalRules.join(' | ')})*',
+        ...optionalRules.map((rule) => '($rule)?'),
       ].join(' ');
       final arguments = properties.isEmpty
           ? '(kimi-empty-arguments | kimi-json-$toolIndex)'
@@ -1142,8 +1142,7 @@ class _MinimaxM3GrammarBuilder {
     }
     return <String>[
       ...requiredMembers.map((rule) => '$rule m3-space'),
-      if (optionalMembers.isNotEmpty)
-        '((${optionalMembers.join(' | ')}) m3-space)*',
+      ...optionalMembers.map((rule) => '($rule m3-space)?'),
     ].join(' ');
   }
 
@@ -1229,8 +1228,7 @@ class _DsmlGrammarBuilder {
 
       final arguments = <String>[
         ...requiredRules.map((rule) => '$rule dsml-space'),
-        if (optionalRules.isNotEmpty)
-          '((${optionalRules.join(' | ')}) dsml-space)*',
+        ...optionalRules.map((rule) => '($rule dsml-space)?'),
       ].join(' ');
 
       final toolRule = 'dsml-tool-$toolIndex';
@@ -1310,8 +1308,7 @@ class _MuseGrammarBuilder {
 
       final arguments = <String>[
         ...requiredRules.map((rule) => '$rule muse-space'),
-        if (optionalRules.isNotEmpty)
-          '((${optionalRules.join(' | ')}) muse-space)*',
+        ...optionalRules.map((rule) => '($rule muse-space)?'),
       ].join(' ');
 
       final toolRule = 'muse-tool-$toolIndex';

--- a/lib/src/core/template/handlers/llama_cpp_specialized_handlers.dart
+++ b/lib/src/core/template/handlers/llama_cpp_specialized_handlers.dart
@@ -1080,9 +1080,15 @@ class _KimiK3GrammarBuilder {
 
       _converter.resolveRefs(schema, schema);
       final jsonRule = _converter.visit(schema, 'kimi-tool-$toolIndex-json');
+      final optionalArguments = _addOptionalStateRules(
+        _rules,
+        'kimi-tool-$toolIndex-optional',
+        optionalRules,
+        separator: '',
+      );
       final rawArguments = <String>[
         ...requiredRules,
-        ...optionalRules.map((rule) => '($rule)?'),
+        ?optionalArguments,
       ].join(' ');
       final rawArgumentsRule = rawArguments.isEmpty ? '""' : rawArguments;
       final arguments = properties.isEmpty
@@ -1218,9 +1224,15 @@ class _MinimaxM3GrammarBuilder {
         rule,
       );
     }
+    final optionalState = _addOptionalStateRules(
+      _rules,
+      '$prefix-optional',
+      optionalMembers,
+      separator: 'm3-space',
+    );
     return <String>[
       ...requiredMembers.map((rule) => '$rule m3-space'),
-      ...optionalMembers.map((rule) => '($rule m3-space)?'),
+      ?optionalState,
     ].join(' ');
   }
 
@@ -1316,9 +1328,15 @@ class _DsmlGrammarBuilder {
         );
       }
 
+      final optionalState = _addOptionalStateRules(
+        _rules,
+        'dsml-tool-$toolIndex-optional',
+        optionalRules,
+        separator: 'dsml-space',
+      );
       final arguments = <String>[
         ...requiredRules.map((rule) => '$rule dsml-space'),
-        ...optionalRules.map((rule) => '($rule dsml-space)?'),
+        ?optionalState,
       ].join(' ');
 
       final toolRule = 'dsml-tool-$toolIndex';
@@ -1404,9 +1422,15 @@ class _MuseGrammarBuilder {
         );
       }
 
+      final optionalState = _addOptionalStateRules(
+        _rules,
+        'muse-tool-$toolIndex-optional',
+        optionalRules,
+        separator: 'muse-space',
+      );
       final arguments = <String>[
         ...requiredRules.map((rule) => '$rule muse-space'),
-        ...optionalRules.map((rule) => '($rule muse-space)?'),
+        ?optionalState,
       ].join(' ');
 
       final toolRule = 'muse-tool-$toolIndex';
@@ -1461,6 +1485,52 @@ class _MuseGrammarBuilder {
     _appendJsonRules(buffer, _converter);
     return buffer.toString();
   }
+}
+
+String? _addOptionalStateRules(
+  List<String> rules,
+  String prefix,
+  List<String> optionalRules, {
+  required String separator,
+}) {
+  if (optionalRules.isEmpty) {
+    return null;
+  }
+
+  final visited = <String>{};
+  String stateName(List<int> remaining) {
+    if (remaining.length == optionalRules.length) {
+      return prefix;
+    }
+    return remaining.isEmpty
+        ? '$prefix-done'
+        : '$prefix-${remaining.join('-')}';
+  }
+
+  void addState(List<int> remaining) {
+    final name = stateName(remaining);
+    if (!visited.add(name)) {
+      return;
+    }
+    if (remaining.isEmpty) {
+      rules.add('$name ::= ""');
+      return;
+    }
+
+    final alternatives = <String>['""'];
+    for (final index in remaining) {
+      final next = <int>[...remaining]..remove(index);
+      addState(next);
+      final continuation = separator.isEmpty
+          ? stateName(next)
+          : '$separator ${stateName(next)}';
+      alternatives.add('${optionalRules[index]} $continuation');
+    }
+    rules.add('$name ::= ${alternatives.join(' | ')}');
+  }
+
+  addState(List<int>.generate(optionalRules.length, (index) => index));
+  return prefix;
 }
 
 String _withRequiredPrefix(
@@ -2066,6 +2136,7 @@ void _requireUniqueToolNames(
         'schema-exact parser route. Use unique tool names.',
       );
     }
+    validateToolParameterIdentities(tool);
   }
 }
 

--- a/lib/src/core/template/handlers/llama_cpp_specialized_handlers.dart
+++ b/lib/src/core/template/handlers/llama_cpp_specialized_handlers.dart
@@ -265,10 +265,12 @@ class KimiK3Handler extends _DirectJinjaHandler {
 
     final calls = <LlamaCompletionChunkToolCall>[];
     for (final match in matches) {
-      final name = _unescapeAttribute(match.group(1) ?? '');
+      final name = _decodeCanonicalAttribute(match.group(1) ?? '');
       final callBody = match.group(2) ?? '';
-      final schema = schemas[name];
-      if (name.isEmpty || (schemas.isNotEmpty && schema == null)) {
+      final schema = name == null ? null : schemas[name];
+      if (name == null ||
+          name.isEmpty ||
+          (schemas.isNotEmpty && schema == null)) {
         return _ParsedCalls.failure();
       }
       final arguments = _parseKimiArguments(callBody, schema: schema);
@@ -322,11 +324,12 @@ class KimiK3Handler extends _DirectJinjaHandler {
     final result = <String, dynamic>{};
     final properties = schema == null ? null : schemaProperties(schema);
     for (final match in argumentPattern.allMatches(body)) {
-      final key = _unescapeAttribute(match.group(1) ?? '');
+      final key = _decodeCanonicalAttribute(match.group(1) ?? '');
       final type = match.group(2) ?? '';
       final raw = match.group(3) ?? '';
-      final propertySchema = properties?[key];
-      if (key.isEmpty ||
+      final propertySchema = key == null ? null : properties?[key];
+      if (key == null ||
+          key.isEmpty ||
           result.containsKey(key) ||
           (properties != null && propertySchema == null) ||
           (propertySchema != null && type != _kimiTypeName(propertySchema))) {
@@ -1628,7 +1631,10 @@ _ParsedCalls _parseInvokeScope(
     if (end < 0) {
       return allowPartial ? partialResult() : _ParsedCalls.failure();
     }
-    final name = _unescapeAttribute(start.group(1) ?? '');
+    final name = _decodeCanonicalAttribute(start.group(1) ?? '');
+    if (name == null) {
+      return allowPartial ? partialResult() : _ParsedCalls.failure();
+    }
     final arguments = parseArguments(name, body.substring(argumentsStart, end));
     if (name.isEmpty || arguments == null) {
       return allowPartial ? partialResult() : _ParsedCalls.failure();
@@ -1860,11 +1866,12 @@ Map<String, dynamic>? _parseDsmlArguments(
   final result = <String, dynamic>{};
   final properties = schema == null ? null : schemaProperties(schema);
   for (final match in pattern.allMatches(body)) {
-    final key = _unescapeAttribute(match.group(1) ?? '');
+    final key = _decodeCanonicalAttribute(match.group(1) ?? '');
     final stringAttribute = match.group(2) == 'true';
     final raw = match.group(3) ?? '';
-    final propertySchema = properties?[key];
-    if (key.isEmpty ||
+    final propertySchema = key == null ? null : properties?[key];
+    if (key == null ||
+        key.isEmpty ||
         result.containsKey(key) ||
         (properties != null && propertySchema == null) ||
         (propertySchema != null &&
@@ -1922,7 +1929,10 @@ List<LlamaCompletionChunkToolCall>? _parseAtemCalls(
   }
   final calls = <LlamaCompletionChunkToolCall>[];
   for (final invoke in invokePattern.allMatches(scope)) {
-    final name = _unescapeAttribute(invoke.group(1) ?? '');
+    final name = _decodeCanonicalAttribute(invoke.group(1) ?? '');
+    if (name == null) {
+      return null;
+    }
     final schema = schemas[name];
     if (schemas.isNotEmpty && schema == null) {
       return null;
@@ -1939,9 +1949,9 @@ List<LlamaCompletionChunkToolCall>? _parseAtemCalls(
     }
     final arguments = <String, dynamic>{};
     for (final parameter in parameterPattern.allMatches(params)) {
-      final key = _unescapeAttribute(parameter.group(1) ?? '');
+      final key = _decodeCanonicalAttribute(parameter.group(1) ?? '');
       final raw = parameter.group(2) ?? '';
-      if (key.isEmpty || arguments.containsKey(key)) {
+      if (key == null || key.isEmpty || arguments.containsKey(key)) {
         return null;
       }
       final propertySchema = properties?[key];
@@ -1977,6 +1987,11 @@ String _unescapeAttribute(String value) => value
     .replaceAll('&lt;', '<')
     .replaceAll('&gt;', '>')
     .replaceAll('&amp;', '&');
+
+String? _decodeCanonicalAttribute(String value) {
+  final decoded = _unescapeAttribute(value);
+  return _escapeAttribute(decoded) == value ? decoded : null;
+}
 
 String _escapeAttribute(String value) => value
     .replaceAll('&', '&amp;')

--- a/lib/src/core/template/handlers/llama_cpp_specialized_handlers.dart
+++ b/lib/src/core/template/handlers/llama_cpp_specialized_handlers.dart
@@ -670,6 +670,7 @@ abstract class _DeepseekDsmlHandler extends _DirectJinjaHandler
     final thinking = _extractDsmlThinking(
       output,
       callsStart: _callsStart,
+      isPartial: isPartial,
       thinkingForcedOpen: thinkingForcedOpen,
     );
     if (!parseToolCalls) {
@@ -1986,6 +1987,7 @@ bool _haveUniqueElementNames(List<_DynamicElement> elements) {
 ThinkingExtraction _extractDsmlThinking(
   String output, {
   required String callsStart,
+  required bool isPartial,
   required bool thinkingForcedOpen,
 }) {
   if (thinkingForcedOpen) {
@@ -1998,8 +2000,46 @@ ThinkingExtraction _extractDsmlThinking(
         reasoning: reasoning.isEmpty ? null : reasoning,
       );
     }
+    if (isPartial) {
+      if (thinkEndIndex >= 0 || output.contains('<think>')) {
+        final thinking = extractThinking(
+          output,
+          thinkingForcedOpen: thinkingForcedOpen,
+        );
+        final pendingMarkerLength = _matchingDelimiterPrefixSuffixLength(
+          thinking.content,
+          callsStart,
+        );
+        return (
+          content: thinking.content
+              .substring(0, thinking.content.length - pendingMarkerLength)
+              .trim(),
+          reasoning: thinking.reasoning,
+        );
+      }
+      final pendingMarkerLength = _matchingDelimiterPrefixSuffixLength(
+        output,
+        callsStart,
+      );
+      final reasoning = output
+          .substring(0, output.length - pendingMarkerLength)
+          .trim();
+      return (content: '', reasoning: reasoning.isEmpty ? null : reasoning);
+    }
   }
   return extractThinking(output, thinkingForcedOpen: thinkingForcedOpen);
+}
+
+int _matchingDelimiterPrefixSuffixLength(String input, String delimiter) {
+  final maxLength = input.length < delimiter.length - 1
+      ? input.length
+      : delimiter.length - 1;
+  for (var length = maxLength; length > 0; length--) {
+    if (input.endsWith(delimiter.substring(0, length))) {
+      return length;
+    }
+  }
+  return 0;
 }
 
 Map<String, dynamic>? _parseDsmlArguments(

--- a/lib/src/core/template/handlers/llama_cpp_specialized_handlers.dart
+++ b/lib/src/core/template/handlers/llama_cpp_specialized_handlers.dart
@@ -670,6 +670,7 @@ abstract class _DeepseekDsmlHandler extends _DirectJinjaHandler {
         reasoningContent: thinking.reasoning,
       );
     }
+    final schemas = toolSchemas(tools);
     final parsed = _parseInvokeScope(
       thinking.content,
       scopeStart: _callsStart,
@@ -677,7 +678,6 @@ abstract class _DeepseekDsmlHandler extends _DirectJinjaHandler {
       invokeStartPattern: RegExp(r'<｜DSML｜invoke name="([^"]+)">'),
       invokeEnd: '</｜DSML｜invoke>',
       parseArguments: (name, body) {
-        final schemas = toolSchemas(tools);
         final schema = schemas[name];
         if (schemas.isNotEmpty && schema == null) {
           return null;
@@ -1532,6 +1532,9 @@ bool _endsWithCharacters(List<String> value, List<String> suffix) {
 String _escapeGbnfCharClass(String character) {
   return switch (character) {
     r'\' => r'\\',
+    '\n' => r'\n',
+    '\r' => r'\r',
+    '\t' => r'\t',
     ']' => r'\]',
     '^' => r'\^',
     '-' => r'\-',

--- a/lib/src/core/template/handlers/llama_cpp_specialized_handlers.dart
+++ b/lib/src/core/template/handlers/llama_cpp_specialized_handlers.dart
@@ -96,7 +96,8 @@ abstract class _DirectJinjaHandler extends ChatTemplateHandler {
 }
 
 /// Handler for Kimi K3's XTML response and typed tool-call protocol.
-class KimiK3Handler extends _DirectJinjaHandler {
+class KimiK3Handler extends _DirectJinjaHandler
+    implements ToolSchemaAwareChatTemplateHandler {
   static const _open = '<|open|>';
   static const _close = '<|close|>';
   static const _sep = '<|sep|>';
@@ -157,6 +158,7 @@ class KimiK3Handler extends _DirectJinjaHandler {
   }
 
   /// Parses Kimi K3 output using [tools] to validate emitted names and values.
+  @override
   ChatParseResult parseWithTools(
     String output, {
     List<ToolDefinition>? tools,
@@ -379,7 +381,8 @@ class KimiK3Handler extends _DirectJinjaHandler {
 }
 
 /// Handler for MiniMax M1 newline-delimited JSON tool calls.
-class MinimaxM1Handler extends _DirectJinjaHandler {
+class MinimaxM1Handler extends _DirectJinjaHandler
+    implements ToolSchemaAwareChatTemplateHandler {
   @override
   ChatFormat get format => ChatFormat.minimaxM1;
 
@@ -412,6 +415,7 @@ class MinimaxM1Handler extends _DirectJinjaHandler {
   }
 
   /// Parses MiniMax M1 output using [tools] to validate emitted call objects.
+  @override
   ChatParseResult parseWithTools(
     String output, {
     List<ToolDefinition>? tools,
@@ -490,7 +494,8 @@ class MinimaxM1Handler extends _DirectJinjaHandler {
 }
 
 /// Handler for MiniMax M3 namespaced XML tool calls.
-class MinimaxM3Handler extends _DirectJinjaHandler {
+class MinimaxM3Handler extends _DirectJinjaHandler
+    implements ToolSchemaAwareChatTemplateHandler {
   /// Namespace prefix emitted before every MiniMax M3 tool tag.
   static const namespace = ']<]minimax[>[';
 
@@ -532,6 +537,7 @@ class MinimaxM3Handler extends _DirectJinjaHandler {
   }
 
   /// Parses MiniMax M3 output using [tools] for schema-directed argument types.
+  @override
   ChatParseResult parseWithTools(
     String output, {
     List<ToolDefinition>? tools,
@@ -613,7 +619,8 @@ class MinimaxM3Handler extends _DirectJinjaHandler {
   }
 }
 
-abstract class _DeepseekDsmlHandler extends _DirectJinjaHandler {
+abstract class _DeepseekDsmlHandler extends _DirectJinjaHandler
+    implements ToolSchemaAwareChatTemplateHandler {
   static const _prefix = '<｜DSML｜';
 
   String get _callsEnvelope;
@@ -652,6 +659,7 @@ abstract class _DeepseekDsmlHandler extends _DirectJinjaHandler {
   }
 
   /// Parses DSML output using [tools] to enforce exact emitted schemas.
+  @override
   ChatParseResult parseWithTools(
     String output, {
     List<ToolDefinition>? tools,
@@ -726,7 +734,8 @@ class DeepseekV4Handler extends _DeepseekDsmlHandler {
 }
 
 /// Handler for Muse Glimmer recipient channels and ATEM tool calls.
-class MuseGlimmerHandler extends _DirectJinjaHandler {
+class MuseGlimmerHandler extends _DirectJinjaHandler
+    implements ToolSchemaAwareChatTemplateHandler {
   @override
   ChatFormat get format => ChatFormat.museGlimmer;
 
@@ -762,6 +771,7 @@ class MuseGlimmerHandler extends _DirectJinjaHandler {
   }
 
   /// Parses Muse output using [tools] for schema-directed argument types.
+  @override
   ChatParseResult parseWithTools(
     String output, {
     List<ToolDefinition>? tools,
@@ -871,7 +881,8 @@ class MuseGlimmerHandler extends _DirectJinjaHandler {
 }
 
 /// Poolside Laguna uses GLM-style argument tags with a distinct turn stop.
-class LagunaHandler extends _DirectJinjaHandler {
+class LagunaHandler extends _DirectJinjaHandler
+    implements ToolSchemaAwareChatTemplateHandler {
   @override
   ChatFormat get format => ChatFormat.laguna;
 
@@ -910,6 +921,7 @@ class LagunaHandler extends _DirectJinjaHandler {
   }
 
   /// Parses Laguna output using [tools] for schema-directed argument types.
+  @override
   ChatParseResult parseWithTools(
     String output, {
     List<ToolDefinition>? tools,

--- a/lib/src/core/template/handlers/llama_cpp_specialized_handlers.dart
+++ b/lib/src/core/template/handlers/llama_cpp_specialized_handlers.dart
@@ -1084,6 +1084,8 @@ class _KimiK3GrammarBuilder {
         _rules,
         'kimi-tool-$toolIndex-optional',
         optionalRules,
+        format: 'Kimi K3',
+        schemaPath: 'tool "${tool.name}" arguments',
         separator: '',
       );
       final rawArguments = <String>[
@@ -1175,7 +1177,11 @@ class _MinimaxM3GrammarBuilder {
         kind: 'tool',
       );
       final schema = tool.toJsonSchema();
-      final arguments = _members(schema, 'm3-tool-$toolIndex-arg');
+      final arguments = _members(
+        schema,
+        'm3-tool-$toolIndex-arg',
+        schemaPath: 'tool "${tool.name}" arguments',
+      );
       final toolRule = 'm3-tool-$toolIndex';
       _rules.add(
         '$toolRule ::= '
@@ -1208,7 +1214,11 @@ class _MinimaxM3GrammarBuilder {
         : grammar;
   }
 
-  String _members(Map<String, dynamic> schema, String prefix) {
+  String _members(
+    Map<String, dynamic> schema,
+    String prefix, {
+    required String schemaPath,
+  }) {
     final properties = schemaProperties(schema);
     final required = schemaRequired(schema);
     final requiredMembers = <String>[];
@@ -1219,6 +1229,7 @@ class _MinimaxM3GrammarBuilder {
         entry.key,
         entry.value,
         '$prefix-${propertyIndex++}',
+        schemaPath: '$schemaPath.${entry.key}',
       );
       (required.contains(entry.key) ? requiredMembers : optionalMembers).add(
         rule,
@@ -1228,6 +1239,8 @@ class _MinimaxM3GrammarBuilder {
       _rules,
       '$prefix-optional',
       optionalMembers,
+      format: 'MiniMax M3',
+      schemaPath: schemaPath,
       separator: 'm3-space',
     );
     return <String>[
@@ -1236,10 +1249,20 @@ class _MinimaxM3GrammarBuilder {
     ].join(' ');
   }
 
-  String _element(String tag, Map<String, dynamic> schema, String rule) {
+  String _element(
+    String tag,
+    Map<String, dynamic> schema,
+    String rule, {
+    required String schemaPath,
+  }) {
     _requireDynamicTagName(tag, format: 'MiniMax M3');
     final closingText = '$_namespace</$tag>';
-    final valueRule = _value(schema, '$rule-value', closingText);
+    final valueRule = _value(
+      schema,
+      '$rule-value',
+      closingText,
+      schemaPath: schemaPath,
+    );
     _rules.add(
       '$rule ::= ${ToolCallGrammarUtils.literal('$_namespace<$tag>')} '
       '$valueRule ${ToolCallGrammarUtils.literal(closingText)}',
@@ -1250,19 +1273,21 @@ class _MinimaxM3GrammarBuilder {
   String _value(
     Map<String, dynamic> schema,
     String prefix,
-    String closingText,
-  ) {
+    String closingText, {
+    required String schemaPath,
+  }) {
     if (schemaResolvesToString(schema)) {
       return _addUntilRules(_rules, '$prefix-string', closingText);
     }
     if (schema['type'] == 'object') {
-      return _members(schema, '$prefix-member');
+      return _members(schema, '$prefix-member', schemaPath: schemaPath);
     }
     if (schema['type'] == 'array' && schema['items'] is Map) {
       final item = _element(
         'item',
         Map<String, dynamic>.from(schema['items'] as Map),
         '$prefix-item',
+        schemaPath: '$schemaPath[]',
       );
       return '($item m3-space)*';
     }
@@ -1332,6 +1357,8 @@ class _DsmlGrammarBuilder {
         _rules,
         'dsml-tool-$toolIndex-optional',
         optionalRules,
+        format: 'DeepSeek DSML',
+        schemaPath: 'tool "${tool.name}" arguments',
         separator: 'dsml-space',
       );
       final arguments = <String>[
@@ -1426,6 +1453,8 @@ class _MuseGrammarBuilder {
         _rules,
         'muse-tool-$toolIndex-optional',
         optionalRules,
+        format: 'Muse Glimmer',
+        schemaPath: 'tool "${tool.name}" arguments',
         separator: 'muse-space',
       );
       final arguments = <String>[
@@ -1491,10 +1520,23 @@ String? _addOptionalStateRules(
   List<String> rules,
   String prefix,
   List<String> optionalRules, {
+  required String format,
+  required String schemaPath,
   required String separator,
 }) {
   if (optionalRules.isEmpty) {
     return null;
+  }
+  // Each optional property doubles the subset-state count. Ten properties cap
+  // one object at 1,024 states and 5,120 non-empty transitions.
+  const maxOptionalProperties = 10;
+  if (optionalRules.length > maxOptionalProperties) {
+    throw LlamaUnsupportedException(
+      '$format grammar supports at most $maxOptionalProperties optional '
+      'properties per object because duplicate-safe any-order grammar states '
+      'grow exponentially; $schemaPath declares ${optionalRules.length}. '
+      'Make additional properties required or reduce the object schema.',
+    );
   }
 
   final visited = <String>{};

--- a/lib/src/core/template/handlers/llama_cpp_specialized_handlers.dart
+++ b/lib/src/core/template/handlers/llama_cpp_specialized_handlers.dart
@@ -539,7 +539,6 @@ class MinimaxM3Handler extends _DirectJinjaHandler {
     bool parseToolCalls = true,
     bool thinkingForcedOpen = false,
   }) {
-    final schemas = toolSchemas(tools);
     final thinking = extractThinking(
       output,
       startTag: thinkingStartTag,
@@ -552,6 +551,7 @@ class MinimaxM3Handler extends _DirectJinjaHandler {
         reasoningContent: thinking.reasoning,
       );
     }
+    final schemas = toolSchemas(tools);
     final rawContent = thinking.content;
     const namespacedScopeStart = '$namespace<tool_call>';
     const namespacedScopeEnd = '$namespace</tool_call>';
@@ -769,7 +769,9 @@ class MuseGlimmerHandler extends _DirectJinjaHandler {
     bool parseToolCalls = true,
     bool thinkingForcedOpen = false,
   }) {
-    final schemas = toolSchemas(tools);
+    final schemas = parseToolCalls
+        ? toolSchemas(tools)
+        : const <String, Map<String, dynamic>>{};
     final channelPattern = RegExp(
       r'(?:<\|start\|>assistant)?\s+to=([^<]+)<\|message\|>([\s\S]*?)(<\|eom\|>|<\|eot\|>|$)',
     );
@@ -1032,7 +1034,7 @@ class _KimiK3GrammarBuilder {
       _requireNonEmptyProtocolName(tool.name, format: 'Kimi K3', kind: 'tool');
       final schema = tool.toJsonSchema();
       final properties = schemaProperties(schema);
-      final required = schemaRequired(schema);
+      final requiredNames = schemaRequired(schema);
       final requiredRules = <String>[];
       final optionalRules = <String>[];
       var propertyIndex = 0;
@@ -1059,7 +1061,7 @@ class _KimiK3GrammarBuilder {
           '$argumentRule ::= ${ToolCallGrammarUtils.literal(opening)} '
           '$valueRule ${ToolCallGrammarUtils.literal(close)}',
         );
-        (required.contains(entry.key) ? requiredRules : optionalRules).add(
+        (requiredNames.contains(entry.key) ? requiredRules : optionalRules).add(
           argumentRule,
         );
       }

--- a/lib/src/core/template/handlers/llama_cpp_specialized_handlers.dart
+++ b/lib/src/core/template/handlers/llama_cpp_specialized_handlers.dart
@@ -1685,6 +1685,11 @@ List<LlamaCompletionChunkToolCall>? _parseJsonObjectSequence(
     if (slice == null || slice.value is! Map) {
       return null;
     }
+    if (!ToolCallParsingUtils.hasUniqueJsonObjectKeys(
+      body.substring(cursor, slice.end),
+    )) {
+      return null;
+    }
     if (schemas.isEmpty) {
       final parsed = ToolCallParsingUtils.parseToolCallArray(<Object?>[
         slice.value,

--- a/lib/src/core/template/handlers/llama_cpp_specialized_handlers.dart
+++ b/lib/src/core/template/handlers/llama_cpp_specialized_handlers.dart
@@ -2045,6 +2045,7 @@ void _requireUniqueToolNames(
 }) {
   final names = <String>{};
   for (final tool in tools) {
+    _requireNonEmptyProtocolName(tool.name, format: format, kind: 'tool');
     if (!names.add(tool.name)) {
       throw LlamaUnsupportedException(
         '$format cannot bind duplicate tool name "${tool.name}" to one '

--- a/lib/src/core/template/handlers/llama_cpp_specialized_handlers.dart
+++ b/lib/src/core/template/handlers/llama_cpp_specialized_handlers.dart
@@ -2,6 +2,7 @@ import 'dart:convert';
 
 import 'package:dinja/dinja.dart';
 
+import '../../exceptions.dart';
 import '../../grammar/json_schema_converter.dart';
 import '../../models/chat/chat_message.dart';
 import '../../models/chat/chat_template_result.dart';
@@ -235,7 +236,12 @@ class KimiK3Handler extends _DirectJinjaHandler {
   }) {
     final scopeStart = input.indexOf(_toolsStart);
     if (scopeStart < 0) {
-      return _ParsedCalls(calls: const [], remaining: _stripKimiTurnEnd(input));
+      return _ParsedCalls(
+        calls: const [],
+        remaining: _stripKimiTurnEnd(
+          isPartial ? _hideIncompleteProtocolSuffix(input, _toolsStart) : input,
+        ),
+      );
     }
     final bodyStart = scopeStart + _toolsStart.length;
     final scopeEnd = input.indexOf(_toolsEnd, bodyStart);
@@ -417,7 +423,11 @@ class MinimaxM1Handler extends _DirectJinjaHandler {
     const end = '</tool_calls>';
     final startIndex = output.indexOf(start);
     if (startIndex < 0) {
-      return ChatParseResult(content: output.trim());
+      return ChatParseResult(
+        content:
+            (isPartial ? _hideIncompleteProtocolSuffix(output, start) : output)
+                .trim(),
+      );
     }
     final endIndex = output.indexOf(end, startIndex + start.length);
     if (endIndex < 0) {
@@ -446,6 +456,7 @@ class MinimaxM1Handler extends _DirectJinjaHandler {
     if (tools == null || tools.isEmpty) {
       return null;
     }
+    _requireUniqueToolNames(tools, format: 'MiniMax M1');
 
     final converter = JsonSchemaConverter();
     final callRules = <String>[];
@@ -544,7 +555,9 @@ class MinimaxM3Handler extends _DirectJinjaHandler {
     final scopeStartIndex = rawContent.indexOf(namespacedScopeStart);
     if (scopeStartIndex < 0) {
       return ChatParseResult(
-        content: rawContent,
+        content: isPartial
+            ? _hideIncompleteProtocolSuffix(rawContent, namespacedScopeStart)
+            : rawContent,
         reasoningContent: thinking.reasoning,
       );
     }
@@ -992,11 +1005,13 @@ class _KimiK3GrammarBuilder {
     if (resolvedTools == null || resolvedTools.isEmpty) {
       return null;
     }
+    _requireUniqueToolNames(resolvedTools, format: 'Kimi K3');
 
     final callRules = <String>[];
     String? stringValueRule;
     for (var toolIndex = 0; toolIndex < resolvedTools.length; toolIndex++) {
       final tool = resolvedTools[toolIndex];
+      _requireNonEmptyProtocolName(tool.name, format: 'Kimi K3', kind: 'tool');
       final schema = tool.toJsonSchema();
       final properties = schemaProperties(schema);
       final required = schemaRequired(schema);
@@ -1004,6 +1019,11 @@ class _KimiK3GrammarBuilder {
       final optionalRules = <String>[];
       var propertyIndex = 0;
       for (final entry in properties.entries) {
+        _requireNonEmptyProtocolName(
+          entry.key,
+          format: 'Kimi K3',
+          kind: 'parameter',
+        );
         final argumentRule = 'kimi-tool-$toolIndex-arg-${propertyIndex++}';
         final typeName = _kimiTypeName(entry.value);
         const close = '<|close|>argument<|sep|>';
@@ -1107,15 +1127,21 @@ class _MinimaxM3GrammarBuilder {
     if (resolvedTools == null || resolvedTools.isEmpty) {
       return null;
     }
+    _requireUniqueToolNames(resolvedTools, format: 'MiniMax M3');
     final toolRules = <String>[];
     for (var toolIndex = 0; toolIndex < resolvedTools.length; toolIndex++) {
       final tool = resolvedTools[toolIndex];
+      _requireNonEmptyProtocolName(
+        tool.name,
+        format: 'MiniMax M3',
+        kind: 'tool',
+      );
       final schema = tool.toJsonSchema();
       final arguments = _members(schema, 'm3-tool-$toolIndex-arg');
       final toolRule = 'm3-tool-$toolIndex';
       _rules.add(
         '$toolRule ::= '
-        '${ToolCallGrammarUtils.literal('$_namespace<invoke name="${tool.name}">')} '
+        '${ToolCallGrammarUtils.literal('$_namespace<invoke name="${_escapeAttribute(tool.name)}">')} '
         'm3-space $arguments m3-space '
         '${ToolCallGrammarUtils.literal('$_namespace</invoke>')} m3-space',
       );
@@ -1167,6 +1193,7 @@ class _MinimaxM3GrammarBuilder {
   }
 
   String _element(String tag, Map<String, dynamic> schema, String rule) {
+    _requireDynamicTagName(tag, format: 'MiniMax M3');
     final closingText = '$_namespace</$tag>';
     final valueRule = _value(schema, '$rule-value', closingText);
     _rules.add(
@@ -1214,12 +1241,18 @@ class _DsmlGrammarBuilder {
     if (resolvedTools == null || resolvedTools.isEmpty) {
       return null;
     }
+    _requireUniqueToolNames(resolvedTools, format: 'DeepSeek DSML');
 
     final callsStart = '<$_prefix$envelope>';
     final callsEnd = '</$_prefix$envelope>';
     final toolRules = <String>[];
     for (var toolIndex = 0; toolIndex < resolvedTools.length; toolIndex++) {
       final tool = resolvedTools[toolIndex];
+      _requireNonEmptyProtocolName(
+        tool.name,
+        format: 'DeepSeek DSML',
+        kind: 'tool',
+      );
       final schema = tool.toJsonSchema();
       _converter.resolveRefs(schema, schema);
       final properties = schemaProperties(schema);
@@ -1228,6 +1261,11 @@ class _DsmlGrammarBuilder {
       final optionalRules = <String>[];
       var propertyIndex = 0;
       for (final entry in properties.entries) {
+        _requireNonEmptyProtocolName(
+          entry.key,
+          format: 'DeepSeek DSML',
+          kind: 'parameter',
+        );
         final argumentRule = 'dsml-tool-$toolIndex-arg-${propertyIndex++}';
         final isString = schemaResolvesToString(entry.value);
         const close = '</｜DSML｜parameter>';
@@ -1235,7 +1273,7 @@ class _DsmlGrammarBuilder {
             ? _addUntilRules(_rules, '$argumentRule-string', close)
             : _converter.visit(entry.value, '$argumentRule-value');
         final opening =
-            '<｜DSML｜parameter name="${entry.key}" '
+            '<｜DSML｜parameter name="${_escapeAttribute(entry.key)}" '
             'string="${isString ? 'true' : 'false'}">';
         _rules.add(
           '$argumentRule ::= ${ToolCallGrammarUtils.literal(opening)} '
@@ -1254,7 +1292,7 @@ class _DsmlGrammarBuilder {
       final toolRule = 'dsml-tool-$toolIndex';
       _rules.add(
         '$toolRule ::= '
-        '${ToolCallGrammarUtils.literal('<｜DSML｜invoke name="${tool.name}">')} '
+        '${ToolCallGrammarUtils.literal('<｜DSML｜invoke name="${_escapeAttribute(tool.name)}">')} '
         'dsml-space $arguments '
         '${ToolCallGrammarUtils.literal('</｜DSML｜invoke>')} dsml-space',
       );
@@ -1298,11 +1336,13 @@ class _MuseGrammarBuilder {
     if (resolvedTools == null || resolvedTools.isEmpty) {
       return null;
     }
+    _requireUniqueToolNames(resolvedTools, format: 'Muse Glimmer');
 
     final toolRules = <String>[];
     final requiredToolRules = <String>[];
     for (var toolIndex = 0; toolIndex < resolvedTools.length; toolIndex++) {
       final tool = resolvedTools[toolIndex];
+      _requireMuseRecipientName(tool.name);
       final schema = tool.toJsonSchema();
       _converter.resolveRefs(schema, schema);
       final properties = schemaProperties(schema);
@@ -1311,12 +1351,18 @@ class _MuseGrammarBuilder {
       final optionalRules = <String>[];
       var propertyIndex = 0;
       for (final entry in properties.entries) {
+        _requireNonEmptyProtocolName(
+          entry.key,
+          format: 'Muse Glimmer',
+          kind: 'parameter',
+        );
         final argumentRule = 'muse-tool-$toolIndex-arg-${propertyIndex++}';
         const close = '</atem:parameter>';
         final valueRule = schemaResolvesToString(entry.value)
             ? _addUntilRules(_rules, '$argumentRule-string', close)
             : _converter.visit(entry.value, '$argumentRule-value');
-        final opening = '<atem:parameter name="${entry.key}">';
+        final opening =
+            '<atem:parameter name="${_escapeAttribute(entry.key)}">';
         _rules.add(
           '$argumentRule ::= ${ToolCallGrammarUtils.literal(opening)} '
           '$valueRule ${ToolCallGrammarUtils.literal(close)}',
@@ -1334,7 +1380,7 @@ class _MuseGrammarBuilder {
       final toolRule = 'muse-tool-$toolIndex';
       _rules.add(
         '$toolRule ::= '
-        '${ToolCallGrammarUtils.literal('<atem:invoke name="${tool.name}">')} '
+        '${ToolCallGrammarUtils.literal('<atem:invoke name="${_escapeAttribute(tool.name)}">')} '
         'muse-space $arguments '
         '${ToolCallGrammarUtils.literal('</atem:invoke>')} muse-space',
       );
@@ -1541,7 +1587,12 @@ _ParsedCalls _parseInvokeScope(
 }) {
   final scopeStartIndex = input.indexOf(scopeStart);
   if (scopeStartIndex < 0) {
-    return _ParsedCalls(calls: const [], remaining: input);
+    return _ParsedCalls(
+      calls: const [],
+      remaining: isPartial
+          ? _hideIncompleteProtocolSuffix(input, scopeStart)
+          : input,
+    );
   }
   final bodyStart = scopeStartIndex + scopeStart.length;
   final scopeEndIndex = input.indexOf(scopeEnd, bodyStart);
@@ -1577,7 +1628,7 @@ _ParsedCalls _parseInvokeScope(
     if (end < 0) {
       return allowPartial ? partialResult() : _ParsedCalls.failure();
     }
-    final name = start.group(1) ?? '';
+    final name = _unescapeAttribute(start.group(1) ?? '');
     final arguments = parseArguments(name, body.substring(argumentsStart, end));
     if (name.isEmpty || arguments == null) {
       return allowPartial ? partialResult() : _ParsedCalls.failure();
@@ -1809,7 +1860,7 @@ Map<String, dynamic>? _parseDsmlArguments(
   final result = <String, dynamic>{};
   final properties = schema == null ? null : schemaProperties(schema);
   for (final match in pattern.allMatches(body)) {
-    final key = match.group(1) ?? '';
+    final key = _unescapeAttribute(match.group(1) ?? '');
     final stringAttribute = match.group(2) == 'true';
     final raw = match.group(3) ?? '';
     final propertySchema = properties?[key];
@@ -1871,7 +1922,7 @@ List<LlamaCompletionChunkToolCall>? _parseAtemCalls(
   }
   final calls = <LlamaCompletionChunkToolCall>[];
   for (final invoke in invokePattern.allMatches(scope)) {
-    final name = invoke.group(1) ?? '';
+    final name = _unescapeAttribute(invoke.group(1) ?? '');
     final schema = schemas[name];
     if (schemas.isNotEmpty && schema == null) {
       return null;
@@ -1888,7 +1939,7 @@ List<LlamaCompletionChunkToolCall>? _parseAtemCalls(
     }
     final arguments = <String, dynamic>{};
     for (final parameter in parameterPattern.allMatches(params)) {
-      final key = parameter.group(1) ?? '';
+      final key = _unescapeAttribute(parameter.group(1) ?? '');
       final raw = parameter.group(2) ?? '';
       if (key.isEmpty || arguments.containsKey(key)) {
         return null;
@@ -1921,11 +1972,77 @@ List<LlamaCompletionChunkToolCall>? _parseAtemCalls(
   return calls.isEmpty ? null : calls;
 }
 
-String _unescapeAttribute(String value) =>
-    value.replaceAll('&quot;', '"').replaceAll('&amp;', '&');
+String _unescapeAttribute(String value) => value
+    .replaceAll('&quot;', '"')
+    .replaceAll('&lt;', '<')
+    .replaceAll('&gt;', '>')
+    .replaceAll('&amp;', '&');
 
-String _escapeAttribute(String value) =>
-    value.replaceAll('&', '&amp;').replaceAll('"', '&quot;');
+String _escapeAttribute(String value) => value
+    .replaceAll('&', '&amp;')
+    .replaceAll('"', '&quot;')
+    .replaceAll('<', '&lt;')
+    .replaceAll('>', '&gt;');
+
+void _requireDynamicTagName(String value, {required String format}) {
+  if (!RegExp(r'^[A-Za-z_][A-Za-z0-9_.-]*$').hasMatch(value)) {
+    throw LlamaUnsupportedException(
+      '$format cannot represent tool parameter "$value" as an XML tag. '
+      'Use a name matching [A-Za-z_][A-Za-z0-9_.-]*.',
+    );
+  }
+}
+
+void _requireNonEmptyProtocolName(
+  String value, {
+  required String format,
+  required String kind,
+}) {
+  if (value.isEmpty) {
+    throw LlamaUnsupportedException(
+      '$format cannot represent an empty $kind name in its tool-call '
+      'protocol.',
+    );
+  }
+}
+
+void _requireUniqueToolNames(
+  List<ToolDefinition> tools, {
+  required String format,
+}) {
+  final names = <String>{};
+  for (final tool in tools) {
+    if (!names.add(tool.name)) {
+      throw LlamaUnsupportedException(
+        '$format cannot bind duplicate tool name "${tool.name}" to one '
+        'schema-exact parser route. Use unique tool names.',
+      );
+    }
+  }
+}
+
+void _requireMuseRecipientName(String value) {
+  if (value.isEmpty ||
+      value.trim() != value ||
+      value == 'self' ||
+      value == 'user' ||
+      value.contains('<')) {
+    throw LlamaUnsupportedException(
+      'Muse Glimmer cannot represent tool name "$value" in its recipient '
+      'channel. Use a non-empty name without surrounding whitespace or "<", '
+      'and do not use the reserved names "self" or "user".',
+    );
+  }
+}
+
+String _hideIncompleteProtocolSuffix(String input, String marker) {
+  for (var length = marker.length - 1; length > 0; length--) {
+    if (input.endsWith(marker.substring(0, length))) {
+      return input.substring(0, input.length - length);
+    }
+  }
+  return input;
+}
 
 String? _nullIfEmpty(String? value) {
   final trimmed = value?.trim();

--- a/lib/src/core/template/handlers/llama_cpp_specialized_handlers.dart
+++ b/lib/src/core/template/handlers/llama_cpp_specialized_handlers.dart
@@ -1,9 +1,12 @@
+import 'dart:convert';
+
 import 'package:dinja/dinja.dart';
 
 import '../../grammar/json_schema_converter.dart';
 import '../../models/chat/chat_message.dart';
 import '../../models/chat/chat_template_result.dart';
 import '../../models/chat/completion_chunk.dart';
+import '../../models/inference/tool_choice.dart';
 import '../../models/tools/tool_definition.dart';
 import '../chat_format.dart';
 import '../chat_parse_result.dart';
@@ -11,6 +14,8 @@ import '../chat_template_handler.dart';
 import '../thinking_utils.dart';
 import '../tool_call_grammar_utils.dart';
 import '../tool_call_parsing_utils.dart';
+import '../tool_schema_utils.dart';
+import '../template_internal_metadata.dart';
 import 'glm45_handler.dart';
 
 abstract class _DirectJinjaHandler extends ChatTemplateHandler {
@@ -23,6 +28,9 @@ abstract class _DirectJinjaHandler extends ChatTemplateHandler {
   String get defaultEosToken => '';
 
   List<String> get grammarTriggerValues => const [];
+
+  String? buildRequiredGrammar(List<ToolDefinition>? tools) =>
+      buildGrammar(tools);
 
   @override
   LlamaChatTemplateResult render({
@@ -62,11 +70,15 @@ abstract class _DirectJinjaHandler extends ChatTemplateHandler {
     }
 
     final hasTools = tools != null && tools.isNotEmpty;
+    final toolCallsRequired =
+        metadata[internalToolChoiceMetadataKey] == ToolChoice.required.name;
     return LlamaChatTemplateResult(
       prompt: prompt,
       format: format.index,
-      grammar: buildGrammar(tools),
-      grammarLazy: hasTools,
+      grammar: toolCallsRequired
+          ? buildRequiredGrammar(tools)
+          : buildGrammar(tools),
+      grammarLazy: hasTools && !toolCallsRequired,
       thinkingForcedOpen: thinkingForcedOpen,
       additionalStops: getStops(
         hasTools: hasTools,
@@ -135,6 +147,22 @@ class KimiK3Handler extends _DirectJinjaHandler {
     bool parseToolCalls = true,
     bool thinkingForcedOpen = false,
   }) {
+    return parseWithTools(
+      output,
+      isPartial: isPartial,
+      parseToolCalls: parseToolCalls,
+      thinkingForcedOpen: thinkingForcedOpen,
+    );
+  }
+
+  /// Parses Kimi K3 output using [tools] to validate emitted names and values.
+  ChatParseResult parseWithTools(
+    String output, {
+    List<ToolDefinition>? tools,
+    bool isPartial = false,
+    bool parseToolCalls = true,
+    bool thinkingForcedOpen = false,
+  }) {
     var remaining = output;
     String? reasoning;
     final thinkEnd = remaining.indexOf(_thinkClose);
@@ -181,7 +209,11 @@ class KimiK3Handler extends _DirectJinjaHandler {
       );
     }
 
-    final parsed = _parseKimiTools(remaining, isPartial: isPartial);
+    final parsed = _parseKimiTools(
+      remaining,
+      isPartial: isPartial,
+      schemas: toolSchemas(tools),
+    );
     if (!parsed.success) {
       final preserved = '$content${_stripKimiTurnEnd(remaining)}'.trim();
       return ChatParseResult(
@@ -196,7 +228,11 @@ class KimiK3Handler extends _DirectJinjaHandler {
     );
   }
 
-  _ParsedCalls _parseKimiTools(String input, {required bool isPartial}) {
+  _ParsedCalls _parseKimiTools(
+    String input, {
+    required bool isPartial,
+    required Map<String, Map<String, dynamic>> schemas,
+  }) {
     final scopeStart = input.indexOf(_toolsStart);
     if (scopeStart < 0) {
       return _ParsedCalls(calls: const [], remaining: _stripKimiTurnEnd(input));
@@ -225,8 +261,12 @@ class KimiK3Handler extends _DirectJinjaHandler {
     for (final match in matches) {
       final name = _unescapeAttribute(match.group(1) ?? '');
       final callBody = match.group(2) ?? '';
-      final arguments = _parseKimiArguments(callBody);
-      if (name.isEmpty || arguments == null) {
+      final schema = schemas[name];
+      if (name.isEmpty || (schemas.isNotEmpty && schema == null)) {
+        return _ParsedCalls.failure();
+      }
+      final arguments = _parseKimiArguments(callBody, schema: schema);
+      if (arguments == null) {
         return _ParsedCalls.failure();
       }
       calls.add(
@@ -243,7 +283,10 @@ class KimiK3Handler extends _DirectJinjaHandler {
     return _ParsedCalls(calls: calls, remaining: _stripKimiTurnEnd(remaining));
   }
 
-  Map<String, dynamic>? _parseKimiArguments(String body) {
+  Map<String, dynamic>? _parseKimiArguments(
+    String body, {
+    Map<String, dynamic>? schema,
+  }) {
     final jsonPattern = RegExp(
       r'<\|open\|>json\s+type="object"<\|sep\|>([\s\S]*?)<\|close\|>json<\|sep\|>',
     );
@@ -252,7 +295,16 @@ class KimiK3Handler extends _DirectJinjaHandler {
       if (body.replaceFirst(jsonPattern, '').trim().isNotEmpty) {
         return null;
       }
-      return ToolCallParsingUtils.decodeJsonObject(jsonMatch.group(1) ?? '');
+      final decoded = ToolCallParsingUtils.decodeJsonObject(
+        jsonMatch.group(1) ?? '',
+      );
+      if (decoded == null || schema == null) {
+        return decoded;
+      }
+      final validated = validateToolSchemaValue(decoded, schema);
+      return validated.valid
+          ? Map<String, dynamic>.from(validated.value! as Map)
+          : null;
     }
 
     final argumentPattern = RegExp(
@@ -262,14 +314,25 @@ class KimiK3Handler extends _DirectJinjaHandler {
       return null;
     }
     final result = <String, dynamic>{};
+    final properties = schema == null ? null : schemaProperties(schema);
     for (final match in argumentPattern.allMatches(body)) {
       final key = _unescapeAttribute(match.group(1) ?? '');
       final type = match.group(2) ?? '';
       final raw = match.group(3) ?? '';
-      if (key.isEmpty) {
+      final propertySchema = properties?[key];
+      if (key.isEmpty ||
+          result.containsKey(key) ||
+          (properties != null && propertySchema == null) ||
+          (propertySchema != null && type != _kimiTypeName(propertySchema))) {
         return null;
       }
-      if (type == 'string') {
+      if (propertySchema != null) {
+        final decoded = decodeToolSchemaText(raw, propertySchema);
+        if (!decoded.valid) {
+          return null;
+        }
+        result[key] = decoded.value;
+      } else if (type == 'string') {
         result[key] = raw;
       } else {
         final decoded = ToolCallParsingUtils.decodeJsonValue(raw);
@@ -278,6 +341,10 @@ class KimiK3Handler extends _DirectJinjaHandler {
         }
         result[key] = decoded;
       }
+    }
+    if (schema != null &&
+        !result.keys.toSet().containsAll(schemaRequired(schema))) {
+      return null;
     }
     return result;
   }
@@ -293,50 +360,12 @@ class KimiK3Handler extends _DirectJinjaHandler {
 
   @override
   String? buildGrammar(List<ToolDefinition>? tools) {
-    if (tools == null || tools.isEmpty) {
-      return null;
-    }
-    final names = tools
-        .map(
-          (tool) => ToolCallGrammarUtils.literal(_escapeAttribute(tool.name)),
-        )
-        .join(' | ');
-    final converter = JsonSchemaConverter();
-    const objectSchema = <String, dynamic>{'type': 'object'};
-    converter.resolveRefs(objectSchema, objectSchema);
-    final objectRule = converter.visit(objectSchema, 'json-object');
-    final buffer = StringBuffer()
-      ..writeln(
-        'root ::= "<|open|>tools<|sep|>" call+ '
-        '"<|close|>tools<|sep|><|close|>message<|sep|>"',
-      )
-      ..writeln(
-        'call ::= "<|open|>call tool=\\"" tool-name '
-        '"\\"" (" index=\\"" [0-9]+ "\\"")? "<|sep|>" '
-        '(argument* | json-block) "<|close|>call<|sep|>"',
-      )
-      ..writeln(
-        'argument ::= "<|open|>argument key=\\"" identifier '
-        '"\\" type=\\"" value-type "\\"<|sep|>" raw '
-        '"<|close|>argument<|sep|>"',
-      )
-      ..writeln(
-        'json-block ::= "<|open|>json type=\\"object\\"<|sep|>" '
-        '$objectRule "<|close|>json<|sep|>"',
-      )
-      ..writeln('tool-name ::= $names')
-      ..writeln(
-        'value-type ::= "string" | "number" | "boolean" | "null" | '
-        '"object" | "array"',
-      )
-      ..writeln('identifier ::= [A-Za-z_] [A-Za-z0-9_.-]*')
-      ..writeln('raw ::= [^<]*');
-    final jsonRules = converter.rules.entries.toList(growable: false)
-      ..sort((a, b) => a.key.compareTo(b.key));
-    for (final entry in jsonRules) {
-      buffer.writeln('${entry.key} ::= ${entry.value}');
-    }
-    return buffer.toString();
+    return _KimiK3GrammarBuilder(tools).build();
+  }
+
+  @override
+  String? buildRequiredGrammar(List<ToolDefinition>? tools) {
+    return _KimiK3GrammarBuilder(tools).build(required: true);
   }
 }
 
@@ -365,6 +394,22 @@ class MinimaxM1Handler extends _DirectJinjaHandler {
     bool parseToolCalls = true,
     bool thinkingForcedOpen = false,
   }) {
+    return parseWithTools(
+      output,
+      isPartial: isPartial,
+      parseToolCalls: parseToolCalls,
+      thinkingForcedOpen: thinkingForcedOpen,
+    );
+  }
+
+  /// Parses MiniMax M1 output using [tools] to validate emitted call objects.
+  ChatParseResult parseWithTools(
+    String output, {
+    List<ToolDefinition>? tools,
+    bool isPartial = false,
+    bool parseToolCalls = true,
+    bool thinkingForcedOpen = false,
+  }) {
     if (!parseToolCalls) {
       return ChatParseResult(content: output.trim());
     }
@@ -384,7 +429,7 @@ class MinimaxM1Handler extends _DirectJinjaHandler {
     }
 
     final body = output.substring(startIndex + start.length, endIndex);
-    final calls = _parseJsonObjectSequence(body);
+    final calls = _parseJsonObjectSequence(body, schemas: toolSchemas(tools));
     if (calls == null) {
       return ChatParseResult(content: output.trim());
     }
@@ -412,7 +457,7 @@ class MinimaxM1Handler extends _DirectJinjaHandler {
       final callRule = 'tool-$i-call';
       converter.rules[callRule] =
           '"{" space "\\"name\\"" space ":" space '
-          '${ToolCallGrammarUtils.literal(tool.name)} space "," space '
+          '${ToolCallGrammarUtils.literal(jsonEncode(tool.name))} space "," space '
           '"\\"arguments\\"" space ":" space $argumentsRule "}" space';
       callRules.add(callRule);
     }
@@ -464,6 +509,23 @@ class MinimaxM3Handler extends _DirectJinjaHandler {
     bool parseToolCalls = true,
     bool thinkingForcedOpen = false,
   }) {
+    return parseWithTools(
+      output,
+      isPartial: isPartial,
+      parseToolCalls: parseToolCalls,
+      thinkingForcedOpen: thinkingForcedOpen,
+    );
+  }
+
+  /// Parses MiniMax M3 output using [tools] for schema-directed argument types.
+  ChatParseResult parseWithTools(
+    String output, {
+    List<ToolDefinition>? tools,
+    bool isPartial = false,
+    bool parseToolCalls = true,
+    bool thinkingForcedOpen = false,
+  }) {
+    final schemas = toolSchemas(tools);
     final thinking = extractThinking(
       output,
       startTag: thinkingStartTag,
@@ -496,24 +558,25 @@ class MinimaxM3Handler extends _DirectJinjaHandler {
         reasoningContent: thinking.reasoning,
       );
     }
-    final scopeEndExclusive = scopeEndIndex < 0
-        ? rawContent.length
-        : scopeEndIndex + namespacedScopeEnd.length;
-    final normalizedScope = rawContent
-        .substring(scopeStartIndex, scopeEndExclusive)
-        .replaceAll('$namespace<', '<');
-    final normalized = rawContent.replaceRange(
-      scopeStartIndex,
-      scopeEndExclusive,
-      normalizedScope,
-    );
     final parsed = _parseInvokeScope(
-      normalized,
-      scopeStart: '<tool_call>',
-      scopeEnd: '</tool_call>',
-      invokeStartPattern: RegExp(r'<invoke name="([^"]+)">'),
-      invokeEnd: '</invoke>',
-      parseArguments: _parseDynamicTagArguments,
+      rawContent,
+      scopeStart: namespacedScopeStart,
+      scopeEnd: namespacedScopeEnd,
+      invokeStartPattern: RegExp(
+        '${RegExp.escape(namespace)}<invoke name="([^"]+)">',
+      ),
+      invokeEnd: '$namespace</invoke>',
+      parseArguments: (name, body) {
+        final schema = schemas[name];
+        if (schemas.isNotEmpty && schema == null) {
+          return null;
+        }
+        return _parseDynamicTagArguments(
+          body,
+          schema: schema,
+          tagPrefix: namespace,
+        );
+      },
       isPartial: isPartial,
     );
     return ChatParseResult(
@@ -525,44 +588,37 @@ class MinimaxM3Handler extends _DirectJinjaHandler {
 
   @override
   String? buildGrammar(List<ToolDefinition>? tools) {
-    if (tools == null || tools.isEmpty) {
-      return null;
-    }
-    final names = tools
-        .map((tool) => ToolCallGrammarUtils.literal(tool.name))
-        .join(' | ');
-    return '''
-root ::= "$namespace<tool_call>\\n" invoke+ "$namespace</tool_call>"
-invoke ::= "$namespace<invoke name=\\"" tool-name "\\">" parameter* "$namespace</invoke>\\n"
-parameter ::= "$namespace<" identifier ">" m3-value "$namespace</" identifier ">"
-tool-name ::= $names
-identifier ::= [A-Za-z_] [A-Za-z0-9_.-]*
-m3-value ::= raw | parameter+
-raw ::= [^]]*
-''';
+    return _MinimaxM3GrammarBuilder(tools).build();
+  }
+
+  @override
+  String? buildRequiredGrammar(List<ToolDefinition>? tools) {
+    return _MinimaxM3GrammarBuilder(tools).build(required: true);
   }
 }
 
-/// Handler for DeepSeek V3.2/V4 DSML tool calls.
-class DeepseekV4Handler extends _DirectJinjaHandler {
+abstract class _DeepseekDsmlHandler extends _DirectJinjaHandler {
   static const _prefix = '<｜DSML｜';
 
-  @override
-  ChatFormat get format => ChatFormat.deepseekV4;
+  String get _callsEnvelope;
+
+  String get _callsStart => '$_prefix$_callsEnvelope>';
+
+  String get _callsEnd => '</｜DSML｜$_callsEnvelope>';
 
   @override
   List<String> get additionalStops => const ['<｜end▁of▁sentence｜>'];
 
   @override
-  List<String> get preservedTokens => const [
+  List<String> get preservedTokens => [
     '<think>',
     '</think>',
-    '<｜DSML｜tool_calls>',
-    '</｜DSML｜tool_calls>',
+    _callsStart,
+    _callsEnd,
   ];
 
   @override
-  List<String> get grammarTriggerValues => const ['<｜DSML｜tool_calls>'];
+  List<String> get grammarTriggerValues => [_callsStart];
 
   @override
   ChatParseResult parse(
@@ -571,8 +627,25 @@ class DeepseekV4Handler extends _DirectJinjaHandler {
     bool parseToolCalls = true,
     bool thinkingForcedOpen = false,
   }) {
-    final thinking = extractThinking(
+    return parseWithTools(
       output,
+      isPartial: isPartial,
+      parseToolCalls: parseToolCalls,
+      thinkingForcedOpen: thinkingForcedOpen,
+    );
+  }
+
+  /// Parses DSML output using [tools] to enforce exact emitted schemas.
+  ChatParseResult parseWithTools(
+    String output, {
+    List<ToolDefinition>? tools,
+    bool isPartial = false,
+    bool parseToolCalls = true,
+    bool thinkingForcedOpen = false,
+  }) {
+    final thinking = _extractDsmlThinking(
+      output,
+      callsStart: _callsStart,
       thinkingForcedOpen: thinkingForcedOpen,
     );
     if (!parseToolCalls) {
@@ -583,13 +656,18 @@ class DeepseekV4Handler extends _DirectJinjaHandler {
     }
     final parsed = _parseInvokeScope(
       thinking.content,
-      scopeStart:
-          '$_prefix'
-          'tool_calls>',
-      scopeEnd: '</｜DSML｜tool_calls>',
+      scopeStart: _callsStart,
+      scopeEnd: _callsEnd,
       invokeStartPattern: RegExp(r'<｜DSML｜invoke name="([^"]+)">'),
       invokeEnd: '</｜DSML｜invoke>',
-      parseArguments: _parseDsmlArguments,
+      parseArguments: (name, body) {
+        final schemas = toolSchemas(tools);
+        final schema = schemas[name];
+        if (schemas.isNotEmpty && schema == null) {
+          return null;
+        }
+        return _parseDsmlArguments(body, schema: schema);
+      },
       isPartial: isPartial,
     );
     return ChatParseResult(
@@ -601,22 +679,34 @@ class DeepseekV4Handler extends _DirectJinjaHandler {
 
   @override
   String? buildGrammar(List<ToolDefinition>? tools) {
-    if (tools == null || tools.isEmpty) {
-      return null;
-    }
-    final names = tools
-        .map((tool) => ToolCallGrammarUtils.literal(tool.name))
-        .join(' | ');
-    return '''
-root ::= "<｜DSML｜tool_calls>\\n" invoke+ "</｜DSML｜tool_calls>"
-invoke ::= "<｜DSML｜invoke name=\\"" tool-name "\\">\\n" parameter* "</｜DSML｜invoke>\\n"
-parameter ::= "<｜DSML｜parameter name=\\"" identifier "\\" string=\\"" boolean "\\">" raw "</｜DSML｜parameter>\\n"
-tool-name ::= $names
-identifier ::= [A-Za-z_] [A-Za-z0-9_.-]*
-boolean ::= "true" | "false"
-raw ::= [^<]*
-''';
+    return _DsmlGrammarBuilder(tools, envelope: _callsEnvelope).build();
   }
+
+  @override
+  String? buildRequiredGrammar(List<ToolDefinition>? tools) {
+    return _DsmlGrammarBuilder(
+      tools,
+      envelope: _callsEnvelope,
+    ).build(required: true);
+  }
+}
+
+/// Handler for DeepSeek V3.2 DSML function calls.
+class DeepseekV32Handler extends _DeepseekDsmlHandler {
+  @override
+  ChatFormat get format => ChatFormat.deepseekV32;
+
+  @override
+  String get _callsEnvelope => 'function_calls';
+}
+
+/// Handler for DeepSeek V4 DSML tool calls.
+class DeepseekV4Handler extends _DeepseekDsmlHandler {
+  @override
+  ChatFormat get format => ChatFormat.deepseekV4;
+
+  @override
+  String get _callsEnvelope => 'tool_calls';
 }
 
 /// Handler for Muse Glimmer recipient channels and ATEM tool calls.
@@ -647,42 +737,70 @@ class MuseGlimmerHandler extends _DirectJinjaHandler {
     bool parseToolCalls = true,
     bool thinkingForcedOpen = false,
   }) {
+    return parseWithTools(
+      output,
+      isPartial: isPartial,
+      parseToolCalls: parseToolCalls,
+      thinkingForcedOpen: thinkingForcedOpen,
+    );
+  }
+
+  /// Parses Muse output using [tools] for schema-directed argument types.
+  ChatParseResult parseWithTools(
+    String output, {
+    List<ToolDefinition>? tools,
+    bool isPartial = false,
+    bool parseToolCalls = true,
+    bool thinkingForcedOpen = false,
+  }) {
+    final schemas = toolSchemas(tools);
     final channelPattern = RegExp(
       r'(?:<\|start\|>assistant)?\s+to=([^<]+)<\|message\|>([\s\S]*?)(<\|eom\|>|<\|eot\|>|$)',
     );
     final matches = channelPattern.allMatches(output).toList(growable: false);
     if (matches.isEmpty) {
-      return ChatParseResult(content: output.trim());
+      return ChatParseResult(
+        content: (isPartial ? _hideIncompleteMuseRoute(output) : output).trim(),
+      );
     }
 
     final content = StringBuffer();
     final reasoning = StringBuffer();
     final calls = <LlamaCompletionChunkToolCall>[];
+    var cursor = 0;
     for (final match in matches) {
+      _appendMuseContent(content, output.substring(cursor, match.start));
       final recipient = (match.group(1) ?? '').trim();
       final body = match.group(2) ?? '';
       if (recipient == 'self') {
         if (reasoning.isNotEmpty) reasoning.writeln();
         reasoning.write(body);
       } else if (recipient == 'user') {
-        if (content.isNotEmpty) content.writeln();
-        content.write(body);
+        _appendMuseContent(content, body, channelBody: true);
       } else if (parseToolCalls) {
-        final parsed = _parseAtemCalls(body, calls.length);
+        final parsed = _parseAtemCalls(body, calls.length, schemas: schemas);
         if (parsed == null) {
           final terminator = match.group(3) ?? '';
           if (!isPartial || terminator.isNotEmpty) {
-            if (content.isNotEmpty) content.writeln();
-            content.write(body);
+            _appendMuseContent(
+              content,
+              match.group(0) ?? body,
+              channelBody: true,
+            );
           }
         } else {
           calls.addAll(parsed);
         }
       } else {
-        if (content.isNotEmpty) content.writeln();
-        content.write(body);
+        _appendMuseContent(content, body, channelBody: true);
       }
+      cursor = match.end;
     }
+    final trailing = output.substring(cursor);
+    _appendMuseContent(
+      content,
+      isPartial ? _hideIncompleteMuseRoute(trailing) : trailing,
+    );
 
     return ChatParseResult(
       content: content.toString().trim(),
@@ -693,20 +811,12 @@ class MuseGlimmerHandler extends _DirectJinjaHandler {
 
   @override
   String? buildGrammar(List<ToolDefinition>? tools) {
-    if (tools == null || tools.isEmpty) {
-      return null;
-    }
-    final names = tools
-        .map((tool) => ToolCallGrammarUtils.literal(tool.name))
-        .join(' | ');
-    return '''
-root ::= "<atem:function_calls>\\n" invoke "</atem:function_calls>"
-invoke ::= "<atem:invoke name=\\"" tool-name "\\">\\n" parameter* "</atem:invoke>\\n"
-parameter ::= "<atem:parameter name=\\"" identifier "\\">" raw "</atem:parameter>\\n"
-tool-name ::= $names
-identifier ::= [A-Za-z_] [A-Za-z0-9_.-]*
-raw ::= [^<]*
-''';
+    return _MuseGrammarBuilder(tools).build();
+  }
+
+  @override
+  String? buildRequiredGrammar(List<ToolDefinition>? tools) {
+    return _MuseGrammarBuilder(tools).build(required: true);
   }
 }
 
@@ -741,6 +851,22 @@ class LagunaHandler extends _DirectJinjaHandler {
     bool parseToolCalls = true,
     bool thinkingForcedOpen = false,
   }) {
+    return parseWithTools(
+      output,
+      isPartial: isPartial,
+      parseToolCalls: parseToolCalls,
+      thinkingForcedOpen: thinkingForcedOpen,
+    );
+  }
+
+  /// Parses Laguna output using [tools] for schema-directed argument types.
+  ChatParseResult parseWithTools(
+    String output, {
+    List<ToolDefinition>? tools,
+    bool isPartial = false,
+    bool parseToolCalls = true,
+    bool thinkingForcedOpen = false,
+  }) {
     if (parseToolCalls && _hasMalformedLagunaToolBlock(output)) {
       final thinking = extractThinking(
         output,
@@ -751,8 +877,9 @@ class LagunaHandler extends _DirectJinjaHandler {
         reasoningContent: thinking.reasoning,
       );
     }
-    return Glm45Handler().parse(
+    return Glm45Handler().parseWithTools(
       output,
+      tools: tools,
       isPartial: isPartial,
       parseToolCalls: parseToolCalls,
       thinkingForcedOpen: thinkingForcedOpen,
@@ -782,9 +909,559 @@ class LagunaHandler extends _DirectJinjaHandler {
   String? buildGrammar(List<ToolDefinition>? tools) {
     return Glm45Handler().buildGrammar(tools);
   }
+
+  @override
+  String? buildRequiredGrammar(List<ToolDefinition>? tools) {
+    final grammar = buildGrammar(tools);
+    return grammar == null
+        ? null
+        : _withRequiredPrefix(
+            grammar,
+            delimiter: '\n<tool_call>',
+            prefixName: 'laguna-required-prefix',
+          );
+  }
 }
 
-List<LlamaCompletionChunkToolCall>? _parseJsonObjectSequence(String body) {
+void _appendMuseContent(
+  StringBuffer content,
+  String value, {
+  bool channelBody = false,
+}) {
+  if (value.isEmpty) {
+    return;
+  }
+  if (channelBody &&
+      content.isNotEmpty &&
+      !_isWhitespace(content.toString().codeUnitAt(content.length - 1)) &&
+      !_isWhitespace(value.codeUnitAt(0))) {
+    content.writeln();
+  }
+  content.write(value);
+}
+
+String _hideIncompleteMuseRoute(String input) {
+  const routeStarts = ['<|start|>assistant to=', ' to='];
+  var hideFrom = input.length;
+  for (final routeStart in routeStarts) {
+    for (var length = 1; length < routeStart.length; length++) {
+      final prefix = routeStart.substring(0, length);
+      if (input.endsWith(prefix)) {
+        hideFrom = hideFrom < input.length - length
+            ? hideFrom
+            : input.length - length;
+      }
+    }
+    final completeStart = input.lastIndexOf(routeStart);
+    if (completeStart >= 0 &&
+        input.indexOf('<|message|>', completeStart + routeStart.length) < 0) {
+      hideFrom = hideFrom < completeStart ? hideFrom : completeStart;
+    }
+  }
+  return input.substring(0, hideFrom);
+}
+
+class _KimiK3GrammarBuilder {
+  final List<ToolDefinition>? tools;
+  final JsonSchemaConverter _converter = JsonSchemaConverter();
+  final List<String> _rules = <String>[];
+
+  _KimiK3GrammarBuilder(this.tools);
+
+  String? build({bool required = false}) {
+    final resolvedTools = tools;
+    if (resolvedTools == null || resolvedTools.isEmpty) {
+      return null;
+    }
+
+    final callRules = <String>[];
+    String? stringValueRule;
+    for (var toolIndex = 0; toolIndex < resolvedTools.length; toolIndex++) {
+      final tool = resolvedTools[toolIndex];
+      final schema = tool.toJsonSchema();
+      final properties = schemaProperties(schema);
+      final required = schemaRequired(schema);
+      final requiredRules = <String>[];
+      final optionalRules = <String>[];
+      var propertyIndex = 0;
+      for (final entry in properties.entries) {
+        final argumentRule = 'kimi-tool-$toolIndex-arg-${propertyIndex++}';
+        final typeName = _kimiTypeName(entry.value);
+        const close = '<|close|>argument<|sep|>';
+        final valueRule = typeName == 'string'
+            ? (stringValueRule ??= _addUntilRules(
+                _rules,
+                'kimi-string-value',
+                close,
+              ))
+            : _converter.visit(entry.value, '$argumentRule-value');
+        final opening =
+            '<|open|>argument key="${_escapeAttribute(entry.key)}" '
+            'type="$typeName"<|sep|>';
+        _rules.add(
+          '$argumentRule ::= ${ToolCallGrammarUtils.literal(opening)} '
+          '$valueRule ${ToolCallGrammarUtils.literal(close)}',
+        );
+        (required.contains(entry.key) ? requiredRules : optionalRules).add(
+          argumentRule,
+        );
+      }
+
+      _converter.resolveRefs(schema, schema);
+      final jsonRule = _converter.visit(schema, 'kimi-tool-$toolIndex-json');
+      final rawArguments = <String>[
+        ...requiredRules,
+        if (optionalRules.isNotEmpty) '(${optionalRules.join(' | ')})*',
+      ].join(' ');
+      final arguments = properties.isEmpty
+          ? '(kimi-empty-arguments | kimi-json-$toolIndex)'
+          : '(kimi-raw-$toolIndex | kimi-json-$toolIndex)';
+      _rules
+        ..add('kimi-raw-$toolIndex ::= $rawArguments')
+        ..add(
+          'kimi-json-$toolIndex ::= '
+          '${ToolCallGrammarUtils.literal('<|open|>json type="object"<|sep|>')} '
+          '$jsonRule '
+          '${ToolCallGrammarUtils.literal('<|close|>json<|sep|>')}',
+        );
+      final callRule = 'kimi-tool-$toolIndex';
+      final callOpen = '<|open|>call tool="${_escapeAttribute(tool.name)}"';
+      _rules.add(
+        '$callRule ::= ${ToolCallGrammarUtils.literal(callOpen)} '
+        '(" index=\\"" [0-9]+ "\\"")? '
+        '${ToolCallGrammarUtils.literal('<|sep|>')} $arguments '
+        '${ToolCallGrammarUtils.literal('<|close|>call<|sep|>')}',
+      );
+      callRules.add(callRule);
+    }
+
+    final buffer = StringBuffer()
+      ..writeln(
+        'root ::= ${ToolCallGrammarUtils.literal('<|open|>tools<|sep|>')} '
+        'kimi-tool+ '
+        '${ToolCallGrammarUtils.literal('<|close|>tools<|sep|>')} '
+        '${ToolCallGrammarUtils.literal('<|close|>message<|sep|>')}',
+      )
+      ..writeln('kimi-tool ::= ${callRules.join(' | ')}')
+      ..writeln('kimi-empty-arguments ::= ""');
+    for (final rule in _rules) {
+      buffer.writeln(rule);
+    }
+    _appendJsonRules(buffer, _converter);
+    final grammar = buffer.toString();
+    return required
+        ? _withRequiredPrefix(
+            grammar,
+            delimiter: '<|open|>tools<|sep|>',
+            prefixName: 'kimi-required-prefix',
+          )
+        : grammar;
+  }
+}
+
+String _kimiTypeName(Map<String, dynamic> schema) {
+  if (schemaResolvesToString(schema)) {
+    return 'string';
+  }
+  return switch (schema['type']) {
+    'integer' || 'number' => 'number',
+    'boolean' => 'boolean',
+    'null' => 'null',
+    'object' => 'object',
+    'array' => 'array',
+    _ => 'string',
+  };
+}
+
+class _MinimaxM3GrammarBuilder {
+  static const _namespace = MinimaxM3Handler.namespace;
+
+  final List<ToolDefinition>? tools;
+  final JsonSchemaConverter _converter = JsonSchemaConverter();
+  final List<String> _rules = <String>[];
+
+  _MinimaxM3GrammarBuilder(this.tools);
+
+  String? build({bool required = false}) {
+    final resolvedTools = tools;
+    if (resolvedTools == null || resolvedTools.isEmpty) {
+      return null;
+    }
+    final toolRules = <String>[];
+    for (var toolIndex = 0; toolIndex < resolvedTools.length; toolIndex++) {
+      final tool = resolvedTools[toolIndex];
+      final schema = tool.toJsonSchema();
+      final arguments = _members(schema, 'm3-tool-$toolIndex-arg');
+      final toolRule = 'm3-tool-$toolIndex';
+      _rules.add(
+        '$toolRule ::= '
+        '${ToolCallGrammarUtils.literal('$_namespace<invoke name="${tool.name}">')} '
+        'm3-space $arguments m3-space '
+        '${ToolCallGrammarUtils.literal('$_namespace</invoke>')} m3-space',
+      );
+      toolRules.add(toolRule);
+    }
+
+    final buffer = StringBuffer()
+      ..writeln(
+        'root ::= '
+        '${ToolCallGrammarUtils.literal('$_namespace<tool_call>')} m3-space '
+        'm3-tool+ ${ToolCallGrammarUtils.literal('$_namespace</tool_call>')}',
+      )
+      ..writeln('m3-tool ::= ${toolRules.join(' | ')}')
+      ..writeln(r'm3-space ::= [ \t\n\r]*');
+    for (final rule in _rules) {
+      buffer.writeln(rule);
+    }
+    _appendJsonRules(buffer, _converter);
+    final grammar = buffer.toString();
+    return required
+        ? _withRequiredPrefix(
+            grammar,
+            delimiter: '$_namespace<tool_call>',
+            prefixName: 'm3-required-prefix',
+          )
+        : grammar;
+  }
+
+  String _members(Map<String, dynamic> schema, String prefix) {
+    final properties = schemaProperties(schema);
+    final required = schemaRequired(schema);
+    final requiredMembers = <String>[];
+    final optionalMembers = <String>[];
+    var propertyIndex = 0;
+    for (final entry in properties.entries) {
+      final rule = _element(
+        entry.key,
+        entry.value,
+        '$prefix-${propertyIndex++}',
+      );
+      (required.contains(entry.key) ? requiredMembers : optionalMembers).add(
+        rule,
+      );
+    }
+    return <String>[
+      ...requiredMembers.map((rule) => '$rule m3-space'),
+      if (optionalMembers.isNotEmpty)
+        '((${optionalMembers.join(' | ')}) m3-space)*',
+    ].join(' ');
+  }
+
+  String _element(String tag, Map<String, dynamic> schema, String rule) {
+    final closingText = '$_namespace</$tag>';
+    final valueRule = _value(schema, '$rule-value', closingText);
+    _rules.add(
+      '$rule ::= ${ToolCallGrammarUtils.literal('$_namespace<$tag>')} '
+      '$valueRule ${ToolCallGrammarUtils.literal(closingText)}',
+    );
+    return rule;
+  }
+
+  String _value(
+    Map<String, dynamic> schema,
+    String prefix,
+    String closingText,
+  ) {
+    if (schemaResolvesToString(schema)) {
+      return _addUntilRules(_rules, '$prefix-string', closingText);
+    }
+    if (schema['type'] == 'object') {
+      return _members(schema, '$prefix-member');
+    }
+    if (schema['type'] == 'array' && schema['items'] is Map) {
+      final item = _element(
+        'item',
+        Map<String, dynamic>.from(schema['items'] as Map),
+        '$prefix-item',
+      );
+      return '($item m3-space)*';
+    }
+    return _converter.visit(schema, prefix);
+  }
+}
+
+class _DsmlGrammarBuilder {
+  static const _prefix = '｜DSML｜';
+
+  final List<ToolDefinition>? tools;
+  final String envelope;
+  final JsonSchemaConverter _converter = JsonSchemaConverter();
+  final List<String> _rules = <String>[];
+
+  _DsmlGrammarBuilder(this.tools, {required this.envelope});
+
+  String? build({bool required = false}) {
+    final resolvedTools = tools;
+    if (resolvedTools == null || resolvedTools.isEmpty) {
+      return null;
+    }
+
+    final callsStart = '<$_prefix$envelope>';
+    final callsEnd = '</$_prefix$envelope>';
+    final toolRules = <String>[];
+    for (var toolIndex = 0; toolIndex < resolvedTools.length; toolIndex++) {
+      final tool = resolvedTools[toolIndex];
+      final schema = tool.toJsonSchema();
+      _converter.resolveRefs(schema, schema);
+      final properties = schemaProperties(schema);
+      final requiredNames = schemaRequired(schema);
+      final requiredRules = <String>[];
+      final optionalRules = <String>[];
+      var propertyIndex = 0;
+      for (final entry in properties.entries) {
+        final argumentRule = 'dsml-tool-$toolIndex-arg-${propertyIndex++}';
+        final isString = schemaResolvesToString(entry.value);
+        const close = '</｜DSML｜parameter>';
+        final valueRule = isString
+            ? _addUntilRules(_rules, '$argumentRule-string', close)
+            : _converter.visit(entry.value, '$argumentRule-value');
+        final opening =
+            '<｜DSML｜parameter name="${entry.key}" '
+            'string="${isString ? 'true' : 'false'}">';
+        _rules.add(
+          '$argumentRule ::= ${ToolCallGrammarUtils.literal(opening)} '
+          '$valueRule ${ToolCallGrammarUtils.literal(close)}',
+        );
+        (requiredNames.contains(entry.key) ? requiredRules : optionalRules).add(
+          argumentRule,
+        );
+      }
+
+      final arguments = <String>[
+        ...requiredRules.map((rule) => '$rule dsml-space'),
+        if (optionalRules.isNotEmpty)
+          '((${optionalRules.join(' | ')}) dsml-space)*',
+      ].join(' ');
+
+      final toolRule = 'dsml-tool-$toolIndex';
+      _rules.add(
+        '$toolRule ::= '
+        '${ToolCallGrammarUtils.literal('<｜DSML｜invoke name="${tool.name}">')} '
+        'dsml-space $arguments '
+        '${ToolCallGrammarUtils.literal('</｜DSML｜invoke>')} dsml-space',
+      );
+      toolRules.add(toolRule);
+    }
+
+    final buffer = StringBuffer()
+      ..writeln(
+        'root ::= ${ToolCallGrammarUtils.literal(callsStart)} dsml-space '
+        'dsml-tool+ ${ToolCallGrammarUtils.literal(callsEnd)}',
+      )
+      ..writeln('dsml-tool ::= ${toolRules.join(' | ')}')
+      ..writeln(r'dsml-space ::= [ \t\n\r]*');
+    for (final rule in _rules) {
+      buffer.writeln(rule);
+    }
+    _appendJsonRules(buffer, _converter);
+    final grammar = buffer.toString();
+    return required
+        ? _withRequiredPrefix(
+            grammar,
+            delimiter: callsStart,
+            prefixName: 'dsml-required-prefix',
+          )
+        : grammar;
+  }
+}
+
+class _MuseGrammarBuilder {
+  static const _scopeStart = '<atem:function_calls>';
+  static const _scopeEnd = '</atem:function_calls>';
+
+  final List<ToolDefinition>? tools;
+  final JsonSchemaConverter _converter = JsonSchemaConverter();
+  final List<String> _rules = <String>[];
+
+  _MuseGrammarBuilder(this.tools);
+
+  String? build({bool required = false}) {
+    final resolvedTools = tools;
+    if (resolvedTools == null || resolvedTools.isEmpty) {
+      return null;
+    }
+
+    final toolRules = <String>[];
+    final requiredToolRules = <String>[];
+    for (var toolIndex = 0; toolIndex < resolvedTools.length; toolIndex++) {
+      final tool = resolvedTools[toolIndex];
+      final schema = tool.toJsonSchema();
+      _converter.resolveRefs(schema, schema);
+      final properties = schemaProperties(schema);
+      final requiredNames = schemaRequired(schema);
+      final requiredRules = <String>[];
+      final optionalRules = <String>[];
+      var propertyIndex = 0;
+      for (final entry in properties.entries) {
+        final argumentRule = 'muse-tool-$toolIndex-arg-${propertyIndex++}';
+        const close = '</atem:parameter>';
+        final valueRule = schemaResolvesToString(entry.value)
+            ? _addUntilRules(_rules, '$argumentRule-string', close)
+            : _converter.visit(entry.value, '$argumentRule-value');
+        final opening = '<atem:parameter name="${entry.key}">';
+        _rules.add(
+          '$argumentRule ::= ${ToolCallGrammarUtils.literal(opening)} '
+          '$valueRule ${ToolCallGrammarUtils.literal(close)}',
+        );
+        (requiredNames.contains(entry.key) ? requiredRules : optionalRules).add(
+          argumentRule,
+        );
+      }
+
+      final arguments = <String>[
+        ...requiredRules.map((rule) => '$rule muse-space'),
+        if (optionalRules.isNotEmpty)
+          '((${optionalRules.join(' | ')}) muse-space)*',
+      ].join(' ');
+
+      final toolRule = 'muse-tool-$toolIndex';
+      _rules.add(
+        '$toolRule ::= '
+        '${ToolCallGrammarUtils.literal('<atem:invoke name="${tool.name}">')} '
+        'muse-space $arguments '
+        '${ToolCallGrammarUtils.literal('</atem:invoke>')} muse-space',
+      );
+      toolRules.add(toolRule);
+
+      final requiredToolRule = 'muse-required-tool-$toolIndex';
+      _rules.add(
+        '$requiredToolRule ::= '
+        '${ToolCallGrammarUtils.literal(' to=${tool.name}<|message|>$_scopeStart')} '
+        'muse-space $toolRule ${ToolCallGrammarUtils.literal(_scopeEnd)}',
+      );
+      requiredToolRules.add(requiredToolRule);
+    }
+
+    final buffer = StringBuffer();
+    if (required) {
+      final analysisBody = _addUntilRules(
+        _rules,
+        'muse-analysis-body',
+        '<|eom|>',
+      );
+      buffer
+        ..writeln(
+          'root ::= (${ToolCallGrammarUtils.literal('<|start|>assistant')})? '
+          'muse-analysis* muse-required-tool',
+        )
+        ..writeln(
+          'muse-analysis ::= '
+          '${ToolCallGrammarUtils.literal(' to=self<|message|>')} '
+          '$analysisBody '
+          '${ToolCallGrammarUtils.literal('<|eom|><|start|>assistant')}',
+        )
+        ..writeln('muse-required-tool ::= ${requiredToolRules.join(' | ')}');
+    } else {
+      buffer
+        ..writeln(
+          'root ::= ${ToolCallGrammarUtils.literal(_scopeStart)} muse-space '
+          'muse-tool+ ${ToolCallGrammarUtils.literal(_scopeEnd)}',
+        )
+        ..writeln('muse-tool ::= ${toolRules.join(' | ')}');
+    }
+    buffer.writeln(r'muse-space ::= [ \t\n\r]*');
+    for (final rule in _rules) {
+      buffer.writeln(rule);
+    }
+    _appendJsonRules(buffer, _converter);
+    return buffer.toString();
+  }
+}
+
+String _withRequiredPrefix(
+  String grammar, {
+  required String delimiter,
+  required String prefixName,
+}) {
+  final lines = grammar.split('\n');
+  final rootIndex = lines.indexWhere((line) => line.startsWith('root ::= '));
+  if (rootIndex < 0) {
+    return grammar;
+  }
+  lines[rootIndex] = lines[rootIndex].replaceFirst(
+    'root ::= ',
+    'required-tool-section ::= ',
+  );
+  final prefixRules = <String>[];
+  final prefixRule = _addUntilRules(prefixRules, prefixName, delimiter);
+  return <String>[
+    'root ::= $prefixRule required-tool-section',
+    ...lines,
+    ...prefixRules,
+  ].join('\n');
+}
+
+void _appendJsonRules(StringBuffer buffer, JsonSchemaConverter converter) {
+  final rules = converter.rules.entries.toList(growable: false)
+    ..sort((a, b) => a.key.compareTo(b.key));
+  for (final entry in rules) {
+    buffer.writeln('${entry.key} ::= ${entry.value}');
+  }
+}
+
+String _addUntilRules(List<String> rules, String name, String delimiter) {
+  final pattern = delimiter.runes
+      .map(String.fromCharCode)
+      .toList(growable: false);
+  final alphabet = <String>[];
+  for (final character in pattern) {
+    if (!alphabet.contains(character)) {
+      alphabet.add(character);
+    }
+  }
+  final fallback = '[^${alphabet.map(_escapeGbnfCharClass).join()}]';
+  String state(int index) => '$name-$index';
+
+  for (var index = 0; index < pattern.length; index++) {
+    final alternatives = <String>[];
+    for (final character in alphabet) {
+      final candidate = <String>[...pattern.take(index), character];
+      var next = candidate.length;
+      while (next > 0 &&
+          !_endsWithCharacters(candidate, pattern.take(next).toList())) {
+        next--;
+      }
+      if (next == pattern.length) {
+        continue;
+      }
+      alternatives.add(
+        '${ToolCallGrammarUtils.literal(character)} ${state(next)}',
+      );
+    }
+    alternatives.add('$fallback ${state(0)}');
+    rules.add('${state(index)} ::= (${alternatives.join(' | ')})?');
+  }
+  rules.add('$name ::= ${state(0)}');
+  return name;
+}
+
+bool _endsWithCharacters(List<String> value, List<String> suffix) {
+  if (suffix.length > value.length) {
+    return false;
+  }
+  final offset = value.length - suffix.length;
+  for (var index = 0; index < suffix.length; index++) {
+    if (value[offset + index] != suffix[index]) {
+      return false;
+    }
+  }
+  return true;
+}
+
+String _escapeGbnfCharClass(String character) {
+  return switch (character) {
+    r'\' => r'\\',
+    ']' => r'\]',
+    '^' => r'\^',
+    '-' => r'\-',
+    _ => character,
+  };
+}
+
+List<LlamaCompletionChunkToolCall>? _parseJsonObjectSequence(
+  String body, {
+  Map<String, Map<String, dynamic>> schemas = const {},
+}) {
   final calls = <LlamaCompletionChunkToolCall>[];
   var cursor = 0;
   while (cursor < body.length) {
@@ -798,13 +1475,39 @@ List<LlamaCompletionChunkToolCall>? _parseJsonObjectSequence(String body) {
     if (slice == null || slice.value is! Map) {
       return null;
     }
-    final parsed = ToolCallParsingUtils.parseToolCallArray(<Object?>[
-      slice.value,
-    ], startIndex: calls.length);
-    if (parsed == null || parsed.length != 1) {
-      return null;
+    if (schemas.isEmpty) {
+      final parsed = ToolCallParsingUtils.parseToolCallArray(<Object?>[
+        slice.value,
+      ], startIndex: calls.length);
+      if (parsed == null || parsed.length != 1) {
+        return null;
+      }
+      calls.add(parsed.single);
+    } else {
+      final call = Map<String, dynamic>.from(slice.value! as Map);
+      if (call.length != 2 ||
+          !call.containsKey('name') ||
+          !call.containsKey('arguments')) {
+        return null;
+      }
+      final name = call['name'];
+      final arguments = call['arguments'];
+      final schema = name is String ? schemas[name] : null;
+      if (schema == null || arguments is! Map) {
+        return null;
+      }
+      final validated = validateToolSchemaValue(arguments, schema);
+      if (!validated.valid) {
+        return null;
+      }
+      calls.add(
+        ToolCallParsingUtils.createFunctionToolCall(
+          index: calls.length,
+          name: name,
+          arguments: Map<String, dynamic>.from(validated.value! as Map),
+        ),
+      );
     }
-    calls.add(parsed.single);
     cursor = slice.end;
   }
   return calls.isEmpty ? null : calls;
@@ -816,7 +1519,7 @@ _ParsedCalls _parseInvokeScope(
   required String scopeEnd,
   required RegExp invokeStartPattern,
   required String invokeEnd,
-  required Map<String, dynamic>? Function(String) parseArguments,
+  required Map<String, dynamic>? Function(String, String) parseArguments,
   required bool isPartial,
 }) {
   final scopeStartIndex = input.indexOf(scopeStart);
@@ -858,7 +1561,7 @@ _ParsedCalls _parseInvokeScope(
       return allowPartial ? partialResult() : _ParsedCalls.failure();
     }
     final name = start.group(1) ?? '';
-    final arguments = parseArguments(body.substring(argumentsStart, end));
+    final arguments = parseArguments(name, body.substring(argumentsStart, end));
     if (name.isEmpty || arguments == null) {
       return allowPartial ? partialResult() : _ParsedCalls.failure();
     }
@@ -885,20 +1588,48 @@ _ParsedCalls _parseInvokeScope(
   return _ParsedCalls(calls: calls, remaining: remaining);
 }
 
-Map<String, dynamic>? _parseDynamicTagArguments(String body) {
-  final parsed = _parseDynamicElements(body);
-  if (parsed == null || parsed.elements.isEmpty) {
+Map<String, dynamic>? _parseDynamicTagArguments(
+  String body, {
+  Map<String, dynamic>? schema,
+  String tagPrefix = '',
+}) {
+  final parsed = _parseDynamicElements(
+    body,
+    schema: schema,
+    tagPrefix: tagPrefix,
+  );
+  if (parsed == null) {
+    return null;
+  }
+  if (parsed.elements.isEmpty) {
+    if (body.trim().isNotEmpty) {
+      return null;
+    }
+    return schema == null || schemaRequired(schema).isEmpty
+        ? <String, dynamic>{}
+        : null;
+  }
+  if (!_haveUniqueElementNames(parsed.elements)) {
     return null;
   }
   final result = <String, dynamic>{};
   for (final element in parsed.elements) {
     result[element.name] = element.value;
   }
+  if (schema != null &&
+      !result.keys.toSet().containsAll(schemaRequired(schema))) {
+    return null;
+  }
   return result;
 }
 
-_DynamicElements? _parseDynamicElements(String input) {
+_DynamicElements? _parseDynamicElements(
+  String input, {
+  Map<String, dynamic>? schema,
+  String tagPrefix = '',
+}) {
   final elements = <_DynamicElement>[];
+  final properties = schema == null ? null : schemaProperties(schema);
   var cursor = 0;
   while (cursor < input.length) {
     while (cursor < input.length && _isWhitespace(input.codeUnitAt(cursor))) {
@@ -908,31 +1639,92 @@ _DynamicElements? _parseDynamicElements(String input) {
       break;
     }
     final opening = RegExp(
-      r'<([A-Za-z_][A-Za-z0-9_.-]*)>',
+      '${RegExp.escape(tagPrefix)}<([A-Za-z_][A-Za-z0-9_.-]*)>',
     ).matchAsPrefix(input, cursor);
     if (opening == null) {
       return null;
     }
     final name = opening.group(1)!;
-    final close = _findMatchingDynamicClose(input, name, opening.end);
+    final close = _findMatchingDynamicClose(
+      input,
+      name,
+      opening.end,
+      tagPrefix: tagPrefix,
+    );
     if (close == null) {
       return null;
     }
     final raw = input.substring(opening.end, close.start);
-    final children = _parseDynamicElements(raw);
+    final propertySchema = properties?[name];
+    if (properties != null && propertySchema == null) {
+      return null;
+    }
     Object? value;
-    if (children != null && children.elements.isNotEmpty) {
-      if (children.elements.every((element) => element.name == 'item')) {
-        value = children.elements
-            .map((element) => element.value)
-            .toList(growable: false);
-      } else {
-        value = <String, dynamic>{
-          for (final element in children.elements) element.name: element.value,
-        };
+    if (propertySchema != null && propertySchema['type'] == 'object') {
+      final children = _parseDynamicElements(
+        raw,
+        schema: propertySchema,
+        tagPrefix: tagPrefix,
+      );
+      if (children == null) {
+        return null;
       }
+      if (!_haveUniqueElementNames(children.elements)) {
+        return null;
+      }
+      value = <String, dynamic>{
+        for (final element in children.elements) element.name: element.value,
+      };
+      if (!(value as Map).keys.toSet().containsAll(
+        schemaRequired(propertySchema),
+      )) {
+        return null;
+      }
+    } else if (propertySchema != null && propertySchema['type'] == 'array') {
+      final itemSchema = propertySchema['items'];
+      final itemProperties = itemSchema is Map
+          ? <String, dynamic>{
+              'type': 'object',
+              'properties': {'item': itemSchema},
+            }
+          : null;
+      final children = _parseDynamicElements(
+        raw,
+        schema: itemProperties,
+        tagPrefix: tagPrefix,
+      );
+      if (children == null ||
+          children.elements.any((element) => element.name != 'item')) {
+        return null;
+      }
+      value = children.elements
+          .map((element) => element.value)
+          .toList(growable: false);
+    } else if (propertySchema != null) {
+      final decoded = decodeToolSchemaText(raw, propertySchema);
+      if (!decoded.valid) {
+        return null;
+      }
+      value = decoded.value;
     } else {
-      value = ToolCallParsingUtils.decodeJsonValueOrString(raw);
+      final children = _parseDynamicElements(raw, tagPrefix: tagPrefix);
+      if (children != null && children.elements.isNotEmpty) {
+        if (children.elements.every((element) => element.name == 'item')) {
+          value = children.elements
+              .map((element) => element.value)
+              .toList(growable: false);
+        } else {
+          if (!_haveUniqueElementNames(children.elements)) {
+            return null;
+          }
+          value = <String, dynamic>{
+            for (final element in children.elements)
+              element.name: element.value,
+          };
+        }
+      } else {
+        value = ToolCallParsingUtils.decodeJsonValueOrString(raw);
+      }
     }
     elements.add(_DynamicElement(name: name, value: value));
     cursor = close.end;
@@ -940,12 +1732,20 @@ _DynamicElements? _parseDynamicElements(String input) {
   return _DynamicElements(elements);
 }
 
+bool _haveUniqueElementNames(List<_DynamicElement> elements) {
+  final names = <String>{};
+  return elements.every((element) => names.add(element.name));
+}
+
 ({int start, int end})? _findMatchingDynamicClose(
   String input,
   String name,
-  int start,
-) {
-  final tagPattern = RegExp('<(/?)${RegExp.escape(name)}>');
+  int start, {
+  String tagPrefix = '',
+}) {
+  final tagPattern = RegExp(
+    '${RegExp.escape(tagPrefix)}<(/?)${RegExp.escape(name)}>',
+  );
   var depth = 1;
   for (final match in tagPattern.allMatches(input, start)) {
     if (match.group(1) == '/') {
@@ -960,7 +1760,29 @@ _DynamicElements? _parseDynamicElements(String input) {
   return null;
 }
 
-Map<String, dynamic>? _parseDsmlArguments(String body) {
+ThinkingExtraction _extractDsmlThinking(
+  String output, {
+  required String callsStart,
+  required bool thinkingForcedOpen,
+}) {
+  if (thinkingForcedOpen) {
+    final callsIndex = output.indexOf(callsStart);
+    final thinkEndIndex = output.indexOf('</think>');
+    if (callsIndex >= 0 && (thinkEndIndex < 0 || callsIndex < thinkEndIndex)) {
+      final reasoning = output.substring(0, callsIndex).trim();
+      return (
+        content: output.substring(callsIndex).trim(),
+        reasoning: reasoning.isEmpty ? null : reasoning,
+      );
+    }
+  }
+  return extractThinking(output, thinkingForcedOpen: thinkingForcedOpen);
+}
+
+Map<String, dynamic>? _parseDsmlArguments(
+  String body, {
+  Map<String, dynamic>? schema,
+}) {
   final pattern = RegExp(
     r'<｜DSML｜parameter name="([^"]+)" string="(true|false)">([\s\S]*?)</｜DSML｜parameter>',
   );
@@ -968,13 +1790,26 @@ Map<String, dynamic>? _parseDsmlArguments(String body) {
     return null;
   }
   final result = <String, dynamic>{};
+  final properties = schema == null ? null : schemaProperties(schema);
   for (final match in pattern.allMatches(body)) {
     final key = match.group(1) ?? '';
+    final stringAttribute = match.group(2) == 'true';
     final raw = match.group(3) ?? '';
-    if (key.isEmpty) {
+    final propertySchema = properties?[key];
+    if (key.isEmpty ||
+        result.containsKey(key) ||
+        (properties != null && propertySchema == null) ||
+        (propertySchema != null &&
+            stringAttribute != schemaResolvesToString(propertySchema))) {
       return null;
     }
-    if (match.group(2) == 'true') {
+    if (propertySchema != null) {
+      final decoded = decodeToolSchemaText(raw, propertySchema);
+      if (!decoded.valid) {
+        return null;
+      }
+      result[key] = decoded.value;
+    } else if (stringAttribute) {
       result[key] = raw;
     } else {
       final decoded = ToolCallParsingUtils.decodeJsonValue(raw);
@@ -984,10 +1819,18 @@ Map<String, dynamic>? _parseDsmlArguments(String body) {
       result[key] = decoded;
     }
   }
+  if (schema != null &&
+      !result.keys.toSet().containsAll(schemaRequired(schema))) {
+    return null;
+  }
   return result;
 }
 
-List<LlamaCompletionChunkToolCall>? _parseAtemCalls(String body, int start) {
+List<LlamaCompletionChunkToolCall>? _parseAtemCalls(
+  String body,
+  int start, {
+  Map<String, Map<String, dynamic>> schemas = const {},
+}) {
   const scopeStart = '<atem:function_calls>';
   const scopeEnd = '</atem:function_calls>';
   final scopeStartIndex = body.indexOf(scopeStart);
@@ -1012,6 +1855,12 @@ List<LlamaCompletionChunkToolCall>? _parseAtemCalls(String body, int start) {
   final calls = <LlamaCompletionChunkToolCall>[];
   for (final invoke in invokePattern.allMatches(scope)) {
     final name = invoke.group(1) ?? '';
+    final schema = schemas[name];
+    if (schemas.isNotEmpty && schema == null) {
+      return null;
+    }
+    final properties = schema == null ? null : schemaProperties(schema);
+    final required = schema == null ? const <String>{} : schemaRequired(schema);
     final params = invoke.group(2) ?? '';
     final parameterPattern = RegExp(
       r'<atem:parameter name="([^"]+)">([\s\S]*?)</atem:parameter>',
@@ -1024,10 +1873,25 @@ List<LlamaCompletionChunkToolCall>? _parseAtemCalls(String body, int start) {
     for (final parameter in parameterPattern.allMatches(params)) {
       final key = parameter.group(1) ?? '';
       final raw = parameter.group(2) ?? '';
-      if (key.isEmpty) {
+      if (key.isEmpty || arguments.containsKey(key)) {
         return null;
       }
-      arguments[key] = ToolCallParsingUtils.decodeJsonValueOrString(raw);
+      final propertySchema = properties?[key];
+      if (properties != null && propertySchema == null) {
+        return null;
+      }
+      if (propertySchema == null) {
+        arguments[key] = ToolCallParsingUtils.decodeJsonValueOrString(raw);
+      } else {
+        final decoded = decodeToolSchemaText(raw, propertySchema);
+        if (!decoded.valid) {
+          return null;
+        }
+        arguments[key] = decoded.value;
+      }
+    }
+    if (!arguments.keys.toSet().containsAll(required)) {
+      return null;
     }
     calls.add(
       ToolCallParsingUtils.createFunctionToolCall(

--- a/lib/src/core/template/handlers/llama_cpp_specialized_handlers.dart
+++ b/lib/src/core/template/handlers/llama_cpp_specialized_handlers.dart
@@ -256,7 +256,7 @@ class KimiK3Handler extends _DirectJinjaHandler {
 
     final body = input.substring(bodyStart, scopeEnd);
     final callPattern = RegExp(
-      r'<\|open\|>call\s+tool="([^"]+)"(?:\s+index="[^"]+")?<\|sep\|>([\s\S]*?)<\|close\|>call<\|sep\|>',
+      r'<\|open\|>call\s+tool="([^"]+)"(?:\s+index="[0-9]+")?<\|sep\|>([\s\S]*?)<\|close\|>call<\|sep\|>',
     );
     final matches = callPattern.allMatches(body).toList(growable: false);
     if (matches.isEmpty || body.replaceAll(callPattern, '').trim().isNotEmpty) {
@@ -791,9 +791,20 @@ class MuseGlimmerHandler extends _DirectJinjaHandler {
         lastContentCodeUnit,
         output.substring(cursor, match.start),
       );
-      final recipient = (match.group(1) ?? '').trim();
+      final rawRecipient = match.group(1) ?? '';
+      final recipient = rawRecipient.trim();
       final body = match.group(2) ?? '';
-      if (recipient == 'self') {
+      if (recipient.isEmpty || rawRecipient != recipient) {
+        final terminator = match.group(3) ?? '';
+        if (!isPartial || terminator.isNotEmpty) {
+          lastContentCodeUnit = _appendMuseContent(
+            content,
+            lastContentCodeUnit,
+            match.group(0) ?? body,
+            channelBody: true,
+          );
+        }
+      } else if (recipient == 'self') {
         if (reasoning.isNotEmpty) reasoning.writeln();
         reasoning.write(body);
       } else if (recipient == 'user') {

--- a/lib/src/core/template/tool_call_grammar_utils.dart
+++ b/lib/src/core/template/tool_call_grammar_utils.dart
@@ -8,6 +8,26 @@ class ToolCallGrammarUtils {
   /// Escapes [value] as a grammar string literal.
   static String literal(String value) => _literal(value);
 
+  /// Encodes [value] as a collision-free GBNF rule-name component.
+  static String ruleName(String value) {
+    if (value.isEmpty) {
+      return 'rule-empty';
+    }
+    final buffer = StringBuffer();
+    for (final rune in value.runes) {
+      final isAsciiAlphaNumeric =
+          (rune >= 0x30 && rune <= 0x39) ||
+          (rune >= 0x41 && rune <= 0x5A) ||
+          (rune >= 0x61 && rune <= 0x7A);
+      if (isAsciiAlphaNumeric) {
+        buffer.writeCharCode(rune);
+      } else {
+        buffer.write('-u${rune.toRadixString(16)}-');
+      }
+    }
+    return buffer.toString();
+  }
+
   /// Builds a grammar for an array of tool calls and wraps it with literals.
   static String? buildWrappedArrayGrammar({
     required List<ToolDefinition>? tools,

--- a/lib/src/core/template/tool_call_parsing_utils.dart
+++ b/lib/src/core/template/tool_call_parsing_utils.dart
@@ -285,6 +285,20 @@ class ToolCallParsingUtils {
     return ParsedJsonValueSlice(value: decoded, end: end);
   }
 
+  /// Whether [input] is valid JSON with unique keys in every object.
+  ///
+  /// JSON decoding normally collapses duplicate keys before schema validation.
+  /// Protocol parsers that must fail closed on ambiguous objects can use this
+  /// check before accepting the decoded value.
+  static bool hasUniqueJsonObjectKeys(String input) {
+    try {
+      jsonDecode(input);
+    } catch (_) {
+      return false;
+    }
+    return _UniqueJsonObjectKeyScanner(input).scan();
+  }
+
   /// Builds a function-style tool call chunk.
   static LlamaCompletionChunkToolCall createFunctionToolCall({
     required int index,
@@ -404,3 +418,143 @@ class ToolCallParsingUtils {
     return null;
   }
 }
+
+class _UniqueJsonObjectKeyScanner {
+  _UniqueJsonObjectKeyScanner(this.input);
+
+  final String input;
+  var _offset = 0;
+
+  bool scan() {
+    if (!_scanValue()) {
+      return false;
+    }
+    _skipWhitespace();
+    return _offset == input.length;
+  }
+
+  bool _scanValue() {
+    _skipWhitespace();
+    if (_offset >= input.length) {
+      return false;
+    }
+    return switch (input.codeUnitAt(_offset)) {
+      0x7B => _scanObject(),
+      0x5B => _scanArray(),
+      0x22 => _scanString(),
+      _ => _scanScalar(),
+    };
+  }
+
+  bool _scanObject() {
+    _offset++;
+    _skipWhitespace();
+    if (_consume(0x7D)) {
+      return true;
+    }
+
+    final keys = <String>{};
+    while (_offset < input.length) {
+      _skipWhitespace();
+      if (_offset >= input.length || input.codeUnitAt(_offset) != 0x22) {
+        return false;
+      }
+      final keyStart = _offset;
+      if (!_scanString()) {
+        return false;
+      }
+      final key = jsonDecode(input.substring(keyStart, _offset)) as String;
+      if (!keys.add(key)) {
+        return false;
+      }
+
+      _skipWhitespace();
+      if (!_consume(0x3A) || !_scanValue()) {
+        return false;
+      }
+      _skipWhitespace();
+      if (_consume(0x7D)) {
+        return true;
+      }
+      if (!_consume(0x2C)) {
+        return false;
+      }
+    }
+    return false;
+  }
+
+  bool _scanArray() {
+    _offset++;
+    _skipWhitespace();
+    if (_consume(0x5D)) {
+      return true;
+    }
+    while (_offset < input.length) {
+      if (!_scanValue()) {
+        return false;
+      }
+      _skipWhitespace();
+      if (_consume(0x5D)) {
+        return true;
+      }
+      if (!_consume(0x2C)) {
+        return false;
+      }
+    }
+    return false;
+  }
+
+  bool _scanString() {
+    if (!_consume(0x22)) {
+      return false;
+    }
+    var escaped = false;
+    while (_offset < input.length) {
+      final character = input.codeUnitAt(_offset++);
+      if (escaped) {
+        escaped = false;
+      } else if (character == 0x5C) {
+        escaped = true;
+      } else if (character == 0x22) {
+        return true;
+      }
+    }
+    return false;
+  }
+
+  bool _scanScalar() {
+    final start = _offset;
+    while (_offset < input.length) {
+      final character = input.codeUnitAt(_offset);
+      if (_isJsonWhitespace(character) ||
+          character == 0x2C ||
+          character == 0x5D ||
+          character == 0x7D) {
+        break;
+      }
+      _offset++;
+    }
+    return _offset > start;
+  }
+
+  void _skipWhitespace() {
+    while (_offset < input.length &&
+        _isJsonWhitespace(input.codeUnitAt(_offset))) {
+      _offset++;
+    }
+  }
+
+  bool _consume(int character) {
+    if (_offset >= input.length || input.codeUnitAt(_offset) != character) {
+      return false;
+    }
+    _offset++;
+    return true;
+  }
+}
+
+bool _isJsonWhitespace(int character) =>
+    character == 0x20 ||
+    character == 0x09 ||
+    character == 0x0A ||
+    character == 0x0D;

--- a/lib/src/core/template/tool_schema_utils.dart
+++ b/lib/src/core/template/tool_schema_utils.dart
@@ -1,5 +1,6 @@
 import '../exceptions.dart';
 import '../models/tools/tool_definition.dart';
+import '../models/tools/tool_param.dart';
 import 'tool_call_parsing_utils.dart';
 
 /// Result of reconstructing one tool argument against its declared schema.
@@ -23,9 +24,22 @@ Map<String, Map<String, dynamic>> toolSchemas(List<ToolDefinition>? tools) {
         '"${tool.name}" is declared more than once.',
       );
     }
+    validateToolParameterIdentities(tool);
     schemas[tool.name] = tool.toJsonSchema();
   }
   return schemas;
+}
+
+/// Rejects parameter definitions that would be lossy when converted to an
+/// object schema.
+void validateToolParameterIdentities(ToolDefinition tool) {
+  final error = toolParamIdentityError(
+    tool.parameters,
+    path: 'tool "${tool.name}" parameters',
+  );
+  if (error != null) {
+    throw LlamaUnsupportedException(error);
+  }
 }
 
 /// Returns object-property schemas keyed by their exact protocol names.

--- a/lib/src/core/template/tool_schema_utils.dart
+++ b/lib/src/core/template/tool_schema_utils.dart
@@ -1,3 +1,4 @@
+import '../exceptions.dart';
 import '../models/tools/tool_definition.dart';
 import 'tool_call_parsing_utils.dart';
 
@@ -9,9 +10,22 @@ Map<String, Map<String, dynamic>> toolSchemas(List<ToolDefinition>? tools) {
   if (tools == null || tools.isEmpty) {
     return const {};
   }
-  return <String, Map<String, dynamic>>{
-    for (final tool in tools) tool.name: tool.toJsonSchema(),
-  };
+  final schemas = <String, Map<String, dynamic>>{};
+  for (final tool in tools) {
+    if (tool.name.isEmpty) {
+      throw LlamaUnsupportedException(
+        'Structured tool schemas require non-empty tool names.',
+      );
+    }
+    if (schemas.containsKey(tool.name)) {
+      throw LlamaUnsupportedException(
+        'Structured tool schemas require unique tool names; '
+        '"${tool.name}" is declared more than once.',
+      );
+    }
+    schemas[tool.name] = tool.toJsonSchema();
+  }
+  return schemas;
 }
 
 /// Returns object-property schemas keyed by their exact protocol names.

--- a/lib/src/core/template/tool_schema_utils.dart
+++ b/lib/src/core/template/tool_schema_utils.dart
@@ -1,0 +1,134 @@
+import '../models/tools/tool_definition.dart';
+import 'tool_call_parsing_utils.dart';
+
+/// Result of reconstructing one tool argument against its declared schema.
+typedef ToolSchemaValueResult = ({bool valid, Object? value});
+
+/// Returns tool schemas keyed by the exact tool name emitted in the protocol.
+Map<String, Map<String, dynamic>> toolSchemas(List<ToolDefinition>? tools) {
+  if (tools == null || tools.isEmpty) {
+    return const {};
+  }
+  return <String, Map<String, dynamic>>{
+    for (final tool in tools) tool.name: tool.toJsonSchema(),
+  };
+}
+
+/// Returns object-property schemas keyed by their exact protocol names.
+Map<String, Map<String, dynamic>> schemaProperties(
+  Map<String, dynamic> schema,
+) {
+  final raw = schema['properties'];
+  if (raw is! Map) {
+    return const {};
+  }
+  return <String, Map<String, dynamic>>{
+    for (final entry in raw.entries)
+      if (entry.key is String && entry.value is Map)
+        entry.key as String: Map<String, dynamic>.from(entry.value as Map),
+  };
+}
+
+/// Returns the required object-property names from [schema].
+Set<String> schemaRequired(Map<String, dynamic> schema) {
+  final raw = schema['required'];
+  return raw is List ? raw.whereType<String>().toSet() : const {};
+}
+
+/// Whether a schema must preserve emitted text as a string.
+bool schemaResolvesToString(Map<String, dynamic> schema) =>
+    schema['type'] == 'string' || schema['enum'] is List;
+
+/// Decodes protocol text according to [schema] without guessing string types.
+ToolSchemaValueResult decodeToolSchemaText(
+  String raw,
+  Map<String, dynamic> schema,
+) {
+  if (schemaResolvesToString(schema)) {
+    return validateToolSchemaValue(raw, schema);
+  }
+  final decoded = ToolCallParsingUtils.decodeJsonValue(raw);
+  if (decoded == null && raw.trim() != 'null') {
+    return (valid: false, value: null);
+  }
+  return validateToolSchemaValue(decoded, schema);
+}
+
+/// Validates and normalizes a decoded value according to [schema].
+ToolSchemaValueResult validateToolSchemaValue(
+  Object? value,
+  Map<String, dynamic> schema,
+) {
+  final type = schema['type'];
+  Object? normalized = value;
+
+  if (type == 'string') {
+    if (value is! String) {
+      return (valid: false, value: null);
+    }
+  } else if (type == 'integer') {
+    if (value is! int) {
+      return (valid: false, value: null);
+    }
+  } else if (type == 'number') {
+    if (value is! num) {
+      return (valid: false, value: null);
+    }
+  } else if (type == 'boolean') {
+    if (value is! bool) {
+      return (valid: false, value: null);
+    }
+  } else if (type == 'null') {
+    if (value != null) {
+      return (valid: false, value: null);
+    }
+  } else if (type == 'object') {
+    if (value is! Map) {
+      return (valid: false, value: null);
+    }
+    final properties = schemaProperties(schema);
+    final required = schemaRequired(schema);
+    final object = <String, dynamic>{};
+    for (final entry in value.entries) {
+      if (entry.key is! String) {
+        return (valid: false, value: null);
+      }
+      final propertySchema = properties[entry.key];
+      if (propertySchema == null) {
+        return (valid: false, value: null);
+      }
+      final nested = validateToolSchemaValue(entry.value, propertySchema);
+      if (!nested.valid) {
+        return (valid: false, value: null);
+      }
+      object[entry.key as String] = nested.value;
+    }
+    if (!object.keys.toSet().containsAll(required)) {
+      return (valid: false, value: null);
+    }
+    normalized = object;
+  } else if (type == 'array') {
+    if (value is! List) {
+      return (valid: false, value: null);
+    }
+    final itemSchema = schema['items'];
+    if (itemSchema is Map) {
+      final resolvedItemSchema = Map<String, dynamic>.from(itemSchema);
+      final items = <Object?>[];
+      for (final item in value) {
+        final nested = validateToolSchemaValue(item, resolvedItemSchema);
+        if (!nested.valid) {
+          return (valid: false, value: null);
+        }
+        items.add(nested.value);
+      }
+      normalized = items;
+    }
+  }
+
+  final enumValues = schema['enum'];
+  if (enumValues is List && !enumValues.contains(normalized)) {
+    return (valid: false, value: null);
+  }
+  return (valid: true, value: normalized);
+}

--- a/test/e2e/template/specialized_tool_grammar_validation_e2e_test.dart
+++ b/test/e2e/template/specialized_tool_grammar_validation_e2e_test.dart
@@ -213,7 +213,12 @@ void main() {
       validator,
       MuseGlimmerHandler().buildRequiredGrammar([_escapedAttributeSchemaTool])!,
       valid: [' to=weather&"alerts<|message|>$museValid'],
-      invalid: [' to=weather<|message|>$museValid'],
+      invalid: [
+        ' to=weather<|message|>$museValid',
+        ' to=other<|message|>$museValid',
+        ' to=weather&"alerts<|message|>'
+            '${museValid.replaceFirst('</atem:function_calls>', '<atem:invoke name="weather&amp;&quot;alerts"></atem:invoke></atem:function_calls>')}',
+      ],
     );
   });
 

--- a/test/e2e/template/specialized_tool_grammar_validation_e2e_test.dart
+++ b/test/e2e/template/specialized_tool_grammar_validation_e2e_test.dart
@@ -425,7 +425,7 @@ void main() {
     },
   );
 
-  test('specialized grammars reject duplicate optional properties', () {
+  test('specialized grammars accept optional properties in any order once', () {
     const open = '<|open|>';
     const close = '<|close|>';
     const separator = '<|sep|>';
@@ -442,6 +442,10 @@ void main() {
             'weather$close'
             'argument$separator'
             '$open'
+            'argument key="detail" type="string"$separator'
+            'verbose$close'
+            'argument$separator'
+            '$open'
             'argument key="note" type="string"$separator'
             'metric$close'
             'argument$separator'
@@ -462,12 +466,16 @@ void main() {
             'weather$close'
             'argument$separator'
             '$open'
-            'argument key="note" type="string"$separator'
-            'metric$close'
+            'argument key="detail" type="string"$separator'
+            'verbose$close'
+            'argument$separator'
+            '$open'
+            'argument key="detail" type="string"$separator'
+            'duplicate$close'
             'argument$separator'
             '$open'
             'argument key="note" type="string"$separator'
-            'duplicate$close'
+            'metric$close'
             'argument$separator'
             '$close'
             'call$separator'
@@ -483,6 +491,7 @@ void main() {
         '$namespace<tool_call>'
         '$namespace<invoke name="lookup">'
         '$namespace<query>weather$namespace</query>'
+        '$namespace<detail>verbose$namespace</detail>'
         '$namespace<note>metric$namespace</note>'
         '$namespace</invoke>'
         '$namespace</tool_call>';
@@ -493,7 +502,7 @@ void main() {
       invalid: [
         m3Valid.replaceFirst(
           '$namespace</invoke>',
-          '$namespace<note>duplicate$namespace</note>$namespace</invoke>',
+          '$namespace<detail>duplicate$namespace</detail>$namespace</invoke>',
         ),
       ],
     );
@@ -502,6 +511,8 @@ void main() {
         '<｜DSML｜function_calls>'
         '<｜DSML｜invoke name="lookup">'
         '<｜DSML｜parameter name="query" string="true">weather'
+        '</｜DSML｜parameter>'
+        '<｜DSML｜parameter name="detail" string="true">verbose'
         '</｜DSML｜parameter>'
         '<｜DSML｜parameter name="note" string="true">metric'
         '</｜DSML｜parameter>'
@@ -514,7 +525,7 @@ void main() {
       invalid: [
         dsmlValid.replaceFirst(
           '</｜DSML｜invoke>',
-          '<｜DSML｜parameter name="note" string="true">duplicate'
+          '<｜DSML｜parameter name="detail" string="true">duplicate'
               '</｜DSML｜parameter></｜DSML｜invoke>',
         ),
       ],
@@ -524,6 +535,7 @@ void main() {
         '<atem:function_calls>'
         '<atem:invoke name="lookup">'
         '<atem:parameter name="query">weather</atem:parameter>'
+        '<atem:parameter name="detail">verbose</atem:parameter>'
         '<atem:parameter name="note">metric</atem:parameter>'
         '</atem:invoke>'
         '</atem:function_calls>';
@@ -534,7 +546,7 @@ void main() {
       invalid: [
         museValid.replaceFirst(
           '</atem:invoke>',
-          '<atem:parameter name="note">duplicate</atem:parameter>'
+          '<atem:parameter name="detail">duplicate</atem:parameter>'
               '</atem:invoke>',
         ),
       ],
@@ -699,6 +711,7 @@ final _optionalTool = ToolDefinition(
   parameters: [
     ToolParam.string('query', required: true),
     ToolParam.string('note'),
+    ToolParam.string('detail'),
   ],
   handler: (_) async => null,
 );

--- a/test/e2e/template/specialized_tool_grammar_validation_e2e_test.dart
+++ b/test/e2e/template/specialized_tool_grammar_validation_e2e_test.dart
@@ -1,0 +1,382 @@
+@TestOn('vm')
+@Tags(['local-only', 'e2e'])
+library;
+
+import 'dart:io';
+
+import 'package:llamadart/src/core/models/tools/tool_definition.dart';
+import 'package:llamadart/src/core/models/tools/tool_param.dart';
+import 'package:llamadart/src/core/template/handlers/llama_cpp_specialized_handlers.dart';
+import 'package:test/test.dart';
+
+void main() {
+  late String validator;
+
+  setUpAll(() {
+    validator = Platform.environment['LLAMA_CPP_GBNF_VALIDATOR'] ?? '';
+    expect(
+      validator,
+      isNotEmpty,
+      reason: 'Set LLAMA_CPP_GBNF_VALIDATOR to llama.cpp test-gbnf-validator.',
+    );
+    expect(File(validator).existsSync(), isTrue);
+  });
+
+  test('MiniMax M1 accepts quoted names and rejects invalid JSON names', () {
+    final grammar = MinimaxM1Handler().buildGrammar([_schemaTool])!;
+    _expectGrammar(
+      validator,
+      grammar,
+      valid: [
+        '<tool_calls>\n'
+            '{"name":"inspect","arguments":'
+            '{"code":"a]b","options":{},"items":[],"count":7,'
+            '"active":true,"empty":null}}\n'
+            '</tool_calls>',
+      ],
+      invalid: [
+        '<tool_calls>\n'
+            '{name:"inspect","arguments":'
+            '{"code":"a","options":{},"items":[],"count":7,'
+            '"active":true,"empty":null}}\n'
+            '</tool_calls>',
+        '<tool_calls>\n'
+            '{"name":"unknown","arguments":'
+            '{"code":"a","options":{},"items":[],"count":7,'
+            '"active":true,"empty":null}}\n'
+            '</tool_calls>',
+        '<tool_calls>\n{"name":"inspect","arguments":\n</tool_calls>',
+      ],
+    );
+  });
+
+  test('Kimi K3 accepts escaped schema keys and rejects undeclared keys', () {
+    final grammar = KimiK3Handler().buildGrammar([_kimiTool])!;
+    const open = '<|open|>';
+    const close = '<|close|>';
+    const separator = '<|sep|>';
+    _expectGrammar(
+      validator,
+      grammar,
+      valid: [
+        '$open'
+            'tools$separator'
+            '$open'
+            'call tool="weather&amp;&quot;alerts"$separator'
+            '$open'
+            'argument key="city&amp;&quot;zone" type="string"$separator'
+            'a<]b$close'
+            'argument$separator'
+            '$close'
+            'call$separator'
+            '$close'
+            'tools$separator'
+            '$close'
+            'message$separator',
+      ],
+      invalid: [
+        '$open'
+            'tools$separator'
+            '$open'
+            'call tool="weather&amp;&quot;alerts"$separator'
+            '$open'
+            'argument key="city&\\"zone" type="string"$separator'
+            'x$close'
+            'argument$separator'
+            '$close'
+            'call$separator'
+            '$close'
+            'tools$separator'
+            '$close'
+            'message$separator',
+        '$open'
+            'tools$separator'
+            '$open'
+            'call tool="weather&amp;&quot;alerts"$separator'
+            '$open'
+            'argument key="unknown" type="string"$separator'
+            'x$close'
+            'argument$separator'
+            '$close'
+            'call$separator'
+            '$close'
+            'tools$separator'
+            '$close'
+            'message$separator',
+      ],
+    );
+  });
+
+  test('MiniMax M3 binds closing tags and preserves string delimiters', () {
+    final grammar = MinimaxM3Handler().buildGrammar([
+      _schemaTool,
+      _zeroArgTool,
+    ])!;
+    const namespace = MinimaxM3Handler.namespace;
+    _expectGrammar(
+      validator,
+      grammar,
+      valid: [
+        '$namespace<tool_call>'
+            '$namespace<invoke name="inspect">'
+            '$namespace<code>a]b$namespace</code>'
+            '$namespace<options>$namespace</options>'
+            '$namespace<items>$namespace</items>'
+            '$namespace<count>7$namespace</count>'
+            '$namespace<active>true$namespace</active>'
+            '$namespace<empty>null$namespace</empty>'
+            '$namespace</invoke>'
+            '$namespace</tool_call>',
+        '$namespace<tool_call>'
+            '$namespace<invoke name="ping">'
+            '$namespace</invoke>'
+            '$namespace</tool_call>',
+        '$namespace<tool_call>'
+            '$namespace<invoke name="inspect">'
+            '$namespace<code>a${namespace}literal$namespace</code>'
+            '$namespace<options>$namespace</options>'
+            '$namespace<items>$namespace</items>'
+            '$namespace<count>7$namespace</count>'
+            '$namespace<active>true$namespace</active>'
+            '$namespace<empty>null$namespace</empty>'
+            '$namespace</invoke>'
+            '$namespace</tool_call>',
+      ],
+      invalid: [
+        '$namespace<tool_call>'
+            '$namespace<invoke name="inspect">'
+            '$namespace<code>a$namespace</count>'
+            '$namespace</invoke>'
+            '$namespace</tool_call>',
+        '$namespace<tool_call>'
+            '$namespace<invoke name="inspect">'
+            '$namespace<unknown>x$namespace</unknown>'
+            '$namespace</invoke>'
+            '$namespace</tool_call>',
+        '$namespace<tool_call>'
+            '$namespace<invoke name="inspect">'
+            '$namespace<code>a$namespace</code>'
+            '$namespace<options>$namespace</options>'
+            '$namespace<items>$namespace</items>'
+            '$namespace<count>oops$namespace</count>'
+            '$namespace<active>true$namespace</active>'
+            '$namespace<empty>null$namespace</empty>'
+            '$namespace</invoke>'
+            '$namespace</tool_call>',
+      ],
+    );
+  });
+
+  test('DeepSeek DSML enforces schema names types and delimiters', () {
+    final grammar = DeepseekV32Handler().buildGrammar([_schemaTool])!;
+    const start = '<｜DSML｜function_calls>';
+    const end = '</｜DSML｜function_calls>';
+    const invoke = '<｜DSML｜invoke name="inspect">';
+    const closeInvoke = '</｜DSML｜invoke>';
+    const valid =
+        '$start\n$invoke\n'
+        '<｜DSML｜parameter name="code" string="true">x < 5]'
+        '</｜DSML｜parameter>\n'
+        '<｜DSML｜parameter name="options" string="false">{}'
+        '</｜DSML｜parameter>\n'
+        '<｜DSML｜parameter name="items" string="false">[]'
+        '</｜DSML｜parameter>\n'
+        '<｜DSML｜parameter name="count" string="false">7'
+        '</｜DSML｜parameter>\n'
+        '<｜DSML｜parameter name="active" string="false">true'
+        '</｜DSML｜parameter>\n'
+        '<｜DSML｜parameter name="empty" string="false">null'
+        '</｜DSML｜parameter>\n'
+        '$closeInvoke\n$end';
+    _expectGrammar(
+      validator,
+      grammar,
+      valid: [valid],
+      invalid: [
+        valid.replaceFirst('name="code"', 'name="unknown"'),
+        valid.replaceFirst('string="true"', 'string="false"'),
+        valid.replaceFirst(
+          '<｜DSML｜parameter name="count" string="false">7'
+              '</｜DSML｜parameter>\n',
+          '',
+        ),
+        valid.replaceFirst('>7</｜DSML｜parameter>', '>seven</｜DSML｜parameter>'),
+      ],
+    );
+  });
+
+  test(
+    'Muse grammar enforces schema names types and delimiter-aware strings',
+    () {
+      final grammar = MuseGlimmerHandler().buildGrammar([_schemaTool])!;
+      const valid =
+          '<atem:function_calls>\n'
+          '<atem:invoke name="inspect">\n'
+          '<atem:parameter name="code">x < 5]</atem:parameter>\n'
+          '<atem:parameter name="options">{}</atem:parameter>\n'
+          '<atem:parameter name="items">[]</atem:parameter>\n'
+          '<atem:parameter name="count">7</atem:parameter>\n'
+          '<atem:parameter name="active">true</atem:parameter>\n'
+          '<atem:parameter name="empty">null</atem:parameter>\n'
+          '</atem:invoke>\n'
+          '</atem:function_calls>';
+      _expectGrammar(
+        validator,
+        grammar,
+        valid: [valid],
+        invalid: [
+          valid.replaceFirst('name="code"', 'name="unknown"'),
+          valid.replaceFirst(
+            '<atem:parameter name="count">7</atem:parameter>\n',
+            '',
+          ),
+          valid.replaceFirst('>7</atem:parameter>', '>seven</atem:parameter>'),
+        ],
+      );
+    },
+  );
+
+  test('required grammars accept prefixes but still require a tool call', () {
+    const kimiCall =
+        '<|open|>tools<|sep|>'
+        '<|open|>call tool="weather"<|sep|>'
+        '<|open|>argument key="city" type="string"<|sep|>Seoul'
+        '<|close|>argument<|sep|><|close|>call<|sep|>'
+        '<|close|>tools<|sep|><|close|>message<|sep|>';
+    _expectGrammar(
+      validator,
+      KimiK3Handler().buildRequiredGrammar([_weatherWithCityTool])!,
+      valid: ['reasoning<|close|>think<|sep|>$kimiCall'],
+      invalid: ['reasoning<|close|>think<|sep|>No tool'],
+    );
+
+    const namespace = MinimaxM3Handler.namespace;
+    const m3Call =
+        '$namespace<tool_call>'
+        '$namespace<invoke name="ping">'
+        '$namespace</invoke>'
+        '$namespace</tool_call>';
+    _expectGrammar(
+      validator,
+      MinimaxM3Handler().buildRequiredGrammar([_zeroArgTool])!,
+      valid: ['<mm:think>reasoning</mm:think>$m3Call'],
+      invalid: ['<mm:think>reasoning</mm:think>No tool'],
+    );
+
+    const dsmlCall =
+        '<｜DSML｜function_calls>'
+        '<｜DSML｜invoke name="weather">'
+        '<｜DSML｜parameter name="city" string="true">Seoul'
+        '</｜DSML｜parameter>'
+        '</｜DSML｜invoke>'
+        '</｜DSML｜function_calls>';
+    _expectGrammar(
+      validator,
+      DeepseekV32Handler().buildRequiredGrammar([_weatherWithCityTool])!,
+      valid: ['reasoning without a closing think tag$dsmlCall'],
+      invalid: ['reasoning without a tool call'],
+    );
+
+    const museCall =
+        ' to=weather<|message|><atem:function_calls>'
+        '<atem:invoke name="weather">'
+        '<atem:parameter name="city">Seoul</atem:parameter>'
+        '</atem:invoke></atem:function_calls>';
+    _expectGrammar(
+      validator,
+      MuseGlimmerHandler().buildRequiredGrammar([_weatherWithCityTool])!,
+      valid: [
+        ' to=self<|message|>reasoning<|eom|>'
+            '<|start|>assistant$museCall',
+      ],
+      invalid: [' to=user<|message|>No tool<|eot|>'],
+    );
+
+    const lagunaCall =
+        '\n<tool_call>weather\n'
+        '<arg_key>city</arg_key>\n'
+        '<arg_value>Seoul</arg_value>\n'
+        '</tool_call>\n';
+    _expectGrammar(
+      validator,
+      LagunaHandler().buildRequiredGrammar([_weatherWithCityTool])!,
+      valid: ['reasoning</think>$lagunaCall'],
+      invalid: ['reasoning</think>No tool'],
+    );
+  });
+}
+
+void _expectGrammar(
+  String validator,
+  String grammar, {
+  required List<String> valid,
+  required List<String> invalid,
+}) {
+  final directory = Directory.systemTemp.createTempSync('llamadart-gbnf-');
+  addTearDown(() => directory.deleteSync(recursive: true));
+  final grammarFile = File('${directory.path}/grammar.gbnf')
+    ..writeAsStringSync(grammar);
+  for (final input in valid) {
+    _validate(validator, grammarFile, input, expected: true);
+  }
+  for (final input in invalid) {
+    _validate(validator, grammarFile, input, expected: false);
+  }
+}
+
+void _validate(
+  String validator,
+  File grammar,
+  String input, {
+  required bool expected,
+}) {
+  final inputFile = File('${grammar.parent.path}/input.txt')
+    ..writeAsStringSync(input);
+  final result = Process.runSync(validator, [grammar.path, inputFile.path]);
+  final output = '${result.stdout}\n${result.stderr}';
+  expect(result.exitCode, 0, reason: output);
+  expect(
+    output.contains('Input string is valid according to the grammar.'),
+    expected,
+    reason: 'Input: $input\n$output\nGrammar:\n${grammar.readAsStringSync()}',
+  );
+}
+
+final _schemaTool = ToolDefinition(
+  name: 'inspect',
+  description: 'Inspect typed values',
+  parameters: [
+    ToolParam.string('code', required: true),
+    ToolParam.object('options', properties: const [], required: true),
+    ToolParam.array(
+      'items',
+      itemType: ToolParam.string('item'),
+      required: true,
+    ),
+    ToolParam.integer('count', required: true),
+    ToolParam.boolean('active', required: true),
+    ToolParam.nullType('empty', required: true),
+  ],
+  handler: (_) async => null,
+);
+
+final _zeroArgTool = ToolDefinition(
+  name: 'ping',
+  description: 'Ping',
+  parameters: const [],
+  handler: (_) async => null,
+);
+
+final _weatherWithCityTool = ToolDefinition(
+  name: 'weather',
+  description: 'Weather',
+  parameters: [ToolParam.string('city', required: true)],
+  handler: (_) async => null,
+);
+
+final _kimiTool = ToolDefinition(
+  name: 'weather&"alerts',
+  description: 'Weather',
+  parameters: [ToolParam.string('city&"zone', required: true)],
+  handler: (_) async => null,
+);

--- a/test/e2e/template/specialized_tool_grammar_validation_e2e_test.dart
+++ b/test/e2e/template/specialized_tool_grammar_validation_e2e_test.dart
@@ -107,6 +107,45 @@ void main() {
     );
   });
 
+  test('Kimi K3 compiles and accepts zero-parameter tools', () {
+    final grammar = KimiK3Handler().buildGrammar([_zeroArgTool])!;
+    const open = '<|open|>';
+    const close = '<|close|>';
+    const separator = '<|sep|>';
+    _expectGrammar(
+      validator,
+      grammar,
+      valid: [
+        '$open'
+            'tools$separator'
+            '$open'
+            'call tool="ping"$separator'
+            '$close'
+            'call$separator'
+            '$close'
+            'tools$separator'
+            '$close'
+            'message$separator',
+      ],
+      invalid: [
+        '$open'
+            'tools$separator'
+            '$open'
+            'call tool="ping"$separator'
+            '$open'
+            'argument key="unexpected" type="string"$separator'
+            'value$close'
+            'argument$separator'
+            '$close'
+            'call$separator'
+            '$close'
+            'tools$separator'
+            '$close'
+            'message$separator',
+      ],
+    );
+  });
+
   test('MiniMax M3 binds closing tags and preserves string delimiters', () {
     final grammar = MinimaxM3Handler().buildGrammar([
       _schemaTool,

--- a/test/e2e/template/specialized_tool_grammar_validation_e2e_test.dart
+++ b/test/e2e/template/specialized_tool_grammar_validation_e2e_test.dart
@@ -236,6 +236,122 @@ void main() {
     },
   );
 
+  test('specialized grammars reject duplicate optional properties', () {
+    const open = '<|open|>';
+    const close = '<|close|>';
+    const separator = '<|sep|>';
+    _expectGrammar(
+      validator,
+      KimiK3Handler().buildGrammar([_optionalTool])!,
+      valid: [
+        '$open'
+            'tools$separator'
+            '$open'
+            'call tool="lookup"$separator'
+            '$open'
+            'argument key="query" type="string"$separator'
+            'weather$close'
+            'argument$separator'
+            '$open'
+            'argument key="note" type="string"$separator'
+            'metric$close'
+            'argument$separator'
+            '$close'
+            'call$separator'
+            '$close'
+            'tools$separator'
+            '$close'
+            'message$separator',
+      ],
+      invalid: [
+        '$open'
+            'tools$separator'
+            '$open'
+            'call tool="lookup"$separator'
+            '$open'
+            'argument key="query" type="string"$separator'
+            'weather$close'
+            'argument$separator'
+            '$open'
+            'argument key="note" type="string"$separator'
+            'metric$close'
+            'argument$separator'
+            '$open'
+            'argument key="note" type="string"$separator'
+            'duplicate$close'
+            'argument$separator'
+            '$close'
+            'call$separator'
+            '$close'
+            'tools$separator'
+            '$close'
+            'message$separator',
+      ],
+    );
+
+    const namespace = MinimaxM3Handler.namespace;
+    const m3Valid =
+        '$namespace<tool_call>'
+        '$namespace<invoke name="lookup">'
+        '$namespace<query>weather$namespace</query>'
+        '$namespace<note>metric$namespace</note>'
+        '$namespace</invoke>'
+        '$namespace</tool_call>';
+    _expectGrammar(
+      validator,
+      MinimaxM3Handler().buildGrammar([_optionalTool])!,
+      valid: [m3Valid],
+      invalid: [
+        m3Valid.replaceFirst(
+          '$namespace</invoke>',
+          '$namespace<note>duplicate$namespace</note>$namespace</invoke>',
+        ),
+      ],
+    );
+
+    const dsmlValid =
+        '<｜DSML｜function_calls>'
+        '<｜DSML｜invoke name="lookup">'
+        '<｜DSML｜parameter name="query" string="true">weather'
+        '</｜DSML｜parameter>'
+        '<｜DSML｜parameter name="note" string="true">metric'
+        '</｜DSML｜parameter>'
+        '</｜DSML｜invoke>'
+        '</｜DSML｜function_calls>';
+    _expectGrammar(
+      validator,
+      DeepseekV32Handler().buildGrammar([_optionalTool])!,
+      valid: [dsmlValid],
+      invalid: [
+        dsmlValid.replaceFirst(
+          '</｜DSML｜invoke>',
+          '<｜DSML｜parameter name="note" string="true">duplicate'
+              '</｜DSML｜parameter></｜DSML｜invoke>',
+        ),
+      ],
+    );
+
+    const museValid =
+        '<atem:function_calls>'
+        '<atem:invoke name="lookup">'
+        '<atem:parameter name="query">weather</atem:parameter>'
+        '<atem:parameter name="note">metric</atem:parameter>'
+        '</atem:invoke>'
+        '</atem:function_calls>';
+    _expectGrammar(
+      validator,
+      MuseGlimmerHandler().buildGrammar([_optionalTool])!,
+      valid: [museValid],
+      invalid: [
+        museValid.replaceFirst(
+          '</atem:invoke>',
+          '<atem:parameter name="note">duplicate</atem:parameter>'
+              '</atem:invoke>',
+        ),
+      ],
+    );
+  });
+
   test('required grammars accept prefixes but still require a tool call', () {
     const kimiCall =
         '<|open|>tools<|sep|>'
@@ -371,6 +487,16 @@ final _weatherWithCityTool = ToolDefinition(
   name: 'weather',
   description: 'Weather',
   parameters: [ToolParam.string('city', required: true)],
+  handler: (_) async => null,
+);
+
+final _optionalTool = ToolDefinition(
+  name: 'lookup',
+  description: 'Lookup',
+  parameters: [
+    ToolParam.string('query', required: true),
+    ToolParam.string('note'),
+  ],
   handler: (_) async => null,
 );
 

--- a/test/e2e/template/specialized_tool_grammar_validation_e2e_test.dart
+++ b/test/e2e/template/specialized_tool_grammar_validation_e2e_test.dart
@@ -146,6 +146,59 @@ void main() {
     );
   });
 
+  test('XML attribute grammars round-trip escaped schema identities', () {
+    const namespace = MinimaxM3Handler.namespace;
+    _expectGrammar(
+      validator,
+      MinimaxM3Handler().buildGrammar([_attributeTool])!,
+      valid: [
+        '$namespace<tool_call>'
+            '$namespace<invoke name="weather&amp;&quot;alerts">'
+            '$namespace</invoke>'
+            '$namespace</tool_call>',
+      ],
+      invalid: [
+        '$namespace<tool_call>'
+            '$namespace<invoke name="weather&"alerts">'
+            '$namespace</invoke>'
+            '$namespace</tool_call>',
+      ],
+    );
+
+    const dsmlValid =
+        '<｜DSML｜function_calls>'
+        '<｜DSML｜invoke name="weather&amp;&quot;alerts">'
+        '<｜DSML｜parameter name="city&amp;&quot;zone" string="true">Seoul'
+        '</｜DSML｜parameter>'
+        '</｜DSML｜invoke>'
+        '</｜DSML｜function_calls>';
+    _expectGrammar(
+      validator,
+      DeepseekV32Handler().buildGrammar([_escapedAttributeSchemaTool])!,
+      valid: [dsmlValid],
+      invalid: [dsmlValid.replaceFirst('&amp;&quot;', '&"')],
+    );
+
+    const museValid =
+        '<atem:function_calls>'
+        '<atem:invoke name="weather&amp;&quot;alerts">'
+        '<atem:parameter name="city&amp;&quot;zone">Seoul</atem:parameter>'
+        '</atem:invoke>'
+        '</atem:function_calls>';
+    _expectGrammar(
+      validator,
+      MuseGlimmerHandler().buildGrammar([_escapedAttributeSchemaTool])!,
+      valid: [museValid],
+      invalid: [museValid.replaceFirst('&amp;&quot;', '&"')],
+    );
+    _expectGrammar(
+      validator,
+      MuseGlimmerHandler().buildRequiredGrammar([_escapedAttributeSchemaTool])!,
+      valid: [' to=weather&"alerts<|message|>$museValid'],
+      invalid: [' to=weather<|message|>$museValid'],
+    );
+  });
+
   test('MiniMax M3 binds closing tags and preserves string delimiters', () {
     final grammar = MinimaxM3Handler().buildGrammar([
       _schemaTool,
@@ -519,6 +572,20 @@ final _zeroArgTool = ToolDefinition(
   name: 'ping',
   description: 'Ping',
   parameters: const [],
+  handler: (_) async => null,
+);
+
+final _attributeTool = ToolDefinition(
+  name: 'weather&"alerts',
+  description: 'Weather alerts',
+  parameters: const [],
+  handler: (_) async => null,
+);
+
+final _escapedAttributeSchemaTool = ToolDefinition(
+  name: 'weather&"alerts',
+  description: 'Weather alerts',
+  parameters: [ToolParam.string('city&"zone', required: true)],
   handler: (_) async => null,
 );
 

--- a/test/e2e/template/specialized_tool_grammar_validation_e2e_test.dart
+++ b/test/e2e/template/specialized_tool_grammar_validation_e2e_test.dart
@@ -216,6 +216,7 @@ void main() {
       invalid: [
         ' to=weather<|message|>$museValid',
         ' to=other<|message|>$museValid',
+        ' to= weather&"alerts <|message|>$museValid',
         ' to=weather&"alerts<|message|>'
             '${museValid.replaceFirst('</atem:function_calls>', '<atem:invoke name="weather&amp;&quot;alerts"></atem:invoke></atem:function_calls>')}',
       ],

--- a/test/e2e/template/specialized_tool_grammar_validation_e2e_test.dart
+++ b/test/e2e/template/specialized_tool_grammar_validation_e2e_test.dart
@@ -6,6 +6,7 @@ import 'dart:io';
 
 import 'package:llamadart/src/core/models/tools/tool_definition.dart';
 import 'package:llamadart/src/core/models/tools/tool_param.dart';
+import 'package:llamadart/src/core/template/handlers/glm45_handler.dart';
 import 'package:llamadart/src/core/template/handlers/llama_cpp_specialized_handlers.dart';
 import 'package:test/test.dart';
 
@@ -143,6 +144,50 @@ void main() {
             '$close'
             'message$separator',
       ],
+    );
+  });
+
+  test('specialized and GLM rule names remain collision-free', () {
+    const open = '<|open|>';
+    const close = '<|close|>';
+    const separator = '<|sep|>';
+    _expectGrammar(
+      validator,
+      KimiK3Handler().buildGrammar([_collidingKeyTool])!,
+      valid: [
+        '$open'
+            'tools$separator'
+            '$open'
+            'call tool="colliding"$separator'
+            '$open'
+            'argument key="a b" type="string"$separator'
+            'first$close'
+            'argument$separator'
+            '$open'
+            'argument key="a-b" type="string"$separator'
+            'second$close'
+            'argument$separator'
+            '$close'
+            'call$separator'
+            '$close'
+            'tools$separator'
+            '$close'
+            'message$separator',
+      ],
+      invalid: const [],
+    );
+    _expectGrammar(
+      validator,
+      Glm45Handler().buildGrammar([_collidingKeyTool])!,
+      valid: const [
+        '\n<tool_call>colliding\n'
+            '<arg_key>a b</arg_key>\n'
+            '<arg_value>first</arg_value>\n'
+            '<arg_key>a-b</arg_key>\n'
+            '<arg_value>second</arg_value>\n'
+            '</tool_call>\n',
+      ],
+      invalid: const [],
     );
   });
 
@@ -634,5 +679,15 @@ final _kimiTool = ToolDefinition(
   name: 'weather&"alerts',
   description: 'Weather',
   parameters: [ToolParam.string('city&"zone', required: true)],
+  handler: (_) async => null,
+);
+
+final _collidingKeyTool = ToolDefinition(
+  name: 'colliding',
+  description: 'Collision coverage',
+  parameters: [
+    ToolParam.string('a b', required: true),
+    ToolParam.string('a-b', required: true),
+  ],
   handler: (_) async => null,
 );

--- a/test/e2e/template/specialized_tool_grammar_validation_e2e_test.dart
+++ b/test/e2e/template/specialized_tool_grammar_validation_e2e_test.dart
@@ -191,6 +191,34 @@ void main() {
     );
   });
 
+  test(
+    'GLM accepts delimiter strings and rejects an invalid enum atomically',
+    () {
+      final grammar = Glm45Handler().buildGrammar([_glmEvidenceTool])!;
+      const validCall =
+          '<tool_call>inspect\n'
+          '<arg_key>code</arg_key>\n'
+          '<arg_value>x < 5</arg_value>\n'
+          '<arg_key>city</arg_key>\n'
+          '<arg_value>Seoul</arg_value>\n'
+          '</tool_call>\n';
+      const invalidEnumCall =
+          '<tool_call>inspect\n'
+          '<arg_key>code</arg_key>\n'
+          '<arg_value>second</arg_value>\n'
+          '<arg_key>city</arg_key>\n'
+          '<arg_value>Rome</arg_value>\n'
+          '</tool_call>\n';
+
+      _expectGrammar(
+        validator,
+        grammar,
+        valid: const [validCall, '\n$validCall'],
+        invalid: const ['$validCall$invalidEnumCall'],
+      );
+    },
+  );
+
   test('XML attribute grammars round-trip escaped schema identities', () {
     const namespace = MinimaxM3Handler.namespace;
     _expectGrammar(
@@ -688,6 +716,20 @@ final _collidingKeyTool = ToolDefinition(
   parameters: [
     ToolParam.string('a b', required: true),
     ToolParam.string('a-b', required: true),
+  ],
+  handler: (_) async => null,
+);
+
+final _glmEvidenceTool = ToolDefinition(
+  name: 'inspect',
+  description: 'GLM donor evidence',
+  parameters: [
+    ToolParam.string('code', required: true),
+    ToolParam.enumType(
+      'city',
+      values: const ['Seoul', 'Paris'],
+      required: true,
+    ),
   ],
   handler: (_) async => null,
 );

--- a/test/e2e/template/specialized_tool_grammar_validation_e2e_test.dart
+++ b/test/e2e/template/specialized_tool_grammar_validation_e2e_test.dart
@@ -209,12 +209,24 @@ void main() {
           '<arg_key>city</arg_key>\n'
           '<arg_value>Rome</arg_value>\n'
           '</tool_call>\n';
+      const protocolMarkers = [
+        '<tool_call>',
+        '</tool_call>',
+        '<arg_key>',
+        '</arg_key>',
+        '<arg_value>',
+        '</arg_value>',
+      ];
 
       _expectGrammar(
         validator,
         grammar,
         valid: const [validCall, '\n$validCall'],
-        invalid: const ['$validCall$invalidEnumCall'],
+        invalid: [
+          '$validCall$invalidEnumCall',
+          for (final marker in protocolMarkers)
+            validCall.replaceFirst('x < 5', 'before$marker after'),
+        ],
       );
     },
   );

--- a/test/e2e/template/specialized_tool_grammar_validation_e2e_test.dart
+++ b/test/e2e/template/specialized_tool_grammar_validation_e2e_test.dart
@@ -221,7 +221,15 @@ void main() {
       _expectGrammar(
         validator,
         grammar,
-        valid: const [validCall, '\n$validCall'],
+        valid: [
+          validCall,
+          '\n$validCall',
+          for (final marker in protocolMarkers)
+            validCall.replaceFirst(
+              'x < 5',
+              'before${marker.substring(0, marker.length - 1)}X after',
+            ),
+        ],
         invalid: [
           '$validCall$invalidEnumCall',
           for (final marker in protocolMarkers)

--- a/test/e2e/template/specialized_tool_grammar_validation_e2e_test.dart
+++ b/test/e2e/template/specialized_tool_grammar_validation_e2e_test.dart
@@ -162,6 +162,14 @@ void main() {
             '$namespace<invoke name="weather&"alerts">'
             '$namespace</invoke>'
             '$namespace</tool_call>',
+        '$namespace<tool_call>'
+            '$namespace<invoke name="weather&&quot;alerts">'
+            '$namespace</invoke>'
+            '$namespace</tool_call>',
+        '$namespace<tool_call>'
+            '$namespace<invoke name="weather&amp;amp;&quot;alerts">'
+            '$namespace</invoke>'
+            '$namespace</tool_call>',
       ],
     );
 
@@ -176,7 +184,12 @@ void main() {
       validator,
       DeepseekV32Handler().buildGrammar([_escapedAttributeSchemaTool])!,
       valid: [dsmlValid],
-      invalid: [dsmlValid.replaceFirst('&amp;&quot;', '&"')],
+      invalid: [
+        dsmlValid.replaceFirst('&amp;&quot;', '&"'),
+        dsmlValid.replaceFirst('&amp;&quot;', '&&quot;'),
+        dsmlValid.replaceFirst('&amp;&quot;', '&bogus;&quot;'),
+        dsmlValid.replaceFirst('&amp;&quot;', '&amp;amp;&quot;'),
+      ],
     );
 
     const museValid =
@@ -189,7 +202,12 @@ void main() {
       validator,
       MuseGlimmerHandler().buildGrammar([_escapedAttributeSchemaTool])!,
       valid: [museValid],
-      invalid: [museValid.replaceFirst('&amp;&quot;', '&"')],
+      invalid: [
+        museValid.replaceFirst('&amp;&quot;', '&"'),
+        museValid.replaceFirst('&amp;&quot;', '&&quot;'),
+        museValid.replaceFirst('&amp;&quot;', '&bogus;&quot;'),
+        museValid.replaceFirst('&amp;&quot;', '&amp;amp;&quot;'),
+      ],
     );
     _expectGrammar(
       validator,

--- a/test/integration/core/template/llama_cpp_template_detection_integration_test.dart
+++ b/test/integration/core/template/llama_cpp_template_detection_integration_test.dart
@@ -154,129 +154,117 @@ void main() {
       );
     }, skip: fixtureSkipReason);
 
-    test(
-      'renders and parses every vendored llama.cpp template',
-      () {
-        expect(templatesDir.existsSync(), isTrue);
+    test('renders and parses every vendored llama.cpp template', () {
+      expect(templatesDir.existsSync(), isTrue);
 
-        final files =
-            templatesDir
-                .listSync()
-                .whereType<File>()
-                .where((f) => f.path.endsWith('.jinja'))
-                .toList()
-              ..sort((a, b) => a.path.compareTo(b.path));
+      final files =
+          templatesDir
+              .listSync()
+              .whereType<File>()
+              .where((f) => f.path.endsWith('.jinja'))
+              .toList()
+            ..sort((a, b) => a.path.compareTo(b.path));
 
-        for (final file in files) {
-          final source = file.readAsStringSync();
-          final detected = detectChatFormat(source);
+      for (final file in files) {
+        final source = file.readAsStringSync();
+        final detected = detectChatFormat(source);
 
-          final rendered = ChatTemplateEngine.render(
-            templateSource: source,
-            messages: messages,
-            metadata: metadata,
-            tools: [tool],
-            parallelToolCalls: true,
-          );
+        final rendered = ChatTemplateEngine.render(
+          templateSource: source,
+          messages: messages,
+          metadata: metadata,
+          tools: [tool],
+          parallelToolCalls: true,
+        );
 
+        expect(
+          rendered.prompt.trim(),
+          isNotEmpty,
+          reason: 'Empty prompt for ${file.uri.pathSegments.last}',
+        );
+
+        final parseInput = sampleOutputForFormat(detected);
+        final parsed = ChatTemplateEngine.parse(
+          rendered.format,
+          parseInput,
+          parser: rendered.parser,
+          thinkingForcedOpen: rendered.thinkingForcedOpen,
+        );
+
+        final hasAnyPayload =
+            parsed.content.isNotEmpty ||
+            parsed.toolCalls.isNotEmpty ||
+            (parsed.reasoningContent?.isNotEmpty ?? false);
+        expect(
+          hasAnyPayload,
+          isTrue,
+          reason:
+              'Parse produced empty payload for ${file.uri.pathSegments.last}',
+        );
+
+        if (parseInput.contains('get_weather')) {
+          final parsedToolName = parsed.toolCalls.isNotEmpty
+              ? parsed.toolCalls.first.function?.name
+              : null;
+          final preservedInContent = parsed.content.contains('get_weather');
           expect(
-            rendered.prompt.trim(),
-            isNotEmpty,
-            reason: 'Empty prompt for ${file.uri.pathSegments.last}',
-          );
-
-          final parseInput = sampleOutputForFormat(detected);
-          final parsed = ChatTemplateEngine.parse(
-            rendered.format,
-            parseInput,
-            parser: rendered.parser,
-            thinkingForcedOpen: rendered.thinkingForcedOpen,
-          );
-
-          final hasAnyPayload =
-              parsed.content.isNotEmpty ||
-              parsed.toolCalls.isNotEmpty ||
-              (parsed.reasoningContent?.isNotEmpty ?? false);
-          expect(
-            hasAnyPayload,
+            parsedToolName == 'get_weather' || preservedInContent,
             isTrue,
             reason:
-                'Parse produced empty payload for ${file.uri.pathSegments.last}',
-          );
-
-          if (parseInput.contains('get_weather')) {
-            final parsedToolName = parsed.toolCalls.isNotEmpty
-                ? parsed.toolCalls.first.function?.name
-                : null;
-            final preservedInContent = parsed.content.contains('get_weather');
-            expect(
-              parsedToolName == 'get_weather' || preservedInContent,
-              isTrue,
-              reason:
-                  'Tool payload was neither parsed nor preserved for ${file.uri.pathSegments.last}',
-            );
-          }
-        }
-      },
-      skip: fixtureSkipReason,
-    );
-
-    test(
-      'preserves classified tool-call shapes through render and parse',
-      () {
-        const expectedMarkers = <String, String>{
-          'Kimi-K3.jinja': '<|open|>call tool="get_weather"',
-          'MiniMax-M1.jinja': '<tool_calls>\n{"name": "get_weather"',
-          'MiniMax-M3.jinja': ']<]minimax[>[<invoke name="get_weather">',
-          'deepseek-ai-DeepSeek-V3.2.jinja':
-              '<｜DSML｜invoke name="get_weather">',
-          'deepseek-ai-DeepSeek-V4.jinja': '<｜DSML｜invoke name="get_weather">',
-          'deepseek-ai-DeepSeek-V4-Flash-0731.jinja':
-              '<｜DSML｜invoke name="get_weather">',
-          'muse-glimmer.jinja': '<atem:invoke name="get_weather">',
-          'poolside-Laguna-S-2.1.jinja': '<tool_call>get_weather',
-          'poolside-Laguna-XS-2.1.jinja': '<tool_call>get_weather',
-          'poolside-Laguna-XS.2.jinja': '<tool_call>get_weather',
-        };
-
-        for (final entry in expectedMarkers.entries) {
-          final source = File(
-            '${templatesDir.path}/${entry.key}',
-          ).readAsStringSync();
-          final rendered = ChatTemplateEngine.render(
-            templateSource: source,
-            messages: toolCallHistory,
-            metadata: metadata,
-            addAssistant: false,
-            tools: [tool],
-            parallelToolCalls: true,
-          );
-
-          expect(
-            rendered.prompt,
-            contains(entry.value),
-            reason: 'Tool-call history shape drifted for ${entry.key}',
-          );
-
-          final parsed = ChatTemplateEngine.parse(
-            rendered.format,
-            sampleOutputForFormat(ChatFormat.values[rendered.format]),
-            thinkingForcedOpen: rendered.thinkingForcedOpen,
-          );
-          expect(
-            parsed.toolCalls,
-            hasLength(1),
-            reason: 'Generated tool-call shape was not parsed for ${entry.key}',
-          );
-          expect(parsed.toolCalls.single.function?.name, 'get_weather');
-          expect(
-            parsed.toolCalls.single.function?.arguments,
-            contains('Seoul'),
+                'Tool payload was neither parsed nor preserved for ${file.uri.pathSegments.last}',
           );
         }
-      },
-      skip: fixtureSkipReason,
-    );
+      }
+    }, skip: fixtureSkipReason);
+
+    test('preserves classified tool-call shapes through render and parse', () {
+      const expectedMarkers = <String, String>{
+        'Kimi-K3.jinja': '<|open|>call tool="get_weather"',
+        'MiniMax-M1.jinja': '<tool_calls>\n{"name": "get_weather"',
+        'MiniMax-M3.jinja': ']<]minimax[>[<invoke name="get_weather">',
+        'deepseek-ai-DeepSeek-V3.2.jinja': '<｜DSML｜invoke name="get_weather">',
+        'deepseek-ai-DeepSeek-V4.jinja': '<｜DSML｜invoke name="get_weather">',
+        'deepseek-ai-DeepSeek-V4-Flash-0731.jinja':
+            '<｜DSML｜invoke name="get_weather">',
+        'muse-glimmer.jinja': '<atem:invoke name="get_weather">',
+        'poolside-Laguna-S-2.1.jinja': '<tool_call>get_weather',
+        'poolside-Laguna-XS-2.1.jinja': '<tool_call>get_weather',
+        'poolside-Laguna-XS.2.jinja': '<tool_call>get_weather',
+      };
+
+      for (final entry in expectedMarkers.entries) {
+        final source = File(
+          '${templatesDir.path}/${entry.key}',
+        ).readAsStringSync();
+        final rendered = ChatTemplateEngine.render(
+          templateSource: source,
+          messages: toolCallHistory,
+          metadata: metadata,
+          addAssistant: false,
+          tools: [tool],
+          parallelToolCalls: true,
+        );
+
+        expect(
+          rendered.prompt,
+          contains(entry.value),
+          reason: 'Tool-call history shape drifted for ${entry.key}',
+        );
+
+        final parsed = ChatTemplateEngine.parse(
+          rendered.format,
+          sampleOutputForFormat(ChatFormat.values[rendered.format]),
+          thinkingForcedOpen: rendered.thinkingForcedOpen,
+        );
+        expect(
+          parsed.toolCalls,
+          hasLength(1),
+          reason: 'Generated tool-call shape was not parsed for ${entry.key}',
+        );
+        expect(parsed.toolCalls.single.function?.name, 'get_weather');
+        expect(parsed.toolCalls.single.function?.arguments, contains('Seoul'));
+      }
+    }, skip: fixtureSkipReason);
   });
 }
 

--- a/test/integration/core/template/llama_cpp_template_detection_integration_test.dart
+++ b/test/integration/core/template/llama_cpp_template_detection_integration_test.dart
@@ -155,221 +155,198 @@ void main() {
       );
     }, skip: fixtureSkipReason);
 
-    test(
-      'renders and parses every vendored llama.cpp template',
-      () {
-        expect(templatesDir.existsSync(), isTrue);
+    test('renders and parses every vendored llama.cpp template', () {
+      expect(templatesDir.existsSync(), isTrue);
 
-        final files =
-            templatesDir
-                .listSync()
-                .whereType<File>()
-                .where((f) => f.path.endsWith('.jinja'))
-                .toList()
-              ..sort((a, b) => a.path.compareTo(b.path));
+      final files =
+          templatesDir
+              .listSync()
+              .whereType<File>()
+              .where((f) => f.path.endsWith('.jinja'))
+              .toList()
+            ..sort((a, b) => a.path.compareTo(b.path));
 
-        for (final file in files) {
-          final source = file.readAsStringSync();
-          final detected = detectChatFormat(source);
+      for (final file in files) {
+        final source = file.readAsStringSync();
+        final detected = detectChatFormat(source);
 
-          final rendered = ChatTemplateEngine.render(
-            templateSource: source,
-            messages: messages,
-            metadata: metadata,
-            tools: [tool],
-            parallelToolCalls: true,
-          );
+        final rendered = ChatTemplateEngine.render(
+          templateSource: source,
+          messages: messages,
+          metadata: metadata,
+          tools: [tool],
+          parallelToolCalls: true,
+        );
 
+        expect(
+          rendered.prompt.trim(),
+          isNotEmpty,
+          reason: 'Empty prompt for ${file.uri.pathSegments.last}',
+        );
+
+        final parseInput = sampleOutputForFormat(detected);
+        final parsed = ChatTemplateEngine.parse(
+          rendered.format,
+          parseInput,
+          parser: rendered.parser,
+          thinkingForcedOpen: rendered.thinkingForcedOpen,
+        );
+
+        final hasAnyPayload =
+            parsed.content.isNotEmpty ||
+            parsed.toolCalls.isNotEmpty ||
+            (parsed.reasoningContent?.isNotEmpty ?? false);
+        expect(
+          hasAnyPayload,
+          isTrue,
+          reason:
+              'Parse produced empty payload for ${file.uri.pathSegments.last}',
+        );
+
+        if (parseInput.contains('get_weather')) {
+          final parsedToolName = parsed.toolCalls.isNotEmpty
+              ? parsed.toolCalls.first.function?.name
+              : null;
+          final preservedInContent = parsed.content.contains('get_weather');
           expect(
-            rendered.prompt.trim(),
-            isNotEmpty,
-            reason: 'Empty prompt for ${file.uri.pathSegments.last}',
-          );
-
-          final parseInput = sampleOutputForFormat(detected);
-          final parsed = ChatTemplateEngine.parse(
-            rendered.format,
-            parseInput,
-            parser: rendered.parser,
-            thinkingForcedOpen: rendered.thinkingForcedOpen,
-          );
-
-          final hasAnyPayload =
-              parsed.content.isNotEmpty ||
-              parsed.toolCalls.isNotEmpty ||
-              (parsed.reasoningContent?.isNotEmpty ?? false);
-          expect(
-            hasAnyPayload,
+            parsedToolName == 'get_weather' || preservedInContent,
             isTrue,
             reason:
-                'Parse produced empty payload for ${file.uri.pathSegments.last}',
-          );
-
-          if (parseInput.contains('get_weather')) {
-            final parsedToolName = parsed.toolCalls.isNotEmpty
-                ? parsed.toolCalls.first.function?.name
-                : null;
-            final preservedInContent = parsed.content.contains('get_weather');
-            expect(
-              parsedToolName == 'get_weather' || preservedInContent,
-              isTrue,
-              reason:
-                  'Tool payload was neither parsed nor preserved for ${file.uri.pathSegments.last}',
-            );
-          }
-        }
-      },
-      skip: fixtureSkipReason,
-    );
-
-    test(
-      'preserves classified tool-call shapes through render and parse',
-      () {
-        const expectedMarkers = <String, String>{
-          'Kimi-K3.jinja': '<|open|>call tool="get_weather"',
-          'MiniMax-M1.jinja': '<tool_calls>\n{"name": "get_weather"',
-          'MiniMax-M3.jinja': ']<]minimax[>[<invoke name="get_weather">',
-          'deepseek-ai-DeepSeek-V3.2.jinja':
-              '<｜DSML｜invoke name="get_weather">',
-          'deepseek-ai-DeepSeek-V4.jinja': '<｜DSML｜invoke name="get_weather">',
-          'deepseek-ai-DeepSeek-V4-Flash-0731.jinja':
-              '<｜DSML｜invoke name="get_weather">',
-          'muse-glimmer.jinja': '<atem:invoke name="get_weather">',
-          'poolside-Laguna-S-2.1.jinja': '<tool_call>get_weather',
-          'poolside-Laguna-XS-2.1.jinja': '<tool_call>get_weather',
-          'poolside-Laguna-XS.2.jinja': '<tool_call>get_weather',
-        };
-
-        for (final entry in expectedMarkers.entries) {
-          final source = File(
-            '${templatesDir.path}/${entry.key}',
-          ).readAsStringSync();
-          final rendered = ChatTemplateEngine.render(
-            templateSource: source,
-            messages: toolCallHistory,
-            metadata: metadata,
-            addAssistant: false,
-            tools: [tool],
-            parallelToolCalls: true,
-          );
-
-          expect(
-            rendered.prompt,
-            contains(entry.value),
-            reason: 'Tool-call history shape drifted for ${entry.key}',
-          );
-
-          final parsed = ChatTemplateEngine.parse(
-            rendered.format,
-            sampleOutputForFormat(ChatFormat.values[rendered.format]),
-            tools: [tool],
-            thinkingForcedOpen: rendered.thinkingForcedOpen,
-          );
-          expect(
-            parsed.toolCalls,
-            hasLength(1),
-            reason: 'Generated tool-call shape was not parsed for ${entry.key}',
-          );
-          expect(parsed.toolCalls.single.function?.name, 'get_weather');
-          expect(
-            parsed.toolCalls.single.function?.arguments,
-            contains('Seoul'),
+                'Tool payload was neither parsed nor preserved for ${file.uri.pathSegments.last}',
           );
         }
-      },
-      skip: fixtureSkipReason,
-    );
+      }
+    }, skip: fixtureSkipReason);
 
-    test(
-      'direct-Jinja grammars preserve tool-choice and prefix semantics',
-      () {
-        const templates = [
-          'Kimi-K3.jinja',
-          'MiniMax-M3.jinja',
-          'deepseek-ai-DeepSeek-V3.2.jinja',
-          'deepseek-ai-DeepSeek-V4.jinja',
-          'muse-glimmer.jinja',
-          'poolside-Laguna-XS-2.1.jinja',
-        ];
-        for (final templateName in templates) {
-          final source = File(
-            '${templatesDir.path}/$templateName',
-          ).readAsStringSync();
-          for (final enableThinking in const [true, false]) {
-            final auto = ChatTemplateEngine.render(
-              templateSource: source,
-              messages: messages,
-              metadata: metadata,
-              tools: [tool],
-              toolChoice: ToolChoice.auto,
-              enableThinking: enableThinking,
-            );
-            expect(auto.grammar, isNotNull, reason: templateName);
-            expect(auto.grammarLazy, isTrue, reason: templateName);
-            expect(auto.grammarTriggers, isNotEmpty, reason: templateName);
+    test('preserves classified tool-call shapes through render and parse', () {
+      const expectedMarkers = <String, String>{
+        'Kimi-K3.jinja': '<|open|>call tool="get_weather"',
+        'MiniMax-M1.jinja': '<tool_calls>\n{"name": "get_weather"',
+        'MiniMax-M3.jinja': ']<]minimax[>[<invoke name="get_weather">',
+        'deepseek-ai-DeepSeek-V3.2.jinja': '<｜DSML｜invoke name="get_weather">',
+        'deepseek-ai-DeepSeek-V4.jinja': '<｜DSML｜invoke name="get_weather">',
+        'deepseek-ai-DeepSeek-V4-Flash-0731.jinja':
+            '<｜DSML｜invoke name="get_weather">',
+        'muse-glimmer.jinja': '<atem:invoke name="get_weather">',
+        'poolside-Laguna-S-2.1.jinja': '<tool_call>get_weather',
+        'poolside-Laguna-XS-2.1.jinja': '<tool_call>get_weather',
+        'poolside-Laguna-XS.2.jinja': '<tool_call>get_weather',
+      };
 
-            final required = ChatTemplateEngine.render(
-              templateSource: source,
-              messages: messages,
-              metadata: metadata,
-              tools: [tool],
-              toolChoice: ToolChoice.required,
-              enableThinking: enableThinking,
-            );
-            expect(required.grammar, isNotNull, reason: templateName);
-            expect(required.grammarLazy, isFalse, reason: templateName);
-            expect(required.grammarTriggers, isEmpty, reason: templateName);
-            expect(
-              required.grammar,
-              startsWith('root ::= '),
-              reason: templateName,
-            );
+      for (final entry in expectedMarkers.entries) {
+        final source = File(
+          '${templatesDir.path}/${entry.key}',
+        ).readAsStringSync();
+        final rendered = ChatTemplateEngine.render(
+          templateSource: source,
+          messages: toolCallHistory,
+          metadata: metadata,
+          addAssistant: false,
+          tools: [tool],
+          parallelToolCalls: true,
+        );
 
-            final none = ChatTemplateEngine.render(
-              templateSource: source,
-              messages: messages,
-              metadata: metadata,
-              tools: [tool],
-              toolChoice: ToolChoice.none,
-              enableThinking: enableThinking,
-            );
-            expect(none.grammar, isNull, reason: templateName);
-            expect(none.grammarLazy, isFalse, reason: templateName);
-            expect(none.grammarTriggers, isEmpty, reason: templateName);
-          }
-        }
-      },
-      skip: fixtureSkipReason,
-    );
+        expect(
+          rendered.prompt,
+          contains(entry.value),
+          reason: 'Tool-call history shape drifted for ${entry.key}',
+        );
 
-    test(
-      'DeepSeek grammars retain template-specific DSML envelopes',
-      () {
-        for (final entry in const {
-          'deepseek-ai-DeepSeek-V3.2.jinja': 'function_calls',
-          'deepseek-ai-DeepSeek-V4.jinja': 'tool_calls',
-        }.entries) {
-          final source = File(
-            '${templatesDir.path}/${entry.key}',
-          ).readAsStringSync();
-          final rendered = ChatTemplateEngine.render(
+        final parsed = ChatTemplateEngine.parse(
+          rendered.format,
+          sampleOutputForFormat(ChatFormat.values[rendered.format]),
+          tools: [tool],
+          thinkingForcedOpen: rendered.thinkingForcedOpen,
+        );
+        expect(
+          parsed.toolCalls,
+          hasLength(1),
+          reason: 'Generated tool-call shape was not parsed for ${entry.key}',
+        );
+        expect(parsed.toolCalls.single.function?.name, 'get_weather');
+        expect(parsed.toolCalls.single.function?.arguments, contains('Seoul'));
+      }
+    }, skip: fixtureSkipReason);
+
+    test('direct-Jinja grammars preserve tool-choice and prefix semantics', () {
+      const templates = [
+        'Kimi-K3.jinja',
+        'MiniMax-M3.jinja',
+        'deepseek-ai-DeepSeek-V3.2.jinja',
+        'deepseek-ai-DeepSeek-V4.jinja',
+        'muse-glimmer.jinja',
+        'poolside-Laguna-XS-2.1.jinja',
+      ];
+      for (final templateName in templates) {
+        final source = File(
+          '${templatesDir.path}/$templateName',
+        ).readAsStringSync();
+        for (final enableThinking in const [true, false]) {
+          final auto = ChatTemplateEngine.render(
             templateSource: source,
             messages: messages,
             metadata: metadata,
             tools: [tool],
+            toolChoice: ToolChoice.auto,
+            enableThinking: enableThinking,
           );
+          expect(auto.grammar, isNotNull, reason: templateName);
+          expect(auto.grammarLazy, isTrue, reason: templateName);
+          expect(auto.grammarTriggers, isNotEmpty, reason: templateName);
+
+          final required = ChatTemplateEngine.render(
+            templateSource: source,
+            messages: messages,
+            metadata: metadata,
+            tools: [tool],
+            toolChoice: ToolChoice.required,
+            enableThinking: enableThinking,
+          );
+          expect(required.grammar, isNotNull, reason: templateName);
+          expect(required.grammarLazy, isFalse, reason: templateName);
+          expect(required.grammarTriggers, isEmpty, reason: templateName);
           expect(
-            rendered.grammar,
-            startsWith('root ::= "<｜DSML｜${entry.value}>'),
+            required.grammar,
+            startsWith('root ::= '),
+            reason: templateName,
           );
-          expect(
-            rendered.grammarTriggers.single.value,
-            '<｜DSML｜${entry.value}>',
+
+          final none = ChatTemplateEngine.render(
+            templateSource: source,
+            messages: messages,
+            metadata: metadata,
+            tools: [tool],
+            toolChoice: ToolChoice.none,
+            enableThinking: enableThinking,
           );
+          expect(none.grammar, isNull, reason: templateName);
+          expect(none.grammarLazy, isFalse, reason: templateName);
+          expect(none.grammarTriggers, isEmpty, reason: templateName);
         }
-      },
-      skip: fixtureSkipReason,
-    );
+      }
+    }, skip: fixtureSkipReason);
+
+    test('DeepSeek grammars retain template-specific DSML envelopes', () {
+      for (final entry in const {
+        'deepseek-ai-DeepSeek-V3.2.jinja': 'function_calls',
+        'deepseek-ai-DeepSeek-V4.jinja': 'tool_calls',
+      }.entries) {
+        final source = File(
+          '${templatesDir.path}/${entry.key}',
+        ).readAsStringSync();
+        final rendered = ChatTemplateEngine.render(
+          templateSource: source,
+          messages: messages,
+          metadata: metadata,
+          tools: [tool],
+        );
+        expect(
+          rendered.grammar,
+          startsWith('root ::= "<｜DSML｜${entry.value}>'),
+        );
+        expect(rendered.grammarTriggers.single.value, '<｜DSML｜${entry.value}>');
+      }
+    }, skip: fixtureSkipReason);
   });
 }
 

--- a/test/integration/core/template/llama_cpp_template_detection_integration_test.dart
+++ b/test/integration/core/template/llama_cpp_template_detection_integration_test.dart
@@ -83,7 +83,7 @@ void main() {
       'deepseek-ai-DeepSeek-R1-Distill-Llama-8B.jinja': ChatFormat.deepseekR1,
       'deepseek-ai-DeepSeek-R1-Distill-Qwen-32B.jinja': ChatFormat.deepseekR1,
       'deepseek-ai-DeepSeek-V3.1.jinja': ChatFormat.deepseekV3,
-      'deepseek-ai-DeepSeek-V3.2.jinja': ChatFormat.deepseekV4,
+      'deepseek-ai-DeepSeek-V3.2.jinja': ChatFormat.deepseekV32,
       'deepseek-ai-DeepSeek-V4.jinja': ChatFormat.deepseekV4,
       'deepseek-ai-DeepSeek-V4-Flash-0731.jinja': ChatFormat.deepseekV4,
       'fireworks-ai-llama-3-firefunction-v2.jinja': ChatFormat.firefunctionV2,
@@ -154,117 +154,129 @@ void main() {
       );
     }, skip: fixtureSkipReason);
 
-    test('renders and parses every vendored llama.cpp template', () {
-      expect(templatesDir.existsSync(), isTrue);
+    test(
+      'renders and parses every vendored llama.cpp template',
+      () {
+        expect(templatesDir.existsSync(), isTrue);
 
-      final files =
-          templatesDir
-              .listSync()
-              .whereType<File>()
-              .where((f) => f.path.endsWith('.jinja'))
-              .toList()
-            ..sort((a, b) => a.path.compareTo(b.path));
+        final files =
+            templatesDir
+                .listSync()
+                .whereType<File>()
+                .where((f) => f.path.endsWith('.jinja'))
+                .toList()
+              ..sort((a, b) => a.path.compareTo(b.path));
 
-      for (final file in files) {
-        final source = file.readAsStringSync();
-        final detected = detectChatFormat(source);
+        for (final file in files) {
+          final source = file.readAsStringSync();
+          final detected = detectChatFormat(source);
 
-        final rendered = ChatTemplateEngine.render(
-          templateSource: source,
-          messages: messages,
-          metadata: metadata,
-          tools: [tool],
-          parallelToolCalls: true,
-        );
+          final rendered = ChatTemplateEngine.render(
+            templateSource: source,
+            messages: messages,
+            metadata: metadata,
+            tools: [tool],
+            parallelToolCalls: true,
+          );
 
-        expect(
-          rendered.prompt.trim(),
-          isNotEmpty,
-          reason: 'Empty prompt for ${file.uri.pathSegments.last}',
-        );
-
-        final parseInput = sampleOutputForFormat(detected);
-        final parsed = ChatTemplateEngine.parse(
-          rendered.format,
-          parseInput,
-          parser: rendered.parser,
-          thinkingForcedOpen: rendered.thinkingForcedOpen,
-        );
-
-        final hasAnyPayload =
-            parsed.content.isNotEmpty ||
-            parsed.toolCalls.isNotEmpty ||
-            (parsed.reasoningContent?.isNotEmpty ?? false);
-        expect(
-          hasAnyPayload,
-          isTrue,
-          reason:
-              'Parse produced empty payload for ${file.uri.pathSegments.last}',
-        );
-
-        if (parseInput.contains('get_weather')) {
-          final parsedToolName = parsed.toolCalls.isNotEmpty
-              ? parsed.toolCalls.first.function?.name
-              : null;
-          final preservedInContent = parsed.content.contains('get_weather');
           expect(
-            parsedToolName == 'get_weather' || preservedInContent,
+            rendered.prompt.trim(),
+            isNotEmpty,
+            reason: 'Empty prompt for ${file.uri.pathSegments.last}',
+          );
+
+          final parseInput = sampleOutputForFormat(detected);
+          final parsed = ChatTemplateEngine.parse(
+            rendered.format,
+            parseInput,
+            parser: rendered.parser,
+            thinkingForcedOpen: rendered.thinkingForcedOpen,
+          );
+
+          final hasAnyPayload =
+              parsed.content.isNotEmpty ||
+              parsed.toolCalls.isNotEmpty ||
+              (parsed.reasoningContent?.isNotEmpty ?? false);
+          expect(
+            hasAnyPayload,
             isTrue,
             reason:
-                'Tool payload was neither parsed nor preserved for ${file.uri.pathSegments.last}',
+                'Parse produced empty payload for ${file.uri.pathSegments.last}',
+          );
+
+          if (parseInput.contains('get_weather')) {
+            final parsedToolName = parsed.toolCalls.isNotEmpty
+                ? parsed.toolCalls.first.function?.name
+                : null;
+            final preservedInContent = parsed.content.contains('get_weather');
+            expect(
+              parsedToolName == 'get_weather' || preservedInContent,
+              isTrue,
+              reason:
+                  'Tool payload was neither parsed nor preserved for ${file.uri.pathSegments.last}',
+            );
+          }
+        }
+      },
+      skip: fixtureSkipReason,
+    );
+
+    test(
+      'preserves classified tool-call shapes through render and parse',
+      () {
+        const expectedMarkers = <String, String>{
+          'Kimi-K3.jinja': '<|open|>call tool="get_weather"',
+          'MiniMax-M1.jinja': '<tool_calls>\n{"name": "get_weather"',
+          'MiniMax-M3.jinja': ']<]minimax[>[<invoke name="get_weather">',
+          'deepseek-ai-DeepSeek-V3.2.jinja':
+              '<｜DSML｜invoke name="get_weather">',
+          'deepseek-ai-DeepSeek-V4.jinja': '<｜DSML｜invoke name="get_weather">',
+          'deepseek-ai-DeepSeek-V4-Flash-0731.jinja':
+              '<｜DSML｜invoke name="get_weather">',
+          'muse-glimmer.jinja': '<atem:invoke name="get_weather">',
+          'poolside-Laguna-S-2.1.jinja': '<tool_call>get_weather',
+          'poolside-Laguna-XS-2.1.jinja': '<tool_call>get_weather',
+          'poolside-Laguna-XS.2.jinja': '<tool_call>get_weather',
+        };
+
+        for (final entry in expectedMarkers.entries) {
+          final source = File(
+            '${templatesDir.path}/${entry.key}',
+          ).readAsStringSync();
+          final rendered = ChatTemplateEngine.render(
+            templateSource: source,
+            messages: toolCallHistory,
+            metadata: metadata,
+            addAssistant: false,
+            tools: [tool],
+            parallelToolCalls: true,
+          );
+
+          expect(
+            rendered.prompt,
+            contains(entry.value),
+            reason: 'Tool-call history shape drifted for ${entry.key}',
+          );
+
+          final parsed = ChatTemplateEngine.parse(
+            rendered.format,
+            sampleOutputForFormat(ChatFormat.values[rendered.format]),
+            thinkingForcedOpen: rendered.thinkingForcedOpen,
+          );
+          expect(
+            parsed.toolCalls,
+            hasLength(1),
+            reason: 'Generated tool-call shape was not parsed for ${entry.key}',
+          );
+          expect(parsed.toolCalls.single.function?.name, 'get_weather');
+          expect(
+            parsed.toolCalls.single.function?.arguments,
+            contains('Seoul'),
           );
         }
-      }
-    }, skip: fixtureSkipReason);
-
-    test('preserves classified tool-call shapes through render and parse', () {
-      const expectedMarkers = <String, String>{
-        'Kimi-K3.jinja': '<|open|>call tool="get_weather"',
-        'MiniMax-M1.jinja': '<tool_calls>\n{"name": "get_weather"',
-        'MiniMax-M3.jinja': ']<]minimax[>[<invoke name="get_weather">',
-        'deepseek-ai-DeepSeek-V3.2.jinja': '<｜DSML｜invoke name="get_weather">',
-        'deepseek-ai-DeepSeek-V4.jinja': '<｜DSML｜invoke name="get_weather">',
-        'deepseek-ai-DeepSeek-V4-Flash-0731.jinja':
-            '<｜DSML｜invoke name="get_weather">',
-        'muse-glimmer.jinja': '<atem:invoke name="get_weather">',
-        'poolside-Laguna-S-2.1.jinja': '<tool_call>get_weather',
-        'poolside-Laguna-XS-2.1.jinja': '<tool_call>get_weather',
-        'poolside-Laguna-XS.2.jinja': '<tool_call>get_weather',
-      };
-
-      for (final entry in expectedMarkers.entries) {
-        final source = File(
-          '${templatesDir.path}/${entry.key}',
-        ).readAsStringSync();
-        final rendered = ChatTemplateEngine.render(
-          templateSource: source,
-          messages: toolCallHistory,
-          metadata: metadata,
-          addAssistant: false,
-          tools: [tool],
-          parallelToolCalls: true,
-        );
-
-        expect(
-          rendered.prompt,
-          contains(entry.value),
-          reason: 'Tool-call history shape drifted for ${entry.key}',
-        );
-
-        final parsed = ChatTemplateEngine.parse(
-          rendered.format,
-          sampleOutputForFormat(ChatFormat.values[rendered.format]),
-          thinkingForcedOpen: rendered.thinkingForcedOpen,
-        );
-        expect(
-          parsed.toolCalls,
-          hasLength(1),
-          reason: 'Generated tool-call shape was not parsed for ${entry.key}',
-        );
-        expect(parsed.toolCalls.single.function?.name, 'get_weather');
-        expect(parsed.toolCalls.single.function?.arguments, contains('Seoul'));
-      }
-    }, skip: fixtureSkipReason);
+      },
+      skip: fixtureSkipReason,
+    );
   });
 }
 

--- a/test/integration/core/template/llama_cpp_template_detection_integration_test.dart
+++ b/test/integration/core/template/llama_cpp_template_detection_integration_test.dart
@@ -6,6 +6,7 @@ import 'dart:io';
 import 'package:llamadart/src/core/models/chat/chat_message.dart';
 import 'package:llamadart/src/core/models/chat/chat_role.dart';
 import 'package:llamadart/src/core/models/chat/content_part.dart';
+import 'package:llamadart/src/core/models/inference/tool_choice.dart';
 import 'package:llamadart/src/core/models/tools/tool_definition.dart';
 import 'package:llamadart/src/core/models/tools/tool_param.dart';
 import 'package:llamadart/src/core/template/chat_format.dart';
@@ -154,117 +155,221 @@ void main() {
       );
     }, skip: fixtureSkipReason);
 
-    test('renders and parses every vendored llama.cpp template', () {
-      expect(templatesDir.existsSync(), isTrue);
+    test(
+      'renders and parses every vendored llama.cpp template',
+      () {
+        expect(templatesDir.existsSync(), isTrue);
 
-      final files =
-          templatesDir
-              .listSync()
-              .whereType<File>()
-              .where((f) => f.path.endsWith('.jinja'))
-              .toList()
-            ..sort((a, b) => a.path.compareTo(b.path));
+        final files =
+            templatesDir
+                .listSync()
+                .whereType<File>()
+                .where((f) => f.path.endsWith('.jinja'))
+                .toList()
+              ..sort((a, b) => a.path.compareTo(b.path));
 
-      for (final file in files) {
-        final source = file.readAsStringSync();
-        final detected = detectChatFormat(source);
+        for (final file in files) {
+          final source = file.readAsStringSync();
+          final detected = detectChatFormat(source);
 
-        final rendered = ChatTemplateEngine.render(
-          templateSource: source,
-          messages: messages,
-          metadata: metadata,
-          tools: [tool],
-          parallelToolCalls: true,
-        );
+          final rendered = ChatTemplateEngine.render(
+            templateSource: source,
+            messages: messages,
+            metadata: metadata,
+            tools: [tool],
+            parallelToolCalls: true,
+          );
 
-        expect(
-          rendered.prompt.trim(),
-          isNotEmpty,
-          reason: 'Empty prompt for ${file.uri.pathSegments.last}',
-        );
-
-        final parseInput = sampleOutputForFormat(detected);
-        final parsed = ChatTemplateEngine.parse(
-          rendered.format,
-          parseInput,
-          parser: rendered.parser,
-          thinkingForcedOpen: rendered.thinkingForcedOpen,
-        );
-
-        final hasAnyPayload =
-            parsed.content.isNotEmpty ||
-            parsed.toolCalls.isNotEmpty ||
-            (parsed.reasoningContent?.isNotEmpty ?? false);
-        expect(
-          hasAnyPayload,
-          isTrue,
-          reason:
-              'Parse produced empty payload for ${file.uri.pathSegments.last}',
-        );
-
-        if (parseInput.contains('get_weather')) {
-          final parsedToolName = parsed.toolCalls.isNotEmpty
-              ? parsed.toolCalls.first.function?.name
-              : null;
-          final preservedInContent = parsed.content.contains('get_weather');
           expect(
-            parsedToolName == 'get_weather' || preservedInContent,
+            rendered.prompt.trim(),
+            isNotEmpty,
+            reason: 'Empty prompt for ${file.uri.pathSegments.last}',
+          );
+
+          final parseInput = sampleOutputForFormat(detected);
+          final parsed = ChatTemplateEngine.parse(
+            rendered.format,
+            parseInput,
+            parser: rendered.parser,
+            thinkingForcedOpen: rendered.thinkingForcedOpen,
+          );
+
+          final hasAnyPayload =
+              parsed.content.isNotEmpty ||
+              parsed.toolCalls.isNotEmpty ||
+              (parsed.reasoningContent?.isNotEmpty ?? false);
+          expect(
+            hasAnyPayload,
             isTrue,
             reason:
-                'Tool payload was neither parsed nor preserved for ${file.uri.pathSegments.last}',
+                'Parse produced empty payload for ${file.uri.pathSegments.last}',
+          );
+
+          if (parseInput.contains('get_weather')) {
+            final parsedToolName = parsed.toolCalls.isNotEmpty
+                ? parsed.toolCalls.first.function?.name
+                : null;
+            final preservedInContent = parsed.content.contains('get_weather');
+            expect(
+              parsedToolName == 'get_weather' || preservedInContent,
+              isTrue,
+              reason:
+                  'Tool payload was neither parsed nor preserved for ${file.uri.pathSegments.last}',
+            );
+          }
+        }
+      },
+      skip: fixtureSkipReason,
+    );
+
+    test(
+      'preserves classified tool-call shapes through render and parse',
+      () {
+        const expectedMarkers = <String, String>{
+          'Kimi-K3.jinja': '<|open|>call tool="get_weather"',
+          'MiniMax-M1.jinja': '<tool_calls>\n{"name": "get_weather"',
+          'MiniMax-M3.jinja': ']<]minimax[>[<invoke name="get_weather">',
+          'deepseek-ai-DeepSeek-V3.2.jinja':
+              '<｜DSML｜invoke name="get_weather">',
+          'deepseek-ai-DeepSeek-V4.jinja': '<｜DSML｜invoke name="get_weather">',
+          'deepseek-ai-DeepSeek-V4-Flash-0731.jinja':
+              '<｜DSML｜invoke name="get_weather">',
+          'muse-glimmer.jinja': '<atem:invoke name="get_weather">',
+          'poolside-Laguna-S-2.1.jinja': '<tool_call>get_weather',
+          'poolside-Laguna-XS-2.1.jinja': '<tool_call>get_weather',
+          'poolside-Laguna-XS.2.jinja': '<tool_call>get_weather',
+        };
+
+        for (final entry in expectedMarkers.entries) {
+          final source = File(
+            '${templatesDir.path}/${entry.key}',
+          ).readAsStringSync();
+          final rendered = ChatTemplateEngine.render(
+            templateSource: source,
+            messages: toolCallHistory,
+            metadata: metadata,
+            addAssistant: false,
+            tools: [tool],
+            parallelToolCalls: true,
+          );
+
+          expect(
+            rendered.prompt,
+            contains(entry.value),
+            reason: 'Tool-call history shape drifted for ${entry.key}',
+          );
+
+          final parsed = ChatTemplateEngine.parse(
+            rendered.format,
+            sampleOutputForFormat(ChatFormat.values[rendered.format]),
+            tools: [tool],
+            thinkingForcedOpen: rendered.thinkingForcedOpen,
+          );
+          expect(
+            parsed.toolCalls,
+            hasLength(1),
+            reason: 'Generated tool-call shape was not parsed for ${entry.key}',
+          );
+          expect(parsed.toolCalls.single.function?.name, 'get_weather');
+          expect(
+            parsed.toolCalls.single.function?.arguments,
+            contains('Seoul'),
           );
         }
-      }
-    }, skip: fixtureSkipReason);
+      },
+      skip: fixtureSkipReason,
+    );
 
-    test('preserves classified tool-call shapes through render and parse', () {
-      const expectedMarkers = <String, String>{
-        'Kimi-K3.jinja': '<|open|>call tool="get_weather"',
-        'MiniMax-M1.jinja': '<tool_calls>\n{"name": "get_weather"',
-        'MiniMax-M3.jinja': ']<]minimax[>[<invoke name="get_weather">',
-        'deepseek-ai-DeepSeek-V3.2.jinja': '<｜DSML｜invoke name="get_weather">',
-        'deepseek-ai-DeepSeek-V4.jinja': '<｜DSML｜invoke name="get_weather">',
-        'deepseek-ai-DeepSeek-V4-Flash-0731.jinja':
-            '<｜DSML｜invoke name="get_weather">',
-        'muse-glimmer.jinja': '<atem:invoke name="get_weather">',
-        'poolside-Laguna-S-2.1.jinja': '<tool_call>get_weather',
-        'poolside-Laguna-XS-2.1.jinja': '<tool_call>get_weather',
-        'poolside-Laguna-XS.2.jinja': '<tool_call>get_weather',
-      };
+    test(
+      'direct-Jinja grammars preserve tool-choice and prefix semantics',
+      () {
+        const templates = [
+          'Kimi-K3.jinja',
+          'MiniMax-M3.jinja',
+          'deepseek-ai-DeepSeek-V3.2.jinja',
+          'deepseek-ai-DeepSeek-V4.jinja',
+          'muse-glimmer.jinja',
+          'poolside-Laguna-XS-2.1.jinja',
+        ];
+        for (final templateName in templates) {
+          final source = File(
+            '${templatesDir.path}/$templateName',
+          ).readAsStringSync();
+          for (final enableThinking in const [true, false]) {
+            final auto = ChatTemplateEngine.render(
+              templateSource: source,
+              messages: messages,
+              metadata: metadata,
+              tools: [tool],
+              toolChoice: ToolChoice.auto,
+              enableThinking: enableThinking,
+            );
+            expect(auto.grammar, isNotNull, reason: templateName);
+            expect(auto.grammarLazy, isTrue, reason: templateName);
+            expect(auto.grammarTriggers, isNotEmpty, reason: templateName);
 
-      for (final entry in expectedMarkers.entries) {
-        final source = File(
-          '${templatesDir.path}/${entry.key}',
-        ).readAsStringSync();
-        final rendered = ChatTemplateEngine.render(
-          templateSource: source,
-          messages: toolCallHistory,
-          metadata: metadata,
-          addAssistant: false,
-          tools: [tool],
-          parallelToolCalls: true,
-        );
+            final required = ChatTemplateEngine.render(
+              templateSource: source,
+              messages: messages,
+              metadata: metadata,
+              tools: [tool],
+              toolChoice: ToolChoice.required,
+              enableThinking: enableThinking,
+            );
+            expect(required.grammar, isNotNull, reason: templateName);
+            expect(required.grammarLazy, isFalse, reason: templateName);
+            expect(required.grammarTriggers, isEmpty, reason: templateName);
+            expect(
+              required.grammar,
+              startsWith('root ::= '),
+              reason: templateName,
+            );
 
-        expect(
-          rendered.prompt,
-          contains(entry.value),
-          reason: 'Tool-call history shape drifted for ${entry.key}',
-        );
+            final none = ChatTemplateEngine.render(
+              templateSource: source,
+              messages: messages,
+              metadata: metadata,
+              tools: [tool],
+              toolChoice: ToolChoice.none,
+              enableThinking: enableThinking,
+            );
+            expect(none.grammar, isNull, reason: templateName);
+            expect(none.grammarLazy, isFalse, reason: templateName);
+            expect(none.grammarTriggers, isEmpty, reason: templateName);
+          }
+        }
+      },
+      skip: fixtureSkipReason,
+    );
 
-        final parsed = ChatTemplateEngine.parse(
-          rendered.format,
-          sampleOutputForFormat(ChatFormat.values[rendered.format]),
-          thinkingForcedOpen: rendered.thinkingForcedOpen,
-        );
-        expect(
-          parsed.toolCalls,
-          hasLength(1),
-          reason: 'Generated tool-call shape was not parsed for ${entry.key}',
-        );
-        expect(parsed.toolCalls.single.function?.name, 'get_weather');
-        expect(parsed.toolCalls.single.function?.arguments, contains('Seoul'));
-      }
-    }, skip: fixtureSkipReason);
+    test(
+      'DeepSeek grammars retain template-specific DSML envelopes',
+      () {
+        for (final entry in const {
+          'deepseek-ai-DeepSeek-V3.2.jinja': 'function_calls',
+          'deepseek-ai-DeepSeek-V4.jinja': 'tool_calls',
+        }.entries) {
+          final source = File(
+            '${templatesDir.path}/${entry.key}',
+          ).readAsStringSync();
+          final rendered = ChatTemplateEngine.render(
+            templateSource: source,
+            messages: messages,
+            metadata: metadata,
+            tools: [tool],
+          );
+          expect(
+            rendered.grammar,
+            startsWith('root ::= "<｜DSML｜${entry.value}>'),
+          );
+          expect(
+            rendered.grammarTriggers.single.value,
+            '<｜DSML｜${entry.value}>',
+          );
+        }
+      },
+      skip: fixtureSkipReason,
+    );
   });
 }
 

--- a/test/integration/core/template/llama_cpp_template_parse_samples.dart
+++ b/test/integration/core/template/llama_cpp_template_parse_samples.dart
@@ -65,6 +65,14 @@ const Map<ChatFormat, String> _sampleOutputsByFormat = <ChatFormat, String>{
       '</｜DSML｜parameter>\n'
       '</｜DSML｜invoke>\n'
       '</｜DSML｜tool_calls>',
+  ChatFormat.deepseekV32:
+      '</think>\n\n'
+      '<｜DSML｜function_calls>\n'
+      '<｜DSML｜invoke name="get_weather">\n'
+      '<｜DSML｜parameter name="location" string="true">Seoul'
+      '</｜DSML｜parameter>\n'
+      '</｜DSML｜invoke>\n'
+      '</｜DSML｜function_calls>',
   ChatFormat.museGlimmer:
       ' to=get_weather<|message|><atem:function_calls>\n'
       '<atem:invoke name="get_weather">\n'

--- a/test/unit/core/engine/chat_completion_stream_parser_test.dart
+++ b/test/unit/core/engine/chat_completion_stream_parser_test.dart
@@ -1,5 +1,9 @@
+import 'dart:convert';
+
 import 'package:llamadart/src/core/engine/chat_completion_stream_parser.dart';
 import 'package:llamadart/src/core/models/chat/chat_template_result.dart';
+import 'package:llamadart/src/core/models/tools/tool_definition.dart';
+import 'package:llamadart/src/core/models/tools/tool_param.dart';
 import 'package:llamadart/src/core/template/chat_format.dart';
 import 'package:test/test.dart';
 
@@ -152,5 +156,143 @@ void main() {
         expect(chunks.last.choices.single.finishReason, 'tool_calls');
       },
     );
+
+    test('carries tool schemas into specialized final parsing', () async {
+      const namespace = ']<]minimax[>[';
+      final tool = ToolDefinition(
+        name: 'inspect',
+        description: 'Inspect',
+        parameters: [ToolParam.string('code', required: true)],
+        handler: (_) async => null,
+      );
+      final chunks = await ChatCompletionStreamParser.parse(
+        tokenStream: Stream.value(
+          '$namespace<tool_call>$namespace<invoke name="inspect">'
+          '$namespace<code>123$namespace</code>'
+          '$namespace</invoke>$namespace</tool_call>',
+        ),
+        templateResult: LlamaChatTemplateResult(
+          prompt: 'prompt',
+          format: ChatFormat.minimaxM3.index,
+        ),
+        parseToolCallsEnabled: true,
+        enableThinking: true,
+        modelName: 'test-model',
+        completionId: 'schema',
+        tools: [tool],
+      ).toList();
+
+      final toolCall = chunks
+          .expand((chunk) => chunk.choices.single.delta.toolCalls ?? const [])
+          .single;
+      expect(jsonDecode(toolCall.function!.arguments!), {'code': '123'});
+      expect(chunks.last.choices.single.finishReason, 'tool_calls');
+    });
+
+    test('does not stream partial Laguna tool markup as content', () async {
+      final chunks = await ChatCompletionStreamParser.parse(
+        tokenStream: Stream.fromIterable(<String>[
+          'Visible answer.',
+          '<',
+          'tool_call>weather\n',
+          '<arg_key>city</arg_key><arg_value>Seoul</arg_value>',
+          '</tool_call>',
+        ]),
+        templateResult: LlamaChatTemplateResult(
+          prompt: 'prompt',
+          format: ChatFormat.laguna.index,
+        ),
+        parseToolCallsEnabled: true,
+        enableThinking: true,
+        modelName: 'test-model',
+        completionId: 'laguna-partial',
+        tools: [_weatherTool],
+      ).toList();
+
+      final content = chunks
+          .map((chunk) => chunk.choices.single.delta.content ?? '')
+          .join();
+      final toolCall = chunks
+          .expand((chunk) => chunk.choices.single.delta.toolCalls ?? const [])
+          .single;
+      expect(content, 'Visible answer.');
+      expect(content, isNot(contains('<tool')));
+      expect(toolCall.function?.name, 'weather');
+      expect(jsonDecode(toolCall.function!.arguments!), {'city': 'Seoul'});
+    });
+
+    test('does not stream partial GLM tool markup as content', () async {
+      final chunks = await ChatCompletionStreamParser.parse(
+        tokenStream: Stream.fromIterable(<String>[
+          'Visible answer.',
+          '<',
+          'tool_call>weather\n',
+          '<arg_key>city</arg_key><arg_value>Seoul</arg_value>',
+          '</tool_call>',
+        ]),
+        templateResult: LlamaChatTemplateResult(
+          prompt: 'prompt',
+          format: ChatFormat.glm45.index,
+        ),
+        parseToolCallsEnabled: true,
+        enableThinking: true,
+        modelName: 'test-model',
+        completionId: 'glm-partial',
+        tools: [_weatherTool],
+      ).toList();
+
+      final content = chunks
+          .map((chunk) => chunk.choices.single.delta.content ?? '')
+          .join();
+      final toolCall = chunks
+          .expand((chunk) => chunk.choices.single.delta.toolCalls ?? const [])
+          .single;
+      expect(content, 'Visible answer.');
+      expect(content, isNot(contains('<tool')));
+      expect(toolCall.function?.name, 'weather');
+      expect(jsonDecode(toolCall.function!.arguments!), {'city': 'Seoul'});
+    });
+
+    test('does not stream partial Muse routing markup as content', () async {
+      const atem =
+          '<atem:function_calls><atem:invoke name="weather">'
+          '<atem:parameter name="city">Seoul</atem:parameter>'
+          '</atem:invoke></atem:function_calls>';
+      final chunks = await ChatCompletionStreamParser.parse(
+        tokenStream: Stream.fromIterable(<String>[
+          'Visible answer.',
+          '<',
+          '|start|>assistant to=weather<|mess',
+          'age|>$atem<|eot|>',
+        ]),
+        templateResult: LlamaChatTemplateResult(
+          prompt: 'prompt',
+          format: ChatFormat.museGlimmer.index,
+        ),
+        parseToolCallsEnabled: true,
+        enableThinking: true,
+        modelName: 'test-model',
+        completionId: 'muse-partial',
+        tools: [_weatherTool],
+      ).toList();
+
+      final content = chunks
+          .map((chunk) => chunk.choices.single.delta.content ?? '')
+          .join();
+      final toolCall = chunks
+          .expand((chunk) => chunk.choices.single.delta.toolCalls ?? const [])
+          .single;
+      expect(content, 'Visible answer.');
+      expect(content, isNot(contains('<|start|>')));
+      expect(toolCall.function?.name, 'weather');
+      expect(jsonDecode(toolCall.function!.arguments!), {'city': 'Seoul'});
+    });
   });
 }
+
+final _weatherTool = ToolDefinition(
+  name: 'weather',
+  description: 'Weather',
+  parameters: [ToolParam.string('city', required: true)],
+  handler: (_) async => null,
+);

--- a/test/unit/core/engine/chat_completion_stream_parser_test.dart
+++ b/test/unit/core/engine/chat_completion_stream_parser_test.dart
@@ -287,6 +287,280 @@ void main() {
       expect(toolCall.function?.name, 'weather');
       expect(jsonDecode(toolCall.function!.arguments!), {'city': 'Seoul'});
     });
+
+    test(
+      'specialized formats suppress split envelopes and reconcile malformed finals',
+      () async {
+        const namespace = ']<]minimax[>[';
+        final cases =
+            <
+              ({
+                String name,
+                int format,
+                String marker,
+                String valid,
+                String malformed,
+              })
+            >[
+              (
+                name: 'Kimi K3',
+                format: ChatFormat.kimiK3.index,
+                marker: '<|open|>tools',
+                valid:
+                    'Visible answer.<|open|>tools<|sep|>'
+                    '<|open|>call tool="weather"<|sep|>'
+                    '<|open|>argument key="city" type="string"<|sep|>Seoul'
+                    '<|close|>argument<|sep|><|close|>call<|sep|>'
+                    '<|close|>tools<|sep|><|close|>message<|sep|>',
+                malformed:
+                    'Visible answer.<|open|>tools<|sep|>'
+                    '<|open|>call tool="unknown"<|sep|>'
+                    '<|open|>argument key="city" type="string"<|sep|>Seoul'
+                    '<|close|>argument<|sep|><|close|>call<|sep|>'
+                    '<|close|>tools<|sep|><|close|>message<|sep|>',
+              ),
+              (
+                name: 'MiniMax M1',
+                format: ChatFormat.minimaxM1.index,
+                marker: '<tool_calls>',
+                valid:
+                    'Visible answer.<tool_calls>\n'
+                    '{"name":"weather","arguments":{"city":"Seoul"}}\n'
+                    '</tool_calls>',
+                malformed:
+                    'Visible answer.<tool_calls>\n'
+                    '{"name":"unknown","arguments":{"city":"Seoul"}}\n'
+                    '</tool_calls>',
+              ),
+              (
+                name: 'MiniMax M3',
+                format: ChatFormat.minimaxM3.index,
+                marker: '$namespace<tool_call>',
+                valid:
+                    'Visible answer.$namespace<tool_call>'
+                    '$namespace<invoke name="weather">'
+                    '$namespace<city>Seoul$namespace</city>'
+                    '$namespace</invoke>$namespace</tool_call>',
+                malformed:
+                    'Visible answer.$namespace<tool_call>'
+                    '$namespace<invoke name="unknown">'
+                    '$namespace<city>Seoul$namespace</city>'
+                    '$namespace</invoke>$namespace</tool_call>',
+              ),
+              (
+                name: 'DeepSeek V3.2',
+                format: ChatFormat.deepseekV32.index,
+                marker: '<｜DSML｜function_calls>',
+                valid:
+                    'Visible answer.<｜DSML｜function_calls>'
+                    '<｜DSML｜invoke name="weather">'
+                    '<｜DSML｜parameter name="city" string="true">Seoul'
+                    '</｜DSML｜parameter></｜DSML｜invoke>'
+                    '</｜DSML｜function_calls>',
+                malformed:
+                    'Visible answer.<｜DSML｜function_calls>'
+                    '<｜DSML｜invoke name="unknown">'
+                    '<｜DSML｜parameter name="city" string="true">Seoul'
+                    '</｜DSML｜parameter></｜DSML｜invoke>'
+                    '</｜DSML｜function_calls>',
+              ),
+              (
+                name: 'DeepSeek V4',
+                format: ChatFormat.deepseekV4.index,
+                marker: '<｜DSML｜tool_calls>',
+                valid:
+                    'Visible answer.<｜DSML｜tool_calls>'
+                    '<｜DSML｜invoke name="weather">'
+                    '<｜DSML｜parameter name="city" string="true">Seoul'
+                    '</｜DSML｜parameter></｜DSML｜invoke>'
+                    '</｜DSML｜tool_calls>',
+                malformed:
+                    'Visible answer.<｜DSML｜tool_calls>'
+                    '<｜DSML｜invoke name="unknown">'
+                    '<｜DSML｜parameter name="city" string="true">Seoul'
+                    '</｜DSML｜parameter></｜DSML｜invoke>'
+                    '</｜DSML｜tool_calls>',
+              ),
+            ];
+
+        for (final testCase in cases) {
+          final markerIndex = testCase.valid.indexOf(testCase.marker);
+          final validChunks = await ChatCompletionStreamParser.parse(
+            tokenStream: Stream.fromIterable([
+              testCase.valid.substring(0, markerIndex + 1),
+              testCase.valid.substring(markerIndex + 1, markerIndex + 3),
+              testCase.valid.substring(markerIndex + 3),
+            ]),
+            templateResult: LlamaChatTemplateResult(
+              prompt: 'prompt',
+              format: testCase.format,
+            ),
+            parseToolCallsEnabled: true,
+            enableThinking: true,
+            modelName: 'test-model',
+            completionId: '${testCase.name}-valid',
+            tools: [_weatherTool],
+          ).toList();
+          final validContent = validChunks
+              .map((chunk) => chunk.choices.single.delta.content ?? '')
+              .join();
+          final toolCall = validChunks
+              .expand(
+                (chunk) => chunk.choices.single.delta.toolCalls ?? const [],
+              )
+              .single;
+          expect(validContent, 'Visible answer.', reason: testCase.name);
+          expect(
+            validContent,
+            isNot(contains(testCase.marker)),
+            reason: testCase.name,
+          );
+          expect(toolCall.function?.name, 'weather', reason: testCase.name);
+          expect(jsonDecode(toolCall.function!.arguments!), {
+            'city': 'Seoul',
+          }, reason: testCase.name);
+
+          final malformedMarkerIndex = testCase.malformed.indexOf(
+            testCase.marker,
+          );
+          final malformedChunks = await ChatCompletionStreamParser.parse(
+            tokenStream: Stream.fromIterable([
+              testCase.malformed.substring(0, malformedMarkerIndex + 1),
+              testCase.malformed.substring(
+                malformedMarkerIndex + 1,
+                malformedMarkerIndex + 3,
+              ),
+              testCase.malformed.substring(malformedMarkerIndex + 3),
+            ]),
+            templateResult: LlamaChatTemplateResult(
+              prompt: 'prompt',
+              format: testCase.format,
+            ),
+            parseToolCallsEnabled: true,
+            enableThinking: true,
+            modelName: 'test-model',
+            completionId: '${testCase.name}-malformed',
+            tools: [_weatherTool],
+          ).toList();
+          final malformedContent = malformedChunks
+              .map((chunk) => chunk.choices.single.delta.content ?? '')
+              .join();
+          final expectedMalformedContent = switch (testCase.format) {
+            final format when format == ChatFormat.kimiK3.index =>
+              testCase.malformed.replaceAll('<|close|>message<|sep|>', ''),
+            _ => testCase.malformed,
+          };
+          expect(
+            malformedContent,
+            expectedMalformedContent,
+            reason: '${testCase.name} final rollback',
+          );
+          expect(
+            malformedContent,
+            contains(testCase.marker),
+            reason: '${testCase.name} malformed protocol preservation',
+          );
+          expect(
+            malformedChunks.expand(
+              (chunk) => chunk.choices.single.delta.toolCalls ?? const [],
+            ),
+            isEmpty,
+            reason: testCase.name,
+          );
+          expect(
+            malformedChunks.last.choices.single.finishReason,
+            'stop',
+            reason: testCase.name,
+          );
+        }
+      },
+    );
+
+    test(
+      'specialized thinking prefixes do not leak following tool markup',
+      () async {
+        const namespace = ']<]minimax[>[';
+        final cases =
+            <({String name, int format, String output, String marker})>[
+              (
+                name: 'Kimi K3',
+                format: ChatFormat.kimiK3.index,
+                output:
+                    'reasoning<|close|>think<|sep|>'
+                    '<|open|>tools<|sep|>'
+                    '<|open|>call tool="weather"<|sep|>'
+                    '<|open|>argument key="city" type="string"<|sep|>Seoul'
+                    '<|close|>argument<|sep|><|close|>call<|sep|>'
+                    '<|close|>tools<|sep|><|close|>message<|sep|>',
+                marker: '<|open|>tools',
+              ),
+              (
+                name: 'MiniMax M3',
+                format: ChatFormat.minimaxM3.index,
+                output:
+                    '<mm:think>reasoning</mm:think>'
+                    '$namespace<tool_call>'
+                    '$namespace<invoke name="weather">'
+                    '$namespace<city>Seoul$namespace</city>'
+                    '$namespace</invoke>$namespace</tool_call>',
+                marker: '$namespace<tool_call>',
+              ),
+              (
+                name: 'DeepSeek V3.2',
+                format: ChatFormat.deepseekV32.index,
+                output:
+                    'reasoning</think>'
+                    '<｜DSML｜function_calls>'
+                    '<｜DSML｜invoke name="weather">'
+                    '<｜DSML｜parameter name="city" string="true">Seoul'
+                    '</｜DSML｜parameter></｜DSML｜invoke>'
+                    '</｜DSML｜function_calls>',
+                marker: '<｜DSML｜function_calls>',
+              ),
+            ];
+
+        for (final testCase in cases) {
+          final markerIndex = testCase.output.indexOf(testCase.marker);
+          final chunks = await ChatCompletionStreamParser.parse(
+            tokenStream: Stream.fromIterable([
+              testCase.output.substring(0, markerIndex + 1),
+              testCase.output.substring(markerIndex + 1),
+            ]),
+            templateResult: LlamaChatTemplateResult(
+              prompt: 'prompt',
+              format: testCase.format,
+              thinkingForcedOpen: testCase.name != 'MiniMax M3',
+            ),
+            parseToolCallsEnabled: true,
+            enableThinking: true,
+            modelName: 'test-model',
+            completionId: '${testCase.name}-thinking',
+            tools: [_weatherTool],
+          ).toList();
+          final content = chunks
+              .map((chunk) => chunk.choices.single.delta.content ?? '')
+              .join();
+          final reasoning = chunks
+              .map((chunk) => chunk.choices.single.delta.thinking ?? '')
+              .join();
+
+          expect(content, isEmpty, reason: testCase.name);
+          expect(reasoning, 'reasoning', reason: testCase.name);
+          expect(reasoning, isNot(contains(testCase.marker)));
+          expect(
+            chunks
+                .expand(
+                  (chunk) => chunk.choices.single.delta.toolCalls ?? const [],
+                )
+                .single
+                .function
+                ?.name,
+            'weather',
+            reason: testCase.name,
+          );
+        }
+      },
+    );
   });
 }
 

--- a/test/unit/core/engine/chat_completion_stream_parser_test.dart
+++ b/test/unit/core/engine/chat_completion_stream_parser_test.dart
@@ -640,6 +640,102 @@ void main() {
         }
       },
     );
+
+    test(
+      'forced-open DSML withholds character-split envelopes from reasoning',
+      () async {
+        for (final testCase in const [
+          (
+            name: 'DeepSeek V3.2',
+            format: ChatFormat.deepseekV32,
+            envelope: 'function_calls',
+          ),
+          (
+            name: 'DeepSeek V4',
+            format: ChatFormat.deepseekV4,
+            envelope: 'tool_calls',
+          ),
+        ]) {
+          final callsStart = '<｜DSML｜${testCase.envelope}>';
+          final callsEnd = '</｜DSML｜${testCase.envelope}>';
+          final valid =
+              'reasoning$callsStart'
+              '<｜DSML｜invoke name="weather">'
+              '<｜DSML｜parameter name="city" string="true">Seoul'
+              '</｜DSML｜parameter></｜DSML｜invoke>$callsEnd';
+          final chunks = await ChatCompletionStreamParser.parse(
+            tokenStream: Stream.fromIterable(valid.split('')),
+            templateResult: LlamaChatTemplateResult(
+              prompt: 'prompt',
+              format: testCase.format.index,
+              thinkingForcedOpen: true,
+            ),
+            parseToolCallsEnabled: true,
+            enableThinking: true,
+            modelName: 'test-model',
+            completionId: '${testCase.name}-split-forced-open',
+            tools: [_weatherTool],
+          ).toList();
+          final reasoning = chunks
+              .map((chunk) => chunk.choices.single.delta.thinking ?? '')
+              .join();
+          final content = chunks
+              .map((chunk) => chunk.choices.single.delta.content ?? '')
+              .join();
+
+          expect(reasoning, 'reasoning', reason: testCase.name);
+          expect(reasoning, isNot(contains('<｜DSML｜')));
+          expect(content, isEmpty, reason: testCase.name);
+          expect(
+            chunks
+                .expand(
+                  (chunk) => chunk.choices.single.delta.toolCalls ?? const [],
+                )
+                .single
+                .function
+                ?.name,
+            'weather',
+            reason: testCase.name,
+          );
+
+          final malformed = valid.replaceFirst('name="weather"', 'name="bad"');
+          final malformedChunks = await ChatCompletionStreamParser.parse(
+            tokenStream: Stream.fromIterable(malformed.split('')),
+            templateResult: LlamaChatTemplateResult(
+              prompt: 'prompt',
+              format: testCase.format.index,
+              thinkingForcedOpen: true,
+            ),
+            parseToolCallsEnabled: true,
+            enableThinking: true,
+            modelName: 'test-model',
+            completionId: '${testCase.name}-split-malformed',
+            tools: [_weatherTool],
+          ).toList();
+          expect(
+            malformedChunks
+                .map((chunk) => chunk.choices.single.delta.thinking ?? '')
+                .join(),
+            'reasoning',
+            reason: '${testCase.name} malformed reasoning',
+          );
+          expect(
+            malformedChunks
+                .map((chunk) => chunk.choices.single.delta.content ?? '')
+                .join(),
+            malformed.substring('reasoning'.length),
+            reason: '${testCase.name} malformed content rollback',
+          );
+          expect(
+            malformedChunks.expand(
+              (chunk) => chunk.choices.single.delta.toolCalls ?? const [],
+            ),
+            isEmpty,
+            reason: testCase.name,
+          );
+        }
+      },
+    );
   });
 }
 

--- a/test/unit/core/engine/chat_completion_stream_parser_test.dart
+++ b/test/unit/core/engine/chat_completion_stream_parser_test.dart
@@ -189,6 +189,48 @@ void main() {
       expect(chunks.last.choices.single.finishReason, 'tool_calls');
     });
 
+    test('preserves MiniMax M3 schema types across split tokens', () async {
+      const namespace = ']<]minimax[>[';
+      const output =
+          '$namespace<tool_call>'
+          '$namespace<invoke name="inspect">'
+          '$namespace<code>123$namespace</code>'
+          '$namespace<options>$namespace</options>'
+          '$namespace<items>$namespace</items>'
+          '$namespace</invoke>$namespace</tool_call>';
+      final chunks = await ChatCompletionStreamParser.parse(
+        tokenStream: Stream.fromIterable(<String>[
+          output.substring(0, 7),
+          output.substring(7, 31),
+          output.substring(31, 58),
+          output.substring(58, 87),
+          output.substring(87),
+        ]),
+        templateResult: LlamaChatTemplateResult(
+          prompt: 'prompt',
+          format: ChatFormat.minimaxM3.index,
+        ),
+        parseToolCallsEnabled: true,
+        enableThinking: true,
+        modelName: 'test-model',
+        completionId: 'm3-typed-split',
+        tools: [_typedStreamTool],
+      ).toList();
+
+      final content = chunks
+          .map((chunk) => chunk.choices.single.delta.content ?? '')
+          .join();
+      final toolCall = chunks
+          .expand((chunk) => chunk.choices.single.delta.toolCalls ?? const [])
+          .single;
+      expect(content, isEmpty);
+      expect(jsonDecode(toolCall.function!.arguments!), {
+        'code': '123',
+        'options': <String, dynamic>{},
+        'items': <Object?>[],
+      });
+    });
+
     test('does not stream partial Laguna tool markup as content', () async {
       final chunks = await ChatCompletionStreamParser.parse(
         tokenStream: Stream.fromIterable(<String>[
@@ -286,6 +328,43 @@ void main() {
       expect(content, isNot(contains('<|start|>')));
       expect(toolCall.function?.name, 'weather');
       expect(jsonDecode(toolCall.function!.arguments!), {'city': 'Seoul'});
+    });
+
+    test('character-split Muse routing never leaks protocol content', () async {
+      const atem =
+          '<atem:function_calls><atem:invoke name="weather">'
+          '<atem:parameter name="city">Seoul</atem:parameter>'
+          '</atem:invoke></atem:function_calls>';
+      const output =
+          'Visible answer.<|start|>assistant to=weather<|message|>'
+          '$atem<|eot|>';
+      final chunks = await ChatCompletionStreamParser.parse(
+        tokenStream: Stream.fromIterable(output.split('')),
+        templateResult: LlamaChatTemplateResult(
+          prompt: 'prompt',
+          format: ChatFormat.museGlimmer.index,
+        ),
+        parseToolCallsEnabled: true,
+        enableThinking: true,
+        modelName: 'test-model',
+        completionId: 'muse-character-split',
+        tools: [_weatherTool],
+      ).toList();
+
+      final content = chunks
+          .map((chunk) => chunk.choices.single.delta.content ?? '')
+          .join();
+      expect(content, 'Visible answer.');
+      expect(content, isNot(contains('<|')));
+      expect(content, isNot(contains('<atem:')));
+      expect(
+        chunks
+            .expand((chunk) => chunk.choices.single.delta.toolCalls ?? const [])
+            .single
+            .function
+            ?.name,
+        'weather',
+      );
     });
 
     test(
@@ -568,5 +647,20 @@ final _weatherTool = ToolDefinition(
   name: 'weather',
   description: 'Weather',
   parameters: [ToolParam.string('city', required: true)],
+  handler: (_) async => null,
+);
+
+final _typedStreamTool = ToolDefinition(
+  name: 'inspect',
+  description: 'Inspect typed values',
+  parameters: [
+    ToolParam.string('code', required: true),
+    ToolParam.object('options', properties: const [], required: true),
+    ToolParam.array(
+      'items',
+      itemType: ToolParam.string('item'),
+      required: true,
+    ),
+  ],
   handler: (_) async => null,
 );

--- a/test/unit/core/models/tools/tool_param_test.dart
+++ b/test/unit/core/models/tools/tool_param_test.dart
@@ -27,6 +27,12 @@ void main() {
       expect(p.toJsonSchema(), {'type': 'boolean'});
     });
 
+    test('null param', () {
+      final p = ToolParam.nullType('test', required: true);
+      expect(p.required, isTrue);
+      expect(p.toJsonSchema(), {'type': 'null'});
+    });
+
     test('enum param', () {
       final p = ToolParam.enumType('test', values: ['a', 'b']);
       expect(p.toJsonSchema(), {

--- a/test/unit/core/template/chat_format_test.dart
+++ b/test/unit/core/template/chat_format_test.dart
@@ -58,6 +58,16 @@ void main() {
       expect(format, equals(ChatFormat.deepseekV4));
     });
 
+    test('detects DeepSeek V3.2 DSML function_calls template', () {
+      const source =
+          "{%- set dsml_token = '｜DSML｜' -%}"
+          "<' + dsml_token + 'function_calls>"
+          "<' + dsml_token + 'invoke name=\"\$FUNCTION_NAME\">"
+          "</' + dsml_token + 'function_calls>";
+      final format = detectChatFormat(source);
+      expect(format, equals(ChatFormat.deepseekV32));
+    });
+
     test('detects Cohere2 MoE / North Code before older Command-R', () {
       const source =
           '<|START_THINKING|><|END_THINKING|><|START_TEXT|>{{ content }}<|END_TEXT|><|START_ACTION|>[]<|END_ACTION|>';

--- a/test/unit/core/template/chat_template_engine_test.dart
+++ b/test/unit/core/template/chat_template_engine_test.dart
@@ -219,6 +219,7 @@ void main() {
         ChatFormat.minimaxM1: TemplateToolCallSerialization.normalizeOnly,
         ChatFormat.minimaxM3: TemplateToolCallSerialization.normalizeOnly,
         ChatFormat.deepseekV4: TemplateToolCallSerialization.normalizeOnly,
+        ChatFormat.deepseekV32: TemplateToolCallSerialization.normalizeOnly,
         ChatFormat.museGlimmer: TemplateToolCallSerialization.normalizeOnly,
         ChatFormat.laguna: TemplateToolCallSerialization.normalizeOnly,
       };
@@ -554,6 +555,79 @@ void main() {
       expect(result.format, equals(ChatFormat.functionaryV32.index));
       expect(result.grammar, isNotNull);
       expect(result.grammar!, contains('tool-0-call'));
+    });
+
+    test('direct-Jinja auto required and none preserve reasoning prefixes', () {
+      const templates = <ChatFormat, String>{
+        ChatFormat.kimiK3:
+            '{# <|open|> <|close|> <|end_of_msg|> #}'
+            '{{ "<|open|>think<|sep|>" }}',
+        ChatFormat.minimaxM3:
+            '{# ]<]minimax[>[ <tool_call> <invoke name= #}'
+            '{{ "<mm:think>" }}',
+        ChatFormat.deepseekV32:
+            '{# dsml_token DSML function_calls #}{{ "<think>" }}',
+        ChatFormat.deepseekV4:
+            '{# dsml_token DSML tool_calls #}{{ "<think>" }}',
+        ChatFormat.museGlimmer:
+            '{# <atem:function_calls> <|eom|> #}'
+            '{{ "<|start|>assistant" }}',
+        ChatFormat.laguna:
+            '{# <assistant> </assistant> <tool_response> '
+            '<arg_key> <arg_value> #}{{ "<think>" }}',
+      };
+
+      for (final entry in templates.entries) {
+        for (final enableThinking in [true, false]) {
+          final auto = ChatTemplateEngine.render(
+            templateSource: entry.value,
+            messages: grammarMessages,
+            metadata: const {},
+            tools: tools,
+            toolChoice: ToolChoice.auto,
+            enableThinking: enableThinking,
+          );
+          expect(auto.format, entry.key.index, reason: '${entry.key} auto');
+          expect(auto.grammar, isNotNull, reason: '${entry.key} auto');
+          expect(auto.grammarLazy, isTrue, reason: '${entry.key} auto');
+
+          final required = ChatTemplateEngine.render(
+            templateSource: entry.value,
+            messages: grammarMessages,
+            metadata: const {},
+            tools: tools,
+            toolChoice: ToolChoice.required,
+            enableThinking: enableThinking,
+          );
+          expect(
+            required.format,
+            entry.key.index,
+            reason: '${entry.key} required',
+          );
+          expect(required.grammar, isNotNull, reason: '${entry.key} required');
+          expect(
+            required.grammarLazy,
+            isFalse,
+            reason: '${entry.key} required',
+          );
+          expect(
+            required.grammar!.split('\n').first,
+            contains('required'),
+            reason: '${entry.key} required',
+          );
+
+          final none = ChatTemplateEngine.render(
+            templateSource: entry.value,
+            messages: grammarMessages,
+            metadata: const {},
+            tools: tools,
+            toolChoice: ToolChoice.none,
+            enableThinking: enableThinking,
+          );
+          expect(none.grammar, isNull, reason: '${entry.key} none');
+          expect(none.grammarLazy, isFalse, reason: '${entry.key} none');
+        }
+      }
     });
 
     test('uses generic routing for tools + schema requests', () {

--- a/test/unit/core/template/chat_template_engine_test.dart
+++ b/test/unit/core/template/chat_template_engine_test.dart
@@ -611,6 +611,11 @@ void main() {
             reason: '${entry.key} required',
           );
           expect(
+            required.grammarTriggers,
+            isEmpty,
+            reason: '${entry.key} required',
+          );
+          expect(
             required.grammar!.split('\n').first,
             contains('required'),
             reason: '${entry.key} required',

--- a/test/unit/core/template/handlers/glm45_handler_test.dart
+++ b/test/unit/core/template/handlers/glm45_handler_test.dart
@@ -1,10 +1,12 @@
 import 'dart:convert';
 
+import 'package:llamadart/src/core/exceptions.dart';
 import 'package:llamadart/src/core/models/chat/chat_message.dart';
 import 'package:llamadart/src/core/models/chat/chat_role.dart';
 import 'package:llamadart/src/core/models/tools/tool_definition.dart';
 import 'package:llamadart/src/core/models/tools/tool_param.dart';
 import 'package:llamadart/src/core/template/handlers/glm45_handler.dart';
+import 'package:llamadart/src/core/template/handlers/llama_cpp_specialized_handlers.dart';
 import 'package:llamadart/src/core/template/chat_format.dart';
 import 'package:llamadart/src/core/template/chat_template_engine.dart';
 import 'package:test/test.dart';
@@ -127,6 +129,105 @@ void main() {
       );
       expect(parsed.toolCalls, isEmpty, reason: invalid);
       expect(parsed.content, output, reason: invalid);
+    }
+  });
+
+  test('final GLM and Laguna parsing rolls back a truncated later call', () {
+    final tool = ToolDefinition(
+      name: 'inspect',
+      description: 'Inspect',
+      parameters: [ToolParam.string('code', required: true)],
+      handler: _noop,
+    );
+    const valid =
+        '<tool_call>inspect\n'
+        '<arg_key>code</arg_key><arg_value>first</arg_value>\n'
+        '</tool_call>';
+    const truncated =
+        '<tool_call>inspect\n'
+        '<arg_key>code</arg_key><arg_value>second';
+    const output = '$valid$truncated';
+
+    for (final format in [ChatFormat.glm45, ChatFormat.laguna]) {
+      for (final finalOutput in const [
+        output,
+        '$valid<tool_cal',
+        '$valid</arg_val',
+      ]) {
+        final parsed = ChatTemplateEngine.parse(
+          format.index,
+          finalOutput,
+          tools: [tool],
+        );
+        expect(parsed.toolCalls, isEmpty, reason: format.name);
+        expect(parsed.content, finalOutput, reason: format.name);
+      }
+
+      for (final partialOutput in const [
+        output,
+        '$valid<tool_cal',
+        '$valid</arg_val',
+      ]) {
+        final partial = ChatTemplateEngine.parse(
+          format.index,
+          partialOutput,
+          tools: [tool],
+          isPartial: true,
+        );
+        expect(partial.toolCalls, hasLength(1), reason: format.name);
+        expect(partial.content, isEmpty, reason: format.name);
+        expect(jsonDecode(partial.toolCalls.single.function!.arguments!), {
+          'code': 'first',
+        }, reason: format.name);
+      }
+    }
+  });
+
+  test('GLM and Laguna reject empty or duplicate tool identities eagerly', () {
+    final empty = ToolDefinition(
+      name: '',
+      description: 'Empty',
+      parameters: const [],
+      handler: _noop,
+    );
+    final duplicateA = ToolDefinition(
+      name: 'inspect',
+      description: 'First',
+      parameters: const [],
+      handler: _noop,
+    );
+    final duplicateB = ToolDefinition(
+      name: 'inspect',
+      description: 'Second',
+      parameters: const [],
+      handler: _noop,
+    );
+
+    final builders = <String? Function(List<ToolDefinition>?)>[
+      Glm45Handler().buildGrammar,
+      LagunaHandler().buildGrammar,
+    ];
+    for (final buildGrammar in builders) {
+      expect(
+        () => buildGrammar([empty]),
+        throwsA(
+          isA<LlamaUnsupportedException>().having(
+            (error) => error.message,
+            'message',
+            contains('non-empty tool names'),
+          ),
+        ),
+      );
+      expect(
+        () => buildGrammar([duplicateA, duplicateB]),
+        throwsA(
+          isA<LlamaUnsupportedException>().having(
+            (error) => error.message,
+            'message',
+            contains('unique tool names'),
+          ),
+        ),
+      );
     }
   });
 

--- a/test/unit/core/template/handlers/glm45_handler_test.dart
+++ b/test/unit/core/template/handlers/glm45_handler_test.dart
@@ -297,7 +297,7 @@ void main() {
     expect(completed.toolCalls, isEmpty);
   });
 
-  test('GLM and Laguna fail closed on protocol markers inside strings', () {
+  test('GLM and Laguna distinguish protocol markers from near-lookalikes', () {
     final tool = ToolDefinition(
       name: 'inspect',
       description: 'Inspect',
@@ -315,18 +315,35 @@ void main() {
 
     for (final format in [ChatFormat.glm45, ChatFormat.laguna]) {
       for (final marker in markers) {
-        final output =
+        final invalidOutput =
             '<tool_call>inspect\n'
             '<arg_key>code</arg_key><arg_value>before$marker after'
             '</arg_value>\n'
             '</tool_call>';
-        final parsed = ChatTemplateEngine.parse(
+        final invalid = ChatTemplateEngine.parse(
           format.index,
-          output,
+          invalidOutput,
           tools: [tool],
         );
-        expect(parsed.toolCalls, isEmpty, reason: '$format $marker');
-        expect(parsed.content, output, reason: '$format $marker');
+        expect(invalid.toolCalls, isEmpty, reason: '$format $marker');
+        expect(invalid.content, invalidOutput, reason: '$format $marker');
+
+        final nearLookalike = '${marker.substring(0, marker.length - 1)}X';
+        final validOutput =
+            '<tool_call>inspect\n'
+            '<arg_key>code</arg_key><arg_value>before$nearLookalike after'
+            '</arg_value>\n'
+            '</tool_call>';
+        final valid = ChatTemplateEngine.parse(
+          format.index,
+          validOutput,
+          tools: [tool],
+        );
+        expect(valid.toolCalls, hasLength(1), reason: '$format $nearLookalike');
+        expect(jsonDecode(valid.toolCalls.single.function!.arguments!), {
+          'code': 'before$nearLookalike after',
+        }, reason: '$format $nearLookalike');
+        expect(valid.content, isEmpty, reason: '$format $nearLookalike');
       }
     }
   });

--- a/test/unit/core/template/handlers/glm45_handler_test.dart
+++ b/test/unit/core/template/handlers/glm45_handler_test.dart
@@ -5,6 +5,8 @@ import 'package:llamadart/src/core/models/chat/chat_role.dart';
 import 'package:llamadart/src/core/models/tools/tool_definition.dart';
 import 'package:llamadart/src/core/models/tools/tool_param.dart';
 import 'package:llamadart/src/core/template/handlers/glm45_handler.dart';
+import 'package:llamadart/src/core/template/chat_format.dart';
+import 'package:llamadart/src/core/template/chat_template_engine.dart';
 import 'package:test/test.dart';
 
 void main() {
@@ -59,6 +61,100 @@ void main() {
     final noToolParse = handler.parse('plain response', parseToolCalls: false);
     expect(noToolParse.content, equals('plain response'));
     expect(noToolParse.toolCalls, isEmpty);
+  });
+
+  test('production parse preserves GLM schema-directed string values', () {
+    final tool = ToolDefinition(
+      name: 'inspect',
+      description: 'Inspect',
+      parameters: [
+        ToolParam.string('code', required: true),
+        ToolParam.integer('count', required: true),
+      ],
+      handler: _noop,
+    );
+    const output =
+        '<tool_call>inspect\n'
+        '<arg_key>code</arg_key><arg_value>123</arg_value>\n'
+        '<arg_key>count</arg_key><arg_value>7</arg_value>\n'
+        '</tool_call>';
+
+    final parsed = ChatTemplateEngine.parse(
+      ChatFormat.glm45.index,
+      output,
+      tools: [tool],
+    );
+
+    expect(jsonDecode(parsed.toolCalls.single.function!.arguments!), {
+      'code': '123',
+      'count': 7,
+    });
+  });
+
+  test('production parse rejects duplicate GLM and Laguna arguments', () {
+    final tool = ToolDefinition(
+      name: 'inspect',
+      description: 'Inspect',
+      parameters: [ToolParam.string('code', required: true)],
+      handler: _noop,
+    );
+    const output =
+        '<tool_call>inspect\n'
+        '<arg_key>code</arg_key><arg_value>first</arg_value>\n'
+        '<arg_key>code</arg_key><arg_value>second</arg_value>\n'
+        '</tool_call>';
+
+    for (final format in [ChatFormat.glm45, ChatFormat.laguna]) {
+      final parsed = ChatTemplateEngine.parse(
+        format.index,
+        output,
+        tools: [tool],
+      );
+      expect(parsed.toolCalls, isEmpty);
+      expect(parsed.content, output);
+    }
+  });
+
+  test('production parse rejects malformed GLM and Laguna argument bodies', () {
+    final tool = ToolDefinition(
+      name: 'inspect',
+      description: 'Inspect',
+      parameters: [ToolParam.string('code', required: true)],
+      handler: _noop,
+    );
+    const validPair = '<arg_key>code</arg_key><arg_value>first</arg_value>';
+    const malformedBodies = [
+      '$validPair<arg_key> </arg_key><arg_value>ignored</arg_value>',
+      '$validPair<arg_key>truncated',
+    ];
+
+    for (final format in [ChatFormat.glm45, ChatFormat.laguna]) {
+      for (final body in malformedBodies) {
+        final output = '<tool_call>inspect\n$body\n</tool_call>';
+        final parsed = ChatTemplateEngine.parse(
+          format.index,
+          output,
+          tools: [tool],
+        );
+        expect(parsed.toolCalls, isEmpty);
+        expect(parsed.content, output);
+      }
+    }
+  });
+
+  test('hides incomplete GLM tool markup only while streaming', () {
+    const output =
+        'Visible answer.\n'
+        '<tool_call>weather\n'
+        '<arg_key>city</arg_key><arg_value>Seo';
+
+    final partial = Glm45Handler().parse(output, isPartial: true);
+    expect(partial.content, 'Visible answer.');
+    expect(partial.toolCalls, isEmpty);
+
+    final completed = Glm45Handler().parse(output);
+    expect(completed.content, output);
+    expect(completed.toolCalls, isEmpty);
   });
 }
 

--- a/test/unit/core/template/handlers/glm45_handler_test.dart
+++ b/test/unit/core/template/handlers/glm45_handler_test.dart
@@ -344,6 +344,27 @@ void main() {
           'code': 'before$nearLookalike after',
         }, reason: '$format $nearLookalike');
         expect(valid.content, isEmpty, reason: '$format $nearLookalike');
+
+        for (final output in [
+          'before$nearLookalike\n$validOutput',
+          '$validOutput\nafter$nearLookalike',
+        ]) {
+          final surrounded = ChatTemplateEngine.parse(
+            format.index,
+            output,
+            tools: [tool],
+          );
+          expect(
+            surrounded.toolCalls,
+            hasLength(1),
+            reason: '$format surrounding $nearLookalike',
+          );
+          expect(
+            surrounded.content,
+            output.replaceFirst(validOutput, '').trim(),
+            reason: '$format surrounding $nearLookalike',
+          );
+        }
       }
     }
   });

--- a/test/unit/core/template/handlers/glm45_handler_test.dart
+++ b/test/unit/core/template/handlers/glm45_handler_test.dart
@@ -68,6 +68,11 @@ void main() {
       name: 'inspect',
       description: 'Inspect',
       parameters: [
+        ToolParam.enumType(
+          'city',
+          values: const ['Seoul', 'Paris'],
+          required: true,
+        ),
         ToolParam.string('code', required: true),
         ToolParam.integer('count', required: true),
       ],
@@ -75,6 +80,7 @@ void main() {
     );
     const output =
         '<tool_call>inspect\n'
+        '<arg_key>city</arg_key><arg_value>"Seoul"</arg_value>\n'
         '<arg_key>code</arg_key><arg_value>123</arg_value>\n'
         '<arg_key>count</arg_key><arg_value>7</arg_value>\n'
         '</tool_call>';
@@ -86,9 +92,42 @@ void main() {
     );
 
     expect(jsonDecode(parsed.toolCalls.single.function!.arguments!), {
+      'city': 'Seoul',
       'code': '123',
       'count': 7,
     });
+  });
+
+  test('production parse rolls back all mixed-validity GLM calls', () {
+    final tool = ToolDefinition(
+      name: 'inspect',
+      description: 'Inspect',
+      parameters: [ToolParam.string('code', required: true)],
+      handler: _noop,
+    );
+    const valid =
+        '<tool_call>inspect\n'
+        '<arg_key>code</arg_key><arg_value>first</arg_value>\n'
+        '</tool_call>';
+    for (final invalid in const [
+      '<tool_call>unknown\n</tool_call>',
+      '<tool_call>inspect\n'
+          '<arg_key>unknown</arg_key><arg_value>ignored</arg_value>\n'
+          '</tool_call>',
+      '<tool_call>inspect\n'
+          '<arg_key>code</arg_key><arg_value>first</arg_value>\n'
+          '<arg_key>code</arg_key><arg_value>second</arg_value>\n'
+          '</tool_call>',
+    ]) {
+      final output = '$valid$invalid';
+      final parsed = ChatTemplateEngine.parse(
+        ChatFormat.glm45.index,
+        output,
+        tools: [tool],
+      );
+      expect(parsed.toolCalls, isEmpty, reason: invalid);
+      expect(parsed.content, output, reason: invalid);
+    }
   });
 
   test('production parse rejects duplicate GLM and Laguna arguments', () {

--- a/test/unit/core/template/handlers/glm45_handler_test.dart
+++ b/test/unit/core/template/handlers/glm45_handler_test.dart
@@ -296,6 +296,40 @@ void main() {
     expect(completed.content, output);
     expect(completed.toolCalls, isEmpty);
   });
+
+  test('GLM and Laguna fail closed on protocol markers inside strings', () {
+    final tool = ToolDefinition(
+      name: 'inspect',
+      description: 'Inspect',
+      parameters: [ToolParam.string('code', required: true)],
+      handler: _noop,
+    );
+    const markers = [
+      '<tool_call>',
+      '</tool_call>',
+      '<arg_key>',
+      '</arg_key>',
+      '<arg_value>',
+      '</arg_value>',
+    ];
+
+    for (final format in [ChatFormat.glm45, ChatFormat.laguna]) {
+      for (final marker in markers) {
+        final output =
+            '<tool_call>inspect\n'
+            '<arg_key>code</arg_key><arg_value>before$marker after'
+            '</arg_value>\n'
+            '</tool_call>';
+        final parsed = ChatTemplateEngine.parse(
+          format.index,
+          output,
+          tools: [tool],
+        );
+        expect(parsed.toolCalls, isEmpty, reason: '$format $marker');
+        expect(parsed.content, output, reason: '$format $marker');
+      }
+    }
+  });
 }
 
 Future<Object?> _noop(_) async {

--- a/test/unit/core/template/handlers/llama_cpp_specialized_handlers_test.dart
+++ b/test/unit/core/template/handlers/llama_cpp_specialized_handlers_test.dart
@@ -376,6 +376,25 @@ void main() {
       expect(MinimaxM3Handler().parse('</mm:think>Hello').content, 'Hello');
     });
 
+    test('does not validate schemas when MiniMax M3 parsing is disabled', () {
+      final duplicate = ToolDefinition(
+        name: 'weather',
+        description: 'Duplicate weather tool',
+        parameters: const [],
+        handler: (_) async => null,
+      );
+      const output = '$ns<tool_call>unparsed</tool_call>';
+
+      final parsed = MinimaxM3Handler().parseWithTools(
+        output,
+        tools: [_weatherTool, duplicate],
+        parseToolCalls: false,
+      );
+
+      expect(parsed.content, output);
+      expect(parsed.toolCalls, isEmpty);
+    });
+
     test('hides an incomplete invoke while streaming', () {
       const output =
           'Prelude$ns<tool_call>\n'
@@ -972,6 +991,25 @@ void main() {
       final parsed = MuseGlimmerHandler().parse(output);
       expect(parsed.toolCalls, isEmpty);
       expect(parsed.content, contains('<atem:function_calls>'));
+    });
+
+    test('does not validate schemas when Muse parsing is disabled', () {
+      final duplicate = ToolDefinition(
+        name: 'weather',
+        description: 'Duplicate weather tool',
+        parameters: const [],
+        handler: (_) async => null,
+      );
+      const output = ' to=weather<|message|>$atem<|eot|>';
+
+      final parsed = MuseGlimmerHandler().parseWithTools(
+        output,
+        tools: [_weatherTool, duplicate],
+        parseToolCalls: false,
+      );
+
+      expect(parsed.content, atem);
+      expect(parsed.toolCalls, isEmpty);
     });
 
     test('preserves malformed tool-channel markup as content', () {

--- a/test/unit/core/template/handlers/llama_cpp_specialized_handlers_test.dart
+++ b/test/unit/core/template/handlers/llama_cpp_specialized_handlers_test.dart
@@ -1,5 +1,6 @@
 import 'dart:convert';
 
+import 'package:llamadart/src/core/exceptions.dart';
 import 'package:llamadart/src/core/models/tools/tool_definition.dart';
 import 'package:llamadart/src/core/models/tools/tool_param.dart';
 import 'package:llamadart/src/core/template/chat_format.dart';
@@ -80,6 +81,38 @@ void main() {
 
       expect(grammar, contains('kimi-raw-0 ::= ""'));
       expect(grammar, isNot(contains(RegExp(r'kimi-raw-0 ::=\s*\n'))));
+    });
+
+    test('grammar rejects ambiguous or empty protocol identities', () {
+      final duplicate = ToolDefinition(
+        name: _weatherTool.name,
+        description: 'Duplicate weather',
+        parameters: [ToolParam.integer('days')],
+        handler: (_) async => null,
+      );
+      final emptyTool = ToolDefinition(
+        name: '',
+        description: 'Empty name',
+        parameters: const [],
+        handler: (_) async => null,
+      );
+      final emptyParameter = ToolDefinition(
+        name: 'empty_parameter',
+        description: 'Empty parameter',
+        parameters: [ToolParam.string('')],
+        handler: (_) async => null,
+      );
+
+      for (final tools in [
+        [_weatherTool, duplicate],
+        [emptyTool],
+        [emptyParameter],
+      ]) {
+        expect(
+          () => KimiK3Handler().buildGrammar(tools),
+          throwsA(isA<LlamaUnsupportedException>()),
+        );
+      }
     });
 
     test('production parse validates escaped Kimi names against schemas', () {
@@ -454,6 +487,32 @@ void main() {
       expect(grammar, isNot(contains('identifier ::=')));
       expect(grammar, isNot(contains(r'raw ::= [^]]*')));
     });
+
+    test('round-trips escaped tool attributes and rejects unsafe tag keys', () {
+      final grammar = MinimaxM3Handler().buildGrammar([_attributeTool])!;
+      expect(grammar, contains(r'invoke name=\"weather&amp;&quot;alerts\"'));
+
+      const output =
+          '$ns<tool_call>$ns<invoke name="weather&amp;&quot;alerts">'
+          '$ns</invoke>$ns</tool_call>';
+      final parsed = ChatTemplateEngine.parse(
+        ChatFormat.minimaxM3.index,
+        output,
+        tools: [_attributeTool],
+      );
+      expect(parsed.toolCalls.single.function?.name, 'weather&"alerts');
+
+      expect(
+        () => MinimaxM3Handler().buildGrammar([_escapedSchemaTool]),
+        throwsA(
+          isA<LlamaUnsupportedException>().having(
+            (error) => error.message,
+            'message',
+            contains('cannot represent tool parameter "city&"zone"'),
+          ),
+        ),
+      );
+    });
   });
 
   group('DeepSeek V3.2 DSML', () {
@@ -488,9 +547,33 @@ void main() {
         grammar.split('\n').first,
         r'root ::= "<｜DSML｜function_calls>" dsml-space dsml-tool+ "</｜DSML｜function_calls>"',
       );
-      expect(grammar, contains(r'invoke name=\"weather&\"alerts\">'));
+      expect(grammar, contains(r'invoke name=\"weather&amp;&quot;alerts\">'));
       expect(grammar, isNot(contains('identifier ::=')));
       expect(grammar, isNot(contains('<｜DSML｜tool_calls>')));
+    });
+
+    test('round-trips escaped DSML tool and parameter attributes', () {
+      final grammar = DeepseekV32Handler().buildGrammar([
+        _escapedAttributeSchemaTool,
+      ])!;
+      expect(grammar, contains(r'invoke name=\"weather&amp;&quot;alerts\"'));
+      expect(grammar, contains(r'parameter name=\"city&amp;&quot;zone\"'));
+
+      const output =
+          '<｜DSML｜function_calls>'
+          '<｜DSML｜invoke name="weather&amp;&quot;alerts">'
+          '<｜DSML｜parameter name="city&amp;&quot;zone" string="true">Seoul'
+          '</｜DSML｜parameter>'
+          '</｜DSML｜invoke>'
+          '</｜DSML｜function_calls>';
+      final parsed = ChatTemplateEngine.parse(
+        ChatFormat.deepseekV32.index,
+        output,
+        tools: [_escapedAttributeSchemaTool],
+      );
+
+      expect(parsed.toolCalls.single.function?.name, 'weather&"alerts');
+      expect(_arguments(parsed), {'city&"zone': 'Seoul'});
     });
 
     test('forced-open reasoning terminates at the V3.2 envelope', () {
@@ -705,6 +788,42 @@ void main() {
       expect(parsed.content, 'On it.');
       expect(parsed.toolCalls.single.function?.name, 'weather');
       expect(_arguments(parsed), {'city': ' New York '});
+    });
+
+    test('round-trips escaped attributes and rejects reserved recipients', () {
+      final grammar = MuseGlimmerHandler().buildGrammar([
+        _escapedAttributeSchemaTool,
+      ])!;
+      expect(grammar, contains(r'invoke name=\"weather&amp;&quot;alerts\"'));
+      expect(grammar, contains(r'parameter name=\"city&amp;&quot;zone\"'));
+
+      const output =
+          ' to=weather&"alerts<|message|>'
+          '<atem:function_calls>'
+          '<atem:invoke name="weather&amp;&quot;alerts">'
+          '<atem:parameter name="city&amp;&quot;zone">Seoul</atem:parameter>'
+          '</atem:invoke>'
+          '</atem:function_calls><|eot|>';
+      final parsed = ChatTemplateEngine.parse(
+        ChatFormat.museGlimmer.index,
+        output,
+        tools: [_escapedAttributeSchemaTool],
+      );
+      expect(parsed.toolCalls.single.function?.name, 'weather&"alerts');
+      expect(_arguments(parsed), {'city&"zone': 'Seoul'});
+
+      for (final reserved in ['self', 'user', ' leading', 'bad<route']) {
+        final tool = ToolDefinition(
+          name: reserved,
+          description: 'Invalid Muse recipient',
+          parameters: const [],
+          handler: (_) async => null,
+        );
+        expect(
+          () => MuseGlimmerHandler().buildGrammar([tool]),
+          throwsA(isA<LlamaUnsupportedException>()),
+        );
+      }
     });
 
     test('does not parse quoted ATEM markup in the user channel', () {
@@ -975,6 +1094,13 @@ final _attributeTool = ToolDefinition(
 final _escapedSchemaTool = ToolDefinition(
   name: 'weather',
   description: 'Weather',
+  parameters: [ToolParam.string('city&"zone', required: true)],
+  handler: (_) async => null,
+);
+
+final _escapedAttributeSchemaTool = ToolDefinition(
+  name: 'weather&"alerts',
+  description: 'Weather alerts',
   parameters: [ToolParam.string('city&"zone', required: true)],
   handler: (_) async => null,
 );

--- a/test/unit/core/template/handlers/llama_cpp_specialized_handlers_test.dart
+++ b/test/unit/core/template/handlers/llama_cpp_specialized_handlers_test.dart
@@ -285,6 +285,39 @@ void main() {
         expect(rejected.content, invalid);
       }
     });
+
+    test('production parse rejects ambiguous MiniMax M1 tool schemas', () {
+      const output =
+          '<tool_calls>\n'
+          '{"name":"weather","arguments":{}}\n'
+          '</tool_calls>';
+      final duplicate = ToolDefinition(
+        name: 'weather',
+        description: 'Duplicate weather tool',
+        parameters: const [],
+        handler: (_) async => null,
+      );
+      final empty = ToolDefinition(
+        name: '',
+        description: 'Empty tool identity',
+        parameters: const [],
+        handler: (_) async => null,
+      );
+
+      for (final tools in [
+        [_weatherTool, duplicate],
+        [empty],
+      ]) {
+        expect(
+          () => ChatTemplateEngine.parse(
+            ChatFormat.minimaxM1.index,
+            output,
+            tools: tools,
+          ),
+          throwsA(isA<LlamaUnsupportedException>()),
+        );
+      }
+    });
   });
 
   group('MiniMax M3', () {
@@ -890,6 +923,41 @@ void main() {
           () => MuseGlimmerHandler().buildGrammar([tool]),
           throwsA(isA<LlamaUnsupportedException>()),
         );
+      }
+    });
+
+    test('requires one invoke matching the Muse recipient route', () {
+      const valid =
+          ' to=weather<|message|>'
+          '<atem:function_calls>'
+          '<atem:invoke name="weather"></atem:invoke>'
+          '</atem:function_calls><|eot|>';
+      final parsed = ChatTemplateEngine.parse(
+        ChatFormat.museGlimmer.index,
+        valid,
+        tools: [_weatherTool],
+      );
+      expect(parsed.toolCalls.single.function?.name, 'weather');
+      expect(parsed.content, isEmpty);
+
+      for (final malformed in [
+        valid.replaceFirst('to=weather', 'to=other'),
+        valid
+            .replaceFirst('to=weather', 'to=other')
+            .replaceFirst('name="weather"', 'name="other"'),
+        valid.replaceFirst(
+          '</atem:function_calls>',
+          '<atem:invoke name="weather"></atem:invoke>'
+              '</atem:function_calls>',
+        ),
+      ]) {
+        final rejected = ChatTemplateEngine.parse(
+          ChatFormat.museGlimmer.index,
+          malformed,
+          tools: [_weatherTool],
+        );
+        expect(rejected.toolCalls, isEmpty);
+        expect(rejected.content, malformed.trim());
       }
     });
 

--- a/test/unit/core/template/handlers/llama_cpp_specialized_handlers_test.dart
+++ b/test/unit/core/template/handlers/llama_cpp_specialized_handlers_test.dart
@@ -287,6 +287,28 @@ void main() {
       }
     });
 
+    test('production parse preserves duplicate MiniMax M1 JSON keys', () {
+      const duplicateTopLevel =
+          '<tool_calls>\n'
+          '{"name":"weather","name":"clock","arguments":{}}\n'
+          '</tool_calls>';
+      const duplicateArgument =
+          '<tool_calls>\n'
+          '{"name":"weather","arguments":'
+          '{"city":"Seoul","c\\u0069ty":"Tokyo"}}\n'
+          '</tool_calls>';
+
+      for (final output in [duplicateTopLevel, duplicateArgument]) {
+        final parsed = ChatTemplateEngine.parse(
+          ChatFormat.minimaxM1.index,
+          output,
+          tools: [_weatherWithCityTool],
+        );
+        expect(parsed.toolCalls, isEmpty);
+        expect(parsed.content, output);
+      }
+    });
+
     test('grammar and parse reject ambiguous MiniMax M1 tool schemas', () {
       const output =
           '<tool_calls>\n'

--- a/test/unit/core/template/handlers/llama_cpp_specialized_handlers_test.dart
+++ b/test/unit/core/template/handlers/llama_cpp_specialized_handlers_test.dart
@@ -75,6 +75,13 @@ void main() {
       expect(grammar, isNot(contains('identifier ::=')));
     });
 
+    test('zero-parameter grammar uses an explicit empty production', () {
+      final grammar = KimiK3Handler().buildGrammar([_zeroArgTool])!;
+
+      expect(grammar, contains('kimi-raw-0 ::= ""'));
+      expect(grammar, isNot(contains(RegExp(r'kimi-raw-0 ::=\s*\n'))));
+    });
+
     test('production parse validates escaped Kimi names against schemas', () {
       const valid =
           '<|open|>tools<|sep|>'

--- a/test/unit/core/template/handlers/llama_cpp_specialized_handlers_test.dart
+++ b/test/unit/core/template/handlers/llama_cpp_specialized_handlers_test.dart
@@ -1097,6 +1097,13 @@ void main() {
   });
 
   group('Poolside Laguna', () {
+    test('escapes the newline delimiter inside required GBNF classes', () {
+      final grammar = LagunaHandler().buildRequiredGrammar([_schemaTool])!;
+
+      expect(grammar, contains(r'[^\n<'));
+      expect(grammar, isNot(contains('[^\n')));
+    });
+
     test('parses reasoning and GLM-style tool calls with raw strings', () {
       const output =
           '<think>check</think>On it.\n'

--- a/test/unit/core/template/handlers/llama_cpp_specialized_handlers_test.dart
+++ b/test/unit/core/template/handlers/llama_cpp_specialized_handlers_test.dart
@@ -139,6 +139,7 @@ void main() {
 
       for (final invalid in [
         valid.replaceFirst('tool="weather"', 'tool="unknown"'),
+        valid.replaceFirst('tool="weather"', 'tool="weather" index="invalid"'),
         valid.replaceFirst('city&amp;&quot;zone', 'unknown'),
         valid.replaceFirst('city&amp;&quot;zone', 'city&&quot;zone'),
         valid.replaceFirst('city&amp;&quot;zone', 'city&bogus;&quot;zone'),
@@ -942,6 +943,7 @@ void main() {
 
       for (final malformed in [
         valid.replaceFirst('to=weather', 'to=other'),
+        valid.replaceFirst('to=weather', 'to= weather '),
         valid
             .replaceFirst('to=weather', 'to=other')
             .replaceFirst('name="weather"', 'name="other"'),

--- a/test/unit/core/template/handlers/llama_cpp_specialized_handlers_test.dart
+++ b/test/unit/core/template/handlers/llama_cpp_specialized_handlers_test.dart
@@ -1273,6 +1273,67 @@ void main() {
       );
     }
   });
+
+  test('specialized any-order optional grammars enforce their state bound', () {
+    ToolDefinition optionalTool(int count) => ToolDefinition(
+      name: 'bounded',
+      description: 'Optional state bound',
+      parameters: [
+        for (var index = 0; index < count; index++)
+          ToolParam.string('option_$index'),
+      ],
+      handler: (_) async => null,
+    );
+    final builders = <String? Function(List<ToolDefinition>?)>[
+      KimiK3Handler().buildGrammar,
+      MinimaxM3Handler().buildGrammar,
+      DeepseekV32Handler().buildGrammar,
+      MuseGlimmerHandler().buildGrammar,
+    ];
+
+    for (final buildGrammar in builders) {
+      expect(() => buildGrammar([optionalTool(10)]), returnsNormally);
+      expect(
+        () => buildGrammar([optionalTool(11)]),
+        throwsA(
+          isA<LlamaUnsupportedException>().having(
+            (error) => error.message,
+            'message',
+            allOf(
+              contains('at most 10 optional properties'),
+              contains('tool "bounded" arguments'),
+              contains('declares 11'),
+            ),
+          ),
+        ),
+      );
+    }
+
+    final nested = ToolDefinition(
+      name: 'nested_bounded',
+      description: 'Nested optional state bound',
+      parameters: [
+        ToolParam.object(
+          'options',
+          properties: [
+            for (var index = 0; index < 11; index++)
+              ToolParam.string('nested_$index'),
+          ],
+        ),
+      ],
+      handler: (_) async => null,
+    );
+    expect(
+      () => MinimaxM3Handler().buildGrammar([nested]),
+      throwsA(
+        isA<LlamaUnsupportedException>().having(
+          (error) => error.message,
+          'message',
+          contains('tool "nested_bounded" arguments.options'),
+        ),
+      ),
+    );
+  });
 }
 
 final _weatherTool = ToolDefinition(

--- a/test/unit/core/template/handlers/llama_cpp_specialized_handlers_test.dart
+++ b/test/unit/core/template/handlers/llama_cpp_specialized_handlers_test.dart
@@ -140,6 +140,9 @@ void main() {
       for (final invalid in [
         valid.replaceFirst('tool="weather"', 'tool="unknown"'),
         valid.replaceFirst('city&amp;&quot;zone', 'unknown'),
+        valid.replaceFirst('city&amp;&quot;zone', 'city&&quot;zone'),
+        valid.replaceFirst('city&amp;&quot;zone', 'city&bogus;&quot;zone'),
+        valid.replaceFirst('city&amp;&quot;zone', 'city&amp;amp;&quot;zone'),
         valid.replaceFirst('type="string"', 'type="number"'),
         duplicate,
       ]) {
@@ -502,6 +505,24 @@ void main() {
       );
       expect(parsed.toolCalls.single.function?.name, 'weather&"alerts');
 
+      for (final malformedName in [
+        'weather&&quot;alerts',
+        'weather&bogus;&quot;alerts',
+        'weather&amp;amp;&quot;alerts',
+      ]) {
+        final malformed = output.replaceFirst(
+          'weather&amp;&quot;alerts',
+          malformedName,
+        );
+        final rejected = ChatTemplateEngine.parse(
+          ChatFormat.minimaxM3.index,
+          malformed,
+          tools: [_attributeTool],
+        );
+        expect(rejected.toolCalls, isEmpty);
+        expect(rejected.content, malformed);
+      }
+
       expect(
         () => MinimaxM3Handler().buildGrammar([_escapedSchemaTool]),
         throwsA(
@@ -574,6 +595,29 @@ void main() {
 
       expect(parsed.toolCalls.single.function?.name, 'weather&"alerts');
       expect(_arguments(parsed), {'city&"zone': 'Seoul'});
+
+      for (final malformed in [
+        output.replaceFirst('weather&amp;&quot;alerts', 'weather&&quot;alerts'),
+        output.replaceFirst(
+          'weather&amp;&quot;alerts',
+          'weather&bogus;&quot;alerts',
+        ),
+        output.replaceFirst(
+          'weather&amp;&quot;alerts',
+          'weather&amp;amp;&quot;alerts',
+        ),
+        output.replaceFirst('city&amp;&quot;zone', 'city&&quot;zone'),
+        output.replaceFirst('city&amp;&quot;zone', 'city&bogus;&quot;zone'),
+        output.replaceFirst('city&amp;&quot;zone', 'city&amp;amp;&quot;zone'),
+      ]) {
+        final rejected = ChatTemplateEngine.parse(
+          ChatFormat.deepseekV32.index,
+          malformed,
+          tools: [_escapedAttributeSchemaTool],
+        );
+        expect(rejected.toolCalls, isEmpty);
+        expect(rejected.content, malformed);
+      }
     });
 
     test('forced-open reasoning terminates at the V3.2 envelope', () {
@@ -811,6 +855,29 @@ void main() {
       );
       expect(parsed.toolCalls.single.function?.name, 'weather&"alerts');
       expect(_arguments(parsed), {'city&"zone': 'Seoul'});
+
+      for (final malformed in [
+        output.replaceFirst('weather&amp;&quot;alerts', 'weather&&quot;alerts'),
+        output.replaceFirst(
+          'weather&amp;&quot;alerts',
+          'weather&bogus;&quot;alerts',
+        ),
+        output.replaceFirst(
+          'weather&amp;&quot;alerts',
+          'weather&amp;amp;&quot;alerts',
+        ),
+        output.replaceFirst('city&amp;&quot;zone', 'city&&quot;zone'),
+        output.replaceFirst('city&amp;&quot;zone', 'city&bogus;&quot;zone'),
+        output.replaceFirst('city&amp;&quot;zone', 'city&amp;amp;&quot;zone'),
+      ]) {
+        final rejected = ChatTemplateEngine.parse(
+          ChatFormat.museGlimmer.index,
+          malformed,
+          tools: [_escapedAttributeSchemaTool],
+        );
+        expect(rejected.toolCalls, isEmpty);
+        expect(rejected.content, malformed.trim());
+      }
 
       for (final reserved in ['self', 'user', ' leading', 'bad<route']) {
         final tool = ToolDefinition(

--- a/test/unit/core/template/handlers/llama_cpp_specialized_handlers_test.dart
+++ b/test/unit/core/template/handlers/llama_cpp_specialized_handlers_test.dart
@@ -1240,6 +1240,39 @@ void main() {
       });
     });
   });
+
+  test('specialized grammars reject nested duplicate parameter identities', () {
+    final ambiguous = ToolDefinition(
+      name: 'ambiguous',
+      description: 'Ambiguous nested parameters',
+      parameters: [
+        ToolParam.object(
+          'options',
+          properties: [ToolParam.string('mode'), ToolParam.boolean('mode')],
+        ),
+      ],
+      handler: (_) async => null,
+    );
+    final builders = <String? Function(List<ToolDefinition>?)>[
+      KimiK3Handler().buildGrammar,
+      MinimaxM3Handler().buildGrammar,
+      DeepseekV32Handler().buildGrammar,
+      MuseGlimmerHandler().buildGrammar,
+    ];
+
+    for (final buildGrammar in builders) {
+      expect(
+        () => buildGrammar([ambiguous]),
+        throwsA(
+          isA<LlamaUnsupportedException>().having(
+            (error) => error.message,
+            'message',
+            allOf(contains('options'), contains('declared more than once')),
+          ),
+        ),
+      );
+    }
+  });
 }
 
 final _weatherTool = ToolDefinition(

--- a/test/unit/core/template/handlers/llama_cpp_specialized_handlers_test.dart
+++ b/test/unit/core/template/handlers/llama_cpp_specialized_handlers_test.dart
@@ -287,7 +287,7 @@ void main() {
       }
     });
 
-    test('production parse rejects ambiguous MiniMax M1 tool schemas', () {
+    test('grammar and parse reject ambiguous MiniMax M1 tool schemas', () {
       const output =
           '<tool_calls>\n'
           '{"name":"weather","arguments":{}}\n'
@@ -309,6 +309,10 @@ void main() {
         [_weatherTool, duplicate],
         [empty],
       ]) {
+        expect(
+          () => MinimaxM1Handler().buildGrammar(tools),
+          throwsA(isA<LlamaUnsupportedException>()),
+        );
         expect(
           () => ChatTemplateEngine.parse(
             ChatFormat.minimaxM1.index,

--- a/test/unit/core/template/handlers/llama_cpp_specialized_handlers_test.dart
+++ b/test/unit/core/template/handlers/llama_cpp_specialized_handlers_test.dart
@@ -49,20 +49,60 @@ void main() {
     test('grammar permits the upstream raw JSON argument block', () {
       final grammar = KimiK3Handler().buildGrammar([_weatherTool])!;
 
-      expect(grammar, contains('(argument* | json-block)'));
+      expect(grammar, contains('(kimi-empty-arguments | kimi-json-0)'));
       expect(grammar, contains(r'(" index=\"" [0-9]+ "\"")? "<|sep|>"'));
       expect(
         grammar,
-        contains(r'"<|open|>json type=\"object\"<|sep|>" json-object'),
+        contains(r'"<|open|>json type=\"object\"<|sep|>" kimi-tool-0-json'),
       );
-      expect(grammar, contains('char ::= '));
+      expect(grammar, contains('kimi-tool-0-json ::= '));
     });
 
     test('grammar HTML-escapes tool names like the upstream XTML macro', () {
       final grammar = KimiK3Handler().buildGrammar([_attributeTool])!;
 
-      expect(grammar, contains(r'tool-name ::= "weather&amp;&quot;alerts"'));
-      expect(grammar, isNot(contains(r'tool-name ::= "weather&\"alerts"')));
+      expect(grammar, contains(r'call tool=\"weather&amp;&quot;alerts\"'));
+      expect(grammar, isNot(contains(r'call tool=\"weather&\"alerts\"')));
+    });
+
+    test('grammar emits exact escaped schema keys and their declared type', () {
+      final grammar = KimiK3Handler().buildGrammar([_escapedSchemaTool])!;
+
+      expect(
+        grammar,
+        contains(r'argument key=\"city&amp;&quot;zone\" type=\"string\"'),
+      );
+      expect(grammar, isNot(contains('identifier ::=')));
+    });
+
+    test('production parse validates escaped Kimi names against schemas', () {
+      const valid =
+          '<|open|>tools<|sep|>'
+          '<|open|>call tool="weather"<|sep|>'
+          '<|open|>argument key="city&amp;&quot;zone" type="string"<|sep|>'
+          '123<|close|>argument<|sep|><|close|>call<|sep|>'
+          '<|close|>tools<|sep|><|close|>message<|sep|>';
+      final parsed = ChatTemplateEngine.parse(
+        ChatFormat.kimiK3.index,
+        valid,
+        tools: [_escapedSchemaTool],
+      );
+
+      expect(_arguments(parsed), {'city&"zone': '123'});
+
+      for (final invalid in [
+        valid.replaceFirst('tool="weather"', 'tool="unknown"'),
+        valid.replaceFirst('city&amp;&quot;zone', 'unknown'),
+        valid.replaceFirst('type="string"', 'type="number"'),
+      ]) {
+        final rejected = ChatTemplateEngine.parse(
+          ChatFormat.kimiK3.index,
+          invalid,
+          tools: [_escapedSchemaTool],
+        );
+        expect(rejected.toolCalls, isEmpty);
+        expect(rejected.content, contains('<|open|>tools<|sep|>'));
+      }
     });
 
     test(
@@ -153,6 +193,47 @@ void main() {
       expect(grammar, contains(r'[\\] (["\\bfnrt] | "u"'));
       expect(grammar, isNot(contains('json-char ::=')));
     });
+
+    test('grammar JSON-encodes the upstream tool-name value', () {
+      final grammar = MinimaxM1Handler().buildGrammar([_weatherTool])!;
+      final callRule = grammar
+          .split('\n')
+          .singleWhere((line) => line.startsWith('tool-0-call ::='));
+
+      expect(callRule, contains(r'\"weather\"'));
+      expect(callRule, isNot(contains(' space "weather" space')));
+    });
+
+    test('production parse rejects MiniMax M1 schema mismatches', () {
+      const valid =
+          '<tool_calls>\n'
+          '{"name":"weather","arguments":{"city":"Seoul"}}\n'
+          '</tool_calls>';
+      final parsed = ChatTemplateEngine.parse(
+        ChatFormat.minimaxM1.index,
+        valid,
+        tools: [_weatherWithCityTool],
+      );
+      expect(_arguments(parsed), {'city': 'Seoul'});
+
+      for (final invalid in [
+        valid.replaceFirst('"weather"', '"unknown"'),
+        valid.replaceFirst('"city"', '"unknown"'),
+        valid.replaceFirst('"Seoul"', '7'),
+        valid.replaceFirst(
+          '"name":"weather"',
+          '"name":"weather","unexpected":true',
+        ),
+      ]) {
+        final rejected = ChatTemplateEngine.parse(
+          ChatFormat.minimaxM1.index,
+          invalid,
+          tools: [_weatherWithCityTool],
+        );
+        expect(rejected.toolCalls, isEmpty);
+        expect(rejected.content, invalid);
+      }
+    });
   });
 
   group('MiniMax M3', () {
@@ -229,6 +310,320 @@ void main() {
       expect(parsed.toolCalls.single.function?.name, 'weather');
       expect(_arguments(parsed), {'city': 'Seoul'});
     });
+
+    test('production parse accepts a zero-parameter invoke as empty args', () {
+      const output =
+          '$ns<tool_call>$ns<invoke name="ping">'
+          '$ns</invoke>$ns</tool_call>';
+      final parsed = ChatTemplateEngine.parse(
+        ChatFormat.minimaxM3.index,
+        output,
+        tools: [_zeroArgTool],
+      );
+
+      expect(parsed.content, isEmpty);
+      expect(parsed.toolCalls.single.function?.name, 'ping');
+      expect(_arguments(parsed), isEmpty);
+    });
+
+    test('production parse preserves schema types and empty containers', () {
+      const output =
+          '$ns<tool_call>$ns<invoke name="inspect">'
+          '$ns<code>123$ns</code>'
+          '$ns<options>$ns</options>'
+          '$ns<items>$ns</items>'
+          '$ns<count>7$ns</count>'
+          '$ns<active>true$ns</active>'
+          '$ns<empty>null$ns</empty>'
+          '$ns</invoke>$ns</tool_call>';
+      final parsed = ChatTemplateEngine.parse(
+        ChatFormat.minimaxM3.index,
+        output,
+        tools: [_schemaTool],
+      );
+
+      expect(_arguments(parsed), {
+        'code': '123',
+        'options': <String, dynamic>{},
+        'items': <Object?>[],
+        'count': 7,
+        'active': true,
+        'empty': null,
+      });
+    });
+
+    test('production schema rejects unknown and mismatched arguments', () {
+      const unknown =
+          '$ns<tool_call>$ns<invoke name="inspect">'
+          '$ns<unknown>x$ns</unknown>$ns</invoke>$ns</tool_call>';
+      const mismatch =
+          '$ns<tool_call>$ns<invoke name="inspect">'
+          '$ns<code>x$ns</code>$ns<options>$ns</options>'
+          '$ns<items>$ns</items>$ns<count>oops$ns</count>'
+          '$ns<active>true$ns</active>$ns<empty>null$ns</empty>'
+          '$ns</invoke>$ns</tool_call>';
+
+      for (final output in [unknown, mismatch]) {
+        final parsed = ChatTemplateEngine.parse(
+          ChatFormat.minimaxM3.index,
+          output,
+          tools: [_schemaTool],
+        );
+        expect(parsed.toolCalls, isEmpty);
+        expect(parsed.content, output);
+      }
+    });
+
+    test('production schema rejects duplicate MiniMax M3 properties', () {
+      const duplicateTopLevel =
+          '$ns<tool_call>$ns<invoke name="inspect">'
+          '$ns<code>first$ns</code>$ns<code>second$ns</code>'
+          '$ns<options>$ns</options>$ns<items>$ns</items>'
+          '$ns<count>7$ns</count>$ns<active>true$ns</active>'
+          '$ns<empty>null$ns</empty>$ns</invoke>$ns</tool_call>';
+      const duplicateNested =
+          '$ns<tool_call>$ns<invoke name="weather">'
+          '$ns<city>Seoul$ns</city>'
+          '$ns<options>$ns<units>metric$ns</units>'
+          '$ns<units>imperial$ns</units>$ns</options>'
+          '$ns</invoke>$ns</tool_call>';
+
+      for (final output in [duplicateTopLevel, duplicateNested]) {
+        final parsed = ChatTemplateEngine.parse(
+          ChatFormat.minimaxM3.index,
+          output,
+          tools: output == duplicateTopLevel
+              ? [_schemaTool]
+              : [_weatherNestedTool],
+        );
+        expect(parsed.toolCalls, isEmpty);
+        expect(parsed.content, output);
+      }
+    });
+
+    test('production schema rejects an unknown MiniMax M3 tool name', () {
+      const output =
+          '$ns<tool_call>$ns<invoke name="unknown">'
+          '$ns</invoke>$ns</tool_call>';
+      final parsed = ChatTemplateEngine.parse(
+        ChatFormat.minimaxM3.index,
+        output,
+        tools: [_zeroArgTool],
+      );
+
+      expect(parsed.toolCalls, isEmpty);
+      expect(parsed.content, output);
+    });
+
+    test('preserves namespace-like text inside MiniMax M3 strings', () {
+      const output =
+          '$ns<tool_call>$ns<invoke name="inspect">'
+          '$ns<code>a${ns}literal$ns</code>'
+          '$ns<options>$ns</options>$ns<items>$ns</items>'
+          '$ns<count>7$ns</count>$ns<active>true$ns</active>'
+          '$ns<empty>null$ns</empty>$ns</invoke>$ns</tool_call>';
+      final parsed = ChatTemplateEngine.parse(
+        ChatFormat.minimaxM3.index,
+        output,
+        tools: [_schemaTool],
+      );
+
+      expect(_arguments(parsed)['code'], 'a${ns}literal');
+    });
+
+    test('grammar binds literal closing tags and permits ] in strings', () {
+      final grammar = MinimaxM3Handler().buildGrammar([_schemaTool])!;
+
+      expect(grammar, contains('$ns<code>'));
+      expect(grammar, contains('$ns</code>'));
+      expect(grammar, isNot(contains('identifier ::=')));
+      expect(grammar, isNot(contains(r'raw ::= [^]]*')));
+    });
+  });
+
+  group('DeepSeek V3.2 DSML', () {
+    const actualUpstreamOutput =
+        'Let me check the time</think>\n\n'
+        '<｜DSML｜function_calls>\n'
+        '<｜DSML｜invoke name="weather">\n'
+        '<｜DSML｜parameter name="city" string="true">Tokyo'
+        '</｜DSML｜parameter>\n'
+        '</｜DSML｜invoke>\n'
+        '</｜DSML｜function_calls>';
+
+    test('parses the actual pinned-upstream function_calls emission', () {
+      final parsed = DeepseekV32Handler().parse(
+        actualUpstreamOutput,
+        thinkingForcedOpen: true,
+      );
+
+      expect(parsed.reasoningContent, 'Let me check the time');
+      expect(parsed.content, isEmpty);
+      expect(parsed.toolCalls.single.function?.name, 'weather');
+      expect(_arguments(parsed), {'city': 'Tokyo'});
+    });
+
+    test('uses the V3.2 envelope for grammar and lazy activation', () {
+      final handler = DeepseekV32Handler();
+      final grammar = handler.buildGrammar([_attributeTool])!;
+
+      expect(handler.grammarTriggerValues, ['<｜DSML｜function_calls>']);
+      expect(handler.preservedTokens, contains('<｜DSML｜function_calls>'));
+      expect(
+        grammar.split('\n').first,
+        r'root ::= "<｜DSML｜function_calls>" dsml-space dsml-tool+ "</｜DSML｜function_calls>"',
+      );
+      expect(grammar, contains(r'invoke name=\"weather&\"alerts\">'));
+      expect(grammar, isNot(contains('identifier ::=')));
+      expect(grammar, isNot(contains('<｜DSML｜tool_calls>')));
+    });
+
+    test('forced-open reasoning terminates at the V3.2 envelope', () {
+      const output =
+          'Need the weather\n\n'
+          '<｜DSML｜function_calls>\n'
+          '<｜DSML｜invoke name="weather">\n'
+          '<｜DSML｜parameter name="city" string="true">Seoul'
+          '</｜DSML｜parameter>\n'
+          '</｜DSML｜invoke>\n'
+          '</｜DSML｜function_calls>';
+      final parsed = ChatTemplateEngine.parse(
+        ChatFormat.deepseekV32.index,
+        output,
+        tools: [_weatherWithCityTool],
+        thinkingForcedOpen: true,
+      );
+
+      expect(parsed.reasoningContent, 'Need the weather');
+      expect(parsed.content, isEmpty);
+      expect(_arguments(parsed), {'city': 'Seoul'});
+    });
+
+    test('production parse enforces the V3.2 schema and string flag', () {
+      const valid =
+          '<｜DSML｜function_calls>\n'
+          '<｜DSML｜invoke name="weather">\n'
+          '<｜DSML｜parameter name="city" string="true">x < 5'
+          '</｜DSML｜parameter>\n'
+          '</｜DSML｜invoke>\n'
+          '</｜DSML｜function_calls>';
+      final parsed = ChatTemplateEngine.parse(
+        ChatFormat.deepseekV32.index,
+        valid,
+        tools: [_weatherWithCityTool],
+      );
+      expect(_arguments(parsed), {'city': 'x < 5'});
+
+      final duplicate = valid.replaceFirst(
+        '</｜DSML｜parameter>',
+        '</｜DSML｜parameter>\n'
+            '<｜DSML｜parameter name="city" string="true">again'
+            '</｜DSML｜parameter>',
+      );
+      for (final invalid in [
+        valid.replaceFirst('name="weather"', 'name="unknown"'),
+        valid.replaceFirst('name="city"', 'name="unknown"'),
+        valid.replaceFirst('string="true"', 'string="false"'),
+        duplicate,
+      ]) {
+        final rejected = ChatTemplateEngine.parse(
+          ChatFormat.deepseekV32.index,
+          invalid,
+          tools: [_weatherWithCityTool],
+        );
+        expect(rejected.toolCalls, isEmpty);
+        expect(rejected.content, contains('<｜DSML｜function_calls>'));
+      }
+    });
+
+    test('preserves the protocol block when tool parsing is disabled', () {
+      final parsed = DeepseekV32Handler().parse(
+        actualUpstreamOutput,
+        parseToolCalls: false,
+        thinkingForcedOpen: true,
+      );
+
+      expect(parsed.reasoningContent, 'Let me check the time');
+      expect(parsed.toolCalls, isEmpty);
+      expect(parsed.content, startsWith('<｜DSML｜function_calls>'));
+      expect(parsed.content, endsWith('</｜DSML｜function_calls>'));
+    });
+
+    test('preserves a forced-open protocol block when parsing is disabled', () {
+      const output =
+          'Need the weather\n\n'
+          '<｜DSML｜function_calls>\n'
+          '<｜DSML｜invoke name="weather">\n'
+          '<｜DSML｜parameter name="city" string="true">Seoul'
+          '</｜DSML｜parameter>\n'
+          '</｜DSML｜invoke>\n'
+          '</｜DSML｜function_calls>';
+      final parsed = DeepseekV32Handler().parse(
+        output,
+        parseToolCalls: false,
+        thinkingForcedOpen: true,
+      );
+
+      expect(parsed.reasoningContent, 'Need the weather');
+      expect(parsed.toolCalls, isEmpty);
+      expect(parsed.content, startsWith('<｜DSML｜function_calls>'));
+      expect(parsed.content, endsWith('</｜DSML｜function_calls>'));
+    });
+
+    test('hides an incomplete function call while streaming', () {
+      const output =
+          'Prelude\n<｜DSML｜function_calls>\n'
+          '<｜DSML｜invoke name="weather">\n'
+          '<｜DSML｜parameter name="city" string="true">Seo';
+      final parsed = DeepseekV32Handler().parse(output, isPartial: true);
+
+      expect(parsed.content, 'Prelude');
+      expect(parsed.toolCalls, isEmpty);
+    });
+
+    test('keeps completed calls before a partial second invoke', () {
+      const output =
+          '<｜DSML｜function_calls>\n'
+          '<｜DSML｜invoke name="weather">\n'
+          '<｜DSML｜parameter name="city" string="true">Seoul'
+          '</｜DSML｜parameter>\n'
+          '</｜DSML｜invoke>\n'
+          '<｜DSML｜invoke name="clock">\n'
+          '<｜DSML｜parameter name="tz" string="true">UT';
+      final parsed = DeepseekV32Handler().parse(output, isPartial: true);
+
+      expect(parsed.content, isEmpty);
+      expect(parsed.toolCalls, hasLength(1));
+      expect(parsed.toolCalls.single.function?.name, 'weather');
+      expect(_arguments(parsed), {'city': 'Seoul'});
+    });
+
+    test('preserves a malformed completed payload', () {
+      const output =
+          '<｜DSML｜function_calls>\n'
+          '<｜DSML｜invoke name="weather">\n'
+          '<｜DSML｜parameter name="days" string="false">two'
+          '</｜DSML｜parameter>\n'
+          '</｜DSML｜invoke>\n'
+          '</｜DSML｜function_calls>';
+      final parsed = DeepseekV32Handler().parse(output);
+
+      expect(parsed.toolCalls, isEmpty);
+      expect(parsed.content, output);
+    });
+
+    test('preserves a truncated full output', () {
+      const output =
+          '<｜DSML｜function_calls>\n'
+          '<｜DSML｜invoke name="weather">\n'
+          '<｜DSML｜parameter name="city" string="true">Seoul'
+          '</｜DSML｜parameter>\n'
+          '</｜DSML｜invoke>';
+      final parsed = DeepseekV32Handler().parse(output);
+
+      expect(parsed.toolCalls, isEmpty);
+      expect(parsed.content, output);
+    });
   });
 
   group('DeepSeek V4 DSML', () {
@@ -263,6 +658,18 @@ void main() {
       expect(parsed.toolCalls, isEmpty);
       expect(parsed.content, output);
     });
+
+    test('keeps the V4 tool_calls grammar and trigger', () {
+      final handler = DeepseekV4Handler();
+      final grammar = handler.buildGrammar([_weatherTool])!;
+
+      expect(handler.grammarTriggerValues, ['<｜DSML｜tool_calls>']);
+      expect(
+        grammar.split('\n').first,
+        r'root ::= "<｜DSML｜tool_calls>" dsml-space dsml-tool+ "</｜DSML｜tool_calls>"',
+      );
+      expect(grammar, isNot(contains('<｜DSML｜function_calls>')));
+    });
   });
 
   group('Muse Glimmer', () {
@@ -296,7 +703,15 @@ void main() {
       const output = ' to=weather<|message|><atem:function_calls>broken<|eot|>';
       final parsed = MuseGlimmerHandler().parse(output);
       expect(parsed.toolCalls, isEmpty);
-      expect(parsed.content, contains('broken'));
+      expect(parsed.content, output.trim());
+    });
+
+    test('rolls a truncated final Muse tool channel back verbatim', () {
+      const output = 'Before. to=weather<|message|><atem:function_calls>broken';
+      final parsed = MuseGlimmerHandler().parse(output);
+
+      expect(parsed.toolCalls, isEmpty);
+      expect(parsed.content, output);
     });
 
     test('hides an incomplete tool channel while streaming', () {
@@ -311,6 +726,50 @@ void main() {
       expect(parsed.toolCalls, isEmpty);
     });
 
+    test('hides a partial Muse routing envelope before the message body', () {
+      const output = 'Visible answer.<|start|>assistant to=weather<|mess';
+      final parsed = MuseGlimmerHandler().parse(output, isPartial: true);
+
+      expect(parsed.content, 'Visible answer.');
+      expect(parsed.toolCalls, isEmpty);
+    });
+
+    test('preserves unmatched content around parsed Muse channels', () {
+      const output =
+          'Before.'
+          ' to=user<|message|>User channel.<|eom|>'
+          'Between.'
+          '<|start|>assistant to=weather<|message|>$atem<|eot|>'
+          'After.';
+      final parsed = MuseGlimmerHandler().parse(output);
+
+      expect(parsed.content, contains('Before.'));
+      expect(parsed.content, contains('User channel.'));
+      expect(parsed.content, contains('Between.'));
+      expect(parsed.content, contains('After.'));
+      expect(
+        parsed.content.indexOf('Before.'),
+        lessThan(parsed.content.indexOf('User channel.')),
+      );
+      expect(
+        parsed.content.indexOf('User channel.'),
+        lessThan(parsed.content.indexOf('Between.')),
+      );
+      expect(
+        parsed.content.indexOf('Between.'),
+        lessThan(parsed.content.indexOf('After.')),
+      );
+      expect(parsed.toolCalls.single.function?.name, 'weather');
+    });
+
+    test('restores an incomplete Muse route as final assistant content', () {
+      const output = 'Visible.<|start|>assistant to=weather<|mess';
+      final parsed = MuseGlimmerHandler().parse(output);
+
+      expect(parsed.content, output);
+      expect(parsed.toolCalls, isEmpty);
+    });
+
     test('lazy grammar activates only at the ATEM tool-call envelope', () {
       final handler = MuseGlimmerHandler();
       final grammar = handler.buildGrammar([_weatherTool])!;
@@ -318,9 +777,51 @@ void main() {
       expect(handler.grammarTriggerValues, ['<atem:function_calls>']);
       expect(
         grammar.split('\n').first,
-        r'root ::= "<atem:function_calls>\n" invoke "</atem:function_calls>"',
+        r'root ::= "<atem:function_calls>" muse-space muse-tool+ "</atem:function_calls>"',
       );
+      expect(grammar, isNot(contains('identifier ::=')));
       expect(grammar.split('\n').first, isNot(contains(' to=')));
+    });
+
+    test('production parse preserves schema-directed Muse values', () {
+      const output =
+          ' to=inspect<|message|><atem:function_calls>'
+          '<atem:invoke name="inspect">'
+          '<atem:parameter name="code">123</atem:parameter>'
+          '<atem:parameter name="options">{}</atem:parameter>'
+          '<atem:parameter name="items">[]</atem:parameter>'
+          '<atem:parameter name="count">7</atem:parameter>'
+          '<atem:parameter name="active">true</atem:parameter>'
+          '<atem:parameter name="empty">null</atem:parameter>'
+          '</atem:invoke></atem:function_calls><|eot|>';
+      final parsed = ChatTemplateEngine.parse(
+        ChatFormat.museGlimmer.index,
+        output,
+        tools: [_schemaTool],
+      );
+
+      expect(_arguments(parsed), {
+        'code': '123',
+        'options': <String, dynamic>{},
+        'items': <Object?>[],
+        'count': 7,
+        'active': true,
+        'empty': null,
+      });
+
+      final duplicate = output.replaceFirst(
+        '</atem:parameter><atem:parameter name="options">',
+        '</atem:parameter>'
+            '<atem:parameter name="code">again</atem:parameter>'
+            '<atem:parameter name="options">',
+      );
+      final rejected = ChatTemplateEngine.parse(
+        ChatFormat.museGlimmer.index,
+        duplicate,
+        tools: [_schemaTool],
+      );
+      expect(rejected.toolCalls, isEmpty);
+      expect(rejected.content, contains('<atem:function_calls>'));
     });
   });
 
@@ -347,6 +848,77 @@ void main() {
       expect(parsed.toolCalls, isEmpty);
       expect(parsed.content, output);
     });
+
+    test('hides an incomplete Laguna tool block while streaming', () {
+      const output =
+          'Visible answer.\n'
+          '<tool_call>weather\n'
+          '<arg_key>city</arg_key><arg_value>Seo';
+      final parsed = LagunaHandler().parse(output, isPartial: true);
+
+      expect(parsed.content, 'Visible answer.');
+      expect(parsed.toolCalls, isEmpty);
+    });
+
+    test('keeps completed Laguna calls before an incomplete next call', () {
+      const output =
+          'Visible answer.\n'
+          '<tool_call>weather\n'
+          '<arg_key>city</arg_key><arg_value>Seoul</arg_value>\n'
+          '</tool_call>\n'
+          '<tool_call>weather\n<arg_key>city</arg_key><arg_value>Tor';
+      final parsed = LagunaHandler().parse(output, isPartial: true);
+
+      expect(parsed.content, 'Visible answer.');
+      expect(parsed.toolCalls, hasLength(1));
+      expect(_arguments(parsed), {'city': 'Seoul'});
+    });
+
+    test('hides a partial Laguna opening marker while streaming', () {
+      const output = 'Visible answer.<tool_cal';
+      final parsed = LagunaHandler().parse(output, isPartial: true);
+
+      expect(parsed.content, 'Visible answer.');
+      expect(parsed.toolCalls, isEmpty);
+    });
+
+    test('keeps incomplete Laguna markup when parsing is disabled', () {
+      const output = 'Visible answer.<tool_call>weather';
+      final parsed = LagunaHandler().parse(
+        output,
+        isPartial: true,
+        parseToolCalls: false,
+      );
+
+      expect(parsed.content, output);
+      expect(parsed.toolCalls, isEmpty);
+    });
+
+    test('production parse preserves schema-directed Laguna values', () {
+      const output =
+          '<tool_call>inspect\n'
+          '<arg_key>code</arg_key><arg_value>123</arg_value>\n'
+          '<arg_key>options</arg_key><arg_value>{}</arg_value>\n'
+          '<arg_key>items</arg_key><arg_value>[]</arg_value>\n'
+          '<arg_key>count</arg_key><arg_value>7</arg_value>\n'
+          '<arg_key>active</arg_key><arg_value>true</arg_value>\n'
+          '<arg_key>empty</arg_key><arg_value>null</arg_value>\n'
+          '</tool_call>';
+      final parsed = ChatTemplateEngine.parse(
+        ChatFormat.laguna.index,
+        output,
+        tools: [_schemaTool],
+      );
+
+      expect(_arguments(parsed), {
+        'code': '123',
+        'options': <String, dynamic>{},
+        'items': <Object?>[],
+        'count': 7,
+        'active': true,
+        'empty': null,
+      });
+    });
   });
 }
 
@@ -364,10 +936,56 @@ final _weatherWithCityTool = ToolDefinition(
   handler: (_) async => null,
 );
 
+final _weatherNestedTool = ToolDefinition(
+  name: 'weather',
+  description: 'Weather with options',
+  parameters: [
+    ToolParam.string('city', required: true),
+    ToolParam.object(
+      'options',
+      properties: [ToolParam.string('units', required: true)],
+      required: true,
+    ),
+  ],
+  handler: (_) async => null,
+);
+
 final _attributeTool = ToolDefinition(
   name: 'weather&"alerts',
   description: 'Weather alerts',
   parameters: const [],
+  handler: (_) async => null,
+);
+
+final _escapedSchemaTool = ToolDefinition(
+  name: 'weather',
+  description: 'Weather',
+  parameters: [ToolParam.string('city&"zone', required: true)],
+  handler: (_) async => null,
+);
+
+final _zeroArgTool = ToolDefinition(
+  name: 'ping',
+  description: 'Ping',
+  parameters: const [],
+  handler: (_) async => null,
+);
+
+final _schemaTool = ToolDefinition(
+  name: 'inspect',
+  description: 'Inspect typed values',
+  parameters: [
+    ToolParam.string('code', required: true),
+    ToolParam.object('options', properties: const [], required: true),
+    ToolParam.array(
+      'items',
+      itemType: ToolParam.string('item'),
+      required: true,
+    ),
+    ToolParam.integer('count', required: true),
+    ToolParam.boolean('active', required: true),
+    ToolParam.nullType('empty', required: true),
+  ],
   handler: (_) async => null,
 );
 

--- a/test/unit/core/template/handlers/llama_cpp_specialized_handlers_test.dart
+++ b/test/unit/core/template/handlers/llama_cpp_specialized_handlers_test.dart
@@ -90,10 +90,18 @@ void main() {
 
       expect(_arguments(parsed), {'city&"zone': '123'});
 
+      final duplicate = valid.replaceFirst(
+        '<|close|>argument<|sep|><|close|>call<|sep|>',
+        '<|close|>argument<|sep|>'
+            '<|open|>argument key="city&amp;&quot;zone" type="string"<|sep|>'
+            'again<|close|>argument<|sep|><|close|>call<|sep|>',
+      );
+
       for (final invalid in [
         valid.replaceFirst('tool="weather"', 'tool="unknown"'),
         valid.replaceFirst('city&amp;&quot;zone', 'unknown'),
         valid.replaceFirst('type="string"', 'type="number"'),
+        duplicate,
       ]) {
         final rejected = ChatTemplateEngine.parse(
           ChatFormat.kimiK3.index,

--- a/test/unit/core/template/tool_call_grammar_utils_test.dart
+++ b/test/unit/core/template/tool_call_grammar_utils_test.dart
@@ -4,6 +4,22 @@ import 'package:llamadart/src/core/template/tool_call_grammar_utils.dart';
 import 'package:test/test.dart';
 
 void main() {
+  test('ruleName preserves safe names and distinguishes escaped runes', () {
+    expect(ToolCallGrammarUtils.ruleName('code'), 'code');
+    expect(
+      ToolCallGrammarUtils.ruleName('a b'),
+      isNot(ToolCallGrammarUtils.ruleName('a-b')),
+    );
+    expect(
+      ToolCallGrammarUtils.ruleName('Weather'),
+      isNot(ToolCallGrammarUtils.ruleName('weather')),
+    );
+    expect(
+      ToolCallGrammarUtils.ruleName(''),
+      isNot(ToolCallGrammarUtils.ruleName('rule-empty')),
+    );
+  });
+
   test('wrapRootGrammar wraps root rule with literals', () {
     const grammar = 'root ::= obj\nobj ::= "{}"\n';
 

--- a/test/unit/core/template/tool_call_parsing_utils_test.dart
+++ b/test/unit/core/template/tool_call_parsing_utils_test.dart
@@ -5,6 +5,28 @@ import 'package:test/test.dart';
 
 void main() {
   group('ToolCallParsingUtils', () {
+    test(
+      'rejects duplicate object keys before JSON decoding collapses them',
+      () {
+        expect(
+          ToolCallParsingUtils.hasUniqueJsonObjectKeys(
+            '{"outer":{"city":"Seoul","c\\u0069ty":"Tokyo"}}',
+          ),
+          isFalse,
+        );
+        expect(
+          ToolCallParsingUtils.hasUniqueJsonObjectKeys(
+            '[{"city":"Seoul"},{"city":"Tokyo"}]',
+          ),
+          isTrue,
+        );
+        expect(
+          ToolCallParsingUtils.hasUniqueJsonObjectKeys('{"city":'),
+          isFalse,
+        );
+      },
+    );
+
     test('decodes JSON objects', () {
       final decoded = ToolCallParsingUtils.decodeJsonObject(
         '{"name":"get_weather","arguments":{"city":"Seoul"}}',

--- a/test/unit/core/template/tool_schema_utils_test.dart
+++ b/test/unit/core/template/tool_schema_utils_test.dart
@@ -1,0 +1,97 @@
+import 'package:llamadart/src/core/models/tools/tool_definition.dart';
+import 'package:llamadart/src/core/models/tools/tool_param.dart';
+import 'package:llamadart/src/core/template/tool_schema_utils.dart';
+import 'package:test/test.dart';
+
+void main() {
+  group('tool schema utilities', () {
+    test('indexes schemas by their exact tool names', () {
+      final schemas = toolSchemas([_tool]);
+
+      expect(schemas.keys, ['inspect']);
+      expect(schemaRequired(schemas['inspect']!), {'code', 'count'});
+      expect(schemaProperties(schemas['inspect']!).keys, {
+        'code',
+        'count',
+        'options',
+        'items',
+        'empty',
+      });
+    });
+
+    test('preserves lexical strings and validates primitive types', () {
+      expect(decodeToolSchemaText('123', const {'type': 'string'}), (
+        valid: true,
+        value: '123',
+      ));
+      expect(decodeToolSchemaText('123', const {'type': 'integer'}), (
+        valid: true,
+        value: 123,
+      ));
+      expect(
+        decodeToolSchemaText('123', const {'type': 'boolean'}).valid,
+        isFalse,
+      );
+      expect(decodeToolSchemaText('null', const {'type': 'null'}), (
+        valid: true,
+        value: null,
+      ));
+    });
+
+    test('validates nested containers, required keys, and unknown keys', () {
+      final schema = _tool.toJsonSchema();
+      expect(
+        validateToolSchemaValue({
+          'code': '001',
+          'count': 7,
+          'options': {'enabled': true},
+          'items': ['a', 'b'],
+          'empty': null,
+        }, schema).valid,
+        isTrue,
+      );
+      expect(validateToolSchemaValue({'code': '001'}, schema).valid, isFalse);
+      expect(
+        validateToolSchemaValue({
+          'code': '001',
+          'count': 7,
+          'unknown': true,
+        }, schema).valid,
+        isFalse,
+      );
+      expect(
+        validateToolSchemaValue({
+          'code': '001',
+          'count': 7,
+          'options': {'enabled': 'true'},
+        }, schema).valid,
+        isFalse,
+      );
+    });
+
+    test('enforces string enum members without coercion', () {
+      const schema = {
+        'type': 'string',
+        'enum': ['auto', 'manual'],
+      };
+      expect(decodeToolSchemaText('auto', schema).valid, isTrue);
+      expect(decodeToolSchemaText('1', schema).valid, isFalse);
+    });
+  });
+}
+
+final _tool = ToolDefinition(
+  name: 'inspect',
+  description: 'Inspect values',
+  parameters: [
+    ToolParam.string('code', required: true),
+    ToolParam.integer('count', required: true),
+    ToolParam.object(
+      'options',
+      properties: [ToolParam.boolean('enabled', required: true)],
+    ),
+    ToolParam.array('items', itemType: ToolParam.string('item')),
+    ToolParam.nullType('empty'),
+  ],
+  handler: (_) async => null,
+);

--- a/test/unit/core/template/tool_schema_utils_test.dart
+++ b/test/unit/core/template/tool_schema_utils_test.dart
@@ -1,3 +1,4 @@
+import 'package:llamadart/src/core/exceptions.dart';
 import 'package:llamadart/src/core/models/tools/tool_definition.dart';
 import 'package:llamadart/src/core/models/tools/tool_param.dart';
 import 'package:llamadart/src/core/template/tool_schema_utils.dart';
@@ -18,6 +19,45 @@ void main() {
         'empty',
       });
     });
+
+    test(
+      'rejects empty and duplicate tool identities before schema lookup',
+      () {
+        final duplicate = ToolDefinition(
+          name: _tool.name,
+          description: 'Duplicate schema',
+          parameters: const [],
+          handler: (_) async => null,
+        );
+        final empty = ToolDefinition(
+          name: '',
+          description: 'Empty schema identity',
+          parameters: const [],
+          handler: (_) async => null,
+        );
+
+        expect(
+          () => toolSchemas([_tool, duplicate]),
+          throwsA(
+            isA<LlamaUnsupportedException>().having(
+              (error) => error.message,
+              'message',
+              contains('declared more than once'),
+            ),
+          ),
+        );
+        expect(
+          () => toolSchemas([empty]),
+          throwsA(
+            isA<LlamaUnsupportedException>().having(
+              (error) => error.message,
+              'message',
+              contains('non-empty tool names'),
+            ),
+          ),
+        );
+      },
+    );
 
     test('preserves lexical strings and validates primitive types', () {
       expect(decodeToolSchemaText('123', const {'type': 'string'}), (

--- a/test/unit/core/template/tool_schema_utils_test.dart
+++ b/test/unit/core/template/tool_schema_utils_test.dart
@@ -59,6 +59,61 @@ void main() {
       },
     );
 
+    test('rejects lossy parameter identities before schema construction', () {
+      final invalidTools = <ToolDefinition>[
+        ToolDefinition(
+          name: 'empty_top_level',
+          description: 'Empty top-level parameter',
+          parameters: [ToolParam.string('')],
+          handler: (_) async => null,
+        ),
+        ToolDefinition(
+          name: 'duplicate_top_level',
+          description: 'Duplicate top-level parameter',
+          parameters: [ToolParam.string('value'), ToolParam.integer('value')],
+          handler: (_) async => null,
+        ),
+        ToolDefinition(
+          name: 'duplicate_nested',
+          description: 'Duplicate nested parameter',
+          parameters: [
+            ToolParam.object(
+              'options',
+              properties: [ToolParam.string('mode'), ToolParam.boolean('mode')],
+            ),
+          ],
+          handler: (_) async => null,
+        ),
+        ToolDefinition(
+          name: 'empty_array_object',
+          description: 'Empty parameter nested in an array object',
+          parameters: [
+            ToolParam.array(
+              'items',
+              itemType: ToolParam.object(
+                'ignored_item_name',
+                properties: [ToolParam.string('')],
+              ),
+            ),
+          ],
+          handler: (_) async => null,
+        ),
+      ];
+
+      for (final tool in invalidTools) {
+        expect(
+          () => toolSchemas([tool]),
+          throwsA(
+            isA<LlamaUnsupportedException>().having(
+              (error) => error.message,
+              'message',
+              anyOf(contains('non-empty parameter names'), contains('unique')),
+            ),
+          ),
+        );
+      }
+    });
+
     test('preserves lexical strings and validates primitive types', () {
       expect(decodeToolSchemaText('123', const {'type': 'string'}), (
         valid: true,

--- a/tool/testing/run_llama_cpp_chat_tests.sh
+++ b/tool/testing/run_llama_cpp_chat_tests.sh
@@ -64,9 +64,10 @@ resolve_target() {
 chat_parser_target="$(resolve_target chat-parser test-chat-parser test-chat-auto-parser)"
 peg_parser_target="$(resolve_target peg-parser test-chat-peg-parser)"
 template_target="$(resolve_target chat-template test-chat-template)"
+gbnf_validator_target="$(resolve_target gbnf-validator test-gbnf-validator)"
 
 ctest_targets=("${chat_parser_target}" "${peg_parser_target}" "${template_target}")
-targets=("${ctest_targets[@]}")
+targets=("${ctest_targets[@]}" "${gbnf_validator_target}")
 if [[ "${include_full}" == "1" ]]; then
   full_target="$(resolve_target full-chat test-chat)"
   targets+=("${full_target}")

--- a/tool/testing/run_template_parity_suites.sh
+++ b/tool/testing/run_template_parity_suites.sh
@@ -15,3 +15,7 @@ dart test -p vm -j 1 test/unit/core/template --exclude-tags local-only
 
 echo "[template-parity] upstream llama.cpp chat/template parser suites"
 dart test -p vm -j 1 test/e2e/template/llama_cpp_chat_tests_e2e_test.dart --run-skipped
+
+echo "[template-parity] compiled specialized grammar acceptance"
+LLAMA_CPP_GBNF_VALIDATOR="${LLAMA_CPP_CHAT_TEST_BUILD_DIR:-${repo_root}/.dart_tool/llama_cpp_chat_tests}/bin/test-gbnf-validator" \
+  dart test -p vm -j 1 test/e2e/template/specialized_tool_grammar_validation_e2e_test.dart --run-skipped

--- a/tool/testing/test_matrix.dart
+++ b/tool/testing/test_matrix.dart
@@ -396,7 +396,9 @@ const List<TestMatrixRow> testMatrixRows = <TestMatrixRow>[
     id: 'template-parity',
     tier: 'targeted',
     mode: 'local-only',
-    covers: 'vendored llama.cpp chat-template detection/render/parse parity',
+    covers:
+        'vendored llama.cpp chat-template detection/render/parse parity and '
+        'compiled specialized GBNF schema acceptance/rejection',
     command: 'tool/testing/run_template_parity_suites.sh',
     useWhen: 'Template engine, handlers, grammar, or parser changes.',
   ),

--- a/website/docs/changelog/recent-releases.md
+++ b/website/docs/changelog/recent-releases.md
@@ -9,6 +9,25 @@ For canonical full release notes, use:
 
 ## Unreleased
 
+- Fixed DeepSeek V3.2 DSML tool calls using their upstream
+  `<｜DSML｜function_calls>` envelope while preserving DeepSeek V4's distinct
+  `<｜DSML｜tool_calls>` grammar and parser behavior.
+
+- Fixed partial GLM 4.5, Poolside Laguna, and Muse Glimmer tool envelopes
+  leaking into streamed assistant content, while preserving completed calls,
+  malformed final output, and ordinary text surrounding Muse recipient
+  channels.
+
+- Fixed schema-constrained tool calls for Kimi K3, MiniMax M1/M3, DeepSeek
+  V3.2/V4, and Muse Glimmer, including exact escaped names, required fields,
+  declared value types, matching MiniMax M3 element tags, zero-argument calls,
+  and strings containing delimiter characters. Required-tool mode now accepts
+  each format's reasoning/content prefix while still requiring a call.
+  MiniMax M3, DeepSeek DSML, Muse Glimmer, Poolside Laguna, and GLM 4.5 now
+  reconstruct argument values from the declared tool schema instead of
+  guessing from text. Added `ToolParam.nullType` for null-only JSON Schema
+  properties.
+
 - Made native video-input capability truthful without claiming end-to-end
   support. Explicit video content now receives a typed actionable rejection,
   public capability remains false, and the native probe calls


### PR DESCRIPTION
## Summary

- restore format-specific parsing, grammar, and streaming behavior for DeepSeek V3.2/V4 DSML, Kimi K3, MiniMax M1/M3, Muse Glimmer, Poolside Laguna, and GLM 4.5
- bind generated grammars and parsed values to the declared tool schema, including collision-free rule identifiers, exact and recursively validated parameter identities, required/optional properties, nested and empty values, zero-argument calls, null-only values, and delimiter-aware strings
- preserve reasoning/content prefixes in required-tool mode while still requiring a tool call, and atomically roll partial or malformed envelopes back to assistant content without leaking protocol markup
- make production routes, pinned-template integrations, compiled pinned-upstream grammar cases, and partial/final stream behavior durable parts of the maintained parity gate

Closes #394
Closes #395
Closes #396
Closes #397
Closes #398
Closes #399
Closes #402
Closes #406
Closes #407
Closes #408
Closes #410

Part of #419

## Causal audit

PR #391 added eight specialized format handlers, but its tests did not execute every production parse/stream route or compile each generated grammar against the actual format envelopes. The missed contracts included DeepSeek V3.2's `function_calls` discriminator, exact schema names/types, MiniMax M3 closing tags and zero-argument form, required-mode reasoning prefixes, partial/final envelope rollback, canonical XML attributes/routes, duplicate optional arguments, and parser/grammar identity for delimiter-like content. This recovery keeps the format-specific handlers while replacing permissive guessing with schema-bound parsing and compiled grammar evidence.

## Scope and compatibility

- No native, Web bridge, asset, pin, capability, or public API removal.
- Adds `ToolParam.nullType` for null-only JSON Schema properties while keeping the public `ToolParam` barrel export stable.
- Malformed, unknown, duplicate, missing-required, wrong-type, mismatched-delimiter, and incomplete calls fail closed as assistant content or remain hidden while partial.
- Optional properties may occur in any order exactly once. Generated subset-state grammars are capped at 10 optional properties per object (1,024 states / 5,120 transitions); larger schemas fail with a typed, path-specific error instead of unbounded expansion.
- Exact GLM/Laguna protocol markers remain invalid inside raw values. Ordinary text containing all six marker-like near-misses is preserved before, inside, and after valid calls; only a trailing incomplete marker prefix causes rollback/suppression.
- Existing generic formats retain their routing. Command R7B/Hermes issue #423 remains separate and its implementation paths are untouched.

## Donor #422 reconciliation

PR #421 is canonical. Closed donor #422 now has no closing linkage. This tree preserves or strengthens its valuable unique behavior:

- collision-free grammar identifiers with compiled collision regressions
- GLM delimiter, quoted string, JSON/raw enum, optional-newline, and atomic rollback behavior
- real pinned-template auto/required/none integration with thinking enabled and disabled
- schema-aware specialized dispatch and typed partial MiniMax M3 streaming
- character-split no-leak coverage for Muse and DSML
- optional-property any-order/single-use behavior, recursive identity validation, and a finite expansion ceiling
- AGENTS guidance requiring production dispatch, pinned-template integration, compiled grammar validation, and partial/final rollback parity

## Exact-head validation

Exact head: `6b35be18197534cb6142f13dee29c93412f47308` using Dart 3.13.1.

| Gate | Result | Evidence |
| --- | --- | --- |
| Full VM | PASS | 1,700 tests, including real native tiny-model inference and state persistence |
| Full Chrome | PASS | 895 tests |
| Pinned template detection/render/parse | PASS | 73 tests |
| Template diagnostics | PASS | 78 tests |
| Dart template parity | PASS | 453 tests |
| Upstream C++ chat/template parity | PASS | selected and full pinned llama.cpp suites |
| Compiled grammar acceptance/rejection | PASS | 11/11 using pinned `test-gbnf-validator` |
| Analysis / format / diff | PASS | `dart analyze lib test tool hook`; 329 Dart files formatter-clean; `git diff --check` clean |
| Representative real-model smoke | PASS | Qwen3.5 0.8B Q4_K_M on Metal; normal/thinking and four tool-choice/thinking-budget variants |
| GitHub CI | PASS | exact-head run 32625883021; all 11 CI jobs plus preview and Copilot completed successfully |
| Independent blocking-only QA | PASS | exact-head Sol audit: no P0/P1; focused production 93/93, compiled GBNF 11/11, and pinned upstream/template suites passed |

## Real-model evidence and limitations

Representative smoke used Qwen3.5-0.8B-Q4_K_M.gguf, 532,517,120 bytes, SHA-256 `bd258782e35f7f458f8aced1adc053e6e92e89bc735ba3be89d38a06121dc517`, on macOS Metal. Normal generation and thinking passed. No-thinking, thinking, four-token thinking-budget, and zero-token thinking-budget tool rows each finished as `tool_calls` with exactly `get_weather({"location":"Seoul"})`, with content/reasoning separation intact.

No matching local GGUF was available for Kimi-K3, MiniMax-M1, MiniMax-M3, DeepSeek-V3.2, DeepSeek-V4-Flash-0731, muse-glimmer, Laguna-S-2.1, Laguna-XS-2.1, or Laguna-XS.2. Qwen proves the public native generation/grammar/stream-parser pipeline only; it is not affected-format emission evidence. Format-specific proof comes from primary pinned/current upstream templates and emitted shapes, production-call-site parsing/streaming tests, durable fixtures, compiled grammar acceptance/rejection, and the full pinned upstream C++ suites.

## Review status

- Exact-head Copilot review: 30/30 files, 0 new comments; final human review recommended because of the breadth.
- Review threads: 8/8 resolved, 0 unresolved.
- Independent exact-head Sol QA: PASS / READY, no P0/P1 blocking finding.
