### PR TITLE
Fix collision-prone tool grammar rule names

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 ## Unreleased
 
+* Fixed Command R7B, Hermes, and Hunyuan V3 tool grammars so distinct tool or
+  parameter names cannot collide after conversion to internal GBNF rule names.
+
 * Fixed DeepSeek V3.2 DSML tool calls using their upstream
   `<｜DSML｜function_calls>` envelope while preserving DeepSeek V4's distinct
   `<｜DSML｜tool_calls>` grammar and parser behavior.

--- a/lib/src/core/template/handlers/command_r7b_handler.dart
+++ b/lib/src/core/template/handlers/command_r7b_handler.dart
@@ -1,3 +1,5 @@
+import 'dart:convert';
+
 import 'package:dinja/dinja.dart';
 
 import '../../models/chat/chat_message.dart';
@@ -10,7 +12,9 @@ import '../chat_parse_result.dart';
 import '../chat_template_handler.dart';
 import '../template_internal_metadata.dart';
 import '../thinking_utils.dart';
+import '../tool_call_grammar_utils.dart';
 import '../tool_call_parsing_utils.dart';
+import '../tool_schema_utils.dart';
 
 /// Handler for Command R7B format.
 ///
@@ -253,21 +257,23 @@ class CommandR7BHandler extends ChatTemplateHandler {
   @override
   String? buildGrammar(List<ToolDefinition>? tools) {
     if (tools == null || tools.isEmpty) return null;
+    toolSchemas(tools);
 
     // Build GBNF for Command R7B style tool calls
     final toolRules = <String>[];
     final toolChoices = <String>[];
 
     for (final tool in tools) {
-      final ruleName = _sanitizeName(tool.name);
+      final ruleName = ToolCallGrammarUtils.ruleName(tool.name);
       toolChoices.add('$ruleName-call');
 
       final schema = tool.toJsonSchema();
       final argsRule = _jsonSchemaToGbnf(schema, '$ruleName-args');
       toolRules.add(argsRule);
-      toolRules.add(
-        '$ruleName-call ::= "{\\"tool_name\\": \\"${tool.name}\\", \\"parameters\\": " $ruleName-args "}"',
+      final prefix = ToolCallGrammarUtils.literal(
+        '{"tool_name": ${jsonEncode(tool.name)}, "parameters": ',
       );
+      toolRules.add('$ruleName-call ::= $prefix $ruleName-args "}"');
     }
 
     final choiceRule = 'tool-choice ::= ${toolChoices.join(' | ')}';
@@ -333,9 +339,6 @@ class CommandR7BHandler extends ChatTemplateHandler {
     return null;
   }
 
-  String _sanitizeName(String name) =>
-      name.replaceAll(RegExp(r'[^a-zA-Z0-9]'), '-').toLowerCase();
-
   String _jsonSchemaToGbnf(Map<String, dynamic> schema, String ruleName) {
     final properties = schema['properties'] as Map<String, dynamic>? ?? {};
 
@@ -346,11 +349,14 @@ class CommandR7BHandler extends ChatTemplateHandler {
     final parts = <String>[];
     var first = true;
     for (final entry in properties.entries) {
-      final sep = first ? '' : '", " space ';
+      final separator = first
+          ? ''
+          : '${ToolCallGrammarUtils.literal(', ')} space ';
       first = false;
       final propType = (entry.value as Map<String, dynamic>)['type'] as String?;
       final valueRule = _typeToGbnf(propType);
-      parts.add('$sep"\\"${entry.key}\\": " space $valueRule');
+      final key = ToolCallGrammarUtils.literal('${jsonEncode(entry.key)}: ');
+      parts.add('$separator$key space $valueRule');
     }
 
     return '$ruleName ::= "{" space ${parts.join(' ')} space "}"';

--- a/lib/src/core/template/handlers/hermes_handler.dart
+++ b/lib/src/core/template/handlers/hermes_handler.dart
@@ -1,3 +1,5 @@
+import 'dart:convert';
+
 import 'package:dinja/dinja.dart';
 
 import '../../models/chat/chat_message.dart';
@@ -8,7 +10,9 @@ import '../chat_format.dart';
 import '../chat_parse_result.dart';
 import '../chat_template_handler.dart';
 import '../thinking_utils.dart';
+import '../tool_call_grammar_utils.dart';
 import '../tool_call_parsing_utils.dart';
+import '../tool_schema_utils.dart';
 
 /// Handler for Hermes 2 Pro / Qwen 2.5 / Qwen 3 format.
 ///
@@ -240,21 +244,23 @@ class HermesHandler extends ChatTemplateHandler {
   @override
   String? buildGrammar(List<ToolDefinition>? tools) {
     if (tools == null || tools.isEmpty) return null;
+    toolSchemas(tools);
 
     // Build a GBNF grammar that constrains output to valid Hermes tool calls
     final toolRules = <String>[];
     final toolChoices = <String>[];
 
     for (final tool in tools) {
-      final ruleName = _sanitizeName(tool.name);
+      final ruleName = ToolCallGrammarUtils.ruleName(tool.name);
       toolChoices.add('$ruleName-call');
 
       final schema = tool.toJsonSchema();
       final argsRule = _jsonSchemaToGbnf(schema, '$ruleName-args');
       toolRules.add(argsRule);
-      toolRules.add(
-        '$ruleName-call ::= "{\\"name\\": \\"${tool.name}\\", \\"arguments\\": " $ruleName-args "}"',
+      final prefix = ToolCallGrammarUtils.literal(
+        '{"name": ${jsonEncode(tool.name)}, "arguments": ',
       );
+      toolRules.add('$ruleName-call ::= $prefix $ruleName-args "}"');
     }
 
     final choiceRule = 'tool-choice ::= ${toolChoices.join(' | ')}';
@@ -355,9 +361,6 @@ class HermesHandler extends ChatTemplateHandler {
       codeUnit == 0x0D ||
       codeUnit == 0x09;
 
-  String _sanitizeName(String name) =>
-      name.replaceAll(RegExp(r'[^a-zA-Z0-9]'), '-').toLowerCase();
-
   String _jsonSchemaToGbnf(Map<String, dynamic> schema, String ruleName) {
     final properties = schema['properties'] as Map<String, dynamic>? ?? {};
 
@@ -368,11 +371,14 @@ class HermesHandler extends ChatTemplateHandler {
     final parts = <String>[];
     var first = true;
     for (final entry in properties.entries) {
-      final sep = first ? '' : '", " space ';
+      final separator = first
+          ? ''
+          : '${ToolCallGrammarUtils.literal(', ')} space ';
       first = false;
       final propType = (entry.value as Map<String, dynamic>)['type'] as String?;
       final valueRule = _typeToGbnf(propType);
-      parts.add('$sep"\\"${entry.key}\\": " space $valueRule');
+      final key = ToolCallGrammarUtils.literal('${jsonEncode(entry.key)}: ');
+      parts.add('$separator$key space $valueRule');
     }
 
     return '$ruleName ::= "{" space ${parts.join(' ')} space "}"';

--- a/lib/src/core/template/handlers/hunyuan_v3_handler.dart
+++ b/lib/src/core/template/handlers/hunyuan_v3_handler.dart
@@ -10,6 +10,7 @@ import '../chat_template_handler.dart';
 import '../thinking_utils.dart';
 import '../tool_call_grammar_utils.dart';
 import '../tool_call_parsing_utils.dart';
+import '../tool_schema_utils.dart';
 
 /// Handler for Tencent Hunyuan V3's namespaced chat and tool-call format.
 class HunyuanV3Handler extends ChatTemplateHandler {
@@ -139,31 +140,47 @@ class HunyuanV3Handler extends ChatTemplateHandler {
       );
     }
 
+    ChatParseResult rollback() => ChatParseResult(
+      content: thinking.content.trim(),
+      reasoningContent: thinking.reasoning,
+    );
+
     final toolCalls = <LlamaCompletionChunkToolCall>[];
     var remaining = thinking.content;
     for (final match in _toolCallBlockPattern.allMatches(thinking.content)) {
       final block = match.group(1) ?? '';
       final separatorIndex = block.indexOf(_toolSeparator);
       if (separatorIndex < 0) {
-        continue;
+        return rollback();
       }
 
       final name = block.substring(0, separatorIndex).trim();
       if (name.isEmpty) {
-        continue;
+        return rollback();
       }
 
       final arguments = <String, dynamic>{};
       final argumentsBlock = block.substring(
         separatorIndex + _toolSeparator.length,
       );
+      var argumentCursor = 0;
       for (final argumentMatch in _argPairPattern.allMatches(argumentsBlock)) {
+        if (argumentsBlock
+            .substring(argumentCursor, argumentMatch.start)
+            .trim()
+            .isNotEmpty) {
+          return rollback();
+        }
         final key = (argumentMatch.group(1) ?? '').trim();
-        if (key.isEmpty) {
-          continue;
+        if (key.isEmpty || arguments.containsKey(key)) {
+          return rollback();
         }
         final value = (argumentMatch.group(2) ?? '').trim();
         arguments[key] = ToolCallParsingUtils.decodeJsonValueOrString(value);
+        argumentCursor = argumentMatch.end;
+      }
+      if (argumentsBlock.substring(argumentCursor).trim().isNotEmpty) {
+        return rollback();
       }
 
       toolCalls.add(
@@ -176,11 +193,15 @@ class HunyuanV3Handler extends ChatTemplateHandler {
       remaining = remaining.replaceFirst(match.group(0)!, '');
     }
 
-    remaining = remaining
-        .replaceAll(_toolCallsStart, '')
-        .replaceAll(_toolCallsEnd, '')
-        .replaceAll(_eos, '')
-        .trim();
+    final withoutEnvelope = _removeBalancedToolCallsEnvelope(remaining);
+    if (withoutEnvelope == null ||
+        (toolCalls.isEmpty && withoutEnvelope != remaining)) {
+      return rollback();
+    }
+    if (_containsToolProtocolFragment(withoutEnvelope)) {
+      return rollback();
+    }
+    remaining = withoutEnvelope.replaceAll(_eos, '').trim();
     return ChatParseResult(
       content: remaining,
       reasoningContent: thinking.reasoning,
@@ -193,17 +214,18 @@ class HunyuanV3Handler extends ChatTemplateHandler {
     if (tools == null || tools.isEmpty) {
       return null;
     }
+    toolSchemas(tools);
 
     final choices = <String>[];
     final rules = <String>[];
     for (final tool in tools) {
-      final toolName = _ruleName(tool.name);
+      final toolName = ToolCallGrammarUtils.ruleName(tool.name);
       final toolRule = '$toolName-call';
       choices.add(toolRule);
 
       final argumentRules = <String>[];
       for (final parameter in tool.parameters) {
-        final parameterName = _ruleName(parameter.name);
+        final parameterName = ToolCallGrammarUtils.ruleName(parameter.name);
         final argumentRule = '$toolName-$parameterName-arg';
         final valueRule = '$argumentRule-value';
         rules.add(_valueRule(valueRule, parameter.toJsonSchema()));
@@ -279,7 +301,37 @@ class HunyuanV3Handler extends ChatTemplateHandler {
 
   static String _literal(String value) => ToolCallGrammarUtils.literal(value);
 
-  static String _ruleName(String value) {
-    return value.replaceAll(RegExp('[^A-Za-z0-9]'), '-').toLowerCase();
+  static bool _containsToolProtocolFragment(String input) {
+    return const [
+      '<tool_calls',
+      '</tool_calls',
+      '<tool_call',
+      '</tool_call',
+      '<tool_sep',
+      '<arg_key',
+      '</arg_key',
+      '<arg_value',
+      '</arg_value',
+    ].any(input.contains);
+  }
+
+  static String? _removeBalancedToolCallsEnvelope(String input) {
+    final start = input.indexOf(_toolCallsStart);
+    final end = input.indexOf(_toolCallsEnd);
+    if (start < 0 && end < 0) {
+      return input;
+    }
+    if (start < 0 ||
+        end < start ||
+        input.indexOf(_toolCallsStart, start + _toolCallsStart.length) >= 0 ||
+        input.indexOf(_toolCallsEnd, end + _toolCallsEnd.length) >= 0 ||
+        input
+            .substring(start + _toolCallsStart.length, end)
+            .trim()
+            .isNotEmpty) {
+      return null;
+    }
+    return '${input.substring(0, start)}'
+        '${input.substring(end + _toolCallsEnd.length)}';
   }
 }

--- a/test/e2e/template/specialized_tool_grammar_validation_e2e_test.dart
+++ b/test/e2e/template/specialized_tool_grammar_validation_e2e_test.dart
@@ -2,11 +2,15 @@
 @Tags(['local-only', 'e2e'])
 library;
 
+import 'dart:convert';
 import 'dart:io';
 
 import 'package:llamadart/src/core/models/tools/tool_definition.dart';
 import 'package:llamadart/src/core/models/tools/tool_param.dart';
+import 'package:llamadart/src/core/template/handlers/command_r7b_handler.dart';
 import 'package:llamadart/src/core/template/handlers/glm45_handler.dart';
+import 'package:llamadart/src/core/template/handlers/hermes_handler.dart';
+import 'package:llamadart/src/core/template/handlers/hunyuan_v3_handler.dart';
 import 'package:llamadart/src/core/template/handlers/llama_cpp_specialized_handlers.dart';
 import 'package:test/test.dart';
 
@@ -188,6 +192,105 @@ void main() {
             '</tool_call>\n',
       ],
       invalid: const [],
+    );
+  });
+
+  test('Command R7B, Hermes, and Hunyuan rule collisions compile', () {
+    _expectGrammar(
+      validator,
+      CommandR7BHandler().buildGrammar(_collidingToolNames)!,
+      valid: const [
+        '<|START_ACTION|>'
+            '[{"tool_name": "a b", "parameters": {}},'
+            '{"tool_name": "a-b", "parameters": {}}]'
+            '<|END_ACTION|>',
+      ],
+      invalid: const [
+        '<|START_ACTION|>'
+            '[{"tool_name": "a-u20-b", "parameters": {}}]'
+            '<|END_ACTION|>',
+      ],
+    );
+
+    _expectGrammar(
+      validator,
+      HermesHandler().buildGrammar(_collidingToolNames)!,
+      valid: const [
+        '<tool_call>{"name": "a b", "arguments": {}}</tool_call>'
+            '<tool_call>{"name": "a-b", "arguments": {}}</tool_call>',
+      ],
+      invalid: const [
+        '<tool_call>{"name": "a-u20-b", "arguments": {}}</tool_call>',
+      ],
+    );
+
+    _expectGrammar(
+      validator,
+      HunyuanV3Handler().buildGrammar(_hunyuanCollisionTools)!,
+      valid: const [
+        '<tool_calls:opensource>\n'
+            '<tool_call:opensource>a b<tool_sep:opensource>\n'
+            '</tool_call:opensource>\n'
+            '<tool_call:opensource>a-b<tool_sep:opensource>\n'
+            '<arg_key:opensource>x y</arg_key:opensource>\n'
+            '<arg_value:opensource>first</arg_value:opensource>\n'
+            '<arg_key:opensource>x-y</arg_key:opensource>\n'
+            '<arg_value:opensource>second</arg_value:opensource>\n'
+            '</tool_call:opensource>\n'
+            '</tool_calls:opensource>',
+      ],
+      invalid: const [
+        '<tool_calls:opensource>\n'
+            '<tool_call:opensource>a-b<tool_sep:opensource>\n'
+            '<arg_key:opensource>x-u20-y</arg_key:opensource>\n'
+            '<arg_value:opensource>first</arg_value:opensource>\n'
+            '<arg_key:opensource>x-y</arg_key:opensource>\n'
+            '<arg_value:opensource>second</arg_value:opensource>\n'
+            '</tool_call:opensource>\n'
+            '</tool_calls:opensource>',
+      ],
+    );
+  });
+
+  test('Command R7B and Hermes preserve escaped JSON wire identities', () {
+    const toolName = 'quote"slash\\tool';
+    const parameterName = 'quote"slash\\parameter';
+    final tool = ToolDefinition(
+      name: toolName,
+      description: 'Escaped JSON identity coverage',
+      parameters: [ToolParam.string(parameterName, required: true)],
+      handler: (_) async => null,
+    );
+    final encodedTool = jsonEncode(toolName);
+    final encodedParameter = jsonEncode(parameterName);
+    final commandCall =
+        '{"tool_name": $encodedTool, "parameters": '
+        '{$encodedParameter: "value"}}';
+    final hermesCall =
+        '{"name": $encodedTool, "arguments": '
+        '{$encodedParameter: "value"}}';
+
+    _expectGrammar(
+      validator,
+      CommandR7BHandler().buildGrammar([tool])!,
+      valid: ['<|START_ACTION|>[$commandCall]<|END_ACTION|>'],
+      invalid: [
+        '<|START_ACTION|>'
+            '[{"tool_name": "quote\\"slash-tool", "parameters": '
+            '{$encodedParameter: "value"}}]'
+            '<|END_ACTION|>',
+      ],
+    );
+    _expectGrammar(
+      validator,
+      HermesHandler().buildGrammar([tool])!,
+      valid: ['<tool_call>$hermesCall</tool_call>'],
+      invalid: [
+        '<tool_call>'
+            '{"name": "quote\\"slash-tool", "arguments": '
+            '{$encodedParameter: "value"}}'
+            '</tool_call>',
+      ],
     );
   });
 
@@ -752,6 +855,34 @@ final _collidingKeyTool = ToolDefinition(
   ],
   handler: (_) async => null,
 );
+
+final _collidingToolNames = <ToolDefinition>[
+  ToolDefinition(
+    name: 'a b',
+    description: 'Spaced tool name',
+    parameters: const [],
+    handler: (_) async => null,
+  ),
+  ToolDefinition(
+    name: 'a-b',
+    description: 'Dashed tool name',
+    parameters: const [],
+    handler: (_) async => null,
+  ),
+];
+
+final _hunyuanCollisionTools = <ToolDefinition>[
+  _collidingToolNames.first,
+  ToolDefinition(
+    name: 'a-b',
+    description: 'Tool and parameter collision coverage',
+    parameters: [
+      ToolParam.string('x y', required: true),
+      ToolParam.string('x-y', required: true),
+    ],
+    handler: (_) async => null,
+  ),
+];
 
 final _glmEvidenceTool = ToolDefinition(
   name: 'inspect',

--- a/test/integration/core/template/llama_cpp_template_detection_integration_test.dart
+++ b/test/integration/core/template/llama_cpp_template_detection_integration_test.dart
@@ -268,6 +268,91 @@ void main() {
       }
     }, skip: fixtureSkipReason);
 
+    test(
+      'collision-prone names survive pinned render and production parse',
+      () {
+        final collisionTools = <ToolDefinition>[
+          ToolDefinition(
+            name: 'a b',
+            description: 'Spaced tool name',
+            parameters: const [],
+            handler: (_) async => null,
+          ),
+          ToolDefinition(
+            name: 'a-b',
+            description: 'Dashed tool name',
+            parameters: [
+              ToolParam.string('x y', required: true),
+              ToolParam.string('x-y', required: true),
+            ],
+            handler: (_) async => null,
+          ),
+        ];
+        const cases = <String, ({ChatFormat format, String output})>{
+          'CohereForAI-c4ai-command-r7b-12-2024-tool_use.jinja': (
+            format: ChatFormat.commandR7B,
+            output:
+                '<|START_ACTION|>'
+                '[{"tool_name":"a-b","parameters":'
+                '{"x y":"first","x-y":"second"}}]'
+                '<|END_ACTION|>',
+          ),
+          'NousResearch-Hermes-2-Pro-Llama-3-8B-tool_use.jinja': (
+            format: ChatFormat.hermes,
+            output:
+                '<tool_call>{"name":"a-b","arguments":'
+                '{"x y":"first","x-y":"second"}}</tool_call>',
+          ),
+          'tencent-Hy3.jinja': (
+            format: ChatFormat.hunyuanV3,
+            output:
+                '</think:opensource><tool_calls:opensource>\n'
+                '<tool_call:opensource>a-b<tool_sep:opensource>\n'
+                '<arg_key:opensource>x y</arg_key:opensource>\n'
+                '<arg_value:opensource>first</arg_value:opensource>\n'
+                '<arg_key:opensource>x-y</arg_key:opensource>\n'
+                '<arg_value:opensource>second</arg_value:opensource>\n'
+                '</tool_call:opensource>\n'
+                '</tool_calls:opensource>',
+          ),
+        };
+
+        for (final entry in cases.entries) {
+          final source = File(
+            '${templatesDir.path}/${entry.key}',
+          ).readAsStringSync();
+          final rendered = ChatTemplateEngine.render(
+            templateSource: source,
+            messages: messages,
+            metadata: metadata,
+            tools: collisionTools,
+          );
+
+          expect(
+            ChatFormat.values[rendered.format],
+            entry.value.format,
+            reason: entry.key,
+          );
+          for (final literal in const ['a b', 'a-b', 'x y', 'x-y']) {
+            expect(rendered.prompt, contains(literal), reason: entry.key);
+          }
+
+          final parsed = ChatTemplateEngine.parse(
+            rendered.format,
+            entry.value.output,
+            tools: collisionTools,
+            thinkingForcedOpen: rendered.thinkingForcedOpen,
+          );
+          expect(parsed.content, isEmpty, reason: entry.key);
+          expect(parsed.toolCalls, hasLength(1), reason: entry.key);
+          expect(parsed.toolCalls.single.function?.name, 'a-b');
+          expect(parsed.toolCalls.single.function?.arguments, contains('x y'));
+          expect(parsed.toolCalls.single.function?.arguments, contains('x-y'));
+        }
+      },
+      skip: fixtureSkipReason,
+    );
+
     test('direct-Jinja grammars preserve tool-choice and prefix semantics', () {
       const templates = [
         'Kimi-K3.jinja',

--- a/test/unit/core/template/handlers/command_r7b_handler_test.dart
+++ b/test/unit/core/template/handlers/command_r7b_handler_test.dart
@@ -5,6 +5,7 @@ import 'package:llamadart/src/core/models/chat/chat_role.dart';
 import 'package:llamadart/src/core/models/tools/tool_definition.dart';
 import 'package:llamadart/src/core/models/tools/tool_param.dart';
 import 'package:llamadart/src/core/template/handlers/command_r7b_handler.dart';
+import 'package:llamadart/src/core/template/tool_call_grammar_utils.dart';
 import 'package:test/test.dart';
 
 void main() {
@@ -213,11 +214,36 @@ void main() {
     ];
 
     final grammar = handler.buildGrammar(tools)!;
+    final writeFileRule = ToolCallGrammarUtils.ruleName('write_file');
 
-    expect(grammar, contains('write-file-args ::= "{"'));
+    expect(grammar, contains('$writeFileRule-args ::= "{"'));
     expect(grammar, contains('"\\"path\\": " space string'));
     expect(grammar, contains('"\\"content\\": " space string'));
-    expect(grammar, isNot(contains('write-file-args ::= "{" space "}"')));
+    expect(grammar, isNot(contains('$writeFileRule-args ::= "{" space "}"')));
+  });
+
+  test('collision-free grammar rules preserve Command R wire names', () {
+    final handler = CommandR7BHandler();
+    final tools = [_tool('a b'), _tool('a-b')];
+    final spacedRule = ToolCallGrammarUtils.ruleName('a b');
+    final dashedRule = ToolCallGrammarUtils.ruleName('a-b');
+
+    expect(spacedRule, isNot(dashedRule));
+    final grammar = handler.buildGrammar(tools)!;
+    expect(grammar, contains('$spacedRule-call ::='));
+    expect(grammar, contains('$dashedRule-call ::='));
+    expect(grammar, contains(r'\"tool_name\": \"a b\"'));
+    expect(grammar, contains(r'\"tool_name\": \"a-b\"'));
+
+    const output =
+        'before '
+        '<|START_ACTION|>[{"tool_name":"a b","parameters":{}}]'
+        '<|END_ACTION|>';
+    final parsed = handler.parse(output);
+    expect(parsed.content, 'before');
+    expect(parsed.toolCalls, hasLength(1));
+    expect(parsed.toolCalls.single.function?.name, 'a b');
+    expect(jsonDecode(parsed.toolCalls.single.function!.arguments!), isEmpty);
   });
 
   test('keeps malformed action block as content', () {
@@ -235,3 +261,10 @@ void main() {
 Future<Object?> _noop(_) async {
   return 'ok';
 }
+
+ToolDefinition _tool(String name) => ToolDefinition(
+  name: name,
+  description: 'Collision coverage',
+  parameters: const [],
+  handler: _noop,
+);

--- a/test/unit/core/template/handlers/hermes_handler_test.dart
+++ b/test/unit/core/template/handlers/hermes_handler_test.dart
@@ -6,6 +6,7 @@ import 'package:llamadart/src/core/models/tools/tool_definition.dart';
 import 'package:llamadart/src/core/models/tools/tool_param.dart';
 import 'package:llamadart/src/core/template/chat_format.dart';
 import 'package:llamadart/src/core/template/handlers/hermes_handler.dart';
+import 'package:llamadart/src/core/template/tool_call_grammar_utils.dart';
 import 'package:test/test.dart';
 
 void main() {
@@ -220,6 +221,30 @@ void main() {
     expect(parsed.content, equals(input));
   });
 
+  test('collision-free grammar rules preserve Hermes wire names', () {
+    final handler = HermesHandler();
+    final tools = [_tool('a b'), _tool('a-b')];
+    final spacedRule = ToolCallGrammarUtils.ruleName('a b');
+    final dashedRule = ToolCallGrammarUtils.ruleName('a-b');
+
+    expect(spacedRule, isNot(dashedRule));
+    final grammar = handler.buildGrammar(tools)!;
+    expect(grammar, contains('$spacedRule-call ::='));
+    expect(grammar, contains('$dashedRule-call ::='));
+    expect(grammar, contains(r'\"name\": \"a b\"'));
+    expect(grammar, contains(r'\"name\": \"a-b\"'));
+
+    const output =
+        'before '
+        '<tool_call>{"name":"a-b","arguments":{}}</tool_call>'
+        ' after';
+    final parsed = handler.parse(output);
+    expect(parsed.content, 'before after');
+    expect(parsed.toolCalls, hasLength(1));
+    expect(parsed.toolCalls.single.function?.name, 'a-b');
+    expect(jsonDecode(parsed.toolCalls.single.function!.arguments!), isEmpty);
+  });
+
   test('keeps non-tagged payload as content', () {
     final handler = HermesHandler();
     final parsed = handler.parse(
@@ -239,3 +264,10 @@ void main() {
 Future<Object?> _noop(_) async {
   return 'ok';
 }
+
+ToolDefinition _tool(String name) => ToolDefinition(
+  name: name,
+  description: 'Collision coverage',
+  parameters: const [],
+  handler: _noop,
+);

--- a/test/unit/core/template/handlers/hunyuan_v3_handler_test.dart
+++ b/test/unit/core/template/handlers/hunyuan_v3_handler_test.dart
@@ -5,6 +5,7 @@ import 'package:llamadart/src/core/models/chat/chat_role.dart';
 import 'package:llamadart/src/core/models/tools/tool_definition.dart';
 import 'package:llamadart/src/core/models/tools/tool_param.dart';
 import 'package:llamadart/src/core/template/handlers/hunyuan_v3_handler.dart';
+import 'package:llamadart/src/core/template/tool_call_grammar_utils.dart';
 import 'package:test/test.dart';
 
 void main() {
@@ -95,13 +96,131 @@ void main() {
     );
 
     final grammar = HunyuanV3Handler().buildGrammar([tool]);
+    final toolRule = ToolCallGrammarUtils.ruleName('get_weather');
 
     expect(
       grammar,
-      contains(
-        'get-weather-units-arg-value ::= "metric" | "imperial" | string',
-      ),
+      contains('$toolRule-units-arg-value ::= "metric" | "imperial" | string'),
     );
     expect(grammar, isNot(contains(r'\"metric\"')));
   });
+
+  test('collision-free rules preserve Hunyuan tool and argument names', () {
+    final tools = [
+      _tool('a b'),
+      ToolDefinition(
+        name: 'a-b',
+        description: 'Parameter collision coverage',
+        parameters: [
+          ToolParam.string('x y', required: true),
+          ToolParam.string('x-y', required: true),
+        ],
+        handler: (_) async => null,
+      ),
+    ];
+    final spacedToolRule = ToolCallGrammarUtils.ruleName('a b');
+    final dashedToolRule = ToolCallGrammarUtils.ruleName('a-b');
+    final spacedParameterRule = ToolCallGrammarUtils.ruleName('x y');
+    final dashedParameterRule = ToolCallGrammarUtils.ruleName('x-y');
+
+    expect(spacedToolRule, isNot(dashedToolRule));
+    expect(spacedParameterRule, isNot(dashedParameterRule));
+    final grammar = HunyuanV3Handler().buildGrammar(tools)!;
+    expect(grammar, contains('$spacedToolRule-call ::='));
+    expect(grammar, contains('$dashedToolRule-call ::='));
+    expect(grammar, contains('$dashedToolRule-$spacedParameterRule-arg ::='));
+    expect(grammar, contains('$dashedToolRule-$dashedParameterRule-arg ::='));
+    expect(grammar, contains('<tool_call:opensource>a b<tool_sep:opensource>'));
+    expect(grammar, contains('<tool_call:opensource>a-b<tool_sep:opensource>'));
+    expect(grammar, contains('<arg_key:opensource>x y</arg_key:opensource>'));
+    expect(grammar, contains('<arg_key:opensource>x-y</arg_key:opensource>'));
+
+    final parsed = HunyuanV3Handler().parse(
+      '<tool_calls:opensource>\n'
+      '<tool_call:opensource>a-b<tool_sep:opensource>\n'
+      '<arg_key:opensource>x y</arg_key:opensource>\n'
+      '<arg_value:opensource>first</arg_value:opensource>\n'
+      '<arg_key:opensource>x-y</arg_key:opensource>\n'
+      '<arg_value:opensource>second</arg_value:opensource>\n'
+      '</tool_call:opensource>\n'
+      '</tool_calls:opensource>',
+    );
+    expect(parsed.content, isEmpty);
+    expect(parsed.toolCalls, hasLength(1));
+    expect(parsed.toolCalls.single.function?.name, 'a-b');
+    expect(jsonDecode(parsed.toolCalls.single.function!.arguments!), {
+      'x y': 'first',
+      'x-y': 'second',
+    });
+  });
+
+  test('malformed Hunyuan blocks roll back atomically', () {
+    const malformed =
+        'before\n'
+        '<tool_calls:opensource>\n'
+        '<tool_call:opensource>a-b<tool_sep:opensource>\n'
+        '<arg_key:opensource>x y</arg_key:opensource>\n'
+        '<arg_value:opensource>unterminated\n'
+        '</tool_call:opensource>\n'
+        '</tool_calls:opensource>';
+
+    final parsed = HunyuanV3Handler().parse(malformed);
+
+    expect(parsed.toolCalls, isEmpty);
+    expect(parsed.content, malformed);
+  });
+
+  test('preserves ordinary content around valid Hunyuan tool calls', () {
+    const output =
+        'before\n'
+        '<tool_calls:opensource>\n'
+        '<tool_call:opensource>inspect<tool_sep:opensource>\n'
+        '</tool_call:opensource>\n'
+        '</tool_calls:opensource>\n'
+        'after<｜hy_eos:opensource｜>';
+
+    final parsed = HunyuanV3Handler().parse(output);
+
+    expect(parsed.content, 'before\n\nafter');
+    expect(parsed.toolCalls, hasLength(1));
+    expect(parsed.toolCalls.single.function?.name, 'inspect');
+  });
+
+  test('trailing partial Hunyuan blocks roll back the complete output', () {
+    const output =
+        'before\n'
+        '<tool_calls:opensource>\n'
+        '<tool_call:opensource>inspect<tool_sep:opensource>\n'
+        '</tool_call:opensource>\n'
+        '<tool_call:open';
+
+    final parsed = HunyuanV3Handler().parse(output);
+
+    expect(parsed.toolCalls, isEmpty);
+    expect(parsed.content, output);
+  });
+
+  test('duplicate Hunyuan argument keys roll back atomically', () {
+    const output =
+        '<tool_calls:opensource>\n'
+        '<tool_call:opensource>inspect<tool_sep:opensource>\n'
+        '<arg_key:opensource>mode</arg_key:opensource>\n'
+        '<arg_value:opensource>first</arg_value:opensource>\n'
+        '<arg_key:opensource>mode</arg_key:opensource>\n'
+        '<arg_value:opensource>second</arg_value:opensource>\n'
+        '</tool_call:opensource>\n'
+        '</tool_calls:opensource>';
+
+    final parsed = HunyuanV3Handler().parse(output);
+
+    expect(parsed.toolCalls, isEmpty);
+    expect(parsed.content, output);
+  });
 }
+
+ToolDefinition _tool(String name) => ToolDefinition(
+  name: name,
+  description: 'Collision coverage',
+  parameters: const [],
+  handler: (_) async => null,
+);

--- a/test/unit/core/template/tool_call_grammar_utils_test.dart
+++ b/test/unit/core/template/tool_call_grammar_utils_test.dart
@@ -1,5 +1,9 @@
+import 'package:llamadart/src/core/exceptions.dart';
 import 'package:llamadart/src/core/models/tools/tool_definition.dart';
 import 'package:llamadart/src/core/models/tools/tool_param.dart';
+import 'package:llamadart/src/core/template/handlers/command_r7b_handler.dart';
+import 'package:llamadart/src/core/template/handlers/hermes_handler.dart';
+import 'package:llamadart/src/core/template/handlers/hunyuan_v3_handler.dart';
 import 'package:llamadart/src/core/template/tool_call_grammar_utils.dart';
 import 'package:test/test.dart';
 
@@ -18,6 +22,44 @@ void main() {
       ToolCallGrammarUtils.ruleName(''),
       isNot(ToolCallGrammarUtils.ruleName('rule-empty')),
     );
+  });
+
+  test('collision-sensitive handlers reject lossy schema identities', () {
+    final duplicateTools = [_tool('inspect'), _tool('inspect')];
+    final duplicateParameters = ToolDefinition(
+      name: 'ambiguous',
+      description: 'Duplicate parameter coverage',
+      parameters: [ToolParam.string('mode'), ToolParam.boolean('mode')],
+      handler: _noop,
+    );
+    final builders = <String? Function(List<ToolDefinition>?)>[
+      CommandR7BHandler().buildGrammar,
+      HermesHandler().buildGrammar,
+      HunyuanV3Handler().buildGrammar,
+    ];
+
+    for (final buildGrammar in builders) {
+      expect(
+        () => buildGrammar(duplicateTools),
+        throwsA(
+          isA<LlamaUnsupportedException>().having(
+            (error) => error.message,
+            'message',
+            contains('unique tool names'),
+          ),
+        ),
+      );
+      expect(
+        () => buildGrammar([duplicateParameters]),
+        throwsA(
+          isA<LlamaUnsupportedException>().having(
+            (error) => error.message,
+            'message',
+            contains('declared more than once'),
+          ),
+        ),
+      );
+    }
   });
 
   test('wrapRootGrammar wraps root rule with literals', () {
@@ -136,3 +178,10 @@ void main() {
 Future<Object?> _noop(_) async {
   return 'ok';
 }
+
+ToolDefinition _tool(String name) => ToolDefinition(
+  name: name,
+  description: 'Identity coverage',
+  parameters: const [],
+  handler: _noop,
+);

--- a/tool/testing/run_template_parity_suites.sh
+++ b/tool/testing/run_template_parity_suites.sh
@@ -16,6 +16,6 @@ dart test -p vm -j 1 test/unit/core/template --exclude-tags local-only
 echo "[template-parity] upstream llama.cpp chat/template parser suites"
 dart test -p vm -j 1 test/e2e/template/llama_cpp_chat_tests_e2e_test.dart --run-skipped
 
-echo "[template-parity] compiled specialized grammar acceptance"
+echo "[template-parity] compiled structured-output grammar acceptance"
 LLAMA_CPP_GBNF_VALIDATOR="${LLAMA_CPP_CHAT_TEST_BUILD_DIR:-${repo_root}/.dart_tool/llama_cpp_chat_tests}/bin/test-gbnf-validator" \
   dart test -p vm -j 1 test/e2e/template/specialized_tool_grammar_validation_e2e_test.dart --run-skipped

--- a/tool/testing/test_matrix.dart
+++ b/tool/testing/test_matrix.dart
@@ -399,7 +399,7 @@ const List<TestMatrixRow> testMatrixRows = <TestMatrixRow>[
     mode: 'local-only',
     covers:
         'vendored llama.cpp chat-template detection/render/parse parity and '
-        'compiled specialized GBNF schema acceptance/rejection',
+        'compiled structured-output GBNF schema and collision acceptance/rejection',
     command: 'tool/testing/run_template_parity_suites.sh',
     useWhen: 'Template engine, handlers, grammar, or parser changes.',
   ),

--- a/website/docs/changelog/recent-releases.md
+++ b/website/docs/changelog/recent-releases.md
@@ -9,6 +9,9 @@ For canonical full release notes, use:
 
 ## Unreleased
 
+- Fixed Command R7B, Hermes, and Hunyuan V3 tool grammars so distinct tool or
+  parameter names cannot collide after conversion to internal GBNF rule names.
+
 - Fixed DeepSeek V3.2 DSML tool calls using their upstream
   `<｜DSML｜function_calls>` envelope while preserving DeepSeek V4's distinct
   `<｜DSML｜tool_calls>` grammar and parser behavior.


### PR DESCRIPTION
## Summary
- encode Command R7B, Hermes, and Hunyuan V3 GBNF rule components with the shared collision-free helper
- preserve exact public tool and parameter wire names, including JSON quote and backslash escaping
- make malformed Hunyuan tool envelopes roll back atomically while preserving ordinary surrounding content

Closes #423
Closes #424

## Production-readiness scope
- **User-facing scope:** Distinct tool and parameter names such as `a b` and `a-b` now produce independent, compilable constrained-output rules instead of duplicate GBNF identifiers.
- **Supported platforms/paths:** Template rendering, parsing, and grammar generation on VM/native and Chrome/Web; compiled grammar validation uses the repository-pinned llama.cpp validator.
- **Unsupported or intentionally unavailable paths:** None added. Duplicate or empty public schema identities fail closed with the existing typed `LlamaUnsupportedException` rather than producing an ambiguous grammar.
- **Out of scope / follow-ups:** None. This PR changes no public API, native ABI, runtime asset, backend capability, or dependency pin.

## Completeness checklist
- [x] Declared scope is fully implemented, or explicitly reduced above.
- [x] Unsupported platform/option combinations fail loudly with actionable diagnostics or are clearly documented as unavailable.
- [x] Public API docs, README/website docs, examples, support matrices, and changelog entries are updated where relevant.
- [x] Regression coverage covers the original issue plus key negative/version-skew paths where relevant.
- [x] Security/privacy review completed: no secrets, bearer tokens, signed URLs, or raw secret-bearing paths leak through logs, cache keys, metadata, errors, or snapshots.
- [x] Follow-up work that is useful but not required for this PR is tracked in GitHub Issues, or explicitly marked "None" above.

## PR type guidance
- **Bugfix PR:** The legacy lossy sanitizers mapped distinct schema names to the same GBNF rule. Exact tool/parameter collisions, malformed/partial rollback, pinned template parity, and compiled-grammar acceptance/rejection are covered.

## Test Plan
- [x] `dart run tool/prepare_workspace.dart`
- [x] `dart format --output=none --set-exit-if-changed .` — hosted stable-SDK gate passed; every touched Dart file also passed the applicable local changed-file check.
- [x] `dart analyze`
- [x] `dart test -p vm -j 1 --exclude-tags local-only` — 1,635 passed / 74 fixture-dependent skips.
- [x] `dart test -p chrome --exclude-tags local-only` — 903 passed.
- [x] Other targeted/local-only validation: template parity 74 detection/render/parse + 78 diagnostics + 461 template units + 2 selected/full upstream C++ suites + 13 compiled GBNF cases; docs build/link/version checks; LCOV 78.54% (13,039/16,602).

## Matrix Evidence
| Matrix row | Scope covered | Platform / model / backend | Result | Evidence / notes |
| --- | --- | --- | --- | --- |
| `static-format-analyze` | formatting, full analyzer, platform boundaries, diff hygiene | hosted Linux stable SDK + local macOS | PASS | Hosted canonical formatting/analyze and local full analyze/changed-file checks passed. |
| `root-vm` | full unit and integration inventory | macOS arm64 / VM | PASS | 1,635 passed; 74 fixture-dependent skips. |
| `root-chrome` | browser-compatible unit and integration inventory | macOS arm64 / Chrome | PASS | 903 passed. |
| `coverage-lib` | maintained library line coverage | macOS arm64 / VM | PASS | 78.54% (13,039/16,602), threshold 70%. |
| `docs-site` | changelog site build and links | Docusaurus | PASS | Production build and broken-link validation passed. |
| `release-doc-version-consistency` | existing release identities | local verifier | PASS | 0.8.20 / 0.0.14 / 0.0.10; native b10545. |
| `template-parity` | pinned render/parse behavior and actual GBNF compiler acceptance | pinned llama.cpp b10549 templates and validator | PASS | Exact Command R7B, Hermes, and Hunyuan collisions, JSON wire escaping, malformed/partial rejection, and upstream selected/full suites passed. |
| `gguf-chat-features-smoke` | representative public native generation/tool-call pipeline | Qwen3.5 0.8B Q4_K_M / CPU | PASS | `get_weather({"location":"Seoul"})` parsed across no-thinking, thinking, four-token, and zero-token thinking budgets. Metal was unavailable in this managed environment. |

## Real-model evidence boundary
The representative Qwen smoke proves the public native generation, grammar, streaming, and tool-call parsing path. Matching Command R7B and Hunyuan V3 weights that emit the synthetic collision identities were not locally available, so exact affected-format evidence comes from the pinned upstream templates, production render/parse tests, and the pinned llama.cpp GBNF compiler exercising both colliding names. No unrelated model result is presented as format-specific proof.

## Review Notes
- Independent review status: adversarial Sol self-audit PASS on commit `283af083e915bc12ef10bd3cf6dad8369bcb76a5`; Copilot reviewed 13/13 files with 0 comments; 0 unresolved threads; no known P0/P1 regression remains.
- CI status / head SHA: 12/12 populated checks passed on `283af083e915bc12ef10bd3cf6dad8369bcb76a5`.
