### PR TITLE
test: make Windows process cleanup identity-safe

### DIFF
--- a/test/unit/tooling/sync_native_release_pins_script_test.dart
+++ b/test/unit/tooling/sync_native_release_pins_script_test.dart
@@ -2160,6 +2160,7 @@ Future<_WindowsProcessIdentity> _windowsProcessIdentity(
     ],
     runInShell: false,
     environment: {markerEnvironment: expectedCommandFragment},
+    includeParentEnvironment: true,
   );
   final stdoutSubscription = probe.stdout.listen(null);
   final stderrSubscription = probe.stderr.listen(null);

--- a/test/unit/tooling/sync_native_release_pins_script_test.dart
+++ b/test/unit/tooling/sync_native_release_pins_script_test.dart
@@ -1207,10 +1207,15 @@ printf '%s\\n' '{"tag_name":"v0.2.0-1","assets":[]}'
       final childScript = File(path.join(root.path, 'child.py'));
       final parentScript = File(path.join(root.path, 'parent.py'));
       final childPidFile = File(path.join(root.path, 'child.pid'));
+      final childStopFile = File(path.join(root.path, 'child.stop'));
       await childScript.writeAsString(r'''
+from pathlib import Path
+import sys
 import time
 
-time.sleep(20)
+deadline = time.monotonic() + 60
+while not Path(sys.argv[1]).exists() and time.monotonic() < deadline:
+    time.sleep(0.1)
 ''');
       await parentScript.writeAsString(r'''
 from pathlib import Path
@@ -1218,23 +1223,21 @@ import subprocess
 import sys
 import time
 
-child = subprocess.Popen([sys.executable, sys.argv[1]])
+child = subprocess.Popen([sys.executable, sys.argv[1], sys.argv[3]])
 Path(sys.argv[2]).write_text(str(child.pid), encoding="utf-8")
 print(f"synthetic child ready: {child.pid}", flush=True)
-time.sleep(300)
+time.sleep(60)
 ''');
 
-      int? parentPid;
+      Process? parentProcess;
       int? childPid;
       addTearDown(() async {
         childPid ??= await _readPidFile(childPidFile);
-        if (parentPid != null) {
-          await _ensureWindowsProcessStopped(
-            parentPid!,
-            expectedCommandFragment: parentScript.path,
-          );
+        if (parentProcess != null) {
+          await _ensureProcessHandleStopped(parentProcess!);
         }
         if (childPid != null) {
+          await childStopFile.writeAsString('stop');
           await _ensureWindowsProcessStopped(
             childPid!,
             expectedCommandFragment: childScript.path,
@@ -1247,7 +1250,13 @@ time.sleep(300)
       final stopwatch = Stopwatch()..start();
       try {
         await _runPython(
-          [parentScript.path, childScript.path, childPidFile.path, secret],
+          [
+            parentScript.path,
+            childScript.path,
+            childPidFile.path,
+            childStopFile.path,
+            secret,
+          ],
           timeout: const Duration(seconds: 5),
           waitUntilReady: () async {
             childPid = await _waitForPidFile(
@@ -1270,7 +1279,7 @@ time.sleep(300)
             );
           },
           redactions: {root.path: '<temp>', secret: '<redacted>'},
-          onStart: (pid) => parentPid = pid,
+          onStart: (process) => parentProcess = process,
         );
       } on Object catch (error) {
         failure = error;
@@ -1291,12 +1300,11 @@ time.sleep(300)
       expect(message, isNot(contains(secret)));
       expect(stopwatch.elapsed, lessThan(const Duration(seconds: 60)));
 
-      expect(parentPid, isNotNull);
+      expect(parentProcess, isNotNull);
       expect(childPid, isNotNull);
       // _terminateProcessTree awaits this exact Process handle. Keep the
       // command-line identity on the child probe because Windows can reuse a
       // numeric PID before this assertion runs.
-      parentPid = null;
       expect(
         await _waitForWindowsProcessToStop(
           childPid!,
@@ -1320,11 +1328,16 @@ time.sleep(300)
       final childScript = File(path.join(root.path, 'child.py'));
       final parentScript = File(path.join(root.path, 'parent.py'));
       final childPidFile = File(path.join(root.path, 'child.pid'));
+      final childStopFile = File(path.join(root.path, 'child.stop'));
       await childScript.writeAsString(r'''
+from pathlib import Path
+import sys
 import time
 
 print("descendant owns inherited output", flush=True)
-time.sleep(4)
+deadline = time.monotonic() + 60
+while not Path(sys.argv[1]).exists() and time.monotonic() < deadline:
+    time.sleep(0.1)
 ''');
       await parentScript.writeAsString(r'''
 from pathlib import Path
@@ -1332,7 +1345,7 @@ import subprocess
 import sys
 
 child = subprocess.Popen(
-    [sys.executable, sys.argv[1]],
+    [sys.executable, sys.argv[1], sys.argv[3]],
     stdout=sys.stdout,
     stderr=sys.stderr,
 )
@@ -1344,6 +1357,7 @@ print("parent exited after spawning child", flush=True)
       addTearDown(() async {
         childPid ??= await _readPidFile(childPidFile);
         if (childPid != null) {
+          await childStopFile.writeAsString('stop');
           await _ensureWindowsProcessStopped(
             childPid!,
             expectedCommandFragment: childScript.path,
@@ -1356,7 +1370,13 @@ print("parent exited after spawning child", flush=True)
       final stopwatch = Stopwatch()..start();
       try {
         await _runPython(
-          [parentScript.path, childScript.path, childPidFile.path, secret],
+          [
+            parentScript.path,
+            childScript.path,
+            childPidFile.path,
+            childStopFile.path,
+            secret,
+          ],
           timeout: const Duration(seconds: 5),
           waitUntilReady: () async {
             childPid = await _waitForPidFile(
@@ -1365,11 +1385,18 @@ print("parent exited after spawning child", flush=True)
             );
           },
           outputDrainTimeout: const Duration(seconds: 1),
-          outputDrainDescendantPid: () {
-            childPid ??= _readPidFileSync(childPidFile);
-            return childPid;
+          outputDrainDescendantCleanup: () async {
+            final descendantPid = childPid ??= _readPidFileSync(childPidFile);
+            if (descendantPid == null) {
+              return false;
+            }
+            await childStopFile.writeAsString('stop');
+            return _waitForWindowsProcessToStop(
+              descendantPid,
+              DateTime.now().add(const Duration(seconds: 25)),
+              expectedCommandFragment: childScript.path,
+            );
           },
-          outputDrainDescendantCommandFragment: childScript.path,
           redactions: {root.path: '<temp>', secret: '<redacted>'},
         );
       } on Object catch (error) {
@@ -1695,11 +1722,10 @@ Future<ProcessResult> _runPython(
   String? executable,
   Duration? timeout,
   Duration outputDrainTimeout = const Duration(seconds: 5),
-  int? Function()? outputDrainDescendantPid,
-  String? outputDrainDescendantCommandFragment,
+  Future<bool> Function()? outputDrainDescendantCleanup,
   Future<void> Function()? waitUntilReady,
   Map<String, String> redactions = const {},
-  void Function(int pid)? onStart,
+  void Function(Process process)? onStart,
 }) async {
   final resolvedExecutable =
       executable ?? (Platform.isWindows ? 'python' : 'python3');
@@ -1736,7 +1762,7 @@ Future<ProcessResult> _runPython(
       '$reason',
     );
   }
-  onStart?.call(process.pid);
+  onStart?.call(process);
   final stdout = _CappedTextBuffer(effectiveRedactions);
   final stderr = _CappedTextBuffer(effectiveRedactions);
   final stdoutSubscription = process.stdout
@@ -1814,22 +1840,11 @@ Future<ProcessResult> _runPython(
   );
   if (!outputDrained) {
     var cleanup = 'not-configured';
-    if (outputDrainDescendantPid != null) {
-      final descendantPid = outputDrainDescendantPid();
-      if (descendantPid == null) {
-        cleanup = 'missing-pid';
-      } else if (outputDrainDescendantCommandFragment == null) {
-        cleanup = 'missing-identity';
-      } else {
-        try {
-          await _ensureWindowsProcessStopped(
-            descendantPid,
-            expectedCommandFragment: outputDrainDescendantCommandFragment,
-          );
-          cleanup = 'confirmed';
-        } on Object {
-          cleanup = 'failed';
-        }
+    if (outputDrainDescendantCleanup != null) {
+      try {
+        cleanup = await outputDrainDescendantCleanup() ? 'confirmed' : 'failed';
+      } on Object {
+        cleanup = 'failed';
       }
     }
     await _cancelOutputSubscriptions(stdoutSubscription, stderrSubscription);

--- a/test/unit/tooling/sync_native_release_pins_script_test.dart
+++ b/test/unit/tooling/sync_native_release_pins_script_test.dart
@@ -1552,6 +1552,38 @@ print("parent exited after spawning child", flush=True)
     },
     skip: Platform.isWindows ? false : 'validates Windows taskkill retries',
   );
+
+  test(
+    'Windows cleanup fails closed when process identity is unknown',
+    () async {
+      var probeCalls = 0;
+
+      await expectLater(
+        _ensureWindowsProcessStopped(
+          12345,
+          expectedCommandFragment: 'synthetic-child-marker',
+          timeout: const Duration(milliseconds: 250),
+          identityProbe:
+              (
+                _, {
+                timeout = const Duration(seconds: 3),
+                required expectedCommandFragment,
+              }) async {
+                probeCalls++;
+                return _WindowsProcessIdentity.unknown;
+              },
+        ),
+        throwsA(
+          isA<TestFailure>().having(
+            (failure) => '$failure',
+            'message',
+            contains('refusing unsafe raw-PID cleanup'),
+          ),
+        ),
+      );
+      expect(probeCalls, greaterThan(0));
+    },
+  );
 }
 
 Future<_LlamaSyncSetup> _writeLlamaOnlyRepo(String currentTag) async {
@@ -2148,6 +2180,13 @@ String _diagnosticTail(String value, {int maxCharacters = 4096}) {
 
 enum _WindowsProcessIdentity { matching, absentOrDifferent, unknown }
 
+typedef _WindowsProcessIdentityProbe =
+    Future<_WindowsProcessIdentity> Function(
+      int pid, {
+      Duration timeout,
+      required String expectedCommandFragment,
+    });
+
 Future<_WindowsProcessIdentity> _windowsProcessIdentity(
   int pid, {
   Duration timeout = const Duration(seconds: 3),
@@ -2237,6 +2276,8 @@ int? _readPidFileSync(File file) {
 Future<void> _ensureWindowsProcessStopped(
   int pid, {
   required String expectedCommandFragment,
+  Duration timeout = const Duration(seconds: 25),
+  _WindowsProcessIdentityProbe? identityProbe,
 }) async {
   // This helper receives only a numeric PID, not the Process handle that Dart
   // opened for the synthetic child. Never terminate through that PID: Windows
@@ -2245,8 +2286,9 @@ Future<void> _ensureWindowsProcessStopped(
   // fallback can safely wait without risking an unrelated process.
   if (await _waitForWindowsProcessToStop(
     pid,
-    DateTime.now().add(const Duration(seconds: 25)),
+    DateTime.now().add(timeout),
     expectedCommandFragment: expectedCommandFragment,
+    identityProbe: identityProbe,
   )) {
     return;
   }
@@ -2260,13 +2302,15 @@ Future<bool> _waitForWindowsProcessToStop(
   int pid,
   DateTime deadline, {
   required String expectedCommandFragment,
+  _WindowsProcessIdentityProbe? identityProbe,
 }) async {
+  final probe = identityProbe ?? _windowsProcessIdentity;
   while (DateTime.now().isBefore(deadline)) {
     final remaining = deadline.difference(DateTime.now());
     final probeTimeout = remaining < const Duration(seconds: 3)
         ? remaining
         : const Duration(seconds: 3);
-    final identity = await _windowsProcessIdentity(
+    final identity = await probe(
       pid,
       timeout: probeTimeout,
       expectedCommandFragment: expectedCommandFragment,

--- a/test/unit/tooling/sync_native_release_pins_script_test.dart
+++ b/test/unit/tooling/sync_native_release_pins_script_test.dart
@@ -1230,10 +1230,16 @@ time.sleep(300)
       addTearDown(() async {
         childPid ??= await _readPidFile(childPidFile);
         if (parentPid != null) {
-          await _ensureWindowsProcessStopped(parentPid!);
+          await _ensureWindowsProcessStopped(
+            parentPid!,
+            expectedCommandFragment: parentScript.path,
+          );
         }
         if (childPid != null) {
-          await _ensureWindowsProcessStopped(childPid!);
+          await _ensureWindowsProcessStopped(
+            childPid!,
+            expectedCommandFragment: childScript.path,
+          );
         }
       });
 
@@ -1248,6 +1254,13 @@ time.sleep(300)
             childPid = await _waitForPidFile(
               childPidFile,
               timeout: const Duration(seconds: 30),
+            );
+            expect(
+              await _windowsProcessExists(
+                childPid!,
+                expectedCommandFragment: childScript.path,
+              ),
+              isTrue,
             );
           },
           redactions: {root.path: '<temp>', secret: '<redacted>'},
@@ -1274,13 +1287,15 @@ time.sleep(300)
 
       expect(parentPid, isNotNull);
       expect(childPid, isNotNull);
-      // _terminateProcessTree awaits this exact Process handle. A numeric PID
-      // probe after exit can observe an unrelated process if Windows reuses it.
+      // _terminateProcessTree awaits this exact Process handle. Keep the
+      // command-line identity on the child probe because Windows can reuse a
+      // numeric PID before this assertion runs.
       parentPid = null;
       expect(
         await _waitForWindowsProcessToStop(
           childPid!,
           DateTime.now().add(const Duration(seconds: 10)),
+          expectedCommandFragment: childScript.path,
         ),
         isTrue,
       );
@@ -1323,7 +1338,10 @@ print("parent exited after spawning child", flush=True)
       addTearDown(() async {
         childPid ??= await _readPidFile(childPidFile);
         if (childPid != null) {
-          await _ensureWindowsProcessStopped(childPid!);
+          await _ensureWindowsProcessStopped(
+            childPid!,
+            expectedCommandFragment: childScript.path,
+          );
         }
       });
 
@@ -1366,6 +1384,7 @@ print("parent exited after spawning child", flush=True)
         await _waitForWindowsProcessToStop(
           childPid!,
           DateTime.now().add(const Duration(seconds: 10)),
+          expectedCommandFragment: childScript.path,
         ),
         isTrue,
       );
@@ -2102,17 +2121,30 @@ String _diagnosticTail(String value, {int maxCharacters = 4096}) {
 Future<bool> _windowsProcessExists(
   int pid, {
   Duration timeout = const Duration(seconds: 3),
+  String? expectedCommandFragment,
 }) async {
+  const markerEnvironment = 'LLAMADART_EXPECTED_PROCESS_MARKER';
   final probe = await Process.start('powershell', [
     '-NoProfile',
     '-NonInteractive',
     '-Command',
     'try { '
         '[System.Diagnostics.Process]::GetProcessById(${pid.toString()}) '
-        '| Out-Null; exit 0 '
+        '| Out-Null; '
+        'if (\$env:$markerEnvironment) { '
+        '\$candidate = Get-CimInstance Win32_Process '
+        '-Filter "ProcessId = ${pid.toString()}"; '
+        'if (\$null -eq \$candidate -or '
+        '-not \$candidate.CommandLine.Contains(\$env:$markerEnvironment)) { '
+        'exit 1 '
+        '} '
+        '} '
+        'exit 0 '
         '} catch [System.ArgumentException] { exit 1 } '
         'catch { exit 2 }',
-  ], runInShell: false);
+  ], runInShell: false, environment: {
+    markerEnvironment: ?expectedCommandFragment,
+  });
   final stdoutSubscription = probe.stdout.listen(null);
   final stderrSubscription = probe.stderr.listen(null);
   final stdoutDone = stdoutSubscription.asFuture<void>();
@@ -2171,8 +2203,14 @@ int? _readPidFileSync(File file) {
   return int.tryParse(file.readAsStringSync().trim());
 }
 
-Future<void> _ensureWindowsProcessStopped(int pid) async {
-  if (!await _windowsProcessExists(pid)) {
+Future<void> _ensureWindowsProcessStopped(
+  int pid, {
+  String? expectedCommandFragment,
+}) async {
+  if (!await _windowsProcessExists(
+    pid,
+    expectedCommandFragment: expectedCommandFragment,
+  )) {
     return;
   }
   final treeCleanupDeadline = DateTime.now().add(const Duration(seconds: 15));
@@ -2191,25 +2229,41 @@ Future<void> _ensureWindowsProcessStopped(int pid) async {
     } on ProcessException {
       continue;
     }
-    if (await _waitForWindowsProcessToStop(pid, treeCleanupDeadline)) {
+    if (await _waitForWindowsProcessToStop(
+      pid,
+      treeCleanupDeadline,
+      expectedCommandFragment: expectedCommandFragment,
+    )) {
       return;
     }
   }
   Process.killPid(pid);
   final directKillDeadline = DateTime.now().add(const Duration(seconds: 5));
-  if (await _waitForWindowsProcessToStop(pid, directKillDeadline)) {
+  if (await _waitForWindowsProcessToStop(
+    pid,
+    directKillDeadline,
+    expectedCommandFragment: expectedCommandFragment,
+  )) {
     return;
   }
   fail('Failed to terminate synthetic Windows process $pid.');
 }
 
-Future<bool> _waitForWindowsProcessToStop(int pid, DateTime deadline) async {
+Future<bool> _waitForWindowsProcessToStop(
+  int pid,
+  DateTime deadline, {
+  String? expectedCommandFragment,
+}) async {
   while (DateTime.now().isBefore(deadline)) {
     final remaining = deadline.difference(DateTime.now());
     final probeTimeout = remaining < const Duration(seconds: 3)
         ? remaining
         : const Duration(seconds: 3);
-    if (!await _windowsProcessExists(pid, timeout: probeTimeout)) {
+    if (!await _windowsProcessExists(
+      pid,
+      timeout: probeTimeout,
+      expectedCommandFragment: expectedCommandFragment,
+    )) {
       return true;
     }
     await Future<void>.delayed(const Duration(milliseconds: 100));

--- a/test/unit/tooling/sync_native_release_pins_script_test.dart
+++ b/test/unit/tooling/sync_native_release_pins_script_test.dart
@@ -2148,7 +2148,7 @@ Future<_WindowsProcessIdentity> _windowsProcessIdentity(
       '-Command',
       'try { '
           '\$candidate = Get-CimInstance Win32_Process '
-          '-Filter "ProcessId = ${pid.toString()}"; '
+          '-Filter "ProcessId = ${pid.toString()}" -ErrorAction Stop; '
           'if (\$null -eq \$candidate) { exit 1 }; '
           'if ([string]::IsNullOrEmpty(\$candidate.CommandLine)) { exit 2 }; '
           'if (-not '

--- a/test/unit/tooling/sync_native_release_pins_script_test.dart
+++ b/test/unit/tooling/sync_native_release_pins_script_test.dart
@@ -1256,11 +1256,18 @@ time.sleep(300)
               timeout: const Duration(seconds: 30),
             );
             expect(
-              await _windowsProcessExists(
+              await _windowsProcessIdentity(
                 childPid!,
                 expectedCommandFragment: childScript.path,
               ),
-              isTrue,
+              _WindowsProcessIdentity.matching,
+            );
+            expect(
+              await _windowsProcessIdentity(
+                childPid!,
+                expectedCommandFragment: '${childScript.path}.mismatch',
+              ),
+              _WindowsProcessIdentity.absentOrDifferent,
             );
           },
           redactions: {root.path: '<temp>', secret: '<redacted>'},
@@ -1363,6 +1370,7 @@ print("parent exited after spawning child", flush=True)
             childPid ??= _readPidFileSync(childPidFile);
             return childPid;
           },
+          outputDrainDescendantCommandFragment: childScript.path,
           redactions: {root.path: '<temp>', secret: '<redacted>'},
         );
       } on Object catch (error) {
@@ -1689,6 +1697,7 @@ Future<ProcessResult> _runPython(
   Duration? timeout,
   Duration outputDrainTimeout = const Duration(seconds: 5),
   int? Function()? outputDrainDescendantPid,
+  String? outputDrainDescendantCommandFragment,
   Future<void> Function()? waitUntilReady,
   Map<String, String> redactions = const {},
   void Function(int pid)? onStart,
@@ -1810,9 +1819,14 @@ Future<ProcessResult> _runPython(
       final descendantPid = outputDrainDescendantPid();
       if (descendantPid == null) {
         cleanup = 'missing-pid';
+      } else if (outputDrainDescendantCommandFragment == null) {
+        cleanup = 'missing-identity';
       } else {
         try {
-          await _ensureWindowsProcessStopped(descendantPid);
+          await _ensureWindowsProcessStopped(
+            descendantPid,
+            expectedCommandFragment: outputDrainDescendantCommandFragment,
+          );
           cleanup = 'confirmed';
         } on Object {
           cleanup = 'failed';
@@ -2118,10 +2132,12 @@ String _diagnosticTail(String value, {int maxCharacters = 4096}) {
   return '<truncated>\n${value.substring(value.length - maxCharacters)}';
 }
 
-Future<bool> _windowsProcessExists(
+enum _WindowsProcessIdentity { matching, absentOrDifferent, unknown }
+
+Future<_WindowsProcessIdentity> _windowsProcessIdentity(
   int pid, {
   Duration timeout = const Duration(seconds: 3),
-  String? expectedCommandFragment,
+  required String expectedCommandFragment,
 }) async {
   const markerEnvironment = 'LLAMADART_EXPECTED_PROCESS_MARKER';
   final probe = await Process.start(
@@ -2131,22 +2147,19 @@ Future<bool> _windowsProcessExists(
       '-NonInteractive',
       '-Command',
       'try { '
-          '[System.Diagnostics.Process]::GetProcessById(${pid.toString()}) '
-          '| Out-Null; '
-          'if (\$env:$markerEnvironment) { '
           '\$candidate = Get-CimInstance Win32_Process '
           '-Filter "ProcessId = ${pid.toString()}"; '
-          'if (\$null -eq \$candidate -or '
-          '-not \$candidate.CommandLine.Contains(\$env:$markerEnvironment)) { '
+          'if (\$null -eq \$candidate) { exit 1 }; '
+          'if ([string]::IsNullOrEmpty(\$candidate.CommandLine)) { exit 2 }; '
+          'if (-not '
+          '\$candidate.CommandLine.Contains(\$env:$markerEnvironment)) { '
           'exit 1 '
           '} '
-          '} '
           'exit 0 '
-          '} catch [System.ArgumentException] { exit 1 } '
-          'catch { exit 2 }',
+          '} catch { exit 2 }',
     ],
     runInShell: false,
-    environment: {markerEnvironment: expectedCommandFragment ?? ''},
+    environment: {markerEnvironment: expectedCommandFragment},
   );
   final stdoutSubscription = probe.stdout.listen(null);
   final stderrSubscription = probe.stderr.listen(null);
@@ -2168,12 +2181,12 @@ Future<bool> _windowsProcessExists(
     await _cancelOutputSubscriptions(stdoutSubscription, stderrSubscription);
   }
   if (timedOut) {
-    return true;
+    return _WindowsProcessIdentity.unknown;
   }
   return switch (exitCode) {
-    0 => true,
-    1 => false,
-    _ => true,
+    0 => _WindowsProcessIdentity.matching,
+    1 => _WindowsProcessIdentity.absentOrDifferent,
+    _ => _WindowsProcessIdentity.unknown,
   };
 }
 
@@ -2208,18 +2221,32 @@ int? _readPidFileSync(File file) {
 
 Future<void> _ensureWindowsProcessStopped(
   int pid, {
-  String? expectedCommandFragment,
+  required String expectedCommandFragment,
 }) async {
-  if (!await _windowsProcessExists(
+  final initialIdentity = await _windowsProcessIdentity(
     pid,
     expectedCommandFragment: expectedCommandFragment,
-  )) {
+  );
+  if (initialIdentity == _WindowsProcessIdentity.absentOrDifferent) {
     return;
+  }
+  if (initialIdentity == _WindowsProcessIdentity.unknown) {
+    fail('Could not confirm synthetic Windows process $pid identity.');
   }
   final treeCleanupDeadline = DateTime.now().add(const Duration(seconds: 15));
   for (var killAttempt = 0; killAttempt < 2; killAttempt++) {
     if (!DateTime.now().isBefore(treeCleanupDeadline)) {
       break;
+    }
+    final identity = await _windowsProcessIdentity(
+      pid,
+      expectedCommandFragment: expectedCommandFragment,
+    );
+    if (identity == _WindowsProcessIdentity.absentOrDifferent) {
+      return;
+    }
+    if (identity == _WindowsProcessIdentity.unknown) {
+      fail('Could not reconfirm synthetic Windows process $pid identity.');
     }
     try {
       final result = await _taskkillWindowsPid(
@@ -2240,6 +2267,16 @@ Future<void> _ensureWindowsProcessStopped(
       return;
     }
   }
+  final fallbackIdentity = await _windowsProcessIdentity(
+    pid,
+    expectedCommandFragment: expectedCommandFragment,
+  );
+  if (fallbackIdentity == _WindowsProcessIdentity.absentOrDifferent) {
+    return;
+  }
+  if (fallbackIdentity == _WindowsProcessIdentity.unknown) {
+    fail('Could not reconfirm synthetic Windows process $pid identity.');
+  }
   Process.killPid(pid);
   final directKillDeadline = DateTime.now().add(const Duration(seconds: 5));
   if (await _waitForWindowsProcessToStop(
@@ -2255,18 +2292,19 @@ Future<void> _ensureWindowsProcessStopped(
 Future<bool> _waitForWindowsProcessToStop(
   int pid,
   DateTime deadline, {
-  String? expectedCommandFragment,
+  required String expectedCommandFragment,
 }) async {
   while (DateTime.now().isBefore(deadline)) {
     final remaining = deadline.difference(DateTime.now());
     final probeTimeout = remaining < const Duration(seconds: 3)
         ? remaining
         : const Duration(seconds: 3);
-    if (!await _windowsProcessExists(
+    final identity = await _windowsProcessIdentity(
       pid,
       timeout: probeTimeout,
       expectedCommandFragment: expectedCommandFragment,
-    )) {
+    );
+    if (identity == _WindowsProcessIdentity.absentOrDifferent) {
       return true;
     }
     await Future<void>.delayed(const Duration(milliseconds: 100));

--- a/test/unit/tooling/sync_native_release_pins_script_test.dart
+++ b/test/unit/tooling/sync_native_release_pins_script_test.dart
@@ -2124,27 +2124,30 @@ Future<bool> _windowsProcessExists(
   String? expectedCommandFragment,
 }) async {
   const markerEnvironment = 'LLAMADART_EXPECTED_PROCESS_MARKER';
-  final probe = await Process.start('powershell', [
-    '-NoProfile',
-    '-NonInteractive',
-    '-Command',
-    'try { '
-        '[System.Diagnostics.Process]::GetProcessById(${pid.toString()}) '
-        '| Out-Null; '
-        'if (\$env:$markerEnvironment) { '
-        '\$candidate = Get-CimInstance Win32_Process '
-        '-Filter "ProcessId = ${pid.toString()}"; '
-        'if (\$null -eq \$candidate -or '
-        '-not \$candidate.CommandLine.Contains(\$env:$markerEnvironment)) { '
-        'exit 1 '
-        '} '
-        '} '
-        'exit 0 '
-        '} catch [System.ArgumentException] { exit 1 } '
-        'catch { exit 2 }',
-  ], runInShell: false, environment: {
-    markerEnvironment: ?expectedCommandFragment,
-  });
+  final probe = await Process.start(
+    'powershell',
+    [
+      '-NoProfile',
+      '-NonInteractive',
+      '-Command',
+      'try { '
+          '[System.Diagnostics.Process]::GetProcessById(${pid.toString()}) '
+          '| Out-Null; '
+          'if (\$env:$markerEnvironment) { '
+          '\$candidate = Get-CimInstance Win32_Process '
+          '-Filter "ProcessId = ${pid.toString()}"; '
+          'if (\$null -eq \$candidate -or '
+          '-not \$candidate.CommandLine.Contains(\$env:$markerEnvironment)) { '
+          'exit 1 '
+          '} '
+          '} '
+          'exit 0 '
+          '} catch [System.ArgumentException] { exit 1 } '
+          'catch { exit 2 }',
+    ],
+    runInShell: false,
+    environment: {markerEnvironment: expectedCommandFragment ?? ''},
+  );
   final stdoutSubscription = probe.stdout.listen(null);
   final stderrSubscription = probe.stderr.listen(null);
   final stdoutDone = stdoutSubscription.asFuture<void>();

--- a/test/unit/tooling/sync_native_release_pins_script_test.dart
+++ b/test/unit/tooling/sync_native_release_pins_script_test.dart
@@ -1210,8 +1210,7 @@ printf '%s\\n' '{"tag_name":"v0.2.0-1","assets":[]}'
       await childScript.writeAsString(r'''
 import time
 
-while True:
-    time.sleep(60)
+time.sleep(20)
 ''');
       await parentScript.writeAsString(r'''
 from pathlib import Path
@@ -1325,7 +1324,7 @@ time.sleep(300)
 import time
 
 print("descendant owns inherited output", flush=True)
-time.sleep(300)
+time.sleep(4)
 ''');
       await parentScript.writeAsString(r'''
 from pathlib import Path
@@ -2224,70 +2223,22 @@ Future<void> _ensureWindowsProcessStopped(
   int pid, {
   required String expectedCommandFragment,
 }) async {
-  final initialIdentity = await _windowsProcessIdentity(
-    pid,
-    expectedCommandFragment: expectedCommandFragment,
-  );
-  if (initialIdentity == _WindowsProcessIdentity.absentOrDifferent) {
-    return;
-  }
-  if (initialIdentity == _WindowsProcessIdentity.unknown) {
-    fail('Could not confirm synthetic Windows process $pid identity.');
-  }
-  final treeCleanupDeadline = DateTime.now().add(const Duration(seconds: 15));
-  for (var killAttempt = 0; killAttempt < 2; killAttempt++) {
-    if (!DateTime.now().isBefore(treeCleanupDeadline)) {
-      break;
-    }
-    final identity = await _windowsProcessIdentity(
-      pid,
-      expectedCommandFragment: expectedCommandFragment,
-    );
-    if (identity == _WindowsProcessIdentity.absentOrDifferent) {
-      return;
-    }
-    if (identity == _WindowsProcessIdentity.unknown) {
-      fail('Could not reconfirm synthetic Windows process $pid identity.');
-    }
-    try {
-      final result = await _taskkillWindowsPid(
-        pid,
-        deadline: treeCleanupDeadline,
-      );
-      if (result.exitCode != 0 || result.timedOut) {
-        continue;
-      }
-    } on ProcessException {
-      continue;
-    }
-    if (await _waitForWindowsProcessToStop(
-      pid,
-      treeCleanupDeadline,
-      expectedCommandFragment: expectedCommandFragment,
-    )) {
-      return;
-    }
-  }
-  final fallbackIdentity = await _windowsProcessIdentity(
-    pid,
-    expectedCommandFragment: expectedCommandFragment,
-  );
-  if (fallbackIdentity == _WindowsProcessIdentity.absentOrDifferent) {
-    return;
-  }
-  if (fallbackIdentity == _WindowsProcessIdentity.unknown) {
-    fail('Could not reconfirm synthetic Windows process $pid identity.');
-  }
-  Process.killPid(pid);
-  final directKillDeadline = DateTime.now().add(const Duration(seconds: 5));
+  // This helper receives only a numeric PID, not the Process handle that Dart
+  // opened for the synthetic child. Never terminate through that PID: Windows
+  // can recycle it between an identity probe and a later taskkill call. The
+  // fixtures self-expire so failed primary cleanup remains bounded and this
+  // fallback can safely wait without risking an unrelated process.
   if (await _waitForWindowsProcessToStop(
     pid,
-    directKillDeadline,
+    DateTime.now().add(const Duration(seconds: 25)),
     expectedCommandFragment: expectedCommandFragment,
   )) {
     return;
   }
-  fail('Failed to terminate synthetic Windows process $pid.');
+  fail(
+    'Synthetic Windows process $pid did not stop; refusing unsafe raw-PID '
+    'cleanup.',
+  );
 }
 
 Future<bool> _waitForWindowsProcessToStop(


### PR DESCRIPTION
## Summary

- bind Windows process probes to the exact synthetic command-line marker instead of trusting a reusable numeric PID
- fail closed when WMI identity is unavailable and preserve the inherited PowerShell environment explicitly
- remove raw-PID fallback termination for saved child PIDs; bounded self-expiring fixtures let cleanup wait safely without risking an unrelated recycled process

Closes #451

## Regression evidence

Post-merge CI run 32712159945 failed the Windows native job because a child PID was still observable after timeout cleanup. Numeric PID observation alone cannot distinguish delayed termination from PID reuse.

The regression test now covers matching and deliberately mismatched command-line identities, WMI/provider failure handling, repeated tree-cleanup behavior, inherited-output cleanup, bounded diagnostics, and the no-raw-PID fallback policy.

## Validation

- focused VM suite: 21 passed, 3 Windows-only cases skipped locally
- scoped Dart analysis and format checks
- `git diff --check`
- replacement exact-head CI: https://github.com/leehack/llamadart/actions/runs/32716125311 (running)
- replacement exact-head review: https://github.com/leehack/llamadart/actions/runs/32716128169 (running)

Hosted Windows CI is the feature-specific merge gate. No production or release behavior changes.
