### PR TITLE
chore: pin dinja to a single minor for private-source imports

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,11 @@
   package, leaving the published example unable to analyze. Both patterns are
   now root-anchored.
 
+* Narrowed the `dinja` dependency constraint to `>=1.0.0 <1.1.0` so chat
+  template capability detection cannot silently resolve against an unverified
+  Jinja parser minor. A 1.0.x patch can still reorganise the private sources
+  the analyzer imports; a new coupling test turns that into a named failure.
+
 * Fixed Command R7B, Hermes, and Hunyuan V3 tool grammars so distinct tool or
   parameter names cannot collide after conversion to internal GBNF rule names.
 

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -32,7 +32,13 @@ dependencies:
   code_assets: '>=1.0.0 <3.0.0'
   hooks: '>=1.0.0 <3.0.0'
   logging: ^1.3.0
-  dinja: ^1.0.0
+  # jinja_analyzer.dart imports dinja's private src/lexer.dart, src/parser.dart
+  # and src/ast/nodes.dart. This bound only rules out a silently resolved 1.1.x;
+  # a 1.0.x patch can move those files just as freely, and consumers of released
+  # versions resolve dinja themselves. jinja_analyzer_dinja_coupling_test.dart
+  # catches the break in CI. Durable fix: dinja exports this surface -
+  # issue #351 option 2. Re-verify the imports to widen.
+  dinja: '>=1.0.0 <1.1.0'
 
 dev_dependencies:
   ffigen: ^21.0.0

--- a/test/unit/core/template/jinja/jinja_analyzer_dinja_coupling_test.dart
+++ b/test/unit/core/template/jinja/jinja_analyzer_dinja_coupling_test.dart
@@ -1,0 +1,164 @@
+// ignore: implementation_imports
+import 'package:dinja/src/ast/nodes.dart';
+// ignore: implementation_imports
+import 'package:dinja/src/lexer.dart';
+// ignore: implementation_imports
+import 'package:dinja/src/parser.dart';
+import 'package:test/test.dart';
+
+import 'package:llamadart/src/core/template/jinja/jinja_analyzer.dart';
+import 'package:llamadart/src/core/template/template_caps.dart';
+
+/// Guards `jinja_analyzer.dart`'s imports of dinja's private sources: the
+/// imports above stop compiling if those files move, and `dinja private-source
+/// coupling` fails if the lexer/parser shape or AST node types change.
+///
+/// The capability goldens are descriptive of the analyzer's current output,
+/// not a dinja guarantee - a deliberate analyzer change is expected to update
+/// them, and that is not dinja drift.
+void main() {
+  const representativeTemplate = '''
+{% for message in messages %}
+{% if message.role == 'system' %}{{ message.content }}{% endif %}
+{% if message.tool_calls %}
+{% for tool_call in message.tool_calls %}{{ tool_call.function.name }}{% endfor %}
+{% endif %}
+{% if message.role == 'user' %}
+{% for item in message.content %}{% if item.type == 'text' %}{{ item.text }}{% endif %}{% endfor %}
+{% endif %}
+{% endfor %}
+{% for tool in tools %}{{ tool.function.name }}{% endfor %}
+''';
+
+  group('dinja private-source coupling', () {
+    test('lexer and parser entry points keep the shape the analyzer uses', () {
+      // Mirrors the call chain in JinjaAnalyzer.analyze().
+      final LexerResult lexed = Lexer(representativeTemplate).tokenize();
+      expect(lexed.tokens, isNotEmpty);
+
+      final Program program = Parser(
+        lexed.tokens,
+        representativeTemplate,
+      ).parse();
+      expect(program.body, isNotEmpty);
+    });
+
+    test('AST node types the analyzer matches on are still produced', () {
+      final lexed = Lexer(representativeTemplate).tokenize();
+      final program = Parser(lexed.tokens, representativeTemplate).parse();
+
+      final seen = <Type>{};
+      void visit(Statement node) {
+        seen.add(node.runtimeType);
+        if (node is Program) {
+          node.body.forEach(visit);
+        } else if (node is IfStatement) {
+          visit(node.test);
+          node.body.forEach(visit);
+          node.alternate.forEach(visit);
+        } else if (node is ForStatement) {
+          visit(node.iterable);
+          visit(node.loopVar);
+          node.body.forEach(visit);
+          node.defaultBlock.forEach(visit);
+        } else if (node is BinaryExpression) {
+          visit(node.left);
+          visit(node.right);
+        } else if (node is MemberExpression) {
+          visit(node.object);
+          visit(node.property);
+        }
+      }
+
+      visit(program);
+
+      expect(
+        seen,
+        containsAll(<Type>[
+          IfStatement,
+          ForStatement,
+          BinaryExpression,
+          MemberExpression,
+          Identifier,
+          StringLiteral,
+        ]),
+        reason: 'JinjaAnalyzer pattern-matches on each of these node types',
+      );
+    });
+  });
+
+  group('JinjaAnalyzer capability goldens', () {
+    const cases = <String, String>{
+      'full chat template': representativeTemplate,
+      'string literal does not imply thinking support':
+          '{{ "thinking about it" }}'
+          '{% for m in messages %}{{ m.content }}{% endfor %}',
+      'typed content parts':
+          "{% for part in message['content'] %}"
+          "{% if part['type'] == 'image' %}Image{% endif %}"
+          '{% endfor %}',
+      'bare tools guard': '{% if tools %}tools available{% endif %}',
+    };
+
+    const goldens = <String, Map<String, bool>>{
+      'full chat template': <String, bool>{
+        'supports_system_role': true,
+        'supports_tool_calls': true,
+        'supports_tools': true,
+        'supports_parallel_tool_calls': true,
+        'supports_string_content': true,
+        'supports_typed_content': true,
+        'supports_thinking': false,
+      },
+      'string literal does not imply thinking support': <String, bool>{
+        'supports_system_role': true,
+        'supports_tool_calls': false,
+        'supports_tools': false,
+        'supports_parallel_tool_calls': false,
+        'supports_string_content': true,
+        'supports_typed_content': false,
+        'supports_thinking': false,
+      },
+      'typed content parts': <String, bool>{
+        'supports_system_role': false,
+        'supports_tool_calls': false,
+        'supports_tools': false,
+        'supports_parallel_tool_calls': false,
+        'supports_string_content': false,
+        'supports_typed_content': true,
+        'supports_thinking': false,
+      },
+      'bare tools guard': <String, bool>{
+        'supports_system_role': false,
+        'supports_tool_calls': false,
+        'supports_tools': false,
+        'supports_parallel_tool_calls': false,
+        'supports_string_content': true,
+        'supports_typed_content': false,
+        'supports_thinking': false,
+      },
+    };
+
+    for (final entry in cases.entries) {
+      test('${entry.key} keeps its capability map', () {
+        final source = entry.value;
+        expect(JinjaAnalyzer.analyze(source).toMap(), goldens[entry.key]);
+        expect(
+          TemplateCaps.detectRegex(source).toMap(),
+          isNot(goldens[entry.key]),
+          reason:
+              'golden must be unreachable via the regex fallback, otherwise a '
+              'broken dinja parse path would still pass',
+        );
+      });
+    }
+
+    test('invalid syntax still falls back to the regex result', () {
+      const invalid = "{% if message.role == 'system' %}{{ message.content }}";
+      expect(
+        JinjaAnalyzer.analyze(invalid).toMap(),
+        TemplateCaps.detectRegex(invalid).toMap(),
+      );
+    });
+  });
+}

--- a/test/unit/core/template/jinja/jinja_analyzer_dinja_coupling_test.dart
+++ b/test/unit/core/template/jinja/jinja_analyzer_dinja_coupling_test.dart
@@ -154,11 +154,18 @@ void main() {
     }
 
     test('invalid syntax still falls back to the regex result', () {
-      const invalid = "{% if message.role == 'system' %}{{ message.content }}";
+      const invalid =
+          "{% if message.role == 'system' %}{{ message.content }} thinking";
+      final regexCaps = TemplateCaps.detectRegex(invalid);
+
       expect(
-        JinjaAnalyzer.analyze(invalid).toMap(),
-        TemplateCaps.detectRegex(invalid).toMap(),
+        regexCaps.supportsThinking,
+        isTrue,
+        reason:
+            'the raw marker must distinguish regex fallback from a silently '
+            'accepted AST path',
       );
+      expect(JinjaAnalyzer.analyze(invalid).toMap(), regexCaps.toMap());
     });
   });
 }

--- a/website/docs/changelog/recent-releases.md
+++ b/website/docs/changelog/recent-releases.md
@@ -29,6 +29,11 @@ For canonical full release notes, use:
   package, leaving the published example unable to analyze. Both patterns are
   now root-anchored.
 
+- Narrowed the `dinja` dependency constraint to `>=1.0.0 <1.1.0` so chat
+  template capability detection cannot silently resolve against an unverified
+  Jinja parser minor. A 1.0.x patch can still reorganise the private sources
+  the analyzer imports; a new coupling test turns that into a named failure.
+
 - Fixed Command R7B, Hermes, and Hunyuan V3 tool grammars so distinct tool or
   parameter names cannot collide after conversion to internal GBNF rule names.
 


### PR DESCRIPTION
## Summary
- `lib/src/core/template/jinja/jinja_analyzer.dart` imports three dinja private sources (`src/lexer.dart`, `src/parser.dart`, `src/ast/nodes.dart`). `dinja: ^1.0.0` let any 1.x minor reorganise them without it being breaking on dinja's side, and the root lockfile is gitignored, so CI and local checkouts could resolve different minors.
- Narrow the constraint to `>=1.0.0 <1.1.0` (issue #351 option 1) with a comment that states the coupling and its residual risk.
- Add `test/unit/core/template/jinja/jinja_analyzer_dinja_coupling_test.dart`: it pins the lexer/parser entry-point shape, the AST node types the analyzer matches on, and the analyzer's capability output for representative templates. Each golden is asserted to differ from `TemplateCaps.detectRegex`, so a broken parse path cannot pass by silently falling back to regex.

### What this pin does and does not do
- **Prevents:** a silently resolved 1.1.x whose reorganised private sources break the imports or quietly change capability detection.
- **Does not prevent:** the same thing from a 1.0.x **patch**. Patch releases can move private sources just as freely, because none of this surface is part of dinja's public API contract. The pin narrows the exposure; it does not remove it.
- **Durable fix:** dinja exports the parser/lexer/AST surface publicly and the three `implementation_imports` suppressions go away — issue #351 option 2. Not done here, and not obtainable from this repo alone.
- **Why not an exact pin:** llamadart is a library published to pub.dev. `dinja: 1.0.0` would propagate a hard version conflict to every consumer that depends on dinja itself, which is a worse trade than the residual patch-level risk.

### What the coupling test actually catches
- The root `pubspec.lock` is gitignored, so CI resolves dependencies fresh on every run. A 1.0.x patch that moves or reshapes those private sources therefore fails **this repo's** CI on the next run: the imports fail to compile, or the entry-point/AST assertions fail, or the capability goldens change.
- It does **not** protect already-released consumers. They resolve dinja at their own `pub get`, after our release, and llamadart's test suite does not run there. A patch published after a release can still break a consumer's build before our CI ever sees it.
- Note the second group in that file (`JinjaAnalyzer capability goldens`) is descriptive of the analyzer's current output, not a dinja contract; a deliberate analyzer change is expected to update it.

## Production-readiness scope
- **User-facing scope:** unchanged behavior. Dependency-resolution hardening plus regression coverage for chat-template capability detection.
- **Supported platforms/paths:** all paths that resolve `dinja` (native, web, Flutter examples). No platform-specific code touched.
- **Unsupported or intentionally unavailable paths:** N/A — no runtime behavior added or removed.
- **Out of scope / follow-ups:** issue #351 stays open, tracking option 2 (upstream public API for the parser/lexer/AST surface). This PR delivers option 1 only, and option 1 leaves patch-level exposure in place, so the issue should not be auto-closed by merge.

## Completeness checklist
- [x] Declared scope is fully implemented, or explicitly reduced above.
- [x] Unsupported platform/option combinations fail loudly with actionable diagnostics or are clearly documented as unavailable.
- [x] Public API docs, README/website docs, examples, support matrices, and changelog entries are updated where relevant. (`CHANGELOG.md`, `website/docs/changelog/recent-releases.md`.)
- [x] Regression coverage covers the original issue plus key negative/version-skew paths where relevant. (Private-import resolution, entry-point shape, AST node types, capability goldens, regex-fallback path.)
- [x] Security/privacy review completed: no secrets, tokens, or secret-bearing paths involved.
- [x] Follow-up work that is useful but not required for this PR is tracked in GitHub Issues. (#351, kept open for option 2.)

## PR type guidance
- **Bugfix PR** (latent-defect hardening): root cause is an unbounded constraint over a private-source import; regression coverage is the new coupling test; affected paths are every platform that resolves dinja.

## Test Plan
- [x] `dart run tool/prepare_workspace.dart`
- [x] `dart pub global run dart_style:format --output=none --set-exit-if-changed .` — 571 files, 0 changed (standalone dart_style 3.1.12; the bundled `dart format` in SDK 3.12.2 disagrees with CI)
- [x] `dart analyze` — No issues found
- [x] `dart test -p vm -j 1 --exclude-tags local-only test/unit/core/template` — 468 tests, all passed (includes the 18 new/covering jinja tests)
- [ ] `dart test -p chrome --exclude-tags local-only` — N/A: no web-specific code path changed; the analyzer is platform-independent Dart.
- [ ] Other targeted/local-only validation: N/A — no model, backend, or device path touched.

## Matrix Evidence
| Matrix row | Scope covered | Platform / model / backend | Result | Evidence / notes |
| --- | --- | --- | --- | --- |
| N/A | Dependency constraint + unit-level regression coverage | VM, no model/backend | PASS | Analyzer/format/unit gates above; no matrix row exercises dependency resolution. |

## Review Notes
- Independent review status: reviewer raised [P1] that `>=1.0.0 <1.1.0` still admits 1.0.x patches that can reshuffle private sources. Diagnosis accepted and documented above and in the `pubspec.yaml` comment; the constraint is unchanged because issue #351 prescribes this range and an exact pin would propagate a hard conflict to library consumers. The durable fix is option 2, tracked by keeping #351 open.
- CI status / head SHA: <!-- fill after CI runs -->

Refs #351 (kept open for option 2 — upstream public API).
