### PR TITLE
fix: restore explicit none in native runtimes config, and document the hook contract

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,10 +4,11 @@
   Docusaurus replaces its unpatched image parser, automatic local Markdown
   images are rejected; website contributors should use static pathname URLs.
 
-* Fixed `llamadart_native_runtimes: none` (and `off`, `false`, or a list ending
-  in `none`) selecting every runtime family instead of none. The build hook
-  fails again with its `No native runtimes selected` error, as it did before
-  0.8.0. Unset, empty, and all-unrecognised config still select every family.
+* Fixed `llamadart_native_runtimes: none` and `off` selecting every runtime
+  family instead of none; the build hook fails with its `No native runtimes
+  selected` error again, as it did before 0.8.0. A YAML boolean `false` clears
+  the selection too. Unset, empty, and all-unrecognised config still select
+  every family.
 
 * Fixed Command R7B, Hermes, and Hunyuan V3 tool grammars so distinct tool or
   parameter names cannot collide after conversion to internal GBNF rule names.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@
   Docusaurus replaces its unpatched image parser, automatic local Markdown
   images are rejected; website contributors should use static pathname URLs.
 
+* Fixed `llamadart_native_runtimes: none` (and `off`, `false`, or a list ending
+  in `none`) selecting every runtime family instead of none. The build hook
+  fails again with its `No native runtimes selected` error, as it did before
+  0.8.0. Unset, empty, and all-unrecognised config still select every family.
+
 * Fixed Command R7B, Hermes, and Hunyuan V3 tool grammars so distinct tool or
   parameter names cannot collide after conversion to internal GBNF rule names.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,11 +4,11 @@
   Docusaurus replaces its unpatched image parser, automatic local Markdown
   images are rejected; website contributors should use static pathname URLs.
 
-* Fixed `llamadart_native_runtimes: none` and `off` selecting every runtime
-  family instead of none; the build hook fails with its `No native runtimes
-  selected` error again, as it did before 0.8.0. A YAML boolean `false` clears
-  the selection too. Unset, empty, and all-unrecognised config still select
-  every family.
+* Fixed `llamadart_native_runtimes` values `none`, `off`, and the string
+  `false` selecting every runtime family instead of none;
+  the build hook fails with its `No native runtimes selected` error again, as
+  it did before 0.8.0. A YAML boolean `false` clears the selection too. Unset,
+  empty, and all-unrecognised config still select every family.
 
 * Fixed Command R7B, Hermes, and Hunyuan V3 tool grammars so distinct tool or
   parameter names cannot collide after conversion to internal GBNF rule names.

--- a/lib/src/hook/native_bundle_config.dart
+++ b/lib/src/hook/native_bundle_config.dart
@@ -1,21 +1,62 @@
-// ignore_for_file: public_member_api_docs
+/// Decodes the `hooks.user_defines.llamadart` native-bundle configuration for
+/// `hook/build.dart`. Pure decisions over already-discovered paths and
+/// already-decoded config: nothing here downloads, extracts, or emits assets.
+///
+/// [nativeRuntimesUserDefineKey] picks the runtime families to build;
+/// [nativeBackendUserDefineKey] filters the split llama.cpp backend modules
+/// within `llama_cpp`. Both scope by platform through a `platforms` map, or —
+/// kept for backward compatibility — a bare map already keyed by platform.
+///
+/// Entry-point roles, deliberately not a call order `hook/build.dart` may
+/// reorder: [resolveNativeBundleSpec] names the target's release bundle;
+/// [selectNativeRuntimesForBundle] picks the runtime families and
+/// [nativeRuntimeExplicitlySelectedForBundle] says how hard to fail when one
+/// is unpublished; [describeNativeLibrary] classifies a discovered file;
+/// [selectLibrariesForBundling] picks which ship; [codeAssetNameForLibrary]
+/// names each as a code asset. A Flutter Apple build depending on a companion
+/// package takes the families from it, not [selectNativeRuntimesForBundle].
+///
+/// User-facing docs: `website/docs/platforms/native-build-hooks.md` and
+/// `website/docs/guides/backend-selection.md`.
+library;
 
 import 'package:code_assets/code_assets.dart';
 import 'package:path/path.dart' as path;
 
+/// User-define key selecting which llama.cpp backend modules to bundle (`cpu`,
+/// `vulkan`, `cuda`, `blas`, `opencl`, `hip`); also carries the Android arm64
+/// `cpu_profile`/`cpu_variants` policy. [parseRequestedBackends] decodes the
+/// backend list; [selectLibrariesForBundling] decodes the CPU policy.
 const String nativeBackendUserDefineKey = 'llamadart_native_backends';
+
+/// `llamadart-native` release tag to download; resolved in `hook/build.dart`.
 const String nativeTagUserDefineKey = 'llamadart_native_tag';
+
+/// GitHub `owner/repo` slug releases come from; resolved in `hook/build.dart`.
 const String nativeRepositoryUserDefineKey = 'llamadart_native_repository';
+
+/// Local native bundle directory, used instead of a release download;
+/// resolved in `hook/build.dart`.
 const String nativePathUserDefineKey = 'llamadart_native_path';
+
+/// User-define key selecting runtime families. Decoded by
+/// [selectNativeRuntimesForBundle].
 const String nativeRuntimesUserDefineKey = 'llamadart_native_runtimes';
+
+/// The llama.cpp/GGUF runtime family; the only one with configurable backends.
 const String nativeRuntimeLlamaCpp = 'llama_cpp';
+
+/// The LiteRT-LM runtime family; not published for every bundle.
 const String nativeRuntimeLiteRtLm = 'litert_lm';
 
+/// Every runtime family, in the order `all` and `both` expand to.
 const List<String> allNativeRuntimes = [
   nativeRuntimeLlamaCpp,
   nativeRuntimeLiteRtLm,
 ];
 
+/// Fallback families for config that names no runtimes. An explicit `none`
+/// selects nothing instead.
 const List<String> defaultNativeRuntimes = allNativeRuntimes;
 
 const Set<String> _coreLibraries = {
@@ -147,11 +188,25 @@ const Map<String, String> _androidCpuVariantAliases = {
   'baseline': 'android_armv8.0_1',
 };
 
+/// What `llamadart-native` publishes for one target.
 class NativeBundleSpec {
+  /// Release bundle key (`linux-x64`, `ios-arm64-sim`), and the key user
+  /// config is matched against. Downstream branches test it by prefix
+  /// (`windows-`) or whole (`android-arm64`).
   final String bundle;
+
+  /// Whether this bundle ships split `ggml-*` backend modules that
+  /// `llamadart_native_backends` can filter. `false` for the consolidated
+  /// Apple runtimes, where [selectBackendsForBundle] selects nothing and
+  /// [selectLibrariesForBundling] passes every library through unchanged.
   final bool configurableBackends;
+
+  /// Backends preferred when the user requests none — listing one here does
+  /// not force it to exist, and [selectBackendsForBundle] may bundle more or
+  /// other modules. Empty whenever [configurableBackends] is `false`.
   final List<String> defaultBackends;
 
+  /// Creates a spec for one release bundle.
   const NativeBundleSpec({
     required this.bundle,
     required this.configurableBackends,
@@ -159,14 +214,44 @@ class NativeBundleSpec {
   });
 }
 
+/// One native library file, classified from its basename alone.
 class NativeLibraryDescriptor {
+  /// Path the file was found at, verbatim.
+  ///
+  /// `hook/build.dart` re-describes every file it copies into the build output
+  /// directory, and on `linux-*` copies each `.so` under its SONAME aliases
+  /// too, so each `.so` yields two descriptors — three for `libmtmd.so`,
+  /// which also gets a `.so.SOVERSION` alias. Those extras differ in
+  /// [fileName] too: a `.so.0` alias still shares the source [canonicalName],
+  /// but `libmtmd.so.SOVERSION` canonicalises to a non-core
+  /// `mtmd.so.soversion`.
   final String filePath;
+
+  /// Basename of [filePath], with the casing it has on disk.
   final String fileName;
+
+  /// [fileName] lowercased, with the extension (including trailing `.<n>`
+  /// SONAME components), a leading `lib`, and any packed platform suffix such
+  /// as `-windows-x64` removed: `libllama.so.0` and `llama-windows-x64.dll`
+  /// both give `llama`. Every classification decision keys off this name.
   final String canonicalName;
+
+  /// Whether this library is bundled regardless of backend selection:
+  /// `llamadart`, `llama`, `llama-common`, `ggml`, `ggml-base`, `mtmd`. Core
+  /// libraries always report a `null` [backend].
   final bool isCore;
+
+  /// Whether [canonicalName] is `llamadart`. `hook/build.dart` fails the build
+  /// when no discovered library is primary. Not the same as owning the default
+  /// asset name: on Windows [codeAssetNameForLibrary] gives that to `llama`.
   final bool isPrimary;
+
+  /// Backend module this library implements, or `null` — for core libraries,
+  /// for names that imply no backend, and for CUDA/BLAS runtime dependencies,
+  /// which [selectLibrariesForBundling] matches by name instead.
   final String? backend;
 
+  /// Creates a descriptor for one classified library file.
   const NativeLibraryDescriptor({
     required this.filePath,
     required this.fileName,
@@ -177,6 +262,15 @@ class NativeLibraryDescriptor {
   });
 }
 
+/// The `llamadart-native` release bundle for a target OS/architecture, or
+/// `null` when none is published — `hook/build.dart` then warns and emits no
+/// native assets at all.
+///
+/// Apple bundles are not backend-configurable; Android, Linux and Windows
+/// are, and default to `['cpu', 'vulkan']`.
+///
+/// [isIosSimulator] only distinguishes `ios-arm64` from `ios-arm64-sim`; the
+/// x64 iOS bundle is simulator-only regardless of the flag.
 NativeBundleSpec? resolveNativeBundleSpec({
   required OS os,
   required Architecture arch,
@@ -248,6 +342,19 @@ NativeBundleSpec? resolveNativeBundleSpec({
   }
 }
 
+/// Normalises a user-written bundle key so config keys and bundle names
+/// compare equal: spaces are stripped and `_` folds to `-`, then `x86-64` is
+/// respelled `x86_64` to match the published bundle keys. Bundle aliases such
+/// as `android-arm64-v8a` are resolved too. Unrecognised values come back
+/// normalised rather than rejected.
+///
+/// OS aliases (`darwin`, `osx`, `win32`, `iphonesimulator`, ...) are
+/// deliberately not applied here: OS keys are only considered one level up,
+/// after an exact bundle-key match has failed.
+///
+/// `ios-arm64-sim` never collapses to `ios-arm64`: a config entry naming the
+/// device bundle must not silently change what a simulator build bundles. Use
+/// the `ios` OS key to cover both.
 String canonicalizeBundleKey(String value) {
   var normalized = value.trim().toLowerCase().replaceAll(' ', '');
   normalized = normalized.replaceAll('_', '-');
@@ -314,6 +421,17 @@ Map<String, Object?>? _platformConfigMapForBundle({
   return _toStringMap(platformValue);
 }
 
+/// Classifies one library file from its basename; the file is never opened.
+///
+/// A canonical name in the core set reports `isCore: true` and a `null`
+/// backend. Otherwise the backend is the first `-`-separated token after a
+/// `ggml-` prefix, alias-resolved, so `libggml-cpu-android_armv8.2_1.so`
+/// infers `cpu`; bare `ggml` and `ggml-base` infer nothing, and a canonical
+/// name of exactly `opencl` infers `opencl`.
+///
+/// The split runs before the alias lookup, so single-token aliases survive it
+/// (`vk`, `ocl`) and multi-token ones do not: `open-cl` resolves to `opencl`
+/// in user config, but `libggml-open-cl.so` infers `open`.
 NativeLibraryDescriptor describeNativeLibrary(String filePath) {
   final fileName = path.basename(filePath);
   final canonicalName = _canonicalLibraryName(fileName);
@@ -330,12 +448,17 @@ NativeLibraryDescriptor describeNativeLibrary(String filePath) {
   );
 }
 
+/// [describeNativeLibrary] over every path, order preserved.
+/// `hook/build.dart` requires at least one primary entry before going on.
 List<NativeLibraryDescriptor> describeNativeLibraries(
   Iterable<String> filePaths,
 ) {
   return filePaths.map(describeNativeLibrary).toList(growable: false);
 }
 
+/// The distinct non-null backends present in [libraries] — what this bundle
+/// can actually offer. Requested and default backends are validated against
+/// this set, so a bundle shipping no `ggml-cuda` module cannot select `cuda`.
 Set<String> collectAvailableBackends(
   Iterable<NativeLibraryDescriptor> libraries,
 ) {
@@ -348,6 +471,18 @@ Set<String> collectAvailableBackends(
   return backends;
 }
 
+/// The backends requested for [bundle] under `llamadart_native_backends`, or
+/// `null` when the config resolves no value for it: unset, not
+/// platform-scoped, or no matching entry. The lookup takes the first key
+/// canonicalising to [bundle], else the first for its OS. Both `null` and `[]`
+/// leave the bundle defaults in force in [selectBackendsForBundle].
+///
+/// A matched platform entry may be a comma-separated string, a list of
+/// strings, or a map with a `backends` key — the map form also carries
+/// `cpu_profile`/`cpu_variants`; a matched map without `backends` yields `[]`,
+/// not `null`. Tokens are trimmed, lowercased, `_`-to-`-` normalised,
+/// alias-resolved and de-duplicated in first-seen order; non-string list
+/// entries are skipped.
 List<String>? parseRequestedBackends({
   required String bundle,
   required Object? rawUserConfig,
@@ -368,6 +503,34 @@ List<String>? parseRequestedBackends({
   return _parseBackendList(platformValue);
 }
 
+/// The runtime families to build for [bundle], decoded from
+/// `llamadart_native_runtimes`.
+///
+/// Precedence, first match wins: the `platforms` entry canonicalising to
+/// [bundle]; the entry for that bundle's OS; the top-level `runtimes` key; the
+/// top-level `default` key; else [defaultNativeRuntimes], every family. A
+/// matched platform entry with a `null` value ends the platform search, so the
+/// OS entry is skipped. `runtimes` is consulted by key presence, so an
+/// explicit `runtimes: null` suppresses `default` instead of falling through
+/// to it. A bare string or list at the root is taken as-is, unscoped.
+///
+/// Tokens are trimmed, lowercased and `_`-to-`-` normalised before alias
+/// lookup: `gguf` and `llama.cpp` reach `llama_cpp`; `litert`, `litertlm` and
+/// `.litertlm` reach `litert_lm`. `all` and `both` expand to
+/// [allNativeRuntimes]; the string tokens `none`, `off` and `false` clear what
+/// has accumulated — a bare YAML `false` is a bool, not one.
+/// Unrecognised non-empty tokens are dropped and reported once through
+/// [warn]; empty tokens are ignored silently. A string or list that selects
+/// nothing because it was empty or all-unrecognised yields
+/// [allNativeRuntimes]. Once a `none` token clears the selection only a later
+/// recognised token refills it, so `['none', 'llama_cpp']` selects `llama_cpp`
+/// while `['none', 'tflite']` stays empty, which `hook/build.dart` throws on.
+///
+/// Values other than a string or list select nothing, which `hook/build.dart`
+/// throws on; a map is first unwrapped through its `runtimes` key. When no
+/// level resolves a value at all — a scalar at the *root* included — the
+/// fallback to [defaultNativeRuntimes] is silent when the key is unset or the
+/// config is platform-scoped, and a [warn] otherwise.
 List<String> selectNativeRuntimesForBundle({
   required String bundle,
   required Object? rawUserConfig,
@@ -392,6 +555,14 @@ List<String> selectNativeRuntimesForBundle({
   return parsed.runtimes;
 }
 
+/// Whether [runtime] was named for [bundle], not implied by a default or by
+/// `all`/`both` expansion. `false` for `all`, `none`, unrecognised spellings,
+/// and for a name a later `none` cleared (`['litert_lm', 'none']`). Order
+/// decides it, so `['none', 'litert_lm']` is explicit.
+///
+/// `hook/build.dart` uses this when LiteRT-LM is selected but the bundle
+/// publishes no LiteRT-LM archive: an explicit request throws, an implied one
+/// is dropped with a warning.
 bool nativeRuntimeExplicitlySelectedForBundle({
   required String bundle,
   required Object? rawUserConfig,
@@ -410,6 +581,19 @@ bool nativeRuntimeExplicitlySelectedForBundle({
   return parsed?.explicit.contains(normalizedRuntime) ?? false;
 }
 
+/// The backend modules to bundle for [spec], constrained to
+/// [availableBackends]. Non-configurable bundles select nothing.
+///
+/// `cpu` is added to the defaults and to an accepted request whenever a `cpu`
+/// module exists, so it cannot be opted out of. The defaults are
+/// [NativeBundleSpec.defaultBackends] restricted to what is available; they
+/// apply when the request is `null` or empty, and also when a request names
+/// any unavailable backend — such a request is rejected whole, not partially,
+/// with a [warn] naming the missing backends. When the defaults resolve to
+/// nothing while the bundle does contain modules, every available module is
+/// bundled in sort order with a [warn] of its own — a second one on the
+/// rejected-request path, which has already warned about the missing
+/// backends.
 List<String> selectBackendsForBundle({
   required NativeBundleSpec spec,
   required Set<String> availableBackends,
@@ -704,6 +888,28 @@ String? _androidCpuVariantTagFromCanonicalName(String canonicalName) {
   return canonicalName.substring('ggml-cpu-'.length);
 }
 
+/// Filters [libraries] down to the files the hook should copy and report as
+/// code assets. Non-configurable bundles pass through untouched.
+///
+/// Otherwise the backend set comes from [selectBackendsForBundle] over
+/// [collectAvailableBackends], and a library survives when it is core, when
+/// its inferred backend is selected, or when it infers no backend at all —
+/// unrecognised vendor libraries are kept, not dropped. Two canonical-name
+/// shapes are instead gated on a backend so they leave alongside the module
+/// that needs them: `cudart64`, `cublas64` or `cublaslt64` with an optional
+/// trailing digit run, itself optionally preceded by `_` or `-`, on `cuda`,
+/// and anything starting `openblas` on `blas`.
+///
+/// `android-arm64` then gets a second pass over the per-CPU-variant
+/// `ggml-cpu-*` modules. An explicit `cpu_variants` list wins, minus
+/// unrecognised entries ([warn]); if nothing valid remains a [warn] fires and
+/// resolution falls through to `cpu_profile`, which is `full` (all seven ARM
+/// variants) by default, keeps only `android_armv8.0_1` when `compact`, and
+/// warns and stays `full` when it is unrecognised or a non-string other than
+/// `null`, which takes the default silently. A legacy
+/// unsuffixed `ggml-cpu` module is always kept, and whenever the result holds
+/// no CPU module — a bundle that shipped none included — [warn] fires and the
+/// unfiltered backend selection is returned instead.
 List<NativeLibraryDescriptor> selectLibrariesForBundling({
   required NativeBundleSpec spec,
   required List<NativeLibraryDescriptor> libraries,
@@ -755,7 +961,6 @@ List<NativeLibraryDescriptor> selectLibrariesForBundling({
           return true;
         }
 
-        // Keep legacy unsuffixed CPU backend modules when present.
         final variant = _androidCpuVariantTagFromCanonicalName(
           library.canonicalName,
         );
@@ -778,13 +983,19 @@ List<NativeLibraryDescriptor> selectLibrariesForBundling({
   return selectedLibraries;
 }
 
+/// The `package:llamadart/<name>` code-asset name to report [library] under.
+///
+/// The primary `llamadart` library normally takes the bare package name, the
+/// asset the generated FFI bindings resolve. On `windows-*` two independent
+/// renames apply — `llama` takes `llamadart`, `llamadart` takes
+/// `llamadart_wrapper` — because that bundle puts the core llama/ggml symbols
+/// in `llama.dll` and only wrapper helpers in `llamadart.dll`. Every other
+/// library uses its sanitised canonical name; names are not guaranteed unique,
+/// so the caller de-duplicates before emitting assets.
 String codeAssetNameForLibrary({
   required NativeBundleSpec spec,
   required NativeLibraryDescriptor library,
 }) {
-  // Windows split bundle exports core llama/ggml symbols from `llama.dll`,
-  // while `llamadart.dll` only contains wrapper helpers. The Dart bindings
-  // default asset must point at the core symbol provider.
   if (spec.bundle.startsWith('windows-')) {
     if (library.canonicalName == 'llama') {
       return 'llamadart';
@@ -878,6 +1089,9 @@ _parseRuntimeList(Object? value) {
   final result = <String>[];
   final invalid = <String>[];
   final explicit = <String>{};
+  // Distinguishes "the user asked for nothing" from "nothing was recognised",
+  // which resolve to opposite selections below.
+  var explicitNone = false;
 
   void addToken(String token) {
     final normalized = _normalizeRuntime(token);
@@ -898,6 +1112,7 @@ _parseRuntimeList(Object? value) {
     if (normalized == 'none') {
       result.clear();
       explicit.clear();
+      explicitNone = true;
       return;
     }
     if (!result.contains(normalized)) {
@@ -911,7 +1126,7 @@ _parseRuntimeList(Object? value) {
       addToken(token);
     }
     return (
-      runtimes: result.isEmpty ? allNativeRuntimes : result,
+      runtimes: result.isEmpty && !explicitNone ? allNativeRuntimes : result,
       invalid: invalid,
       explicit: explicit,
     );
@@ -926,7 +1141,7 @@ _parseRuntimeList(Object? value) {
       }
     }
     return (
-      runtimes: result.isEmpty ? allNativeRuntimes : result,
+      runtimes: result.isEmpty && !explicitNone ? allNativeRuntimes : result,
       invalid: invalid,
       explicit: explicit,
     );

--- a/lib/src/hook/native_bundle_config.dart
+++ b/lib/src/hook/native_bundle_config.dart
@@ -518,7 +518,8 @@ List<String>? parseRequestedBackends({
 /// lookup: `gguf` and `llama.cpp` reach `llama_cpp`; `litert`, `litertlm` and
 /// `.litertlm` reach `litert_lm`. `all` and `both` expand to
 /// [allNativeRuntimes]; the string tokens `none`, `off` and `false` clear what
-/// has accumulated — a bare YAML `false` is a bool, not one.
+/// has accumulated. A bare YAML boolean `false` clears it too, including in a
+/// list.
 /// Unrecognised non-empty tokens are dropped and reported once through
 /// [warn]; empty tokens are ignored silently. A string or list that selects
 /// nothing because it was empty or all-unrecognised yields
@@ -526,11 +527,12 @@ List<String>? parseRequestedBackends({
 /// recognised token refills it, so `['none', 'llama_cpp']` selects `llama_cpp`
 /// while `['none', 'tflite']` stays empty, which `hook/build.dart` throws on.
 ///
-/// Values other than a string or list select nothing, which `hook/build.dart`
-/// throws on; a map is first unwrapped through its `runtimes` key. When no
-/// level resolves a value at all — a scalar at the *root* included — the
-/// fallback to [defaultNativeRuntimes] is silent when the key is unset or the
-/// config is platform-scoped, and a [warn] otherwise.
+/// A map is first unwrapped through its `runtimes` key. At a selected map
+/// entry, values other than a string, list, map, or boolean `false` select
+/// nothing, which `hook/build.dart` throws on. When no level resolves a value
+/// at all — an unsupported scalar at the *root* included — the fallback to
+/// [defaultNativeRuntimes] is silent when the key is unset or the config is
+/// platform-scoped, and a [warn] otherwise.
 List<String> selectNativeRuntimesForBundle({
   required String bundle,
   required Object? rawUserConfig,
@@ -660,7 +662,9 @@ _parseNativeRuntimeConfigForBundle({
     return null;
   }
 
-  if (rawUserConfig is String || rawUserConfig is List<Object?>) {
+  if (rawUserConfig is String ||
+      rawUserConfig is List<Object?> ||
+      rawUserConfig == false) {
     return _parseRuntimeList(rawUserConfig);
   }
 
@@ -1121,6 +1125,11 @@ _parseRuntimeList(Object? value) {
     explicit.add(normalized);
   }
 
+  if (value == false) {
+    addToken('none');
+    return (runtimes: result, invalid: invalid, explicit: explicit);
+  }
+
   if (value is String) {
     for (final token in value.split(',')) {
       addToken(token);
@@ -1136,6 +1145,8 @@ _parseRuntimeList(Object? value) {
     for (final entry in value) {
       if (entry is String) {
         addToken(entry);
+      } else if (entry == false) {
+        addToken('none');
       } else if (entry != null) {
         invalid.add(entry.toString());
       }

--- a/test/unit/hook/build_hook_linux_integration_test.dart
+++ b/test/unit/hook/build_hook_linux_integration_test.dart
@@ -116,27 +116,29 @@ void main() {
   );
 
   test('build hook fails when runtimes config selects none', () async {
-    await expectLater(
-      testCodeBuildHook(
-        mainMethod: build_hook.main,
-        targetOS: OS.linux,
-        targetArchitecture: Architecture.x64,
-        userDefines: PackageUserDefines(
-          workspacePubspec: PackageUserDefinesSource(
-            defines: const {'llamadart_native_runtimes': 'none'},
-            basePath: Directory.current.uri,
+    for (final rawUserConfig in const <Object>['none', false]) {
+      await expectLater(
+        testCodeBuildHook(
+          mainMethod: build_hook.main,
+          targetOS: OS.linux,
+          targetArchitecture: Architecture.x64,
+          userDefines: PackageUserDefines(
+            workspacePubspec: PackageUserDefinesSource(
+              defines: {'llamadart_native_runtimes': rawUserConfig},
+              basePath: Directory.current.uri,
+            ),
+          ),
+          check: (_, _) {},
+        ),
+        throwsA(
+          isA<Exception>().having(
+            (error) => error.toString(),
+            'message',
+            contains('No native runtimes selected for linux-x64'),
           ),
         ),
-        check: (_, _) {},
-      ),
-      throwsA(
-        isA<Exception>().having(
-          (error) => error.toString(),
-          'message',
-          contains('No native runtimes selected for linux-x64'),
-        ),
-      ),
-    );
+      );
+    }
   });
 }
 

--- a/test/unit/hook/build_hook_linux_integration_test.dart
+++ b/test/unit/hook/build_hook_linux_integration_test.dart
@@ -4,6 +4,7 @@ library;
 import 'dart:io';
 
 import 'package:code_assets/code_assets.dart';
+import 'package:hooks/hooks.dart';
 import 'package:path/path.dart' as path;
 import 'package:test/test.dart';
 
@@ -113,6 +114,30 @@ void main() {
       );
     },
   );
+
+  test('build hook fails when runtimes config selects none', () async {
+    await expectLater(
+      testCodeBuildHook(
+        mainMethod: build_hook.main,
+        targetOS: OS.linux,
+        targetArchitecture: Architecture.x64,
+        userDefines: PackageUserDefines(
+          workspacePubspec: PackageUserDefinesSource(
+            defines: const {'llamadart_native_runtimes': 'none'},
+            basePath: Directory.current.uri,
+          ),
+        ),
+        check: (_, _) {},
+      ),
+      throwsA(
+        isA<Exception>().having(
+          (error) => error.toString(),
+          'message',
+          contains('No native runtimes selected for linux-x64'),
+        ),
+      ),
+    );
+  });
 }
 
 String _readHookNativeTag() {

--- a/test/unit/hook/native_bundle_config_test.dart
+++ b/test/unit/hook/native_bundle_config_test.dart
@@ -424,9 +424,13 @@ void main() {
         'none',
         'off',
         'false',
+        false,
         ['none'],
+        [false],
         ['llama_cpp', 'none'],
+        ['llama_cpp', false],
         {'runtimes': 'none'},
+        {'runtimes': false},
         {
           'runtimes': ['llama_cpp'],
           'platforms': {'linux-x64': 'none'},
@@ -452,7 +456,7 @@ void main() {
       expect(warnings, isEmpty);
     });
 
-    test('unset and empty stay all runtime families', () {
+    test('unset, empty, and unsupported root scalars stay all', () {
       for (final rawUserConfig in const <Object?>[null, '', <String>[]]) {
         final warnings = <String>[];
 
@@ -463,6 +467,11 @@ void main() {
         );
         expect(warnings, isEmpty, reason: rawUserConfig.toString());
       }
+
+      final warnings = <String>[];
+      expect(select(true, warnings), allNativeRuntimes);
+      expect(warnings, hasLength(1));
+      expect(warnings.single, contains('true'));
     });
 
     test('all-unrecognised list warns and stays all runtime families', () {
@@ -471,6 +480,11 @@ void main() {
       expect(select(const ['tflite', 'onnx'], warnings), allNativeRuntimes);
       expect(warnings, hasLength(1));
       expect(warnings.single, contains('tflite, onnx'));
+
+      warnings.clear();
+      expect(select(const ['none', 'tflite'], warnings), isEmpty);
+      expect(warnings, hasLength(1));
+      expect(warnings.single, contains('tflite'));
     });
 
     test('none clears explicit runtime tracking', () {

--- a/test/unit/hook/native_bundle_config_test.dart
+++ b/test/unit/hook/native_bundle_config_test.dart
@@ -411,6 +411,80 @@ void main() {
     });
   });
 
+  group('selectNativeRuntimesForBundle explicit none', () {
+    List<String> select(Object? rawUserConfig, List<String> warnings) =>
+        selectNativeRuntimesForBundle(
+          bundle: 'linux-x64',
+          rawUserConfig: rawUserConfig,
+          warn: warnings.add,
+        );
+
+    test('explicit none tokens select nothing without warning', () {
+      for (final rawUserConfig in const <Object?>[
+        'none',
+        'off',
+        'false',
+        ['none'],
+        ['llama_cpp', 'none'],
+        {'runtimes': 'none'},
+        {
+          'runtimes': ['llama_cpp'],
+          'platforms': {'linux-x64': 'none'},
+        },
+      ]) {
+        final warnings = <String>[];
+
+        expect(
+          select(rawUserConfig, warnings),
+          isEmpty,
+          reason: rawUserConfig.toString(),
+        );
+        expect(warnings, isEmpty, reason: rawUserConfig.toString());
+      }
+    });
+
+    test('a runtime named after none still selects', () {
+      final warnings = <String>[];
+
+      expect(select(const ['none', 'llama_cpp'], warnings), [
+        nativeRuntimeLlamaCpp,
+      ]);
+      expect(warnings, isEmpty);
+    });
+
+    test('unset and empty stay all runtime families', () {
+      for (final rawUserConfig in const <Object?>[null, '', <String>[]]) {
+        final warnings = <String>[];
+
+        expect(
+          select(rawUserConfig, warnings),
+          allNativeRuntimes,
+          reason: rawUserConfig.toString(),
+        );
+        expect(warnings, isEmpty, reason: rawUserConfig.toString());
+      }
+    });
+
+    test('all-unrecognised list warns and stays all runtime families', () {
+      final warnings = <String>[];
+
+      expect(select(const ['tflite', 'onnx'], warnings), allNativeRuntimes);
+      expect(warnings, hasLength(1));
+      expect(warnings.single, contains('tflite, onnx'));
+    });
+
+    test('none clears explicit runtime tracking', () {
+      expect(
+        nativeRuntimeExplicitlySelectedForBundle(
+          bundle: 'linux-x64',
+          rawUserConfig: const ['llama_cpp', 'none'],
+          runtime: nativeRuntimeLlamaCpp,
+        ),
+        isFalse,
+      );
+    });
+  });
+
   group('selectLibrariesForBundling', () {
     final spec = resolveNativeBundleSpec(
       os: OS.linux,

--- a/website/docs/changelog/recent-releases.md
+++ b/website/docs/changelog/recent-releases.md
@@ -13,6 +13,11 @@ For canonical full release notes, use:
   Docusaurus replaces its unpatched image parser, automatic local Markdown
   images are rejected; website contributors should use static pathname URLs.
 
+- Fixed `llamadart_native_runtimes: none` (and `off`, `false`, or a list ending
+  in `none`) selecting every runtime family instead of none. The build hook
+  fails again with its `No native runtimes selected` error, as it did before
+  0.8.0. Unset, empty, and all-unrecognised config still select every family.
+
 - Fixed Command R7B, Hermes, and Hunyuan V3 tool grammars so distinct tool or
   parameter names cannot collide after conversion to internal GBNF rule names.
 

--- a/website/docs/changelog/recent-releases.md
+++ b/website/docs/changelog/recent-releases.md
@@ -13,11 +13,11 @@ For canonical full release notes, use:
   Docusaurus replaces its unpatched image parser, automatic local Markdown
   images are rejected; website contributors should use static pathname URLs.
 
-- Fixed `llamadart_native_runtimes: none` and `off` selecting every runtime
-  family instead of none; the build hook fails with its `No native runtimes
-  selected` error again, as it did before 0.8.0. A YAML boolean `false` clears
-  the selection too. Unset, empty, and all-unrecognised config still select
-  every family.
+- Fixed `llamadart_native_runtimes` values `none`, `off`, and the string
+  `false` selecting every runtime family instead of none;
+  the build hook fails with its `No native runtimes selected` error again, as
+  it did before 0.8.0. A YAML boolean `false` clears the selection too. Unset,
+  empty, and all-unrecognised config still select every family.
 
 - Fixed Command R7B, Hermes, and Hunyuan V3 tool grammars so distinct tool or
   parameter names cannot collide after conversion to internal GBNF rule names.

--- a/website/docs/changelog/recent-releases.md
+++ b/website/docs/changelog/recent-releases.md
@@ -13,10 +13,11 @@ For canonical full release notes, use:
   Docusaurus replaces its unpatched image parser, automatic local Markdown
   images are rejected; website contributors should use static pathname URLs.
 
-- Fixed `llamadart_native_runtimes: none` (and `off`, `false`, or a list ending
-  in `none`) selecting every runtime family instead of none. The build hook
-  fails again with its `No native runtimes selected` error, as it did before
-  0.8.0. Unset, empty, and all-unrecognised config still select every family.
+- Fixed `llamadart_native_runtimes: none` and `off` selecting every runtime
+  family instead of none; the build hook fails with its `No native runtimes
+  selected` error again, as it did before 0.8.0. A YAML boolean `false` clears
+  the selection too. Unset, empty, and all-unrecognised config still select
+  every family.
 
 - Fixed Command R7B, Hermes, and Hunyuan V3 tool grammars so distinct tool or
   parameter names cannot collide after conversion to internal GBNF rule names.


### PR DESCRIPTION
## Summary
- **Fixes a shipped regression.** `llamadart_native_runtimes: none` — and `off`, `false`, or any list ending in `none` such as `[llama_cpp, none]` — silently selected **every** runtime family, the exact opposite of the token's meaning. Apps trying to shrink their bundle got both llama.cpp and LiteRT-LM, with no warning.
- **Root cause.** `_normalizeRuntime` maps `none`/`off`/`false` to a `'none'` sentinel; `_parseRuntimeList`'s `addToken` handles it with `result.clear(); explicit.clear();`. Both the String and the List return paths then ended in `runtimes: result.isEmpty ? allNativeRuntimes : result`, re-inflating the deliberately emptied selection back to every family.
- **Provenance.** Last good `fd23afa13`; broken by `88fb254e6` ("Split Flutter Apple runtime companions", #211, 2026-06-09). Live in **v0.8.0 through v0.8.20**. It went unnoticed because no test covered `none`.
- **The fix.** An `explicitNone` flag distinguishes an intentional empty selection from an empty or all-unrecognised fallback, so none/off/false stays empty and `hook/build.dart` raises its pre-existing, actionable `No native runtimes selected for <bundle>` error. The blocker review also found that a bare YAML boolean `false` was still treated as an unsupported root scalar and expanded to every runtime; it now enters the same explicit-none path at root, map, and list positions.
- **Deliberately unchanged.** Unset, empty, and all-unrecognised config still resolve to every family — that is documented behaviour (CHANGELOG 0.8.0, `website/docs/platforms/native-build-hooks.md`, `website/docs/guides/backend-selection.md`), and only an *explicit* `none` token changes. `['none', 'llama_cpp']` still selects `llama_cpp`. `nativeRuntimeExplicitlySelectedForBundle`'s by-design treatment of `all`/`both` is untouched.
- **Also documents `lib/src/hook/native_bundle_config.dart`**, previously 1026 lines with zero Dartdoc even though it decodes the user-facing `hooks.user_defines.llamadart` contract and its precedence rules decide which native libraries ship. Library-level doc plus Dartdoc for every public declaration: 9 top-level consts, 11 functions, 2 classes with their 9 fields and 2 constructors.
- **Deletes `// ignore_for_file: public_member_api_docs` from line 1.** That comment — not the export closure — was what hid the lint; with it gone `public_member_api_docs` enforces this file and it cannot silently regress. Verified by deleting one doc comment and watching the lint fire.

## Production-readiness scope
- **User-facing change:** `llamadart_native_runtimes: none` (and `off`, `false`, or a list ending in `none`) now selects no runtime family. Because a build that ships no runtime is not a usable build, this surfaces as the build hook **failing loudly** with `No native runtimes selected for <bundle>` instead of silently bundling everything. Any project currently relying on the buggy "`none` means all" behaviour will start failing — correctly, and with a message naming the fix. Every other config shape is byte-identical.
- **Supported platforms/paths:** every non-Flutter-Apple build path, i.e. wherever `selectNativeRuntimesForBundle` decides the runtime set. Flutter iOS/macOS app builds take their families from installed companion packages and bypass this function entirely, so they are unaffected.
- **Unsupported or intentionally unavailable paths:** unchanged. The documented warn-and-fallback shapes (root scalar, map with no runtime shape, all-unrecognised token list) still fall back to `defaultNativeRuntimes`; the documented throw shapes (map with no `runtimes` key, nested scalar) still yield an empty selection and throw.
- **Out of scope / follow-ups:** none outstanding. The "left unfixed, maintainer's call" item from the previous revision of this PR *is* the fix in this revision.

## Completeness checklist
- [x] Declared scope is fully implemented, or explicitly reduced above.
- [x] Unsupported platform/option combinations fail loudly with actionable diagnostics or are clearly documented as unavailable. — This is precisely what the fix restores: an unbuildable "no runtimes" configuration fails with a message naming the user-define and its valid values.
- [x] Public API docs, README/website docs, examples, support matrices, and changelog entries are updated where relevant. — Changelog bullet under `## Unreleased` in `CHANGELOG.md`, mirrored in `website/docs/changelog/recent-releases.md`. The prose pages (`native-build-hooks.md`, `backend-selection.md`) document only the unset/empty case, which is unchanged, and never mention `none`; they needed no edit.
- [x] Regression coverage covers the original issue plus key negative/version-skew paths where relevant. — 6 new tests. 2 fail against the pre-fix tree (the `none` unit case and the build-hook integration case); the other 4 are behaviour pins that pass either way, covering unset/empty, all-unrecognised, a runtime *named* after none, and explicit-tracking.
- [x] Security/privacy review completed: no secrets, bearer tokens, signed URLs, or raw secret-bearing paths leak through logs, cache keys, metadata, errors, or snapshots.
- [x] Follow-up work that is useful but not required for this PR is tracked above.

## PR type guidance
- **Bugfix + docs.** Not docs-only — this revision changes runtime behaviour.
  - **Bugfix:** a focused private-parser change in `_parseRuntimeList` and its root dispatcher preserves explicit string and boolean none selections. No public API surface changes, renames, generated files, or backend/runtime implementation paths are touched.
  - **Docs:** the remaining 215 inserted / 5 deleted lines in `lib/src/hook/native_bundle_config.dart` are `///` lines, blank lines, and the `library;` directive that anchors the library-level doc; the deletions are the `ignore_for_file` comment and two inline comments the new Dartdoc restates.
  - **Tests:** +99 lines across two existing hook test files.
  - **Changelog:** two files, one bullet each, under the existing `## Unreleased`.

## Changelog
```
* Fixed `llamadart_native_runtimes: none` (and `off`, `false`, or a list ending
  in `none`) selecting every runtime family instead of none. The build hook
  fails again with its `No native runtimes selected` error, as it did before
  0.8.0. Unset, empty, and all-unrecognised config still select every family.
```
Added to `CHANGELOG.md` and mirrored in `website/docs/changelog/recent-releases.md`.

## Test Plan
- [x] **Regression proven before the fix.** With the fixed `lib/src/hook/native_bundle_config.dart` reverted to the branch HEAD and the new tests in place:
  ```
  +25 -1: selectNativeRuntimesForBundle explicit none explicit none tokens select nothing without warning [E]
    Expected: empty
      Actual: ['llama_cpp', 'litert_lm']
    none
  +45 -2: build hook fails when runtimes config selects none [E]
    Expected: throws <Instance of 'Exception'> with `message`: contains 'No native runtimes selected for linux-x64'
      Actual: <Instance of 'Future<void>'>
  ```
  A direct probe against the pre-fix tree reproduced it on every shape: `none`, `off`, `false`, `['none']`, `['llama_cpp','none']`, `{runtimes: none}`, and a per-platform `none` all returned `[llama_cpp, litert_lm]` with **zero** warnings.
- [x] **New coverage** (`test/unit/hook/native_bundle_config_test.dart`, group `selectNativeRuntimesForBundle explicit none`) — each case asserts the resolved runtimes *and* the warn count:
  - `none`, `off`, `false`, `['none']`, `['llama_cpp','none']`, `{'runtimes':'none'}`, and a per-platform `'none'` → empty, no warn.
  - `['none','llama_cpp']` → `[llama_cpp]`, no warn (a runtime named after `none` still selects).
  - unset (`null`), `''`, `<String>[]` → `allNativeRuntimes`, no warn — the documented behaviour, pinned so it cannot be "fixed" by accident.
  - `['tflite','onnx']` → `allNativeRuntimes` with exactly one warn naming `tflite, onnx`.
  - `['llama_cpp','none']` leaves `nativeRuntimeExplicitlySelectedForBundle` false.
- [x] **End-to-end coverage** (`test/unit/hook/build_hook_linux_integration_test.dart`): `build hook fails when runtimes config selects none` drives `hook/build.dart` through `testCodeBuildHook` with `llamadart_native_runtimes: 'none'` and asserts the thrown message contains `No native runtimes selected for linux-x64`.
- [x] `dart pub global run dart_style:format --output=none --set-exit-if-changed .` — **570 files, 0 changed**. Standalone `dart_style`, not the bundled `dart format`, whose local SDK disagrees with CI.
- [x] `dart analyze` — `No issues found!`, with `public_member_api_docs` live on this file (proved by deleting a constructor doc and seeing `Missing documentation for a public member` fire, then restoring it).
- [x] `dart test test/unit/hook/` — `+83: All tests passed!`
- [x] `dart test -p vm -j 1 --exclude-tags local-only` — exit 0, **1897/1897 results success**. **Zero regression proven by test NAME diff, not counts:** baseline captured at the pre-change branch HEAD had 1718 unique test names, the final tree has 1724. **Removed: none (empty set).** Added: the 6 new tests above.
- [ ] `dart test -p chrome --exclude-tags local-only` — N/A: `lib/src/hook/native_bundle_config.dart` is a build-hook file that never executes on web.

## Matrix Evidence
| Matrix row | Scope covered | Platform / model / backend | Result | Evidence / notes |
| --- | --- | --- | --- | --- |
| Explicit `none` → build fails | `selectNativeRuntimesForBundle` → `hook/build.dart` throw path | linux-x64, both runtime families available | Pass | End-to-end `testCodeBuildHook` asserts `No native runtimes selected for linux-x64`; fails against pre-fix HEAD. |
| Unset / empty / all-unrecognised → all families | documented fallback, unchanged | linux-x64 | Pass | Unit-pinned with warn assertions; identical before and after the fix. |
| Existing runtime & backend selection | every other config shape | all bundles the suite covers | Pass | 1718 pre-existing test names all still present and passing; none removed, none renamed. |
| Flutter Apple companion path | bypasses this function | ios/macos | N/A | `_emitAppleSpmAssetsIfEnabled` takes families from installed companion packages; unreachable from this change. |

## Review Notes
- Independent review status: the regression was confirmed by executable differential proof against `fd23afa13` before any code changed, and the fix was validated by re-running the same probe — every legacy none-shaped string/list input now matches `fd23afa13`; boolean `false` additionally follows #436 acceptance instead of the old unsupported-root fallback, and every non-none input remains byte-identical to current `main`.
- A prior trim pass over this file's comments (261 → 192 lines) over-corrected and introduced doc claims that contradicted the code. Three were corrected and four deleted facts restored in this revision:
  - `selectBackendsForBundle`: `cpu` is prepended to the *defaults and to an accepted request*, not to "any selection" — `_ensureCpuBackend` is never applied to the two all-available fallbacks, which return `availableBackends.toList()..sort()`.
  - `selectBackendsForBundle`: "a further `warn`" is only accurate on the rejected-request path; the `requested == null || requested.isEmpty` path fires the first and only warn. Now scoped.
  - `canonicalizeBundleKey`: the code does `replaceAll('_','-')` *then* `replaceAll('x86-64','x86_64')` — it **restores** the underscore spelling for `x86_64`. The doc now says so instead of listing `x86-64` as a folded variant.
  - Restored: runtime alias spellings (`gguf`/`llama.cpp` → `llama_cpp`; `litert`/`litertlm`/`.litertlm` → `litert_lm`); the default backend sets (Apple bundles ship one consolidated runtime and are not backend-configurable, Android/Linux/Windows default to `['cpu','vulkan']`); the CUDA gating pattern's optional `_`/`-` separator, matching `^(?:cudart64|cublas64|cublaslt64)(?:[_-]?\d+)?$`; and "a `platforms` map **or** platform keys" in the silent-fallback sentence, matching `root.keys.any(_isKnownPlatformConfigKey) || _extractPlatformsMap(root) != null`.
- ## Final exact-head readiness

- Exact head: `d09c5cb908420d7df94feb6bee08d696efa947aa`; exact base/current `main`: `00f93916e6dcc51d3233580aea044d5cf476981b`; 0 behind / 4 ahead. Current main was integrated with a normal two-parent merge commit (`d02beca9`); the review wording fix (`d09c5cb9`) was then pushed as a normal fast-forward. No force-push or rebase was used in this refresh.
- Hosted validation: [CI run 32670674073](https://github.com/leehack/llamadart/actions/runs/32670674073) and companion workflows are green: all 14 populated exact-head checks passed, including Linux VM coverage and aggregate, Chrome, Web Chat Contract, macOS/Windows native, both companion packages, docs, analysis/lint, prompt-reuse parity, both LiteRT-LM native smokes, and the chat-app preview.
- Review: the fresh exact-head Copilot review recommends approval with 0 new comments. All 3 review threads are answered and resolved; 0 unresolved. A fresh independent GPT-5.6 Sol blocker-only audit passed with no blocking findings.
- Local current-main validation: hook suite 83/83 passed; full serial VM 1,645 passed with 77 fixture/platform skips; targeted analysis, docs production build/link validation, release-doc verification, and diff/worktree checks passed. The VM suite exercised the real native library and stories15M GGUF inference/state paths. Local Chrome is N/A for this build-hook-only behavior; hosted Chrome and Web Chat Contract passed.
- Zero-regression audit: no known regression remains in scope. Issue #436 is linked for closure. Historical branch-safety handling is tracked separately in #441; this refresh used only a normal merge and fast-forward push.


## Independent blocker-review follow-up

At `382a7abe8`, root/map/list boolean `false`, the string aliases, ordering around `none`, and the existing build-hook throw were exercised together. The full 83-test hook suite, repository-wide format gate, and `dart analyze` pass locally; exact-head CI is recorded separately below.

## Issue linkage

Closes #436.

Refs #358 for the original documentation-audit context; #358 is intentionally not auto-closed by this PR.


