### PR TITLE
fix: apply native ASR chat template

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 ## Unreleased
 
+* Fixed native Qwen3-ASR transcription by applying the model chat template to
+  audio turns, while preserving the validated raw-prompt Web bridge contract.
+  Empty ASR output now fails explicitly instead of reporting an empty result.
+
 * Fixed Gemma 4 thinking-budget output so split channel controls and tool-call
   envelopes stay out of visible assistant content while preserving ordinary
   whitespace. The chat example now also validates custom tool declarations,

--- a/example/chat_app/test/chat_input_test.dart
+++ b/example/chat_app/test/chat_input_test.dart
@@ -1221,6 +1221,10 @@ void main() {
 
     await tester.tap(find.text('Stop & transcribe'));
     await tester.pumpAndSettle();
+    for (var turn = 0; turn < 10 && recorder.deletedPaths.isEmpty; turn++) {
+      await tester.runAsync(() => Future<void>.delayed(Duration.zero));
+      await tester.pump();
+    }
 
     expect(find.byKey(const ValueKey('audio_recording_status')), findsNothing);
     expect(find.byTooltip('Record for transcription'), findsOneWidget);

--- a/lib/src/core/speech/speech_platform_stub.dart
+++ b/lib/src/core/speech/speech_platform_stub.dart
@@ -1,6 +1,12 @@
 /// Whether this platform requires a backend runtime opt-in for prompt ASR.
 bool get speechToTextRequiresBackendCapability => false;
 
+/// Whether prompt-adapted audio is rendered through the model chat template.
+///
+/// Native Qwen3-ASR only emits a transcript when the audio turn is wrapped by
+/// the model's own chat template, so raw prompt generation returns nothing.
+bool get speechToTextUsesChatTemplate => true;
+
 /// Whether local filesystem speech input is available on this platform.
 bool get speechToTextSupportsFileInput => true;
 

--- a/lib/src/core/speech/speech_platform_web.dart
+++ b/lib/src/core/speech/speech_platform_web.dart
@@ -1,6 +1,9 @@
 /// Web requires an explicitly validated bridge runtime.
 bool get speechToTextRequiresBackendCapability => true;
 
+/// The validated Web bridge contract takes the raw prompt plus audio bytes.
+bool get speechToTextUsesChatTemplate => false;
+
 /// Browsers do not expose local filesystem paths to the runtime.
 bool get speechToTextSupportsFileInput => false;
 

--- a/lib/src/core/speech/speech_to_text.dart
+++ b/lib/src/core/speech/speech_to_text.dart
@@ -458,6 +458,9 @@ class SpeechToTextTask {
     _cancelled = true;
     try {
       _onCancel();
+    } catch (_) {
+      // Cancellation is authoritative; the task runner still owns cleanup and
+      // terminal completion when a backend cancellation hook fails.
     } finally {
       _cancelTokenStream?.call();
     }

--- a/lib/src/core/speech/speech_to_text.dart
+++ b/lib/src/core/speech/speech_to_text.dart
@@ -5,6 +5,8 @@ import '../../backends/backend.dart';
 import '../../backends/litert_lm/litert_lm_asr_types.dart';
 import '../engine/engine.dart';
 import '../exceptions.dart';
+import '../models/chat/chat_message.dart';
+import '../models/chat/chat_role.dart';
 import '../models/chat/content_part.dart';
 import '../models/inference/generation_params.dart';
 import 'litert_lm_speech_to_text_driver.dart';
@@ -426,6 +428,7 @@ class SpeechToTextTask {
   final StreamController<SpeechToTextEvent> _eventsController;
   final Completer<SpeechToTextCompletion> _doneCompleter;
   final void Function() _onCancel;
+  void Function()? _cancelTokenStream;
   bool _cancelled = false;
 
   SpeechToTextTask._({required void Function() onCancel})
@@ -453,7 +456,11 @@ class SpeechToTextTask {
       return;
     }
     _cancelled = true;
-    _onCancel();
+    try {
+      _onCancel();
+    } finally {
+      _cancelTokenStream?.call();
+    }
   }
 }
 
@@ -765,7 +772,7 @@ class SpeechToTextEngine {
         // Preserve the first recognition failure.
       }
       if (task.isCancellationRequested) {
-        await _completeCancelled(task);
+        _completeCancelled(task);
       } else {
         final speechError = _speechError(error);
         task._eventsController.addError(speechError, stackTrace);
@@ -904,43 +911,55 @@ class SpeechToTextEngine {
   ) async {
     try {
       if (task.isCancellationRequested) {
-        await _completeCancelled(task);
+        _completeCancelled(task);
         return;
       }
 
-      final prompt = _promptFor(request);
       final output = StringBuffer();
-      await for (final text in _engine!.generate(
-        prompt,
-        parts: <LlamaContentPart>[_contentFor(request.audio)],
-        params: GenerationParams(
-          maxTokens: request.maxOutputTokens,
-          temp: 0,
-          topK: 1,
-          topP: 1,
-          penalty: 1,
-          seed: 1,
-          streamBatchTokenThreshold: 1,
-        ),
-      )) {
-        if (task.isCancellationRequested) {
-          break;
+      final tokenIterator = StreamIterator<String>(
+        _promptAdapterTokens(request),
+      );
+      Future<void>? tokenStreamCancellation;
+      void cancelTokenStream() {
+        if (tokenStreamCancellation != null) {
+          return;
         }
-        output.write(text);
+        final cancellation = tokenIterator.cancel();
+        tokenStreamCancellation = cancellation;
+        unawaited(cancellation.catchError((Object _, StackTrace _) {}));
+      }
+
+      task._cancelTokenStream = cancelTokenStream;
+      try {
+        while (await tokenIterator.moveNext()) {
+          if (task.isCancellationRequested) {
+            break;
+          }
+          output.write(tokenIterator.current);
+        }
+      } finally {
+        if (identical(task._cancelTokenStream, cancelTokenStream)) {
+          task._cancelTokenStream = null;
+        }
+        cancelTokenStream();
+        await tokenStreamCancellation;
       }
 
       if (task.isCancellationRequested) {
-        await _completeCancelled(task);
+        _completeCancelled(task);
         return;
       }
 
       final normalized = _normalizeTranscript(output.toString());
+      if (normalized.text.isEmpty) {
+        throw LlamaSpeechException(
+          'Speech recognition produced an empty transcript.',
+        );
+      }
       final result = SpeechToTextResult(
         text: normalized.text,
         language: normalized.language,
-        segments: normalized.text.isEmpty
-            ? const <TranscriptSegment>[]
-            : <TranscriptSegment>[TranscriptSegment(text: normalized.text)],
+        segments: <TranscriptSegment>[TranscriptSegment(text: normalized.text)],
         sourceFormat: request.audio.format,
       );
       task._eventsController.add(SpeechToTextFinalEvent(result));
@@ -948,7 +967,7 @@ class SpeechToTextEngine {
       task._doneCompleter.complete(SpeechToTextCompletion.completed(result));
     } catch (error, stackTrace) {
       if (task.isCancellationRequested) {
-        await _completeCancelled(task);
+        _completeCancelled(task);
         return;
       }
       final speechError = _speechError(error);
@@ -960,13 +979,59 @@ class SpeechToTextEngine {
     }
   }
 
-  Future<void> _completeCancelled(SpeechToTextTask task) async {
+  void _completeCancelled(SpeechToTextTask task) {
     if (!task._eventsController.isClosed) {
       unawaited(task._eventsController.close());
     }
     if (!task._doneCompleter.isCompleted) {
       task._doneCompleter.complete(const SpeechToTextCompletion.cancelled());
     }
+  }
+
+  /// Streams transcript text for the prompt-adapted profile.
+  ///
+  /// Native Qwen3-ASR needs the audio turn wrapped by the model chat template,
+  /// so it goes through [LlamaEngine.create]. The Web bridge speech contract is
+  /// validated against raw prompt generation with bytes-only audio parts.
+  Stream<String> _promptAdapterTokens(SpeechToTextRequest request) {
+    final engine = _engine!;
+    final params = GenerationParams(
+      maxTokens: request.maxOutputTokens,
+      temp: 0,
+      topK: 1,
+      topP: 1,
+      penalty: 1,
+      seed: 1,
+      streamBatchTokenThreshold: 1,
+    );
+    if (!speechToTextUsesChatTemplate) {
+      return engine.generate(
+        _promptFor(request),
+        parts: <LlamaContentPart>[_contentFor(request.audio)],
+        params: params,
+      );
+    }
+    return engine
+        .create(
+          <LlamaChatMessage>[
+            LlamaChatMessage.withContent(
+              role: LlamaChatRole.user,
+              content: <LlamaContentPart>[
+                LlamaTextContent(_promptFor(request)),
+                _contentFor(request.audio),
+              ],
+            ),
+          ],
+          params: params,
+          enableThinking: false,
+        )
+        .expand((chunk) {
+          if (chunk.choices.isEmpty) {
+            return const <String>[];
+          }
+          final text = chunk.choices.first.delta.content;
+          return text == null ? const <String>[] : <String>[text];
+        });
   }
 
   String _promptFor(SpeechToTextRequest request) {

--- a/lib/src/core/speech/speech_to_text.dart
+++ b/lib/src/core/speech/speech_to_text.dart
@@ -930,6 +930,8 @@ class SpeechToTextEngine {
       }
 
       task._cancelTokenStream = cancelTokenStream;
+      Object? tokenStreamError;
+      StackTrace? tokenStreamStackTrace;
       try {
         while (await tokenIterator.moveNext()) {
           if (task.isCancellationRequested) {
@@ -937,12 +939,23 @@ class SpeechToTextEngine {
           }
           output.write(tokenIterator.current);
         }
+      } catch (error, stackTrace) {
+        tokenStreamError = error;
+        tokenStreamStackTrace = stackTrace;
       } finally {
         if (identical(task._cancelTokenStream, cancelTokenStream)) {
           task._cancelTokenStream = null;
         }
-        cancelTokenStream();
-        await tokenStreamCancellation;
+        try {
+          cancelTokenStream();
+          await tokenStreamCancellation;
+        } catch (error, stackTrace) {
+          tokenStreamError ??= error;
+          tokenStreamStackTrace ??= stackTrace;
+        }
+      }
+      if (tokenStreamError != null) {
+        Error.throwWithStackTrace(tokenStreamError, tokenStreamStackTrace!);
       }
 
       if (task.isCancellationRequested) {

--- a/lib/src/core/speech/speech_to_text.dart
+++ b/lib/src/core/speech/speech_to_text.dart
@@ -916,32 +916,61 @@ class SpeechToTextEngine {
       }
 
       final output = StringBuffer();
-      final tokenIterator = StreamIterator<String>(
-        _promptAdapterTokens(request),
-      );
+      final tokenStreamDone = Completer<void>();
+      StreamSubscription<String>? tokenSubscription;
       Future<void>? tokenStreamCancellation;
       void cancelTokenStream() {
         if (tokenStreamCancellation != null) {
           return;
         }
-        final cancellation = tokenIterator.cancel();
+        final subscription = tokenSubscription;
+        if (subscription == null) {
+          return;
+        }
+        late final Future<void> cancellation;
+        try {
+          cancellation = subscription.cancel();
+        } catch (error, stackTrace) {
+          cancellation = Future<void>.error(error, stackTrace);
+        }
         tokenStreamCancellation = cancellation;
         unawaited(cancellation.catchError((Object _, StackTrace _) {}));
+        if (!tokenStreamDone.isCompleted) {
+          tokenStreamDone.complete();
+        }
       }
 
-      task._cancelTokenStream = cancelTokenStream;
       Object? tokenStreamError;
       StackTrace? tokenStreamStackTrace;
       try {
-        while (await tokenIterator.moveNext()) {
-          if (task.isCancellationRequested) {
-            break;
-          }
-          output.write(tokenIterator.current);
+        tokenSubscription = _promptAdapterTokens(request).listen(
+          (token) {
+            if (!task.isCancellationRequested && tokenStreamError == null) {
+              output.write(token);
+            }
+          },
+          onError: (Object error, StackTrace stackTrace) {
+            tokenStreamError ??= error;
+            tokenStreamStackTrace ??= stackTrace;
+            if (!tokenStreamDone.isCompleted) {
+              tokenStreamDone.complete();
+            }
+          },
+          onDone: () {
+            if (!tokenStreamDone.isCompleted) {
+              tokenStreamDone.complete();
+            }
+          },
+          cancelOnError: false,
+        );
+        task._cancelTokenStream = cancelTokenStream;
+        if (task.isCancellationRequested) {
+          cancelTokenStream();
         }
+        await tokenStreamDone.future;
       } catch (error, stackTrace) {
-        tokenStreamError = error;
-        tokenStreamStackTrace = stackTrace;
+        tokenStreamError ??= error;
+        tokenStreamStackTrace ??= stackTrace;
       } finally {
         if (identical(task._cancelTokenStream, cancelTokenStream)) {
           task._cancelTokenStream = null;
@@ -954,8 +983,9 @@ class SpeechToTextEngine {
           tokenStreamStackTrace ??= stackTrace;
         }
       }
-      if (tokenStreamError != null) {
-        Error.throwWithStackTrace(tokenStreamError, tokenStreamStackTrace!);
+      final error = tokenStreamError;
+      if (error != null) {
+        Error.throwWithStackTrace(error, tokenStreamStackTrace!);
       }
 
       if (task.isCancellationRequested) {

--- a/test/unit/core/speech/speech_platform_stub_test.dart
+++ b/test/unit/core/speech/speech_platform_stub_test.dart
@@ -7,6 +7,7 @@ import 'package:test/test.dart';
 void main() {
   test('native platform accepts file input and unencoded audio', () {
     expect(speechToTextRequiresBackendCapability, isFalse);
+    expect(speechToTextUsesChatTemplate, isTrue);
     expect(speechToTextSupportsFileInput, isTrue);
     expect(speechToTextRequiresEncodedAudioFormat, isFalse);
     expect(

--- a/test/unit/core/speech/speech_platform_web_test.dart
+++ b/test/unit/core/speech/speech_platform_web_test.dart
@@ -7,6 +7,7 @@ import 'package:test/test.dart';
 void main() {
   test('web platform exposes byte-only WAV prompt speech support', () {
     expect(speechToTextRequiresBackendCapability, isTrue);
+    expect(speechToTextUsesChatTemplate, isFalse);
     expect(speechToTextSupportsFileInput, isFalse);
     expect(speechToTextRequiresEncodedAudioFormat, isTrue);
     expect(speechToTextEncodedAudioFormats, equals(<String>{'wav'}));

--- a/test/unit/core/speech/speech_to_text_test.dart
+++ b/test/unit/core/speech/speech_to_text_test.dart
@@ -378,6 +378,59 @@ void main() {
       expect((await retry.done).result?.text, 'transcript');
     });
 
+    test('awaits stream cleanup before releasing the backend lease', () async {
+      await _loadSpeechModel(llamaEngine);
+      final generationRelease = Completer<void>();
+      final cleanupStarted = Completer<void>();
+      final cleanupRelease = Completer<void>();
+      Stream<List<int>> generationStream() async* {
+        try {
+          await generationRelease.future;
+        } finally {
+          cleanupStarted.complete();
+          await cleanupRelease.future;
+        }
+      }
+
+      backend
+        ..generationStream = generationStream()
+        ..onCancelGeneration = () => generationRelease.complete();
+
+      final task = await speechEngine.transcribe(
+        const SpeechToTextRequest(audio: SpeechAudioFileInput('/tmp/test.wav')),
+      );
+      await backend.generationStarted.future;
+
+      task.cancel();
+      await cleanupStarted.future;
+
+      var taskCompleted = false;
+      unawaited(task.done.whenComplete(() => taskCompleted = true));
+      await Future<void>.delayed(Duration.zero);
+      expect(taskCompleted, isFalse);
+      await expectLater(
+        speechEngine.transcribe(
+          const SpeechToTextRequest(
+            audio: SpeechAudioFileInput('/tmp/retry.wav'),
+          ),
+        ),
+        throwsA(isA<LlamaStateException>()),
+      );
+
+      cleanupRelease.complete();
+      expect((await task.done).state, SpeechToTextCompletionState.cancelled);
+
+      backend
+        ..generationStream = null
+        ..onCancelGeneration = null;
+      final retry = await speechEngine.transcribe(
+        const SpeechToTextRequest(
+          audio: SpeechAudioFileInput('/tmp/retry.wav'),
+        ),
+      );
+      expect((await retry.done).result?.text, 'transcript');
+    });
+
     test('allows only one active task per wrapper', () async {
       backend.blockGeneration = true;
       await _loadSpeechModel(llamaEngine);
@@ -544,6 +597,8 @@ class _SpeechBackend implements LlamaBackend {
   String generationText = 'transcript';
   List<String>? generationChunks;
   Object? generationError;
+  Stream<List<int>>? generationStream;
+  void Function()? onCancelGeneration;
   bool blockGeneration = false;
   bool blockAudioProbe = false;
   bool blockMetadata = false;
@@ -639,13 +694,17 @@ class _SpeechBackend implements LlamaBackend {
     String prompt,
     GenerationParams params, {
     List<LlamaContentPart>? parts,
-  }) async* {
+  }) {
     lastGenerationPrompt = prompt;
     lastGenerationParams = params;
     lastParts = parts;
     if (!generationStarted.isCompleted) {
       generationStarted.complete();
     }
+    return generationStream ?? _defaultGenerationStream();
+  }
+
+  Stream<List<int>> _defaultGenerationStream() async* {
     if (blockGeneration) {
       await _generationRelease.future;
     }
@@ -680,6 +739,7 @@ class _SpeechBackend implements LlamaBackend {
   @override
   void cancelGeneration() {
     cancelGenerationCalls += 1;
+    onCancelGeneration?.call();
   }
 
   @override

--- a/test/unit/core/speech/speech_to_text_test.dart
+++ b/test/unit/core/speech/speech_to_text_test.dart
@@ -109,16 +109,46 @@ void main() {
         expect(finalEvent.result.segments.single.text, finalEvent.result.text);
         expect(completion.state, SpeechToTextCompletionState.completed);
         expect(completion.result, same(finalEvent.result));
-        expect(backend.lastParts, hasLength(1));
-        expect(backend.lastParts!.single, isA<LlamaAudioContent>());
+        expect(backend.lastParts, hasLength(2));
+        expect(backend.lastParts!.first, isA<LlamaTextContent>());
         expect(
-          (backend.lastParts!.single as LlamaAudioContent).path,
+          (backend.lastParts!.first as LlamaTextContent).text,
+          'Transcribe this audio accurately. Context: llamadart',
+        );
+        expect(backend.lastParts![1], isA<LlamaAudioContent>());
+        expect(
+          (backend.lastParts![1] as LlamaAudioContent).path,
           '/tmp/test.wav',
         );
         expect(backend.lastGenerationPrompt, contains('Context: llamadart'));
         expect(backend.lastGenerationParams?.temp, 0);
         expect(backend.lastGenerationParams?.topK, 1);
+        expect(backend.lastGenerationParams?.topP, 1);
+        expect(backend.lastGenerationParams?.penalty, 1);
+        expect(backend.lastGenerationParams?.seed, 1);
         expect(backend.lastGenerationParams?.maxTokens, 64);
+        expect(backend.lastGenerationParams?.streamBatchTokenThreshold, 1);
+      },
+    );
+
+    test(
+      'renders the native audio turn with the model chat template',
+      () async {
+        await _loadSpeechModel(llamaEngine);
+
+        final task = await speechEngine.transcribe(
+          const SpeechToTextRequest(
+            audio: SpeechAudioFileInput('/tmp/test.wav'),
+          ),
+        );
+        await task.done;
+
+        expect(backend.lastGenerationPrompt, startsWith('user: '));
+        expect(backend.lastGenerationPrompt, endsWith('assistant: '));
+        expect(
+          backend.lastGenerationPrompt,
+          isNot('Transcribe this audio accurately.'),
+        );
       },
     );
 
@@ -135,8 +165,41 @@ void main() {
 
       expect(result.text, 'Byte-backed transcript.');
       expect(result.language, isNull);
-      final audio = backend.lastParts!.single as LlamaAudioContent;
+      final audio = backend.lastParts![1] as LlamaAudioContent;
       expect(audio.bytes, <int>[1, 2, 3]);
+    });
+
+    test('reports an empty transcript as a typed failure', () async {
+      backend.generationText = ' <asr_text> ';
+      await _loadSpeechModel(llamaEngine);
+
+      final task = await speechEngine.transcribe(
+        const SpeechToTextRequest(audio: SpeechAudioFileInput('/tmp/test.wav')),
+      );
+      final streamError = Completer<Object>();
+      task.events.listen(
+        (_) {},
+        onError: (Object error) => streamError.complete(error),
+      );
+      final completion = await task.done;
+
+      expect(
+        await streamError.future,
+        isA<LlamaSpeechException>().having(
+          (error) => error.message,
+          'message',
+          contains('empty transcript'),
+        ),
+      );
+      expect(completion.state, SpeechToTextCompletionState.failed);
+      expect(completion.result, isNull);
+      expect(completion.error, isA<LlamaSpeechException>());
+
+      backend.generationText = 'Recovered transcript.';
+      final retry = await speechEngine.transcribe(
+        const SpeechToTextRequest(audio: SpeechAudioFileInput('/tmp/test.wav')),
+      );
+      expect((await retry.done).result?.text, 'Recovered transcript.');
     });
 
     test('rejects unsupported encoded file formats before inference', () async {
@@ -218,7 +281,7 @@ void main() {
       );
 
       expect((await task.done).result?.text, 'Transcript.');
-      final audio = backend.lastParts!.single as LlamaAudioContent;
+      final audio = backend.lastParts![1] as LlamaAudioContent;
       expect(audio.path, '/tmp/content-addressed-audio');
     });
 
@@ -290,6 +353,29 @@ void main() {
       expect(await task.events.toList(), isEmpty);
       expect((await task.done).state, SpeechToTextCompletionState.cancelled);
       expect(backend.cancelGenerationCalls, 1);
+    });
+
+    test('cancels while the native chat template is being prepared', () async {
+      await _loadSpeechModel(llamaEngine);
+      backend.blockMetadata = true;
+
+      final task = await speechEngine.transcribe(
+        const SpeechToTextRequest(audio: SpeechAudioFileInput('/tmp/test.wav')),
+      );
+      await backend.metadataStarted.future;
+
+      task.cancel();
+      backend.releaseMetadata();
+
+      expect(await task.events.toList(), isEmpty);
+      expect((await task.done).state, SpeechToTextCompletionState.cancelled);
+      expect(backend.generationStarted.isCompleted, isFalse);
+      expect(backend.cancelGenerationCalls, 1);
+
+      final retry = await speechEngine.transcribe(
+        const SpeechToTextRequest(audio: SpeechAudioFileInput('/tmp/test.wav')),
+      );
+      expect((await retry.done).result?.text, 'transcript');
     });
 
     test('allows only one active task per wrapper', () async {
@@ -460,8 +546,11 @@ class _SpeechBackend implements LlamaBackend {
   Object? generationError;
   bool blockGeneration = false;
   bool blockAudioProbe = false;
+  bool blockMetadata = false;
   Completer<void> audioProbeStarted = Completer<void>();
   final Completer<void> _audioProbeRelease = Completer<void>();
+  Completer<void> metadataStarted = Completer<void>();
+  final Completer<void> _metadataRelease = Completer<void>();
   Completer<void> generationStarted = Completer<void>();
   final Completer<void> _generationRelease = Completer<void>();
   int cancelGenerationCalls = 0;
@@ -518,13 +607,21 @@ class _SpeechBackend implements LlamaBackend {
   Future<bool> supportsVision(int mmContextHandle) async => false;
 
   @override
-  Future<Map<String, String>> modelMetadata(int modelHandle) async => const {
-    'llm.context_length': '4096',
-    'tokenizer.chat_template':
-        '{% for message in messages %}{{ message["role"] + ": " + '
-        'message["content"] }}{% endfor %}{% if add_generation_prompt %}'
-        '{{ "assistant: " }}{% endif %}',
-  };
+  Future<Map<String, String>> modelMetadata(int modelHandle) async {
+    if (!metadataStarted.isCompleted) {
+      metadataStarted.complete();
+    }
+    if (blockMetadata) {
+      await _metadataRelease.future;
+    }
+    return const {
+      'llm.context_length': '4096',
+      'tokenizer.chat_template':
+          '{% for message in messages %}{{ message["role"] + ": " + '
+          'message["content"] }}{% endfor %}{% if add_generation_prompt %}'
+          '{{ "assistant: " }}{% endif %}',
+    };
+  }
 
   @override
   Future<String> applyChatTemplate(
@@ -571,6 +668,12 @@ class _SpeechBackend implements LlamaBackend {
   void releaseGeneration() {
     if (!_generationRelease.isCompleted) {
       _generationRelease.complete();
+    }
+  }
+
+  void releaseMetadata() {
+    if (!_metadataRelease.isCompleted) {
+      _metadataRelease.complete();
     }
   }
 

--- a/test/unit/core/speech/speech_to_text_test.dart
+++ b/test/unit/core/speech/speech_to_text_test.dart
@@ -546,6 +546,64 @@ void main() {
       expect(completion.error, isA<LlamaUnsupportedException>());
     });
 
+    test(
+      'preserves the generation failure when stream cleanup also fails',
+      () async {
+        await _loadSpeechModel(llamaEngine);
+        late final StreamController<LlamaCompletionChunk> generation;
+        generation = StreamController<LlamaCompletionChunk>(
+          onListen: () {
+            scheduleMicrotask(() {
+              generation.addError(
+                LlamaUnsupportedException('first generation failure'),
+              );
+            });
+          },
+          onCancel: () => Future<void>.error(
+            StateError('secondary stream cleanup failure'),
+          ),
+        );
+        llamaEngine.chatCompletionStream = generation.stream;
+
+        final task = await speechEngine.transcribe(
+          const SpeechToTextRequest(
+            audio: SpeechAudioFileInput('/tmp/test.wav'),
+          ),
+        );
+        final streamError = Completer<Object>();
+        task.events.listen(
+          (_) {},
+          onError: (Object error) => streamError.complete(error),
+        );
+        final completion = await task.done;
+
+        expect(
+          await streamError.future,
+          isA<LlamaUnsupportedException>().having(
+            (error) => error.message,
+            'message',
+            'first generation failure',
+          ),
+        );
+        expect(
+          completion.error,
+          isA<LlamaUnsupportedException>().having(
+            (error) => error.message,
+            'message',
+            'first generation failure',
+          ),
+        );
+
+        llamaEngine.chatCompletionStream = null;
+        final retry = await speechEngine.transcribe(
+          const SpeechToTextRequest(
+            audio: SpeechAudioFileInput('/tmp/retry.wav'),
+          ),
+        );
+        expect((await retry.done).result?.text, 'transcript');
+      },
+    );
+
     test('cancellation wins over a simultaneous backend failure', () async {
       backend
         ..blockGeneration = true
@@ -761,5 +819,37 @@ class _SpeechBackend implements LlamaBackend {
 }
 
 class _SpeechLlamaEngine extends LlamaEngine {
+  Stream<LlamaCompletionChunk>? chatCompletionStream;
+
   _SpeechLlamaEngine(super.backend);
+
+  @override
+  Stream<LlamaCompletionChunk> create(
+    List<LlamaChatMessage> messages, {
+    GenerationParams? params,
+    List<ToolDefinition>? tools,
+    ToolChoice? toolChoice,
+    bool parallelToolCalls = false,
+    bool enableThinking = true,
+    Map<String, dynamic>? responseFormat,
+    String? sourceLangCode,
+    String? targetLangCode,
+    Map<String, dynamic>? chatTemplateKwargs,
+    DateTime? templateNow,
+  }) {
+    return chatCompletionStream ??
+        super.create(
+          messages,
+          params: params,
+          tools: tools,
+          toolChoice: toolChoice,
+          parallelToolCalls: parallelToolCalls,
+          enableThinking: enableThinking,
+          responseFormat: responseFormat,
+          sourceLangCode: sourceLangCode,
+          targetLangCode: targetLangCode,
+          chatTemplateKwargs: chatTemplateKwargs,
+          templateNow: templateNow,
+        );
+  }
 }

--- a/test/unit/core/speech/speech_to_text_test.dart
+++ b/test/unit/core/speech/speech_to_text_test.dart
@@ -355,6 +355,40 @@ void main() {
       expect(backend.cancelGenerationCalls, 1);
     });
 
+    test(
+      'keeps cancellation authoritative when backend cancel throws',
+      () async {
+        backend
+          ..blockGeneration = true
+          ..onCancelGeneration = () {
+            throw StateError('synchronous backend cancellation failure');
+          };
+        await _loadSpeechModel(llamaEngine);
+
+        final task = await speechEngine.transcribe(
+          const SpeechToTextRequest(
+            audio: SpeechAudioFileInput('/tmp/test.wav'),
+          ),
+        );
+        await backend.generationStarted.future;
+
+        expect(task.cancel, returnsNormally);
+        backend.releaseGeneration();
+
+        expect(await task.events.toList(), isEmpty);
+        expect((await task.done).state, SpeechToTextCompletionState.cancelled);
+        expect(backend.cancelGenerationCalls, 1);
+
+        backend.onCancelGeneration = null;
+        final retry = await speechEngine.transcribe(
+          const SpeechToTextRequest(
+            audio: SpeechAudioFileInput('/tmp/retry.wav'),
+          ),
+        );
+        expect((await retry.done).result?.text, 'transcript');
+      },
+    );
+
     test('cancels while the native chat template is being prepared', () async {
       await _loadSpeechModel(llamaEngine);
       backend.blockMetadata = true;

--- a/test/unit/core/speech/speech_to_text_web_test.dart
+++ b/test/unit/core/speech/speech_to_text_web_test.dart
@@ -69,6 +69,103 @@ void main() {
     await engine.dispose();
   });
 
+  test('validated Web bridge keeps the raw bytes-only prompt path', () async {
+    final backend = _WebSpeechBackend(promptSpeechToTextSupported: true);
+    final engine = LlamaEngine(backend);
+    await engine.loadModel('https://example.com/qwen3-asr.gguf');
+    await engine.loadMultimodalProjector(
+      'https://example.com/qwen3-asr-mmproj.gguf',
+    );
+    final recognizer = SpeechToTextEngine(
+      engine,
+      modelProfile: SpeechToTextModelProfile.qwen3Asr,
+    );
+
+    final task = await recognizer.transcribe(
+      SpeechToTextRequest(
+        audio: SpeechAudioBytesInput(
+          Uint8List.fromList(<int>[0x52, 0x49, 0x46, 0x46]),
+          format: const SpeechAudioFormat(encoding: 'wav'),
+        ),
+        maxOutputTokens: 37,
+      ),
+    );
+    await task.done;
+
+    expect(backend.lastPrompt, 'Transcribe this audio accurately.');
+    expect(backend.lastParts, hasLength(1));
+    expect(backend.lastParts!.single, isA<LlamaAudioContent>());
+    expect((backend.lastParts!.single as LlamaAudioContent).bytes, <int>[
+      0x52,
+      0x49,
+      0x46,
+      0x46,
+    ]);
+    expect(backend.lastGenerationParams?.maxTokens, 37);
+    expect(backend.lastGenerationParams?.temp, 0);
+    expect(backend.lastGenerationParams?.topK, 1);
+    expect(backend.lastGenerationParams?.topP, 1);
+    expect(backend.lastGenerationParams?.penalty, 1);
+    expect(backend.lastGenerationParams?.seed, 1);
+    expect(backend.lastGenerationParams?.streamBatchTokenThreshold, 1);
+    await engine.dispose();
+  });
+
+  test('validated Web bridge reports an empty transcript as failure', () async {
+    final backend = _WebSpeechBackend(
+      promptSpeechToTextSupported: true,
+      generationText: ' <asr_text> ',
+    );
+    final engine = LlamaEngine(backend);
+    await engine.loadModel('https://example.com/qwen3-asr.gguf');
+    await engine.loadMultimodalProjector(
+      'https://example.com/qwen3-asr-mmproj.gguf',
+    );
+    final recognizer = SpeechToTextEngine(
+      engine,
+      modelProfile: SpeechToTextModelProfile.qwen3Asr,
+    );
+
+    final task = await recognizer.transcribe(
+      SpeechToTextRequest(
+        audio: SpeechAudioBytesInput(
+          Uint8List.fromList(<int>[0x52, 0x49, 0x46, 0x46]),
+          format: const SpeechAudioFormat(encoding: 'wav'),
+        ),
+      ),
+    );
+    final streamError = Completer<Object>();
+    task.events.listen(
+      (_) {},
+      onError: (Object error) => streamError.complete(error),
+    );
+    final completion = await task.done;
+
+    expect(
+      await streamError.future,
+      isA<LlamaSpeechException>().having(
+        (error) => error.message,
+        'message',
+        contains('empty transcript'),
+      ),
+    );
+    expect(completion.state, SpeechToTextCompletionState.failed);
+    expect(completion.result, isNull);
+    expect(completion.error, isA<LlamaSpeechException>());
+
+    backend.generationText = 'Recovered transcript.';
+    final retry = await recognizer.transcribe(
+      SpeechToTextRequest(
+        audio: SpeechAudioBytesInput(
+          Uint8List.fromList(<int>[0x52, 0x49, 0x46, 0x46]),
+          format: const SpeechAudioFormat(encoding: 'wav'),
+        ),
+      ),
+    );
+    expect((await retry.done).result?.text, 'Recovered transcript.');
+    await engine.dispose();
+  });
+
   test('validated Web bridge cancels an active transcription', () async {
     final generationGate = Completer<void>();
     final backend = _WebSpeechBackend(
@@ -189,11 +286,16 @@ class _WebSpeechBackend
   @override
   final bool supportsPromptSpeechToText;
   final Completer<void>? generationGate;
+  String generationText;
   bool cancelCalled = false;
+  String? lastPrompt;
+  List<LlamaContentPart>? lastParts;
+  GenerationParams? lastGenerationParams;
 
   _WebSpeechBackend({
     required bool promptSpeechToTextSupported,
     this.generationGate,
+    this.generationText = 'Hello.',
   }) : supportsPromptSpeechToText = promptSpeechToTextSupported;
 
   @override
@@ -258,12 +360,15 @@ class _WebSpeechBackend
     GenerationParams params, {
     List<LlamaContentPart>? parts,
   }) async* {
+    lastPrompt = prompt;
+    lastParts = parts;
+    lastGenerationParams = params;
     final gate = generationGate;
     if (gate != null) {
       await gate.future;
     }
     if (!cancelCalled) {
-      yield utf8.encode('Hello.');
+      yield utf8.encode(generationText);
     }
   }
 


### PR DESCRIPTION
## Summary
- Apply the model chat template to native prompt-adapted ASR audio turns so Qwen3-ASR emits its transcript.
- Keep the validated Web bridge on its raw prompt plus bytes-only audio contract.
- Fail typed ASR explicitly on empty output and make cancellation interrupt native chat-template preparation.

## Production-readiness scope
- **User-facing scope:** Native Qwen3-ASR whole-file and microphone transcription now return normalized text instead of an empty success.
- **Supported platforms/paths:** Native llama.cpp prompt-adapted Qwen3-ASR; the existing validated Web bridge path remains supported and unchanged at the bridge boundary.
- **Unsupported or intentionally unavailable paths:** Existing capability probes and typed unsupported errors remain unchanged. LiteRT-LM TTS remains unsupported. The TTS intelligibility round trip was not rerun because the office environment prohibited audible output.
- **Out of scope / follow-ups:** None.

## Completeness checklist
- [x] Declared scope is fully implemented.
- [x] Unsupported combinations continue to fail through existing typed capability diagnostics.
- [x] Changelog and targeted regression coverage are updated; no public API shape changed.
- [x] Regression coverage includes native template application, Web contract preservation, empty output, cancellation during template preparation, and retry after failure/cancellation.
- [x] Security/privacy review completed; retained evidence is sanitized and contains no secrets.
- [x] No follow-up work is required for this focused fix.

## PR type guidance
- **Bugfix PR:** Root cause was native Qwen3-ASR receiving a raw prompt/audio generation request instead of the model's required chat-templated audio turn. Focused regressions fail if native routing bypasses the template or if Web is accidentally switched to it.

## Test Plan
- [x] `dart run tool/prepare_workspace.dart` — clean tracked state
- [x] Changed-file `dart format --output=none --set-exit-if-changed ...`
- [x] `dart analyze`
- [x] `dart test -p vm -j 1 test/unit/core/speech` — 55 passed
- [x] `dart test -p chrome test/unit/core/speech/speech_platform_web_test.dart test/unit/core/speech/speech_to_text_web_test.dart` — 9 passed
- [x] Chat app tests — 356 passed; the CI cleanup-order regression also passed 25/25 repeated focused runs
- [x] `git diff --check`
- [x] Physical Pixel 9 Pro / Android 17 exact release APK and immutable real models
- [x] Exact-head CI and HF preview — 12/12 checks successful

## Matrix Evidence
| Matrix row | Scope covered | Platform / model / backend | Result | Evidence / notes |
| --- | --- | --- | --- | --- |
| Native known WAV | Exact transcript | Pixel 9 Pro / Qwen3-ASR 0.6B / llama.cpp CPU | PASS | Exact `The quick brown fox jumps over the lazy dog.` |
| Native microphone | Exact transcript | Pixel 9 Pro / Qwen3-ASR 0.6B / llama.cpp CPU | PASS | Exact normalized phrase on the exact APK; retained before the later silent-office constraint. |
| LiteRT-LM streaming | Partial + exact final | Pixel 9 Pro / Moonshine Tiny / dedicated backend | PASS | One partial; exact `The Quick Brown Fox jumps over the lazy dog.` from silent pinned-WAV injection. |
| LiteRT-LM lifecycle | Cancel + process restart/cache | Pixel 9 Pro / Moonshine Tiny / dedicated backend | PASS | Cancellation returned idle; force-stop/relaunch and fresh cached run returned the same exact partial/final transcript; crash buffer empty. |
| Web contract | Raw prompt + WAV bytes | Chrome unit runtime / Qwen3-ASR adapter | PASS | 9 Chrome tests preserve the validated bridge boundary and typed empty-output failure. |
| TTS intelligibility | Audible round trip | Pixel 9 Pro | UNAVAILABLE | Jhin prohibited all audible output in the office; prior structural TTS evidence is unchanged and no sound was emitted. |

Immutable evidence:
- APK SHA-256 `2dd98b9ebd4048e72e49d9cbf63c1812f1d1ffebd7e354bcdd6f2d0dcc722b3d`
- WAV SHA-256 `312ba074561f9ad83278906bde4e79364c6cb4f2cf93b025f5edf1da5c94cda4`
- Qwen3-ASR model/projector revision `928ab958557df9aa2ef1c93e0e83c7ad0933fae2`; SHA-256 `bca259818b50ca7c4c05e9bdb35a5dc04fa039653a6d6f3f0f331f96f6aa1971` / `41a342b5e4c514e968cb756de6cd1b7be39eff43c44c57a2ef5fc6522e36603d`
- Moonshine model revision `beb49ee5028b4fb21eb989bcbd2db30a433373db`, SHA-256 `97abdeea122d579229091659c24c59d988c6419d453a200f6471241a53b9a9b9`; tokenizer revision `390624ed33d594443aa4aa221f5b9f283b545b5a`, SHA-256 `6579793438bc4fbafffacf699169ff53e3769c5a0a0f5e71cdee8853e8130deb`

## Review Notes
- Independent review status: PASS at exact final head. Repeated fresh Codex `gpt-5.6-sol` xhigh audits found and fixed cancellation/cleanup error-precedence and lease-lifecycle gaps; independent critical QA then validated the complete final diff, failure paths, browser/native contracts, and CI synchronization correction.
- CI status / head SHA: all 12 exact-head checks and the HF preview passed at `05797e059da871878ba7a1726326bc124f346dc4` (CI run `33005518088`, preview run `33005518145`).
- Review status: 0 unresolved threads. The automatic final-head Copilot run failed internally without new comments; the prior code head received a no-new-findings review, and the final test-only commit was independently reviewed and covered by green exact-head CI.

## High-risk regression review
- **Classification:** high risk — backend/runtime routing and streaming cancellation
- **Implementation task:** Hermes Kanban `t_cbbec1fc`
- **Independent blocking QA task:** PASS_EXACT_HEAD_CRITICAL_QA on the complete final diff, retained physical-Pixel semantic evidence, cancellation/error paths, browser/native contracts, and test synchronization
- **Exact head / current base:** `05797e059da871878ba7a1726326bc124f346dc4` / `526f0349bd0fd549689b9b9c431e2f691c89478e`
- **Production-branch deletion, bypass, or miswire proof:** The new native template regression fails on `origin/main`; focused tests assert native template routing and the distinct Web raw-prompt route.
- **Affected-family real-model/artifact evidence:** Qwen3-ASR 0.6B and Moonshine Tiny on physical Pixel 9 Pro, immutable digests above.
- **Explicit unavailable-family or other N/A evidence:** Audible TTS round trip not rerun under explicit silent-office constraint.
- **Known PR-caused P1 regressions:** 0
- **Unresolved review threads:** 0

