### PR TITLE
fix: restore a self-consistent chat app lockfile SDK bound

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,6 +27,11 @@ jobs:
       - name: Install dependencies
         run: dart run tool/prepare_workspace.dart
 
+      # A tracked lockfile pub rewrites on every resolve is a real defect, and
+      # nothing else in CI would notice it.
+      - name: Verify dependency preparation leaves tracked files unchanged
+        run: git diff --exit-code
+
       - name: Verify formatting
         run: dart format --output=none --set-exit-if-changed .
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -18,8 +18,11 @@ dart test -p chrome --exclude-tags local-only
 The workspace preparation command resolves the root package and every
 maintained example, and fails if any example or companion package is missing or
 unclassified. Run it from a clean checkout before the root format/analyze
-gates; CI uses the same entry point. Companion packages retain their own
-dependency, analyze, test, SwiftPM, and publish-validation lanes.
+gates; CI uses the same entry point and fails if it leaves tracked files
+modified. Never hand-edit a `pubspec.lock`: pin the offending dependency in
+`pubspec.yaml` and let pub regenerate the lock, so its `sdks:` block stays one
+pub can actually produce. Companion packages retain their own dependency,
+analyze, test, SwiftPM, and publish-validation lanes.
 Run repository-wide quality gates with the current Flutter stable SDK used by
 CI; older Dart formatters can produce different source layouts.
 

--- a/example/chat_app/pubspec.lock
+++ b/example/chat_app/pubspec.lock
@@ -858,13 +858,13 @@ packages:
     source: hosted
     version: "0.3.1"
   synchronized:
-    dependency: transitive
+    dependency: "direct main"
     description:
       name: synchronized
-      sha256: "61894a1956de6b4fc1aefd0892e109514a1a706cbece3ac59decd90ff5a7a423"
+      sha256: c254ade258ec8282947a0acbbc90b9575b4f19673533ee46f2f6e9b3aeefd7c0
       url: "https://pub.dev"
     source: hosted
-    version: "3.4.1+1"
+    version: "3.4.0"
   term_glyph:
     dependency: transitive
     description:

--- a/example/chat_app/pubspec.lock
+++ b/example/chat_app/pubspec.lock
@@ -448,10 +448,10 @@ packages:
     dependency: transitive
     description:
       name: matcher
-      sha256: dc0b7dc7651697ea4ff3e69ef44b0407ea32c487a39fff6a4004fa585e901861
+      sha256: "31bd099b47c10cd1aeb55146a2d46ce0277630ecef3f7dae54ad7873f36696cd"
       url: "https://pub.dev"
     source: hosted
-    version: "0.12.19"
+    version: "0.12.20"
   material_color_utilities:
     dependency: transitive
     description:
@@ -464,10 +464,10 @@ packages:
     dependency: transitive
     description:
       name: meta
-      sha256: "1741988757a65eb6b36abe716829688cf01910bbf91c34354ff7ec1c3de2b349"
+      sha256: "307249ce4ff29d58a18e97f6345f539382eb9c9c29ecda628900f31de0443dd9"
       url: "https://pub.dev"
     source: hosted
-    version: "1.18.0"
+    version: "1.19.0"
   mime:
     dependency: transitive
     description:
@@ -877,26 +877,26 @@ packages:
     dependency: "direct dev"
     description:
       name: test
-      sha256: "8d9ceddbab833f180fbefed08afa76d7c03513dfdba87ffcec2718b02bbcbf20"
+      sha256: ca578dc12bb8b2f40b67b7d3bd2fac4f31c01a6ff7130a14e2597b919934507f
       url: "https://pub.dev"
     source: hosted
-    version: "1.31.0"
+    version: "1.31.1"
   test_api:
     dependency: transitive
     description:
       name: test_api
-      sha256: "949a932224383300f01be9221c39180316445ecb8e7547f70a41a35bf421fb9e"
+      sha256: "2a122cbe059f8b610d3a5415f42e255b6c17b1f21eee1d960f31080237fb4f11"
       url: "https://pub.dev"
     source: hosted
-    version: "0.7.11"
+    version: "0.7.12"
   test_core:
     dependency: transitive
     description:
       name: test_core
-      sha256: "1991d4cfe85d5043241acac92962c3977c8d2f2add1ee73130c7b286417d1d34"
+      sha256: d2e98ec12998368dc59ddd47ab709f2cd55acd6b66dc7db764455a44082f4bc5
       url: "https://pub.dev"
     source: hosted
-    version: "0.6.17"
+    version: "0.6.18"
   typed_data:
     dependency: transitive
     description:
@@ -981,10 +981,10 @@ packages:
     dependency: transitive
     description:
       name: vector_math
-      sha256: d530bd74fea330e6e364cda7a85019c434070188383e1cd8d9777ee586914c5b
+      sha256: f36f9f3be64c6198714492bb455c11056e33e2f85d9a0b676a48301e44fdcf47
       url: "https://pub.dev"
     source: hosted
-    version: "2.2.0"
+    version: "2.4.2"
   vm_service:
     dependency: transitive
     description:
@@ -1074,5 +1074,5 @@ packages:
     source: hosted
     version: "3.1.3"
 sdks:
-  dart: ">=3.10.7 <4.0.0"
+  dart: ">=3.11.0-0 <4.0.0"
   flutter: ">=3.38.4 <4.0.0"

--- a/example/chat_app/pubspec.yaml
+++ b/example/chat_app/pubspec.yaml
@@ -26,9 +26,9 @@ dependencies:
   crypto: ^3.0.6
   path_provider: ^2.1.5
   record: ^6.2.1
-  # Version pins that hold the SDK floor declared above: audioplayers 6.6.0
-  # pulls platform packages requiring Flutter 3.44, and synchronized 3.4.0+1
-  # requires Dart 3.11.
+  # Keep runtime dependencies compatible with the declared minimum:
+  # audioplayers 6.6.0 pulls platform packages requiring Flutter 3.44, and
+  # synchronized 3.4.0+1 requires Dart 3.11.
   audioplayers: 6.5.1
   synchronized: 3.4.0
   google_fonts: ^8.0.0

--- a/example/chat_app/pubspec.yaml
+++ b/example/chat_app/pubspec.yaml
@@ -26,7 +26,11 @@ dependencies:
   crypto: ^3.0.6
   path_provider: ^2.1.5
   record: ^6.2.1
+  # Version pins that hold the SDK floor declared above: audioplayers 6.6.0
+  # pulls platform packages requiring Flutter 3.44, and synchronized 3.4.0+1
+  # requires Dart 3.11.
   audioplayers: 6.5.1
+  synchronized: 3.4.0
   google_fonts: ^8.0.0
   flutter_markdown: ^0.7.7+1
   url_launcher: ^6.3.2


### PR DESCRIPTION
## Summary
- The documented first workspace gate, `dart run tool/prepare_workspace.dart`, rewrote the tracked `example/chat_app/pubspec.lock` from a clean checkout.
- **Original root cause:** PR #330 hand-edited the lockfile's `sdks:` block to Dart 3.10.7 while its resolved `synchronized 3.4.1+1` requires Dart 3.12. This PR pins `synchronized: 3.4.0`, the newest release compatible with the chat app's declared Dart minimum, and regenerates the lockfile with pub.
- **Current-stable follow-up:** the first PR head was regenerated with Flutter 3.44.4. Hosted CI had advanced to Flutter 3.47.1, whose `flutter`, `flutter_test`, and `integration_test` SDK packages require Dart `^3.11.0-0` and whose test stack resolves newer pinned versions. Flutter 3.47.1 therefore still changed six lockfile packages plus the generated `sdks: dart:` value. The final lockfile is regenerated with the exact hosted Flutter 3.47.1 / Dart 3.13.1 toolchain and is byte-stable across consecutive workspace preparations.
- The advertised package minimums do **not** change: `sdk: ^3.10.7` and `flutter: ^3.38.0` remain untouched. The generated lockfile records the current toolchain's `>=3.11.0-0` floor because Flutter 3.47.1's own SDK packages declare it; that is not a new constraint in the chat app manifest.
- Adds an Analyze & Lint guard immediately after preparation so future tracked lockfile drift fails with the exact diff.
- No `lib/`, native, WebGPU, API, or runtime behavior changes.

Closes #437.

## Production-readiness scope
- **User-facing scope:** no runtime or API change. Contributors and CI get a clean tree after the documented workspace gate.
- **Supported platforms/paths:** `example/chat_app` dependency resolution and the repository Analyze & Lint lane.
- **Unsupported or intentionally unavailable paths:** none introduced.
- **Out of scope / follow-ups:** deliberately raising the chat app's declared Dart/Flutter floor and unpinning floor-sensitive runtime dependencies are separate maintainer decisions.

## Completeness checklist
- [x] Declared scope is fully implemented, or explicitly reduced above.
- [x] Unsupported platform/option combinations fail loudly with actionable diagnostics or are clearly documented as unavailable. — N/A for runtime behavior; the CI guard fails loudly and prints the mutation.
- [x] Public API docs, README/website docs, examples, support matrices, and changelog entries are updated where relevant. — No public behavior or support claim changes; `AGENTS.md` records the durable lockfile rule.
- [x] Regression coverage covers the original issue plus key negative/version-skew paths where relevant. — The CI clean-diff assertion caught both the original inconsistency and the initial Flutter-version-skewed regeneration.
- [x] Security/privacy review completed: no secrets, bearer tokens, signed URLs, or raw secret-bearing paths are added to logs, cache keys, metadata, errors, or snapshots.
- [x] Follow-up work that is useful but not required for this PR is tracked in GitHub Issues, or explicitly marked "None" above.

### Changelog
No `CHANGELOG.md` or website changelog entry. This changes no published-package behavior, public API, runtime capability, or declared platform/SDK support. It fixes contributor-facing workspace hygiene in an unpublished example (`publish_to: 'none'`).

## PR type guidance
- **Bugfix PR:** PR #330 introduced a self-inconsistent hand-edited lockfile and the CI lane lacked a clean-diff assertion. The dependency pin plus current-stable regeneration repairs the graph; the new CI assertion directly observes the regression.
- **Feature PR / Docs-only PR:** N/A.

## Test Plan
Local exact toolchain: Flutter 3.47.1 (revision `6655482ec0`) / Dart 3.13.1, isolated clean clone at commit `bebae847a02a2aff6a092b0566c11532c38edc78` against base `034e94221f10a0ee260cdcf012696583453920d4`.

- [x] `dart run tool/prepare_workspace.dart` twice consecutively, each followed by `git diff --exit-code` — PASS; final `git status --porcelain` empty and lockfile SHA-256 remained `ad368c4e00b4320b6c978a35bd513fe94a8b4abef0d2fbe5b413fa480bad4505`.
- [x] `dart format --output=none --set-exit-if-changed .` — PASS; 570 files, zero changed.
- [x] `dart analyze` — PASS; no issues.
- [x] `dart test -p vm test/unit/tooling/prepare_workspace_test.dart test/unit/tooling/test_matrix_test.dart` — PASS; 21 tests.
- [x] `dart test -p chrome --exclude-tags local-only` — PASS; 903 tests.
- [x] `cd example/chat_app && flutter analyze` — PASS; no issues.
- [x] `cd example/chat_app && flutter test` — PASS; 337 tests.
- [x] `cd example/chat_app && flutter test --platform chrome test/chat_generation_service_test.dart` — PASS; 4 tests.
- [x] Ruby YAML parse of `.github/workflows/ci.yml` and `example/chat_app/pubspec.yaml` — PASS.
- [ ] `dart test -p vm -j 1 --exclude-tags local-only` — local macOS run reached +1506 ~3 before unrelated native integration setup timeouts (`engine_reloading_test` and the following native setup); unit/tooling coverage was green. Exact-head hosted Linux VM and native jobs are the authoritative completion gate below.
- [x] Exact-head GitHub Actions on `bebae847a02a2aff6a092b0566c11532c38edc78` — PASS; 12/12 checks successful, including Analyze & Lint's clean-diff assertion, Linux VM with coverage, full Chrome, macOS/Windows native, Web Chat Contract, docs security tests/build, both companion packages, prompt-reuse parity, aggregate coverage gate, and PR preview verification.

## Matrix Evidence
| Matrix row | Scope covered | Platform / model / backend | Result | Evidence / notes |
| --- | --- | --- | --- | --- |
| `static-format-analyze` | preparation, clean diff, format, analyzer | macOS arm64 / Flutter 3.47.1 | PASS | Two clean preparation runs; 570 files unchanged; analyzer clean |
| `root-vm` | native-safe unit/integration coverage | Linux hosted / macOS local | PASS hosted | Exact-head Linux VM+coverage green; local macOS reached +1506 ~3 before unrelated native integration setup timeouts; both hosted native jobs are also green |
| `root-chrome` | browser-compatible unit/integration coverage | macOS arm64 / Chrome | PASS | 903 tests |
| `examples-tests` | chat-app dependency consumer | macOS arm64 / VM + Chrome | PASS | analyze clean; VM +337; Chrome +4 |
| `coverage-lib` | maintainable `lib/` coverage | — | N/A | No `lib/` change |
| `docs-site` | website build and links | hosted Linux | PASS | Exact-head Docs Build Check, including documentation-tooling security tests, green; no website/README change |
| companion package lanes | package-specific analyze/test/publish validation | hosted macOS | PASS | Both exact-head companion jobs green; no companion-package change |
| native/model/device rows | runtime and model behavior | — | N/A | No native, hook, backend, model-path, or runtime behavior change |

## Review Notes
- Independent blocker-only Sol QA: **no blocking findings** at head `bebae847a02a2aff6a092b0566c11532c38edc78` against base `034e94221f10a0ee260cdcf012696583453920d4`; the four-file diff, current-stable lock idempotence, #433 security-workflow integration, issue linkage, CI, and review threads were re-attested.
- CI status / head SHA: **12/12 SUCCESS** on `bebae847a02a2aff6a092b0566c11532c38edc78` ([CI run](https://github.com/leehack/llamadart/actions/runs/32667461041), [preview run](https://github.com/leehack/llamadart/actions/runs/32667461044)).
- Integration provenance: an earlier update-branch merge (`aa785ddb`) was briefly replaced by the pre-integration head; guarded recovery produced `bebae847`, whose two-parent tree is byte-identical to the clean merge of the prior PR head with base `034e9422`. Replacement exact-head CI and QA above are authoritative.
