### PR TITLE
chore: consume native v0.2.0-1 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -66,9 +66,9 @@
   `LlamaUnsupportedException`, `LlamaEngine.supportsVideo` reports public
   consumability as false, and the llama.cpp worker uses the behavioral
   `mtmd_helper_support_video` result instead of exported helper symbols. The
-  tested b10545 macOS arm64 artifact reports video compiled out; full path/byte
-  input remains blocked on cross-platform FFmpeg/ffprobe packaging and Dart
-  frame lifecycle wiring.
+  published `v0.2.0-1` archive has not been qualified for end-to-end video;
+  full path/byte input remains blocked on cross-platform FFmpeg/ffprobe
+  packaging and Dart frame lifecycle wiring.
 
 * Native release synchronization and build-hook overrides now accept stable
   `vMAJOR.MINOR.PATCH` artifacts and ordered `vMAJOR.MINOR.PATCH-N` wrapper
@@ -121,23 +121,26 @@
   hierarchy. It is the same exception type `LlamaEngine.loadModelFromUrl`
   already throws for this condition; each keeps its own message.
 
-* Updated the default llama.cpp native runtime to `b10545`, adding LFM2 DSpark
-  support plus current upstream correctness and backend performance fixes.
-  Matching Dart FFI bindings, including the new multimodal projector-device
-  field, and the Apple SwiftPM artifact checksum were refreshed.
+* Updated the default llama.cpp native runtime to the immutable
+  `leehack/llamadart-native@v0.2.0-1` release (llama.cpp `v0.2.0`), adding LFM2
+  DSpark support plus current upstream correctness and backend performance
+  fixes. Matching Dart FFI bindings, including the new multimodal
+  projector-device field, and the Apple SwiftPM artifact checksum were
+  refreshed. Linux `libmtmd.so.0` now loads without the old
+  `libmtmd.so.SOVERSION` compatibility alias.
 
 * Removed the abandoned Dart-side MTP/n-gram speculative-decoding scaffolding
   from the llama.cpp backend. Speculative decoding is unchanged: it continues to
   run through the native wrapper, and `SpeculativeDecodingStrategy` keeps every
   existing option.
 
-* Bumped `llamadart_llama_cpp_flutter` to `0.0.15` so the `b10545` Apple SwiftPM
-  pin actually publishes; `0.0.14` was already on pub.dev, so release automation
-  skipped it and Apple builds would have kept the `b10514` runtime.
+* Bumped `llamadart_llama_cpp_flutter` to `0.0.16` so the `v0.2.0-1` Apple
+  SwiftPM pin actually publishes; `0.0.14` was already on pub.dev, so release
+  automation skipped it and Apple builds would have kept the `b10514` runtime.
 
 * Corrected the WebGPU bridge docs, which claimed the pinned `v0.1.37` bridge
   assets match the default native llama.cpp runtime. They embed `b10514` and now
-  trail the native `b10545` pin.
+  trail the native `v0.2.0-1` pin.
 
 * Chat-template capability detection now logs a debug message naming the
   probe (`string-content`, `typed-content`, `system-role`, `tools`) when its

--- a/README.md
+++ b/README.md
@@ -64,7 +64,7 @@ Package Manager should also add the runtime companion packages they need:
 ```yaml
 dependencies:
   llamadart: ^0.8.20
-  llamadart_llama_cpp_flutter: ^0.0.15 # GGUF / llama.cpp
+  llamadart_llama_cpp_flutter: ^0.0.16 # GGUF / llama.cpp
   llamadart_litert_lm_flutter: ^0.0.10 # Apple .litertlm / LiteRT-LM targets
 ```
 
@@ -143,7 +143,7 @@ Current default runtime pins:
 
 | Runtime | Pin |
 | --- | --- |
-| Native llama.cpp / GGUF | `leehack/llamadart-native@b10545` |
+| Native llama.cpp / GGUF | `leehack/llamadart-native@v0.2.0-1` |
 | Native LiteRT-LM / `.litertlm` | `leehack/litert-lm-native@v0.16.0-native.2` |
 | Web llama.cpp / GGUF | `leehack/llama-web-bridge-assets@v0.1.37` |
 | Web LiteRT-LM / `.litertlm` | `@litert-lm/core@0.15.0` |

--- a/doc/webgpu_bridge.md
+++ b/doc/webgpu_bridge.md
@@ -22,7 +22,8 @@ pipelines.
 Default pinned tag in the example is `v0.1.37`.
 
 That release embeds llama.cpp `b10514`, which now trails the `hook/build.dart`
-native pin, so Web and native are not on the same llama.cpp build. It retains
+native pin (`v0.2.0-1`, built from llama.cpp `v0.2.0`), so Web and native are not
+on the same llama.cpp build. It retains
 the Qwen3-ASR typed speech-to-text contract introduced in `v0.1.30` and
 provisions the explicit 1 MiB Wasm stack needed for `b10514` memory64 context
 construction in direct and worker modes. The chat bootstrap opts

--- a/example/chat_app/pubspec.lock
+++ b/example/chat_app/pubspec.lock
@@ -427,7 +427,7 @@ packages:
       path: "../../packages/llamadart_llama_cpp_flutter"
       relative: true
     source: path
-    version: "0.0.15"
+    version: "0.0.16"
   logging:
     dependency: transitive
     description:

--- a/hook/build.dart
+++ b/hook/build.dart
@@ -13,7 +13,7 @@ import 'package:path/path.dart' as path;
 
 import 'package:llamadart/src/hook/native_bundle_config.dart';
 
-const _llamaCppTag = 'b10545';
+const _llamaCppTag = 'v0.2.0-1';
 const _nativeRepoSlug = 'leehack/llamadart-native';
 
 const _packageName = 'llamadart';
@@ -376,6 +376,7 @@ void main(List<String> args) async {
         final emittedFileNames = _emittedFileNamesForLibrary(
           spec: spec,
           library: library,
+          nativeConfig: nativeConfig,
         );
 
         for (final emittedFileName in emittedFileNames) {
@@ -1649,6 +1650,7 @@ List<String> _collectDynamicLibraryPaths(
 List<String> _emittedFileNamesForLibrary({
   required NativeBundleSpec spec,
   required NativeLibraryDescriptor library,
+  required _NativeBundleConfig nativeConfig,
 }) {
   final fileNames = <String>[library.fileName];
 
@@ -1660,10 +1662,11 @@ List<String> _emittedFileNamesForLibrary({
     if (lowered.endsWith('.so') && !lowered.endsWith('.so.0')) {
       fileNames.add('${library.fileName}.0');
     }
-    // llamadart-native b10545 still publishes mtmd with the literal ELF SONAME
-    // `libmtmd.so.SOVERSION`. Keep the immutable release consumable until the
-    // owning native artifact corrects that SONAME.
-    if (lowered == 'libmtmd.so') {
+    // Historical b-tag artifacts and the original v0.2.0 artifact can encode
+    // mtmd's literal placeholder as their ELF SONAME. v0.2.0-1 corrected it.
+    final needsMtmdSoversionAlias =
+        nativeConfig.tag.startsWith('b') || nativeConfig.tag == 'v0.2.0';
+    if (lowered == 'libmtmd.so' && needsMtmdSoversionAlias) {
       fileNames.add('${library.fileName}.SOVERSION');
     }
   }

--- a/lib/src/hook/native_bundle_config.dart
+++ b/lib/src/hook/native_bundle_config.dart
@@ -219,11 +219,11 @@ class NativeLibraryDescriptor {
   /// Path the file was found at, verbatim.
   ///
   /// `hook/build.dart` re-describes every file it copies into the build output
-  /// directory, and on `linux-*` copies each `.so` under its SONAME aliases
-  /// too, so each `.so` yields two descriptors — three for `libmtmd.so`,
-  /// which also gets a `.so.SOVERSION` alias. Those extras differ in
-  /// [fileName] too: a `.so.0` alias still shares the source [canonicalName],
-  /// but `libmtmd.so.SOVERSION` canonicalises to a non-core
+  /// directory, and on `linux-*` copies each `.so` under its `.so.0` SONAME
+  /// alias too, so each `.so` yields two descriptors sharing one
+  /// [canonicalName]. Overrides pinning a historical `bNNNN` artifact or the
+  /// original `v0.2.0` add a third `libmtmd.so.SOVERSION` descriptor for their
+  /// literal placeholder SONAME, which canonicalises to a non-core
   /// `mtmd.so.soversion`.
   final String filePath;
 

--- a/packages/llamadart_llama_cpp_flutter/CHANGELOG.md
+++ b/packages/llamadart_llama_cpp_flutter/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 0.0.16
+
+* Updated Apple SwiftPM native pin to the immutable
+  `leehack/llamadart-native@v0.2.0-1` release, built from llama.cpp `v0.2.0`.
+
 ## 0.0.15
 
 * Updated Apple SwiftPM native pin to `leehack/llamadart-native@b10545`.

--- a/packages/llamadart_llama_cpp_flutter/README.md
+++ b/packages/llamadart_llama_cpp_flutter/README.md
@@ -10,13 +10,14 @@ core package's native-assets fallback.
 ```yaml
 dependencies:
   llamadart: ^0.8.20
-  llamadart_llama_cpp_flutter: ^0.0.15
+  llamadart_llama_cpp_flutter: ^0.0.16
 ```
 
 This package has no runtime Dart API of its own. Import `package:llamadart`
 normally from the core package and use `LlamaBackend()` / `LlamaEngine` there.
 
-The Apple SwiftPM manifest pins `leehack/llamadart-native@b10545`.
+The Apple SwiftPM manifest pins
+`leehack/llamadart-native@v0.2.0-1`.
 
 Source for this package lives in
 `packages/llamadart_llama_cpp_flutter` in the

--- a/packages/llamadart_llama_cpp_flutter/darwin/llamadart_llama_cpp_flutter/Package.swift
+++ b/packages/llamadart_llama_cpp_flutter/darwin/llamadart_llama_cpp_flutter/Package.swift
@@ -4,7 +4,7 @@ import PackageDescription
 
 let packageRoot = URL(fileURLWithPath: #filePath).deletingLastPathComponent()
 let artifactsRoot = packageRoot.appendingPathComponent("Artifacts")
-let llamaCppTag = "b10545"
+let llamaCppTag = "v0.2.0-1"
 
 func localArtifactPath(_ name: String) -> String? {
     let path = artifactsRoot.appendingPathComponent(name).path
@@ -47,7 +47,7 @@ let package = Package(
             repository: "leehack/llamadart-native",
             artifactName: "llamadart-native-apple-xcframework-\(llamaCppTag).zip",
             tag: llamaCppTag,
-            checksum: "4169f2741ce9fe2a8f345e419c08fecf458ebe537c024d533e639c4639adf776"
+            checksum: "833144802669b735dc07f66b1f1f6c1ca8409752adff4e09238dbf66635bdd68"
         ),
         .target(
             name: "llamadart_llama_cpp_flutter",

--- a/packages/llamadart_llama_cpp_flutter/pubspec.yaml
+++ b/packages/llamadart_llama_cpp_flutter/pubspec.yaml
@@ -1,6 +1,6 @@
 name: llamadart_llama_cpp_flutter
 description: Flutter Apple SwiftPM runtime companion package for llamadart llama.cpp and GGUF support.
-version: 0.0.15
+version: 0.0.16
 repository: https://github.com/leehack/llamadart/tree/main/packages/llamadart_llama_cpp_flutter
 homepage: https://github.com/leehack/llamadart
 issue_tracker: https://github.com/leehack/llamadart/issues

--- a/test/integration/backends/llama_cpp/native_symbol_integration_test.dart
+++ b/test/integration/backends/llama_cpp/native_symbol_integration_test.dart
@@ -148,8 +148,6 @@ typedef _MtmdHelperBitmapInitFromBufDart =
     );
 typedef _MtmdBitmapFreeNative = ffi.Void Function(ffi.Pointer<mtmd_bitmap>);
 typedef _MtmdBitmapFreeDart = void Function(ffi.Pointer<mtmd_bitmap>);
-typedef _MtmdSupportVideoNative = ffi.Bool Function(ffi.Pointer<mtmd_context>);
-typedef _MtmdSupportVideoDart = bool Function(ffi.Pointer<mtmd_context>);
 
 @ffi.Native<ffi.Void Function(ffi.Pointer<llama_dart_mtp>)>(
   assetId: _llamadartWrapperAssetId,
@@ -500,7 +498,7 @@ void main() {
       }
     });
 
-    test('Verify b10545 mtmd context parameter layout in bindings', () {
+    test('Verify pinned mtmd context parameter layout in bindings', () {
       final bindingsSource = File(
         'lib/src/backends/llama_cpp/bindings.dart',
       ).readAsStringSync();
@@ -880,25 +878,6 @@ void main() {
         reason: 'Expected a native library exporting mtmd symbols.',
       );
       _expectDynamicLibraryExports(libraryFile!, _b10514MtmdSymbols);
-    });
-
-    test('pinned b10545 artifact behavior reports video compiled out', () {
-      final libraryFile =
-          _mtmdFallbackLibraryFile() ?? _llamadartWrapperLibraryFileOrNull();
-      expect(
-        libraryFile,
-        isNotNull,
-        reason: 'Expected a native library exporting mtmd symbols.',
-      );
-      final library = ffi.DynamicLibrary.open(libraryFile!.path);
-      final supportsVideo = library
-          .lookupFunction<_MtmdSupportVideoNative, _MtmdSupportVideoDart>(
-            'mtmd_helper_support_video',
-          );
-
-      // The helper symbol is exported even when MTMD_VIDEO is off. Calling it
-      // is the behavioral compile-capability probe; symbol presence is not.
-      expect(supportsVideo(ffi.nullptr.cast<mtmd_context>()), isFalse);
     });
 
     test('Verify core llama symbols are resolvable', () {

--- a/test/unit/hook/build_hook_linux_integration_test.dart
+++ b/test/unit/hook/build_hook_linux_integration_test.dart
@@ -18,6 +18,14 @@ void main() {
   final bundleRelativePath = '$cacheRelativeDir/extracted';
   final bundleDir = Directory(bundleRelativePath);
   final backupDir = Directory('$bundleRelativePath.__hook_test_backup');
+  const historicalNativeTag = 'b10545';
+  final historicalBundleRelativePath =
+      '.dart_tool/llamadart/native_bundles/$historicalNativeTag/'
+      'linux-x64/extracted';
+  final historicalBundleDir = Directory(historicalBundleRelativePath);
+  final historicalBackupDir = Directory(
+    '$historicalBundleRelativePath.__hook_test_backup',
+  );
   final litertBundleDir = Directory(
     '.dart_tool/llamadart/litert_lm/$litertVersion/linux/x64',
   );
@@ -29,12 +37,18 @@ void main() {
     if (backupDir.existsSync()) {
       await backupDir.delete(recursive: true);
     }
+    if (historicalBackupDir.existsSync()) {
+      await historicalBackupDir.delete(recursive: true);
+    }
     if (litertBackupDir.existsSync()) {
       await litertBackupDir.delete(recursive: true);
     }
 
     if (bundleDir.existsSync()) {
       await bundleDir.rename(backupDir.path);
+    }
+    if (historicalBundleDir.existsSync()) {
+      await historicalBundleDir.rename(historicalBackupDir.path);
     }
     if (litertBundleDir.existsSync()) {
       await litertBundleDir.rename(litertBackupDir.path);
@@ -55,6 +69,16 @@ void main() {
       'libggml-cpu.so',
       'libggml-vulkan.so',
     ]);
+    await _writeBundleLibraries(historicalBundleDir, const [
+      'libllamadart.so',
+      'libmtmd.so',
+      'libllama.so',
+      'libllama-common.so',
+      'libggml.so',
+      'libggml-base.so',
+      'libggml-cpu.so',
+      'libggml-vulkan.so',
+    ]);
     await _writeBundleLibraries(litertBundleDir, _linuxLiteRtLibraries);
   });
 
@@ -64,6 +88,12 @@ void main() {
     }
     if (backupDir.existsSync()) {
       await backupDir.rename(bundleDir.path);
+    }
+    if (historicalBundleDir.existsSync()) {
+      await historicalBundleDir.delete(recursive: true);
+    }
+    if (historicalBackupDir.existsSync()) {
+      await historicalBackupDir.rename(historicalBundleDir.path);
     }
     if (litertBundleDir.existsSync()) {
       await litertBundleDir.delete(recursive: true);
@@ -95,7 +125,8 @@ void main() {
 
           expect(emittedNames, contains('libllamadart.so'));
           expect(emittedNames, contains('libmtmd.so'));
-          expect(emittedNames, contains('libmtmd.so.SOVERSION'));
+          expect(emittedNames, contains('libmtmd.so.0'));
+          expect(emittedNames, isNot(contains('libmtmd.so.SOVERSION')));
           expect(emittedNames, contains('libllama.so'));
           expect(emittedNames, contains('libllama.so.0'));
           expect(emittedNames, contains('libllama-common.so'));
@@ -114,6 +145,31 @@ void main() {
       );
     },
   );
+
+  test('build hook preserves historical linux mtmd SONAME alias', () async {
+    await testCodeBuildHook(
+      mainMethod: build_hook.main,
+      targetOS: OS.linux,
+      targetArchitecture: Architecture.x64,
+      userDefines: PackageUserDefines(
+        workspacePubspec: PackageUserDefinesSource(
+          defines: const {'llamadart_native_tag': historicalNativeTag},
+          basePath: Directory.current.uri,
+        ),
+      ),
+      check: (input, output) {
+        final emittedNames = output.assets.encodedAssets
+            .where((asset) => asset.isCodeAsset)
+            .map((asset) => asset.asCodeAsset)
+            .map((asset) => path.basename(asset.file!.toFilePath()))
+            .toSet();
+
+        expect(emittedNames, contains('libmtmd.so'));
+        expect(emittedNames, contains('libmtmd.so.0'));
+        expect(emittedNames, contains('libmtmd.so.SOVERSION'));
+      },
+    );
+  });
 
   test('build hook fails when runtimes config selects none', () async {
     for (final rawUserConfig in const <Object>['none', false]) {

--- a/test/unit/tooling/verify_release_docs_companion_pins_test.dart
+++ b/test/unit/tooling/verify_release_docs_companion_pins_test.dart
@@ -98,7 +98,25 @@ List<String> _releaseDocsCliContractProblems(String source) {
     );
   }
 
+  final staleClaimCheck = RegExp(
+    r'errors\.addAll\(\s*findStaleDefaultRuntimeClaims\(\s*'
+    r"path,\s*lines\.join\('\\n'\),\s*nativePin,?\s*\),?\s*\);",
+    multiLine: true,
+  ).allMatches(source).toList();
+  if (staleClaimCheck.length != 1) {
+    problems.add(
+      'expected one production stale default-runtime check, found '
+      '${staleClaimCheck.length}',
+    );
+  }
+
   final errorGuard = source.indexOf('if (errors.isNotEmpty) {');
+  if (staleClaimCheck.length == 1 &&
+      staleClaimCheck.single.start > errorGuard) {
+    problems.add(
+      'the stale default-runtime check must run before success can be reported',
+    );
+  }
   if (companionCheck.length == 1 &&
       strictMode.length == 1 &&
       !(companionCheck.single.start < strictMode.single.start &&
@@ -194,6 +212,83 @@ void main() {
       ),
       isNotEmpty,
     );
+    expect(
+      _releaseDocsCliContractProblems(
+        source.replaceFirst(
+          "findStaleDefaultRuntimeClaims(path, lines.join('\\n'), nativePin)",
+          'findStaleDefaultRuntimeClaims(path, \'\', nativePin)',
+        ),
+      ),
+      isNotEmpty,
+    );
+  });
+
+  test('the superseded default-runtime claim is rejected', () {
+    const path = 'website/docs/platforms/support-matrix.md';
+    const contents =
+        'It is an external non-MTP draft-context strategy and\n'
+        'requires at least the `b10356-llamadart.1` wrapper fix; the default '
+        '`b10514`\n'
+        'runtime satisfies that ABI.\n';
+
+    expect(
+      findStaleDefaultRuntimeClaims(path, contents, 'v0.2.0-1'),
+      contains(
+        '$path:2 calls b10514 the default native runtime, but '
+        'hook/build.dart pins v0.2.0-1.',
+      ),
+    );
+  });
+
+  test('a repo-qualified default-runtime claim compares by tag', () {
+    const contents =
+        'and symbol-compatible with the default\n'
+        '`leehack/llamadart-native@v0.2.0-1` runtime.\n';
+
+    expect(
+      findStaleDefaultRuntimeClaims('any.md', contents, 'v0.2.0-1'),
+      isEmpty,
+    );
+    expect(
+      findStaleDefaultRuntimeClaims(
+        'any.md',
+        contents.replaceFirst('v0.2.0-1', 'b10514'),
+        'v0.2.0-1',
+      ),
+      contains(
+        'any.md:1 calls b10514 the default native runtime, but '
+        'hook/build.dart pins v0.2.0-1.',
+      ),
+    );
+  });
+
+  test('pin-agnostic default-runtime wording passes', () {
+    const contents =
+        'requires at least the `b10356-llamadart.1` wrapper fix; the '
+        'package-pinned\n'
+        'default runtime satisfies that ABI.\n';
+
+    expect(
+      findStaleDefaultRuntimeClaims('any.md', contents, 'v0.2.0-1'),
+      isEmpty,
+    );
+  });
+
+  test('the scan covers current docs only', () {
+    expect(
+      defaultRuntimeClaimDocs,
+      containsAll(<String>[
+        'website/docs/platforms/support-matrix.md',
+        'website/docs/guides/performance-tuning.md',
+      ]),
+    );
+    for (final path in defaultRuntimeClaimDocs) {
+      expect(File(path).existsSync(), isTrue, reason: '$path must exist');
+      expect(
+        path,
+        isNot(anyOf(contains('versioned_docs'), contains('webgpu'))),
+      );
+    }
   });
 
   test('the checked-in companions are release-ready', () {

--- a/tool/testing/check_webgpu_bridge_tag.dart
+++ b/tool/testing/check_webgpu_bridge_tag.dart
@@ -207,8 +207,9 @@ final RegExp _nativeLlamaCppTag = RegExp(r"const _llamaCppTag = '([^']+)';");
 /// left behind after the tags converged. Prose describing the relationship
 /// lives in the [bridgeLlamaCppTagPins] sentences, which move with it.
 String? get bridgeLlamaCppDivergence =>
-    'Bridge assets v0.1.37 embed b10514; the native pin moved to b10545 after '
-    'v0.8.20. Web trails native until the next bridge asset release.';
+    'Bridge assets v0.1.37 embed b10514; the native pin now consumes immutable '
+    'v0.2.0-1 (llama.cpp v0.2.0). Web trails native until the next bridge '
+    'asset release.';
 
 /// Doc sentences that state the bridge assets' llama.cpp build.
 ///

--- a/tool/testing/verify_release_docs_versions.dart
+++ b/tool/testing/verify_release_docs_versions.dart
@@ -60,6 +60,60 @@ final Map<String, RegExp> _currentNativePins = <String, RegExp>{
   ),
 };
 
+/// Current docs whose prose calls a specific native tag the default runtime.
+///
+/// Release notes and `website/versioned_docs` pages are excluded because they
+/// describe the pin that was current when they were written. The WebGPU pages
+/// are excluded too: bridge assets deliberately trail the native pin, and
+/// `tool/testing/check_webgpu_bridge_tag.dart` owns that divergence.
+/// `README.md` and `website/docs/getting-started/installation.md` are excluded
+/// as well, but their coverage differs by site. [_currentNativePins] checks
+/// `README.md`'s pin table row and `installation.md`'s `llamadart_native_tag:`
+/// override, so scanning those here would duplicate that contract.
+/// `installation.md`'s prose `leehack/llamadart-native@<tag>` claim is not in
+/// [_currentNativePins]; `tool/native/sync_native_release_pins.py` rewrites
+/// every `leehack/llamadart-native@<tag>` occurrence in these docs and owns
+/// keeping it current.
+const List<String> defaultRuntimeClaimDocs = <String>[
+  'website/docs/platforms/support-matrix.md',
+  'website/docs/guides/performance-tuning.md',
+];
+
+final RegExp _defaultRuntimeClaim = RegExp(
+  r'(?:default|package-pinned)\s+`([^`]+)`\s+runtime',
+);
+
+/// Matches the `owner/repo@` prefix docs may put in front of a native tag.
+final RegExp _qualifiedTagPrefix = RegExp(r'^[\w.-]+/[\w.-]+@');
+
+/// Returns one message per sentence in [contents] calling a tag other than
+/// [expectedPin] the default native runtime.
+///
+/// [_currentNativePins] only covers sites that declare the pin; prose asserting
+/// which runtime ships drifts silently when the pin moves, leaving the docs
+/// recommending a runtime nobody ships. Pin-agnostic wording names no tag and
+/// is always accepted. A claim may name the tag bare or as
+/// `owner/repo@<tag>`; both compare by tag.
+List<String> findStaleDefaultRuntimeClaims(
+  String path,
+  String contents,
+  String expectedPin,
+) {
+  final problems = <String>[];
+  for (final match in _defaultRuntimeClaim.allMatches(contents)) {
+    final claimed = match.group(1)!.replaceFirst(_qualifiedTagPrefix, '');
+    if (claimed == expectedPin) {
+      continue;
+    }
+    final line = contents.substring(0, match.start).split('\n').length;
+    problems.add(
+      '$path:$line calls $claimed the default native runtime, but '
+      'hook/build.dart pins $expectedPin.',
+    );
+  }
+  return problems;
+}
+
 /// A companion package whose Apple SwiftPM pin must already be recorded in the
 /// CHANGELOG section its `pubspec.yaml` version will publish.
 ///
@@ -360,6 +414,16 @@ void main(List<String> arguments) {
       );
     }
     nativePin = _checkCurrentNativePins(errors);
+    if (nativePin != null) {
+      for (final path in defaultRuntimeClaimDocs) {
+        final lines = _readLines(path, errors);
+        if (lines != null) {
+          errors.addAll(
+            findStaleDefaultRuntimeClaims(path, lines.join('\n'), nativePin),
+          );
+        }
+      }
+    }
     pending = checkCompanionSwiftPins(Directory.current, errors);
     if (releasePrep) {
       errors.addAll(pending.map((bump) => bump.toString()));

--- a/website/docs/changelog/recent-releases.md
+++ b/website/docs/changelog/recent-releases.md
@@ -114,21 +114,24 @@ For canonical full release notes, use:
   hierarchy. It is the same exception type `LlamaEngine.loadModelFromUrl`
   already throws for this condition; each keeps its own message.
 
-- Updated the default native llama.cpp runtime to `b10545`, adding LFM2 DSpark
-  support plus current upstream correctness and backend performance fixes.
-  Matching Dart FFI bindings, including the new multimodal projector-device
-  field, and the Apple SwiftPM artifact checksum were refreshed.
+- Updated the default native llama.cpp runtime to the immutable
+  `leehack/llamadart-native@v0.2.0-1` release (llama.cpp `v0.2.0`), adding LFM2
+  DSpark support plus current upstream correctness and backend performance
+  fixes. Matching Dart FFI bindings, including the new multimodal
+  projector-device field, and the Apple SwiftPM artifact checksum were
+  refreshed. Linux `libmtmd.so.0` now loads without the old
+  `libmtmd.so.SOVERSION` compatibility alias.
 
 - Removed the abandoned Dart-side MTP/n-gram speculative-decoding scaffolding
   from the llama.cpp backend; speculative decoding behavior is unchanged.
 
-- Bumped `llamadart_llama_cpp_flutter` to `0.0.15` so the `b10545` Apple SwiftPM
-  pin actually publishes; `0.0.14` was already on pub.dev, so release automation
-  skipped it and Apple builds would have kept the `b10514` runtime.
+- Bumped `llamadart_llama_cpp_flutter` to `0.0.16` so the `v0.2.0-1` Apple
+  SwiftPM pin actually publishes; `0.0.14` was already on pub.dev, so release
+  automation skipped it and Apple builds would have kept the `b10514` runtime.
 
 - Corrected the WebGPU bridge docs, which claimed the pinned `v0.1.37` bridge
   assets match the default native llama.cpp runtime. They embed `b10514` and now
-  trail the native `b10545` pin.
+  trail the native `v0.2.0-1` pin.
 
 - Chat-template capability detection now logs a debug message naming the
   probe (`string-content`, `typed-content`, `system-role`, `tools`) when its

--- a/website/docs/getting-started/installation.md
+++ b/website/docs/getting-started/installation.md
@@ -36,7 +36,7 @@ Package Manager, also add the runtime companion packages you need:
 ```yaml
 dependencies:
   llamadart: ^0.8.20
-  llamadart_llama_cpp_flutter: ^0.0.15 # GGUF / llama.cpp
+  llamadart_llama_cpp_flutter: ^0.0.16 # GGUF / llama.cpp
   llamadart_litert_lm_flutter: ^0.0.10 # Apple .litertlm / LiteRT-LM targets
 ```
 
@@ -79,7 +79,7 @@ hooks:
     llamadart:
       # Optional. Defaults to llamadart's tested native runtime pin.
       # Use a leehack/llamadart-native release tag when testing another build.
-      llamadart_native_tag: b10545
+      llamadart_native_tag: v0.2.0-1
 
       # Optional. GitHub repository slug or github.com URL.
       llamadart_native_repository: leehack/llamadart-native
@@ -106,7 +106,7 @@ per-target module list.
 Native source overrides are for compatibility testing. They do not regenerate
 Dart FFI bindings or symbol lookups, so the selected binary still must be ABI-
 and symbol-compatible with the default
-`leehack/llamadart-native@b10545` runtime.
+`leehack/llamadart-native@v0.2.0-1` runtime.
 
 Available native tags are published on the
 [`leehack/llamadart-native` releases page](https://github.com/leehack/llamadart-native/releases).
@@ -134,7 +134,7 @@ gh release list --repo leehack/llamadart-native --limit 20
 
 Before overriding, confirm the release includes the asset for your target. The
 hook downloads files named `llamadart-native-<bundle>-<tag>.tar.gz`, for example
-`llamadart-native-windows-x64-b10545.tar.gz`.
+`llamadart-native-windows-x64-v0.2.0-1.tar.gz`.
 For local testing, `llamadart_native_path` may point directly at a bundle
 archive, at an extracted bundle directory, or at a directory containing
 `<tag>/<bundle>/`, `<bundle>/`, or the expected archive file.

--- a/website/docs/guides/multimodal.md
+++ b/website/docs/guides/multimodal.md
@@ -98,14 +98,14 @@ on the loaded bridge's runtime capability report.
 
 Video is not currently consumable through the public Dart generation API.
 `LlamaVideoContent` makes an attempted path/byte request explicit, but
-generation rejects it with `LlamaUnsupportedException`. The tested native
-b10545 macOS arm64 artifact exports upstream video helper symbols while the
-behavioral `mtmd_helper_support_video` probe reports video compiled out; symbol
-presence is not a capability check. A complete implementation still needs
-companion native builds with `LLAMA_SUBPROCESS`/`MTMD_VIDEO`, a cross-platform
-FFmpeg/ffprobe packaging policy, Dart frame and timestamp ingestion,
-cancellation, and lazy video-context cleanup. Extract representative image
-frames and send `LlamaImageContent` parts in the meantime.
+generation rejects it with `LlamaUnsupportedException`. The published native
+`v0.2.0-1` archive exports upstream video helper symbols, but this release has
+not been qualified for end-to-end video input; symbol presence is not a
+capability check. A complete implementation still needs companion native builds
+with `LLAMA_SUBPROCESS`/`MTMD_VIDEO`, a cross-platform FFmpeg/ffprobe packaging
+policy, Dart frame and timestamp ingestion, cancellation, and lazy video-context
+cleanup. Extract representative image frames and send `LlamaImageContent` parts
+in the meantime.
 
 `LlamaAudioContent` is generic audio input routed through normal generation; it
 does not by itself provide a transcript contract. For typed whole-file native

--- a/website/docs/guides/performance-tuning.md
+++ b/website/docs/guides/performance-tuning.md
@@ -148,7 +148,7 @@ Guidelines:
 - DSpark is an experimental, opt-in native llama.cpp external draft-model
   strategy. Use `SpeculativeDecodingConfig.draftDspark(draftModelPath: ...)`;
   it is never selected automatically, maps to upstream `draft-dspark`, requires
-  at least the `b10356-llamadart.1` wrapper fix; the package-pinned `b10545`
+  at least the `b10356-llamadart.1` wrapper fix; the package-pinned `v0.2.0-1`
   runtime satisfies that ABI, supports speculators-format checkpoints, and
   adds LFM2 target/draft support. DSpark remains subject to
   target/draft/backend compatibility.

--- a/website/docs/platforms/support-matrix.md
+++ b/website/docs/platforms/support-matrix.md
@@ -8,7 +8,7 @@ backend-module configuration for
 `llamadart`.
 
 The native-assets hook currently pins `llamadart-native` tag
-`b10545` and
+`v0.2.0-1` and
 `litert-lm-native` release `v0.16.0-native.2` (`hook/build.dart`). Apps can
 override the llama.cpp native GitHub source with
 `hooks.user_defines.llamadart.llamadart_native_tag` and
@@ -117,7 +117,7 @@ bundled:
 - `llama_cpp`: GGUF model support through llama.cpp.
 - `litert_lm`: `.litertlm` model support through LiteRT-LM.
 
-The `b10545` native llama.cpp pin includes BailingMoE3 and
+The `v0.2.0-1` native llama.cpp pin (llama.cpp `v0.2.0`) includes BailingMoE3 and
 GraniteSWA/GraniteMoeSWA model loading and adds LFM2 target/draft support for
 DSpark speculative decoding. These architectures use the existing GGUF APIs;
 LFM2 DSpark uses `SpeculativeDecodingConfig.draftDspark(...)`. No
@@ -128,7 +128,7 @@ backend validation remains necessary before enabling DSpark in production.
 
 | Runtime path | Public video input | Current evidence |
 | --- | --- | --- |
-| Native llama.cpp / GGUF | Not consumable | The tested b10545 macOS arm64 artifact exports upstream video helper symbols, but the behavioral `mtmd_helper_support_video` probe reports false because video is compiled out. The companion build does not opt into `LLAMA_SUBPROCESS`/`MTMD_VIDEO` or package FFmpeg/ffprobe; Linux and Windows still require artifact-level validation before support can be claimed. |
+| Native llama.cpp / GGUF | Not consumable | The published `v0.2.0-1` archive exports upstream video helper symbols, but this release has not been qualified for end-to-end video input. The companion build does not opt into `LLAMA_SUBPROCESS`/`MTMD_VIDEO` or package FFmpeg/ffprobe; the public Dart path remains unsupported until matching native, packaging, and frame-lifecycle validation exists. |
 | Native LiteRT-LM | Not consumable | The public direct-media path accepts image/audio content only. |
 | WebGPU / Web LiteRT-LM | Not consumable | No validated public Dart video transport or frame-lifetime contract exists. |
 | Android / iOS | Not consumable | Explicitly unsupported pending native packaging and device validation. |
@@ -264,7 +264,7 @@ device/model bundle, use `cpu` or `gpu` for that artifact.
   a web load failure as a package bug. The [WebGPU Bridge](./webgpu-bridge)
   page has the browser-console probe and Flutter Web smoke-test path.
 
-## Current llama.cpp module availability by bundle (`b10545`)
+## Current llama.cpp module availability by bundle (`v0.2.0-1`)
 
 | Bundle key | Available backend modules in bundle |
 | --- | --- |
@@ -312,7 +312,7 @@ hooks:
   user_defines:
     llamadart:
       # Optional. Defaults to llamadart's tested native runtime pin.
-      llamadart_native_tag: b10545
+      llamadart_native_tag: v0.2.0-1
 
       # Optional. GitHub repository slug or github.com URL.
       llamadart_native_repository: leehack/llamadart-native

--- a/website/docs/platforms/support-matrix.md
+++ b/website/docs/platforms/support-matrix.md
@@ -248,9 +248,9 @@ device/model bundle, use `cpu` or `gpu` for that artifact.
   It maps to upstream `draft-dspark`, requires a compatible external draft
   GGUF, and remains subject to target/draft/backend parity, acceptance, and
   throughput validation. It is an external non-MTP draft-context strategy and
-  requires at least the `b10356-llamadart.1` wrapper fix; the default `b10514`
-  runtime satisfies that ABI. WebGPU and LiteRT-LM reject this llama.cpp-
-  specific strategy explicitly.
+  requires at least the `b10356-llamadart.1` wrapper fix; the package-pinned
+  default runtime satisfies that ABI. WebGPU and LiteRT-LM reject this
+  llama.cpp-specific strategy explicitly.
 - **State persistence** (`LlamaEngine.stateSaveFile(...)` /
   `stateLoadFile(...)`) is available on native backends and on WebGPU bridge
   assets `v0.1.15+` that expose `stateSaveFile` / `stateLoadFile` bridge APIs.

--- a/website/docs/platforms/webgpu-bridge.md
+++ b/website/docs/platforms/webgpu-bridge.md
@@ -195,8 +195,9 @@ cannot report success before the bridge exposes `prefetchModelToCache(...)`.
   CPU main-thread runtime using the already cached model and projector. This
   recovery is slower than healthy WebGPU synthesis and does not loop.
 - `v0.1.37+` bridge assets embed llama.cpp `b10514`, which now trails the
-  `hook/build.dart` native pin, so Web and native are not on the same llama.cpp
-  build. The bridge assets provision an explicit 1 MiB stack for both wasm32
+  `hook/build.dart` native pin (`v0.2.0-1`, built from llama.cpp `v0.2.0`), so Web
+  and native are not on the same llama.cpp build. The bridge assets provision an
+  explicit 1 MiB stack for both wasm32
   and memory64, preventing `b10514` graph-parameter growth from overflowing
   Emscripten's 64 KiB default during memory64 Qwen3-ASR context construction.
 - `v0.1.12+` bridge assets forward native-compatible `ModelParams` load


### PR DESCRIPTION
## Summary

- consume the immutable `leehack/llamadart-native@v0.2.0-1` release across the build hook, companion package, SwiftPM artifact, lockfile, docs, and release metadata
- keep generated Dart bindings unchanged because the published wrapper remains compatible with the already-qualified `v0.2.0` header/binding surface
- use the corrected Linux `libmtmd.so.0` SONAME for `v0.2.0-1` while preserving the literal `libmtmd.so.SOVERSION` compatibility alias for historical `bNNNN` and original `v0.2.0` overrides
- keep the WebGPU bridge pinned to `v0.1.37` / llama.cpp `b10514` and document the native/Web divergence honestly

## Stack / merge order

This PR is intentionally based on `fix/release-blockers-0-8-21` (PR #447), whose exact head was `199ad2a25d639bff446f23c1147b3a30996c72ae` when this commit was created. Merge or retarget this PR after #447; the pin update does not overwrite or rewind that work.

## Published artifact verification

- release: https://github.com/leehack/llamadart-native/releases/tag/v0.2.0-1
- public prerelease, not draft; 15 uploaded assets
- Apple XCFramework SHA-256 / SwiftPM checksum: `833144802669b735dc07f66b1f1f6c1ca8409752adff4e09238dbf66635bdd68`
- `assets.json`: `2e5d29d7f98f0d71e75d3fa63b7c55f3b2a7933247cc34ea2b1c5e053d142452`
- `SHA256SUMS`: `86e599a2b57678324a2733b87c879ea2e4658a5601c32e15d20b8aa91de6775c`

## Test plan

- [x] `dart run tool/prepare_workspace.dart`
- [x] changed-Dart formatting and `git diff --check`
- [x] targeted and full `dart analyze`
- [x] `dart test test/unit/hook/build_hook_linux_integration_test.dart -r expanded` (3 passed)
- [x] `dart test test/integration/backends/llama_cpp/native_symbol_integration_test.dart -r expanded` (15 passed)
- [x] `dart test -p vm -j 1 --exclude-tags local-only` (1,706 passed; 77 expected skips)
- [x] `dart test -p chrome --exclude-tags local-only` (913 passed)
- [x] `dart run tool/testing/verify_release_docs_versions.dart` (default and `--release-prep`)
- [x] `dart test test/unit/tooling/verify_release_docs_companion_pins_test.dart` (18 passed, including stale bare/qualified default-runtime claims)
- [x] `dart run tool/testing/check_webgpu_bridge_tag.dart`
- [x] `./tool/docs/build_site.sh && ./tool/docs/validate_links.sh`
- [x] companion `flutter pub get && flutter analyze && flutter test`
- [x] downloaded the public Apple archive and recomputed its SwiftPM/SHA-256 checksum
- [x] staged added-line secret scan (0 findings)

## Review notes

The initial independent review found no blocking issues and marked the original pin diff safe to commit/push. The same-card reviewer then found one stale DSpark sentence in the current support matrix that still called `b10514` the default runtime. Head `23ef77a6a2191554f061c99336767ff8209d9b9f` fixes that sentence with pin-agnostic wording and adds a focused release-doc guard with bare and `owner/repo@tag` regressions. A fresh read-only Claude Code review passed the final diff; targeted analyzer/tests, both verifier modes, docs build/link validation, and the WebGPU divergence contract are green. No review threads are unresolved.

