### PR TITLE
chore: exclude maintainer doc/ from the published package

### DIFF
--- a/.pubignore
+++ b/.pubignore
@@ -47,9 +47,13 @@ lib/src/backends/wllama/
 test/integration/backends/wllama/
 test/unit/backends/wllama/
 
-# Local scratch docs directory
-docs/
-website/
+# Root-only: scratch docs output and the Docusaurus site source. Anchored so
+# nested docs/ directories (tool/docs, example .../presentation/docs) still ship.
+/docs/
+/website/
+
+# Contributor/maintainer docs: GitHub-only; packaged files link by absolute URL
+/doc/
 
 # Agent-only maintainer notes
 AGENTS.md

--- a/.pubignore
+++ b/.pubignore
@@ -52,8 +52,8 @@ test/unit/backends/wllama/
 /docs/
 /website/
 
-# Contributor/maintainer docs: GitHub-only; packaged documentation links use
-# absolute GitHub URLs
+# Contributor/maintainer docs: GitHub-only. Packaged Markdown and Dartdoc link
+# to them by absolute URL; tool scripts still read them by path from a checkout.
 /doc/
 
 # Agent-only maintainer notes

--- a/.pubignore
+++ b/.pubignore
@@ -52,7 +52,8 @@ test/unit/backends/wllama/
 /docs/
 /website/
 
-# Contributor/maintainer docs: GitHub-only; packaged files link by absolute URL
+# Contributor/maintainer docs: GitHub-only; packaged documentation links use
+# absolute GitHub URLs
 /doc/
 
 # Agent-only maintainer notes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,16 @@
   it did before 0.8.0. A YAML boolean `false` clears the selection too. Unset,
   empty, and all-unrecognised config still select every family.
 
+* The published package no longer ships the `doc/` directory; that contributor
+  and maintainer documentation is maintained on GitHub, and packaged files now
+  link to it by absolute URL.
+
+* Fixed unanchored `docs/` and `website/` publish-exclusions that matched those
+  directory names at any depth and dropped `tool/docs/` plus the
+  `llamadart_server` example's OpenAPI spec and Swagger UI sources from the
+  package, leaving the published example unable to analyze. Both patterns are
+  now root-anchored.
+
 * Fixed Command R7B, Hermes, and Hunyuan V3 tool grammars so distinct tool or
   parameter names cannot collide after conversion to internal GBNF rule names.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,8 +11,8 @@
   empty, and all-unrecognised config still select every family.
 
 * The published package no longer ships the `doc/` directory; that contributor
-  and maintainer documentation is maintained on GitHub, and packaged files now
-  link to it by absolute URL.
+  and maintainer documentation is maintained on GitHub, and the packaged files
+  that link to it now use absolute URLs.
 
 * Fixed unanchored `docs/` and `website/` publish-exclusions that matched those
   directory names at any depth and dropped `tool/docs/` plus the

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -127,9 +127,10 @@ Always verify paths in your environment before using them.
 We take testing seriously. CI enforces **>=70% line coverage on maintainable `lib/` code**. Auto-generated files are excluded when they are marked with `// coverage:ignore-file`.
 
 The authoritative contributor test matrix lives in
-[`doc/testing_matrix.md`](doc/testing_matrix.md) and
-`tool/testing/test_matrix.dart`. Use it to decide which runtime/model/feature
-rows apply to a PR and to generate the evidence table for the pull request:
+[`doc/testing_matrix.md`](https://github.com/leehack/llamadart/blob/main/doc/testing_matrix.md)
+and `tool/testing/test_matrix.dart`. Use it to decide which
+runtime/model/feature rows apply to a PR and to generate the evidence table for
+the pull request:
 
 ```bash
 dart run tool/testing/test_matrix.dart --list

--- a/lib/src/backends/litert_lm/litert_lm_chat_template.dart
+++ b/lib/src/backends/litert_lm/litert_lm_chat_template.dart
@@ -3,8 +3,8 @@
 /// LiteRT-LM `.litertlm` bundles do not expose their chat template through the
 /// native FFI, so the backend must supply `tokenizer.chat_template` itself,
 /// keyed by detecting the model family from the bundle filename. See
-/// `doc/litert_lm_templates.md` for the full rationale and the recipe for
-/// adding a new family.
+/// [`doc/litert_lm_templates.md`](https://github.com/leehack/llamadart/blob/main/doc/litert_lm_templates.md)
+/// for the full rationale and the recipe for adding a new family.
 class LiteRtLmChatTemplate {
   /// Creates a built-in chat template descriptor.
   const LiteRtLmChatTemplate({

--- a/test/unit/tooling/pubignore_test.dart
+++ b/test/unit/tooling/pubignore_test.dart
@@ -17,6 +17,10 @@ void main() {
       '--quiet',
     ], workingDirectory: repository.path);
     expect(result.exitCode, 0, reason: '${result.stdout}\n${result.stderr}');
+    await File(
+      '${repository.path}${Platform.pathSeparator}.git'
+      '${Platform.pathSeparator}empty_excludes',
+    ).writeAsString('');
   });
 
   tearDownAll(() async {
@@ -51,7 +55,12 @@ void main() {
 }
 
 Future<bool> _isIgnored(Directory repository, String candidate) async {
+  final emptyExcludes =
+      '${repository.path}${Platform.pathSeparator}.git'
+      '${Platform.pathSeparator}empty_excludes';
   final result = await Process.run('git', [
+    '-c',
+    'core.excludesFile=$emptyExcludes',
     'check-ignore',
     '--no-index',
     '--quiet',

--- a/test/unit/tooling/pubignore_test.dart
+++ b/test/unit/tooling/pubignore_test.dart
@@ -10,7 +10,9 @@ void main() {
 
   setUpAll(() async {
     repository = await Directory.systemTemp.createTemp('pubignore_contract_');
-    await File('.pubignore').copy('${repository.path}/.gitignore');
+    await File(
+      '.pubignore',
+    ).copy('${repository.path}${Platform.pathSeparator}.gitignore');
 
     final result = await Process.run('git', [
       'init',
@@ -20,6 +22,13 @@ void main() {
     await File(
       '${repository.path}${Platform.pathSeparator}.git'
       '${Platform.pathSeparator}empty_excludes',
+    ).writeAsString('');
+    // check-ignore also reads .git/info/exclude, which init.templateDir can
+    // populate on a contributor's machine.
+    await File(
+      '${repository.path}${Platform.pathSeparator}.git'
+      '${Platform.pathSeparator}info'
+      '${Platform.pathSeparator}exclude',
     ).writeAsString('');
   });
 

--- a/test/unit/tooling/pubignore_test.dart
+++ b/test/unit/tooling/pubignore_test.dart
@@ -1,0 +1,70 @@
+@TestOn('vm')
+library;
+
+import 'dart:io';
+
+import 'package:test/test.dart';
+
+void main() {
+  late Directory repository;
+
+  setUpAll(() async {
+    repository = await Directory.systemTemp.createTemp('pubignore_contract_');
+    await File('.pubignore').copy('${repository.path}/.gitignore');
+
+    final result = await Process.run('git', [
+      'init',
+      '--quiet',
+    ], workingDirectory: repository.path);
+    expect(result.exitCode, 0, reason: '${result.stdout}\n${result.stderr}');
+  });
+
+  tearDownAll(() async {
+    await repository.delete(recursive: true);
+  });
+
+  test('anchors repository-only documentation exclusions at the root', () async {
+    for (final candidate in <String>[
+      'doc/testing_matrix.md',
+      'docs/scratch.md',
+      'website/docs/index.md',
+    ]) {
+      expect(
+        await _isIgnored(repository, candidate),
+        isTrue,
+        reason: candidate,
+      );
+    }
+
+    for (final candidate in <String>[
+      'tool/docs/build_site.sh',
+      'example/llamadart_server/lib/src/features/openai_api/presentation/docs/docs.dart',
+      'nested/doc/public_api.md',
+    ]) {
+      expect(
+        await _isIgnored(repository, candidate),
+        isFalse,
+        reason: candidate,
+      );
+    }
+  });
+}
+
+Future<bool> _isIgnored(Directory repository, String candidate) async {
+  final result = await Process.run('git', [
+    'check-ignore',
+    '--no-index',
+    '--quiet',
+    candidate,
+  ], workingDirectory: repository.path);
+  if (result.exitCode == 0) {
+    return true;
+  }
+  if (result.exitCode == 1) {
+    return false;
+  }
+  fail(
+    'git check-ignore failed for $candidate: '
+    '${result.stdout}\n${result.stderr}',
+  );
+}

--- a/tool/gen_litert_lm_templates.dart
+++ b/tool/gen_litert_lm_templates.dart
@@ -12,7 +12,7 @@
 //   2. Add an `_Entry` to `_manifest` below (id, family substrings, bos/eos).
 //   3. Run: dart run tool/gen_litert_lm_templates.dart
 //
-// See https://github.com/leehack/llamadart/blob/main/doc/litert_lm_templates.md.
+// See https://github.com/leehack/llamadart/blob/main/doc/litert_lm_templates.md
 
 import 'dart:io';
 

--- a/tool/gen_litert_lm_templates.dart
+++ b/tool/gen_litert_lm_templates.dart
@@ -12,7 +12,7 @@
 //   2. Add an `_Entry` to `_manifest` below (id, family substrings, bos/eos).
 //   3. Run: dart run tool/gen_litert_lm_templates.dart
 //
-// See `doc/litert_lm_templates.md`.
+// See https://github.com/leehack/llamadart/blob/main/doc/litert_lm_templates.md.
 
 import 'dart:io';
 
@@ -43,7 +43,7 @@ class _Entry {
 
 // Order matters: the registry matches top-to-bottom and the first hit wins, so
 // more specific families must precede broader ones (gemma-4 and gemma-3n before
-// gemma-3). See `doc/litert_lm_templates.md`.
+// gemma-3).
 const List<_Entry> _manifest = [
   _Entry(
     id: 'gemma4',

--- a/tool/testing/test_matrix.dart
+++ b/tool/testing/test_matrix.dart
@@ -664,7 +664,7 @@ const List<TestMatrixRow> testMatrixRows = <TestMatrixRow>[
     command:
         'Run android-arm64-device-smoke on old and modern arm64 devices with '
         'the cpu_profile full and compact configurations; see '
-        'doc/android_runtime_smoke_test_plan.md.',
+        'https://github.com/leehack/llamadart/blob/main/doc/android_runtime_smoke_test_plan.md.',
     useWhen:
         'Android runtime selection, CPU variants, release candidates, or '
         'native bundle changes affecting Android.',

--- a/tool/testing/test_matrix.dart
+++ b/tool/testing/test_matrix.dart
@@ -664,7 +664,7 @@ const List<TestMatrixRow> testMatrixRows = <TestMatrixRow>[
     command:
         'Run android-arm64-device-smoke on old and modern arm64 devices with '
         'the cpu_profile full and compact configurations; see '
-        'https://github.com/leehack/llamadart/blob/main/doc/android_runtime_smoke_test_plan.md.',
+        'https://github.com/leehack/llamadart/blob/main/doc/android_runtime_smoke_test_plan.md',
     useWhen:
         'Android runtime selection, CPU variants, release candidates, or '
         'native bundle changes affecting Android.',

--- a/website/docs/changelog/recent-releases.md
+++ b/website/docs/changelog/recent-releases.md
@@ -19,6 +19,16 @@ For canonical full release notes, use:
   it did before 0.8.0. A YAML boolean `false` clears the selection too. Unset,
   empty, and all-unrecognised config still select every family.
 
+- The published package no longer ships the `doc/` directory; that contributor
+  and maintainer documentation is maintained on GitHub, and packaged files now
+  link to it by absolute URL.
+
+- Fixed unanchored `docs/` and `website/` publish-exclusions that matched those
+  directory names at any depth and dropped `tool/docs/` plus the
+  `llamadart_server` example's OpenAPI spec and Swagger UI sources from the
+  package, leaving the published example unable to analyze. Both patterns are
+  now root-anchored.
+
 - Fixed Command R7B, Hermes, and Hunyuan V3 tool grammars so distinct tool or
   parameter names cannot collide after conversion to internal GBNF rule names.
 

--- a/website/docs/changelog/recent-releases.md
+++ b/website/docs/changelog/recent-releases.md
@@ -20,8 +20,8 @@ For canonical full release notes, use:
   empty, and all-unrecognised config still select every family.
 
 - The published package no longer ships the `doc/` directory; that contributor
-  and maintainer documentation is maintained on GitHub, and packaged files now
-  link to it by absolute URL.
+  and maintainer documentation is maintained on GitHub, and the packaged files
+  that link to it now use absolute URLs.
 
 - Fixed unanchored `docs/` and `website/` publish-exclusions that matched those
   directory names at any depth and dropped `tool/docs/` plus the


### PR DESCRIPTION
## Summary

Two defects in `.pubignore`, one root cause: **pub applies gitignore semantics, so an unanchored directory pattern matches that name at any depth.** One pattern was missing and shipped files that should not ship; two others were unanchored and dropped files that should ship. `PR #45` already fixed this exact class for `models/`.

**Defect 1 — `doc/` shipped.** `.pubignore` excluded `docs/` and `website/` but not `doc/`, so four contributor/maintainer documents went to pub.dev.
- **Ownership decision:** `doc/` is contributor and maintainer documentation, maintained on GitHub, **not** package content. Added `/doc/` under its own comment saying exactly that. `AGENTS.md` keeps its own "Agent-only maintainer notes" comment — that label was wrong for `doc/`, since `doc/testing_matrix.md` is the contributor test matrix and `doc/litert_lm_templates.md` is cited from published `lib/` source.
- **No shipped file points at the removed path.** Scanned the publish listing and rewrote every relative `doc/` reference to an absolute GitHub URL, following the precedent in `website/docs` and in CHANGELOG 0.5.1 ("Updated README internal links to absolute GitHub URLs so they resolve reliably on pub.dev"): `CONTRIBUTING.md:130`, the `LiteRtLmChatTemplate` dartdoc, `tool/gen_litert_lm_templates.dart`, `tool/testing/test_matrix.dart`. Left alone: `tool/testing/check_webgpu_bridge_tag.dart`, where `doc/webgpu_bridge.md` is a filesystem path the script opens, not a link (already non-functional inside the tarball, since it also reads the long-excluded `website/`); and the released CHANGELOG 0.7.x entry, which release rules forbid editing.
- Referrers, for the record: `testing_matrix.md` ← CONTRIBUTING.md, AGENTS.md:307, CODEOWNERS; `litert_lm_templates.md` ← website docs, `lib/src/backends/litert_lm/litert_lm_chat_template.dart`, `tool/gen_litert_lm_templates.dart`; `webgpu_bridge.md` ← website docs, `tool/testing/check_webgpu_bridge_tag.dart`; `android_runtime_smoke_test_plan.md` ← `tool/testing/test_matrix.dart`.

**Defect 2 — `docs/` silently broke the published example.** The previous revision of this PR listed this as a follow-up. It is the same bug in the same file, so it is fixed here instead of in a separate ticket.
- Bare `docs/` at line 51 sat under the comment "Local scratch docs directory". The root `docs/` that comment describes **does not exist in the repo**. What the pattern actually matched was every nested `docs/`: `tool/docs/` and `example/llamadart_server/lib/src/features/openai_api/presentation/docs/`.
- **Observable harm:** the pub-cache copy of `example/llamadart_server` could not analyze or compile. 20 sources were missing — including `openapi_spec_builder.dart` and `swagger_ui_page.dart` — leaving three unresolved imports/exports of `docs/docs.dart` (`openai_api.dart:1`, `presentation/http/handlers/system_handlers.dart:5`, `presentation/http/openai_api_server.dart:6`). The shipped `README.md:212-213` also invoked `./tool/docs/build_site.sh` and `./tool/docs/validate_links.sh`, neither of which was in the package.
- **Age:** introduced 2026-02-13 in `d5a8f45c4` (PR #41); live in v0.6.0 through v0.8.20.
- Anchored to `/docs/`, and `/website/` for symmetry, with a comment that describes what the pattern now covers.
- **Closes #363.** Items 1–3 already landed on main (#365, #369), verified here: `_analyzeAST(Program template)` has no `source` parameter; `peg_chat_parser.dart:96,100` use `ChatPegBuilder.reasoningTag`/`.contentTag`; `llama_cpp_backend.dart` has no `UnimplementedError`. Item 4 lists five `doc/` files; `litert_lm_structured_output.md` was deleted by #367 (e754ba716), so four remained — those four are what this excludes.

## Proof of effect

`dart pub publish --dry-run`, tree listing flattened to full paths (1001 tree entries, no truncation), before and after.

**Defect 1** — adding the `/doc/` block removes exactly four files:

```
19,23d18
< ├── doc
< │   ├── android_runtime_smoke_test_plan.md (2 KB)
< │   ├── litert_lm_templates.md (10 KB)
< │   ├── testing_matrix.md (15 KB)
< │   └── webgpu_bridge.md (8 KB)
```

**Defect 2** — anchoring `docs/` → `/docs/` and `website/` → `/website/` takes the listing from **775 → 797 files**. `comm -23 before after` (removed) is **empty**. `comm -13 before after` (added) is exactly 22 paths:

```
tool/docs/build_site.sh
tool/docs/validate_links.sh
example/llamadart_server/lib/src/features/openai_api/presentation/docs/docs.dart
example/llamadart_server/lib/src/features/openai_api/presentation/docs/openapi_spec_builder.dart
example/llamadart_server/lib/src/features/openai_api/presentation/docs/openapi_spec_components.dart
example/llamadart_server/lib/src/features/openai_api/presentation/docs/openapi_spec_paths.dart
example/llamadart_server/lib/src/features/openai_api/presentation/docs/swagger_ui_page.dart
example/llamadart_server/lib/src/features/openai_api/presentation/docs/openapi_components/{responses,schemas_chat,schemas_embeddings,schemas_error,schemas_system,security_schemes}.dart
example/llamadart_server/lib/src/features/openai_api/presentation/docs/openapi_components/chat_schemas/{primitives,request,response}.dart
example/llamadart_server/lib/src/features/openai_api/presentation/docs/openapi_paths/{chat_paths,docs_paths,embeddings_paths,model_paths,path_security,system_paths}.dart
```

`find <example docs dir> -type f | wc -l` = 20, matching the 20 example paths.

**Nothing that should stay excluded reappears.** Over the after-fix listing: `^doc/` = 0 (the four maintainer files are still excluded), `^website/` = 0 (including the nested `website/docs/`), `^AGENTS.md` = 0, `^docs/` = 0.

**Root scratch `docs/` control.** Since no root `docs/` exists, its exclusion could not be observed passively. Created `docs/scratch.md` and re-ran the dry-run: `^docs/` = 0 and the flattened listing is byte-identical to the after-fix listing. The anchored `/docs/` still excludes a root scratch directory. Control file removed.

Both runs report `Package has 0 warnings.` Compressed archive stays at 1 MB.

## Production-readiness scope
- **User-facing scope:** consumers stop receiving four maintainer documents, and start receiving 22 files they should always have had — the `llamadart_server` example from the pub cache now analyzes instead of failing on three unresolved imports. Links to `doc/` from packaged files resolve on pub.dev. No API or behavior change.
- **Supported platforms/paths:** all — packaging metadata and comments only.
- **Unsupported or intentionally unavailable paths:** N/A.
- **Out of scope / follow-ups:** none remaining. The `docs/` follow-up noted in the previous revision is fixed here. The remaining unanchored patterns in the file (`build/`, `coverage/`, `test_assets/`, etc.) are directory names that do not occur nested in this repo; not touched.

## Completeness checklist
- [x] Declared scope is fully implemented.
- [x] Unsupported platform/option combinations fail loudly or are documented as unavailable. — N/A, no code paths added.
- [x] Public API docs, README/website docs, examples, support matrices, and changelog updated. — every relative `doc/` link in a packaged file converted to an absolute URL; two `## Unreleased` CHANGELOG bullets added; website docs already used absolute URLs.
- [x] Regression coverage. — `test/unit/tooling/pubignore_test.dart` loads `.pubignore` as Git ignore rules with global excludes disabled, then proves root `doc/`, `docs/`, and `website/` paths stay excluded while nested `tool/docs/`, example `presentation/docs/`, and `doc/` paths stay included.
- [x] Security/privacy review. — packaging only; the added files are already-public example and tooling sources from this repo.
- [x] Follow-up work tracked above.

## PR type guidance
- **Feature PR:** N/A — no API, example, or platform surface added.
- **Bugfix PR:** applies, two defects sharing one root cause — unanchored directory patterns under gitignore semantics. (1) `.pubignore` listed `docs/` but not `doc/`, and pub ships every non-ignored tracked path. (2) bare `docs/` matched at any depth and dropped `tool/docs/` and the example's `presentation/docs/`. The durable regression test exercises root-versus-nested ignore semantics; the with/without `--dry-run` listing diffs are above. Affected platforms: none.
- **Docs-only PR:** N/A — packaging metadata plus comment/link edits.

## Test Plan
- [x] `dart run tool/prepare_workspace.dart` — exit 0. (Locally it rewrites `example/chat_app/pubspec.lock`'s sdk constraint under a non-CI SDK; reverted, not committed.)
- [x] `dart format --output=none --set-exit-if-changed .` — run as `dart pub global run dart_style:format` (standalone dart_style 3.1.12, matching CI): `Formatted 570 files (0 changed)`.
- [x] `dart analyze` — `No issues found!`
- [x] `dart test -p vm -j 1 --exclude-tags local-only` — `All tests passed!` (+1635 ~74) on the original branch head. Exact-head follow-up: `dart test -p vm test/unit/tooling/pubignore_test.dart test/unit/tooling/test_matrix_test.dart` passed, with the new ignore-semantics contract test isolated from global Git excludes.
- [ ] `dart test -p chrome --exclude-tags local-only` — N/A: nothing web-specific; the Dart edits are comment/string only.
- [x] Other: `dart pub publish --dry-run` before/after for both defects, listings flattened and diffed (above); `dart run tool/testing/test_matrix.dart --list` exit 0 with the updated row; `dart run tool/testing/check_webgpu_bridge_tag.dart` → `OK: 12 pins agree on v0.1.37`.

## Matrix Evidence
| Matrix row | Scope covered | Platform / model / backend | Result | Evidence / notes |
| --- | --- | --- | --- | --- |
| N/A | Package contents and documentation links only; no backend, model, or platform code path is exercised. | N/A | N/A | `dart pub publish --dry-run` listings diffed: `/doc/` removes exactly the four maintainer files; `/docs/` + `/website/` add exactly `tool/docs/` and the example `presentation/docs/` tree (775 → 797, nothing removed). |

## Review Notes
- Independent review status: adversarial review run; blocked on a dangling `CONTRIBUTING.md` link, a false AGENTS.md claim, and the unaddressed ownership half of issue item 4. All three fixed. A subsequent archaeology pass promoted the `docs/` follow-up into this PR as Defect 2.
- CI status / head SHA: fill after CI runs.
