### PR TITLE
chore: consume native v0.2.0-1 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -66,9 +66,9 @@
   `LlamaUnsupportedException`, `LlamaEngine.supportsVideo` reports public
   consumability as false, and the llama.cpp worker uses the behavioral
   `mtmd_helper_support_video` result instead of exported helper symbols. The
-  tested b10545 macOS arm64 artifact reports video compiled out; full path/byte
-  input remains blocked on cross-platform FFmpeg/ffprobe packaging and Dart
-  frame lifecycle wiring.
+  published `v0.2.0-1` archive has not been qualified for end-to-end video;
+  full path/byte input remains blocked on cross-platform FFmpeg/ffprobe
+  packaging and Dart frame lifecycle wiring.
 
 * Native release synchronization and build-hook overrides now accept stable
   `vMAJOR.MINOR.PATCH` artifacts and ordered `vMAJOR.MINOR.PATCH-N` wrapper
@@ -121,23 +121,26 @@
   hierarchy. It is the same exception type `LlamaEngine.loadModelFromUrl`
   already throws for this condition; each keeps its own message.
 
-* Updated the default llama.cpp native runtime to `b10545`, adding LFM2 DSpark
-  support plus current upstream correctness and backend performance fixes.
-  Matching Dart FFI bindings, including the new multimodal projector-device
-  field, and the Apple SwiftPM artifact checksum were refreshed.
+* Updated the default llama.cpp native runtime to the immutable
+  `leehack/llamadart-native@v0.2.0-1` release (llama.cpp `v0.2.0`), adding LFM2
+  DSpark support plus current upstream correctness and backend performance
+  fixes. Matching Dart FFI bindings, including the new multimodal
+  projector-device field, and the Apple SwiftPM artifact checksum were
+  refreshed. Linux `libmtmd.so.0` now loads without the old
+  `libmtmd.so.SOVERSION` compatibility alias.
 
 * Removed the abandoned Dart-side MTP/n-gram speculative-decoding scaffolding
   from the llama.cpp backend. Speculative decoding is unchanged: it continues to
   run through the native wrapper, and `SpeculativeDecodingStrategy` keeps every
   existing option.
 
-* Bumped `llamadart_llama_cpp_flutter` to `0.0.15` so the `b10545` Apple SwiftPM
-  pin actually publishes; `0.0.14` was already on pub.dev, so release automation
-  skipped it and Apple builds would have kept the `b10514` runtime.
+* Bumped `llamadart_llama_cpp_flutter` to `0.0.16` so the `v0.2.0-1` Apple
+  SwiftPM pin actually publishes; `0.0.14` was already on pub.dev, so release
+  automation skipped it and Apple builds would have kept the `b10514` runtime.
 
 * Corrected the WebGPU bridge docs, which claimed the pinned `v0.1.37` bridge
   assets match the default native llama.cpp runtime. They embed `b10514` and now
-  trail the native `b10545` pin.
+  trail the native `v0.2.0-1` pin.
 
 * Chat-template capability detection now logs a debug message naming the
   probe (`string-content`, `typed-content`, `system-role`, `tools`) when its

--- a/README.md
+++ b/README.md
@@ -64,7 +64,7 @@ Package Manager should also add the runtime companion packages they need:
 ```yaml
 dependencies:
   llamadart: ^0.8.20
-  llamadart_llama_cpp_flutter: ^0.0.15 # GGUF / llama.cpp
+  llamadart_llama_cpp_flutter: ^0.0.16 # GGUF / llama.cpp
   llamadart_litert_lm_flutter: ^0.0.10 # Apple .litertlm / LiteRT-LM targets
 ```
 
@@ -143,7 +143,7 @@ Current default runtime pins:
 
 | Runtime | Pin |
 | --- | --- |
-| Native llama.cpp / GGUF | `leehack/llamadart-native@b10545` |
+| Native llama.cpp / GGUF | `leehack/llamadart-native@v0.2.0-1` |
 | Native LiteRT-LM / `.litertlm` | `leehack/litert-lm-native@v0.16.0-native.2` |
 | Web llama.cpp / GGUF | `leehack/llama-web-bridge-assets@v0.1.37` |
 | Web LiteRT-LM / `.litertlm` | `@litert-lm/core@0.15.0` |

--- a/doc/webgpu_bridge.md
+++ b/doc/webgpu_bridge.md
@@ -22,7 +22,8 @@ pipelines.
 Default pinned tag in the example is `v0.1.37`.
 
 That release embeds llama.cpp `b10514`, which now trails the `hook/build.dart`
-native pin, so Web and native are not on the same llama.cpp build. It retains
+native pin (`v0.2.0-1`, built from llama.cpp `v0.2.0`), so Web and native are not
+on the same llama.cpp build. It retains
 the Qwen3-ASR typed speech-to-text contract introduced in `v0.1.30` and
 provisions the explicit 1 MiB Wasm stack needed for `b10514` memory64 context
 construction in direct and worker modes. The chat bootstrap opts

--- a/example/chat_app/pubspec.lock
+++ b/example/chat_app/pubspec.lock
@@ -427,7 +427,7 @@ packages:
       path: "../../packages/llamadart_llama_cpp_flutter"
       relative: true
     source: path
-    version: "0.0.15"
+    version: "0.0.16"
   logging:
     dependency: transitive
     description:

--- a/hook/build.dart
+++ b/hook/build.dart
@@ -13,7 +13,7 @@ import 'package:path/path.dart' as path;
 
 import 'package:llamadart/src/hook/native_bundle_config.dart';
 
-const _llamaCppTag = 'b10545';
+const _llamaCppTag = 'v0.2.0-1';
 const _nativeRepoSlug = 'leehack/llamadart-native';
 
 const _packageName = 'llamadart';
@@ -376,6 +376,7 @@ void main(List<String> args) async {
         final emittedFileNames = _emittedFileNamesForLibrary(
           spec: spec,
           library: library,
+          nativeConfig: nativeConfig,
         );
 
         for (final emittedFileName in emittedFileNames) {
@@ -1649,6 +1650,7 @@ List<String> _collectDynamicLibraryPaths(
 List<String> _emittedFileNamesForLibrary({
   required NativeBundleSpec spec,
   required NativeLibraryDescriptor library,
+  required _NativeBundleConfig nativeConfig,
 }) {
   final fileNames = <String>[library.fileName];
 
@@ -1660,10 +1662,11 @@ List<String> _emittedFileNamesForLibrary({
     if (lowered.endsWith('.so') && !lowered.endsWith('.so.0')) {
       fileNames.add('${library.fileName}.0');
     }
-    // llamadart-native b10545 still publishes mtmd with the literal ELF SONAME
-    // `libmtmd.so.SOVERSION`. Keep the immutable release consumable until the
-    // owning native artifact corrects that SONAME.
-    if (lowered == 'libmtmd.so') {
+    // Historical b-tag artifacts and the original v0.2.0 artifact can encode
+    // mtmd's literal placeholder as their ELF SONAME. v0.2.0-1 corrected it.
+    final needsMtmdSoversionAlias =
+        nativeConfig.tag.startsWith('b') || nativeConfig.tag == 'v0.2.0';
+    if (lowered == 'libmtmd.so' && needsMtmdSoversionAlias) {
       fileNames.add('${library.fileName}.SOVERSION');
     }
   }

--- a/hook/build.dart
+++ b/hook/build.dart
@@ -2110,12 +2110,18 @@ Future<void> _extractArchive({
     throw Exception('Failed to decode native bundle archive: $archivePath');
   }
 
+  // An archive may repeat a normalized path (GNU tar emits `./`-prefixed names)
+  // and may even switch its kind between repeats, so the whole archive is
+  // scanned for traversal and deduplicated before anything touches the disk.
+  // Only the last entry for a path decides whether it lands as a directory, a
+  // regular file, or a materialized link alias.
   final entriesByArchivePath = <String, ArchiveFile>{};
-  // Insertion-ordered and deduplicated: an archive may repeat a path, and only
-  // its last entry decides whether that path ends up a link alias or a file.
-  final symbolicLinkPaths = <String>{};
+  final targetPathsByArchivePath = <String, String>{};
+  final winningEntryIndexes = <String, int>{};
+  final archiveRelativePaths = <String>[];
 
-  for (final file in archive.files) {
+  for (var index = 0; index < archive.files.length; index++) {
+    final file = archive.files[index];
     final relativePath = path.normalize(file.name);
     final targetPath = path.normalize(path.join(outputRoot, relativePath));
     final isInRoot =
@@ -2127,24 +2133,37 @@ Future<void> _extractArchive({
       );
     }
 
-    if (file.isDirectory) {
-      await Directory(targetPath).create(recursive: true);
+    final archiveRelativePath = path.posix.joinAll(path.split(relativePath));
+    entriesByArchivePath[archiveRelativePath] = file;
+    targetPathsByArchivePath[archiveRelativePath] = targetPath;
+    winningEntryIndexes[archiveRelativePath] = index;
+    archiveRelativePaths.add(archiveRelativePath);
+  }
+
+  // Symbolic links are materialized after the extraction loop so link targets
+  // that appear later in the archive still resolve.
+  final symbolicLinkPaths = <String>[];
+
+  for (var index = 0; index < archive.files.length; index++) {
+    final archiveRelativePath = archiveRelativePaths[index];
+    if (winningEntryIndexes[archiveRelativePath] != index) {
       continue;
     }
 
-    final archiveRelativePath = path.posix.joinAll(path.split(relativePath));
-    entriesByArchivePath[archiveRelativePath] = file;
+    final file = archive.files[index];
+    final targetPath = targetPathsByArchivePath[archiveRelativePath]!;
 
-    // Symbolic links are materialized after the loop so link targets that
-    // appear later in the archive still resolve.
+    if (file.isDirectory) {
+      await _createExtractionDirectory(targetPath);
+      continue;
+    }
+
     if (file.isSymbolicLink) {
       symbolicLinkPaths.add(archiveRelativePath);
       continue;
     }
 
-    final bytes = file.content as List<int>;
-    await Directory(path.dirname(targetPath)).create(recursive: true);
-    await File(targetPath).writeAsBytes(bytes);
+    await _writeExtractionFile(targetPath, file.content as List<int>);
   }
 
   for (final linkPath in symbolicLinkPaths) {
@@ -2154,30 +2173,57 @@ Future<void> _extractArchive({
       entriesByArchivePath: entriesByArchivePath,
     );
 
-    final linkFilePath = path.join(
-      outputRoot,
-      path.joinAll(linkPath.split('/')),
-    );
-    await Directory(path.dirname(linkFilePath)).create(recursive: true);
+    final linkFilePath = targetPathsByArchivePath[linkPath]!;
 
     // Archive symlinks are materialized as regular files holding the resolved
     // target's bytes rather than as OS symlinks: Windows refuses symlink
     // creation without developer mode or elevation, and bundled native assets
     // are copied around by downstream tooling that would not carry a link.
-    await File(linkFilePath).writeAsBytes(resolved.entry.content as List<int>);
+    await _writeExtractionFile(
+      linkFilePath,
+      resolved.entry.content as List<int>,
+    );
     log.fine(
       'Materialized archive symlink $linkPath as a copy of ${resolved.path}.',
     );
   }
 }
 
+/// Creates [targetPath] as a directory, replacing a file left by an earlier
+/// entry for the same normalized path.
+Future<void> _createExtractionDirectory(String targetPath) async {
+  final existingType = await FileSystemEntity.type(
+    targetPath,
+    followLinks: false,
+  );
+  if (existingType == FileSystemEntityType.file ||
+      existingType == FileSystemEntityType.link) {
+    await File(targetPath).delete();
+  }
+  await Directory(targetPath).create(recursive: true);
+}
+
+/// Writes [bytes] to [targetPath], replacing a directory left by an earlier
+/// entry for the same normalized path.
+Future<void> _writeExtractionFile(String targetPath, List<int> bytes) async {
+  await Directory(path.dirname(targetPath)).create(recursive: true);
+  final existingType = await FileSystemEntity.type(
+    targetPath,
+    followLinks: false,
+  );
+  if (existingType == FileSystemEntityType.directory) {
+    await Directory(targetPath).delete(recursive: true);
+  }
+  await File(targetPath).writeAsBytes(bytes);
+}
+
 typedef _ResolvedArchiveEntry = ({String path, ArchiveFile entry});
 
 /// Follows an archive-internal symlink chain to the regular file it points at.
 ///
-/// Throws when the chain escapes the archive root, cycles, or dangles, so a
-/// malicious or truncated bundle cannot write outside the extraction root or
-/// leave unloadable placeholder libraries behind.
+/// Throws when the chain escapes the archive root, cycles, dangles, or lands on
+/// a directory, so a malicious or truncated bundle cannot write outside the
+/// extraction root or leave unloadable placeholder libraries behind.
 _ResolvedArchiveEntry _resolveArchiveSymlink({
   required String archivePath,
   required String linkPath,
@@ -2212,6 +2258,13 @@ _ResolvedArchiveEntry _resolveArchiveSymlink({
     if (next == null) {
       throw Exception(
         'Archive symlink target missing in $archivePath: $linkPath -> $target',
+      );
+    }
+
+    if (next.isDirectory) {
+      throw Exception(
+        'Archive symlink target is a directory in $archivePath: '
+        '$linkPath -> $target',
       );
     }
 

--- a/hook/build.dart
+++ b/hook/build.dart
@@ -2078,6 +2078,22 @@ final class _RuntimeBundleDownloadHttpException implements Exception {
   String toString() => 'Failed to download $url ($statusCode).';
 }
 
+/// Extracts a native bundle archive through the hardened build-hook path.
+///
+/// This is intended for hook tests that need to assert extraction behaviour;
+/// production code should use the build hook entrypoint.
+Future<void> extractArchiveForTesting({
+  required String archivePath,
+  required String outputDirectory,
+  required Logger log,
+}) {
+  return _extractArchive(
+    archivePath: archivePath,
+    outputDirectory: outputDirectory,
+    log: log,
+  );
+}
+
 Future<void> _extractArchive({
   required String archivePath,
   required String outputDirectory,
@@ -2093,6 +2109,11 @@ Future<void> _extractArchive({
     log.severe('Failed to decode archive $archivePath: $error');
     throw Exception('Failed to decode native bundle archive: $archivePath');
   }
+
+  final entriesByArchivePath = <String, ArchiveFile>{};
+  // Insertion-ordered and deduplicated: an archive may repeat a path, and only
+  // its last entry decides whether that path ends up a link alias or a file.
+  final symbolicLinkPaths = <String>{};
 
   for (final file in archive.files) {
     final relativePath = path.normalize(file.name);
@@ -2111,8 +2132,92 @@ Future<void> _extractArchive({
       continue;
     }
 
+    final archiveRelativePath = path.posix.joinAll(path.split(relativePath));
+    entriesByArchivePath[archiveRelativePath] = file;
+
+    // Symbolic links are materialized after the loop so link targets that
+    // appear later in the archive still resolve.
+    if (file.isSymbolicLink) {
+      symbolicLinkPaths.add(archiveRelativePath);
+      continue;
+    }
+
     final bytes = file.content as List<int>;
     await Directory(path.dirname(targetPath)).create(recursive: true);
     await File(targetPath).writeAsBytes(bytes);
   }
+
+  for (final linkPath in symbolicLinkPaths) {
+    final resolved = _resolveArchiveSymlink(
+      archivePath: archivePath,
+      linkPath: linkPath,
+      entriesByArchivePath: entriesByArchivePath,
+    );
+
+    final linkFilePath = path.join(
+      outputRoot,
+      path.joinAll(linkPath.split('/')),
+    );
+    await Directory(path.dirname(linkFilePath)).create(recursive: true);
+
+    // Archive symlinks are materialized as regular files holding the resolved
+    // target's bytes rather than as OS symlinks: Windows refuses symlink
+    // creation without developer mode or elevation, and bundled native assets
+    // are copied around by downstream tooling that would not carry a link.
+    await File(linkFilePath).writeAsBytes(resolved.entry.content as List<int>);
+    log.fine(
+      'Materialized archive symlink $linkPath as a copy of ${resolved.path}.',
+    );
+  }
+}
+
+typedef _ResolvedArchiveEntry = ({String path, ArchiveFile entry});
+
+/// Follows an archive-internal symlink chain to the regular file it points at.
+///
+/// Throws when the chain escapes the archive root, cycles, or dangles, so a
+/// malicious or truncated bundle cannot write outside the extraction root or
+/// leave unloadable placeholder libraries behind.
+_ResolvedArchiveEntry _resolveArchiveSymlink({
+  required String archivePath,
+  required String linkPath,
+  required Map<String, ArchiveFile> entriesByArchivePath,
+}) {
+  final visited = <String>{};
+  var currentPath = linkPath;
+  var current = entriesByArchivePath[currentPath]!;
+
+  while (current.isSymbolicLink) {
+    if (!visited.add(currentPath)) {
+      throw Exception(
+        'Archive symlink cycle blocked for $archivePath: $linkPath',
+      );
+    }
+
+    final target = current.symbolicLink!;
+    final resolvedPath = path.posix.normalize(
+      path.posix.join(path.posix.dirname(currentPath), target),
+    );
+    if (path.posix.isAbsolute(target) ||
+        path.isAbsolute(target) ||
+        resolvedPath == '..' ||
+        resolvedPath.startsWith('../')) {
+      throw Exception(
+        'Archive symlink traversal blocked for $archivePath: '
+        '$linkPath -> $target',
+      );
+    }
+
+    final next = entriesByArchivePath[resolvedPath];
+    if (next == null) {
+      throw Exception(
+        'Archive symlink target missing in $archivePath: $linkPath -> $target',
+      );
+    }
+
+    currentPath = resolvedPath;
+    current = next;
+  }
+
+  return (path: currentPath, entry: current);
 }

--- a/hook/build.dart
+++ b/hook/build.dart
@@ -2133,6 +2133,15 @@ Future<void> _extractArchive({
       );
     }
 
+    // `./` directory entries are normal in GNU tar output, but a regular file
+    // or symlink named `.` would make extraction delete the output root and
+    // replace it with a file, so it is rejected before anything touches disk.
+    if (targetPath == outputRoot && !file.isDirectory) {
+      throw Exception(
+        'Archive root replacement entry blocked for $archivePath: ${file.name}',
+      );
+    }
+
     final archiveRelativePath = path.posix.joinAll(path.split(relativePath));
     entriesByArchivePath[archiveRelativePath] = file;
     targetPathsByArchivePath[archiveRelativePath] = targetPath;

--- a/lib/src/hook/native_bundle_config.dart
+++ b/lib/src/hook/native_bundle_config.dart
@@ -219,11 +219,11 @@ class NativeLibraryDescriptor {
   /// Path the file was found at, verbatim.
   ///
   /// `hook/build.dart` re-describes every file it copies into the build output
-  /// directory, and on `linux-*` copies each `.so` under its SONAME aliases
-  /// too, so each `.so` yields two descriptors — three for `libmtmd.so`,
-  /// which also gets a `.so.SOVERSION` alias. Those extras differ in
-  /// [fileName] too: a `.so.0` alias still shares the source [canonicalName],
-  /// but `libmtmd.so.SOVERSION` canonicalises to a non-core
+  /// directory, and on `linux-*` copies each `.so` under its `.so.0` SONAME
+  /// alias too, so each `.so` yields two descriptors sharing one
+  /// [canonicalName]. Overrides pinning a historical `bNNNN` artifact or the
+  /// original `v0.2.0` add a third `libmtmd.so.SOVERSION` descriptor for their
+  /// literal placeholder SONAME, which canonicalises to a non-core
   /// `mtmd.so.soversion`.
   final String filePath;
 

--- a/packages/llamadart_llama_cpp_flutter/CHANGELOG.md
+++ b/packages/llamadart_llama_cpp_flutter/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 0.0.16
+
+* Updated Apple SwiftPM native pin to the immutable
+  `leehack/llamadart-native@v0.2.0-1` release, built from llama.cpp `v0.2.0`.
+
 ## 0.0.15
 
 * Updated Apple SwiftPM native pin to `leehack/llamadart-native@b10545`.

--- a/packages/llamadart_llama_cpp_flutter/README.md
+++ b/packages/llamadart_llama_cpp_flutter/README.md
@@ -10,13 +10,14 @@ core package's native-assets fallback.
 ```yaml
 dependencies:
   llamadart: ^0.8.20
-  llamadart_llama_cpp_flutter: ^0.0.15
+  llamadart_llama_cpp_flutter: ^0.0.16
 ```
 
 This package has no runtime Dart API of its own. Import `package:llamadart`
 normally from the core package and use `LlamaBackend()` / `LlamaEngine` there.
 
-The Apple SwiftPM manifest pins `leehack/llamadart-native@b10545`.
+The Apple SwiftPM manifest pins
+`leehack/llamadart-native@v0.2.0-1`.
 
 Source for this package lives in
 `packages/llamadart_llama_cpp_flutter` in the

--- a/packages/llamadart_llama_cpp_flutter/darwin/llamadart_llama_cpp_flutter/Package.swift
+++ b/packages/llamadart_llama_cpp_flutter/darwin/llamadart_llama_cpp_flutter/Package.swift
@@ -4,7 +4,7 @@ import PackageDescription
 
 let packageRoot = URL(fileURLWithPath: #filePath).deletingLastPathComponent()
 let artifactsRoot = packageRoot.appendingPathComponent("Artifacts")
-let llamaCppTag = "b10545"
+let llamaCppTag = "v0.2.0-1"
 
 func localArtifactPath(_ name: String) -> String? {
     let path = artifactsRoot.appendingPathComponent(name).path
@@ -47,7 +47,7 @@ let package = Package(
             repository: "leehack/llamadart-native",
             artifactName: "llamadart-native-apple-xcframework-\(llamaCppTag).zip",
             tag: llamaCppTag,
-            checksum: "4169f2741ce9fe2a8f345e419c08fecf458ebe537c024d533e639c4639adf776"
+            checksum: "833144802669b735dc07f66b1f1f6c1ca8409752adff4e09238dbf66635bdd68"
         ),
         .target(
             name: "llamadart_llama_cpp_flutter",

--- a/packages/llamadart_llama_cpp_flutter/pubspec.yaml
+++ b/packages/llamadart_llama_cpp_flutter/pubspec.yaml
@@ -1,6 +1,6 @@
 name: llamadart_llama_cpp_flutter
 description: Flutter Apple SwiftPM runtime companion package for llamadart llama.cpp and GGUF support.
-version: 0.0.15
+version: 0.0.16
 repository: https://github.com/leehack/llamadart/tree/main/packages/llamadart_llama_cpp_flutter
 homepage: https://github.com/leehack/llamadart
 issue_tracker: https://github.com/leehack/llamadart/issues

--- a/test/integration/backends/llama_cpp/native_symbol_integration_test.dart
+++ b/test/integration/backends/llama_cpp/native_symbol_integration_test.dart
@@ -148,8 +148,6 @@ typedef _MtmdHelperBitmapInitFromBufDart =
     );
 typedef _MtmdBitmapFreeNative = ffi.Void Function(ffi.Pointer<mtmd_bitmap>);
 typedef _MtmdBitmapFreeDart = void Function(ffi.Pointer<mtmd_bitmap>);
-typedef _MtmdSupportVideoNative = ffi.Bool Function(ffi.Pointer<mtmd_context>);
-typedef _MtmdSupportVideoDart = bool Function(ffi.Pointer<mtmd_context>);
 
 @ffi.Native<ffi.Void Function(ffi.Pointer<llama_dart_mtp>)>(
   assetId: _llamadartWrapperAssetId,
@@ -500,7 +498,7 @@ void main() {
       }
     });
 
-    test('Verify b10545 mtmd context parameter layout in bindings', () {
+    test('Verify pinned mtmd context parameter layout in bindings', () {
       final bindingsSource = File(
         'lib/src/backends/llama_cpp/bindings.dart',
       ).readAsStringSync();
@@ -880,25 +878,6 @@ void main() {
         reason: 'Expected a native library exporting mtmd symbols.',
       );
       _expectDynamicLibraryExports(libraryFile!, _b10514MtmdSymbols);
-    });
-
-    test('pinned b10545 artifact behavior reports video compiled out', () {
-      final libraryFile =
-          _mtmdFallbackLibraryFile() ?? _llamadartWrapperLibraryFileOrNull();
-      expect(
-        libraryFile,
-        isNotNull,
-        reason: 'Expected a native library exporting mtmd symbols.',
-      );
-      final library = ffi.DynamicLibrary.open(libraryFile!.path);
-      final supportsVideo = library
-          .lookupFunction<_MtmdSupportVideoNative, _MtmdSupportVideoDart>(
-            'mtmd_helper_support_video',
-          );
-
-      // The helper symbol is exported even when MTMD_VIDEO is off. Calling it
-      // is the behavioral compile-capability probe; symbol presence is not.
-      expect(supportsVideo(ffi.nullptr.cast<mtmd_context>()), isFalse);
     });
 
     test('Verify core llama symbols are resolvable', () {

--- a/test/unit/hook/build_hook_archive_extraction_test.dart
+++ b/test/unit/hook/build_hook_archive_extraction_test.dart
@@ -1,0 +1,243 @@
+@TestOn('vm')
+library;
+
+import 'dart:io';
+
+import 'package:archive/archive.dart';
+import 'package:logging/logging.dart';
+import 'package:path/path.dart' as path;
+import 'package:test/test.dart';
+
+import '../../../hook/build.dart' as build_hook;
+
+void main() {
+  late Directory tempDir;
+  late Directory outputDir;
+  late Logger log;
+
+  setUp(() async {
+    tempDir = await Directory.systemTemp.createTemp('llamadart-extract-test-');
+    outputDir = Directory(path.join(tempDir.path, 'extracted'));
+    await outputDir.create(recursive: true);
+    log = Logger('llamadart-extract-test');
+  });
+
+  tearDown(() async {
+    if (tempDir.existsSync()) {
+      await tempDir.delete(recursive: true);
+    }
+  });
+
+  Future<String> writeArchive(List<ArchiveFile> entries) async {
+    final archive = Archive();
+    for (final entry in entries) {
+      archive.addFile(entry);
+    }
+    final archiveFile = File(path.join(tempDir.path, 'bundle.tar.gz'));
+    await archiveFile.writeAsBytes(
+      GZipEncoder().encode(TarEncoder().encode(archive)),
+    );
+    return archiveFile.path;
+  }
+
+  Future<void> extract(String archivePath) {
+    return build_hook.extractArchiveForTesting(
+      archivePath: archivePath,
+      outputDirectory: outputDir.path,
+      log: log,
+    );
+  }
+
+  test(
+    'resolves relative shared library symlink chains to target bytes',
+    () async {
+      final archivePath = await writeArchive([
+        _regularFile('libmtmd.so.0.2.0', 'mtmd-elf-payload'),
+        ArchiveFile.symlink('libmtmd.so.0', 'libmtmd.so.0.2.0'),
+        ArchiveFile.symlink('libmtmd.so', 'libmtmd.so.0'),
+        _regularFile('libllamadart.so', 'llamadart-elf-payload'),
+      ]);
+
+      await extract(archivePath);
+
+      for (final fileName in const [
+        'libmtmd.so',
+        'libmtmd.so.0',
+        'libmtmd.so.0.2.0',
+      ]) {
+        final extractedPath = path.join(outputDir.path, fileName);
+        final extracted = File(extractedPath);
+        expect(extracted.existsSync(), isTrue, reason: fileName);
+        expect(
+          FileSystemEntity.isLinkSync(extractedPath),
+          isFalse,
+          reason: fileName,
+        );
+        expect(
+          await extracted.readAsString(),
+          'mtmd-elf-payload',
+          reason: fileName,
+        );
+      }
+
+      expect(
+        await File(path.join(outputDir.path, 'libllamadart.so')).readAsString(),
+        'llamadart-elf-payload',
+      );
+    },
+  );
+
+  test(
+    'resolves symlinks that target files in other archive directories',
+    () async {
+      final archivePath = await writeArchive([
+        _regularFile('lib/libggml.so.0', 'ggml-elf-payload'),
+        ArchiveFile.symlink('bin/libggml.so', '../lib/libggml.so.0'),
+      ]);
+
+      await extract(archivePath);
+
+      expect(
+        await File(
+          path.join(outputDir.path, 'bin', 'libggml.so'),
+        ).readAsString(),
+        'ggml-elf-payload',
+      );
+    },
+  );
+
+  // GNU tar emits `./`-prefixed names, so an archive can carry two entries that
+  // normalize to one extraction path. The last entry has to win, and neither
+  // ordering may degrade into copying a file onto itself.
+  test(
+    'applies the last entry when duplicate paths repeat a symlink',
+    () async {
+      final archivePath = await writeArchive([
+        _regularFile('libfoo.so.1', 'first-payload'),
+        _regularFile('libfoo.so.2', 'second-payload'),
+        ArchiveFile.symlink('libfoo.so', 'libfoo.so.1'),
+        ArchiveFile.symlink('./libfoo.so', 'libfoo.so.2'),
+      ]);
+
+      await extract(archivePath);
+
+      expect(
+        await File(path.join(outputDir.path, 'libfoo.so')).readAsString(),
+        'second-payload',
+      );
+    },
+  );
+
+  test(
+    'keeps file bytes when a duplicate regular entry follows a symlink',
+    () async {
+      final archivePath = await writeArchive([
+        _regularFile('libfoo.so.1', 'link-target-payload'),
+        ArchiveFile.symlink('./libfoo.so', 'libfoo.so.1'),
+        _regularFile('libfoo.so', 'regular-payload'),
+      ]);
+
+      await extract(archivePath);
+
+      expect(
+        await File(path.join(outputDir.path, 'libfoo.so')).readAsString(),
+        'regular-payload',
+      );
+    },
+  );
+
+  test(
+    'resolves target bytes when a duplicate symlink follows a file',
+    () async {
+      final archivePath = await writeArchive([
+        _regularFile('libfoo.so.1', 'link-target-payload'),
+        _regularFile('libfoo.so', 'regular-payload'),
+        ArchiveFile.symlink('./libfoo.so', 'libfoo.so.1'),
+      ]);
+
+      await extract(archivePath);
+
+      expect(
+        await File(path.join(outputDir.path, 'libfoo.so')).readAsString(),
+        'link-target-payload',
+      );
+    },
+  );
+
+  test('blocks symlinks escaping the extraction root', () async {
+    for (final target in const ['../../outside.so', '/etc/passwd']) {
+      final archivePath = await writeArchive([
+        _regularFile('libllamadart.so', 'llamadart-elf-payload'),
+        ArchiveFile.symlink('libescape.so', target),
+      ]);
+
+      await expectLater(
+        extract(archivePath),
+        throwsA(
+          isA<Exception>().having(
+            (error) => error.toString(),
+            'message for $target',
+            contains('Archive symlink traversal blocked'),
+          ),
+        ),
+      );
+    }
+  });
+
+  test('blocks archive entries escaping the extraction root', () async {
+    final archivePath = await writeArchive([
+      _regularFile('../outside.so', 'escaped-payload'),
+    ]);
+
+    await expectLater(
+      extract(archivePath),
+      throwsA(
+        isA<Exception>().having(
+          (error) => error.toString(),
+          'message',
+          contains('Archive traversal entry blocked'),
+        ),
+      ),
+    );
+  });
+
+  test('rejects dangling symlinks', () async {
+    final archivePath = await writeArchive([
+      _regularFile('libllamadart.so', 'llamadart-elf-payload'),
+      ArchiveFile.symlink('libmtmd.so', 'libmtmd.so.0'),
+    ]);
+
+    await expectLater(
+      extract(archivePath),
+      throwsA(
+        isA<Exception>().having(
+          (error) => error.toString(),
+          'message',
+          contains('Archive symlink target missing'),
+        ),
+      ),
+    );
+  });
+
+  test('rejects cyclic symlinks', () async {
+    final archivePath = await writeArchive([
+      ArchiveFile.symlink('libcycle.so', 'libcycle.so.0'),
+      ArchiveFile.symlink('libcycle.so.0', 'libcycle.so'),
+    ]);
+
+    await expectLater(
+      extract(archivePath),
+      throwsA(
+        isA<Exception>().having(
+          (error) => error.toString(),
+          'message',
+          contains('Archive symlink cycle blocked'),
+        ),
+      ),
+    );
+  });
+}
+
+ArchiveFile _regularFile(String name, String content) {
+  return ArchiveFile(name, content.length, content.codeUnits);
+}

--- a/test/unit/hook/build_hook_archive_extraction_test.dart
+++ b/test/unit/hook/build_hook_archive_extraction_test.dart
@@ -164,6 +164,89 @@ void main() {
     },
   );
 
+  test(
+    'drops symlink materialization when a duplicate directory follows',
+    () async {
+      final archivePath = await writeArchive([
+        _regularFile('libfoo.so.1', 'link-target-payload'),
+        ArchiveFile.symlink('libfoo.so', 'libfoo.so.1'),
+        ArchiveFile.directory('./libfoo.so'),
+        _regularFile('libfoo.so/nested.so', 'nested-payload'),
+      ]);
+
+      await extract(archivePath);
+
+      final duplicatePath = path.join(outputDir.path, 'libfoo.so');
+      expect(Directory(duplicatePath).existsSync(), isTrue);
+      expect(File(duplicatePath).existsSync(), isFalse);
+      expect(
+        await File(path.join(duplicatePath, 'nested.so')).readAsString(),
+        'nested-payload',
+      );
+    },
+  );
+
+  test('replaces an earlier file when a duplicate directory follows', () async {
+    final archivePath = await writeArchive([
+      _regularFile('libfoo.so', 'regular-payload'),
+      ArchiveFile.directory('./libfoo.so'),
+    ]);
+
+    await extract(archivePath);
+
+    final duplicatePath = path.join(outputDir.path, 'libfoo.so');
+    expect(Directory(duplicatePath).existsSync(), isTrue);
+    expect(File(duplicatePath).existsSync(), isFalse);
+  });
+
+  test('replaces an earlier directory when a duplicate file follows', () async {
+    final archivePath = await writeArchive([
+      ArchiveFile.directory('libfoo.so'),
+      _regularFile('./libfoo.so', 'regular-payload'),
+    ]);
+
+    await extract(archivePath);
+
+    final duplicatePath = path.join(outputDir.path, 'libfoo.so');
+    expect(Directory(duplicatePath).existsSync(), isFalse);
+    expect(await File(duplicatePath).readAsString(), 'regular-payload');
+  });
+
+  test(
+    'replaces an earlier directory when a duplicate symlink follows',
+    () async {
+      final archivePath = await writeArchive([
+        _regularFile('libfoo.so.1', 'link-target-payload'),
+        ArchiveFile.directory('libfoo.so'),
+        ArchiveFile.symlink('./libfoo.so', 'libfoo.so.1'),
+      ]);
+
+      await extract(archivePath);
+
+      final duplicatePath = path.join(outputDir.path, 'libfoo.so');
+      expect(Directory(duplicatePath).existsSync(), isFalse);
+      expect(await File(duplicatePath).readAsString(), 'link-target-payload');
+    },
+  );
+
+  test('rejects symlinks that target a directory', () async {
+    final archivePath = await writeArchive([
+      ArchiveFile.directory('lib'),
+      ArchiveFile.symlink('libfoo.so', 'lib'),
+    ]);
+
+    await expectLater(
+      extract(archivePath),
+      throwsA(
+        isA<Exception>().having(
+          (error) => error.toString(),
+          'message',
+          contains('Archive symlink target is a directory'),
+        ),
+      ),
+    );
+  });
+
   test('blocks symlinks escaping the extraction root', () async {
     for (final target in const ['../../outside.so', '/etc/passwd']) {
       final archivePath = await writeArchive([

--- a/test/unit/hook/build_hook_archive_extraction_test.dart
+++ b/test/unit/hook/build_hook_archive_extraction_test.dart
@@ -284,6 +284,71 @@ void main() {
     );
   });
 
+  test(
+    'blocks regular file entries that replace the extraction root',
+    () async {
+      for (final name in const ['.', './']) {
+        final archivePath = await writeArchive([
+          _regularFile(name, 'root-replacement-payload'),
+        ]);
+
+        await expectLater(
+          extract(archivePath),
+          throwsA(
+            isA<Exception>().having(
+              (error) => error.toString(),
+              'message for $name',
+              contains('Archive root replacement entry blocked'),
+            ),
+          ),
+        );
+
+        expect(outputDir.existsSync(), isTrue, reason: name);
+        expect(File(outputDir.path).existsSync(), isFalse, reason: name);
+      }
+    },
+  );
+
+  test('blocks symlink entries that replace the extraction root', () async {
+    for (final name in const ['.', './']) {
+      final archivePath = await writeArchive([
+        _regularFile('libfoo.so.1', 'link-target-payload'),
+        ArchiveFile.symlink(name, 'libfoo.so.1'),
+      ]);
+
+      await expectLater(
+        extract(archivePath),
+        throwsA(
+          isA<Exception>().having(
+            (error) => error.toString(),
+            'message for $name',
+            contains('Archive root replacement entry blocked'),
+          ),
+        ),
+      );
+
+      expect(outputDir.existsSync(), isTrue, reason: name);
+      expect(File(outputDir.path).existsSync(), isFalse, reason: name);
+    }
+  });
+
+  test(
+    'keeps extracting when the archive carries a root directory entry',
+    () async {
+      final archivePath = await writeArchive([
+        ArchiveFile.directory('./'),
+        _regularFile('./libllamadart.so', 'llamadart-elf-payload'),
+      ]);
+
+      await extract(archivePath);
+
+      expect(
+        await File(path.join(outputDir.path, 'libllamadart.so')).readAsString(),
+        'llamadart-elf-payload',
+      );
+    },
+  );
+
   test('rejects dangling symlinks', () async {
     final archivePath = await writeArchive([
       _regularFile('libllamadart.so', 'llamadart-elf-payload'),

--- a/test/unit/hook/build_hook_linux_integration_test.dart
+++ b/test/unit/hook/build_hook_linux_integration_test.dart
@@ -3,6 +3,7 @@ library;
 
 import 'dart:io';
 
+import 'package:archive/archive.dart';
 import 'package:code_assets/code_assets.dart';
 import 'package:hooks/hooks.dart';
 import 'package:path/path.dart' as path;
@@ -32,6 +33,10 @@ void main() {
   final litertBackupDir = Directory(
     '${litertBundleDir.path}.__hook_test_backup',
   );
+  final archiveFile = File(
+    '$cacheRelativeDir/llamadart-native-linux-x64-$nativeTag.tar.gz',
+  );
+  final archiveBackupFile = File('${archiveFile.path}.__hook_test_backup');
 
   setUpAll(() async {
     if (backupDir.existsSync()) {
@@ -43,9 +48,15 @@ void main() {
     if (litertBackupDir.existsSync()) {
       await litertBackupDir.delete(recursive: true);
     }
+    if (archiveBackupFile.existsSync()) {
+      await archiveBackupFile.delete();
+    }
 
     if (bundleDir.existsSync()) {
       await bundleDir.rename(backupDir.path);
+    }
+    if (archiveFile.existsSync()) {
+      await archiveFile.rename(archiveBackupFile.path);
     }
     if (historicalBundleDir.existsSync()) {
       await historicalBundleDir.rename(historicalBackupDir.path);
@@ -80,9 +91,19 @@ void main() {
       'libggml-vulkan.so',
     ]);
     await _writeBundleLibraries(litertBundleDir, _linuxLiteRtLibraries);
+
+    if (archiveFile.existsSync()) {
+      await archiveFile.delete();
+    }
   });
 
   tearDownAll(() async {
+    if (archiveFile.existsSync()) {
+      await archiveFile.delete();
+    }
+    if (archiveBackupFile.existsSync()) {
+      await archiveBackupFile.rename(archiveFile.path);
+    }
     if (bundleDir.existsSync()) {
       await bundleDir.delete(recursive: true);
     }
@@ -171,6 +192,38 @@ void main() {
     );
   });
 
+  test('build hook emits archive symlink aliases with target bytes', () async {
+    await bundleDir.delete(recursive: true);
+    await _writeSymlinkedBundleArchive(archiveFile);
+
+    await testCodeBuildHook(
+      mainMethod: build_hook.main,
+      targetOS: OS.linux,
+      targetArchitecture: Architecture.x64,
+      check: (input, output) {
+        final assetFilesByName = <String, File>{};
+        for (final asset
+            in output.assets.encodedAssets
+                .where((asset) => asset.isCodeAsset)
+                .map((asset) => asset.asCodeAsset)) {
+          final assetFile = File(asset.file!.toFilePath());
+          assetFilesByName[path.basename(assetFile.path)] = assetFile;
+        }
+
+        for (final fileName in const ['libmtmd.so', 'libmtmd.so.0']) {
+          final assetFile = assetFilesByName[fileName];
+          expect(assetFile, isNotNull, reason: fileName);
+          expect(assetFile!.readAsStringSync(), _mtmdPayload, reason: fileName);
+        }
+
+        expect(
+          assetFilesByName['libllamadart.so']?.readAsStringSync(),
+          'archive-libllamadart.so',
+        );
+      },
+    );
+  });
+
   test('build hook fails when runtimes config selects none', () async {
     for (final rawUserConfig in const <Object>['none', false]) {
       await expectLater(
@@ -235,6 +288,36 @@ const List<String> _linuxLiteRtAssetNames = [
   'litert_lm_LiteRtTopKWebGpuSampler',
   'litert_lm_LiteRtWebGpuAccelerator',
 ];
+
+const String _mtmdPayload = 'archive-libmtmd.so.0.2.0';
+
+Future<void> _writeSymlinkedBundleArchive(File archiveFile) async {
+  final archive = Archive();
+
+  void addRegularFile(String name, String content) {
+    archive.addFile(ArchiveFile(name, content.length, content.codeUnits));
+  }
+
+  addRegularFile('libllamadart.so', 'archive-libllamadart.so');
+  addRegularFile('libmtmd.so.0.2.0', _mtmdPayload);
+  archive.addFile(ArchiveFile.symlink('libmtmd.so.0', 'libmtmd.so.0.2.0'));
+  archive.addFile(ArchiveFile.symlink('libmtmd.so', 'libmtmd.so.0'));
+  for (final name in const [
+    'libllama.so',
+    'libllama-common.so',
+    'libggml.so',
+    'libggml-base.so',
+    'libggml-cpu.so',
+    'libggml-vulkan.so',
+  ]) {
+    addRegularFile(name, 'archive-$name');
+  }
+
+  await archiveFile.parent.create(recursive: true);
+  await archiveFile.writeAsBytes(
+    GZipEncoder().encode(TarEncoder().encode(archive)),
+  );
+}
 
 Future<void> _writeBundleLibraries(
   Directory bundleDir,

--- a/test/unit/hook/build_hook_linux_integration_test.dart
+++ b/test/unit/hook/build_hook_linux_integration_test.dart
@@ -18,6 +18,14 @@ void main() {
   final bundleRelativePath = '$cacheRelativeDir/extracted';
   final bundleDir = Directory(bundleRelativePath);
   final backupDir = Directory('$bundleRelativePath.__hook_test_backup');
+  const historicalNativeTag = 'b10545';
+  final historicalBundleRelativePath =
+      '.dart_tool/llamadart/native_bundles/$historicalNativeTag/'
+      'linux-x64/extracted';
+  final historicalBundleDir = Directory(historicalBundleRelativePath);
+  final historicalBackupDir = Directory(
+    '$historicalBundleRelativePath.__hook_test_backup',
+  );
   final litertBundleDir = Directory(
     '.dart_tool/llamadart/litert_lm/$litertVersion/linux/x64',
   );
@@ -29,12 +37,18 @@ void main() {
     if (backupDir.existsSync()) {
       await backupDir.delete(recursive: true);
     }
+    if (historicalBackupDir.existsSync()) {
+      await historicalBackupDir.delete(recursive: true);
+    }
     if (litertBackupDir.existsSync()) {
       await litertBackupDir.delete(recursive: true);
     }
 
     if (bundleDir.existsSync()) {
       await bundleDir.rename(backupDir.path);
+    }
+    if (historicalBundleDir.existsSync()) {
+      await historicalBundleDir.rename(historicalBackupDir.path);
     }
     if (litertBundleDir.existsSync()) {
       await litertBundleDir.rename(litertBackupDir.path);
@@ -55,6 +69,16 @@ void main() {
       'libggml-cpu.so',
       'libggml-vulkan.so',
     ]);
+    await _writeBundleLibraries(historicalBundleDir, const [
+      'libllamadart.so',
+      'libmtmd.so',
+      'libllama.so',
+      'libllama-common.so',
+      'libggml.so',
+      'libggml-base.so',
+      'libggml-cpu.so',
+      'libggml-vulkan.so',
+    ]);
     await _writeBundleLibraries(litertBundleDir, _linuxLiteRtLibraries);
   });
 
@@ -64,6 +88,12 @@ void main() {
     }
     if (backupDir.existsSync()) {
       await backupDir.rename(bundleDir.path);
+    }
+    if (historicalBundleDir.existsSync()) {
+      await historicalBundleDir.delete(recursive: true);
+    }
+    if (historicalBackupDir.existsSync()) {
+      await historicalBackupDir.rename(historicalBundleDir.path);
     }
     if (litertBundleDir.existsSync()) {
       await litertBundleDir.delete(recursive: true);
@@ -95,7 +125,8 @@ void main() {
 
           expect(emittedNames, contains('libllamadart.so'));
           expect(emittedNames, contains('libmtmd.so'));
-          expect(emittedNames, contains('libmtmd.so.SOVERSION'));
+          expect(emittedNames, contains('libmtmd.so.0'));
+          expect(emittedNames, isNot(contains('libmtmd.so.SOVERSION')));
           expect(emittedNames, contains('libllama.so'));
           expect(emittedNames, contains('libllama.so.0'));
           expect(emittedNames, contains('libllama-common.so'));
@@ -114,6 +145,31 @@ void main() {
       );
     },
   );
+
+  test('build hook preserves historical linux mtmd SONAME alias', () async {
+    await testCodeBuildHook(
+      mainMethod: build_hook.main,
+      targetOS: OS.linux,
+      targetArchitecture: Architecture.x64,
+      userDefines: PackageUserDefines(
+        workspacePubspec: PackageUserDefinesSource(
+          defines: const {'llamadart_native_tag': historicalNativeTag},
+          basePath: Directory.current.uri,
+        ),
+      ),
+      check: (input, output) {
+        final emittedNames = output.assets.encodedAssets
+            .where((asset) => asset.isCodeAsset)
+            .map((asset) => asset.asCodeAsset)
+            .map((asset) => path.basename(asset.file!.toFilePath()))
+            .toSet();
+
+        expect(emittedNames, contains('libmtmd.so'));
+        expect(emittedNames, contains('libmtmd.so.0'));
+        expect(emittedNames, contains('libmtmd.so.SOVERSION'));
+      },
+    );
+  });
 
   test('build hook fails when runtimes config selects none', () async {
     for (final rawUserConfig in const <Object>['none', false]) {

--- a/tool/testing/check_webgpu_bridge_tag.dart
+++ b/tool/testing/check_webgpu_bridge_tag.dart
@@ -207,8 +207,9 @@ final RegExp _nativeLlamaCppTag = RegExp(r"const _llamaCppTag = '([^']+)';");
 /// left behind after the tags converged. Prose describing the relationship
 /// lives in the [bridgeLlamaCppTagPins] sentences, which move with it.
 String? get bridgeLlamaCppDivergence =>
-    'Bridge assets v0.1.37 embed b10514; the native pin moved to b10545 after '
-    'v0.8.20. Web trails native until the next bridge asset release.';
+    'Bridge assets v0.1.37 embed b10514; the native pin now consumes immutable '
+    'v0.2.0-1 (llama.cpp v0.2.0). Web trails native until the next bridge '
+    'asset release.';
 
 /// Doc sentences that state the bridge assets' llama.cpp build.
 ///

--- a/website/docs/changelog/recent-releases.md
+++ b/website/docs/changelog/recent-releases.md
@@ -114,21 +114,24 @@ For canonical full release notes, use:
   hierarchy. It is the same exception type `LlamaEngine.loadModelFromUrl`
   already throws for this condition; each keeps its own message.
 
-- Updated the default native llama.cpp runtime to `b10545`, adding LFM2 DSpark
-  support plus current upstream correctness and backend performance fixes.
-  Matching Dart FFI bindings, including the new multimodal projector-device
-  field, and the Apple SwiftPM artifact checksum were refreshed.
+- Updated the default native llama.cpp runtime to the immutable
+  `leehack/llamadart-native@v0.2.0-1` release (llama.cpp `v0.2.0`), adding LFM2
+  DSpark support plus current upstream correctness and backend performance
+  fixes. Matching Dart FFI bindings, including the new multimodal
+  projector-device field, and the Apple SwiftPM artifact checksum were
+  refreshed. Linux `libmtmd.so.0` now loads without the old
+  `libmtmd.so.SOVERSION` compatibility alias.
 
 - Removed the abandoned Dart-side MTP/n-gram speculative-decoding scaffolding
   from the llama.cpp backend; speculative decoding behavior is unchanged.
 
-- Bumped `llamadart_llama_cpp_flutter` to `0.0.15` so the `b10545` Apple SwiftPM
-  pin actually publishes; `0.0.14` was already on pub.dev, so release automation
-  skipped it and Apple builds would have kept the `b10514` runtime.
+- Bumped `llamadart_llama_cpp_flutter` to `0.0.16` so the `v0.2.0-1` Apple
+  SwiftPM pin actually publishes; `0.0.14` was already on pub.dev, so release
+  automation skipped it and Apple builds would have kept the `b10514` runtime.
 
 - Corrected the WebGPU bridge docs, which claimed the pinned `v0.1.37` bridge
   assets match the default native llama.cpp runtime. They embed `b10514` and now
-  trail the native `b10545` pin.
+  trail the native `v0.2.0-1` pin.
 
 - Chat-template capability detection now logs a debug message naming the
   probe (`string-content`, `typed-content`, `system-role`, `tools`) when its

--- a/website/docs/getting-started/installation.md
+++ b/website/docs/getting-started/installation.md
@@ -36,7 +36,7 @@ Package Manager, also add the runtime companion packages you need:
 ```yaml
 dependencies:
   llamadart: ^0.8.20
-  llamadart_llama_cpp_flutter: ^0.0.15 # GGUF / llama.cpp
+  llamadart_llama_cpp_flutter: ^0.0.16 # GGUF / llama.cpp
   llamadart_litert_lm_flutter: ^0.0.10 # Apple .litertlm / LiteRT-LM targets
 ```
 
@@ -79,7 +79,7 @@ hooks:
     llamadart:
       # Optional. Defaults to llamadart's tested native runtime pin.
       # Use a leehack/llamadart-native release tag when testing another build.
-      llamadart_native_tag: b10545
+      llamadart_native_tag: v0.2.0-1
 
       # Optional. GitHub repository slug or github.com URL.
       llamadart_native_repository: leehack/llamadart-native
@@ -106,7 +106,7 @@ per-target module list.
 Native source overrides are for compatibility testing. They do not regenerate
 Dart FFI bindings or symbol lookups, so the selected binary still must be ABI-
 and symbol-compatible with the default
-`leehack/llamadart-native@b10545` runtime.
+`leehack/llamadart-native@v0.2.0-1` runtime.
 
 Available native tags are published on the
 [`leehack/llamadart-native` releases page](https://github.com/leehack/llamadart-native/releases).
@@ -134,7 +134,7 @@ gh release list --repo leehack/llamadart-native --limit 20
 
 Before overriding, confirm the release includes the asset for your target. The
 hook downloads files named `llamadart-native-<bundle>-<tag>.tar.gz`, for example
-`llamadart-native-windows-x64-b10545.tar.gz`.
+`llamadart-native-windows-x64-v0.2.0-1.tar.gz`.
 For local testing, `llamadart_native_path` may point directly at a bundle
 archive, at an extracted bundle directory, or at a directory containing
 `<tag>/<bundle>/`, `<bundle>/`, or the expected archive file.

--- a/website/docs/guides/multimodal.md
+++ b/website/docs/guides/multimodal.md
@@ -98,14 +98,14 @@ on the loaded bridge's runtime capability report.
 
 Video is not currently consumable through the public Dart generation API.
 `LlamaVideoContent` makes an attempted path/byte request explicit, but
-generation rejects it with `LlamaUnsupportedException`. The tested native
-b10545 macOS arm64 artifact exports upstream video helper symbols while the
-behavioral `mtmd_helper_support_video` probe reports video compiled out; symbol
-presence is not a capability check. A complete implementation still needs
-companion native builds with `LLAMA_SUBPROCESS`/`MTMD_VIDEO`, a cross-platform
-FFmpeg/ffprobe packaging policy, Dart frame and timestamp ingestion,
-cancellation, and lazy video-context cleanup. Extract representative image
-frames and send `LlamaImageContent` parts in the meantime.
+generation rejects it with `LlamaUnsupportedException`. The published native
+`v0.2.0-1` archive exports upstream video helper symbols, but this release has
+not been qualified for end-to-end video input; symbol presence is not a
+capability check. A complete implementation still needs companion native builds
+with `LLAMA_SUBPROCESS`/`MTMD_VIDEO`, a cross-platform FFmpeg/ffprobe packaging
+policy, Dart frame and timestamp ingestion, cancellation, and lazy video-context
+cleanup. Extract representative image frames and send `LlamaImageContent` parts
+in the meantime.
 
 `LlamaAudioContent` is generic audio input routed through normal generation; it
 does not by itself provide a transcript contract. For typed whole-file native

--- a/website/docs/guides/performance-tuning.md
+++ b/website/docs/guides/performance-tuning.md
@@ -148,7 +148,7 @@ Guidelines:
 - DSpark is an experimental, opt-in native llama.cpp external draft-model
   strategy. Use `SpeculativeDecodingConfig.draftDspark(draftModelPath: ...)`;
   it is never selected automatically, maps to upstream `draft-dspark`, requires
-  at least the `b10356-llamadart.1` wrapper fix; the package-pinned `b10545`
+  at least the `b10356-llamadart.1` wrapper fix; the package-pinned `v0.2.0-1`
   runtime satisfies that ABI, supports speculators-format checkpoints, and
   adds LFM2 target/draft support. DSpark remains subject to
   target/draft/backend compatibility.

--- a/website/docs/platforms/support-matrix.md
+++ b/website/docs/platforms/support-matrix.md
@@ -8,7 +8,7 @@ backend-module configuration for
 `llamadart`.
 
 The native-assets hook currently pins `llamadart-native` tag
-`b10545` and
+`v0.2.0-1` and
 `litert-lm-native` release `v0.16.0-native.2` (`hook/build.dart`). Apps can
 override the llama.cpp native GitHub source with
 `hooks.user_defines.llamadart.llamadart_native_tag` and
@@ -117,7 +117,7 @@ bundled:
 - `llama_cpp`: GGUF model support through llama.cpp.
 - `litert_lm`: `.litertlm` model support through LiteRT-LM.
 
-The `b10545` native llama.cpp pin includes BailingMoE3 and
+The `v0.2.0-1` native llama.cpp pin (llama.cpp `v0.2.0`) includes BailingMoE3 and
 GraniteSWA/GraniteMoeSWA model loading and adds LFM2 target/draft support for
 DSpark speculative decoding. These architectures use the existing GGUF APIs;
 LFM2 DSpark uses `SpeculativeDecodingConfig.draftDspark(...)`. No
@@ -128,7 +128,7 @@ backend validation remains necessary before enabling DSpark in production.
 
 | Runtime path | Public video input | Current evidence |
 | --- | --- | --- |
-| Native llama.cpp / GGUF | Not consumable | The tested b10545 macOS arm64 artifact exports upstream video helper symbols, but the behavioral `mtmd_helper_support_video` probe reports false because video is compiled out. The companion build does not opt into `LLAMA_SUBPROCESS`/`MTMD_VIDEO` or package FFmpeg/ffprobe; Linux and Windows still require artifact-level validation before support can be claimed. |
+| Native llama.cpp / GGUF | Not consumable | The published `v0.2.0-1` archive exports upstream video helper symbols, but this release has not been qualified for end-to-end video input. The companion build does not opt into `LLAMA_SUBPROCESS`/`MTMD_VIDEO` or package FFmpeg/ffprobe; the public Dart path remains unsupported until matching native, packaging, and frame-lifecycle validation exists. |
 | Native LiteRT-LM | Not consumable | The public direct-media path accepts image/audio content only. |
 | WebGPU / Web LiteRT-LM | Not consumable | No validated public Dart video transport or frame-lifetime contract exists. |
 | Android / iOS | Not consumable | Explicitly unsupported pending native packaging and device validation. |
@@ -264,7 +264,7 @@ device/model bundle, use `cpu` or `gpu` for that artifact.
   a web load failure as a package bug. The [WebGPU Bridge](./webgpu-bridge)
   page has the browser-console probe and Flutter Web smoke-test path.
 
-## Current llama.cpp module availability by bundle (`b10545`)
+## Current llama.cpp module availability by bundle (`v0.2.0-1`)
 
 | Bundle key | Available backend modules in bundle |
 | --- | --- |
@@ -312,7 +312,7 @@ hooks:
   user_defines:
     llamadart:
       # Optional. Defaults to llamadart's tested native runtime pin.
-      llamadart_native_tag: b10545
+      llamadart_native_tag: v0.2.0-1
 
       # Optional. GitHub repository slug or github.com URL.
       llamadart_native_repository: leehack/llamadart-native

--- a/website/docs/platforms/webgpu-bridge.md
+++ b/website/docs/platforms/webgpu-bridge.md
@@ -195,8 +195,9 @@ cannot report success before the bridge exposes `prefetchModelToCache(...)`.
   CPU main-thread runtime using the already cached model and projector. This
   recovery is slower than healthy WebGPU synthesis and does not loop.
 - `v0.1.37+` bridge assets embed llama.cpp `b10514`, which now trails the
-  `hook/build.dart` native pin, so Web and native are not on the same llama.cpp
-  build. The bridge assets provision an explicit 1 MiB stack for both wasm32
+  `hook/build.dart` native pin (`v0.2.0-1`, built from llama.cpp `v0.2.0`), so Web
+  and native are not on the same llama.cpp build. The bridge assets provision an
+  explicit 1 MiB stack for both wasm32
   and memory64, preventing `b10514` graph-parameter growth from overflowing
   Emscripten's 64 KiB default during memory64 Qwen3-ASR context construction.
 - `v0.1.12+` bridge assets forward native-compatible `ModelParams` load


### PR DESCRIPTION
## Summary

- consume the immutable `llamadart-native` `v0.2.0-1` release across all native pin and companion-package surfaces
- publish companion metadata as `llamadart_llama_cpp_flutter` `0.0.16` with the verified SwiftPM checksum
- preserve the historical Linux `libmtmd.so.SOVERSION` alias only for legacy `b*`/original `v0.2.0` overrides while using the published `.so.0` layout by default
- document the intentional temporary divergence from WebGPU bridge assets `v0.1.37` / embedded `b10514`

## PR recovery

This PR supersedes #456. That PR was intentionally stacked on #447 and GitHub auto-closed it when #447 was squash-merged and its base branch was deleted. GitHub would not reopen or retarget the closed PR. This replacement branch starts from the resulting `main` SHA `fc5e90b74e995faa32cbc79b72d03b9dfb1b2136` and carries only the reviewed 19-file native-pin tree delta; it does not replay #447's history.

## Release evidence

- Published release: https://github.com/leehack/llamadart-native/releases/tag/v0.2.0-1
- Published source commit: `e5c240e34b525da953ed98dc743516eef78cb738`
- 15 public assets verified, including 13 payload checksums plus `assets.json` and `SHA256SUMS`
- Manifest SHA-256: `2e5d29d7f98f0d71e75d3fa63b7c55f3b2a7933247cc34ea2b1c5e053d142452`
- `SHA256SUMS` SHA-256: `86e599a2b57678324a2733b87c879ea2e4658a5601c32e15d20b8aa91de6775c`

## Local verification

- [x] `dart run tool/prepare_workspace.dart`
- [x] changed Dart format check
- [x] targeted Dart analysis
- [x] Linux build-hook integration tests: 3 passed, including default `v0.2.0-1` and historical `b10545` alias behavior
- [x] release-doc verifier, normal and `--release-prep`
- [x] WebGPU bridge pin/divergence contract
- [x] `git diff --check`
- [x] replacement tree verified byte-for-byte equal to the approved #456 head before recommitting on `main`

The identical source tree previously passed the full CI-equivalent VM suite (1706 passed / 77 expected skips), Chrome suite (913 passed), native symbol suite (15 passed), docs build/link validation, companion-package checks, SwiftPM checksum verification, and tiny-GGUF/native archive smoke.

## CI remediation

The first exact-head CI run exposed that the published Linux tarballs preserve shared-library aliases as relative symlinks, while the Dart archive extractor had written symlink entry payloads as tiny regular files. This caused `Native Prompt Reuse Parity` and Linux VM tests to fail with `libmtmd.so.0: file too short`.

The follow-up commit now securely materializes each archive-internal relative symlink chain as regular target bytes, rejects absolute/traversing, dangling, and cyclic links, and handles duplicate archive paths with last-entry semantics. Added extraction and full build-hook regressions cover the published `libmtmd.so -> libmtmd.so.0 -> libmtmd.so.0.2.0` shape. Local verification after the fix:

- [x] changed-file format and analysis
- [x] all hook tests: 102 passed
- [x] independent read-only review: approved with no P0/P1 findings
- [x] published Linux x64 tar inventory verified as regular files plus relative symlink chains (no hardlinks)

## Review notes

- Fixed Copilot's duplicate-path finding in `ebb257f76`: extraction now applies consistent last-entry-wins semantics across files, directories, and symlinks. Added four kind-transition regressions plus directory-target rejection; the thread is resolved.
- Fixed Copilot's extraction-root finding in `92f0bd9c1`: file and symlink entries normalized to `.` are rejected before filesystem mutation while normal `./` directory entries remain supported. Added three root-entry regressions; the thread is resolved.
- Kept the cumulative Unreleased binding-refresh sentence. It already exists on `main` for earlier work in the same unreleased release; this PR only updates that release-note bullet's runtime pin, SwiftPM checksum, and Linux alias details. Generated bindings remain intentionally unchanged in this replacement.

## Scope note

The release no longer claims qualified end-to-end video behavior for this native baseline; video qualification remains intentionally out of scope. Generated bindings are unchanged.

## Existing issue / PR check

No dedicated issue is being closed. This is the recoverable replacement for auto-closed #456 after its stacked base merged.



