### PR TITLE
fix: restore specialized structured output semantics

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -33,6 +33,13 @@ For docs and release-sensitive snippets:
 dart run tool/testing/verify_release_docs_versions.dart
 ```
 
+For chat-template handler, parser, or grammar changes, run the pinned upstream
+suite plus compiled specialized-grammar acceptance checks:
+
+```bash
+tool/testing/run_template_parity_suites.sh
+```
+
 For coverage when `lib/` behavior changes or coverage is in doubt:
 
 ```bash

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 ## Unreleased
 
+* Hardened direct-Jinja structured output against upstream format skew. Kimi
+  K3, MiniMax M1/M3, DeepSeek V3.2/V4, Muse Glimmer, and Poolside Laguna now
+  constrain and parse exact tool names, parameter keys, schema-directed values,
+  required-tool prefixes, zero-argument calls, and partial streams without
+  leaking malformed tool markup into successful calls.
+
 * llama.cpp backend initialization failures now complete the worker startup
   handshake with a typed `LlamaBackendInitializationException` and collected
   native-loader diagnostics. A failed or incompatible worker is torn down

--- a/lib/src/core/engine/chat_completion_stream_parser.dart
+++ b/lib/src/core/engine/chat_completion_stream_parser.dart
@@ -3,6 +3,8 @@ import 'dart:async';
 import '../llama_logger.dart';
 import '../models/chat/chat_template_result.dart';
 import '../models/chat/completion_chunk.dart';
+import '../models/tools/tool_definition.dart';
+import '../template/chat_format.dart';
 import '../template/chat_template_engine.dart';
 
 enum _ToolStreamingMode { undecided, raw, parsed }
@@ -34,12 +36,23 @@ class _ThinkingSplitResult {
 class ChatCompletionStreamParser {
   const ChatCompletionStreamParser._();
 
+  static const _delayedToolEnvelopeFormats = {
+    ChatFormat.kimiK3,
+    ChatFormat.minimaxM1,
+    ChatFormat.minimaxM3,
+    ChatFormat.deepseekV3,
+    ChatFormat.deepseekV4,
+    ChatFormat.museGlimmer,
+    ChatFormat.laguna,
+  };
+
   /// Parses [tokenStream] into incremental content, thinking, and tool chunks.
   static Stream<LlamaCompletionChunk> parse({
     required Stream<String> tokenStream,
     required LlamaChatTemplateResult templateResult,
     required bool parseToolCallsEnabled,
     required bool enableThinking,
+    List<ToolDefinition>? tools,
     required String modelName,
     required String completionId,
   }) async* {
@@ -56,9 +69,19 @@ class ChatCompletionStreamParser {
     var lastPartialParseAtMs = 0;
     final partialParseStopwatch = Stopwatch()..start();
     // A forced-open thought can transition straight into a tool envelope
-    // without producing `</think>`. Start in parsed mode so that envelope is
-    // never streamed as reasoning before the final structured parse.
-    var streamingMode = templateResult.thinkingForcedOpen
+    // without producing `</think>`. Tool-aware formats can also emit ordinary
+    // content before a later tool envelope. Start in parsed mode for both so
+    // that format markup is never leaked as a content delta.
+    final format =
+        templateResult.format >= 0 &&
+            templateResult.format < ChatFormat.values.length
+        ? ChatFormat.values[templateResult.format]
+        : ChatFormat.contentOnly;
+    final parseDelayedToolEnvelope =
+        (tools?.isNotEmpty ?? false) &&
+        _delayedToolEnvelopeFormats.contains(format);
+    var streamingMode =
+        templateResult.thinkingForcedOpen || parseDelayedToolEnvelope
         ? _ToolStreamingMode.parsed
         : _ToolStreamingMode.undecided;
     var undecidedPrefix = '';
@@ -163,6 +186,7 @@ class ChatCompletionStreamParser {
           final partialParsed = ChatTemplateEngine.parse(
             templateResult.format,
             buffer.toString(),
+            tools: tools,
             isPartial: true,
             parseToolCalls: true,
             thinkingForcedOpen: templateResult.thinkingForcedOpen,
@@ -283,6 +307,7 @@ class ChatCompletionStreamParser {
     final parsed = ChatTemplateEngine.parse(
       templateResult.format,
       fullOutput,
+      tools: tools,
       parseToolCalls: parseToolCallsEnabled,
       thinkingForcedOpen: templateResult.thinkingForcedOpen,
       parser: templateResult.parser,

--- a/lib/src/core/engine/engine.dart
+++ b/lib/src/core/engine/engine.dart
@@ -684,6 +684,7 @@ class LlamaEngine {
       templateResult: plan.templateResult,
       parseToolCallsEnabled: plan.parseToolCallsEnabled,
       enableThinking: enableThinking,
+      tools: effectiveTools,
       modelName: _modelPath ?? 'llama_model',
       completionId: completionId,
     );

--- a/lib/src/core/template/chat_template_engine.dart
+++ b/lib/src/core/template/chat_template_engine.dart
@@ -354,9 +354,7 @@ class ChatTemplateEngine {
         ? ChatFormat.values[result.format]
         : ChatFormat.generic;
 
-    if (toolChoice == ToolChoice.none &&
-        resultFormat == ChatFormat.ministral &&
-        result.grammar != null) {
+    if (toolChoice == ToolChoice.none && result.grammar != null) {
       return LlamaChatTemplateResult(
         prompt: result.prompt,
         format: result.format,
@@ -427,6 +425,30 @@ class ChatTemplateEngine {
       return result;
     }
 
+    final handler = handlerFor(resultFormat);
+    if (handler is RequiredToolGrammarHandler &&
+        result.grammarTriggers.isNotEmpty) {
+      final trigger = result.grammarTriggers.first.value;
+      if (trigger.isNotEmpty) {
+        return LlamaChatTemplateResult(
+          prompt: result.prompt,
+          format: result.format,
+          grammar: (handler as RequiredToolGrammarHandler)
+              .buildRequiredToolGrammar(
+                grammar: result.grammar!,
+                trigger: trigger,
+              ),
+          grammarLazy: false,
+          additionalStops: result.additionalStops,
+          preservedTokens: result.preservedTokens,
+          grammarTriggers: const [],
+          thinkingForcedOpen: result.thinkingForcedOpen,
+          parser: result.parser,
+          tokenCount: result.tokenCount,
+        );
+      }
+    }
+
     return LlamaChatTemplateResult(
       prompt: result.prompt,
       format: result.format,
@@ -447,6 +469,7 @@ class ChatTemplateEngine {
   static ChatParseResult parse(
     int formatIndex,
     String output, {
+    List<ToolDefinition>? tools,
     bool isPartial = false,
     bool parseToolCalls = true,
     bool thinkingForcedOpen = false,
@@ -479,6 +502,16 @@ class ChatTemplateEngine {
         output: output,
         isPartial: isPartial,
         parseToolCalls: parseToolCalls,
+      );
+    }
+
+    if (handler is ToolSchemaAwareChatTemplateHandler) {
+      return (handler as ToolSchemaAwareChatTemplateHandler).parseWithTools(
+        output,
+        tools: tools,
+        isPartial: isPartial,
+        parseToolCalls: parseToolCalls,
+        thinkingForcedOpen: thinkingForcedOpen,
       );
     }
 

--- a/lib/src/core/template/chat_template_handler.dart
+++ b/lib/src/core/template/chat_template_handler.dart
@@ -236,3 +236,31 @@ abstract class ChatTemplateHandler {
     return DateTime.now();
   }
 }
+
+/// Optional handler contract for output formats whose argument decoding depends
+/// on the tool JSON schemas supplied for the completion request.
+///
+/// [ChatTemplateEngine] uses this contract when schemas are available while
+/// retaining [ChatTemplateHandler.parse] for callers that only have raw output.
+abstract interface class ToolSchemaAwareChatTemplateHandler {
+  /// Parses [output] using [tools] to validate names, required properties, and
+  /// schema-directed argument types.
+  ChatParseResult parseWithTools(
+    String output, {
+    required List<ToolDefinition>? tools,
+    bool isPartial = false,
+    bool parseToolCalls = true,
+    bool thinkingForcedOpen = false,
+  });
+}
+
+/// Optional handler contract for required-tool grammars that must admit a
+/// format-specific reasoning or content prefix before the tool envelope.
+abstract interface class RequiredToolGrammarHandler {
+  /// Returns an eager grammar that accepts a prefix before [trigger] while
+  /// still requiring the original tool grammar to match through end-of-input.
+  String buildRequiredToolGrammar({
+    required String grammar,
+    required String trigger,
+  });
+}

--- a/lib/src/core/template/handlers/glm45_handler.dart
+++ b/lib/src/core/template/handlers/glm45_handler.dart
@@ -354,6 +354,10 @@ class Glm45Handler extends ChatTemplateHandler
           }
           continue;
         }
+        if (tools != null && args.containsKey(key)) {
+          validArguments = false;
+          break;
+        }
         final schema = tool?.toJsonSchema();
         final property = schema?['properties']?[key];
         if (tool != null && property is! Map<String, dynamic>) {

--- a/lib/src/core/template/handlers/glm45_handler.dart
+++ b/lib/src/core/template/handlers/glm45_handler.dart
@@ -8,6 +8,7 @@ import '../chat_format.dart';
 import '../chat_parse_result.dart';
 import '../chat_template_handler.dart';
 import '../thinking_utils.dart';
+import '../tool_call_grammar_utils.dart';
 import '../tool_call_parsing_utils.dart';
 
 /// Handler for GLM 4.5 format.
@@ -207,16 +208,18 @@ class Glm45Handler extends ChatTemplateHandler
     final toolRules = <String>[];
 
     for (final tool in tools) {
-      final toolRuleName = '${_sanitizeRuleName(tool.name)}-call';
+      final toolRuleName = '${ToolCallGrammarUtils.ruleName(tool.name)}-call';
       toolChoiceRules.add(toolRuleName);
 
       final argParts = <String>[];
       for (final parameter in tool.parameters) {
         final paramSchema = parameter.toJsonSchema();
         final paramRuleName =
-            '${_sanitizeRuleName(tool.name)}-arg-${_sanitizeRuleName(parameter.name)}';
+            '${ToolCallGrammarUtils.ruleName(tool.name)}-arg-'
+            '${ToolCallGrammarUtils.ruleName(parameter.name)}';
         final valueRuleName =
-            '${_sanitizeRuleName(tool.name)}-arg-${_sanitizeRuleName(parameter.name)}-value';
+            '${ToolCallGrammarUtils.ruleName(tool.name)}-arg-'
+            '${ToolCallGrammarUtils.ruleName(parameter.name)}-value';
 
         final valueRules = _buildValueRules(
           valueRuleName: valueRuleName,
@@ -296,10 +299,6 @@ class Glm45Handler extends ChatTemplateHandler
     }
 
     return ['$valueRuleName ::= value'];
-  }
-
-  String _sanitizeRuleName(String input) {
-    return input.replaceAll(RegExp(r'[^a-zA-Z0-9]'), '-').toLowerCase();
   }
 
   String _escapeLiteral(String input) {
@@ -426,10 +425,12 @@ ToolDefinition? _glmToolByName(List<ToolDefinition>? tools, String name) {
 
 Object? _decodeGlmSchemaValue(String raw, Map<String, dynamic> schema) {
   if (schema['type'] == 'string') {
+    final decoded = ToolCallParsingUtils.decodeJsonValue(raw);
+    final value = decoded is String ? decoded : raw;
     final enumValues = schema['enum'];
-    return enumValues is List && !enumValues.contains(raw)
+    return enumValues is List && !enumValues.contains(value)
         ? _glmSchemaFailure
-        : raw;
+        : value;
   }
   final decoded = ToolCallParsingUtils.decodeJsonValue(raw);
   if (decoded == null && raw.trim() != 'null') {

--- a/lib/src/core/template/handlers/glm45_handler.dart
+++ b/lib/src/core/template/handlers/glm45_handler.dart
@@ -319,6 +319,8 @@ class Glm45Handler extends ChatTemplateHandler
   }) {
     final toolCalls = <LlamaCompletionChunkToolCall>[];
     var remaining = input;
+    _ExtractedToolCalls schemaFailure() =>
+        _ExtractedToolCalls(toolCalls: const [], remainingContent: input);
 
     final matches = _toolCallBlockPattern.allMatches(input);
     for (final match in matches) {
@@ -329,41 +331,51 @@ class Glm45Handler extends ChatTemplateHandler
           : block.substring(0, firstArgIdx).trim();
       final tool = _glmToolByName(tools, toolName);
       if (tools != null && tool == null) {
-        continue;
+        return schemaFailure();
       }
       final args = <String, dynamic>{};
       final argumentBody = firstArgIdx == -1
           ? ''
           : block.substring(firstArgIdx);
       if (argumentBody.replaceAll(_argPairPattern, '').trim().isNotEmpty) {
+        if (tools != null) {
+          return schemaFailure();
+        }
         continue;
       }
+      var validArguments = true;
       for (final argMatch in _argPairPattern.allMatches(block)) {
         final key = (argMatch.group(1) ?? '').trim();
         final rawValue = (argMatch.group(2) ?? '').trim();
         if (key.isEmpty) {
+          if (tools != null) {
+            validArguments = false;
+            break;
+          }
           continue;
         }
         final schema = tool?.toJsonSchema();
         final property = schema?['properties']?[key];
         if (tool != null && property is! Map<String, dynamic>) {
-          args.clear();
+          validArguments = false;
           break;
         }
         final decoded = property is Map<String, dynamic>
             ? _decodeGlmSchemaValue(rawValue, property)
             : _decodeArgValue(rawValue);
         if (identical(decoded, _glmSchemaFailure)) {
-          args.clear();
+          validArguments = false;
           break;
         }
         args[key] = decoded;
       }
 
-      if (toolName.isEmpty) {
-        continue;
-      }
-      if (tool != null && !_glmObjectMatchesSchema(args, tool.toJsonSchema())) {
+      final schemaMatches =
+          tool == null || _glmObjectMatchesSchema(args, tool.toJsonSchema());
+      if (toolName.isEmpty || !validArguments || !schemaMatches) {
+        if (tools != null) {
+          return schemaFailure();
+        }
         continue;
       }
 

--- a/lib/src/core/template/handlers/glm45_handler.dart
+++ b/lib/src/core/template/handlers/glm45_handler.dart
@@ -17,7 +17,8 @@ import '../tool_call_parsing_utils.dart';
 /// `<tool_call>func_name<arg_key>key</arg_key><arg_value>value</arg_value></tool_call>`
 ///
 /// Supports `<think>`/`</think>` for reasoning.
-class Glm45Handler extends ChatTemplateHandler {
+class Glm45Handler extends ChatTemplateHandler
+    implements ToolSchemaAwareChatTemplateHandler {
   static final RegExp _toolCallBlockPattern = RegExp(
     r'<tool_call>\s*([\s\S]*?)</tool_call>',
   );
@@ -127,6 +128,35 @@ class Glm45Handler extends ChatTemplateHandler {
     bool isPartial = false,
     bool parseToolCalls = true,
     bool thinkingForcedOpen = false,
+  }) => _parse(
+    output,
+    tools: null,
+    isPartial: isPartial,
+    parseToolCalls: parseToolCalls,
+    thinkingForcedOpen: thinkingForcedOpen,
+  );
+
+  @override
+  ChatParseResult parseWithTools(
+    String output, {
+    required List<ToolDefinition>? tools,
+    bool isPartial = false,
+    bool parseToolCalls = true,
+    bool thinkingForcedOpen = false,
+  }) => _parse(
+    output,
+    tools: tools,
+    isPartial: isPartial,
+    parseToolCalls: parseToolCalls,
+    thinkingForcedOpen: thinkingForcedOpen,
+  );
+
+  ChatParseResult _parse(
+    String output, {
+    required List<ToolDefinition>? tools,
+    required bool isPartial,
+    required bool parseToolCalls,
+    required bool thinkingForcedOpen,
   }) {
     final thinking = extractThinking(
       output,
@@ -141,7 +171,20 @@ class Glm45Handler extends ChatTemplateHandler {
       );
     }
 
-    final extractedFromContent = _extractToolCalls(text);
+    var parseableText = text;
+    if (isPartial) {
+      final incompleteStart = text.lastIndexOf('<tool_call>');
+      if (incompleteStart >= 0 &&
+          text.indexOf('</tool_call>', incompleteStart) < 0) {
+        parseableText = text.substring(0, incompleteStart);
+      } else {
+        final partialStart = _glmPartialMarkerStart(text, '<tool_call>');
+        if (partialStart != null) {
+          parseableText = text.substring(0, partialStart);
+        }
+      }
+    }
+    final extractedFromContent = _extractToolCalls(parseableText, tools: tools);
     final toolCalls = <LlamaCompletionChunkToolCall>[
       ...extractedFromContent.toolCalls,
     ];
@@ -175,12 +218,12 @@ class Glm45Handler extends ChatTemplateHandler {
         final valueRuleName =
             '${_sanitizeRuleName(tool.name)}-arg-${_sanitizeRuleName(parameter.name)}-value';
 
-        final valueRule = _buildValueRule(
+        final valueRules = _buildValueRules(
           valueRuleName: valueRuleName,
           schema: paramSchema,
         );
 
-        toolRules.add(valueRule);
+        toolRules.addAll(valueRules);
         toolRules.add(
           '$paramRuleName ::= "<arg_key>${_escapeLiteral(parameter.name)}</arg_key>\\n<arg_value>" $valueRuleName "</arg_value>\\n"',
         );
@@ -197,12 +240,9 @@ class Glm45Handler extends ChatTemplateHandler {
 
     return [
       'root ::= tool-call+',
-      'tool-call ::= "\\n<tool_call>" tool-choice "</tool_call>\\n"',
+      'tool-call ::= "\\n"? "<tool_call>" tool-choice "</tool_call>\\n"',
       toolChoiceRule,
       ...toolRules,
-      'raw-alpha ::= [A-Za-z]',
-      'raw-tail ::= [A-Za-z0-9_ ./:-]',
-      'raw-string ::= raw-alpha raw-tail*',
       'space ::= " "?',
       'string ::= "\\"" ([^"\\\\] | "\\\\" .)* "\\""',
       'number ::= "-"? ([0-9] | [1-9] [0-9]*) ("." [0-9]+)? ([eE] [+-]? [0-9]+)?',
@@ -214,7 +254,7 @@ class Glm45Handler extends ChatTemplateHandler {
     ].join('\n');
   }
 
-  String _buildValueRule({
+  List<String> _buildValueRules({
     required String valueRuleName,
     required Map<String, dynamic> schema,
   }) {
@@ -231,28 +271,31 @@ class Glm45Handler extends ChatTemplateHandler {
             .whereType<String>()
             .map((value) => '"\\"${_escapeLiteral(value)}\\""')
             .join(' | ');
-        return '$valueRuleName ::= $rawEnum | $jsonEnum';
+        return ['$valueRuleName ::= $rawEnum | $jsonEnum'];
       }
-      return '$valueRuleName ::= raw-string | string';
+      return [
+        '$valueRuleName ::= $valueRuleName-raw-0',
+        ..._glmUntilLiteralRules('$valueRuleName-raw', '</arg_value>'),
+      ];
     }
 
     if (type == 'integer' || type == 'number') {
-      return '$valueRuleName ::= number';
+      return ['$valueRuleName ::= number'];
     }
 
     if (type == 'boolean') {
-      return '$valueRuleName ::= boolean';
+      return ['$valueRuleName ::= boolean'];
     }
 
     if (type == 'array') {
-      return '$valueRuleName ::= arr';
+      return ['$valueRuleName ::= arr'];
     }
 
     if (type == 'object') {
-      return '$valueRuleName ::= obj';
+      return ['$valueRuleName ::= obj'];
     }
 
-    return '$valueRuleName ::= value';
+    return ['$valueRuleName ::= value'];
   }
 
   String _sanitizeRuleName(String input) {
@@ -271,7 +314,10 @@ class Glm45Handler extends ChatTemplateHandler {
     return ToolCallParsingUtils.decodeJsonValueOrString(value);
   }
 
-  _ExtractedToolCalls _extractToolCalls(String input) {
+  _ExtractedToolCalls _extractToolCalls(
+    String input, {
+    required List<ToolDefinition>? tools,
+  }) {
     final toolCalls = <LlamaCompletionChunkToolCall>[];
     var remaining = input;
 
@@ -282,17 +328,43 @@ class Glm45Handler extends ChatTemplateHandler {
       final toolName = firstArgIdx == -1
           ? block.trim()
           : block.substring(0, firstArgIdx).trim();
+      final tool = _glmToolByName(tools, toolName);
+      if (tools != null && tool == null) {
+        continue;
+      }
       final args = <String, dynamic>{};
+      final argumentBody = firstArgIdx == -1
+          ? ''
+          : block.substring(firstArgIdx);
+      if (argumentBody.replaceAll(_argPairPattern, '').trim().isNotEmpty) {
+        continue;
+      }
       for (final argMatch in _argPairPattern.allMatches(block)) {
         final key = (argMatch.group(1) ?? '').trim();
         final rawValue = (argMatch.group(2) ?? '').trim();
         if (key.isEmpty) {
           continue;
         }
-        args[key] = _decodeArgValue(rawValue);
+        final schema = tool?.toJsonSchema();
+        final property = schema?['properties']?[key];
+        if (tool != null && property is! Map<String, dynamic>) {
+          args.clear();
+          break;
+        }
+        final decoded = property is Map<String, dynamic>
+            ? _decodeGlmSchemaValue(rawValue, property)
+            : _decodeArgValue(rawValue);
+        if (identical(decoded, _glmSchemaFailure)) {
+          args.clear();
+          break;
+        }
+        args[key] = decoded;
       }
 
       if (toolName.isEmpty) {
+        continue;
+      }
+      if (tool != null && !_glmObjectMatchesSchema(args, tool.toJsonSchema())) {
         continue;
       }
 
@@ -318,6 +390,18 @@ class Glm45Handler extends ChatTemplateHandler {
   }
 }
 
+int? _glmPartialMarkerStart(String input, String marker) {
+  final lowerBound = input.length > marker.length
+      ? input.length - marker.length
+      : 0;
+  for (var index = lowerBound; index < input.length; index++) {
+    if (marker.startsWith(input.substring(index))) {
+      return index;
+    }
+  }
+  return null;
+}
+
 class _ExtractedToolCalls {
   final List<LlamaCompletionChunkToolCall> toolCalls;
   final String remainingContent;
@@ -326,4 +410,144 @@ class _ExtractedToolCalls {
     required this.toolCalls,
     required this.remainingContent,
   });
+}
+
+ToolDefinition? _glmToolByName(List<ToolDefinition>? tools, String name) {
+  if (tools == null) {
+    return null;
+  }
+  for (final tool in tools) {
+    if (tool.name == name) {
+      return tool;
+    }
+  }
+  return null;
+}
+
+Object? _decodeGlmSchemaValue(String raw, Map<String, dynamic> schema) {
+  if (schema['type'] == 'string') {
+    final enumValues = schema['enum'];
+    return enumValues is List && !enumValues.contains(raw)
+        ? _glmSchemaFailure
+        : raw;
+  }
+  final decoded = ToolCallParsingUtils.decodeJsonValue(raw);
+  if (decoded == null && raw.trim() != 'null') {
+    return _glmSchemaFailure;
+  }
+  return _glmValueMatchesSchema(decoded, schema) ? decoded : _glmSchemaFailure;
+}
+
+bool _glmObjectMatchesSchema(
+  Map<String, dynamic> value,
+  Map<String, dynamic> schema,
+) {
+  final properties =
+      (schema['properties'] as Map<String, dynamic>?) ??
+      const <String, dynamic>{};
+  final required = Set<String>.from(
+    (schema['required'] as List?)?.whereType<String>() ?? const <String>[],
+  );
+  if (!value.keys.toSet().containsAll(required)) {
+    return false;
+  }
+  for (final entry in value.entries) {
+    final property = properties[entry.key];
+    if (property is! Map<String, dynamic> ||
+        !_glmValueMatchesSchema(entry.value, property)) {
+      return false;
+    }
+  }
+  return true;
+}
+
+bool _glmValueMatchesSchema(Object? value, Map<String, dynamic> schema) {
+  final enumValues = schema['enum'];
+  if (enumValues is List && !enumValues.contains(value)) {
+    return false;
+  }
+  return switch (schema['type']) {
+    'string' => value is String,
+    'integer' => value is int,
+    'number' => value is num,
+    'boolean' => value is bool,
+    'null' => value == null,
+    'array' =>
+      value is List &&
+          (schema['items'] is! Map<String, dynamic> ||
+              value.every(
+                (item) => _glmValueMatchesSchema(
+                  item,
+                  schema['items'] as Map<String, dynamic>,
+                ),
+              )),
+    'object' || null =>
+      value is Map &&
+          _glmObjectMatchesSchema(Map<String, dynamic>.from(value), schema),
+    _ => false,
+  };
+}
+
+const _glmSchemaFailure = _GlmSchemaFailure();
+
+class _GlmSchemaFailure {
+  const _GlmSchemaFailure();
+}
+
+List<String> _glmUntilLiteralRules(String ruleBase, String delimiter) {
+  final marker = delimiter.runes
+      .map(String.fromCharCode)
+      .toList(growable: false);
+  final alphabet = marker.toSet().toList(growable: false);
+  final lines = <String>[
+    '$ruleBase-other ::= [^${alphabet.map(_escapeGlmCharacterClass).join()}]',
+  ];
+  for (var state = 0; state < marker.length; state++) {
+    final alternatives = <String>['$ruleBase-other $ruleBase-0'];
+    for (final character in alphabet) {
+      final next = _glmDelimiterTransition(marker, state, character);
+      if (next == marker.length) {
+        continue;
+      }
+      alternatives.add(
+        '"${_escapeLiteralCharacter(character)}" $ruleBase-$next',
+      );
+    }
+    lines.add('$ruleBase-$state ::= (${alternatives.join(' | ')})?');
+  }
+  return lines;
+}
+
+int _glmDelimiterTransition(List<String> marker, int state, String character) {
+  final candidate = <String>[...marker.take(state), character];
+  final max = candidate.length < marker.length
+      ? candidate.length
+      : marker.length;
+  for (var length = max; length >= 0; length--) {
+    var matches = true;
+    for (var index = 0; index < length; index++) {
+      if (candidate[candidate.length - length + index] != marker[index]) {
+        matches = false;
+        break;
+      }
+    }
+    if (matches) {
+      return length;
+    }
+  }
+  return 0;
+}
+
+String _escapeGlmCharacterClass(String character) {
+  return switch (character) {
+    r'\' => r'\\',
+    ']' => r'\]',
+    '-' => r'\-',
+    '^' => r'\^',
+    _ => character,
+  };
+}
+
+String _escapeLiteralCharacter(String character) {
+  return character.replaceAll(r'\', r'\\').replaceAll('"', r'\"');
 }

--- a/lib/src/core/template/handlers/llama_cpp_specialized_handlers.dart
+++ b/lib/src/core/template/handlers/llama_cpp_specialized_handlers.dart
@@ -366,7 +366,7 @@ class KimiK3Handler extends _DirectJinjaHandler {
       final key = _unescapeAttribute(match.group(1) ?? '');
       final type = match.group(2) ?? '';
       final raw = match.group(3) ?? '';
-      if (key.isEmpty) {
+      if (key.isEmpty || result.containsKey(key)) {
         return null;
       }
       final property = schema?['properties']?[key];
@@ -1980,7 +1980,7 @@ Map<String, dynamic>? _parseDsmlArguments(
   for (final match in pattern.allMatches(body)) {
     final key = match.group(1) ?? '';
     final raw = match.group(3) ?? '';
-    if (key.isEmpty) {
+    if (key.isEmpty || result.containsKey(key)) {
       return null;
     }
     final property = schema?['properties']?[key];
@@ -2062,7 +2062,7 @@ List<LlamaCompletionChunkToolCall>? _parseAtemCalls(
     for (final parameter in parameterPattern.allMatches(params)) {
       final key = parameter.group(1) ?? '';
       final raw = parameter.group(2) ?? '';
-      if (key.isEmpty) {
+      if (key.isEmpty || arguments.containsKey(key)) {
         return null;
       }
       final property = tool?.toJsonSchema()['properties']?[key];

--- a/lib/src/core/template/handlers/llama_cpp_specialized_handlers.dart
+++ b/lib/src/core/template/handlers/llama_cpp_specialized_handlers.dart
@@ -1,3 +1,5 @@
+import 'dart:convert';
+
 import 'package:dinja/dinja.dart';
 
 import '../../grammar/json_schema_converter.dart';
@@ -13,7 +15,8 @@ import '../tool_call_grammar_utils.dart';
 import '../tool_call_parsing_utils.dart';
 import 'glm45_handler.dart';
 
-abstract class _DirectJinjaHandler extends ChatTemplateHandler {
+abstract class _DirectJinjaHandler extends ChatTemplateHandler
+    implements ToolSchemaAwareChatTemplateHandler, RequiredToolGrammarHandler {
   @override
   TemplateToolCallSerialization get toolCallSerialization =>
       TemplateToolCallSerialization.normalizeOnly;
@@ -23,6 +26,17 @@ abstract class _DirectJinjaHandler extends ChatTemplateHandler {
   String get defaultEosToken => '';
 
   List<String> get grammarTriggerValues => const [];
+
+  List<String> grammarTriggerValuesForTemplate(String templateSource) =>
+      grammarTriggerValues;
+
+  List<String> preservedTokensForTemplate(String templateSource) =>
+      preservedTokens;
+
+  String? buildGrammarForTemplate(
+    String templateSource,
+    List<ToolDefinition>? tools,
+  ) => buildGrammar(tools);
 
   @override
   LlamaChatTemplateResult render({
@@ -65,21 +79,45 @@ abstract class _DirectJinjaHandler extends ChatTemplateHandler {
     return LlamaChatTemplateResult(
       prompt: prompt,
       format: format.index,
-      grammar: buildGrammar(tools),
+      grammar: buildGrammarForTemplate(templateSource, tools),
       grammarLazy: hasTools,
       thinkingForcedOpen: thinkingForcedOpen,
       additionalStops: getStops(
         hasTools: hasTools,
         enableThinking: enableThinking,
       ),
-      preservedTokens: hasTools ? preservedTokens : const [],
+      preservedTokens: hasTools
+          ? preservedTokensForTemplate(templateSource)
+          : const [],
       grammarTriggers: hasTools
-          ? grammarTriggerValues
+          ? grammarTriggerValuesForTemplate(templateSource)
                 .map((value) => GrammarTrigger(type: 0, value: value))
                 .toList(growable: false)
           : const [],
     );
   }
+
+  @override
+  ChatParseResult parseWithTools(
+    String output, {
+    required List<ToolDefinition>? tools,
+    bool isPartial = false,
+    bool parseToolCalls = true,
+    bool thinkingForcedOpen = false,
+  }) {
+    return parse(
+      output,
+      isPartial: isPartial,
+      parseToolCalls: parseToolCalls,
+      thinkingForcedOpen: thinkingForcedOpen,
+    );
+  }
+
+  @override
+  String buildRequiredToolGrammar({
+    required String grammar,
+    required String trigger,
+  }) => _buildRequiredPrefixGrammar(grammar, trigger);
 }
 
 /// Handler for Kimi K3's XTML response and typed tool-call protocol.
@@ -134,6 +172,35 @@ class KimiK3Handler extends _DirectJinjaHandler {
     bool isPartial = false,
     bool parseToolCalls = true,
     bool thinkingForcedOpen = false,
+  }) => _parse(
+    output,
+    tools: null,
+    isPartial: isPartial,
+    parseToolCalls: parseToolCalls,
+    thinkingForcedOpen: thinkingForcedOpen,
+  );
+
+  @override
+  ChatParseResult parseWithTools(
+    String output, {
+    required List<ToolDefinition>? tools,
+    bool isPartial = false,
+    bool parseToolCalls = true,
+    bool thinkingForcedOpen = false,
+  }) => _parse(
+    output,
+    tools: tools,
+    isPartial: isPartial,
+    parseToolCalls: parseToolCalls,
+    thinkingForcedOpen: thinkingForcedOpen,
+  );
+
+  ChatParseResult _parse(
+    String output, {
+    required List<ToolDefinition>? tools,
+    required bool isPartial,
+    required bool parseToolCalls,
+    required bool thinkingForcedOpen,
   }) {
     var remaining = output;
     String? reasoning;
@@ -181,7 +248,11 @@ class KimiK3Handler extends _DirectJinjaHandler {
       );
     }
 
-    final parsed = _parseKimiTools(remaining, isPartial: isPartial);
+    final parsed = _parseKimiTools(
+      remaining,
+      tools: tools,
+      isPartial: isPartial,
+    );
     if (!parsed.success) {
       final preserved = '$content${_stripKimiTurnEnd(remaining)}'.trim();
       return ChatParseResult(
@@ -196,10 +267,22 @@ class KimiK3Handler extends _DirectJinjaHandler {
     );
   }
 
-  _ParsedCalls _parseKimiTools(String input, {required bool isPartial}) {
+  _ParsedCalls _parseKimiTools(
+    String input, {
+    required List<ToolDefinition>? tools,
+    required bool isPartial,
+  }) {
     final scopeStart = input.indexOf(_toolsStart);
     if (scopeStart < 0) {
-      return _ParsedCalls(calls: const [], remaining: _stripKimiTurnEnd(input));
+      final partialStart = isPartial
+          ? _partialMarkerStart(input, const [_toolsStart])
+          : null;
+      return _ParsedCalls(
+        calls: const [],
+        remaining: _stripKimiTurnEnd(
+          partialStart == null ? input : input.substring(0, partialStart),
+        ),
+      );
     }
     final bodyStart = scopeStart + _toolsStart.length;
     final scopeEnd = input.indexOf(_toolsEnd, bodyStart);
@@ -225,7 +308,14 @@ class KimiK3Handler extends _DirectJinjaHandler {
     for (final match in matches) {
       final name = _unescapeAttribute(match.group(1) ?? '');
       final callBody = match.group(2) ?? '';
-      final arguments = _parseKimiArguments(callBody);
+      final tool = _toolByName(tools, name);
+      if (tools != null && tool == null) {
+        return _ParsedCalls.failure();
+      }
+      final arguments = _parseKimiArguments(
+        callBody,
+        schema: tool?.toJsonSchema(),
+      );
       if (name.isEmpty || arguments == null) {
         return _ParsedCalls.failure();
       }
@@ -243,7 +333,10 @@ class KimiK3Handler extends _DirectJinjaHandler {
     return _ParsedCalls(calls: calls, remaining: _stripKimiTurnEnd(remaining));
   }
 
-  Map<String, dynamic>? _parseKimiArguments(String body) {
+  Map<String, dynamic>? _parseKimiArguments(
+    String body, {
+    required Map<String, dynamic>? schema,
+  }) {
     final jsonPattern = RegExp(
       r'<\|open\|>json\s+type="object"<\|sep\|>([\s\S]*?)<\|close\|>json<\|sep\|>',
     );
@@ -252,7 +345,14 @@ class KimiK3Handler extends _DirectJinjaHandler {
       if (body.replaceFirst(jsonPattern, '').trim().isNotEmpty) {
         return null;
       }
-      return ToolCallParsingUtils.decodeJsonObject(jsonMatch.group(1) ?? '');
+      final decoded = ToolCallParsingUtils.decodeJsonObject(
+        jsonMatch.group(1) ?? '',
+      );
+      if (decoded == null ||
+          (schema != null && !_objectMatchesSchema(decoded, schema))) {
+        return null;
+      }
+      return decoded;
     }
 
     final argumentPattern = RegExp(
@@ -269,7 +369,20 @@ class KimiK3Handler extends _DirectJinjaHandler {
       if (key.isEmpty) {
         return null;
       }
-      if (type == 'string') {
+      final property = schema?['properties']?[key];
+      if (schema != null && property is! Map<String, dynamic>) {
+        return null;
+      }
+      if (property is Map<String, dynamic>) {
+        if (type != _schemaProtocolType(property)) {
+          return null;
+        }
+        final decoded = _decodeRawBySchema(raw, property);
+        if (identical(decoded, _schemaDecodeFailure)) {
+          return null;
+        }
+        result[key] = decoded;
+      } else if (type == 'string') {
         result[key] = raw;
       } else {
         final decoded = ToolCallParsingUtils.decodeJsonValue(raw);
@@ -278,6 +391,9 @@ class KimiK3Handler extends _DirectJinjaHandler {
         }
         result[key] = decoded;
       }
+    }
+    if (schema != null && !_objectMatchesSchema(result, schema)) {
+      return null;
     }
     return result;
   }
@@ -293,50 +409,7 @@ class KimiK3Handler extends _DirectJinjaHandler {
 
   @override
   String? buildGrammar(List<ToolDefinition>? tools) {
-    if (tools == null || tools.isEmpty) {
-      return null;
-    }
-    final names = tools
-        .map(
-          (tool) => ToolCallGrammarUtils.literal(_escapeAttribute(tool.name)),
-        )
-        .join(' | ');
-    final converter = JsonSchemaConverter();
-    const objectSchema = <String, dynamic>{'type': 'object'};
-    converter.resolveRefs(objectSchema, objectSchema);
-    final objectRule = converter.visit(objectSchema, 'json-object');
-    final buffer = StringBuffer()
-      ..writeln(
-        'root ::= "<|open|>tools<|sep|>" call+ '
-        '"<|close|>tools<|sep|><|close|>message<|sep|>"',
-      )
-      ..writeln(
-        'call ::= "<|open|>call tool=\\"" tool-name '
-        '"\\"" (" index=\\"" [0-9]+ "\\"")? "<|sep|>" '
-        '(argument* | json-block) "<|close|>call<|sep|>"',
-      )
-      ..writeln(
-        'argument ::= "<|open|>argument key=\\"" identifier '
-        '"\\" type=\\"" value-type "\\"<|sep|>" raw '
-        '"<|close|>argument<|sep|>"',
-      )
-      ..writeln(
-        'json-block ::= "<|open|>json type=\\"object\\"<|sep|>" '
-        '$objectRule "<|close|>json<|sep|>"',
-      )
-      ..writeln('tool-name ::= $names')
-      ..writeln(
-        'value-type ::= "string" | "number" | "boolean" | "null" | '
-        '"object" | "array"',
-      )
-      ..writeln('identifier ::= [A-Za-z_] [A-Za-z0-9_.-]*')
-      ..writeln('raw ::= [^<]*');
-    final jsonRules = converter.rules.entries.toList(growable: false)
-      ..sort((a, b) => a.key.compareTo(b.key));
-    for (final entry in jsonRules) {
-      buffer.writeln('${entry.key} ::= ${entry.value}');
-    }
-    return buffer.toString();
+    return _buildKimiK3Grammar(tools);
   }
 }
 
@@ -364,6 +437,32 @@ class MinimaxM1Handler extends _DirectJinjaHandler {
     bool isPartial = false,
     bool parseToolCalls = true,
     bool thinkingForcedOpen = false,
+  }) => _parse(
+    output,
+    tools: null,
+    isPartial: isPartial,
+    parseToolCalls: parseToolCalls,
+  );
+
+  @override
+  ChatParseResult parseWithTools(
+    String output, {
+    required List<ToolDefinition>? tools,
+    bool isPartial = false,
+    bool parseToolCalls = true,
+    bool thinkingForcedOpen = false,
+  }) => _parse(
+    output,
+    tools: tools,
+    isPartial: isPartial,
+    parseToolCalls: parseToolCalls,
+  );
+
+  ChatParseResult _parse(
+    String output, {
+    required List<ToolDefinition>? tools,
+    required bool isPartial,
+    required bool parseToolCalls,
   }) {
     if (!parseToolCalls) {
       return ChatParseResult(content: output.trim());
@@ -372,7 +471,14 @@ class MinimaxM1Handler extends _DirectJinjaHandler {
     const end = '</tool_calls>';
     final startIndex = output.indexOf(start);
     if (startIndex < 0) {
-      return ChatParseResult(content: output.trim());
+      final partialStart = isPartial
+          ? _partialMarkerStart(output, const [start])
+          : null;
+      return ChatParseResult(
+        content:
+            (partialStart == null ? output : output.substring(0, partialStart))
+                .trim(),
+      );
     }
     final endIndex = output.indexOf(end, startIndex + start.length);
     if (endIndex < 0) {
@@ -384,7 +490,7 @@ class MinimaxM1Handler extends _DirectJinjaHandler {
     }
 
     final body = output.substring(startIndex + start.length, endIndex);
-    final calls = _parseJsonObjectSequence(body);
+    final calls = _parseJsonObjectSequence(body, tools: tools);
     if (calls == null) {
       return ChatParseResult(content: output.trim());
     }
@@ -412,7 +518,7 @@ class MinimaxM1Handler extends _DirectJinjaHandler {
       final callRule = 'tool-$i-call';
       converter.rules[callRule] =
           '"{" space "\\"name\\"" space ":" space '
-          '${ToolCallGrammarUtils.literal(tool.name)} space "," space '
+          '${ToolCallGrammarUtils.literal(jsonEncode(tool.name))} space "," space '
           '"\\"arguments\\"" space ":" space $argumentsRule "}" space';
       callRules.add(callRule);
     }
@@ -463,6 +569,35 @@ class MinimaxM3Handler extends _DirectJinjaHandler {
     bool isPartial = false,
     bool parseToolCalls = true,
     bool thinkingForcedOpen = false,
+  }) => _parse(
+    output,
+    tools: null,
+    isPartial: isPartial,
+    parseToolCalls: parseToolCalls,
+    thinkingForcedOpen: thinkingForcedOpen,
+  );
+
+  @override
+  ChatParseResult parseWithTools(
+    String output, {
+    required List<ToolDefinition>? tools,
+    bool isPartial = false,
+    bool parseToolCalls = true,
+    bool thinkingForcedOpen = false,
+  }) => _parse(
+    output,
+    tools: tools,
+    isPartial: isPartial,
+    parseToolCalls: parseToolCalls,
+    thinkingForcedOpen: thinkingForcedOpen,
+  );
+
+  ChatParseResult _parse(
+    String output, {
+    required List<ToolDefinition>? tools,
+    required bool isPartial,
+    required bool parseToolCalls,
+    required bool thinkingForcedOpen,
   }) {
     final thinking = extractThinking(
       output,
@@ -481,8 +616,13 @@ class MinimaxM3Handler extends _DirectJinjaHandler {
     const namespacedScopeEnd = '$namespace</tool_call>';
     final scopeStartIndex = rawContent.indexOf(namespacedScopeStart);
     if (scopeStartIndex < 0) {
+      final partialStart = isPartial
+          ? _partialMarkerStart(rawContent, const [namespacedScopeStart])
+          : null;
       return ChatParseResult(
-        content: rawContent,
+        content: partialStart == null
+            ? rawContent
+            : rawContent.substring(0, partialStart).trim(),
         reasoningContent: thinking.reasoning,
       );
     }
@@ -513,7 +653,13 @@ class MinimaxM3Handler extends _DirectJinjaHandler {
       scopeEnd: '</tool_call>',
       invokeStartPattern: RegExp(r'<invoke name="([^"]+)">'),
       invokeEnd: '</invoke>',
-      parseArguments: _parseDynamicTagArguments,
+      parseArguments: (name, body) {
+        final tool = _toolByName(tools, name);
+        if (tools != null && tool == null) {
+          return null;
+        }
+        return _parseDynamicTagArguments(body, schema: tool?.toJsonSchema());
+      },
       isPartial: isPartial,
     );
     return ChatParseResult(
@@ -525,27 +671,14 @@ class MinimaxM3Handler extends _DirectJinjaHandler {
 
   @override
   String? buildGrammar(List<ToolDefinition>? tools) {
-    if (tools == null || tools.isEmpty) {
-      return null;
-    }
-    final names = tools
-        .map((tool) => ToolCallGrammarUtils.literal(tool.name))
-        .join(' | ');
-    return '''
-root ::= "$namespace<tool_call>\\n" invoke+ "$namespace</tool_call>"
-invoke ::= "$namespace<invoke name=\\"" tool-name "\\">" parameter* "$namespace</invoke>\\n"
-parameter ::= "$namespace<" identifier ">" m3-value "$namespace</" identifier ">"
-tool-name ::= $names
-identifier ::= [A-Za-z_] [A-Za-z0-9_.-]*
-m3-value ::= raw | parameter+
-raw ::= [^]]*
-''';
+    return _buildMinimaxM3Grammar(tools);
   }
 }
 
 /// Handler for DeepSeek V3.2/V4 DSML tool calls.
 class DeepseekV4Handler extends _DirectJinjaHandler {
-  static const _prefix = '<｜DSML｜';
+  static const _v3Scope = 'function_calls';
+  static const _v4Scope = 'tool_calls';
 
   @override
   ChatFormat get format => ChatFormat.deepseekV4;
@@ -564,15 +697,68 @@ class DeepseekV4Handler extends _DirectJinjaHandler {
   @override
   List<String> get grammarTriggerValues => const ['<｜DSML｜tool_calls>'];
 
+  bool _usesV3Envelope(String templateSource) =>
+      templateSource.contains('function_calls>');
+
+  @override
+  List<String> grammarTriggerValuesForTemplate(String templateSource) => [
+    '<｜DSML｜${_usesV3Envelope(templateSource) ? _v3Scope : _v4Scope}>',
+  ];
+
+  @override
+  List<String> preservedTokensForTemplate(String templateSource) {
+    final scope = _usesV3Envelope(templateSource) ? _v3Scope : _v4Scope;
+    return ['<think>', '</think>', '<｜DSML｜$scope>', '</｜DSML｜$scope>'];
+  }
+
+  @override
+  String? buildGrammarForTemplate(
+    String templateSource,
+    List<ToolDefinition>? tools,
+  ) => _buildDsmlGrammar(
+    tools,
+    scope: _usesV3Envelope(templateSource) ? _v3Scope : _v4Scope,
+  );
+
   @override
   ChatParseResult parse(
     String output, {
     bool isPartial = false,
     bool parseToolCalls = true,
     bool thinkingForcedOpen = false,
+  }) => _parse(
+    output,
+    tools: null,
+    isPartial: isPartial,
+    parseToolCalls: parseToolCalls,
+    thinkingForcedOpen: thinkingForcedOpen,
+  );
+
+  @override
+  ChatParseResult parseWithTools(
+    String output, {
+    required List<ToolDefinition>? tools,
+    bool isPartial = false,
+    bool parseToolCalls = true,
+    bool thinkingForcedOpen = false,
+  }) => _parse(
+    output,
+    tools: tools,
+    isPartial: isPartial,
+    parseToolCalls: parseToolCalls,
+    thinkingForcedOpen: thinkingForcedOpen,
+  );
+
+  ChatParseResult _parse(
+    String output, {
+    required List<ToolDefinition>? tools,
+    required bool isPartial,
+    required bool parseToolCalls,
+    required bool thinkingForcedOpen,
   }) {
-    final thinking = extractThinking(
+    final thinking = _extractDsmlThinking(
       output,
+      isPartial: isPartial,
       thinkingForcedOpen: thinkingForcedOpen,
     );
     if (!parseToolCalls) {
@@ -581,15 +767,34 @@ class DeepseekV4Handler extends _DirectJinjaHandler {
         reasoningContent: thinking.reasoning,
       );
     }
+    final scope = _findDsmlScope(thinking.content);
+    if (scope == null) {
+      final partialStart = isPartial
+          ? _partialMarkerStart(thinking.content, const [
+              '<｜DSML｜function_calls>',
+              '<｜DSML｜tool_calls>',
+            ])
+          : null;
+      return ChatParseResult(
+        content: partialStart == null
+            ? thinking.content
+            : thinking.content.substring(0, partialStart).trim(),
+        reasoningContent: thinking.reasoning,
+      );
+    }
     final parsed = _parseInvokeScope(
       thinking.content,
-      scopeStart:
-          '$_prefix'
-          'tool_calls>',
-      scopeEnd: '</｜DSML｜tool_calls>',
+      scopeStart: '<｜DSML｜${scope.name}>',
+      scopeEnd: '</｜DSML｜${scope.name}>',
       invokeStartPattern: RegExp(r'<｜DSML｜invoke name="([^"]+)">'),
       invokeEnd: '</｜DSML｜invoke>',
-      parseArguments: _parseDsmlArguments,
+      parseArguments: (name, body) {
+        final tool = _toolByName(tools, name);
+        if (tools != null && tool == null) {
+          return null;
+        }
+        return _parseDsmlArguments(body, schema: tool?.toJsonSchema());
+      },
       isPartial: isPartial,
     );
     return ChatParseResult(
@@ -601,21 +806,7 @@ class DeepseekV4Handler extends _DirectJinjaHandler {
 
   @override
   String? buildGrammar(List<ToolDefinition>? tools) {
-    if (tools == null || tools.isEmpty) {
-      return null;
-    }
-    final names = tools
-        .map((tool) => ToolCallGrammarUtils.literal(tool.name))
-        .join(' | ');
-    return '''
-root ::= "<｜DSML｜tool_calls>\\n" invoke+ "</｜DSML｜tool_calls>"
-invoke ::= "<｜DSML｜invoke name=\\"" tool-name "\\">\\n" parameter* "</｜DSML｜invoke>\\n"
-parameter ::= "<｜DSML｜parameter name=\\"" identifier "\\" string=\\"" boolean "\\">" raw "</｜DSML｜parameter>\\n"
-tool-name ::= $names
-identifier ::= [A-Za-z_] [A-Za-z0-9_.-]*
-boolean ::= "true" | "false"
-raw ::= [^<]*
-''';
+    return _buildDsmlGrammar(tools, scope: _v4Scope);
   }
 }
 
@@ -646,42 +837,84 @@ class MuseGlimmerHandler extends _DirectJinjaHandler {
     bool isPartial = false,
     bool parseToolCalls = true,
     bool thinkingForcedOpen = false,
+  }) => _parse(
+    output,
+    tools: null,
+    isPartial: isPartial,
+    parseToolCalls: parseToolCalls,
+  );
+
+  @override
+  ChatParseResult parseWithTools(
+    String output, {
+    required List<ToolDefinition>? tools,
+    bool isPartial = false,
+    bool parseToolCalls = true,
+    bool thinkingForcedOpen = false,
+  }) => _parse(
+    output,
+    tools: tools,
+    isPartial: isPartial,
+    parseToolCalls: parseToolCalls,
+  );
+
+  ChatParseResult _parse(
+    String output, {
+    required List<ToolDefinition>? tools,
+    required bool isPartial,
+    required bool parseToolCalls,
   }) {
     final channelPattern = RegExp(
       r'(?:<\|start\|>assistant)?\s+to=([^<]+)<\|message\|>([\s\S]*?)(<\|eom\|>|<\|eot\|>|$)',
     );
     final matches = channelPattern.allMatches(output).toList(growable: false);
     if (matches.isEmpty) {
-      return ChatParseResult(content: output.trim());
+      final partialRoute = isPartial ? _partialMuseRouteStart(output) : null;
+      return ChatParseResult(
+        content: partialRoute == null
+            ? output.trim()
+            : output.substring(0, partialRoute).trim(),
+      );
     }
 
     final content = StringBuffer();
     final reasoning = StringBuffer();
     final calls = <LlamaCompletionChunkToolCall>[];
+    var cursor = 0;
     for (final match in matches) {
+      _appendParsedText(content, output.substring(cursor, match.start));
       final recipient = (match.group(1) ?? '').trim();
       final body = match.group(2) ?? '';
       if (recipient == 'self') {
-        if (reasoning.isNotEmpty) reasoning.writeln();
-        reasoning.write(body);
+        _appendParsedText(reasoning, body);
       } else if (recipient == 'user') {
-        if (content.isNotEmpty) content.writeln();
-        content.write(body);
+        _appendParsedText(content, body);
       } else if (parseToolCalls) {
-        final parsed = _parseAtemCalls(body, calls.length);
+        final parsed = _parseAtemCalls(
+          body,
+          calls.length,
+          tools: tools,
+          expectedRecipient: recipient,
+        );
         if (parsed == null) {
           final terminator = match.group(3) ?? '';
           if (!isPartial || terminator.isNotEmpty) {
-            if (content.isNotEmpty) content.writeln();
-            content.write(body);
+            _appendParsedText(content, body);
           }
         } else {
           calls.addAll(parsed);
         }
       } else {
-        if (content.isNotEmpty) content.writeln();
-        content.write(body);
+        _appendParsedText(content, body);
       }
+      cursor = match.end;
+    }
+    final tail = output.substring(cursor);
+    final partialRoute = isPartial ? _partialMuseRouteStart(tail) : null;
+    if (partialRoute == null) {
+      _appendParsedText(content, tail);
+    } else {
+      _appendParsedText(content, tail.substring(0, partialRoute));
     }
 
     return ChatParseResult(
@@ -693,20 +926,7 @@ class MuseGlimmerHandler extends _DirectJinjaHandler {
 
   @override
   String? buildGrammar(List<ToolDefinition>? tools) {
-    if (tools == null || tools.isEmpty) {
-      return null;
-    }
-    final names = tools
-        .map((tool) => ToolCallGrammarUtils.literal(tool.name))
-        .join(' | ');
-    return '''
-root ::= "<atem:function_calls>\\n" invoke "</atem:function_calls>"
-invoke ::= "<atem:invoke name=\\"" tool-name "\\">\\n" parameter* "</atem:invoke>\\n"
-parameter ::= "<atem:parameter name=\\"" identifier "\\">" raw "</atem:parameter>\\n"
-tool-name ::= $names
-identifier ::= [A-Za-z_] [A-Za-z0-9_.-]*
-raw ::= [^<]*
-''';
+    return _buildAtemGrammar(tools);
   }
 }
 
@@ -740,6 +960,35 @@ class LagunaHandler extends _DirectJinjaHandler {
     bool isPartial = false,
     bool parseToolCalls = true,
     bool thinkingForcedOpen = false,
+  }) => _parse(
+    output,
+    tools: null,
+    isPartial: isPartial,
+    parseToolCalls: parseToolCalls,
+    thinkingForcedOpen: thinkingForcedOpen,
+  );
+
+  @override
+  ChatParseResult parseWithTools(
+    String output, {
+    required List<ToolDefinition>? tools,
+    bool isPartial = false,
+    bool parseToolCalls = true,
+    bool thinkingForcedOpen = false,
+  }) => _parse(
+    output,
+    tools: tools,
+    isPartial: isPartial,
+    parseToolCalls: parseToolCalls,
+    thinkingForcedOpen: thinkingForcedOpen,
+  );
+
+  ChatParseResult _parse(
+    String output, {
+    required List<ToolDefinition>? tools,
+    required bool isPartial,
+    required bool parseToolCalls,
+    required bool thinkingForcedOpen,
   }) {
     if (parseToolCalls && _hasMalformedLagunaToolBlock(output)) {
       final thinking = extractThinking(
@@ -751,8 +1000,9 @@ class LagunaHandler extends _DirectJinjaHandler {
         reasoningContent: thinking.reasoning,
       );
     }
-    return Glm45Handler().parse(
+    return Glm45Handler().parseWithTools(
       output,
+      tools: tools,
       isPartial: isPartial,
       parseToolCalls: parseToolCalls,
       thinkingForcedOpen: thinkingForcedOpen,
@@ -784,7 +1034,548 @@ class LagunaHandler extends _DirectJinjaHandler {
   }
 }
 
-List<LlamaCompletionChunkToolCall>? _parseJsonObjectSequence(String body) {
+ThinkingExtraction _extractDsmlThinking(
+  String output, {
+  required bool isPartial,
+  required bool thinkingForcedOpen,
+}) {
+  if (!thinkingForcedOpen) {
+    return extractThinking(output);
+  }
+  final markerStart = _partialMarkerStart(output, const [
+    '<｜DSML｜function_calls>',
+    '<｜DSML｜tool_calls>',
+  ], includePartial: isPartial);
+  final explicitEnd = output.indexOf('</think>');
+  if (markerStart != null && (explicitEnd < 0 || markerStart < explicitEnd)) {
+    final reasoning = output.substring(0, markerStart).trim();
+    return (
+      content: output.substring(markerStart).trim(),
+      reasoning: reasoning.isEmpty ? null : reasoning,
+    );
+  }
+  return extractThinking(output, thinkingForcedOpen: true);
+}
+
+({String name, int start})? _findDsmlScope(String output) {
+  ({String name, int start})? result;
+  for (final name in const ['function_calls', 'tool_calls']) {
+    final start = output.indexOf('<｜DSML｜$name>');
+    if (start >= 0 && (result == null || start < result.start)) {
+      result = (name: name, start: start);
+    }
+  }
+  return result;
+}
+
+int? _partialMarkerStart(
+  String input,
+  List<String> markers, {
+  bool includePartial = true,
+}) {
+  int? earliest;
+  for (final marker in markers) {
+    final complete = input.indexOf(marker);
+    if (complete >= 0 && (earliest == null || complete < earliest)) {
+      earliest = complete;
+    }
+    if (!includePartial) {
+      continue;
+    }
+    final lowerBound = input.length > marker.length
+        ? input.length - marker.length
+        : 0;
+    for (var index = lowerBound; index < input.length; index++) {
+      if (marker.startsWith(input.substring(index)) &&
+          (earliest == null || index < earliest)) {
+        earliest = index;
+      }
+    }
+  }
+  return earliest;
+}
+
+int? _partialMuseRouteStart(String input) {
+  final match = RegExp(
+    r'(?:<\|start\|>assistant)?\s+to=[^<]*$',
+  ).firstMatch(input);
+  final partial = _partialMarkerStart(input, const [
+    '<|start|>assistant to=',
+    ' to=',
+  ]);
+  if (match == null) {
+    return partial;
+  }
+  if (partial == null) {
+    return match.start;
+  }
+  return match.start < partial ? match.start : partial;
+}
+
+void _appendParsedText(StringBuffer buffer, String value) {
+  buffer.write(value);
+}
+
+String? _buildKimiK3Grammar(List<ToolDefinition>? tools) {
+  if (tools == null || tools.isEmpty) {
+    return null;
+  }
+  const argumentClose = '<|close|>argument<|sep|>';
+  final buffer = StringBuffer()
+    ..writeln(
+      'root ::= "<|open|>tools<|sep|>" call+ '
+      '"<|close|>tools<|sep|><|close|>message<|sep|>"',
+    );
+  final converter = JsonSchemaConverter();
+  final callRules = <String>[];
+  for (var toolIndex = 0; toolIndex < tools.length; toolIndex++) {
+    final tool = tools[toolIndex];
+    final schema = tool.toJsonSchema();
+    converter.resolveRefs(schema, schema);
+    final requiredRules = <String>[];
+    final optionalRules = <String>[];
+    final properties =
+        (schema['properties'] as Map<String, dynamic>?) ??
+        const <String, dynamic>{};
+    final required = Set<String>.from(
+      (schema['required'] as List?)?.whereType<String>() ?? const <String>[],
+    );
+    for (final entry in properties.entries) {
+      final propertySchema = entry.value as Map<String, dynamic>;
+      final ruleBase = _grammarRuleName('kimi-$toolIndex-${entry.key}');
+      final valueRule = _buildDelimitedOrJsonValueRule(
+        buffer: buffer,
+        converter: converter,
+        ruleBase: '$ruleBase-value',
+        schema: propertySchema,
+        delimiter: argumentClose,
+      );
+      final propertyRule = '$ruleBase-argument';
+      buffer.writeln(
+        '$propertyRule ::= '
+        '${ToolCallGrammarUtils.literal('<|open|>argument key="${_escapeAttribute(entry.key)}" type="${_schemaProtocolType(propertySchema)}"<|sep|>')} '
+        '$valueRule ${ToolCallGrammarUtils.literal(argumentClose)}',
+      );
+      (required.contains(entry.key) ? requiredRules : optionalRules).add(
+        propertyRule,
+      );
+    }
+
+    final jsonRule = converter.visit(schema, 'kimi-$toolIndex-json-object');
+    final jsonBlockRule = 'kimi-$toolIndex-json-block';
+    buffer.writeln(
+      '$jsonBlockRule ::= '
+      '"<|open|>json type=\\"object\\"<|sep|>" $jsonRule '
+      '"<|close|>json<|sep|>"',
+    );
+    final arguments = _buildRequiredThenOptionalBody(
+      requiredRules: requiredRules,
+      optionalRules: optionalRules,
+      separatorRule: null,
+    );
+    final body = requiredRules.isEmpty && optionalRules.isEmpty
+        ? '($jsonBlockRule)?'
+        : '(($arguments) | $jsonBlockRule)';
+    final callRule = 'kimi-$toolIndex-call';
+    buffer.writeln(
+      '$callRule ::= '
+      '${ToolCallGrammarUtils.literal('<|open|>call tool="${_escapeAttribute(tool.name)}"')} '
+      '(" index=\\"" [0-9]+ "\\"")? "<|sep|>" $body '
+      '"<|close|>call<|sep|>"',
+    );
+    callRules.add(callRule);
+  }
+  buffer.writeln('call ::= ${callRules.join(' | ')}');
+  _appendJsonRules(buffer, converter);
+  return buffer.toString();
+}
+
+String? _buildMinimaxM3Grammar(List<ToolDefinition>? tools) {
+  if (tools == null || tools.isEmpty) {
+    return null;
+  }
+  const namespace = MinimaxM3Handler.namespace;
+  final buffer = StringBuffer()
+    ..writeln(
+      'root ::= "$namespace<tool_call>\\n" invoke+ '
+      '"$namespace</tool_call>"',
+    );
+  final converter = JsonSchemaConverter();
+  final invokeRules = <String>[];
+  for (var toolIndex = 0; toolIndex < tools.length; toolIndex++) {
+    final tool = tools[toolIndex];
+    final schema = tool.toJsonSchema();
+    converter.resolveRefs(schema, schema);
+    final argsRule = _buildMinimaxObjectBodyRule(
+      buffer: buffer,
+      converter: converter,
+      ruleBase: 'm3-$toolIndex-arguments',
+      schema: schema,
+    );
+    final invokeRule = 'm3-$toolIndex-invoke';
+    buffer.writeln(
+      '$invokeRule ::= '
+      '${ToolCallGrammarUtils.literal('$namespace<invoke name="${tool.name}">')} '
+      'space $argsRule space "$namespace</invoke>\\n"',
+    );
+    invokeRules.add(invokeRule);
+  }
+  buffer.writeln('invoke ::= ${invokeRules.join(' | ')}');
+  _appendJsonRules(buffer, converter);
+  return buffer.toString();
+}
+
+String _buildMinimaxObjectBodyRule({
+  required StringBuffer buffer,
+  required JsonSchemaConverter converter,
+  required String ruleBase,
+  required Map<String, dynamic> schema,
+}) {
+  final properties =
+      (schema['properties'] as Map<String, dynamic>?) ??
+      const <String, dynamic>{};
+  final required = Set<String>.from(
+    (schema['required'] as List?)?.whereType<String>() ?? const <String>[],
+  );
+  final requiredRules = <String>[];
+  final optionalRules = <String>[];
+  for (final entry in properties.entries) {
+    final propertyRule = _buildMinimaxElementRule(
+      buffer: buffer,
+      converter: converter,
+      ruleBase: '$ruleBase-${_grammarRuleName(entry.key)}',
+      tagName: entry.key,
+      schema: entry.value as Map<String, dynamic>,
+    );
+    (required.contains(entry.key) ? requiredRules : optionalRules).add(
+      propertyRule,
+    );
+  }
+  final body = _buildRequiredThenOptionalBody(
+    requiredRules: requiredRules,
+    optionalRules: optionalRules,
+    separatorRule: 'space',
+  );
+  buffer.writeln('$ruleBase ::= $body');
+  return ruleBase;
+}
+
+String _buildMinimaxElementRule({
+  required StringBuffer buffer,
+  required JsonSchemaConverter converter,
+  required String ruleBase,
+  required String tagName,
+  required Map<String, dynamic> schema,
+}) {
+  const namespace = MinimaxM3Handler.namespace;
+  final close = '$namespace</$tagName>';
+  final type = schema['type'];
+  late final String valueRule;
+  if (_schemaResolvesToString(schema)) {
+    final enumValues = schema['enum'];
+    if (enumValues is List && enumValues.isNotEmpty) {
+      valueRule = enumValues
+          .whereType<String>()
+          .map(ToolCallGrammarUtils.literal)
+          .join(' | ');
+    } else {
+      valueRule = _appendUntilLiteralRules(buffer, '$ruleBase-text', close);
+    }
+  } else if (type == 'object' ||
+      (type == null && schema.containsKey('properties'))) {
+    valueRule = _buildMinimaxObjectBodyRule(
+      buffer: buffer,
+      converter: converter,
+      ruleBase: '$ruleBase-object',
+      schema: schema,
+    );
+  } else if (type == 'array') {
+    final itemSchema =
+        schema['items'] as Map<String, dynamic>? ??
+        const <String, dynamic>{'type': 'string'};
+    final itemRule = _buildMinimaxElementRule(
+      buffer: buffer,
+      converter: converter,
+      ruleBase: '$ruleBase-item',
+      tagName: 'item',
+      schema: itemSchema,
+    );
+    valueRule = '($itemRule)*';
+  } else {
+    valueRule = converter.visit(schema, '$ruleBase-json');
+  }
+  buffer.writeln(
+    '$ruleBase ::= ${ToolCallGrammarUtils.literal('$namespace<$tagName>')} '
+    '($valueRule) ${ToolCallGrammarUtils.literal(close)}',
+  );
+  return ruleBase;
+}
+
+String? _buildDsmlGrammar(
+  List<ToolDefinition>? tools, {
+  required String scope,
+}) {
+  if (tools == null || tools.isEmpty) {
+    return null;
+  }
+  const parameterClose = '</｜DSML｜parameter>';
+  final buffer = StringBuffer()
+    ..writeln('root ::= "<｜DSML｜$scope>\\n" invoke+ "</｜DSML｜$scope>"');
+  final converter = JsonSchemaConverter();
+  final invokeRules = <String>[];
+  for (var toolIndex = 0; toolIndex < tools.length; toolIndex++) {
+    final tool = tools[toolIndex];
+    final schema = tool.toJsonSchema();
+    converter.resolveRefs(schema, schema);
+    final propertyRules = _buildNamedParameterRules(
+      buffer: buffer,
+      converter: converter,
+      ruleBase: 'dsml-$toolIndex',
+      schema: schema,
+      openFor: (name, propertySchema) =>
+          '<｜DSML｜parameter name="$name" string="${_schemaResolvesToString(propertySchema)}">',
+      close: parameterClose,
+      trailing: '\n',
+    );
+    final invokeRule = 'dsml-$toolIndex-invoke';
+    buffer.writeln(
+      '$invokeRule ::= '
+      '${ToolCallGrammarUtils.literal('<｜DSML｜invoke name="${tool.name}">\n')} '
+      '$propertyRules space "</｜DSML｜invoke>\\n"',
+    );
+    invokeRules.add(invokeRule);
+  }
+  buffer.writeln('invoke ::= ${invokeRules.join(' | ')}');
+  _appendJsonRules(buffer, converter);
+  return buffer.toString();
+}
+
+String? _buildAtemGrammar(List<ToolDefinition>? tools) {
+  if (tools == null || tools.isEmpty) {
+    return null;
+  }
+  const parameterClose = '</atem:parameter>';
+  final buffer = StringBuffer()
+    ..writeln(
+      'root ::= "<atem:function_calls>\\n" invoke+ '
+      '"</atem:function_calls>"',
+    );
+  final converter = JsonSchemaConverter();
+  final invokeRules = <String>[];
+  for (var toolIndex = 0; toolIndex < tools.length; toolIndex++) {
+    final tool = tools[toolIndex];
+    final schema = tool.toJsonSchema();
+    converter.resolveRefs(schema, schema);
+    final propertyRules = _buildNamedParameterRules(
+      buffer: buffer,
+      converter: converter,
+      ruleBase: 'atem-$toolIndex',
+      schema: schema,
+      openFor: (name, _) => '<atem:parameter name="$name">',
+      close: parameterClose,
+      trailing: '\n',
+    );
+    final invokeRule = 'atem-$toolIndex-invoke';
+    buffer.writeln(
+      '$invokeRule ::= '
+      '${ToolCallGrammarUtils.literal('<atem:invoke name="${tool.name}">\n')} '
+      '$propertyRules space "</atem:invoke>\\n"',
+    );
+    invokeRules.add(invokeRule);
+  }
+  buffer.writeln('invoke ::= ${invokeRules.join(' | ')}');
+  _appendJsonRules(buffer, converter);
+  return buffer.toString();
+}
+
+String _buildNamedParameterRules({
+  required StringBuffer buffer,
+  required JsonSchemaConverter converter,
+  required String ruleBase,
+  required Map<String, dynamic> schema,
+  required String Function(String, Map<String, dynamic>) openFor,
+  required String close,
+  required String trailing,
+}) {
+  final properties =
+      (schema['properties'] as Map<String, dynamic>?) ??
+      const <String, dynamic>{};
+  final required = Set<String>.from(
+    (schema['required'] as List?)?.whereType<String>() ?? const <String>[],
+  );
+  final requiredRules = <String>[];
+  final optionalRules = <String>[];
+  for (final entry in properties.entries) {
+    final propertySchema = entry.value as Map<String, dynamic>;
+    final propertyRule = '$ruleBase-${_grammarRuleName(entry.key)}-parameter';
+    final valueRule = _buildDelimitedOrJsonValueRule(
+      buffer: buffer,
+      converter: converter,
+      ruleBase: '$propertyRule-value',
+      schema: propertySchema,
+      delimiter: close,
+    );
+    buffer.writeln(
+      '$propertyRule ::= ${ToolCallGrammarUtils.literal(openFor(entry.key, propertySchema))} '
+      '$valueRule ${ToolCallGrammarUtils.literal('$close$trailing')}',
+    );
+    (required.contains(entry.key) ? requiredRules : optionalRules).add(
+      propertyRule,
+    );
+  }
+  final argsRule = '$ruleBase-arguments';
+  final body = _buildRequiredThenOptionalBody(
+    requiredRules: requiredRules,
+    optionalRules: optionalRules,
+    separatorRule: 'space',
+  );
+  buffer.writeln('$argsRule ::= $body');
+  return argsRule;
+}
+
+String _buildRequiredThenOptionalBody({
+  required List<String> requiredRules,
+  required List<String> optionalRules,
+  required String? separatorRule,
+}) {
+  final separator = separatorRule == null ? '' : ' $separatorRule ';
+  var body = requiredRules.isEmpty ? '""' : requiredRules.join(separator);
+  if (optionalRules.isEmpty) {
+    return body;
+  }
+  final optionalChoice = optionalRules.length == 1
+      ? optionalRules.single
+      : '(${optionalRules.join(' | ')})';
+  final repeatedSeparator = separatorRule == null ? '' : '$separatorRule ';
+  body = '$body ($repeatedSeparator$optionalChoice)*';
+  return body;
+}
+
+String _buildDelimitedOrJsonValueRule({
+  required StringBuffer buffer,
+  required JsonSchemaConverter converter,
+  required String ruleBase,
+  required Map<String, dynamic> schema,
+  required String delimiter,
+}) {
+  if (_schemaResolvesToString(schema)) {
+    final enumValues = schema['enum'];
+    if (enumValues is List && enumValues.isNotEmpty) {
+      return enumValues
+          .whereType<String>()
+          .map(ToolCallGrammarUtils.literal)
+          .join(' | ');
+    }
+    return _appendUntilLiteralRules(buffer, ruleBase, delimiter);
+  }
+  return converter.visit(schema, ruleBase);
+}
+
+void _appendJsonRules(StringBuffer buffer, JsonSchemaConverter converter) {
+  final rules = converter.rules.entries.toList(growable: false)
+    ..sort((a, b) => a.key.compareTo(b.key));
+  for (final entry in rules) {
+    buffer.writeln('${entry.key} ::= ${entry.value}');
+  }
+}
+
+String _grammarRuleName(String value) {
+  final sanitized = value
+      .replaceAll(RegExp(r'[^A-Za-z0-9-]+'), '-')
+      .replaceAll(RegExp(r'^-+|-+$'), '')
+      .toLowerCase();
+  return sanitized.isEmpty ? 'value' : sanitized;
+}
+
+String _appendUntilLiteralRules(
+  StringBuffer buffer,
+  String ruleBase,
+  String delimiter,
+) {
+  final rules = _buildUntilLiteralRuleLines(ruleBase, delimiter);
+  for (final line in rules) {
+    buffer.writeln(line);
+  }
+  return '$ruleBase-0';
+}
+
+String _buildRequiredPrefixGrammar(String grammar, String trigger) {
+  final lines = grammar.trimRight().split('\n');
+  final rootIndex = lines.indexWhere((line) => line.startsWith('root ::= '));
+  if (rootIndex < 0) {
+    return grammar;
+  }
+  final rootExpression = lines[rootIndex].substring('root ::= '.length);
+  lines[rootIndex] = 'root ::= required-prefix-0 required-tool-root';
+  lines.insert(rootIndex + 1, 'required-tool-root ::= $rootExpression');
+  lines.insertAll(
+    rootIndex + 2,
+    _buildUntilLiteralRuleLines('required-prefix', trigger),
+  );
+  return '${lines.join('\n')}\n';
+}
+
+List<String> _buildUntilLiteralRuleLines(String ruleBase, String delimiter) {
+  final marker = delimiter.runes
+      .map(String.fromCharCode)
+      .toList(growable: false);
+  if (marker.isEmpty) {
+    return ['$ruleBase-0 ::= ""'];
+  }
+  final alphabet = marker.toSet().toList(growable: false);
+  final lines = <String>[
+    '$ruleBase-other ::= [^${alphabet.map(_escapeGbnfCharacterClass).join()}]',
+  ];
+  for (var state = 0; state < marker.length; state++) {
+    final alternatives = <String>['$ruleBase-other $ruleBase-0'];
+    for (final character in alphabet) {
+      final next = _delimiterTransition(marker, state, character);
+      if (next == marker.length) {
+        continue;
+      }
+      alternatives.add(
+        '${ToolCallGrammarUtils.literal(character)} $ruleBase-$next',
+      );
+    }
+    lines.add('$ruleBase-$state ::= (${alternatives.join(' | ')})?');
+  }
+  return lines;
+}
+
+int _delimiterTransition(List<String> marker, int state, String character) {
+  final candidate = <String>[...marker.take(state), character];
+  final max = candidate.length < marker.length
+      ? candidate.length
+      : marker.length;
+  for (var length = max; length >= 0; length--) {
+    var matches = true;
+    for (var index = 0; index < length; index++) {
+      if (candidate[candidate.length - length + index] != marker[index]) {
+        matches = false;
+        break;
+      }
+    }
+    if (matches) {
+      return length;
+    }
+  }
+  return 0;
+}
+
+String _escapeGbnfCharacterClass(String character) {
+  return switch (character) {
+    r'\' => r'\\',
+    ']' => r'\]',
+    '-' => r'\-',
+    '^' => r'\^',
+    _ => character,
+  };
+}
+
+List<LlamaCompletionChunkToolCall>? _parseJsonObjectSequence(
+  String body, {
+  List<ToolDefinition>? tools,
+}) {
   final calls = <LlamaCompletionChunkToolCall>[];
   var cursor = 0;
   while (cursor < body.length) {
@@ -798,6 +1589,20 @@ List<LlamaCompletionChunkToolCall>? _parseJsonObjectSequence(String body) {
     if (slice == null || slice.value is! Map) {
       return null;
     }
+    if (tools != null) {
+      final value = Map<String, dynamic>.from(slice.value as Map);
+      final name = value['name'];
+      final arguments = value['arguments'];
+      final tool = name is String ? _toolByName(tools, name) : null;
+      if (tool == null ||
+          arguments is! Map ||
+          !_objectMatchesSchema(
+            Map<String, dynamic>.from(arguments),
+            tool.toJsonSchema(),
+          )) {
+        return null;
+      }
+    }
     final parsed = ToolCallParsingUtils.parseToolCallArray(<Object?>[
       slice.value,
     ], startIndex: calls.length);
@@ -810,13 +1615,140 @@ List<LlamaCompletionChunkToolCall>? _parseJsonObjectSequence(String body) {
   return calls.isEmpty ? null : calls;
 }
 
+ToolDefinition? _toolByName(List<ToolDefinition>? tools, String name) {
+  if (tools == null) {
+    return null;
+  }
+  for (final tool in tools) {
+    if (tool.name == name) {
+      return tool;
+    }
+  }
+  return null;
+}
+
+bool _schemaResolvesToString(Map<String, dynamic> schema) {
+  final type = schema['type'];
+  if (type == 'string') {
+    return true;
+  }
+  final enumValues = schema['enum'];
+  return enumValues is List && enumValues.every((value) => value is String);
+}
+
+String _schemaProtocolType(Map<String, dynamic> schema) {
+  if (_schemaResolvesToString(schema)) {
+    return 'string';
+  }
+  return switch (schema['type']) {
+    'integer' || 'number' => 'number',
+    'boolean' => 'boolean',
+    'null' => 'null',
+    'object' => 'object',
+    'array' => 'array',
+    _ => 'object',
+  };
+}
+
+Object? _decodeRawBySchema(String raw, Map<String, dynamic> schema) {
+  if (_schemaResolvesToString(schema)) {
+    return _valueMatchesSchema(raw, schema) ? raw : _schemaDecodeFailure;
+  }
+  final decoded = ToolCallParsingUtils.decodeJsonValue(raw);
+  if (decoded == null && raw.trim() != 'null') {
+    return _schemaDecodeFailure;
+  }
+  return _valueMatchesSchema(decoded, schema) ? decoded : _schemaDecodeFailure;
+}
+
+bool _valueMatchesSchema(Object? value, Map<String, dynamic> schema) {
+  final enumValues = schema['enum'];
+  if (enumValues is List && !enumValues.contains(value)) {
+    return false;
+  }
+
+  final type = schema['type'];
+  if (type is List) {
+    return type.any(
+      (candidate) => _valueMatchesSchema(value, <String, dynamic>{
+        ...schema,
+        'type': candidate,
+      }),
+    );
+  }
+
+  switch (type) {
+    case 'string':
+      return value is String;
+    case 'integer':
+      return value is int;
+    case 'number':
+      return value is num;
+    case 'boolean':
+      return value is bool;
+    case 'null':
+      return value == null;
+    case 'array':
+      if (value is! List) {
+        return false;
+      }
+      final itemSchema = schema['items'];
+      return itemSchema is! Map<String, dynamic> ||
+          value.every((item) => _valueMatchesSchema(item, itemSchema));
+    case 'object':
+    case null:
+      if (value is! Map) {
+        return false;
+      }
+      final stringMap = <String, dynamic>{};
+      for (final entry in value.entries) {
+        if (entry.key is! String) {
+          return false;
+        }
+        stringMap[entry.key as String] = entry.value;
+      }
+      return _objectMatchesSchema(stringMap, schema);
+    default:
+      return false;
+  }
+}
+
+bool _objectMatchesSchema(
+  Map<String, dynamic> value,
+  Map<String, dynamic> schema,
+) {
+  final properties =
+      (schema['properties'] as Map<String, dynamic>?) ??
+      const <String, dynamic>{};
+  final required = Set<String>.from(
+    (schema['required'] as List?)?.whereType<String>() ?? const <String>[],
+  );
+  if (!value.keys.toSet().containsAll(required)) {
+    return false;
+  }
+  for (final entry in value.entries) {
+    final property = properties[entry.key];
+    if (property is! Map<String, dynamic> ||
+        !_valueMatchesSchema(entry.value, property)) {
+      return false;
+    }
+  }
+  return true;
+}
+
+const _schemaDecodeFailure = _SchemaDecodeFailure();
+
+class _SchemaDecodeFailure {
+  const _SchemaDecodeFailure();
+}
+
 _ParsedCalls _parseInvokeScope(
   String input, {
   required String scopeStart,
   required String scopeEnd,
   required RegExp invokeStartPattern,
   required String invokeEnd,
-  required Map<String, dynamic>? Function(String) parseArguments,
+  required Map<String, dynamic>? Function(String, String) parseArguments,
   required bool isPartial,
 }) {
   final scopeStartIndex = input.indexOf(scopeStart);
@@ -858,7 +1790,7 @@ _ParsedCalls _parseInvokeScope(
       return allowPartial ? partialResult() : _ParsedCalls.failure();
     }
     final name = start.group(1) ?? '';
-    final arguments = parseArguments(body.substring(argumentsStart, end));
+    final arguments = parseArguments(name, body.substring(argumentsStart, end));
     if (name.isEmpty || arguments == null) {
       return allowPartial ? partialResult() : _ParsedCalls.failure();
     }
@@ -885,16 +1817,106 @@ _ParsedCalls _parseInvokeScope(
   return _ParsedCalls(calls: calls, remaining: remaining);
 }
 
-Map<String, dynamic>? _parseDynamicTagArguments(String body) {
+Map<String, dynamic>? _parseDynamicTagArguments(
+  String body, {
+  Map<String, dynamic>? schema,
+}) {
   final parsed = _parseDynamicElements(body);
-  if (parsed == null || parsed.elements.isEmpty) {
+  if (parsed == null) {
     return null;
+  }
+  if (schema != null) {
+    return _coerceDynamicObject(parsed.elements, schema);
   }
   final result = <String, dynamic>{};
   for (final element in parsed.elements) {
-    result[element.name] = element.value;
+    if (result.containsKey(element.name)) {
+      return null;
+    }
+    result[element.name] = _inferDynamicValue(element);
   }
   return result;
+}
+
+Map<String, dynamic>? _coerceDynamicObject(
+  List<_DynamicElement> elements,
+  Map<String, dynamic> schema,
+) {
+  final properties =
+      (schema['properties'] as Map<String, dynamic>?) ??
+      const <String, dynamic>{};
+  final required = Set<String>.from(
+    (schema['required'] as List?)?.whereType<String>() ?? const <String>[],
+  );
+  final result = <String, dynamic>{};
+  for (final element in elements) {
+    final propertySchema = properties[element.name];
+    if (propertySchema is! Map<String, dynamic> ||
+        result.containsKey(element.name)) {
+      return null;
+    }
+    final value = _coerceDynamicElement(element, propertySchema);
+    if (identical(value, _schemaDecodeFailure)) {
+      return null;
+    }
+    result[element.name] = value;
+  }
+  if (!result.keys.toSet().containsAll(required)) {
+    return null;
+  }
+  return result;
+}
+
+Object? _coerceDynamicElement(
+  _DynamicElement element,
+  Map<String, dynamic> schema,
+) {
+  if (_schemaResolvesToString(schema)) {
+    return _valueMatchesSchema(element.raw, schema)
+        ? element.raw
+        : _schemaDecodeFailure;
+  }
+  final type = schema['type'];
+  if (type == 'object' || (type == null && schema.containsKey('properties'))) {
+    final children = element.children;
+    if (children == null) {
+      return _schemaDecodeFailure;
+    }
+    return _coerceDynamicObject(children, schema) ?? _schemaDecodeFailure;
+  }
+  if (type == 'array') {
+    final children = element.children;
+    final itemSchema = schema['items'];
+    if (children == null || itemSchema is! Map<String, dynamic>) {
+      return _schemaDecodeFailure;
+    }
+    final result = <Object?>[];
+    for (final child in children) {
+      if (child.name != 'item') {
+        return _schemaDecodeFailure;
+      }
+      final value = _coerceDynamicElement(child, itemSchema);
+      if (identical(value, _schemaDecodeFailure)) {
+        return _schemaDecodeFailure;
+      }
+      result.add(value);
+    }
+    return result;
+  }
+  return _decodeRawBySchema(element.raw, schema);
+}
+
+Object? _inferDynamicValue(_DynamicElement element) {
+  final children = element.children;
+  if (children != null && children.isNotEmpty) {
+    if (children.every((child) => child.name == 'item')) {
+      return children.map(_inferDynamicValue).toList(growable: false);
+    }
+    return <String, dynamic>{
+      for (final child in children) child.name: _inferDynamicValue(child),
+    };
+  }
+  return ToolCallParsingUtils.decodeJsonValueOrString(element.raw);
 }
 
 _DynamicElements? _parseDynamicElements(String input) {
@@ -920,21 +1942,9 @@ _DynamicElements? _parseDynamicElements(String input) {
     }
     final raw = input.substring(opening.end, close.start);
     final children = _parseDynamicElements(raw);
-    Object? value;
-    if (children != null && children.elements.isNotEmpty) {
-      if (children.elements.every((element) => element.name == 'item')) {
-        value = children.elements
-            .map((element) => element.value)
-            .toList(growable: false);
-      } else {
-        value = <String, dynamic>{
-          for (final element in children.elements) element.name: element.value,
-        };
-      }
-    } else {
-      value = ToolCallParsingUtils.decodeJsonValueOrString(raw);
-    }
-    elements.add(_DynamicElement(name: name, value: value));
+    elements.add(
+      _DynamicElement(name: name, raw: raw, children: children?.elements),
+    );
     cursor = close.end;
   }
   return _DynamicElements(elements);
@@ -960,7 +1970,10 @@ _DynamicElements? _parseDynamicElements(String input) {
   return null;
 }
 
-Map<String, dynamic>? _parseDsmlArguments(String body) {
+Map<String, dynamic>? _parseDsmlArguments(
+  String body, {
+  Map<String, dynamic>? schema,
+}) {
   final pattern = RegExp(
     r'<｜DSML｜parameter name="([^"]+)" string="(true|false)">([\s\S]*?)</｜DSML｜parameter>',
   );
@@ -974,7 +1987,21 @@ Map<String, dynamic>? _parseDsmlArguments(String body) {
     if (key.isEmpty) {
       return null;
     }
-    if (match.group(2) == 'true') {
+    final property = schema?['properties']?[key];
+    if (schema != null && property is! Map<String, dynamic>) {
+      return null;
+    }
+    if (property is Map<String, dynamic>) {
+      final expectsString = _schemaResolvesToString(property);
+      if ((match.group(2) == 'true') != expectsString) {
+        return null;
+      }
+      final decoded = _decodeRawBySchema(raw, property);
+      if (identical(decoded, _schemaDecodeFailure)) {
+        return null;
+      }
+      result[key] = decoded;
+    } else if (match.group(2) == 'true') {
       result[key] = raw;
     } else {
       final decoded = ToolCallParsingUtils.decodeJsonValue(raw);
@@ -984,10 +2011,18 @@ Map<String, dynamic>? _parseDsmlArguments(String body) {
       result[key] = decoded;
     }
   }
+  if (schema != null && !_objectMatchesSchema(result, schema)) {
+    return null;
+  }
   return result;
 }
 
-List<LlamaCompletionChunkToolCall>? _parseAtemCalls(String body, int start) {
+List<LlamaCompletionChunkToolCall>? _parseAtemCalls(
+  String body,
+  int start, {
+  List<ToolDefinition>? tools,
+  String? expectedRecipient,
+}) {
   const scopeStart = '<atem:function_calls>';
   const scopeEnd = '</atem:function_calls>';
   final scopeStartIndex = body.indexOf(scopeStart);
@@ -1013,6 +2048,13 @@ List<LlamaCompletionChunkToolCall>? _parseAtemCalls(String body, int start) {
   for (final invoke in invokePattern.allMatches(scope)) {
     final name = invoke.group(1) ?? '';
     final params = invoke.group(2) ?? '';
+    final tool = _toolByName(tools, name);
+    if ((tools != null && tool == null) ||
+        (expectedRecipient != null &&
+            expectedRecipient.isNotEmpty &&
+            name != expectedRecipient)) {
+      return null;
+    }
     final parameterPattern = RegExp(
       r'<atem:parameter name="([^"]+)">([\s\S]*?)</atem:parameter>',
     );
@@ -1027,7 +2069,22 @@ List<LlamaCompletionChunkToolCall>? _parseAtemCalls(String body, int start) {
       if (key.isEmpty) {
         return null;
       }
-      arguments[key] = ToolCallParsingUtils.decodeJsonValueOrString(raw);
+      final property = tool?.toJsonSchema()['properties']?[key];
+      if (tool != null && property is! Map<String, dynamic>) {
+        return null;
+      }
+      if (property is Map<String, dynamic>) {
+        final decoded = _decodeRawBySchema(raw, property);
+        if (identical(decoded, _schemaDecodeFailure)) {
+          return null;
+        }
+        arguments[key] = decoded;
+      } else {
+        arguments[key] = ToolCallParsingUtils.decodeJsonValueOrString(raw);
+      }
+    }
+    if (tool != null && !_objectMatchesSchema(arguments, tool.toJsonSchema())) {
+      return null;
     }
     calls.add(
       ToolCallParsingUtils.createFunctionToolCall(
@@ -1079,7 +2136,12 @@ class _DynamicElements {
 
 class _DynamicElement {
   final String name;
-  final Object? value;
+  final String raw;
+  final List<_DynamicElement>? children;
 
-  const _DynamicElement({required this.name, required this.value});
+  const _DynamicElement({
+    required this.name,
+    required this.raw,
+    required this.children,
+  });
 }

--- a/lib/src/core/template/handlers/llama_cpp_specialized_handlers.dart
+++ b/lib/src/core/template/handlers/llama_cpp_specialized_handlers.dart
@@ -1438,7 +1438,7 @@ String _buildRequiredThenOptionalBody({
   required List<String> optionalRules,
   required String? separatorRule,
 }) {
-  final separator = separatorRule == null ? '' : ' $separatorRule ';
+  final separator = separatorRule == null ? ' ' : ' $separatorRule ';
   var body = requiredRules.isEmpty ? '""' : requiredRules.join(separator);
   if (optionalRules.isEmpty) {
     return body;
@@ -1480,11 +1480,7 @@ void _appendJsonRules(StringBuffer buffer, JsonSchemaConverter converter) {
 }
 
 String _grammarRuleName(String value) {
-  final sanitized = value
-      .replaceAll(RegExp(r'[^A-Za-z0-9-]+'), '-')
-      .replaceAll(RegExp(r'^-+|-+$'), '')
-      .toLowerCase();
-  return sanitized.isEmpty ? 'value' : sanitized;
+  return ToolCallGrammarUtils.ruleName(value);
 }
 
 String _appendUntilLiteralRules(

--- a/lib/src/core/template/tool_call_grammar_utils.dart
+++ b/lib/src/core/template/tool_call_grammar_utils.dart
@@ -8,6 +8,26 @@ class ToolCallGrammarUtils {
   /// Escapes [value] as a grammar string literal.
   static String literal(String value) => _literal(value);
 
+  /// Encodes [value] as a collision-free GBNF rule-name component.
+  static String ruleName(String value) {
+    if (value.isEmpty) {
+      return 'rule-empty';
+    }
+    final buffer = StringBuffer();
+    for (final rune in value.runes) {
+      final isAsciiAlphaNumeric =
+          (rune >= 0x30 && rune <= 0x39) ||
+          (rune >= 0x41 && rune <= 0x5A) ||
+          (rune >= 0x61 && rune <= 0x7A);
+      if (isAsciiAlphaNumeric) {
+        buffer.writeCharCode(rune);
+      } else {
+        buffer.write('-u${rune.toRadixString(16)}-');
+      }
+    }
+    return buffer.toString();
+  }
+
   /// Builds a grammar for an array of tool calls and wraps it with literals.
   static String? buildWrappedArrayGrammar({
     required List<ToolDefinition>? tools,

--- a/test/e2e/template/specialized_grammar_acceptance_e2e_test.dart
+++ b/test/e2e/template/specialized_grammar_acceptance_e2e_test.dart
@@ -72,6 +72,20 @@ void main() {
         ],
       ),
       _GrammarCase(
+        name: 'Kimi K3 collision-free argument rule names',
+        grammar: KimiK3Handler().buildGrammar([_collidingKeyTool])!,
+        valid:
+            '<|open|>tools<|sep|>'
+            '<|open|>call tool="colliding"<|sep|>'
+            '<|open|>argument key="a b" type="string"<|sep|>first'
+            '<|close|>argument<|sep|>'
+            '<|open|>argument key="a-b" type="string"<|sep|>second'
+            '<|close|>argument<|sep|>'
+            '<|close|>call<|sep|><|close|>tools<|sep|>'
+            '<|close|>message<|sep|>',
+        invalid: const [],
+      ),
+      _GrammarCase(
         name: 'MiniMax M1 quoted name',
         grammar: MinimaxM1Handler().buildGrammar([_weatherTool])!,
         valid:
@@ -242,6 +256,18 @@ void main() {
               '<arg_value>x</arg_value>\n'
               '</tool_call>\n',
         ],
+      ),
+      _GrammarCase(
+        name: 'GLM collision-free argument rule names',
+        grammar: Glm45Handler().buildGrammar([_collidingKeyTool])!,
+        valid:
+            '<tool_call>colliding\n'
+            '<arg_key>a b</arg_key>\n'
+            '<arg_value>first</arg_value>\n'
+            '<arg_key>a-b</arg_key>\n'
+            '<arg_value>second</arg_value>\n'
+            '</tool_call>\n',
+        invalid: const [],
       ),
     ];
 
@@ -444,6 +470,16 @@ final _typedTool = ToolDefinition(
       itemType: ToolParam.string('item'),
       required: true,
     ),
+  ],
+  handler: (_) async => null,
+);
+
+final _collidingKeyTool = ToolDefinition(
+  name: 'colliding',
+  description: 'Collision coverage',
+  parameters: [
+    ToolParam.string('a b', required: true),
+    ToolParam.string('a-b', required: true),
   ],
   handler: (_) async => null,
 );

--- a/test/e2e/template/specialized_grammar_acceptance_e2e_test.dart
+++ b/test/e2e/template/specialized_grammar_acceptance_e2e_test.dart
@@ -1,0 +1,449 @@
+@TestOn('vm')
+@Tags(['local-only', 'e2e'])
+library;
+
+import 'dart:io';
+
+import 'package:llamadart/src/core/models/chat/chat_message.dart';
+import 'package:llamadart/src/core/models/chat/chat_role.dart';
+import 'package:llamadart/src/core/models/inference/tool_choice.dart';
+import 'package:llamadart/src/core/models/tools/tool_definition.dart';
+import 'package:llamadart/src/core/models/tools/tool_param.dart';
+import 'package:llamadart/src/core/template/chat_template_engine.dart';
+import 'package:llamadart/src/core/template/handlers/glm45_handler.dart';
+import 'package:llamadart/src/core/template/handlers/llama_cpp_specialized_handlers.dart';
+import 'package:test/test.dart';
+
+void main() {
+  const validator = '.dart_tool/llama_cpp_chat_tests/bin/test-gbnf-validator';
+  final validatorFile = File(validator);
+
+  setUpAll(() {
+    expect(
+      validatorFile.existsSync(),
+      isTrue,
+      reason:
+          'Build the pinned upstream validator with '
+          'tool/testing/run_llama_cpp_chat_tests.sh first.',
+    );
+  });
+
+  test('accepts and rejects schema-exact specialized output shapes', () async {
+    final cases = <_GrammarCase>[
+      _GrammarCase(
+        name: 'Kimi K3 escaped key and delimiter-aware string',
+        grammar: KimiK3Handler().buildGrammar([_escapedTool])!,
+        valid:
+            '<|open|>tools<|sep|>'
+            '<|open|>call tool="weather&amp;&quot;alerts"<|sep|>'
+            '<|open|>argument key="city&amp;&quot;unit" type="string"<|sep|>'
+            'x < 5<|close|>argument<|sep|>'
+            '<|close|>call<|sep|><|close|>tools<|sep|>'
+            '<|close|>message<|sep|>',
+        invalid: [
+          '<|open|>tools<|sep|>'
+              '<|open|>call tool="weather&amp;&quot;alerts"<|sep|>'
+              '<|open|>argument key="unknown" type="string"<|sep|>x'
+              '<|close|>argument<|sep|><|close|>call<|sep|>'
+              '<|close|>tools<|sep|><|close|>message<|sep|>',
+        ],
+      ),
+      _GrammarCase(
+        name: 'Kimi K3 required-first and flexible optional arguments',
+        grammar: KimiK3Handler().buildGrammar([_orderedTool])!,
+        valid:
+            '<|open|>tools<|sep|>'
+            '<|open|>call tool="ordered"<|sep|>'
+            '<|open|>argument key="required_city" type="string"<|sep|>Seoul'
+            '<|close|>argument<|sep|>'
+            '<|open|>argument key="optional_last" type="string"<|sep|>C'
+            '<|close|>argument<|sep|>'
+            '<|open|>argument key="optional_first" type="string"<|sep|>A'
+            '<|close|>argument<|sep|>'
+            '<|close|>call<|sep|><|close|>tools<|sep|>'
+            '<|close|>message<|sep|>',
+        invalid: [
+          '<|open|>tools<|sep|>'
+              '<|open|>call tool="ordered"<|sep|>'
+              '<|open|>argument key="optional_first" type="string"<|sep|>A'
+              '<|close|>argument<|sep|>'
+              '<|close|>call<|sep|><|close|>tools<|sep|>'
+              '<|close|>message<|sep|>',
+        ],
+      ),
+      _GrammarCase(
+        name: 'MiniMax M1 quoted name',
+        grammar: MinimaxM1Handler().buildGrammar([_weatherTool])!,
+        valid:
+            '<tool_calls>\n'
+            '{"name":"weather","arguments":{"city":"Seoul"}}\n'
+            '</tool_calls>',
+        invalid: [
+          '<tool_calls>\n'
+              '{"name":weather,"arguments":{"city":"Seoul"}}\n'
+              '</tool_calls>',
+          '<tool_calls>\n'
+              '{"name":"unknown","arguments":{"city":"Seoul"}}\n'
+              '</tool_calls>',
+        ],
+      ),
+      _GrammarCase(
+        name: 'MiniMax M3 literal tag pairs and closing-bracket strings',
+        grammar: MinimaxM3Handler().buildGrammar([_typedTool])!,
+        valid:
+            '${MinimaxM3Handler.namespace}<tool_call>\n'
+            '${MinimaxM3Handler.namespace}<invoke name="typed">'
+            '${MinimaxM3Handler.namespace}<code>x ] y'
+            '${MinimaxM3Handler.namespace}</code>'
+            '${MinimaxM3Handler.namespace}<options>'
+            '${MinimaxM3Handler.namespace}</options>'
+            '${MinimaxM3Handler.namespace}<items>'
+            '${MinimaxM3Handler.namespace}</items>'
+            '${MinimaxM3Handler.namespace}</invoke>\n'
+            '${MinimaxM3Handler.namespace}</tool_call>',
+        invalid: [
+          '${MinimaxM3Handler.namespace}<tool_call>\n'
+              '${MinimaxM3Handler.namespace}<invoke name="typed">'
+              '${MinimaxM3Handler.namespace}<code>x'
+              '${MinimaxM3Handler.namespace}</items>'
+              '${MinimaxM3Handler.namespace}</invoke>\n'
+              '${MinimaxM3Handler.namespace}</tool_call>',
+        ],
+      ),
+      _GrammarCase(
+        name: 'MiniMax M3 required-first and flexible optional arguments',
+        grammar: MinimaxM3Handler().buildGrammar([_orderedTool])!,
+        valid:
+            '${MinimaxM3Handler.namespace}<tool_call>\n'
+            '${MinimaxM3Handler.namespace}<invoke name="ordered">'
+            '${MinimaxM3Handler.namespace}<required_city>Seoul'
+            '${MinimaxM3Handler.namespace}</required_city>'
+            '${MinimaxM3Handler.namespace}<optional_last>C'
+            '${MinimaxM3Handler.namespace}</optional_last>'
+            '${MinimaxM3Handler.namespace}<optional_first>A'
+            '${MinimaxM3Handler.namespace}</optional_first>'
+            '${MinimaxM3Handler.namespace}</invoke>\n'
+            '${MinimaxM3Handler.namespace}</tool_call>',
+        invalid: [
+          '${MinimaxM3Handler.namespace}<tool_call>\n'
+              '${MinimaxM3Handler.namespace}<invoke name="ordered">'
+              '${MinimaxM3Handler.namespace}<optional_first>A'
+              '${MinimaxM3Handler.namespace}</optional_first>'
+              '${MinimaxM3Handler.namespace}</invoke>\n'
+              '${MinimaxM3Handler.namespace}</tool_call>',
+        ],
+      ),
+      _GrammarCase(
+        name: 'MiniMax M3 zero-argument call',
+        grammar: MinimaxM3Handler().buildGrammar([_pingTool])!,
+        valid:
+            '${MinimaxM3Handler.namespace}<tool_call>\n'
+            '${MinimaxM3Handler.namespace}<invoke name="ping">'
+            '${MinimaxM3Handler.namespace}</invoke>\n'
+            '${MinimaxM3Handler.namespace}</tool_call>',
+        invalid: [
+          '${MinimaxM3Handler.namespace}<tool_call>\n'
+              '${MinimaxM3Handler.namespace}<invoke name="ping">'
+              '${MinimaxM3Handler.namespace}<unexpected>x'
+              '${MinimaxM3Handler.namespace}</unexpected>'
+              '${MinimaxM3Handler.namespace}</invoke>\n'
+              '${MinimaxM3Handler.namespace}</tool_call>',
+        ],
+      ),
+      _GrammarCase(
+        name: 'DeepSeek V4 schema-directed DSML',
+        grammar: DeepseekV4Handler().buildGrammar([_weatherTool])!,
+        valid:
+            '<｜DSML｜tool_calls>\n'
+            '<｜DSML｜invoke name="weather">\n'
+            '<｜DSML｜parameter name="city" string="true">x < 5'
+            '</｜DSML｜parameter>\n'
+            '</｜DSML｜invoke>\n'
+            '</｜DSML｜tool_calls>',
+        invalid: [
+          '<｜DSML｜tool_calls>\n'
+              '<｜DSML｜invoke name="weather">\n'
+              '<｜DSML｜parameter name="city" string="false">"Seoul"'
+              '</｜DSML｜parameter>\n'
+              '</｜DSML｜invoke>\n'
+              '</｜DSML｜tool_calls>',
+        ],
+      ),
+      _GrammarCase(
+        name: 'DeepSeek required-first and flexible optional parameters',
+        grammar: DeepseekV4Handler().buildGrammar([_orderedTool])!,
+        valid:
+            '<｜DSML｜tool_calls>\n'
+            '<｜DSML｜invoke name="ordered">\n'
+            '<｜DSML｜parameter name="required_city" string="true">Seoul'
+            '</｜DSML｜parameter>\n'
+            '<｜DSML｜parameter name="optional_last" string="true">C'
+            '</｜DSML｜parameter>\n'
+            '<｜DSML｜parameter name="optional_first" string="true">A'
+            '</｜DSML｜parameter>\n'
+            '</｜DSML｜invoke>\n'
+            '</｜DSML｜tool_calls>',
+        invalid: [
+          '<｜DSML｜tool_calls>\n'
+              '<｜DSML｜invoke name="ordered">\n'
+              '<｜DSML｜parameter name="optional_first" string="true">A'
+              '</｜DSML｜parameter>\n'
+              '</｜DSML｜invoke>\n'
+              '</｜DSML｜tool_calls>',
+        ],
+      ),
+      _GrammarCase(
+        name: 'Muse Glimmer schema-directed ATEM',
+        grammar: MuseGlimmerHandler().buildGrammar([_weatherTool])!,
+        valid:
+            '<atem:function_calls>\n'
+            '<atem:invoke name="weather">\n'
+            '<atem:parameter name="city">x < 5</atem:parameter>\n'
+            '</atem:invoke>\n'
+            '</atem:function_calls>',
+        invalid: [
+          '<atem:function_calls>\n'
+              '<atem:invoke name="weather">\n'
+              '<atem:parameter name="unknown">x</atem:parameter>\n'
+              '</atem:invoke>\n'
+              '</atem:function_calls>',
+        ],
+      ),
+      _GrammarCase(
+        name: 'Muse required-first and flexible optional parameters',
+        grammar: MuseGlimmerHandler().buildGrammar([_orderedTool])!,
+        valid:
+            '<atem:function_calls>\n'
+            '<atem:invoke name="ordered">\n'
+            '<atem:parameter name="required_city">Seoul</atem:parameter>\n'
+            '<atem:parameter name="optional_last">C</atem:parameter>\n'
+            '<atem:parameter name="optional_first">A</atem:parameter>\n'
+            '</atem:invoke>\n'
+            '</atem:function_calls>',
+        invalid: [
+          '<atem:function_calls>\n'
+              '<atem:invoke name="ordered">\n'
+              '<atem:parameter name="optional_first">A</atem:parameter>\n'
+              '</atem:invoke>\n'
+              '</atem:function_calls>',
+        ],
+      ),
+      _GrammarCase(
+        name: 'Laguna delimiter-aware GLM arguments',
+        grammar: Glm45Handler().buildGrammar([_weatherTool])!,
+        valid:
+            '<tool_call>weather\n'
+            '<arg_key>city</arg_key>\n'
+            '<arg_value>x < 5</arg_value>\n'
+            '</tool_call>\n',
+        invalid: [
+          '<tool_call>weather\n'
+              '<arg_key>unknown</arg_key>\n'
+              '<arg_value>x</arg_value>\n'
+              '</tool_call>\n',
+        ],
+      ),
+    ];
+
+    for (final grammarCase in cases) {
+      await _expectGrammarMatch(
+        validator: validator,
+        name: grammarCase.name,
+        grammar: grammarCase.grammar,
+        input: grammarCase.valid,
+        expected: true,
+      );
+      for (final invalid in grammarCase.invalid) {
+        await _expectGrammarMatch(
+          validator: validator,
+          name: grammarCase.name,
+          grammar: grammarCase.grammar,
+          input: invalid,
+          expected: false,
+        );
+      }
+    }
+  });
+
+  test('required grammars accept prefixes but still require a tool', () async {
+    const templateNames = [
+      'Kimi-K3.jinja',
+      'MiniMax-M3.jinja',
+      'deepseek-ai-DeepSeek-V3.2.jinja',
+      'deepseek-ai-DeepSeek-V4.jinja',
+      'muse-glimmer.jinja',
+      'poolside-Laguna-XS-2.1.jinja',
+    ];
+    for (final name in templateNames) {
+      final source = File(
+        '.dart_tool/llama_cpp/models/templates/$name',
+      ).readAsStringSync();
+      final rendered = ChatTemplateEngine.render(
+        templateSource: source,
+        messages: const [
+          LlamaChatMessage.fromText(role: LlamaChatRole.user, text: 'weather?'),
+        ],
+        metadata: const {},
+        tools: [_weatherTool],
+        toolChoice: ToolChoice.required,
+      );
+      final toolOutput = _requiredOutputFor(name);
+      await _expectGrammarMatch(
+        validator: validator,
+        name: '$name required prefix',
+        grammar: rendered.grammar!,
+        input: toolOutput,
+        expected: true,
+      );
+      await _expectGrammarMatch(
+        validator: validator,
+        name: '$name required no-call rejection',
+        grammar: rendered.grammar!,
+        input: 'reasoning and final content only',
+        expected: false,
+      );
+    }
+  });
+}
+
+String _requiredOutputFor(String templateName) {
+  if (templateName == 'Kimi-K3.jinja') {
+    return 'reasoning<|close|>think<|sep|>'
+        '<|open|>response<|sep|>Checking.<|close|>response<|sep|>'
+        '<|open|>tools<|sep|>'
+        '<|open|>call tool="weather"<|sep|>'
+        '<|open|>argument key="city" type="string"<|sep|>Seoul'
+        '<|close|>argument<|sep|><|close|>call<|sep|>'
+        '<|close|>tools<|sep|><|close|>message<|sep|>';
+  }
+  if (templateName == 'MiniMax-M3.jinja') {
+    return '<mm:think>reasoning</mm:think>'
+        '${MinimaxM3Handler.namespace}<tool_call>\n'
+        '${MinimaxM3Handler.namespace}<invoke name="weather">'
+        '${MinimaxM3Handler.namespace}<city>Seoul'
+        '${MinimaxM3Handler.namespace}</city>'
+        '${MinimaxM3Handler.namespace}</invoke>\n'
+        '${MinimaxM3Handler.namespace}</tool_call>';
+  }
+  if (templateName.startsWith('deepseek-ai-DeepSeek-V3.2')) {
+    return 'reasoning</think>Checking.\n'
+        '<｜DSML｜function_calls>\n'
+        '<｜DSML｜invoke name="weather">\n'
+        '<｜DSML｜parameter name="city" string="true">Seoul'
+        '</｜DSML｜parameter>\n'
+        '</｜DSML｜invoke>\n'
+        '</｜DSML｜function_calls>';
+  }
+  if (templateName.startsWith('deepseek-ai-DeepSeek-V4')) {
+    return 'reasoning</think>Checking.\n'
+        '<｜DSML｜tool_calls>\n'
+        '<｜DSML｜invoke name="weather">\n'
+        '<｜DSML｜parameter name="city" string="true">Seoul'
+        '</｜DSML｜parameter>\n'
+        '</｜DSML｜invoke>\n'
+        '</｜DSML｜tool_calls>';
+  }
+  if (templateName == 'muse-glimmer.jinja') {
+    return ' to=self<|message|>reasoning<|eom|>'
+        '<|start|>assistant to=weather<|message|>'
+        '<atem:function_calls>\n'
+        '<atem:invoke name="weather">\n'
+        '<atem:parameter name="city">Seoul</atem:parameter>\n'
+        '</atem:invoke>\n'
+        '</atem:function_calls>';
+  }
+  return '<think>reasoning</think>Checking.\n'
+      '<tool_call>weather\n'
+      '<arg_key>city</arg_key>\n'
+      '<arg_value>Seoul</arg_value>\n'
+      '</tool_call>\n';
+}
+
+Future<void> _expectGrammarMatch({
+  required String validator,
+  required String name,
+  required String grammar,
+  required String input,
+  required bool expected,
+}) async {
+  final directory = await Directory.systemTemp.createTemp(
+    'llamadart-specialized-grammar-',
+  );
+  addTearDown(() => directory.delete(recursive: true));
+  final grammarFile = File('${directory.path}/grammar.gbnf');
+  final inputFile = File('${directory.path}/input.txt');
+  await grammarFile.writeAsString(grammar);
+  await inputFile.writeAsString(input);
+  final result = await Process.run(validator, [
+    grammarFile.path,
+    inputFile.path,
+  ]);
+  final output = '${result.stdout}\n${result.stderr}';
+  expect(result.exitCode, 0, reason: '$name\n$output');
+  expect(
+    output.contains('Input string is valid according to the grammar.'),
+    expected,
+    reason: '$name\n$output\nGrammar:\n$grammar\nInput:\n$input',
+  );
+}
+
+class _GrammarCase {
+  const _GrammarCase({
+    required this.name,
+    required this.grammar,
+    required this.valid,
+    required this.invalid,
+  });
+
+  final String name;
+  final String grammar;
+  final String valid;
+  final List<String> invalid;
+}
+
+final _weatherTool = ToolDefinition(
+  name: 'weather',
+  description: 'Weather',
+  parameters: [ToolParam.string('city', required: true)],
+  handler: (_) async => null,
+);
+
+final _escapedTool = ToolDefinition(
+  name: 'weather&"alerts',
+  description: 'Weather',
+  parameters: [ToolParam.string('city&"unit', required: true)],
+  handler: (_) async => null,
+);
+
+final _orderedTool = ToolDefinition(
+  name: 'ordered',
+  description: 'Ordering coverage',
+  parameters: [
+    ToolParam.string('optional_first'),
+    ToolParam.string('required_city', required: true),
+    ToolParam.string('optional_last'),
+  ],
+  handler: (_) async => null,
+);
+
+final _pingTool = ToolDefinition(
+  name: 'ping',
+  description: 'Ping',
+  parameters: const [],
+  handler: (_) async => null,
+);
+
+final _typedTool = ToolDefinition(
+  name: 'typed',
+  description: 'Typed values',
+  parameters: [
+    ToolParam.string('code', required: true),
+    ToolParam.object('options', properties: const [], required: true),
+    ToolParam.array(
+      'items',
+      itemType: ToolParam.string('item'),
+      required: true,
+    ),
+  ],
+  handler: (_) async => null,
+);

--- a/test/integration/core/template/llama_cpp_template_detection_integration_test.dart
+++ b/test/integration/core/template/llama_cpp_template_detection_integration_test.dart
@@ -6,9 +6,9 @@ import 'dart:io';
 import 'package:llamadart/src/core/models/chat/chat_message.dart';
 import 'package:llamadart/src/core/models/chat/chat_role.dart';
 import 'package:llamadart/src/core/models/chat/content_part.dart';
+import 'package:llamadart/src/core/models/inference/tool_choice.dart';
 import 'package:llamadart/src/core/models/tools/tool_definition.dart';
 import 'package:llamadart/src/core/models/tools/tool_param.dart';
-import 'package:llamadart/src/core/models/inference/tool_choice.dart';
 import 'package:llamadart/src/core/template/chat_format.dart';
 import 'package:llamadart/src/core/template/chat_template_engine.dart';
 import 'package:test/test.dart';
@@ -155,232 +155,209 @@ void main() {
       );
     }, skip: fixtureSkipReason);
 
-    test(
-      'renders and parses every vendored llama.cpp template',
-      () {
-        expect(templatesDir.existsSync(), isTrue);
+    test('renders and parses every vendored llama.cpp template', () {
+      expect(templatesDir.existsSync(), isTrue);
 
-        final files =
-            templatesDir
-                .listSync()
-                .whereType<File>()
-                .where((f) => f.path.endsWith('.jinja'))
-                .toList()
-              ..sort((a, b) => a.path.compareTo(b.path));
+      final files =
+          templatesDir
+              .listSync()
+              .whereType<File>()
+              .where((f) => f.path.endsWith('.jinja'))
+              .toList()
+            ..sort((a, b) => a.path.compareTo(b.path));
 
-        for (final file in files) {
-          final source = file.readAsStringSync();
-          final detected = detectChatFormat(source);
+      for (final file in files) {
+        final source = file.readAsStringSync();
+        final detected = detectChatFormat(source);
 
-          final rendered = ChatTemplateEngine.render(
-            templateSource: source,
-            messages: messages,
-            metadata: metadata,
-            tools: [tool],
-            parallelToolCalls: true,
-          );
+        final rendered = ChatTemplateEngine.render(
+          templateSource: source,
+          messages: messages,
+          metadata: metadata,
+          tools: [tool],
+          parallelToolCalls: true,
+        );
 
+        expect(
+          rendered.prompt.trim(),
+          isNotEmpty,
+          reason: 'Empty prompt for ${file.uri.pathSegments.last}',
+        );
+
+        final parseInput = sampleOutputForFormat(detected);
+        final parsed = ChatTemplateEngine.parse(
+          rendered.format,
+          parseInput,
+          tools: [tool],
+          parser: rendered.parser,
+          thinkingForcedOpen: rendered.thinkingForcedOpen,
+        );
+
+        final hasAnyPayload =
+            parsed.content.isNotEmpty ||
+            parsed.toolCalls.isNotEmpty ||
+            (parsed.reasoningContent?.isNotEmpty ?? false);
+        expect(
+          hasAnyPayload,
+          isTrue,
+          reason:
+              'Parse produced empty payload for ${file.uri.pathSegments.last}',
+        );
+
+        if (parseInput.contains('get_weather')) {
+          final parsedToolName = parsed.toolCalls.isNotEmpty
+              ? parsed.toolCalls.first.function?.name
+              : null;
+          final preservedInContent = parsed.content.contains('get_weather');
           expect(
-            rendered.prompt.trim(),
-            isNotEmpty,
-            reason: 'Empty prompt for ${file.uri.pathSegments.last}',
-          );
-
-          final parseInput = sampleOutputForFormat(detected);
-          final parsed = ChatTemplateEngine.parse(
-            rendered.format,
-            parseInput,
-            tools: [tool],
-            parser: rendered.parser,
-            thinkingForcedOpen: rendered.thinkingForcedOpen,
-          );
-
-          final hasAnyPayload =
-              parsed.content.isNotEmpty ||
-              parsed.toolCalls.isNotEmpty ||
-              (parsed.reasoningContent?.isNotEmpty ?? false);
-          expect(
-            hasAnyPayload,
+            parsedToolName == 'get_weather' || preservedInContent,
             isTrue,
             reason:
-                'Parse produced empty payload for ${file.uri.pathSegments.last}',
-          );
-
-          if (parseInput.contains('get_weather')) {
-            final parsedToolName = parsed.toolCalls.isNotEmpty
-                ? parsed.toolCalls.first.function?.name
-                : null;
-            final preservedInContent = parsed.content.contains('get_weather');
-            expect(
-              parsedToolName == 'get_weather' || preservedInContent,
-              isTrue,
-              reason:
-                  'Tool payload was neither parsed nor preserved for ${file.uri.pathSegments.last}',
-            );
-          }
-        }
-      },
-      skip: fixtureSkipReason,
-    );
-
-    test(
-      'preserves classified tool-call shapes through render and parse',
-      () {
-        const expectedMarkers = <String, String>{
-          'Kimi-K3.jinja': '<|open|>call tool="get_weather"',
-          'MiniMax-M1.jinja': '<tool_calls>\n{"name": "get_weather"',
-          'MiniMax-M3.jinja': ']<]minimax[>[<invoke name="get_weather">',
-          'deepseek-ai-DeepSeek-V3.2.jinja':
-              '<｜DSML｜invoke name="get_weather">',
-          'deepseek-ai-DeepSeek-V4.jinja': '<｜DSML｜invoke name="get_weather">',
-          'deepseek-ai-DeepSeek-V4-Flash-0731.jinja':
-              '<｜DSML｜invoke name="get_weather">',
-          'muse-glimmer.jinja': '<atem:invoke name="get_weather">',
-          'poolside-Laguna-S-2.1.jinja': '<tool_call>get_weather',
-          'poolside-Laguna-XS-2.1.jinja': '<tool_call>get_weather',
-          'poolside-Laguna-XS.2.jinja': '<tool_call>get_weather',
-        };
-
-        for (final entry in expectedMarkers.entries) {
-          final source = File(
-            '${templatesDir.path}/${entry.key}',
-          ).readAsStringSync();
-          final rendered = ChatTemplateEngine.render(
-            templateSource: source,
-            messages: toolCallHistory,
-            metadata: metadata,
-            addAssistant: false,
-            tools: [tool],
-            parallelToolCalls: true,
-          );
-
-          expect(
-            rendered.prompt,
-            contains(entry.value),
-            reason: 'Tool-call history shape drifted for ${entry.key}',
-          );
-
-          final parseInput = entry.key == 'deepseek-ai-DeepSeek-V3.2.jinja'
-              ? sampleOutputForFormat(
-                  ChatFormat.deepseekV4,
-                ).replaceAll('tool_calls', 'function_calls')
-              : sampleOutputForFormat(ChatFormat.values[rendered.format]);
-          final parsed = ChatTemplateEngine.parse(
-            rendered.format,
-            parseInput,
-            tools: [tool],
-            thinkingForcedOpen: rendered.thinkingForcedOpen,
-          );
-          expect(
-            parsed.toolCalls,
-            hasLength(1),
-            reason: 'Generated tool-call shape was not parsed for ${entry.key}',
-          );
-          expect(parsed.toolCalls.single.function?.name, 'get_weather');
-          expect(
-            parsed.toolCalls.single.function?.arguments,
-            contains('Seoul'),
+                'Tool payload was neither parsed nor preserved for ${file.uri.pathSegments.last}',
           );
         }
-      },
-      skip: fixtureSkipReason,
-    );
+      }
+    }, skip: fixtureSkipReason);
 
-    test(
-      'direct-Jinja grammars preserve tool-choice and prefix semantics',
-      () {
-        const templates = [
-          'Kimi-K3.jinja',
-          'MiniMax-M3.jinja',
-          'deepseek-ai-DeepSeek-V3.2.jinja',
-          'deepseek-ai-DeepSeek-V4.jinja',
-          'muse-glimmer.jinja',
-          'poolside-Laguna-XS-2.1.jinja',
-        ];
-        for (final templateName in templates) {
-          final source = File(
-            '${templatesDir.path}/$templateName',
-          ).readAsStringSync();
-          for (final enableThinking in const [true, false]) {
-            final auto = ChatTemplateEngine.render(
-              templateSource: source,
-              messages: messages,
-              metadata: metadata,
-              tools: [tool],
-              toolChoice: ToolChoice.auto,
-              enableThinking: enableThinking,
-            );
-            expect(auto.grammar, isNotNull, reason: templateName);
-            expect(auto.grammarLazy, isTrue, reason: templateName);
-            expect(auto.grammarTriggers, isNotEmpty, reason: templateName);
+    test('preserves classified tool-call shapes through render and parse', () {
+      const expectedMarkers = <String, String>{
+        'Kimi-K3.jinja': '<|open|>call tool="get_weather"',
+        'MiniMax-M1.jinja': '<tool_calls>\n{"name": "get_weather"',
+        'MiniMax-M3.jinja': ']<]minimax[>[<invoke name="get_weather">',
+        'deepseek-ai-DeepSeek-V3.2.jinja': '<｜DSML｜invoke name="get_weather">',
+        'deepseek-ai-DeepSeek-V4.jinja': '<｜DSML｜invoke name="get_weather">',
+        'deepseek-ai-DeepSeek-V4-Flash-0731.jinja':
+            '<｜DSML｜invoke name="get_weather">',
+        'muse-glimmer.jinja': '<atem:invoke name="get_weather">',
+        'poolside-Laguna-S-2.1.jinja': '<tool_call>get_weather',
+        'poolside-Laguna-XS-2.1.jinja': '<tool_call>get_weather',
+        'poolside-Laguna-XS.2.jinja': '<tool_call>get_weather',
+      };
 
-            final required = ChatTemplateEngine.render(
-              templateSource: source,
-              messages: messages,
-              metadata: metadata,
-              tools: [tool],
-              toolChoice: ToolChoice.required,
-              enableThinking: enableThinking,
-            );
-            expect(required.grammar, isNotNull, reason: templateName);
-            expect(required.grammarLazy, isFalse, reason: templateName);
-            expect(required.grammarTriggers, isEmpty, reason: templateName);
-            expect(
-              required.grammar,
-              startsWith('root ::= required-prefix-0 required-tool-root'),
-              reason: templateName,
-            );
-            expect(
-              required.grammar,
-              anyOf(contains('invoke'), contains('call')),
-              reason: templateName,
-            );
+      for (final entry in expectedMarkers.entries) {
+        final source = File(
+          '${templatesDir.path}/${entry.key}',
+        ).readAsStringSync();
+        final rendered = ChatTemplateEngine.render(
+          templateSource: source,
+          messages: toolCallHistory,
+          metadata: metadata,
+          addAssistant: false,
+          tools: [tool],
+          parallelToolCalls: true,
+        );
 
-            final none = ChatTemplateEngine.render(
-              templateSource: source,
-              messages: messages,
-              metadata: metadata,
-              tools: [tool],
-              toolChoice: ToolChoice.none,
-              enableThinking: enableThinking,
-            );
-            expect(none.grammar, isNull, reason: templateName);
-            expect(none.grammarLazy, isFalse, reason: templateName);
-            expect(none.grammarTriggers, isEmpty, reason: templateName);
-          }
-        }
-      },
-      skip: fixtureSkipReason,
-    );
+        expect(
+          rendered.prompt,
+          contains(entry.value),
+          reason: 'Tool-call history shape drifted for ${entry.key}',
+        );
 
-    test(
-      'DeepSeek grammars retain their template-specific DSML envelopes',
-      () {
-        for (final entry in const {
-          'deepseek-ai-DeepSeek-V3.2.jinja': 'function_calls',
-          'deepseek-ai-DeepSeek-V4.jinja': 'tool_calls',
-        }.entries) {
-          final source = File(
-            '${templatesDir.path}/${entry.key}',
-          ).readAsStringSync();
-          final rendered = ChatTemplateEngine.render(
+        final parseInput = entry.key == 'deepseek-ai-DeepSeek-V3.2.jinja'
+            ? sampleOutputForFormat(
+                ChatFormat.deepseekV4,
+              ).replaceAll('tool_calls', 'function_calls')
+            : sampleOutputForFormat(ChatFormat.values[rendered.format]);
+        final parsed = ChatTemplateEngine.parse(
+          rendered.format,
+          parseInput,
+          tools: [tool],
+          thinkingForcedOpen: rendered.thinkingForcedOpen,
+        );
+        expect(
+          parsed.toolCalls,
+          hasLength(1),
+          reason: 'Generated tool-call shape was not parsed for ${entry.key}',
+        );
+        expect(parsed.toolCalls.single.function?.name, 'get_weather');
+        expect(parsed.toolCalls.single.function?.arguments, contains('Seoul'));
+      }
+    }, skip: fixtureSkipReason);
+
+    test('direct-Jinja grammars preserve tool-choice and prefix semantics', () {
+      const templates = [
+        'Kimi-K3.jinja',
+        'MiniMax-M3.jinja',
+        'deepseek-ai-DeepSeek-V3.2.jinja',
+        'deepseek-ai-DeepSeek-V4.jinja',
+        'muse-glimmer.jinja',
+        'poolside-Laguna-XS-2.1.jinja',
+      ];
+      for (final templateName in templates) {
+        final source = File(
+          '${templatesDir.path}/$templateName',
+        ).readAsStringSync();
+        for (final enableThinking in const [true, false]) {
+          final auto = ChatTemplateEngine.render(
             templateSource: source,
             messages: messages,
             metadata: metadata,
             tools: [tool],
+            toolChoice: ToolChoice.auto,
+            enableThinking: enableThinking,
+          );
+          expect(auto.grammar, isNotNull, reason: templateName);
+          expect(auto.grammarLazy, isTrue, reason: templateName);
+          expect(auto.grammarTriggers, isNotEmpty, reason: templateName);
+
+          final required = ChatTemplateEngine.render(
+            templateSource: source,
+            messages: messages,
+            metadata: metadata,
+            tools: [tool],
+            toolChoice: ToolChoice.required,
+            enableThinking: enableThinking,
+          );
+          expect(required.grammar, isNotNull, reason: templateName);
+          expect(required.grammarLazy, isFalse, reason: templateName);
+          expect(required.grammarTriggers, isEmpty, reason: templateName);
+          expect(
+            required.grammar,
+            startsWith('root ::= required-prefix-0 required-tool-root'),
+            reason: templateName,
           );
           expect(
-            rendered.grammar,
-            startsWith('root ::= "<｜DSML｜${entry.value}>'),
+            required.grammar,
+            anyOf(contains('invoke'), contains('call')),
+            reason: templateName,
           );
-          expect(
-            rendered.grammarTriggers.single.value,
-            '<｜DSML｜${entry.value}>',
+
+          final none = ChatTemplateEngine.render(
+            templateSource: source,
+            messages: messages,
+            metadata: metadata,
+            tools: [tool],
+            toolChoice: ToolChoice.none,
+            enableThinking: enableThinking,
           );
+          expect(none.grammar, isNull, reason: templateName);
+          expect(none.grammarLazy, isFalse, reason: templateName);
+          expect(none.grammarTriggers, isEmpty, reason: templateName);
         }
-      },
-      skip: fixtureSkipReason,
-    );
+      }
+    }, skip: fixtureSkipReason);
+
+    test('DeepSeek grammars retain their template-specific DSML envelopes', () {
+      for (final entry in const {
+        'deepseek-ai-DeepSeek-V3.2.jinja': 'function_calls',
+        'deepseek-ai-DeepSeek-V4.jinja': 'tool_calls',
+      }.entries) {
+        final source = File(
+          '${templatesDir.path}/${entry.key}',
+        ).readAsStringSync();
+        final rendered = ChatTemplateEngine.render(
+          templateSource: source,
+          messages: messages,
+          metadata: metadata,
+          tools: [tool],
+        );
+        expect(
+          rendered.grammar,
+          startsWith('root ::= "<｜DSML｜${entry.value}>'),
+        );
+        expect(rendered.grammarTriggers.single.value, '<｜DSML｜${entry.value}>');
+      }
+    }, skip: fixtureSkipReason);
   });
 }
 

--- a/test/integration/core/template/llama_cpp_template_detection_integration_test.dart
+++ b/test/integration/core/template/llama_cpp_template_detection_integration_test.dart
@@ -8,6 +8,7 @@ import 'package:llamadart/src/core/models/chat/chat_role.dart';
 import 'package:llamadart/src/core/models/chat/content_part.dart';
 import 'package:llamadart/src/core/models/tools/tool_definition.dart';
 import 'package:llamadart/src/core/models/tools/tool_param.dart';
+import 'package:llamadart/src/core/models/inference/tool_choice.dart';
 import 'package:llamadart/src/core/template/chat_format.dart';
 import 'package:llamadart/src/core/template/chat_template_engine.dart';
 import 'package:test/test.dart';
@@ -154,117 +155,232 @@ void main() {
       );
     }, skip: fixtureSkipReason);
 
-    test('renders and parses every vendored llama.cpp template', () {
-      expect(templatesDir.existsSync(), isTrue);
+    test(
+      'renders and parses every vendored llama.cpp template',
+      () {
+        expect(templatesDir.existsSync(), isTrue);
 
-      final files =
-          templatesDir
-              .listSync()
-              .whereType<File>()
-              .where((f) => f.path.endsWith('.jinja'))
-              .toList()
-            ..sort((a, b) => a.path.compareTo(b.path));
+        final files =
+            templatesDir
+                .listSync()
+                .whereType<File>()
+                .where((f) => f.path.endsWith('.jinja'))
+                .toList()
+              ..sort((a, b) => a.path.compareTo(b.path));
 
-      for (final file in files) {
-        final source = file.readAsStringSync();
-        final detected = detectChatFormat(source);
+        for (final file in files) {
+          final source = file.readAsStringSync();
+          final detected = detectChatFormat(source);
 
-        final rendered = ChatTemplateEngine.render(
-          templateSource: source,
-          messages: messages,
-          metadata: metadata,
-          tools: [tool],
-          parallelToolCalls: true,
-        );
+          final rendered = ChatTemplateEngine.render(
+            templateSource: source,
+            messages: messages,
+            metadata: metadata,
+            tools: [tool],
+            parallelToolCalls: true,
+          );
 
-        expect(
-          rendered.prompt.trim(),
-          isNotEmpty,
-          reason: 'Empty prompt for ${file.uri.pathSegments.last}',
-        );
-
-        final parseInput = sampleOutputForFormat(detected);
-        final parsed = ChatTemplateEngine.parse(
-          rendered.format,
-          parseInput,
-          parser: rendered.parser,
-          thinkingForcedOpen: rendered.thinkingForcedOpen,
-        );
-
-        final hasAnyPayload =
-            parsed.content.isNotEmpty ||
-            parsed.toolCalls.isNotEmpty ||
-            (parsed.reasoningContent?.isNotEmpty ?? false);
-        expect(
-          hasAnyPayload,
-          isTrue,
-          reason:
-              'Parse produced empty payload for ${file.uri.pathSegments.last}',
-        );
-
-        if (parseInput.contains('get_weather')) {
-          final parsedToolName = parsed.toolCalls.isNotEmpty
-              ? parsed.toolCalls.first.function?.name
-              : null;
-          final preservedInContent = parsed.content.contains('get_weather');
           expect(
-            parsedToolName == 'get_weather' || preservedInContent,
+            rendered.prompt.trim(),
+            isNotEmpty,
+            reason: 'Empty prompt for ${file.uri.pathSegments.last}',
+          );
+
+          final parseInput = sampleOutputForFormat(detected);
+          final parsed = ChatTemplateEngine.parse(
+            rendered.format,
+            parseInput,
+            tools: [tool],
+            parser: rendered.parser,
+            thinkingForcedOpen: rendered.thinkingForcedOpen,
+          );
+
+          final hasAnyPayload =
+              parsed.content.isNotEmpty ||
+              parsed.toolCalls.isNotEmpty ||
+              (parsed.reasoningContent?.isNotEmpty ?? false);
+          expect(
+            hasAnyPayload,
             isTrue,
             reason:
-                'Tool payload was neither parsed nor preserved for ${file.uri.pathSegments.last}',
+                'Parse produced empty payload for ${file.uri.pathSegments.last}',
+          );
+
+          if (parseInput.contains('get_weather')) {
+            final parsedToolName = parsed.toolCalls.isNotEmpty
+                ? parsed.toolCalls.first.function?.name
+                : null;
+            final preservedInContent = parsed.content.contains('get_weather');
+            expect(
+              parsedToolName == 'get_weather' || preservedInContent,
+              isTrue,
+              reason:
+                  'Tool payload was neither parsed nor preserved for ${file.uri.pathSegments.last}',
+            );
+          }
+        }
+      },
+      skip: fixtureSkipReason,
+    );
+
+    test(
+      'preserves classified tool-call shapes through render and parse',
+      () {
+        const expectedMarkers = <String, String>{
+          'Kimi-K3.jinja': '<|open|>call tool="get_weather"',
+          'MiniMax-M1.jinja': '<tool_calls>\n{"name": "get_weather"',
+          'MiniMax-M3.jinja': ']<]minimax[>[<invoke name="get_weather">',
+          'deepseek-ai-DeepSeek-V3.2.jinja':
+              '<｜DSML｜invoke name="get_weather">',
+          'deepseek-ai-DeepSeek-V4.jinja': '<｜DSML｜invoke name="get_weather">',
+          'deepseek-ai-DeepSeek-V4-Flash-0731.jinja':
+              '<｜DSML｜invoke name="get_weather">',
+          'muse-glimmer.jinja': '<atem:invoke name="get_weather">',
+          'poolside-Laguna-S-2.1.jinja': '<tool_call>get_weather',
+          'poolside-Laguna-XS-2.1.jinja': '<tool_call>get_weather',
+          'poolside-Laguna-XS.2.jinja': '<tool_call>get_weather',
+        };
+
+        for (final entry in expectedMarkers.entries) {
+          final source = File(
+            '${templatesDir.path}/${entry.key}',
+          ).readAsStringSync();
+          final rendered = ChatTemplateEngine.render(
+            templateSource: source,
+            messages: toolCallHistory,
+            metadata: metadata,
+            addAssistant: false,
+            tools: [tool],
+            parallelToolCalls: true,
+          );
+
+          expect(
+            rendered.prompt,
+            contains(entry.value),
+            reason: 'Tool-call history shape drifted for ${entry.key}',
+          );
+
+          final parseInput = entry.key == 'deepseek-ai-DeepSeek-V3.2.jinja'
+              ? sampleOutputForFormat(
+                  ChatFormat.deepseekV4,
+                ).replaceAll('tool_calls', 'function_calls')
+              : sampleOutputForFormat(ChatFormat.values[rendered.format]);
+          final parsed = ChatTemplateEngine.parse(
+            rendered.format,
+            parseInput,
+            tools: [tool],
+            thinkingForcedOpen: rendered.thinkingForcedOpen,
+          );
+          expect(
+            parsed.toolCalls,
+            hasLength(1),
+            reason: 'Generated tool-call shape was not parsed for ${entry.key}',
+          );
+          expect(parsed.toolCalls.single.function?.name, 'get_weather');
+          expect(
+            parsed.toolCalls.single.function?.arguments,
+            contains('Seoul'),
           );
         }
-      }
-    }, skip: fixtureSkipReason);
+      },
+      skip: fixtureSkipReason,
+    );
 
-    test('preserves classified tool-call shapes through render and parse', () {
-      const expectedMarkers = <String, String>{
-        'Kimi-K3.jinja': '<|open|>call tool="get_weather"',
-        'MiniMax-M1.jinja': '<tool_calls>\n{"name": "get_weather"',
-        'MiniMax-M3.jinja': ']<]minimax[>[<invoke name="get_weather">',
-        'deepseek-ai-DeepSeek-V3.2.jinja': '<｜DSML｜invoke name="get_weather">',
-        'deepseek-ai-DeepSeek-V4.jinja': '<｜DSML｜invoke name="get_weather">',
-        'deepseek-ai-DeepSeek-V4-Flash-0731.jinja':
-            '<｜DSML｜invoke name="get_weather">',
-        'muse-glimmer.jinja': '<atem:invoke name="get_weather">',
-        'poolside-Laguna-S-2.1.jinja': '<tool_call>get_weather',
-        'poolside-Laguna-XS-2.1.jinja': '<tool_call>get_weather',
-        'poolside-Laguna-XS.2.jinja': '<tool_call>get_weather',
-      };
+    test(
+      'direct-Jinja grammars preserve tool-choice and prefix semantics',
+      () {
+        const templates = [
+          'Kimi-K3.jinja',
+          'MiniMax-M3.jinja',
+          'deepseek-ai-DeepSeek-V3.2.jinja',
+          'deepseek-ai-DeepSeek-V4.jinja',
+          'muse-glimmer.jinja',
+          'poolside-Laguna-XS-2.1.jinja',
+        ];
+        for (final templateName in templates) {
+          final source = File(
+            '${templatesDir.path}/$templateName',
+          ).readAsStringSync();
+          for (final enableThinking in const [true, false]) {
+            final auto = ChatTemplateEngine.render(
+              templateSource: source,
+              messages: messages,
+              metadata: metadata,
+              tools: [tool],
+              toolChoice: ToolChoice.auto,
+              enableThinking: enableThinking,
+            );
+            expect(auto.grammar, isNotNull, reason: templateName);
+            expect(auto.grammarLazy, isTrue, reason: templateName);
+            expect(auto.grammarTriggers, isNotEmpty, reason: templateName);
 
-      for (final entry in expectedMarkers.entries) {
-        final source = File(
-          '${templatesDir.path}/${entry.key}',
-        ).readAsStringSync();
-        final rendered = ChatTemplateEngine.render(
-          templateSource: source,
-          messages: toolCallHistory,
-          metadata: metadata,
-          addAssistant: false,
-          tools: [tool],
-          parallelToolCalls: true,
-        );
+            final required = ChatTemplateEngine.render(
+              templateSource: source,
+              messages: messages,
+              metadata: metadata,
+              tools: [tool],
+              toolChoice: ToolChoice.required,
+              enableThinking: enableThinking,
+            );
+            expect(required.grammar, isNotNull, reason: templateName);
+            expect(required.grammarLazy, isFalse, reason: templateName);
+            expect(required.grammarTriggers, isEmpty, reason: templateName);
+            expect(
+              required.grammar,
+              startsWith('root ::= required-prefix-0 required-tool-root'),
+              reason: templateName,
+            );
+            expect(
+              required.grammar,
+              anyOf(contains('invoke'), contains('call')),
+              reason: templateName,
+            );
 
-        expect(
-          rendered.prompt,
-          contains(entry.value),
-          reason: 'Tool-call history shape drifted for ${entry.key}',
-        );
+            final none = ChatTemplateEngine.render(
+              templateSource: source,
+              messages: messages,
+              metadata: metadata,
+              tools: [tool],
+              toolChoice: ToolChoice.none,
+              enableThinking: enableThinking,
+            );
+            expect(none.grammar, isNull, reason: templateName);
+            expect(none.grammarLazy, isFalse, reason: templateName);
+            expect(none.grammarTriggers, isEmpty, reason: templateName);
+          }
+        }
+      },
+      skip: fixtureSkipReason,
+    );
 
-        final parsed = ChatTemplateEngine.parse(
-          rendered.format,
-          sampleOutputForFormat(ChatFormat.values[rendered.format]),
-          thinkingForcedOpen: rendered.thinkingForcedOpen,
-        );
-        expect(
-          parsed.toolCalls,
-          hasLength(1),
-          reason: 'Generated tool-call shape was not parsed for ${entry.key}',
-        );
-        expect(parsed.toolCalls.single.function?.name, 'get_weather');
-        expect(parsed.toolCalls.single.function?.arguments, contains('Seoul'));
-      }
-    }, skip: fixtureSkipReason);
+    test(
+      'DeepSeek grammars retain their template-specific DSML envelopes',
+      () {
+        for (final entry in const {
+          'deepseek-ai-DeepSeek-V3.2.jinja': 'function_calls',
+          'deepseek-ai-DeepSeek-V4.jinja': 'tool_calls',
+        }.entries) {
+          final source = File(
+            '${templatesDir.path}/${entry.key}',
+          ).readAsStringSync();
+          final rendered = ChatTemplateEngine.render(
+            templateSource: source,
+            messages: messages,
+            metadata: metadata,
+            tools: [tool],
+          );
+          expect(
+            rendered.grammar,
+            startsWith('root ::= "<｜DSML｜${entry.value}>'),
+          );
+          expect(
+            rendered.grammarTriggers.single.value,
+            '<｜DSML｜${entry.value}>',
+          );
+        }
+      },
+      skip: fixtureSkipReason,
+    );
   });
 }
 

--- a/test/unit/core/engine/chat_completion_stream_parser_test.dart
+++ b/test/unit/core/engine/chat_completion_stream_parser_test.dart
@@ -1,5 +1,7 @@
 import 'package:llamadart/src/core/engine/chat_completion_stream_parser.dart';
 import 'package:llamadart/src/core/models/chat/chat_template_result.dart';
+import 'package:llamadart/src/core/models/tools/tool_definition.dart';
+import 'package:llamadart/src/core/models/tools/tool_param.dart';
 import 'package:llamadart/src/core/template/chat_format.dart';
 import 'package:test/test.dart';
 
@@ -152,5 +154,121 @@ void main() {
         expect(chunks.last.choices.single.finishReason, 'tool_calls');
       },
     );
+
+    test(
+      'keeps schema-directed MiniMax values typed across partial chunks',
+      () async {
+        const namespace = ']<]minimax[>[';
+        final chunks = await ChatCompletionStreamParser.parse(
+          tokenStream: Stream.fromIterable(<String>[
+            'On it.',
+            ...'$namespace<tool_call>\n$namespace<invoke name="typed">'.split(
+              '',
+            ),
+            '$namespace<code>12',
+            '3$namespace</code>',
+            '$namespace<options>$namespace</options>',
+            '$namespace<items>$namespace</items>',
+            '$namespace</invoke>\n$namespace</tool_call>',
+          ]),
+          templateResult: LlamaChatTemplateResult(
+            prompt: 'prompt',
+            format: ChatFormat.minimaxM3.index,
+          ),
+          tools: [_typedTool],
+          parseToolCallsEnabled: true,
+          enableThinking: true,
+          modelName: 'test-model',
+          completionId: 'm3-stream',
+        ).toList();
+
+        final content = chunks
+            .map((chunk) => chunk.choices.single.delta.content ?? '')
+            .join();
+        final toolCall = chunks
+            .firstWhere((chunk) => chunk.choices.single.delta.toolCalls != null)
+            .choices
+            .single
+            .delta
+            .toolCalls!
+            .single;
+
+        expect(content, 'On it.');
+        expect(toolCall.function?.name, 'typed');
+        expect(
+          toolCall.function?.arguments,
+          '{"code":"123","options":{},"items":[]}',
+        );
+        expect(chunks.last.choices.single.finishReason, 'tool_calls');
+      },
+    );
+
+    test(
+      'does not leak a character-split Muse route before its tool call',
+      () async {
+        const toolOutput =
+            '<|start|>assistant to=weather<|message|>'
+            '<atem:function_calls>\n'
+            '<atem:invoke name="weather">\n'
+            '<atem:parameter name="city">Seoul</atem:parameter>\n'
+            '</atem:invoke>\n'
+            '</atem:function_calls>';
+        final chunks = await ChatCompletionStreamParser.parse(
+          tokenStream: Stream.fromIterable(<String>[
+            'Prelude',
+            ...toolOutput.split(''),
+          ]),
+          templateResult: LlamaChatTemplateResult(
+            prompt: 'prompt',
+            format: ChatFormat.museGlimmer.index,
+          ),
+          tools: [_weatherTool],
+          parseToolCallsEnabled: true,
+          enableThinking: true,
+          modelName: 'test-model',
+          completionId: 'muse-stream',
+        ).toList();
+
+        final content = chunks
+            .map((chunk) => chunk.choices.single.delta.content ?? '')
+            .join();
+        final toolCall = chunks
+            .firstWhere((chunk) => chunk.choices.single.delta.toolCalls != null)
+            .choices
+            .single
+            .delta
+            .toolCalls!
+            .single;
+
+        expect(content, 'Prelude');
+        expect(content, isNot(contains('<|start|>')));
+        expect(content, isNot(contains('assistant to=')));
+        expect(toolCall.function?.name, 'weather');
+        expect(toolCall.function?.arguments, '{"city":"Seoul"}');
+        expect(chunks.last.choices.single.finishReason, 'tool_calls');
+      },
+    );
   });
 }
+
+final _weatherTool = ToolDefinition(
+  name: 'weather',
+  description: 'Weather',
+  parameters: [ToolParam.string('city', required: true)],
+  handler: (_) async => null,
+);
+
+final _typedTool = ToolDefinition(
+  name: 'typed',
+  description: 'Typed values',
+  parameters: [
+    ToolParam.string('code', required: true),
+    ToolParam.object('options', properties: const [], required: true),
+    ToolParam.array(
+      'items',
+      itemType: ToolParam.string('item'),
+      required: true,
+    ),
+  ],
+  handler: (_) async => null,
+);

--- a/test/unit/core/template/handlers/glm45_handler_test.dart
+++ b/test/unit/core/template/handlers/glm45_handler_test.dart
@@ -118,6 +118,10 @@ void main() {
       '<tool_call>get_weather\n'
           '<arg_key>city</arg_key><arg_value>"Rome"</arg_value>\n'
           '</tool_call>',
+      '<tool_call>get_weather\n'
+          '<arg_key>city</arg_key><arg_value>"Seoul"</arg_value>\n'
+          '<arg_key>city</arg_key><arg_value>"Paris"</arg_value>\n'
+          '</tool_call>',
     ]) {
       final output = '$valid$invalid';
       final parsed = ChatTemplateEngine.parse(

--- a/test/unit/core/template/handlers/glm45_handler_test.dart
+++ b/test/unit/core/template/handlers/glm45_handler_test.dart
@@ -4,6 +4,8 @@ import 'package:llamadart/src/core/models/chat/chat_message.dart';
 import 'package:llamadart/src/core/models/chat/chat_role.dart';
 import 'package:llamadart/src/core/models/tools/tool_definition.dart';
 import 'package:llamadart/src/core/models/tools/tool_param.dart';
+import 'package:llamadart/src/core/template/chat_format.dart';
+import 'package:llamadart/src/core/template/chat_template_engine.dart';
 import 'package:llamadart/src/core/template/handlers/glm45_handler.dart';
 import 'package:test/test.dart';
 
@@ -59,6 +61,39 @@ void main() {
     final noToolParse = handler.parse('plain response', parseToolCalls: false);
     expect(noToolParse.content, equals('plain response'));
     expect(noToolParse.toolCalls, isEmpty);
+  });
+
+  test('schema-aware parsing decodes quoted strings before enum checks', () {
+    final tool = ToolDefinition(
+      name: 'get_weather',
+      description: 'Get weather',
+      parameters: [
+        ToolParam.enumType(
+          'city',
+          values: const ['Seoul', 'Paris'],
+          required: true,
+        ),
+        ToolParam.string('code', required: true),
+      ],
+      handler: _noop,
+    );
+    const output =
+        '<tool_call>get_weather\n'
+        '<arg_key>city</arg_key><arg_value>"Seoul"</arg_value>\n'
+        '<arg_key>code</arg_key><arg_value>123</arg_value>\n'
+        '</tool_call>';
+
+    final parsed = ChatTemplateEngine.parse(
+      ChatFormat.glm45.index,
+      output,
+      tools: [tool],
+    );
+
+    expect(parsed.toolCalls, hasLength(1));
+    expect(jsonDecode(parsed.toolCalls.single.function!.arguments!), {
+      'city': 'Seoul',
+      'code': '123',
+    });
   });
 }
 

--- a/test/unit/core/template/handlers/glm45_handler_test.dart
+++ b/test/unit/core/template/handlers/glm45_handler_test.dart
@@ -95,6 +95,41 @@ void main() {
       'code': '123',
     });
   });
+
+  test('schema-aware parsing rolls back all mixed-validity calls', () {
+    final tool = ToolDefinition(
+      name: 'get_weather',
+      description: 'Get weather',
+      parameters: [
+        ToolParam.enumType(
+          'city',
+          values: const ['Seoul', 'Paris'],
+          required: true,
+        ),
+      ],
+      handler: _noop,
+    );
+    const valid =
+        '<tool_call>get_weather\n'
+        '<arg_key>city</arg_key><arg_value>"Seoul"</arg_value>\n'
+        '</tool_call>';
+    for (final invalid in const [
+      '<tool_call>unknown\n</tool_call>',
+      '<tool_call>get_weather\n'
+          '<arg_key>city</arg_key><arg_value>"Rome"</arg_value>\n'
+          '</tool_call>',
+    ]) {
+      final output = '$valid$invalid';
+      final parsed = ChatTemplateEngine.parse(
+        ChatFormat.glm45.index,
+        output,
+        tools: [tool],
+      );
+
+      expect(parsed.toolCalls, isEmpty, reason: invalid);
+      expect(parsed.content, output, reason: invalid);
+    }
+  });
 }
 
 Future<Object?> _noop(_) async {

--- a/test/unit/core/template/handlers/llama_cpp_specialized_handlers_test.dart
+++ b/test/unit/core/template/handlers/llama_cpp_specialized_handlers_test.dart
@@ -49,20 +49,57 @@ void main() {
     test('grammar permits the upstream raw JSON argument block', () {
       final grammar = KimiK3Handler().buildGrammar([_weatherTool])!;
 
-      expect(grammar, contains('(argument* | json-block)'));
+      expect(grammar, contains('kimi-0-json-block'));
       expect(grammar, contains(r'(" index=\"" [0-9]+ "\"")? "<|sep|>"'));
       expect(
         grammar,
-        contains(r'"<|open|>json type=\"object\"<|sep|>" json-object'),
+        contains(r'"<|open|>json type=\"object\"<|sep|>" kimi-0-json-object'),
       );
-      expect(grammar, contains('char ::= '));
     });
 
     test('grammar HTML-escapes tool names like the upstream XTML macro', () {
       final grammar = KimiK3Handler().buildGrammar([_attributeTool])!;
 
-      expect(grammar, contains(r'tool-name ::= "weather&amp;&quot;alerts"'));
-      expect(grammar, isNot(contains(r'tool-name ::= "weather&\"alerts"')));
+      expect(grammar, contains(r'tool=\"weather&amp;&quot;alerts\"'));
+      expect(grammar, isNot(contains(r'tool=\"weather&\"alerts\"')));
+    });
+
+    test('grammar and parser round-trip escaped schema property names', () {
+      final grammar = KimiK3Handler().buildGrammar([_escapedKeyTool])!;
+      const output =
+          '<|open|>tools<|sep|>'
+          '<|open|>call tool="weather&amp;&quot;alerts"<|sep|>'
+          '<|open|>argument key="city&amp;&quot;unit" type="string"<|sep|>'
+          'x < 5<|close|>argument<|sep|>'
+          '<|close|>call<|sep|><|close|>tools<|sep|>'
+          '<|close|>message<|sep|>';
+
+      expect(grammar, contains('key=\\"city&amp;&quot;unit\\"'));
+      expect(grammar, isNot(contains('identifier ::=')));
+      final parsed = ChatTemplateEngine.parse(
+        ChatFormat.kimiK3.index,
+        output,
+        tools: [_escapedKeyTool],
+      );
+      expect(parsed.content, isEmpty);
+      expect(parsed.toolCalls.single.function?.name, 'weather&"alerts');
+      expect(_arguments(parsed), {'city&"unit': 'x < 5'});
+    });
+
+    test('schema-aware parsing rejects missing or undeclared arguments', () {
+      const output =
+          '<|open|>tools<|sep|>'
+          '<|open|>call tool="weather"<|sep|>'
+          '<|open|>argument key="unknown" type="string"<|sep|>x'
+          '<|close|>argument<|sep|><|close|>call<|sep|>'
+          '<|close|>tools<|sep|><|close|>message<|sep|>';
+      final parsed = ChatTemplateEngine.parse(
+        ChatFormat.kimiK3.index,
+        output,
+        tools: [_weatherWithCityTool],
+      );
+      expect(parsed.toolCalls, isEmpty);
+      expect(parsed.content, contains('key="unknown"'));
     });
 
     test(
@@ -106,6 +143,15 @@ void main() {
       expect(parsed.toolCalls, isEmpty);
       expect(parsed.content, contains('<|open|>tools<|sep|>'));
       expect(parsed.content, contains('On it.'));
+    });
+
+    test('suppresses a split tools marker while streaming', () {
+      final parsed = KimiK3Handler().parse(
+        '<|open|>response<|sep|>On it.<|close|>response<|sep|><|op',
+        isPartial: true,
+      );
+      expect(parsed.content, 'On it.');
+      expect(parsed.toolCalls, isEmpty);
     });
   });
 
@@ -152,6 +198,27 @@ void main() {
       expect(grammar, contains(r'[^"\\\x7F\x00-\x1F]'));
       expect(grammar, contains(r'[\\] (["\\bfnrt] | "u"'));
       expect(grammar, isNot(contains('json-char ::=')));
+      expect(callRule, contains(r'"\"weather\""'));
+    });
+
+    test('schema-aware parsing rejects unknown tool names', () {
+      const output =
+          '<tool_calls>\n'
+          '{"name":"unknown","arguments":{"city":"Seoul"}}\n'
+          '</tool_calls>';
+      final parsed = ChatTemplateEngine.parse(
+        ChatFormat.minimaxM1.index,
+        output,
+        tools: [_weatherWithCityTool],
+      );
+      expect(parsed.toolCalls, isEmpty);
+      expect(parsed.content, output);
+    });
+
+    test('suppresses a split tool-call marker while streaming', () {
+      final parsed = MinimaxM1Handler().parse('Prelude<tool_', isPartial: true);
+      expect(parsed.content, 'Prelude');
+      expect(parsed.toolCalls, isEmpty);
     });
   });
 
@@ -216,6 +283,15 @@ void main() {
       expect(parsed.toolCalls, isEmpty);
     });
 
+    test('suppresses a split namespace marker while streaming', () {
+      final parsed = MinimaxM3Handler().parse(
+        'Prelude${ns.substring(0, ns.length - 2)}',
+        isPartial: true,
+      );
+      expect(parsed.content, 'Prelude');
+      expect(parsed.toolCalls, isEmpty);
+    });
+
     test('keeps completed calls before a partial invoke', () {
       const output =
           'Prelude$ns<tool_call>\n'
@@ -228,6 +304,58 @@ void main() {
       expect(parsed.toolCalls, hasLength(1));
       expect(parsed.toolCalls.single.function?.name, 'weather');
       expect(_arguments(parsed), {'city': 'Seoul'});
+    });
+
+    test('parses zero-argument calls with an empty object', () {
+      const output =
+          '$ns<tool_call>\n'
+          '$ns<invoke name="ping">$ns</invoke>\n'
+          '$ns</tool_call>';
+      final parsed = ChatTemplateEngine.parse(
+        ChatFormat.minimaxM3.index,
+        output,
+        tools: [_pingTool],
+      );
+      expect(parsed.content, isEmpty);
+      expect(parsed.toolCalls.single.function?.name, 'ping');
+      expect(_arguments(parsed), isEmpty);
+    });
+
+    test('reconstructs schema-directed scalars and empty containers', () {
+      const output =
+          '$ns<tool_call>\n'
+          '$ns<invoke name="typed">'
+          '$ns<code>123$ns</code>'
+          '$ns<options>$ns</options>'
+          '$ns<items>$ns</items>'
+          '$ns</invoke>\n$ns</tool_call>';
+      final parsed = ChatTemplateEngine.parse(
+        ChatFormat.minimaxM3.index,
+        output,
+        tools: [_typedTool],
+      );
+      expect(_arguments(parsed), {'code': '123', 'options': {}, 'items': []});
+    });
+
+    test('schema grammar uses identical literal parameter tag pairs', () {
+      final grammar = MinimaxM3Handler().buildGrammar([_typedTool])!;
+      expect(grammar, contains('$ns<code>'));
+      expect(grammar, contains('$ns</code>'));
+      expect(grammar, isNot(contains('identifier ::=')));
+      expect(grammar, contains('m3-0-arguments-code-text'));
+    });
+
+    test('preserves mismatched parameter closing tags', () {
+      const output =
+          '$ns<tool_call>$ns<invoke name="typed">'
+          '$ns<code>123$ns</items>$ns</invoke>$ns</tool_call>';
+      final parsed = ChatTemplateEngine.parse(
+        ChatFormat.minimaxM3.index,
+        output,
+        tools: [_typedTool],
+      );
+      expect(parsed.toolCalls, isEmpty);
+      expect(parsed.content, output);
     });
   });
 
@@ -262,6 +390,130 @@ void main() {
       final parsed = DeepseekV4Handler().parse(output);
       expect(parsed.toolCalls, isEmpty);
       expect(parsed.content, output);
+    });
+
+    test('parses the V3.2 function_calls envelope', () {
+      const output =
+          'check first'
+          '<｜DSML｜function_calls>\n'
+          '<｜DSML｜invoke name="weather">\n'
+          '<｜DSML｜parameter name="city" string="true">x < 5'
+          '</｜DSML｜parameter>\n'
+          '</｜DSML｜invoke>\n'
+          '</｜DSML｜function_calls>';
+      final parsed = ChatTemplateEngine.parse(
+        ChatFormat.deepseekV4.index,
+        output,
+        tools: [_weatherWithCityTool],
+        thinkingForcedOpen: true,
+      );
+      expect(parsed.reasoningContent, 'check first');
+      expect(parsed.content, isEmpty);
+      expect(_arguments(parsed), {'city': 'x < 5'});
+    });
+
+    test('preserves malformed and finalized truncated V3.2 envelopes', () {
+      const malformed =
+          '<｜DSML｜function_calls>\n'
+          '<｜DSML｜invoke name="weather">\n'
+          '<｜DSML｜parameter name="city" string="true">Seoul'
+          '</｜DSML｜parameter>\n'
+          '</｜DSML｜tool_calls>';
+      const truncated =
+          '<｜DSML｜function_calls>\n'
+          '<｜DSML｜invoke name="weather">\n'
+          '<｜DSML｜parameter name="city" string="true">Seo';
+
+      final malformedParsed = ChatTemplateEngine.parse(
+        ChatFormat.deepseekV4.index,
+        malformed,
+        tools: [_weatherWithCityTool],
+      );
+      final finalizedTruncated = ChatTemplateEngine.parse(
+        ChatFormat.deepseekV4.index,
+        truncated,
+        tools: [_weatherWithCityTool],
+      );
+      final partialTruncated = ChatTemplateEngine.parse(
+        ChatFormat.deepseekV4.index,
+        'reasoning$truncated',
+        tools: [_weatherWithCityTool],
+        thinkingForcedOpen: true,
+        isPartial: true,
+      );
+
+      expect(malformedParsed.toolCalls, isEmpty);
+      expect(malformedParsed.content, malformed);
+      expect(finalizedTruncated.toolCalls, isEmpty);
+      expect(finalizedTruncated.content, truncated);
+      expect(partialTruncated.reasoningContent, 'reasoning');
+      expect(partialTruncated.content, isEmpty);
+      expect(partialTruncated.toolCalls, isEmpty);
+    });
+
+    test('preserves V3.2 markup when tool parsing is disabled', () {
+      const output =
+          '<｜DSML｜function_calls>\n'
+          '<｜DSML｜invoke name="weather">\n'
+          '<｜DSML｜parameter name="city" string="true">Seoul'
+          '</｜DSML｜parameter>\n'
+          '</｜DSML｜invoke>\n'
+          '</｜DSML｜function_calls>';
+
+      final parsed = DeepseekV4Handler().parse(output, parseToolCalls: false);
+
+      expect(parsed.toolCalls, isEmpty);
+      expect(parsed.content, output);
+    });
+
+    test('parses a V3.2 tool name containing regex metacharacters', () {
+      const output =
+          '<｜DSML｜function_calls>\n'
+          '<｜DSML｜invoke name="weather.v2+alerts[0]">\n'
+          '</｜DSML｜invoke>\n'
+          '</｜DSML｜function_calls>';
+
+      final parsed = ChatTemplateEngine.parse(
+        ChatFormat.deepseekV4.index,
+        output,
+        tools: [_regexNameTool],
+      );
+
+      expect(parsed.content, isEmpty);
+      expect(parsed.toolCalls.single.function?.name, 'weather.v2+alerts[0]');
+      expect(_arguments(parsed), isEmpty);
+    });
+
+    test('DSML envelope ends forced-open thinking without a think close', () {
+      const output =
+          'reasoning'
+          '<｜DSML｜tool_calls>\n'
+          '<｜DSML｜invoke name="weather">\n'
+          '<｜DSML｜parameter name="city" string="true">Seoul'
+          '</｜DSML｜parameter>\n'
+          '</｜DSML｜invoke>\n'
+          '</｜DSML｜tool_calls>';
+      final parsed = ChatTemplateEngine.parse(
+        ChatFormat.deepseekV4.index,
+        output,
+        tools: [_weatherWithCityTool],
+        thinkingForcedOpen: true,
+      );
+      expect(parsed.reasoningContent, 'reasoning');
+      expect(_arguments(parsed), {'city': 'Seoul'});
+    });
+
+    test('suppresses a partial DSML envelope after forced reasoning', () {
+      final parsed = ChatTemplateEngine.parse(
+        ChatFormat.deepseekV4.index,
+        'reasoning<｜DSML｜function_',
+        tools: [_weatherWithCityTool],
+        thinkingForcedOpen: true,
+        isPartial: true,
+      );
+      expect(parsed.reasoningContent, 'reasoning');
+      expect(parsed.content, isEmpty);
+      expect(parsed.toolCalls, isEmpty);
     });
   });
 
@@ -318,9 +570,43 @@ void main() {
       expect(handler.grammarTriggerValues, ['<atem:function_calls>']);
       expect(
         grammar.split('\n').first,
-        r'root ::= "<atem:function_calls>\n" invoke "</atem:function_calls>"',
+        r'root ::= "<atem:function_calls>\n" invoke+ "</atem:function_calls>"',
       );
       expect(grammar.split('\n').first, isNot(contains(' to=')));
+    });
+
+    test('preserves unmatched surrounding content around channels', () {
+      const output =
+          'prefix<|start|>assistant to=user<|message|>Hello<|eot|>suffix';
+      final parsed = MuseGlimmerHandler().parse(output);
+      expect(parsed.content, 'prefixHellosuffix');
+    });
+
+    test('suppresses an incomplete routing prefix while streaming', () {
+      for (final output in [
+        'Prelude to=weather',
+        'Prelude<|start|>assis',
+        'Prelude<|start|>assistant to=wea',
+      ]) {
+        final parsed = MuseGlimmerHandler().parse(output, isPartial: true);
+        expect(parsed.content, 'Prelude', reason: output);
+      }
+    });
+
+    test('uses the schema to keep JSON-looking strings as strings', () {
+      const output =
+          ' to=typed<|message|><atem:function_calls>\n'
+          '<atem:invoke name="typed">\n'
+          '<atem:parameter name="code">123</atem:parameter>\n'
+          '<atem:parameter name="options">{}</atem:parameter>\n'
+          '<atem:parameter name="items">[]</atem:parameter>\n'
+          '</atem:invoke>\n</atem:function_calls><|eot|>';
+      final parsed = ChatTemplateEngine.parse(
+        ChatFormat.museGlimmer.index,
+        output,
+        tools: [_typedTool],
+      );
+      expect(_arguments(parsed), {'code': '123', 'options': {}, 'items': []});
     });
   });
 
@@ -347,6 +633,37 @@ void main() {
       expect(parsed.toolCalls, isEmpty);
       expect(parsed.content, output);
     });
+
+    test('suppresses partial markup and restores it at finalization', () {
+      const output =
+          'Prelude<tool_call>weather<arg_key>city</arg_key>'
+          '<arg_value>Seo';
+      final partial = LagunaHandler().parse(output, isPartial: true);
+      final complete = LagunaHandler().parse(output);
+      expect(partial.content, 'Prelude');
+      expect(complete.content, output);
+    });
+
+    test('suppresses a split tool marker while streaming', () {
+      final parsed = LagunaHandler().parse('Prelude<tool_', isPartial: true);
+      expect(parsed.content, 'Prelude');
+      expect(parsed.toolCalls, isEmpty);
+    });
+
+    test('uses schema-directed values through the production parse path', () {
+      const output =
+          '<tool_call>typed\n'
+          '<arg_key>code</arg_key>\n<arg_value>123</arg_value>\n'
+          '<arg_key>options</arg_key>\n<arg_value>{}</arg_value>\n'
+          '<arg_key>items</arg_key>\n<arg_value>[]</arg_value>\n'
+          '</tool_call>';
+      final parsed = ChatTemplateEngine.parse(
+        ChatFormat.laguna.index,
+        output,
+        tools: [_typedTool],
+      );
+      expect(_arguments(parsed), {'code': '123', 'options': {}, 'items': []});
+    });
   });
 }
 
@@ -368,6 +685,42 @@ final _attributeTool = ToolDefinition(
   name: 'weather&"alerts',
   description: 'Weather alerts',
   parameters: const [],
+  handler: (_) async => null,
+);
+
+final _escapedKeyTool = ToolDefinition(
+  name: 'weather&"alerts',
+  description: 'Weather alerts',
+  parameters: [ToolParam.string('city&"unit', required: true)],
+  handler: (_) async => null,
+);
+
+final _pingTool = ToolDefinition(
+  name: 'ping',
+  description: 'Ping',
+  parameters: const [],
+  handler: (_) async => null,
+);
+
+final _regexNameTool = ToolDefinition(
+  name: 'weather.v2+alerts[0]',
+  description: 'Weather alerts',
+  parameters: const [],
+  handler: (_) async => null,
+);
+
+final _typedTool = ToolDefinition(
+  name: 'typed',
+  description: 'Typed values',
+  parameters: [
+    ToolParam.string('code', required: true),
+    ToolParam.object('options', properties: const [], required: true),
+    ToolParam.array(
+      'items',
+      itemType: ToolParam.string('item'),
+      required: true,
+    ),
+  ],
   handler: (_) async => null,
 );
 

--- a/test/unit/core/template/handlers/llama_cpp_specialized_handlers_test.dart
+++ b/test/unit/core/template/handlers/llama_cpp_specialized_handlers_test.dart
@@ -102,6 +102,28 @@ void main() {
       expect(parsed.content, contains('key="unknown"'));
     });
 
+    test('preserves duplicate schema arguments as malformed content', () {
+      const output =
+          '<|open|>tools<|sep|>'
+          '<|open|>call tool="weather"<|sep|>'
+          '<|open|>argument key="city" type="string"<|sep|>Seoul'
+          '<|close|>argument<|sep|>'
+          '<|open|>argument key="city" type="string"<|sep|>Paris'
+          '<|close|>argument<|sep|>'
+          '<|close|>call<|sep|><|close|>tools<|sep|>'
+          '<|close|>message<|sep|>';
+      final parsed = ChatTemplateEngine.parse(
+        ChatFormat.kimiK3.index,
+        output,
+        tools: [_weatherWithCityTool],
+      );
+
+      expect(parsed.toolCalls, isEmpty);
+      expect(parsed.content, contains('<|open|>tools<|sep|>'));
+      expect(parsed.content, contains('Seoul'));
+      expect(parsed.content, contains('Paris'));
+    });
+
     test(
       'parses a tool call without the optional upstream index attribute',
       () {
@@ -392,6 +414,25 @@ void main() {
       expect(parsed.content, output);
     });
 
+    test('preserves duplicate DSML parameters as malformed content', () {
+      const output =
+          '<｜DSML｜tool_calls>\n'
+          '<｜DSML｜invoke name="weather">\n'
+          '<｜DSML｜parameter name="city" string="true">Seoul'
+          '</｜DSML｜parameter>\n'
+          '<｜DSML｜parameter name="city" string="true">Paris'
+          '</｜DSML｜parameter>\n'
+          '</｜DSML｜invoke>\n</｜DSML｜tool_calls>';
+      final parsed = ChatTemplateEngine.parse(
+        ChatFormat.deepseekV4.index,
+        output,
+        tools: [_weatherWithCityTool],
+      );
+
+      expect(parsed.toolCalls, isEmpty);
+      expect(parsed.content, output);
+    });
+
     test('parses the V3.2 function_calls envelope', () {
       const output =
           'check first'
@@ -549,6 +590,25 @@ void main() {
       final parsed = MuseGlimmerHandler().parse(output);
       expect(parsed.toolCalls, isEmpty);
       expect(parsed.content, contains('broken'));
+    });
+
+    test('preserves duplicate ATEM parameters as malformed content', () {
+      const duplicateAtem =
+          '<atem:function_calls>\n'
+          '<atem:invoke name="weather">\n'
+          '<atem:parameter name="city">Seoul</atem:parameter>\n'
+          '<atem:parameter name="city">Paris</atem:parameter>\n'
+          '</atem:invoke>\n'
+          '</atem:function_calls>';
+      const output = ' to=weather<|message|>$duplicateAtem<|eot|>';
+      final parsed = ChatTemplateEngine.parse(
+        ChatFormat.museGlimmer.index,
+        output,
+        tools: [_weatherWithCityTool],
+      );
+
+      expect(parsed.toolCalls, isEmpty);
+      expect(parsed.content, contains(duplicateAtem));
     });
 
     test('hides an incomplete tool channel while streaming', () {

--- a/test/unit/core/template/tool_call_grammar_utils_test.dart
+++ b/test/unit/core/template/tool_call_grammar_utils_test.dart
@@ -4,6 +4,18 @@ import 'package:llamadart/src/core/template/tool_call_grammar_utils.dart';
 import 'package:test/test.dart';
 
 void main() {
+  test('ruleName preserves safe names and distinguishes escaped runes', () {
+    expect(ToolCallGrammarUtils.ruleName('code'), 'code');
+    expect(
+      ToolCallGrammarUtils.ruleName('a b'),
+      isNot(ToolCallGrammarUtils.ruleName('a-b')),
+    );
+    expect(
+      ToolCallGrammarUtils.ruleName('Weather'),
+      isNot(ToolCallGrammarUtils.ruleName('weather')),
+    );
+  });
+
   test('wrapRootGrammar wraps root rule with literals', () {
     const grammar = 'root ::= obj\nobj ::= "{}"\n';
 

--- a/tool/testing/run_llama_cpp_chat_tests.sh
+++ b/tool/testing/run_llama_cpp_chat_tests.sh
@@ -64,9 +64,10 @@ resolve_target() {
 chat_parser_target="$(resolve_target chat-parser test-chat-parser test-chat-auto-parser)"
 peg_parser_target="$(resolve_target peg-parser test-chat-peg-parser)"
 template_target="$(resolve_target chat-template test-chat-template)"
+grammar_validator_target="$(resolve_target gbnf-validator test-gbnf-validator)"
 
 ctest_targets=("${chat_parser_target}" "${peg_parser_target}" "${template_target}")
-targets=("${ctest_targets[@]}")
+targets=("${ctest_targets[@]}" "${grammar_validator_target}")
 if [[ "${include_full}" == "1" ]]; then
   full_target="$(resolve_target full-chat test-chat)"
   targets+=("${full_target}")

--- a/tool/testing/run_template_parity_suites.sh
+++ b/tool/testing/run_template_parity_suites.sh
@@ -15,3 +15,6 @@ dart test -p vm -j 1 test/unit/core/template --exclude-tags local-only
 
 echo "[template-parity] upstream llama.cpp chat/template parser suites"
 dart test -p vm -j 1 test/e2e/template/llama_cpp_chat_tests_e2e_test.dart --run-skipped
+
+echo "[template-parity] compiled specialized grammar acceptance"
+dart test -p vm -j 1 test/e2e/template/specialized_grammar_acceptance_e2e_test.dart --run-skipped

--- a/tool/testing/test_matrix.dart
+++ b/tool/testing/test_matrix.dart
@@ -396,7 +396,10 @@ const List<TestMatrixRow> testMatrixRows = <TestMatrixRow>[
     id: 'template-parity',
     tier: 'targeted',
     mode: 'local-only',
-    covers: 'vendored llama.cpp chat-template detection/render/parse parity',
+    covers:
+        'vendored llama.cpp chat-template detection/render/parse parity, '
+        'pinned upstream chat tests, and compiled specialized grammar '
+        'acceptance/rejection',
     command: 'tool/testing/run_template_parity_suites.sh',
     useWhen: 'Template engine, handlers, grammar, or parser changes.',
   ),


### PR DESCRIPTION
## Superseded

This donor PR is superseded by canonical recovery PR #421. Every valuable unique change was audited and either preserved or strengthened there, including collision-free grammar rule identifiers, compiled collision coverage, schema-aware specialized dispatch, GLM delimiter and rollback behavior, required-mode pinned-template integration, partial streaming coverage, bounded optional-property state expansion, and durable parity guidance.

The detailed reconciliation and validation evidence is recorded in the closing comment on this PR. Issue #423 remains separate for Command R7B/Hermes.

Related issues: #394, #395, #396, #397, #398, #399, #402, #406, #407, #408, and #410.

This closed donor intentionally has no issue-closing directives; #421 is the sole canonical closing PR.