### PR TITLE
fix: harden Gemma 4 tool-call continuation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 ## Unreleased
 
+* Fixed Gemma 4 thinking-budget output so split channel controls and tool-call
+  envelopes stay out of visible assistant content while preserving ordinary
+  whitespace. The chat example now also validates custom tool declarations,
+  executes declared host handlers exactly once, appends tool results, and
+  performs a bounded continuation for both llama.cpp and LiteRT-LM backends.
+
 * Patched the website's vulnerable `nanoid` and `uuid` dependency paths. Until
   Docusaurus replaces its unpatched image parser, automatic local Markdown
   images are rejected; website contributors should use static pathname URLs.

--- a/example/chat_app/lib/providers/chat_provider.dart
+++ b/example/chat_app/lib/providers/chat_provider.dart
@@ -20,6 +20,7 @@ import '../services/chat_service.dart';
 import '../services/chat_generation_service.dart';
 import '../services/chat_session_service.dart';
 import '../services/conversation_state_service.dart';
+import '../services/host_tool_service.dart';
 import '../services/runtime_profile_service.dart';
 import '../services/settings_service.dart';
 import '../services/model_service_base.dart' as model_service;
@@ -146,6 +147,7 @@ class ChatProvider extends ChangeNotifier {
   final LiveSpeechTranscriptionService _liveSpeechTranscriptionService;
   final AssistantOutputService _assistantOutputService;
   final ToolDeclarationService _toolDeclarationService;
+  final HostToolService _hostToolService;
   final bool _enableWebModelPrefetch;
 
   final List<ChatMessage> _messages = [];
@@ -160,7 +162,8 @@ class ChatProvider extends ChangeNotifier {
   // Chat session for stateful conversation
   ChatSession? _session;
 
-  // Tool declarations supplied by the user (schema only; no local execution).
+  // Tool declarations supplied by the user, bound to the built-in host
+  // implementations that are allowed to execute locally.
   List<ToolDefinition> _declaredTools = const <ToolDefinition>[];
   String? _toolDeclarationsError;
 
@@ -600,6 +603,7 @@ class ChatProvider extends ChangeNotifier {
     LiveSpeechTranscriptionService? liveSpeechTranscriptionService,
     AssistantOutputService? assistantOutputService,
     ToolDeclarationService? toolDeclarationService,
+    HostToolService? hostToolService,
     ChatSettings? initialSettings,
     bool? enableWebModelPrefetch,
   }) : _chatService = chatService ?? ChatService(),
@@ -622,6 +626,7 @@ class ChatProvider extends ChangeNotifier {
            assistantOutputService ?? const AssistantOutputService(),
        _toolDeclarationService =
            toolDeclarationService ?? const ToolDeclarationService(),
+       _hostToolService = hostToolService ?? const HostToolService(),
        _enableWebModelPrefetch = enableWebModelPrefetch ?? kIsWeb,
        _settings = initialSettings ?? const ChatSettings() {
     _createInitialConversation();
@@ -820,7 +825,7 @@ class ChatProvider extends ChangeNotifier {
     try {
       _declaredTools = _toolDeclarationService.parseDefinitions(
         raw,
-        handler: _declarationOnlyToolHandler,
+        handlerFor: _hostToolService.handlerFor,
       );
       _toolDeclarationsError = null;
     } catch (error) {
@@ -830,10 +835,6 @@ class ChatProvider extends ChangeNotifier {
         fallback: 'Tool declarations are invalid.',
       );
     }
-  }
-
-  static Future<Object?> _declarationOnlyToolHandler(ToolParams _) async {
-    return 'Tool execution is disabled in this chat app.';
   }
 
   Future<void> _init() async {
@@ -2017,6 +2018,8 @@ class ChatProvider extends ChangeNotifier {
     String text, {
     required _GenerationContext context,
     List<LlamaContentPart>? parts,
+    bool allowToolExecution = true,
+    List<ToolDefinition>? turnTools,
   }) async {
     if (!_generationContextMatches(context)) {
       _releaseGeneration(context);
@@ -2032,11 +2035,13 @@ class ChatProvider extends ChangeNotifier {
       decodeElapsedMs: 0,
     );
     _lastFirstTokenLatencyMs = null;
-    final toolsForTurn = _toolsForTurn();
+    final toolsForTurn = turnTools ?? _toolsForTurn();
     var appliedGeneratedTokenDeltas = 0;
     var hasMediaPartsInTurn = false;
     var hasAudioPartsInTurn = false;
     var isCpuMultimodalTurn = false;
+    var pendingToolCalls = const <LlamaToolCallContent>[];
+    var accountingApplied = false;
 
     try {
       if (!_generationContextMatches(context)) {
@@ -2201,9 +2206,6 @@ class ChatProvider extends ChangeNotifier {
           }
           if (toolCalls.isNotEmpty) {
             messageParts.addAll(toolCalls);
-            if (finalText.isEmpty) {
-              finalText = toolCalls.map((call) => call.rawJson).join('\n');
-            }
           } else if (finalText.isNotEmpty) {
             messageParts.add(LlamaTextContent(finalText));
           }
@@ -2230,8 +2232,31 @@ class ChatProvider extends ChangeNotifier {
           if (_messages.isNotEmpty && !_messages.last.isUser) {
             _messages.last.tokenCount = tokenCount;
           }
+          if (allowToolExecution &&
+              toolsForTurn != null &&
+              toolCalls.isNotEmpty) {
+            pendingToolCalls = toolCalls;
+          }
         }
       }
+
+      if (pendingToolCalls.isNotEmpty) {
+        // Close out this leg's accounting before the tool result and the
+        // continuation leg change which message is current.
+        await _applyGenerationAccounting(
+          context: context,
+          generationResult: generationResult,
+          appliedGeneratedTokenDeltas: appliedGeneratedTokenDeltas,
+        );
+        accountingApplied = true;
+        await _runToolCallContinuation(
+          context: context,
+          toolCalls: pendingToolCalls,
+          declaredTools: toolsForTurn!,
+        );
+        return;
+      }
+
       _removeEmptyAssistantPlaceholder();
     } catch (e) {
       if (!_generationContextMatches(context)) {
@@ -2312,75 +2337,210 @@ class ChatProvider extends ChangeNotifier {
       } else {
         _messages.add(
           ChatMessage(
-            text: 'Error: ${_formatDisplayError(e)}',
+            text:
+                'Generation failed before a usable response was produced. '
+                'Reload the model and retry; if it continues, check backend diagnostics.',
             isUser: false,
             isInfo: true,
           ),
         );
       }
     } finally {
-      if (_generationContextMatches(context)) {
-        final generatedTokens = generationResult.generatedTokens;
-        final elapsedMs = generationResult.elapsedMs;
-        final decodeElapsedMs = generationResult.decodeElapsedMs;
-
-        BackendPerfContextData? performance;
-        try {
-          performance = await _chatService.engine.getPerformanceContext();
-        } catch (_) {
-          performance = null;
-        }
-
-        if (_generationContextMatches(context)) {
-          final nativeEvalTokens = performance?.evalTokens;
-          final nativeEvalMs = performance?.evalMs;
-          _lastNativePromptEvalMs = performance?.promptEvalMs.round();
-          _lastNativeEvalMs = performance?.evalMs.round();
-          _lastNativeSampleMs = performance?.sampleMs.round();
-          _lastNativePromptEvalTokens = performance?.promptEvalTokens;
-          _lastNativeEvalTokens = nativeEvalTokens;
-          _lastNativeReusedGraphs = performance?.reusedGraphs;
-
-          final effectiveGeneratedTokens = nativeEvalTokens ?? generatedTokens;
-          if (_messages.isNotEmpty &&
-              !_messages.last.isUser &&
-              !_messages.last.isInfo) {
-            _messages.last.generatedTokenCount = effectiveGeneratedTokens;
-          }
-          if (nativeEvalTokens != null &&
-              nativeEvalTokens != appliedGeneratedTokenDeltas) {
-            _currentTokens = math.max(
-              0,
-              _currentTokens + nativeEvalTokens - appliedGeneratedTokenDeltas,
-            );
-          }
-
-          if (effectiveGeneratedTokens > 0 && elapsedMs > 0) {
-            _lastTokensPerSecond =
-                effectiveGeneratedTokens / (elapsedMs / 1000);
-          } else {
-            _lastTokensPerSecond = null;
-          }
-
-          final effectiveDecodeElapsedMs =
-              nativeEvalMs != null && nativeEvalMs > 0
-              ? nativeEvalMs
-              : decodeElapsedMs.toDouble();
-          if (effectiveGeneratedTokens > 0 && effectiveDecodeElapsedMs > 0) {
-            _lastDecodeTokensPerSecond =
-                effectiveGeneratedTokens / (effectiveDecodeElapsedMs / 1000);
-          } else {
-            _lastDecodeTokensPerSecond = null;
-          }
-
-          if (generationResult.firstTokenLatencyMs != null ||
-              generationResult.fullResponse.isNotEmpty ||
-              generationResult.fullThinking.isNotEmpty) {
-            _lastGenerationLatencyMs = elapsedMs;
-          }
-        }
+      if (!accountingApplied) {
+        await _applyGenerationAccounting(
+          context: context,
+          generationResult: generationResult,
+          appliedGeneratedTokenDeltas: appliedGeneratedTokenDeltas,
+        );
       }
       _releaseGeneration(context);
+    }
+  }
+
+  Future<void> _applyGenerationAccounting({
+    required _GenerationContext context,
+    required GenerationStreamResult generationResult,
+    required int appliedGeneratedTokenDeltas,
+  }) async {
+    if (!_generationContextMatches(context)) {
+      return;
+    }
+
+    final generatedTokens = generationResult.generatedTokens;
+    final elapsedMs = generationResult.elapsedMs;
+    final decodeElapsedMs = generationResult.decodeElapsedMs;
+
+    BackendPerfContextData? performance;
+    try {
+      performance = await _chatService.engine.getPerformanceContext();
+    } catch (_) {
+      performance = null;
+    }
+
+    if (!_generationContextMatches(context)) {
+      return;
+    }
+
+    final nativeEvalTokens = performance?.evalTokens;
+    final nativeEvalMs = performance?.evalMs;
+    _lastNativePromptEvalMs = performance?.promptEvalMs.round();
+    _lastNativeEvalMs = performance?.evalMs.round();
+    _lastNativeSampleMs = performance?.sampleMs.round();
+    _lastNativePromptEvalTokens = performance?.promptEvalTokens;
+    _lastNativeEvalTokens = nativeEvalTokens;
+    _lastNativeReusedGraphs = performance?.reusedGraphs;
+
+    final effectiveGeneratedTokens = nativeEvalTokens ?? generatedTokens;
+    if (_messages.isNotEmpty &&
+        !_messages.last.isUser &&
+        !_messages.last.isInfo) {
+      _messages.last.generatedTokenCount = effectiveGeneratedTokens;
+    }
+    if (nativeEvalTokens != null &&
+        nativeEvalTokens != appliedGeneratedTokenDeltas) {
+      _currentTokens = math.max(
+        0,
+        _currentTokens + nativeEvalTokens - appliedGeneratedTokenDeltas,
+      );
+    }
+
+    if (effectiveGeneratedTokens > 0 && elapsedMs > 0) {
+      _lastTokensPerSecond = effectiveGeneratedTokens / (elapsedMs / 1000);
+    } else {
+      _lastTokensPerSecond = null;
+    }
+
+    final effectiveDecodeElapsedMs = nativeEvalMs != null && nativeEvalMs > 0
+        ? nativeEvalMs
+        : decodeElapsedMs.toDouble();
+    if (effectiveGeneratedTokens > 0 && effectiveDecodeElapsedMs > 0) {
+      _lastDecodeTokensPerSecond =
+          effectiveGeneratedTokens / (effectiveDecodeElapsedMs / 1000);
+    } else {
+      _lastDecodeTokensPerSecond = null;
+    }
+
+    if (generationResult.firstTokenLatencyMs != null ||
+        generationResult.fullResponse.isNotEmpty ||
+        generationResult.fullThinking.isNotEmpty) {
+      _lastGenerationLatencyMs = elapsedMs;
+    }
+  }
+
+  /// Executes the parsed [toolCalls], records their results, and runs the
+  /// single follow-up model turn that produces the final assistant answer.
+  Future<void> _runToolCallContinuation({
+    required _GenerationContext context,
+    required List<LlamaToolCallContent> toolCalls,
+    required List<ToolDefinition> declaredTools,
+  }) async {
+    if (!_generationContextMatches(context)) {
+      return;
+    }
+
+    // The session reports when even the active turn could not be compacted
+    // into the context window. Executing a model-proposed side effect from a
+    // request that did not fit would act on an unreliable prompt.
+    if (!context.session.lastRequestFitContext) {
+      _addInfoMessage(
+        'The requested tool was not executed because this turn no longer fits '
+        'the context window. Increase Context size or clear earlier turns.',
+      );
+      notifyListeners();
+      return;
+    }
+
+    final results = <LlamaToolResultContent>[];
+    for (final call in toolCalls) {
+      final result = await _executeDeclaredToolCall(call, declaredTools);
+      if (!_generationContextMatches(context)) {
+        return;
+      }
+      results.add(result);
+    }
+
+    final lastIndex = _messages.length - 1;
+    if (lastIndex >= 0 &&
+        (_messages[lastIndex].parts
+                ?.whereType<LlamaToolCallContent>()
+                .isNotEmpty ??
+            false)) {
+      final toolCallMessage = _messages[lastIndex];
+      _messages[lastIndex] = toolCallMessage.copyWith(
+        parts: <LlamaContentPart>[...?toolCallMessage.parts, ...results],
+      );
+    }
+
+    _messages.add(
+      ChatMessage(
+        text: '',
+        isUser: false,
+        role: LlamaChatRole.tool,
+        parts: List<LlamaContentPart>.from(results),
+      ),
+    );
+    context.session.addMessage(
+      LlamaChatMessage.withContent(
+        role: LlamaChatRole.tool,
+        content: List<LlamaContentPart>.from(results),
+      ),
+    );
+    _syncActiveConversationSnapshot();
+    notifyListeners();
+
+    await _yieldUiFrame();
+    if (!_generationContextMatches(context)) {
+      return;
+    }
+
+    await _generateResponse(
+      '',
+      context: context,
+      allowToolExecution: false,
+      turnTools: declaredTools,
+    );
+
+    final history = context.session.history;
+    if (_generationIdentityMatches(context) &&
+        history.isNotEmpty &&
+        history.last.role == LlamaChatRole.assistant &&
+        history.last.parts.isEmpty) {
+      _restoreSessionFromMessages();
+    }
+  }
+
+  Future<LlamaToolResultContent> _executeDeclaredToolCall(
+    LlamaToolCallContent call,
+    List<ToolDefinition> declaredTools,
+  ) async {
+    ToolDefinition? declared;
+    for (final tool in declaredTools) {
+      if (tool.name == call.name) {
+        declared = tool;
+        break;
+      }
+    }
+
+    if (declared == null) {
+      return LlamaToolResultContent(
+        id: call.id,
+        name: call.name,
+        result: _hostToolService.unsupportedToolResult(call.name),
+      );
+    }
+
+    try {
+      return LlamaToolResultContent(
+        id: call.id,
+        name: call.name,
+        result: await declared.invoke(call.arguments),
+      );
+    } catch (_) {
+      return LlamaToolResultContent(
+        id: call.id,
+        name: call.name,
+        result: _hostToolService.failedToolResult(call.name),
+      );
     }
   }
 
@@ -4095,7 +4255,7 @@ class ChatProvider extends ChangeNotifier {
     try {
       final parsed = _toolDeclarationService.parseDefinitions(
         normalized,
-        handler: _declarationOnlyToolHandler,
+        handlerFor: _hostToolService.handlerFor,
       );
       _declaredTools = parsed;
       _toolDeclarationsError = null;

--- a/example/chat_app/lib/services/chat_session_service.dart
+++ b/example/chat_app/lib/services/chat_session_service.dart
@@ -48,8 +48,17 @@ class ChatSessionService {
     final role =
         message.role ??
         (message.isUser ? LlamaChatRole.user : LlamaChatRole.assistant);
-    final parts = message.parts != null && message.parts!.isNotEmpty
-        ? List<LlamaContentPart>.from(message.parts!)
+    // Tool results are mirrored onto the assistant tool-call message so the UI
+    // can render a call and its result together; only the tool-role message may
+    // carry them back into the prompt.
+    final storedParts = message.parts
+        ?.where(
+          (part) =>
+              role == LlamaChatRole.tool || part is! LlamaToolResultContent,
+        )
+        .toList(growable: false);
+    final parts = storedParts != null && storedParts.isNotEmpty
+        ? List<LlamaContentPart>.from(storedParts)
         : <LlamaContentPart>[
             if (message.text.trim().isNotEmpty) LlamaTextContent(message.text),
           ];

--- a/example/chat_app/lib/services/host_tool_service.dart
+++ b/example/chat_app/lib/services/host_tool_service.dart
@@ -1,0 +1,89 @@
+import 'package:llamadart/llamadart.dart';
+
+/// Supplies the example app's built-in host implementations for declared tools.
+///
+/// Declarations are user-editable, so a declared name is never treated as
+/// permission to run arbitrary code: only names with a built-in implementation
+/// produce a real result and every other name resolves to an explicit error
+/// payload that is sent back to the model as the tool result.
+class HostToolService {
+  const HostToolService();
+
+  /// The name of the built-in demo tool shipped with the default declarations.
+  static const String getWeatherToolName = 'getWeather';
+
+  static const List<String> _simulatedConditions = <String>[
+    'clear sky',
+    'partly cloudy',
+    'overcast',
+    'light rain',
+    'thunderstorms',
+    'light snow',
+  ];
+
+  /// Returns the handler bound to [toolName] when a declaration is parsed.
+  ToolHandler handlerFor(String toolName) {
+    final normalized = toolName.trim();
+    if (normalized == getWeatherToolName) {
+      return getWeather;
+    }
+    return (ToolParams params) async => unsupportedToolResult(normalized);
+  }
+
+  /// The tool result returned for a declaration without an implementation.
+  Map<String, Object?> unsupportedToolResult(String toolName) {
+    return <String, Object?>{
+      'tool': toolName,
+      'error': 'unsupported_tool',
+      'message':
+          'This example app has no built-in implementation for "$toolName", '
+          'so nothing was executed.',
+    };
+  }
+
+  /// The tool result returned when a handler throws.
+  Map<String, Object?> failedToolResult(String toolName) {
+    return <String, Object?>{
+      'tool': toolName,
+      'error': 'tool_execution_failed',
+      'message': 'The "$toolName" handler failed, so no result was produced.',
+    };
+  }
+
+  /// Returns a deterministic simulated forecast for the requested city.
+  ///
+  /// The values are derived from a stable hash of the city name so repeated
+  /// runs and semantic assertions stay reproducible. This never contacts a
+  /// weather service.
+  Future<Object?> getWeather(ToolParams params) async {
+    final rawCity = params['city'];
+    final city = rawCity is String ? rawCity.trim() : '';
+    if (city.isEmpty) {
+      return <String, Object?>{
+        'tool': getWeatherToolName,
+        'error': 'invalid_arguments',
+        'message': 'getWeather requires a non-empty "city" string argument.',
+      };
+    }
+
+    final seed = _stableSeed(city.toLowerCase());
+    return <String, Object?>{
+      'tool': getWeatherToolName,
+      'city': city,
+      'condition': _simulatedConditions[seed % _simulatedConditions.length],
+      'temperatureCelsius': 4 + (seed % 28),
+      'humidityPercent': 35 + (seed % 45),
+      'simulated': true,
+      'source':
+          'llamadart chat example built-in simulation; not live weather data',
+    };
+  }
+
+  int _stableSeed(String value) {
+    var hash = 7;
+    for (final codeUnit in value.codeUnits) {
+      hash = (hash * 31 + codeUnit) & 0x7fffffff;
+    }
+    return hash;
+  }
+}

--- a/example/chat_app/lib/services/tool_declaration_service.dart
+++ b/example/chat_app/lib/services/tool_declaration_service.dart
@@ -12,9 +12,12 @@ class ToolDeclarationService {
   }
 
   /// Parses a JSON declaration array into typed [ToolDefinition] values.
+  ///
+  /// [handlerFor] binds each declared name to a safe host implementation or an
+  /// explicit unsupported-tool result.
   List<ToolDefinition> parseDefinitions(
     String rawJson, {
-    required Future<Object?> Function(ToolParams params) handler,
+    required ToolHandler Function(String toolName) handlerFor,
   }) {
     Object decoded;
     try {
@@ -28,6 +31,7 @@ class ToolDeclarationService {
     }
 
     final tools = <ToolDefinition>[];
+    final seenNames = <String>{};
 
     for (var i = 0; i < decoded.length; i++) {
       final entry = decoded[i];
@@ -64,12 +68,18 @@ class ToolDeclarationService {
         toolNumber: i + 1,
       );
 
+      final normalizedName = name.trim();
+      if (!seenNames.add(normalizedName)) {
+        throw FormatException(
+          'Tool #${i + 1} duplicates the name `$normalizedName`.',
+        );
+      }
       tools.add(
         ToolDefinition(
-          name: name.trim(),
+          name: normalizedName,
           description: description?.trim() ?? '',
           parameters: parameters,
-          handler: handler,
+          handler: handlerFor(normalizedName),
         ),
       );
     }
@@ -127,8 +137,17 @@ class ToolDeclarationService {
       );
     }
 
+    final requiredSet = _parseRequiredSet(
+      schema['required'],
+      location: 'Tool #$toolNumber required list',
+    );
     final rawProperties = schema['properties'];
     if (rawProperties == null) {
+      if (requiredSet.isNotEmpty) {
+        throw FormatException(
+          'Tool #$toolNumber required list contains undeclared properties.',
+        );
+      }
       return const <ToolParam>[];
     }
     if (rawProperties is! Map) {
@@ -137,12 +156,13 @@ class ToolDeclarationService {
       );
     }
 
-    final requiredSet = _parseRequiredSet(
-      schema['required'],
-      location: 'Tool #$toolNumber required list',
-    );
-
     final properties = Map<String, dynamic>.from(rawProperties);
+    final unknownRequired = requiredSet.difference(properties.keys.toSet());
+    if (unknownRequired.isNotEmpty) {
+      throw FormatException(
+        'Tool #$toolNumber required list contains undeclared properties.',
+      );
+    }
     final params = <ToolParam>[];
 
     for (final entry in properties.entries) {
@@ -241,11 +261,21 @@ class ToolDeclarationService {
         location: '$location required list',
       );
       final nested = <ToolParam>[];
-      if (nestedPropertiesRaw != null) {
-        if (nestedPropertiesRaw is! Map) {
-          throw FormatException('$location properties must be an object.');
-        }
-        final nestedProperties = Map<String, dynamic>.from(nestedPropertiesRaw);
+      if (nestedPropertiesRaw != null && nestedPropertiesRaw is! Map) {
+        throw FormatException('$location properties must be an object.');
+      }
+      final nestedProperties = nestedPropertiesRaw == null
+          ? const <String, dynamic>{}
+          : Map<String, dynamic>.from(nestedPropertiesRaw as Map);
+      final unknownRequired = nestedRequired.difference(
+        nestedProperties.keys.toSet(),
+      );
+      if (unknownRequired.isNotEmpty) {
+        throw FormatException(
+          '$location required list contains undeclared properties.',
+        );
+      }
+      if (nestedProperties.isNotEmpty) {
         for (final entry in nestedProperties.entries) {
           final nestedSchema = entry.value;
           if (nestedSchema is! Map) {

--- a/example/chat_app/lib/widgets/tool_declarations_dialog.dart
+++ b/example/chat_app/lib/widgets/tool_declarations_dialog.dart
@@ -108,7 +108,10 @@ Future<void> showToolDeclarationsDialog(
                       ],
                     ),
                     Text(
-                      'Enter the function declarations the model can call.',
+                      'Enter the function declarations the model can call. '
+                      'Only the built-in getWeather demo runs locally, and it '
+                      'returns simulated data; any other declared name returns '
+                      'an error result to the model.',
                       style: TextStyle(
                         color: colorScheme.onSurfaceVariant,
                         fontSize: 13,

--- a/example/chat_app/test/chat_session_service_test.dart
+++ b/example/chat_app/test/chat_session_service_test.dart
@@ -22,6 +22,47 @@ void main() {
       );
     });
 
+    test('keeps mirrored tool results out of the assistant turn', () {
+      const call = LlamaToolCallContent(
+        id: 'call_1',
+        name: 'getWeather',
+        arguments: {'city': 'Seoul'},
+        rawJson: '{"city":"Seoul"}',
+      );
+      const result = LlamaToolResultContent(
+        id: 'call_1',
+        name: 'getWeather',
+        result: {'city': 'Seoul', 'simulated': true},
+      );
+
+      final assistant = service.toLlamaChatMessage(
+        ChatMessage(
+          text: '',
+          isUser: false,
+          parts: const <LlamaContentPart>[call, result],
+        ),
+      );
+      expect(assistant, isNotNull);
+      expect(assistant!.role, LlamaChatRole.assistant);
+      expect(assistant.parts.whereType<LlamaToolCallContent>(), hasLength(1));
+      expect(assistant.parts.whereType<LlamaToolResultContent>(), isEmpty);
+
+      final toolMessage = service.toLlamaChatMessage(
+        ChatMessage(
+          text: '',
+          isUser: false,
+          role: LlamaChatRole.tool,
+          parts: const <LlamaContentPart>[result],
+        ),
+      );
+      expect(toolMessage, isNotNull);
+      expect(toolMessage!.role, LlamaChatRole.tool);
+      expect(
+        toolMessage.parts.whereType<LlamaToolResultContent>(),
+        hasLength(1),
+      );
+    });
+
     test('ignores informational messages during serialization', () {
       final serialized = service.toLlamaChatMessage(
         ChatMessage(text: 'info', isUser: false, isInfo: true),

--- a/example/chat_app/test/tool_call_continuation_test.dart
+++ b/example/chat_app/test/tool_call_continuation_test.dart
@@ -1,0 +1,683 @@
+import 'dart:async';
+
+import 'package:flutter/foundation.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:llamadart/llamadart.dart';
+import 'package:llamadart_chat_example/models/chat_settings.dart';
+import 'package:llamadart_chat_example/providers/chat_provider.dart';
+import 'package:llamadart_chat_example/services/host_tool_service.dart';
+import 'package:llamadart_chat_example/services/chat_session_service.dart';
+
+import 'mocks.dart';
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  tearDown(() {
+    debugDefaultTargetPlatformOverride = null;
+  });
+
+  Future<ChatProvider> buildProvider(
+    MockLlamaEngine engine, {
+    HostToolService? hostToolService,
+    String modelPath = 'test_model.gguf',
+  }) async {
+    final settings = ChatSettings(modelPath: modelPath);
+    final settingsService = MockSettingsService()..settings = settings;
+    final provider = ChatProvider(
+      chatService: MockChatService(engine: engine),
+      settingsService: settingsService,
+      hostToolService: hostToolService,
+      initialSettings: settings,
+    );
+    addTearDown(provider.dispose);
+
+    await provider.loadModel();
+    provider.updateToolsEnabled(true);
+    provider.resetToolDeclarations();
+    return provider;
+  }
+
+  Map<String, Object?> singleResultPayload(ChatProvider provider) {
+    final toolMessage = provider.messages.firstWhere(
+      (message) => message.role == LlamaChatRole.tool,
+    );
+    final results = toolMessage.parts!
+        .whereType<LlamaToolResultContent>()
+        .toList(growable: false);
+    expect(results, hasLength(1));
+    return results.first.result as Map<String, Object?>;
+  }
+
+  group('declared tool execution and continuation', () {
+    test(
+      'runs the declared handler and continues with a final answer',
+      () async {
+        final engine = _ScriptedToolCallEngine(
+          toolCalls: const [
+            _ScriptedToolCall(
+              id: 'call_1',
+              name: 'getWeather',
+              arguments: '{"city":"Seoul"}',
+            ),
+          ],
+          continuationText: 'Seoul currently reports the simulated conditions.',
+        );
+        final provider = await buildProvider(engine);
+
+        await provider.sendMessage('what is the weather in Seoul?');
+
+        expect(engine.createCallCount, 2);
+
+        final toolCallMessage = provider.messages.firstWhere(
+          (m) => m.isToolCall,
+        );
+        expect(toolCallMessage.generatedTokenCount, 1);
+        final results = toolCallMessage.parts!
+            .whereType<LlamaToolResultContent>()
+            .toList(growable: false);
+        expect(results, hasLength(1));
+        expect(results.first.name, 'getWeather');
+        expect(results.first.id, 'call_1');
+        final payload = results.first.result as Map<String, Object?>;
+        expect(payload['city'], 'Seoul');
+        expect(payload['simulated'], isTrue);
+        expect(payload['condition'], isA<String>());
+        expect(payload['temperatureCelsius'], isA<int>());
+
+        final toolHistoryMessage = provider.messages.firstWhere(
+          (m) => m.role == LlamaChatRole.tool,
+        );
+        expect(
+          toolHistoryMessage.parts!.whereType<LlamaToolResultContent>(),
+          hasLength(1),
+        );
+
+        final last = provider.messages.last;
+        expect(last.isUser, isFalse);
+        expect(last.isToolCall, isFalse);
+        expect(last.text, 'Seoul currently reports the simulated conditions.');
+        expect(last.generatedTokenCount, 1);
+        expect(provider.currentTokens, 2);
+
+        final continuationRequest = engine.requests.last;
+        expect(
+          continuationRequest.any(
+            (message) =>
+                message.role == LlamaChatRole.assistant &&
+                message.parts.whereType<LlamaToolCallContent>().isNotEmpty,
+          ),
+          isTrue,
+        );
+        expect(
+          continuationRequest.any(
+            (message) => message.role == LlamaChatRole.tool,
+          ),
+          isTrue,
+        );
+
+        final rebuilt = const ChatSessionService().rebuildFromMessages(
+          engine: engine,
+          contextSize: provider.contextSize,
+          messages: provider.messages,
+        );
+        expect(rebuilt.history.map((message) => message.role), <LlamaChatRole>[
+          LlamaChatRole.user,
+          LlamaChatRole.assistant,
+          LlamaChatRole.tool,
+          LlamaChatRole.assistant,
+        ]);
+        expect(
+          rebuilt.history[1].parts.whereType<LlamaToolResultContent>(),
+          isEmpty,
+        );
+        expect(
+          rebuilt.history[2].parts.whereType<LlamaToolResultContent>(),
+          hasLength(1),
+        );
+      },
+    );
+
+    test('uses the same bounded continuation path for both backends', () async {
+      for (final modelPath in <String>[
+        'test_model.gguf',
+        'test_model.litertlm',
+      ]) {
+        final engine = _ScriptedToolCallEngine(
+          toolCalls: const [
+            _ScriptedToolCall(
+              id: 'call_backend',
+              name: 'getWeather',
+              arguments: '{"city":"Seoul"}',
+            ),
+          ],
+          continuationText: 'Final answer.',
+        );
+        final provider = await buildProvider(engine, modelPath: modelPath);
+
+        await provider.sendMessage('weather');
+
+        expect(engine.createCallCount, 2, reason: modelPath);
+        expect(
+          engine.requests.last.map((message) => message.role),
+          containsAllInOrder(<LlamaChatRole>[
+            LlamaChatRole.user,
+            LlamaChatRole.assistant,
+            LlamaChatRole.tool,
+          ]),
+          reason: modelPath,
+        );
+        expect(provider.messages.last.text, 'Final answer.');
+      }
+    });
+
+    test('returns a safe error result for an undeclared tool name', () async {
+      final engine = _ScriptedToolCallEngine(
+        toolCalls: const [
+          _ScriptedToolCall(
+            id: 'call_unknown',
+            name: 'launchRocket',
+            arguments: '{"target":"moon"}',
+          ),
+        ],
+        continuationText: 'That tool is not available.',
+      );
+      final provider = await buildProvider(engine);
+
+      await provider.sendMessage('launch a rocket');
+
+      expect(engine.createCallCount, 2);
+      final payload = singleResultPayload(provider);
+      expect(payload['error'], 'unsupported_tool');
+      expect(payload['tool'], 'launchRocket');
+      expect(provider.messages.last.text, 'That tool is not available.');
+    });
+
+    test('reports a safe error result when the handler throws', () async {
+      final engine = _ScriptedToolCallEngine(
+        toolCalls: const [
+          _ScriptedToolCall(
+            id: 'call_boom',
+            name: 'getWeather',
+            arguments: '{"city":"Seoul"}',
+          ),
+        ],
+        continuationText: 'The tool failed, so I cannot answer.',
+      );
+      final provider = await buildProvider(
+        engine,
+        hostToolService: _ThrowingHostToolService(),
+      );
+
+      await provider.sendMessage('weather please');
+
+      expect(engine.createCallCount, 2);
+      final payload = singleResultPayload(provider);
+      expect(payload['error'], 'tool_execution_failed');
+      expect(payload['message'], isNot(contains('simulated handler failure')));
+      expect(payload['message'], contains('no result was produced'));
+      expect(
+        provider.messages.last.text,
+        'The tool failed, so I cannot answer.',
+      );
+    });
+
+    test('malformed arguments return a safe explicit result error', () async {
+      final engine = _ScriptedToolCallEngine(
+        toolCalls: const [
+          _ScriptedToolCall(
+            id: 'call_invalid',
+            name: 'getWeather',
+            arguments: 'not-json',
+          ),
+        ],
+        continuationText: 'The request was invalid.',
+      );
+      final provider = await buildProvider(engine);
+
+      await provider.sendMessage('weather');
+
+      expect(engine.createCallCount, 2);
+      final payload = singleResultPayload(provider);
+      expect(payload['error'], 'invalid_arguments');
+      expect(payload['message'], isNot(contains('not-json')));
+      expect(provider.messages.last.text, 'The request was invalid.');
+    });
+
+    test('executes every call in one batch exactly once', () async {
+      final engine = _ScriptedToolCallEngine(
+        toolCalls: const [
+          _ScriptedToolCall(
+            id: 'call_a',
+            name: 'getWeather',
+            arguments: '{"city":"Seoul"}',
+          ),
+          _ScriptedToolCall(
+            id: 'call_b',
+            name: 'getWeather',
+            arguments: '{"city":"Paris"}',
+          ),
+        ],
+        continuationText: 'Both cities are covered.',
+      );
+      final spy = _CountingHostToolService();
+      final provider = await buildProvider(engine, hostToolService: spy);
+
+      await provider.sendMessage('compare Seoul and Paris');
+
+      expect(spy.invocations, 2);
+      final toolMessage = provider.messages.firstWhere(
+        (message) => message.role == LlamaChatRole.tool,
+      );
+      final results = toolMessage.parts!
+          .whereType<LlamaToolResultContent>()
+          .toList(growable: false);
+      expect(results.map((result) => result.id), ['call_a', 'call_b']);
+      expect(
+        results
+            .map((result) => (result.result as Map<String, Object?>)['city'])
+            .toList(),
+        ['Seoul', 'Paris'],
+      );
+    });
+
+    test('keeps the originating declarations for the continuation', () async {
+      final engine = _ScriptedToolCallEngine(
+        toolCalls: const [
+          _ScriptedToolCall(
+            id: 'call_frozen',
+            name: 'getWeather',
+            arguments: '{"city":"Seoul"}',
+          ),
+        ],
+        continuationText: 'Final answer.',
+      );
+      late ChatProvider provider;
+      final host = _CountingHostToolService(
+        onInvoke: () => provider.updateToolDeclarations('[]'),
+      );
+      provider = await buildProvider(engine, hostToolService: host);
+
+      await provider.sendMessage('weather');
+
+      expect(engine.createCallCount, 2);
+      expect(engine.requestedToolNames, <List<String>>[
+        <String>['getWeather'],
+        <String>['getWeather'],
+      ]);
+    });
+
+    test('stops after one tool batch and one continuation', () async {
+      final engine = _AlwaysToolCallEngine();
+      final spy = _CountingHostToolService();
+      final provider = await buildProvider(engine, hostToolService: spy);
+
+      await provider.sendMessage('weather in Seoul');
+
+      expect(engine.createCallCount, 2);
+      expect(spy.invocations, 1);
+      expect(
+        provider.messages.where((m) => m.role == LlamaChatRole.tool),
+        hasLength(1),
+      );
+      expect(provider.messages.where((m) => m.isToolCall), hasLength(2));
+      final repeatedCall = provider.messages.last;
+      expect(repeatedCall.parts!.whereType<LlamaToolResultContent>(), isEmpty);
+    });
+
+    test('removes an empty final continuation without another call', () async {
+      final engine = _ScriptedToolCallEngine(
+        toolCalls: const [
+          _ScriptedToolCall(
+            id: 'call_empty_final',
+            name: 'getWeather',
+            arguments: '{"city":"Seoul"}',
+          ),
+        ],
+        continuationText: '',
+      );
+      final provider = await buildProvider(engine);
+
+      await provider.sendMessage('weather');
+
+      expect(engine.createCallCount, 2);
+      expect(provider.messages.where((m) => m.isToolCall), hasLength(1));
+      expect(
+        provider.messages.where((m) => m.role == LlamaChatRole.tool),
+        hasLength(1),
+      );
+      expect(
+        provider.messages.where(
+          (m) => !m.isUser && !m.isInfo && m.role != LlamaChatRole.tool,
+        ),
+        hasLength(1),
+      );
+
+      await provider.sendMessage('next question');
+
+      expect(engine.createCallCount, 3);
+      expect(
+        engine.requests.last.map((message) => message.role),
+        <LlamaChatRole>[
+          LlamaChatRole.system,
+          LlamaChatRole.user,
+          LlamaChatRole.assistant,
+          LlamaChatRole.tool,
+          LlamaChatRole.user,
+        ],
+      );
+    });
+
+    test('does not execute a tool when the request missed context', () async {
+      final engine = _OversizedContextToolCallEngine();
+      final spy = _CountingHostToolService();
+      final provider = await buildProvider(engine, hostToolService: spy);
+
+      await provider.sendMessage('weather');
+
+      expect(engine.createCallCount, 1);
+      expect(spy.invocations, 0);
+      expect(
+        provider.messages.where((m) => m.role == LlamaChatRole.tool),
+        isEmpty,
+      );
+      expect(
+        provider.messages.any(
+          (message) => message.text.contains('no longer fits'),
+        ),
+        isTrue,
+      );
+    });
+
+    test('does not mutate a cleared conversation mid tool execution', () async {
+      final engine = _ScriptedToolCallEngine(
+        toolCalls: const [
+          _ScriptedToolCall(
+            id: 'call_stale',
+            name: 'getWeather',
+            arguments: '{"city":"Seoul"}',
+          ),
+        ],
+        continuationText: 'Stale continuation must not appear.',
+      );
+      late ChatProvider provider;
+      final hostToolService = _CountingHostToolService(
+        onInvoke: () => provider.clearConversation(),
+      );
+      provider = await buildProvider(engine, hostToolService: hostToolService);
+
+      await provider.sendMessage('weather in Seoul');
+
+      expect(hostToolService.invocations, 1);
+      expect(engine.createCallCount, 1);
+      expect(
+        provider.messages.any((m) => m.role == LlamaChatRole.tool),
+        isFalse,
+      );
+      expect(
+        provider.messages.any(
+          (m) => m.text == 'Stale continuation must not appear.',
+        ),
+        isFalse,
+      );
+    });
+
+    test(
+      'does not mutate a switched conversation mid tool execution',
+      () async {
+        final engine = _ScriptedToolCallEngine(
+          toolCalls: const [
+            _ScriptedToolCall(
+              id: 'call_switched',
+              name: 'getWeather',
+              arguments: '{"city":"Seoul"}',
+            ),
+          ],
+          continuationText: 'Stale continuation must not appear.',
+        );
+        late ChatProvider provider;
+        Future<void>? switchFuture;
+        late String targetConversationId;
+        final hostToolService = _CountingHostToolService(
+          onInvoke: () {
+            switchFuture = provider.switchConversation(targetConversationId);
+          },
+        );
+        provider = await buildProvider(
+          engine,
+          hostToolService: hostToolService,
+        );
+        final sourceConversationId = provider.activeConversationId;
+        provider.createConversation();
+        targetConversationId = provider.activeConversationId;
+        await provider.switchConversation(sourceConversationId);
+
+        await provider.sendMessage('weather in Seoul');
+        await switchFuture;
+
+        expect(provider.activeConversationId, targetConversationId);
+        expect(hostToolService.invocations, 1);
+        expect(engine.createCallCount, 1);
+        expect(
+          provider.messages.any((m) => m.role == LlamaChatRole.tool),
+          isFalse,
+        );
+        expect(
+          provider.messages.any(
+            (m) => m.text == 'Stale continuation must not appear.',
+          ),
+          isFalse,
+        );
+      },
+    );
+
+    test('leaves a plain text turn as a single generation', () async {
+      final engine = MockLlamaEngine()..createChunkContents = const ['Hello.'];
+      final provider = await buildProvider(engine);
+
+      await provider.sendMessage('hi');
+
+      expect(engine.createCalls, 1);
+      expect(
+        provider.messages.any((m) => m.role == LlamaChatRole.tool),
+        isFalse,
+      );
+      expect(provider.messages.last.text, 'Hello.');
+    });
+  });
+}
+
+class _AlwaysToolCallEngine extends MockLlamaEngine {
+  int createCallCount = 0;
+
+  @override
+  Stream<LlamaCompletionChunk> create(
+    List<LlamaChatMessage> messages, {
+    GenerationParams? params,
+    List<ToolDefinition>? tools,
+    ToolChoice? toolChoice,
+    bool parallelToolCalls = false,
+    bool enableThinking = true,
+    Map<String, dynamic>? responseFormat,
+    String? sourceLangCode,
+    String? targetLangCode,
+    Map<String, dynamic>? chatTemplateKwargs,
+    DateTime? templateNow,
+  }) async* {
+    createCallCount++;
+    yield LlamaCompletionChunk(
+      id: 'always-tool-call',
+      object: 'chat.completion.chunk',
+      created: 1,
+      model: 'mock-model',
+      choices: [
+        LlamaCompletionChunkChoice(
+          index: 0,
+          delta: LlamaCompletionChunkDelta(
+            toolCalls: [
+              LlamaCompletionChunkToolCall(
+                index: 0,
+                id: 'call_repeat_$createCallCount',
+                type: 'function',
+                function: LlamaCompletionChunkFunction(
+                  name: 'getWeather',
+                  arguments: '{"city":"Seoul"}',
+                ),
+              ),
+            ],
+          ),
+        ),
+      ],
+    );
+  }
+}
+
+class _OversizedContextToolCallEngine extends _ScriptedToolCallEngine {
+  _OversizedContextToolCallEngine()
+    : super(
+        toolCalls: const [
+          _ScriptedToolCall(
+            id: 'call_oversized',
+            name: 'getWeather',
+            arguments: '{"city":"Seoul"}',
+          ),
+        ],
+        continuationText: 'Must not continue.',
+      );
+
+  @override
+  Future<LlamaChatTemplateResult> chatTemplate(
+    List<LlamaChatMessage> messages, {
+    bool addAssistant = true,
+    Map<String, dynamic>? jsonSchema,
+    List<ToolDefinition>? tools,
+    ToolChoice toolChoice = ToolChoice.auto,
+    bool parallelToolCalls = false,
+    bool enableThinking = true,
+    Map<String, dynamic>? responseFormat,
+    String? customTemplate,
+    String? sourceLangCode,
+    String? targetLangCode,
+    bool includeTokenCount = true,
+    Map<String, dynamic>? chatTemplateKwargs,
+    DateTime? templateNow,
+  }) async => const LlamaChatTemplateResult(
+    prompt: 'oversized prompt',
+    tokenCount: 100000,
+  );
+}
+
+class _CountingHostToolService extends HostToolService {
+  final void Function()? onInvoke;
+
+  int invocations = 0;
+
+  _CountingHostToolService({this.onInvoke});
+
+  @override
+  ToolHandler handlerFor(String toolName) {
+    final delegate = super.handlerFor(toolName);
+    return (ToolParams params) async {
+      invocations += 1;
+      onInvoke?.call();
+      return delegate(params);
+    };
+  }
+}
+
+class _ThrowingHostToolService extends HostToolService {
+  @override
+  ToolHandler handlerFor(String toolName) {
+    return (ToolParams params) async =>
+        throw StateError('simulated handler failure');
+  }
+}
+
+class _ScriptedToolCall {
+  final String id;
+  final String name;
+  final String arguments;
+
+  const _ScriptedToolCall({
+    required this.id,
+    required this.name,
+    required this.arguments,
+  });
+}
+
+class _ScriptedToolCallEngine extends MockLlamaEngine {
+  final List<_ScriptedToolCall> toolCalls;
+  final String continuationText;
+
+  int createCallCount = 0;
+  final List<List<LlamaChatMessage>> requests = <List<LlamaChatMessage>>[];
+  final List<List<String>> requestedToolNames = <List<String>>[];
+
+  _ScriptedToolCallEngine({
+    required this.toolCalls,
+    required this.continuationText,
+  });
+
+  @override
+  Stream<LlamaCompletionChunk> create(
+    List<LlamaChatMessage> messages, {
+    GenerationParams? params,
+    List<ToolDefinition>? tools,
+    ToolChoice? toolChoice,
+    bool parallelToolCalls = false,
+    bool enableThinking = true,
+    Map<String, dynamic>? responseFormat,
+    String? sourceLangCode,
+    String? targetLangCode,
+    Map<String, dynamic>? chatTemplateKwargs,
+    DateTime? templateNow,
+  }) async* {
+    createCallCount++;
+    requests.add(List<LlamaChatMessage>.from(messages));
+    requestedToolNames.add(
+      tools?.map((tool) => tool.name).toList(growable: false) ?? const [],
+    );
+
+    if (createCallCount > 1) {
+      yield LlamaCompletionChunk(
+        id: 'continuation',
+        object: 'chat.completion.chunk',
+        created: 1,
+        model: 'mock-model',
+        choices: [
+          LlamaCompletionChunkChoice(
+            index: 0,
+            delta: LlamaCompletionChunkDelta(content: continuationText),
+          ),
+        ],
+      );
+      return;
+    }
+
+    yield LlamaCompletionChunk(
+      id: 'tool-call',
+      object: 'chat.completion.chunk',
+      created: 1,
+      model: 'mock-model',
+      choices: [
+        LlamaCompletionChunkChoice(
+          index: 0,
+          delta: LlamaCompletionChunkDelta(
+            toolCalls: [
+              for (var index = 0; index < toolCalls.length; index++)
+                LlamaCompletionChunkToolCall(
+                  index: index,
+                  id: toolCalls[index].id,
+                  type: 'function',
+                  function: LlamaCompletionChunkFunction(
+                    name: toolCalls[index].name,
+                    arguments: toolCalls[index].arguments,
+                  ),
+                ),
+            ],
+          ),
+        ),
+      ],
+    );
+  }
+}

--- a/example/chat_app/test/tool_declaration_service_test.dart
+++ b/example/chat_app/test/tool_declaration_service_test.dart
@@ -1,5 +1,6 @@
 import 'package:flutter_test/flutter_test.dart';
 import 'package:llamadart/llamadart.dart';
+import 'package:llamadart_chat_example/services/host_tool_service.dart';
 import 'package:llamadart_chat_example/services/tool_declaration_service.dart';
 
 void main() {
@@ -12,7 +13,8 @@ void main() {
     });
 
     test('parses OpenAI function-style declarations', () {
-      final tools = service.parseDefinitions('''
+      final tools = service.parseDefinitions(
+        '''
 [
   {
     "type": "function",
@@ -29,7 +31,10 @@ void main() {
     }
   }
 ]
-''', handler: (ToolParams _) async => 'ok');
+''',
+        handlerFor: (String _) =>
+            (ToolParams _) async => 'ok',
+      );
 
       expect(tools, hasLength(1));
       final tool = tools.first;
@@ -43,7 +48,11 @@ void main() {
 
     test('returns readable parser errors', () {
       expect(
-        () => service.parseDefinitions('not-json', handler: (_) async => null),
+        () => service.parseDefinitions(
+          'not-json',
+          handlerFor: (String _) =>
+              (ToolParams _) async => null,
+        ),
         throwsFormatException,
       );
 
@@ -58,6 +67,108 @@ void main() {
         fallback: 'invalid',
       );
       expect(fallback, 'invalid');
+    });
+
+    test('rejects duplicate declaration names after normalization', () {
+      expect(
+        () => service.parseDefinitions(
+          '[{"name":"getWeather"},{"name":" getWeather "}]',
+          handlerFor: (String _) =>
+              (ToolParams _) async => null,
+        ),
+        throwsA(
+          isA<FormatException>().having(
+            (error) => error.message,
+            'message',
+            contains('duplicates the name'),
+          ),
+        ),
+      );
+    });
+
+    test('rejects required properties absent from their schema', () {
+      expect(
+        () => service.parseDefinitions(
+          '''
+[
+  {
+    "name": "getWeather",
+    "parameters": {
+      "type": "object",
+      "properties": {"city": {"type": "string"}},
+      "required": ["missing"]
+    }
+  }
+]
+''',
+          handlerFor: (String _) =>
+              (ToolParams _) async => null,
+        ),
+        throwsA(
+          isA<FormatException>().having(
+            (error) => error.message,
+            'message',
+            contains('required list contains undeclared properties'),
+          ),
+        ),
+      );
+    });
+
+    test('rejects required properties when properties is absent', () {
+      expect(
+        () => service.parseDefinitions(
+          '''
+[
+  {
+    "name": "getWeather",
+    "parameters": {
+      "type": "object",
+      "required": ["city"]
+    }
+  }
+]
+''',
+          handlerFor: (String _) =>
+              (ToolParams _) async => null,
+        ),
+        throwsA(
+          isA<FormatException>().having(
+            (error) => error.message,
+            'message',
+            contains('required list contains undeclared properties'),
+          ),
+        ),
+      );
+    });
+  });
+
+  group('HostToolService', () {
+    const host = HostToolService();
+
+    test('returns a deterministic clearly simulated weather result', () async {
+      final first =
+          await host.getWeather(
+                ToolParams(<String, dynamic>{'city': 'Montréal'}),
+              )
+              as Map<String, Object?>;
+      final second =
+          await host.getWeather(
+                ToolParams(<String, dynamic>{'city': 'Montréal'}),
+              )
+              as Map<String, Object?>;
+
+      expect(second, first);
+      expect(first['simulated'], isTrue);
+      expect(first['source'], contains('not live weather data'));
+    });
+
+    test('arbitrary declaration names resolve to an explicit error', () async {
+      final result =
+          await host.handlerFor('launchRocket')(ToolParams(<String, dynamic>{}))
+              as Map<String, Object?>;
+
+      expect(result['error'], 'unsupported_tool');
+      expect(result['message'], contains('nothing was executed'));
     });
   });
 }

--- a/example/chat_app/test/unit_test.dart
+++ b/example/chat_app/test/unit_test.dart
@@ -935,7 +935,7 @@ void main() {
       );
     });
 
-    test('generation errors redact credentialed URLs', () async {
+    test('generation errors do not expose backend exception details', () async {
       final failingProvider = ChatProvider(
         chatService: MockChatService(
           engine: _FailingCreateEngine(
@@ -956,7 +956,12 @@ void main() {
       final errorMessage = failingProvider.messages.last;
       expect(errorMessage.isInfo, isTrue);
       expect(failingProvider.canRegenerateLastResponse, isFalse);
-      expect(errorMessage.text, contains('https://example.com/model.gguf'));
+      expect(
+        errorMessage.text,
+        'Generation failed before a usable response was produced. '
+        'Reload the model and retry; if it continues, check backend diagnostics.',
+      );
+      expect(errorMessage.text, isNot(contains('example.com')));
       expect(errorMessage.text, isNot(contains('token=secret')));
       expect(errorMessage.text, isNot(contains('signed-fragment')));
     });
@@ -1186,7 +1191,7 @@ void main() {
       expect(captureEngine.lastTools!.first.name, 'lookup_city');
     });
 
-    test('handles tool-call responses in a single pass', () async {
+    test('parses a streamed tool call and runs one continuation', () async {
       final engine = _SinglePassToolCallEngine();
       final singlePassProvider = ChatProvider(
         chatService: MockChatService(engine: engine),
@@ -1200,15 +1205,19 @@ void main() {
 
       await singlePassProvider.sendMessage('what time is it?');
 
-      expect(engine.createCallCount, 1);
-      final assistant = singlePassProvider.messages
-          .where((m) => !m.isUser && !m.isInfo)
-          .last;
-      expect(assistant.isToolCall, isTrue);
+      expect(engine.createCallCount, 2);
+      final toolCallMessage = singlePassProvider.messages.firstWhere(
+        (m) => m.isToolCall,
+      );
       expect(
-        assistant.parts?.whereType<LlamaToolCallContent>().length,
+        toolCallMessage.parts?.whereType<LlamaToolCallContent>().length,
         equals(1),
       );
+      expect(
+        toolCallMessage.parts?.whereType<LlamaToolResultContent>().length,
+        equals(1),
+      );
+      expect(singlePassProvider.messages.last.text, 'It is sunny in Seoul.');
     });
 
     test(
@@ -1227,18 +1236,33 @@ void main() {
 
         await customProvider.sendMessage('weather in london');
 
-        final assistant = customProvider.messages
-            .where((m) => !m.isUser && !m.isInfo)
-            .last;
+        final assistant = customProvider.messages.firstWhere(
+          (m) => m.isToolCall,
+        );
         final toolCalls =
             assistant.parts?.whereType<LlamaToolCallContent>().toList(
               growable: false,
             ) ??
             const <LlamaToolCallContent>[];
-        expect(assistant.isToolCall, isTrue);
         expect(toolCalls, hasLength(1));
         expect(toolCalls.first.name, equals('getWeather'));
         expect(toolCalls.first.arguments, equals({'city': 'London'}));
+
+        final results =
+            assistant.parts?.whereType<LlamaToolResultContent>().toList(
+              growable: false,
+            ) ??
+            const <LlamaToolResultContent>[];
+        expect(results, hasLength(1));
+        expect(
+          (results.first.result as Map<String, Object?>)['city'],
+          equals('London'),
+        );
+        expect(engine.createCallCount, 2);
+        expect(
+          customProvider.messages.last.text,
+          equals('London is showing the simulated forecast.'),
+        );
       },
     );
 
@@ -2234,6 +2258,22 @@ class _SinglePassToolCallEngine extends MockLlamaEngine {
     DateTime? templateNow,
   }) async* {
     createCallCount++;
+    if (createCallCount > 1) {
+      yield LlamaCompletionChunk(
+        id: 'single-pass-tool-continuation',
+        object: 'chat.completion.chunk',
+        created: 1,
+        model: 'mock-model',
+        choices: [
+          LlamaCompletionChunkChoice(
+            index: 0,
+            delta: LlamaCompletionChunkDelta(content: 'It is sunny in Seoul.'),
+          ),
+        ],
+      );
+      return;
+    }
+
     yield LlamaCompletionChunk(
       id: 'single-pass-tool-call',
       object: 'chat.completion.chunk',
@@ -2482,6 +2522,8 @@ class _RecordingModelService
 }
 
 class _FunctionGemmaRawCallTextEngine extends MockLlamaEngine {
+  int createCallCount = 0;
+
   @override
   Future<Map<String, String>> getMetadata() async => {
     'tokenizer.chat_template': '<start_function_declaration>',
@@ -2501,6 +2543,25 @@ class _FunctionGemmaRawCallTextEngine extends MockLlamaEngine {
     Map<String, dynamic>? chatTemplateKwargs,
     DateTime? templateNow,
   }) async* {
+    createCallCount++;
+    if (createCallCount > 1) {
+      yield LlamaCompletionChunk(
+        id: 'function-gemma-continuation',
+        object: 'chat.completion.chunk',
+        created: 1,
+        model: 'mock-model',
+        choices: [
+          LlamaCompletionChunkChoice(
+            index: 0,
+            delta: LlamaCompletionChunkDelta(
+              content: 'London is showing the simulated forecast.',
+            ),
+          ),
+        ],
+      );
+      return;
+    }
+
     yield LlamaCompletionChunk(
       id: 'function-gemma-tool',
       object: 'chat.completion.chunk',

--- a/lib/src/core/engine/chat_completion_stream_parser.dart
+++ b/lib/src/core/engine/chat_completion_stream_parser.dart
@@ -74,8 +74,11 @@ class ChatCompletionStreamParser {
     final endTag = thinkingTags.endTag;
     var isThinking = templateResult.thinkingForcedOpen;
     var pendingBuffer = '';
+    final useStructuredStreaming =
+        parseToolCallsEnabled ||
+        templateResult.format == ChatFormat.gemma4.index;
 
-    if (parseToolCallsEnabled) {
+    if (useStructuredStreaming) {
       await for (final token in tokenStream) {
         buffer.write(token);
 
@@ -169,7 +172,7 @@ class ChatCompletionStreamParser {
             templateResult.format,
             buffer.toString(),
             isPartial: true,
-            parseToolCalls: true,
+            parseToolCalls: parseToolCallsEnabled,
             thinkingForcedOpen: templateResult.thinkingForcedOpen,
             parser: templateResult.parser,
             tools: tools,
@@ -222,14 +225,15 @@ class ChatCompletionStreamParser {
         }
       }
 
+      // Whitespace-only output never provides enough signal to leave the
+      // undecided state. Preserve it verbatim at EOF, while continuing to
+      // withhold non-whitespace partial control-marker prefixes.
       if (streamingMode == _ToolStreamingMode.undecided &&
+          undecidedPrefix.trim().isEmpty &&
           undecidedPrefix.isNotEmpty) {
-        streamedContent += undecidedPrefix;
-        yield _chunk(
-          completionId: completionId,
-          modelName: modelName,
-          delta: LlamaCompletionChunkDelta(content: undecidedPrefix),
-        );
+        streamingMode = _ToolStreamingMode.raw;
+        pendingBuffer += undecidedPrefix;
+        undecidedPrefix = '';
       }
 
       if (streamingMode == _ToolStreamingMode.raw && pendingBuffer.isNotEmpty) {
@@ -295,7 +299,7 @@ class ChatCompletionStreamParser {
       tools: tools,
     );
 
-    if (parseToolCallsEnabled) {
+    if (useStructuredStreaming) {
       final finalReasoning = parsed.reasoningContent ?? '';
       final reasoningDelta = _computeFinalReconciliationDelta(
         streamedValue: streamedReasoning,
@@ -336,19 +340,11 @@ class ChatCompletionStreamParser {
       }
     }
 
-    LlamaLogger.instance.debug('Parsed result: $parsed');
-    if (parsed.hasToolCalls) {
-      for (final tc in parsed.toolCalls) {
-        LlamaLogger.instance.debug(
-          '  Tool call: ${tc.function?.name}(${tc.function?.arguments})',
-        );
-      }
-    }
-    if (parsed.hasReasoning) {
-      LlamaLogger.instance.debug(
-        '  Reasoning: ${parsed.reasoningContent?.length ?? 0} chars',
-      );
-    }
+    LlamaLogger.instance.debug(
+      'Parsed completion: contentChars=${parsed.content.length}, '
+      'reasoningChars=${parsed.reasoningContent?.length ?? 0}, '
+      'toolCallCount=${parsed.toolCalls.length}',
+    );
 
     if (parsed.hasToolCalls) {
       final toolCallsWithIds = parsed.toolCalls
@@ -427,7 +423,8 @@ class ChatCompletionStreamParser {
       formatIndex == ChatFormat.deepseekV4.index ||
       formatIndex == ChatFormat.museGlimmer.index ||
       formatIndex == ChatFormat.glm45.index ||
-      formatIndex == ChatFormat.laguna.index;
+      formatIndex == ChatFormat.laguna.index ||
+      formatIndex == ChatFormat.gemma4.index;
 
   static int? _firstNonWhitespaceIndex(String value) {
     for (var i = 0; i < value.length; i++) {

--- a/lib/src/core/template/handlers/gemma4_handler.dart
+++ b/lib/src/core/template/handlers/gemma4_handler.dart
@@ -430,7 +430,7 @@ class Gemma4Handler extends ChatTemplateHandler
         : 0;
     return (
       channel: block.substring(0, newline).trim(),
-      body: rawBody.substring(0, rawBody.length - heldPrefixLength).trim(),
+      body: rawBody.substring(0, rawBody.length - heldPrefixLength),
     );
   }
 

--- a/lib/src/core/template/handlers/gemma4_handler.dart
+++ b/lib/src/core/template/handlers/gemma4_handler.dart
@@ -1,27 +1,34 @@
 import 'package:dinja/dinja.dart';
 
+import '../../grammar/json_schema_converter.dart';
 import '../../models/chat/chat_message.dart';
 import '../../models/chat/chat_role.dart';
 import '../../models/chat/chat_template_result.dart';
 import '../../models/chat/completion_chunk.dart';
 import '../../models/chat/content_part.dart';
+import '../../models/inference/tool_choice.dart';
 import '../../models/tools/tool_definition.dart';
 import '../chat_format.dart';
 import '../chat_parse_result.dart';
 import '../chat_template_handler.dart';
+import '../template_internal_metadata.dart';
 import '../thinking_utils.dart';
 import '../tool_call_fallback_parser.dart';
+import '../tool_call_grammar_utils.dart';
 import '../tool_call_parsing_utils.dart';
+import '../tool_schema_utils.dart';
 
 /// Handler for Gemma 4 chat templates.
 ///
 /// Gemma 4 uses `<|turn>/<turn|>` message frames, optional
 /// `<|channel>thought...<channel|>` reasoning blocks, and
 /// `<|tool_call>call:name{args}<tool_call|>` tool-call envelopes.
-class Gemma4Handler extends ChatTemplateHandler {
+class Gemma4Handler extends ChatTemplateHandler
+    implements ToolSchemaAwareChatTemplateHandler {
   static const String _turnEnd = '<turn|>';
   static const String _toolCallStart = '<|tool_call>';
   static const String _toolCallEnd = '<tool_call|>';
+  static const String _callMarker = 'call:';
   static const String _channelStart = '<|channel>';
   static const String _channelEnd = '<channel|>';
   static const List<String> _customQuoteTokens = <String>['<|\\"|>', '<|"|>'];
@@ -124,10 +131,14 @@ class Gemma4Handler extends ChatTemplateHandler {
     }
 
     final hasTools = tools != null && tools.isNotEmpty;
+    // Upstream llama.cpp only makes the Gemma 4 tool grammar eager for
+    // `required`; `auto` stays unconstrained so the model can answer in prose.
+    final toolChoiceRequired =
+        metadata[internalToolChoiceMetadataKey] == ToolChoice.required.name;
     return LlamaChatTemplateResult(
       prompt: prompt,
       format: format.index,
-      grammar: buildGrammar(tools),
+      grammar: hasTools && toolChoiceRequired ? buildGrammar(tools) : null,
       grammarLazy: false,
       thinkingForcedOpen: thinkingForcedOpen,
       additionalStops: getStops(
@@ -204,6 +215,35 @@ class Gemma4Handler extends ChatTemplateHandler {
     bool isPartial = false,
     bool parseToolCalls = true,
     bool thinkingForcedOpen = false,
+  }) => _parseInternal(
+    output,
+    tools: null,
+    isPartial: isPartial,
+    parseToolCalls: parseToolCalls,
+    thinkingForcedOpen: thinkingForcedOpen,
+  );
+
+  @override
+  ChatParseResult parseWithTools(
+    String output, {
+    List<ToolDefinition>? tools,
+    bool isPartial = false,
+    bool parseToolCalls = true,
+    bool thinkingForcedOpen = false,
+  }) => _parseInternal(
+    output,
+    tools: tools,
+    isPartial: isPartial,
+    parseToolCalls: parseToolCalls,
+    thinkingForcedOpen: thinkingForcedOpen,
+  );
+
+  ChatParseResult _parseInternal(
+    String output, {
+    required List<ToolDefinition>? tools,
+    required bool isPartial,
+    required bool parseToolCalls,
+    required bool thinkingForcedOpen,
   }) {
     final reasoning = _extractReasoning(
       output,
@@ -212,28 +252,50 @@ class Gemma4Handler extends ChatTemplateHandler {
     );
 
     if (!parseToolCalls) {
+      final sanitized = _extractToolCalls(
+        reasoning.content,
+        isPartial: isPartial,
+        tools: tools,
+      );
       return ChatParseResult(
-        content: reasoning.content.trim(),
+        content: _visibleContent(
+          sanitized.content,
+          hasToolCalls: sanitized.toolCalls.isNotEmpty,
+        ),
         reasoningContent: reasoning.reasoning,
       );
     }
 
-    final parsed = _extractToolCalls(reasoning.content, isPartial: isPartial);
+    final parsed = _extractToolCalls(
+      reasoning.content,
+      isPartial: isPartial,
+      tools: tools,
+    );
     if (parsed.toolCalls.isEmpty) {
       final fallback = parseToolCallsFromLooseText(parsed.content);
       if (fallback.toolCalls.isNotEmpty) {
         return ChatParseResult(
-          content: fallback.content.trim(),
+          content: fallback.content,
           reasoningContent: reasoning.reasoning,
           toolCalls: fallback.toolCalls,
         );
       }
     }
     return ChatParseResult(
-      content: parsed.content.trim(),
+      content: _visibleContent(
+        parsed.content,
+        hasToolCalls: parsed.toolCalls.isNotEmpty,
+      ),
       reasoningContent: reasoning.reasoning,
       toolCalls: parsed.toolCalls,
     );
+  }
+
+  String _visibleContent(String content, {required bool hasToolCalls}) {
+    // A pure structured call may be surrounded by protocol whitespace that
+    // should not become an assistant message. Once there is ordinary visible
+    // text, preserve its whitespace exactly.
+    return hasToolCalls && content.trim().isEmpty ? '' : content;
   }
 
   ({String content, String? reasoning}) _extractReasoning(
@@ -246,26 +308,54 @@ class Gemma4Handler extends ChatTemplateHandler {
     var cursor = 0;
 
     while (cursor < output.length) {
+      if (thinkingForcedOpen) {
+        final end = output.indexOf(_channelEnd, cursor);
+        if (end == -1) {
+          final remaining = output.substring(cursor);
+          final heldPrefixLength = _controlMarkerPrefixLength(
+            remaining,
+            _channelEnd,
+            isPartial: isPartial,
+          );
+          final reasoning = remaining.substring(
+            0,
+            remaining.length - heldPrefixLength,
+          );
+          if (reasoning.isNotEmpty) {
+            reasoningParts.add(reasoning);
+          }
+          break;
+        }
+
+        final reasoning = output.substring(cursor, end);
+        if (reasoning.isNotEmpty) {
+          reasoningParts.add(reasoning);
+        }
+        cursor = end + _channelEnd.length;
+        thinkingForcedOpen = false;
+        continue;
+      }
+
       final start = output.indexOf(_channelStart, cursor);
       if (start == -1) {
-        if (thinkingForcedOpen) {
-          final end = output.indexOf(_channelEnd, cursor);
-          if (end == -1) {
-            final reasoning = output.substring(cursor);
-            if (reasoning.isNotEmpty) {
-              reasoningParts.add(reasoning);
-            }
-          } else {
-            final reasoning = output.substring(cursor, end);
-            if (reasoning.isNotEmpty) {
-              reasoningParts.add(reasoning);
-            }
-            content.write(output.substring(end + _channelEnd.length));
-            thinkingForcedOpen = false;
-          }
-        } else {
-          content.write(output.substring(cursor));
-        }
+        final remaining = output.substring(cursor);
+        final heldPrefixLength = _max(
+          _controlMarkerPrefixLength(
+            remaining,
+            _channelStart,
+            isPartial: isPartial,
+          ),
+          _controlMarkerPrefixLength(
+            remaining,
+            _channelEnd,
+            isPartial: isPartial,
+          ),
+        );
+        content.write(
+          remaining
+              .substring(0, remaining.length - heldPrefixLength)
+              .replaceAll(_channelEnd, ''),
+        );
         break;
       }
 
@@ -276,12 +366,12 @@ class Gemma4Handler extends ChatTemplateHandler {
           output.substring(start),
           isPartial: true,
         );
-        if (isPartial && partial != null && partial.channel == 'thought') {
+        if (partial != null && partial.channel == 'thought') {
           if (partial.body.isNotEmpty) {
             reasoningParts.add(partial.body);
           }
-        } else {
-          content.write(output.substring(start));
+        } else if (!isPartial && partial != null && partial.body.isNotEmpty) {
+          content.write(partial.body);
         }
         break;
       }
@@ -299,7 +389,7 @@ class Gemma4Handler extends ChatTemplateHandler {
           reasoningParts.add(body);
         }
       } else {
-        content.write(output.substring(start, end + _channelEnd.length));
+        content.write(body);
       }
 
       cursor = end + _channelEnd.length;
@@ -334,14 +424,22 @@ class Gemma4Handler extends ChatTemplateHandler {
           : (channel: block.trim(), body: '');
     }
 
+    final rawBody = block.substring(newline + 1);
+    final heldPrefixLength = isPartial
+        ? _trailingMarkerPrefixLength(rawBody, _channelEnd)
+        : 0;
     return (
       channel: block.substring(0, newline).trim(),
-      body: block.substring(newline + 1).trim(),
+      body: rawBody.substring(0, rawBody.length - heldPrefixLength).trim(),
     );
   }
 
   ({String content, List<LlamaCompletionChunkToolCall> toolCalls})
-  _extractToolCalls(String output, {required bool isPartial}) {
+  _extractToolCalls(
+    String output, {
+    required bool isPartial,
+    required List<ToolDefinition>? tools,
+  }) {
     final toolCalls = <LlamaCompletionChunkToolCall>[];
     final content = StringBuffer();
     var cursor = 0;
@@ -349,16 +447,35 @@ class Gemma4Handler extends ChatTemplateHandler {
     while (cursor < output.length) {
       final start = output.indexOf(_toolCallStart, cursor);
       if (start == -1) {
-        content.write(output.substring(cursor));
+        final remaining = output.substring(cursor);
+        final heldPrefixLength = _max(
+          _controlMarkerPrefixLength(
+            remaining,
+            _toolCallStart,
+            isPartial: isPartial,
+          ),
+          _controlMarkerPrefixLength(
+            remaining,
+            _toolCallEnd,
+            isPartial: isPartial,
+          ),
+        );
+        content.write(
+          remaining
+              .substring(0, remaining.length - heldPrefixLength)
+              .replaceAll(_toolCallEnd, ''),
+        );
         break;
       }
 
       content.write(output.substring(cursor, start));
-      final parsed = _parseToolCall(output, start, toolCalls.length);
+      final parsed = _parseToolCall(
+        output,
+        start,
+        toolCalls.length,
+        tools: tools,
+      );
       if (parsed == null) {
-        if (!isPartial) {
-          content.write(output.substring(start));
-        }
         break;
       }
 
@@ -372,8 +489,9 @@ class Gemma4Handler extends ChatTemplateHandler {
   ({int end, LlamaCompletionChunkToolCall toolCall})? _parseToolCall(
     String output,
     int start,
-    int index,
-  ) {
+    int index, {
+    required List<ToolDefinition>? tools,
+  }) {
     var cursor = _skipWhitespace(output, start + _toolCallStart.length);
 
     if (output.startsWith('call', cursor)) {
@@ -385,22 +503,12 @@ class Gemma4Handler extends ChatTemplateHandler {
       cursor = _skipWhitespace(output, cursor);
     }
 
-    final nameStart = cursor;
-    while (cursor < output.length &&
-        _isIdentifierChar(output.codeUnitAt(cursor))) {
-      cursor++;
-    }
-
-    final name = output.substring(nameStart, cursor).trim();
-    if (name.isEmpty || _invalidToolNames.contains(name)) {
+    final parsedName = _parseToolName(output, cursor, tools: tools);
+    if (parsedName == null) {
       return null;
     }
-
-    cursor = _skipWhitespace(output, cursor);
-
-    if (cursor >= output.length || output.codeUnitAt(cursor) != 0x7B) {
-      return null;
-    }
+    final name = parsedName.name;
+    cursor = parsedName.argumentsStart;
 
     final endBrace = _findMatchingBrace(output, cursor);
     if (endBrace == -1) {
@@ -512,14 +620,80 @@ class Gemma4Handler extends ChatTemplateHandler {
     return offset;
   }
 
-  bool _isIdentifierChar(int codeUnit) {
-    return (codeUnit >= 0x30 && codeUnit <= 0x39) ||
-        (codeUnit >= 0x41 && codeUnit <= 0x5A) ||
-        (codeUnit >= 0x61 && codeUnit <= 0x7A) ||
-        codeUnit == 0x5F ||
-        codeUnit == 0x2D ||
-        codeUnit == 0x2E;
+  ({String name, int argumentsStart})? _parseToolName(
+    String output,
+    int start, {
+    required List<ToolDefinition>? tools,
+  }) {
+    if (tools != null && tools.isNotEmpty) {
+      ToolDefinition? bestMatch;
+      var bestArgumentsStart = -1;
+      for (final tool in tools) {
+        if (!output.startsWith(tool.name, start)) {
+          continue;
+        }
+        final argumentsStart = _skipWhitespace(
+          output,
+          start + tool.name.length,
+        );
+        if (argumentsStart >= output.length ||
+            output.codeUnitAt(argumentsStart) != 0x7B) {
+          continue;
+        }
+        if (bestMatch == null || tool.name.length > bestMatch.name.length) {
+          bestMatch = tool;
+          bestArgumentsStart = argumentsStart;
+        }
+      }
+      if (bestMatch == null) {
+        return _parseUndeclaredToolName(output, start);
+      }
+      return (name: bestMatch.name, argumentsStart: bestArgumentsStart);
+    }
+
+    return _parseUndeclaredToolName(output, start);
   }
+
+  ({String name, int argumentsStart})? _parseUndeclaredToolName(
+    String output,
+    int start,
+  ) {
+    var cursor = start;
+    while (cursor < output.length && output.codeUnitAt(cursor) != 0x7B) {
+      cursor++;
+    }
+    final name = output.substring(start, cursor).trimRight();
+    if (name.isEmpty || _invalidToolNames.contains(name)) {
+      return null;
+    }
+    if (cursor >= output.length || output.codeUnitAt(cursor) != 0x7B) {
+      return null;
+    }
+    return (name: name, argumentsStart: cursor);
+  }
+
+  int _trailingMarkerPrefixLength(String text, String marker) {
+    final maxLength = text.length < marker.length
+        ? text.length
+        : marker.length - 1;
+    for (var length = maxLength; length > 0; length--) {
+      if (text.endsWith(marker.substring(0, length))) {
+        return length;
+      }
+    }
+    return 0;
+  }
+
+  int _controlMarkerPrefixLength(
+    String text,
+    String marker, {
+    required bool isPartial,
+  }) {
+    final length = _trailingMarkerPrefixLength(text, marker);
+    return isPartial || length >= 2 ? length : 0;
+  }
+
+  int _max(int a, int b) => a > b ? a : b;
 
   bool _isWhitespace(int codeUnit) {
     return codeUnit == 0x20 ||
@@ -528,8 +702,47 @@ class Gemma4Handler extends ChatTemplateHandler {
         codeUnit == 0x09;
   }
 
+  /// Builds a grammar admitting exactly one
+  /// `<|tool_call>call:<name>{args}<tool_call|>` envelope.
+  ///
+  /// Arguments use standard JSON, which [parse] already accepts alongside the
+  /// model's pseudo-JSON spelling.
   @override
   String? buildGrammar(List<ToolDefinition>? tools) {
-    return null;
+    if (tools == null || tools.isEmpty) {
+      return null;
+    }
+
+    // Grammar alternatives and parser routing both depend on exact tool and
+    // parameter identities. Reject lossy duplicates before constructing rules.
+    toolSchemas(tools);
+
+    final converter = JsonSchemaConverter();
+    final callRules = <String>[];
+
+    for (var i = 0; i < tools.length; i++) {
+      final tool = tools[i];
+      final schema = tool.toJsonSchema();
+      converter.resolveRefs(schema, schema);
+      final argsRule = converter.visit(schema, 'tool-$i-args');
+      final callRule = 'tool-$i-call';
+      converter.rules[callRule] =
+          '${ToolCallGrammarUtils.literal('$_toolCallStart$_callMarker${tool.name}')} '
+          '$argsRule '
+          '${ToolCallGrammarUtils.literal(_toolCallEnd)}';
+      callRules.add(callRule);
+    }
+
+    final buffer = StringBuffer()..writeln('root ::= ${callRules.join(' | ')}');
+    final otherRules = converter.rules.entries.toList(growable: false)
+      ..sort((a, b) => a.key.compareTo(b.key));
+    for (final entry in otherRules) {
+      if (entry.key == 'root') {
+        continue;
+      }
+      buffer.writeln('${entry.key} ::= ${entry.value}');
+    }
+
+    return buffer.toString();
   }
 }

--- a/test/e2e/template/specialized_tool_grammar_validation_e2e_test.dart
+++ b/test/e2e/template/specialized_tool_grammar_validation_e2e_test.dart
@@ -8,6 +8,7 @@ import 'dart:io';
 import 'package:llamadart/src/core/models/tools/tool_definition.dart';
 import 'package:llamadart/src/core/models/tools/tool_param.dart';
 import 'package:llamadart/src/core/template/handlers/command_r7b_handler.dart';
+import 'package:llamadart/src/core/template/handlers/gemma4_handler.dart';
 import 'package:llamadart/src/core/template/handlers/glm45_handler.dart';
 import 'package:llamadart/src/core/template/handlers/hermes_handler.dart';
 import 'package:llamadart/src/core/template/handlers/hunyuan_v3_handler.dart';
@@ -25,6 +26,48 @@ void main() {
       reason: 'Set LLAMA_CPP_GBNF_VALIDATOR to llama.cpp test-gbnf-validator.',
     );
     expect(File(validator).existsSync(), isTrue);
+  });
+
+  test('Gemma 4 eager grammar enforces one exact schema-valid envelope', () {
+    final grammar = Gemma4Handler().buildGrammar([
+      _weatherWithCityTool,
+      _zeroArgTool,
+      _gemmaEscapedTool,
+    ])!;
+    final weatherCall = '<|tool_call>call:weather{"city":"Seoul"}<tool_call|>';
+    final pingCall = '<|tool_call>call:ping{}<tool_call|>';
+    final escapedRequiredArguments = <String, dynamic>{
+      'a b': 'one',
+      r'city&"zone\path': 'Montréal {north}',
+    };
+    final escapedOptionalArguments = <String, dynamic>{
+      ...escapedRequiredArguments,
+      'a-b': 'two',
+    };
+    String escapedCall(Map<String, dynamic> arguments) =>
+        '<|tool_call>call:${_gemmaEscapedTool.name}'
+        '${jsonEncode(arguments)}<tool_call|>';
+
+    _expectGrammar(
+      validator,
+      grammar,
+      valid: [
+        weatherCall,
+        pingCall,
+        escapedCall(escapedRequiredArguments),
+        escapedCall(escapedOptionalArguments),
+      ],
+      invalid: [
+        'leading prose$weatherCall',
+        '$weatherCall$pingCall',
+        '<|tool_call>call:unknown{}<tool_call|>',
+        '<|tool_call>call:weather{}<tool_call|>',
+        '<|tool_call>call:weather{"city":7}<tool_call|>',
+        '<|tool_call>call:weather{"city":"Seoul","extra":true}'
+            '<tool_call|>',
+        escapedCall(<String, dynamic>{'a b': 'one'}),
+      ],
+    );
   });
 
   test('MiniMax M1 accepts quoted names and rejects invalid JSON names', () {
@@ -835,6 +878,17 @@ final _optionalTool = ToolDefinition(
     ToolParam.string('query', required: true),
     ToolParam.string('note'),
     ToolParam.string('detail'),
+  ],
+  handler: (_) async => null,
+);
+
+final _gemmaEscapedTool = ToolDefinition(
+  name: r'weather&"alerts\route|primary',
+  description: 'Gemma escaped identity and collision coverage',
+  parameters: [
+    ToolParam.string('a b', required: true),
+    ToolParam.string('a-b'),
+    ToolParam.string(r'city&"zone\path', required: true),
   ],
   handler: (_) async => null,
 );

--- a/test/unit/core/engine/chat_completion_stream_parser_test.dart
+++ b/test/unit/core/engine/chat_completion_stream_parser_test.dart
@@ -1,7 +1,9 @@
 import 'dart:convert';
 
 import 'package:llamadart/src/core/engine/chat_completion_stream_parser.dart';
+import 'package:llamadart/src/core/llama_logger.dart';
 import 'package:llamadart/src/core/models/chat/chat_template_result.dart';
+import 'package:llamadart/src/core/models/config/log_level.dart';
 import 'package:llamadart/src/core/models/tools/tool_definition.dart';
 import 'package:llamadart/src/core/models/tools/tool_param.dart';
 import 'package:llamadart/src/core/template/chat_format.dart';
@@ -156,6 +158,212 @@ void main() {
         expect(chunks.last.choices.single.finishReason, 'tool_calls');
       },
     );
+
+    test(
+      'Gemma 4 withholds a character-split tool envelope after thinking',
+      () async {
+        const output =
+            'private reasoning<channel|>'
+            '<|tool_call>call:weather{"city":"Seoul"}<tool_call|>';
+        final chunks = await ChatCompletionStreamParser.parse(
+          tokenStream: Stream.fromIterable(output.split('')),
+          templateResult: LlamaChatTemplateResult(
+            prompt: 'prompt',
+            format: ChatFormat.gemma4.index,
+            thinkingForcedOpen: true,
+          ),
+          parseToolCallsEnabled: true,
+          enableThinking: true,
+          modelName: 'test-model',
+          completionId: 'gemma4-character-split',
+          tools: [_weatherTool],
+        ).toList();
+
+        final reasoning = chunks
+            .map((chunk) => chunk.choices.single.delta.thinking ?? '')
+            .join();
+        final content = chunks
+            .map((chunk) => chunk.choices.single.delta.content ?? '')
+            .join();
+        final toolCall = chunks
+            .expand((chunk) => chunk.choices.single.delta.toolCalls ?? const [])
+            .single;
+
+        expect(reasoning, 'private reasoning');
+        expect(content, isEmpty);
+        expect(content, isNot(contains('<|tool_call>')));
+        expect(toolCall.function?.name, 'weather');
+        expect(jsonDecode(toolCall.function!.arguments!), {'city': 'Seoul'});
+        expect(chunks.last.choices.single.finishReason, 'tool_calls');
+      },
+    );
+
+    test(
+      'Gemma 4 withholds a character-split tool envelope after content',
+      () async {
+        const output =
+            'Visible answer.'
+            '<|tool_call>call:weather{"city":"Seoul"}<tool_call|>';
+        final chunks = await ChatCompletionStreamParser.parse(
+          tokenStream: Stream.fromIterable(output.split('')),
+          templateResult: LlamaChatTemplateResult(
+            prompt: 'prompt',
+            format: ChatFormat.gemma4.index,
+          ),
+          parseToolCallsEnabled: true,
+          enableThinking: true,
+          modelName: 'test-model',
+          completionId: 'gemma4-content-tool-split',
+          tools: [_weatherTool],
+        ).toList();
+
+        final content = chunks
+            .map((chunk) => chunk.choices.single.delta.content ?? '')
+            .join();
+        final toolCall = chunks
+            .expand((chunk) => chunk.choices.single.delta.toolCalls ?? const [])
+            .single;
+
+        expect(content, 'Visible answer.');
+        expect(content, isNot(contains('<|tool_call>')));
+        expect(toolCall.function?.name, 'weather');
+        expect(jsonDecode(toolCall.function!.arguments!), {'city': 'Seoul'});
+      },
+    );
+
+    test(
+      'Gemma 4 suppresses split tool controls when parsing is disabled',
+      () async {
+        const output =
+            'Visible answer.'
+            '<|tool_call>call:weather{"city":"Seoul"}<tool_call|>';
+        final chunks = await ChatCompletionStreamParser.parse(
+          tokenStream: Stream.fromIterable(output.split('')),
+          templateResult: LlamaChatTemplateResult(
+            prompt: 'prompt',
+            format: ChatFormat.gemma4.index,
+          ),
+          parseToolCallsEnabled: false,
+          enableThinking: true,
+          modelName: 'test-model',
+          completionId: 'gemma4-no-tool-parse',
+          tools: [_weatherTool],
+        ).toList();
+
+        final content = chunks
+            .map((chunk) => chunk.choices.single.delta.content ?? '')
+            .join();
+
+        expect(content, 'Visible answer.');
+        expect(content, isNot(contains('<|tool_call>')));
+        expect(
+          chunks.expand(
+            (chunk) => chunk.choices.single.delta.toolCalls ?? const [],
+          ),
+          isEmpty,
+        );
+        expect(chunks.last.choices.single.finishReason, 'stop');
+      },
+    );
+
+    test('Gemma 4 preserves ordinary raw whitespace exactly', () async {
+      const output = ' \tVisible answer.  \n';
+
+      for (final parseToolCallsEnabled in <bool>[true, false]) {
+        final chunks = await ChatCompletionStreamParser.parse(
+          tokenStream: Stream.fromIterable(output.split('')),
+          templateResult: LlamaChatTemplateResult(
+            prompt: 'prompt',
+            format: ChatFormat.gemma4.index,
+          ),
+          parseToolCallsEnabled: parseToolCallsEnabled,
+          enableThinking: true,
+          modelName: 'test-model',
+          completionId: 'gemma4-raw-whitespace-$parseToolCallsEnabled',
+          tools: [_weatherTool],
+        ).toList();
+
+        final content = chunks
+            .map((chunk) => chunk.choices.single.delta.content ?? '')
+            .join();
+
+        expect(content, output, reason: 'parse tools: $parseToolCallsEnabled');
+        expect(
+          chunks.expand(
+            (chunk) => chunk.choices.single.delta.toolCalls ?? const [],
+          ),
+          isEmpty,
+        );
+      }
+    });
+
+    test(
+      'Gemma 4 character-split explicit thinking never becomes content',
+      () async {
+        const output = '<|channel>thought\ninternal draft<channel|>';
+
+        for (final enableThinking in <bool>[true, false]) {
+          final chunks = await ChatCompletionStreamParser.parse(
+            tokenStream: Stream.fromIterable(output.split('')),
+            templateResult: LlamaChatTemplateResult(
+              prompt: 'prompt',
+              format: ChatFormat.gemma4.index,
+            ),
+            parseToolCallsEnabled: true,
+            enableThinking: enableThinking,
+            modelName: 'test-model',
+            completionId: 'gemma4-thinking-$enableThinking',
+            tools: [_weatherTool],
+          ).toList();
+
+          final reasoning = chunks
+              .map((chunk) => chunk.choices.single.delta.thinking ?? '')
+              .join();
+          final content = chunks
+              .map((chunk) => chunk.choices.single.delta.content ?? '')
+              .join();
+
+          expect(content, isEmpty);
+          expect(content, isNot(contains('<|channel>')));
+          expect(content, isNot(contains('<channel|>')));
+          expect(reasoning, enableThinking ? 'internal draft' : isEmpty);
+        }
+      },
+    );
+
+    test('debug logging records only parsed output metadata', () async {
+      final messages = <String>[];
+      LlamaLogger.instance
+        ..setLevel(LlamaLogLevel.debug)
+        ..setHandler((record) => messages.add(record.message));
+
+      try {
+        await ChatCompletionStreamParser.parse(
+          tokenStream: Stream.value(
+            '<|channel>thought\ninternal draft<channel|>'
+            '<|tool_call>call:weather{"city":"Seoul"}<tool_call|>',
+          ),
+          templateResult: LlamaChatTemplateResult(
+            prompt: 'prompt',
+            format: ChatFormat.gemma4.index,
+          ),
+          parseToolCallsEnabled: true,
+          enableThinking: true,
+          modelName: 'test-model',
+          completionId: 'safe-debug-log',
+          tools: [_weatherTool],
+        ).toList();
+      } finally {
+        LlamaLogger.instance
+          ..setHandler(null)
+          ..setLevel(LlamaLogLevel.none);
+      }
+
+      expect(messages, [
+        'Parsed completion: contentChars=0, reasoningChars=14, '
+            'toolCallCount=1',
+      ]);
+    });
 
     test('carries tool schemas into specialized final parsing', () async {
       const namespace = ']<]minimax[>[';

--- a/test/unit/core/template/handlers/gemma4_handler_test.dart
+++ b/test/unit/core/template/handlers/gemma4_handler_test.dart
@@ -4,9 +4,14 @@ library;
 import 'dart:convert';
 import 'dart:typed_data';
 
+import 'package:llamadart/src/core/exceptions.dart';
 import 'package:llamadart/src/core/models/chat/chat_message.dart';
 import 'package:llamadart/src/core/models/chat/chat_role.dart';
+import 'package:llamadart/src/core/models/chat/chat_template_result.dart';
 import 'package:llamadart/src/core/models/chat/content_part.dart';
+import 'package:llamadart/src/core/models/inference/tool_choice.dart';
+import 'package:llamadart/src/core/models/tools/tool_definition.dart';
+import 'package:llamadart/src/core/models/tools/tool_param.dart';
 import 'package:llamadart/src/core/template/chat_format.dart';
 import 'package:llamadart/src/core/template/chat_template_engine.dart';
 import 'package:test/test.dart';
@@ -171,6 +176,34 @@ void main() {
       expect(parsed.content, isEmpty);
     });
 
+    test('strips channel controls while preserving public channel text', () {
+      const output =
+          '<|channel>thought\ninternal draft<channel|>'
+          '<|channel>final\nVisible answer.<channel|><channel|>';
+
+      final parsed = ChatTemplateEngine.parse(ChatFormat.gemma4.index, output);
+
+      expect(parsed.reasoningContent, 'internal draft');
+      expect(parsed.content, 'Visible answer.');
+      expect(parsed.content, isNot(contains('<|channel>')));
+      expect(parsed.content, isNot(contains('<channel|>')));
+    });
+
+    test('preserves ordinary raw content whitespace exactly', () {
+      const output = ' \tVisible answer.  \n';
+
+      for (final parseToolCalls in <bool>[true, false]) {
+        final parsed = ChatTemplateEngine.parse(
+          ChatFormat.gemma4.index,
+          output,
+          parseToolCalls: parseToolCalls,
+        );
+
+        expect(parsed.content, output, reason: 'parse tools: $parseToolCalls');
+        expect(parsed.toolCalls, isEmpty);
+      }
+    });
+
     test('parses output after a force-opened thought channel', () {
       final thinkingOnly = ChatTemplateEngine.parse(
         ChatFormat.gemma4.index,
@@ -190,6 +223,25 @@ void main() {
       expect(thinkingOnly.content, isEmpty);
       expect(closed.reasoningContent, equals('Need a short calculation.'));
       expect(closed.content, equals('391'));
+    });
+
+    test('forced thinking stays private before later channel blocks', () {
+      const output =
+          'first draft<channel|>'
+          '<|channel>thought\nsecond draft<channel|>'
+          '<|channel>final\nVisible answer.<channel|>';
+
+      final parsed = ChatTemplateEngine.parse(
+        ChatFormat.gemma4.index,
+        output,
+        thinkingForcedOpen: true,
+      );
+
+      expect(parsed.reasoningContent, 'first draft\nsecond draft');
+      expect(parsed.content, 'Visible answer.');
+      expect(parsed.content, isNot(contains('draft')));
+      expect(parsed.content, isNot(contains('<|channel>')));
+      expect(parsed.content, isNot(contains('<channel|>')));
     });
 
     test('serializes tool responses for Gemma 4 templates', () {
@@ -220,6 +272,304 @@ void main() {
 
       expect(result.format, equals(ChatFormat.gemma4.index));
       expect(result.prompt, contains('get_current_time=2026-04-02T13:10:00'));
+    });
+
+    group('tool-call grammar', () {
+      const toolTemplate =
+          '<|turn>user\n{{ messages[0]["content"] }}<turn|>\n'
+          '{% if add_generation_prompt %}<|turn>model\n{% endif %}';
+
+      final weatherTool = ToolDefinition(
+        name: 'get_weather',
+        description: 'Weather',
+        parameters: [ToolParam.string('location', required: true)],
+        handler: (_) async => null,
+      );
+
+      LlamaChatTemplateResult renderWithChoice(
+        ToolChoice toolChoice, {
+        bool enableThinking = true,
+      }) {
+        return ChatTemplateEngine.render(
+          templateSource: toolTemplate,
+          messages: const [
+            LlamaChatMessage.fromText(role: LlamaChatRole.user, text: 'hi'),
+          ],
+          metadata: const {},
+          tools: [weatherTool],
+          toolChoice: toolChoice,
+          enableThinking: enableThinking,
+        );
+      }
+
+      Map<String, String> rulesOf(String grammar) {
+        final rules = <String, String>{};
+        for (final line in grammar.split('\n')) {
+          final separator = line.indexOf(' ::= ');
+          if (separator == -1) {
+            continue;
+          }
+          rules[line.substring(0, separator).trim()] = line
+              .substring(separator + ' ::= '.length)
+              .trim();
+        }
+        return rules;
+      }
+
+      test('required tool choice renders an eager envelope grammar', () {
+        final result = renderWithChoice(ToolChoice.required);
+
+        expect(result.format, equals(ChatFormat.gemma4.index));
+        expect(result.grammar, isNotNull);
+        expect(result.grammarLazy, isFalse);
+        expect(result.grammarTriggers, isEmpty);
+        expect(
+          renderWithChoice(ToolChoice.required, enableThinking: false).grammar,
+          result.grammar,
+        );
+
+        final rules = rulesOf(result.grammar!);
+        expect(rules, contains('root'));
+
+        // Every root alternative must start by committing to the tool-call
+        // envelope, so no leading prose can be generated before it.
+        for (final alternative in rules['root']!.split('|')) {
+          final head = alternative.trim().split(RegExp(r'\s+')).first;
+          final expansion = head.startsWith('"') ? head : rules[head];
+          expect(
+            expansion,
+            isNotNull,
+            reason: 'root alternative "$alternative" has no rule for $head',
+          );
+          expect(
+            expansion!.startsWith('"<|tool_call>call:'),
+            isTrue,
+            reason: 'root alternative "$alternative" admits leading prose',
+          );
+        }
+      });
+
+      test('required grammar constrains tool names and argument schema', () {
+        final grammar = renderWithChoice(ToolChoice.required).grammar!;
+
+        expect(grammar, contains('"<|tool_call>call:get_weather"'));
+        expect(grammar, contains(r'"<tool_call|>"'));
+        expect(grammar, contains(r'\"location\"'));
+        expect(grammar, isNot(contains('call:other_tool')));
+      });
+
+      test('parser accepts the standard JSON arguments the grammar emits', () {
+        const output =
+            '<|tool_call>call:get_weather{"location": "Seoul"}<tool_call|>';
+
+        final parsed = ChatTemplateEngine.parse(
+          ChatFormat.gemma4.index,
+          output,
+        );
+
+        expect(parsed.content, isEmpty);
+        expect(parsed.toolCalls, hasLength(1));
+        expect(parsed.toolCalls.first.function?.name, equals('get_weather'));
+        expect(
+          jsonDecode(parsed.toolCalls.first.function!.arguments!),
+          equals({'location': 'Seoul'}),
+        );
+      });
+
+      test('parser preserves exact escaped tool and schema names', () {
+        final tool = ToolDefinition(
+          name: r'weather&"alerts\route|primary',
+          description: 'Escaped identity coverage',
+          parameters: [ToolParam.string(r'city&"zone\path', required: true)],
+          handler: (_) async => null,
+        );
+        final arguments = <String, dynamic>{
+          r'city&"zone\path': 'Montréal {north}',
+        };
+        final output =
+            '<|tool_call>call:${tool.name}'
+            '${jsonEncode(arguments)}<tool_call|>';
+
+        final parsed = ChatTemplateEngine.parse(
+          ChatFormat.gemma4.index,
+          output,
+          tools: [tool],
+        );
+
+        expect(parsed.content, isEmpty);
+        expect(parsed.toolCalls, hasLength(1));
+        expect(parsed.toolCalls.single.function?.name, tool.name);
+        expect(
+          jsonDecode(parsed.toolCalls.single.function!.arguments!),
+          arguments,
+        );
+      });
+
+      test('parser preserves an undeclared tool envelope without markup', () {
+        const output =
+            '<|tool_call>call:unknown tool{"city":"Seoul"}<tool_call|>';
+
+        final parsed = ChatTemplateEngine.parse(
+          ChatFormat.gemma4.index,
+          output,
+          tools: [weatherTool],
+        );
+
+        expect(parsed.content, isEmpty);
+        expect(parsed.toolCalls, hasLength(1));
+        expect(parsed.toolCalls.single.function?.name, 'unknown tool');
+        expect(jsonDecode(parsed.toolCalls.single.function!.arguments!), {
+          'city': 'Seoul',
+        });
+      });
+
+      test('malformed tool envelopes fail closed without visible markup', () {
+        const output =
+            'Visible answer.'
+            '<|tool_call>call:get_weather{"location":<tool_call|>';
+
+        final parsed = ChatTemplateEngine.parse(
+          ChatFormat.gemma4.index,
+          output,
+          tools: [weatherTool],
+        );
+
+        expect(parsed.content, 'Visible answer.');
+        expect(parsed.toolCalls, isEmpty);
+        expect(parsed.content, isNot(contains('<|tool_call>')));
+        expect(parsed.content, isNot(contains('<tool_call|>')));
+      });
+
+      test('pure tool-call protocol whitespace stays non-visible', () {
+        const output =
+            ' \n<|tool_call>call:get_weather{"location":"Seoul"}'
+            '<tool_call|>\t ';
+
+        for (final parseToolCalls in <bool>[true, false]) {
+          final parsed = ChatTemplateEngine.parse(
+            ChatFormat.gemma4.index,
+            output,
+            parseToolCalls: parseToolCalls,
+            tools: [weatherTool],
+          );
+
+          expect(parsed.content, isEmpty);
+          expect(parsed.toolCalls, parseToolCalls ? hasLength(1) : isEmpty);
+        }
+      });
+
+      test('partial parser withholds every split control marker prefix', () {
+        const channelMarker = '<|channel>';
+        for (var length = 1; length < channelMarker.length; length++) {
+          final parsed = ChatTemplateEngine.parse(
+            ChatFormat.gemma4.index,
+            'visible${channelMarker.substring(0, length)}',
+            isPartial: true,
+          );
+          expect(
+            parsed.content,
+            'visible',
+            reason: 'channel prefix length $length',
+          );
+          expect(
+            parsed.reasoningContent,
+            isNull,
+            reason: 'channel prefix length $length',
+          );
+        }
+
+        const marker = '<|tool_call>';
+        for (var length = 1; length < marker.length; length++) {
+          final parsed = ChatTemplateEngine.parse(
+            ChatFormat.gemma4.index,
+            'visible${marker.substring(0, length)}',
+            isPartial: true,
+          );
+          expect(parsed.content, 'visible', reason: 'prefix length $length');
+          expect(parsed.toolCalls, isEmpty, reason: 'prefix length $length');
+
+          final afterThinking = ChatTemplateEngine.parse(
+            ChatFormat.gemma4.index,
+            'reasoning<channel|>${marker.substring(0, length)}',
+            isPartial: true,
+            thinkingForcedOpen: true,
+            tools: [weatherTool],
+          );
+          expect(
+            afterThinking.reasoningContent,
+            'reasoning',
+            reason: 'thinking prefix length $length',
+          );
+          expect(
+            afterThinking.content,
+            isEmpty,
+            reason: 'thinking prefix length $length',
+          );
+        }
+
+        const completeEnvelope =
+            '<|tool_call>call:get_weather{"location":"Seoul"}<tool_call|>';
+        for (var length = 1; length <= completeEnvelope.length; length++) {
+          final parsed = ChatTemplateEngine.parse(
+            ChatFormat.gemma4.index,
+            'reasoning<channel|>${completeEnvelope.substring(0, length)}',
+            isPartial: true,
+            thinkingForcedOpen: true,
+            tools: [weatherTool],
+          );
+          expect(
+            parsed.reasoningContent,
+            'reasoning',
+            reason: 'envelope prefix length $length',
+          );
+          expect(
+            parsed.content,
+            isEmpty,
+            reason: 'envelope prefix length $length',
+          );
+        }
+
+        final finalParsed = ChatTemplateEngine.parse(
+          ChatFormat.gemma4.index,
+          'visible<|tool_',
+        );
+        expect(finalParsed.content, 'visible');
+
+        final contentOnly = ChatTemplateEngine.parse(
+          ChatFormat.gemma4.index,
+          'visible$completeEnvelope',
+          parseToolCalls: false,
+        );
+        expect(contentOnly.content, 'visible');
+        expect(contentOnly.toolCalls, isEmpty);
+      });
+
+      test('required grammar rejects duplicate tool identities', () {
+        final duplicate = ToolDefinition(
+          name: weatherTool.name,
+          description: 'Duplicate',
+          parameters: const [],
+          handler: (_) async => null,
+        );
+
+        expect(
+          () => ChatTemplateEngine.render(
+            templateSource: toolTemplate,
+            messages: const [
+              LlamaChatMessage.fromText(role: LlamaChatRole.user, text: 'hi'),
+            ],
+            metadata: const {},
+            tools: [weatherTool, duplicate],
+            toolChoice: ToolChoice.required,
+          ),
+          throwsA(isA<LlamaUnsupportedException>()),
+        );
+      });
+
+      test('auto and none tool choice stay unconstrained', () {
+        expect(renderWithChoice(ToolChoice.auto).grammar, isNull);
+        expect(renderWithChoice(ToolChoice.none).grammar, isNull);
+      });
     });
   });
 }

--- a/test/unit/core/template/handlers/gemma4_handler_test.dart
+++ b/test/unit/core/template/handlers/gemma4_handler_test.dart
@@ -189,6 +189,15 @@ void main() {
       expect(parsed.content, isNot(contains('<channel|>')));
     });
 
+    test('preserves whitespace inside public channel content', () {
+      const output = '<|channel>final\n \tVisible answer.  \n<channel|>';
+
+      final parsed = ChatTemplateEngine.parse(ChatFormat.gemma4.index, output);
+
+      expect(parsed.content, ' \tVisible answer.  \n');
+      expect(parsed.reasoningContent, isNull);
+    });
+
     test('preserves ordinary raw content whitespace exactly', () {
       const output = ' \tVisible answer.  \n';
 

--- a/tool/gguf_chat_features_smoke.dart
+++ b/tool/gguf_chat_features_smoke.dart
@@ -75,6 +75,13 @@ Future<void> main(List<String> args) async {
     if (mmprojPath != null) {
       await engine.loadMultimodalProjector(mmprojPath);
     }
+    final backendName = await engine.getBackendName();
+    // Emitted before every semantic assertion so a failing run still records
+    // which backend actually served it.
+    print(
+      'BACKEND gguf_chat_features '
+      '${jsonEncode({'backendName': backendName, 'requestedBackend': backend.name})}',
+    );
 
     if (audioFixture != null) {
       final audioChat = await _runScenario(
@@ -93,7 +100,7 @@ Future<void> main(List<String> args) async {
         enableThinking: false,
         maxTokens: 64,
       );
-      verifyExactAudioChatAnswer(
+      _verifyExactAudioChatAnswer(
         scenarioName: audioChat.name,
         actualText: audioChat.content,
         expectedText: audioExpectedText!,
@@ -101,7 +108,7 @@ Future<void> main(List<String> args) async {
       _verifyNoThinking(audioChat);
 
       final result = {
-        'backendName': await engine.getBackendName(),
+        'backendName': backendName,
         'requestedBackend': backend.name,
         'variant': 'audioAnswer',
         'audioInput': audioFixture.toJson(),
@@ -274,7 +281,7 @@ Future<void> main(List<String> args) async {
       _verifyNoThinking(multimodal);
     }
     final result = {
-      'backendName': await engine.getBackendName(),
+      'backendName': backendName,
       'requestedBackend': backend.name,
       'format': template.format,
       'noThinking': noThinking.toJson(),
@@ -365,6 +372,18 @@ void _verifyHasOutput(_ScenarioResult result) {
   }
 }
 
+void _verifyExactAudioChatAnswer({
+  required String scenarioName,
+  required String actualText,
+  required String expectedText,
+}) {
+  final expected = normalizeAudioChatAnswer(expectedText);
+  final actual = normalizeAudioChatAnswer(actualText);
+  if (actual != expected) {
+    throw StateError('$scenarioName answer did not match the expected text.');
+  }
+}
+
 void _verifyNoThinking(_ScenarioResult result) {
   _verifyHasOutput(result);
   if (result.thinking.trim().isNotEmpty) {
@@ -409,12 +428,13 @@ void _verifyToolCall(_ScenarioResult result) {
   if (result.finishReason != 'tool_calls') {
     throw StateError(
       '${result.name} scenario finished with ${result.finishReason}; '
-      'content=${_tail(result.content)}',
+      'contentLength=${result.content.length}',
     );
   }
   if (result.content.trim().isNotEmpty) {
     throw StateError(
-      '${result.name} scenario leaked content: ${_tail(result.content)}',
+      '${result.name} scenario leaked ${result.content.length} content '
+      'characters.',
     );
   }
   if (result.toolCalls.length != 1) {
@@ -425,21 +445,24 @@ void _verifyToolCall(_ScenarioResult result) {
 
   final function = result.toolCalls.first['function'];
   if (function is! Map || function['name'] != 'get_weather') {
-    throw StateError(
-      '${result.name} scenario did not call get_weather: '
-      '${result.toolCalls.first}',
-    );
+    throw StateError('${result.name} scenario did not call get_weather.');
   }
   final arguments = function['arguments'];
   if (arguments is! String) {
+    throw StateError('${result.name} tool call has no string arguments.');
+  }
+  Object? decoded;
+  try {
+    decoded = jsonDecode(arguments);
+  } catch (_) {
     throw StateError(
-      '${result.name} tool call has no string arguments: $function',
+      '${result.name} tool call has invalid JSON arguments '
+      '(${arguments.length} characters).',
     );
   }
-  final decoded = jsonDecode(arguments);
   final location = decoded is Map ? decoded['location'] : null;
   if (location is! String || !location.toLowerCase().contains('seoul')) {
-    throw StateError('${result.name} unexpected tool arguments: $arguments');
+    throw StateError('${result.name} tool arguments did not contain Seoul.');
   }
 }
 
@@ -495,18 +518,8 @@ class _ScenarioResult {
     'chunks': chunks,
     'finishReason': finishReason,
     'contentLength': content.length,
-    'contentTail': _tail(content),
     'thinkingLength': thinking.length,
-    'thinkingTail': _tail(thinking),
     'thinkingObserved': thinking.trim().isNotEmpty,
     'toolCallCount': toolCalls.length,
-    'toolCalls': toolCalls,
   };
-}
-
-String _tail(String value) {
-  if (value.length <= 240) {
-    return value;
-  }
-  return value.substring(value.length - 240);
 }


### PR DESCRIPTION
## Summary

- add a required-only eager Gemma 4 grammar that permits exactly one declared, schema-valid tool-call envelope from the first generated token
- keep thinking and split control markers out of visible content while preserving ordinary assistant whitespace
- make the chat example execute only safe built-in host tools, append canonical tool-result history, and perform one bounded final continuation
- remove generated content, private reasoning, raw arguments, and exception details from smoke/debug/error output

## Root cause

Gemma 4 rendering did not apply the upstream-style eager grammar for `ToolChoice.required`. After a thinking-budget closure, decoding could therefore emit prose or control text before the required tool envelope. The streaming parser also needed Gemma-specific split-marker withholding and final reconciliation so partial channel/tool markers could never enter the visible stream.

Separately, the example app treated user-entered tools as schema declarations only. It displayed parsed tool calls but did not invoke a host handler, record a tool-role result, or ask the model for a final continuation.

## Production-readiness scope

- `ToolChoice.required` is constrained to one exact declared Gemma 4 tool call; `auto` and `none` remain unconstrained.
- Thinking-enabled, disabled, budgeted, malformed, and character-split paths keep private thinking/control data out of visible content.
- Exact escaped tool/schema identities and duplicate/collision failures are covered by compiled grammar checks.
- The example app executes only its deterministic simulated `getWeather` implementation. Other declared names return an explicit unsupported result; declarations never authorize arbitrary local execution.
- Tool execution is bounded to one batch and one continuation, guarded by context fit and conversation-generation identity.
- Assistant/tool history is canonical: UI mirroring does not duplicate tool results in the model prompt.

## Verification

- [x] `dart test test/unit/core/template/handlers/gemma4_handler_test.dart test/unit/core/engine/chat_completion_stream_parser_test.dart`
- [x] compiled specialized GBNF validation with the repository validator: 14 passed
- [x] full template parity: detection 74 passed; diagnostics 78 passed; template unit 478 passed; upstream llama.cpp suites 2 passed; compiled grammars 14 passed
- [x] full root VM suite: 1,811 passed, 3 skipped
- [x] full root Chrome suite: 914 passed
- [x] chat example focused continuation/declaration/session suite: 94 passed
- [x] full chat example suite: 355 passed
- [x] root and chat example analysis: no issues
- [x] changed-file formatting and `git diff --check`: clean
- [x] post-final-audit whitespace regression rerun on VM and Chrome: 2 passed

## Real-model evidence

Pinned Gemma 4 E2B IT GGUF revision `90f9618340396838ee7ff5b0ba2da27da62953d3`, SHA-256 `0a2fac16f388b4839f075dedb681357aec3e73a96bd66b413e462b6853550c99`:

- physical Apple M4 Max, actual Metal backend: deterministic structured tool/thinking semantic smoke passed
- physical Apple M4 Max, explicit actual CPU backend: the same smoke passed
- real Gemma 4 LiteRT-LM GPU app path: exactly one built-in `getWeather` execution, one appended tool result, and a non-empty clean final continuation

Generated text and private reasoning remain local and are intentionally omitted. A macOS real-app GGUF continuation harness reached the app bundle but hit the existing five-second llama.cpp worker initialization timeout, so this PR does not claim real-app GGUF continuation evidence from that harness; the direct GGUF semantic smoke and backend-neutral app regressions cover that path separately.

## Review notes

Personal Claude Code performed the primary implementation/reasoning pass. Fresh writable Codex CLI `gpt-5.6-sol` xhigh audits actively remediated grammar escaping/collisions, marker withholding, output privacy, bounded host execution, stale-conversation/context guards, history duplication, and the final whitespace-preservation regression. The final committed diff and checks were independently inspected/rerun afterward.

Copilot's only inline finding identified trimming inside public `final` channel bodies. Commit `83c6e27834d4c2f02a9cbdbf20c3ddd41d6d8721` added a RED regression, preserved the exact channel-body whitespace, reran focused/parity/analyze/real-model gates, and received a fresh current-head Copilot review with no new comments. Exact-head CI and the chat preview are green; unresolved review threads are zero.

## Existing issue check

Focused searches for the Gemma 4 thinking-budget leak and chat-app host-tool continuation found no dedicated open issue. This PR directly remediates the physical-device RC blocker.
