### PR TITLE
fix(litert-lm): reject unenforceable Qwen required tools

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 ## Unreleased
 
+* Fixed Qwen 2.5/3 LiteRT-LM `ToolChoice.required` requests silently running
+  without their required-call grammar and finishing with no call. They now fail
+  with an actionable `LlamaUnsupportedException` before generation when the
+  backend cannot enforce the declared tool schema; Gemma 4 compatibility and
+  `auto`/`none` tool routing are unchanged.
+
 * Fixed Gemma 4 thinking-budget output so split channel controls and tool-call
   envelopes stay out of visible assistant content while preserving ordinary
   whitespace. The chat example now also validates custom tool declarations,

--- a/doc/litert_lm_templates.md
+++ b/doc/litert_lm_templates.md
@@ -55,13 +55,21 @@ llama.cpp reads `tokenizer.chat_template` straight from the GGUF metadata.
 | Gemma 4 (E2B/E4B) | `gemma4` | `gemma-4`, `gemma4` | ✅ | ✅ native `<\|tool_call>` | ✅ `<\|channel>` |
 | Gemma 3n (E2B/E4B) | `gemma` | `gemma-3n`, `gemma3n` | ✅ | ⚠️ prompt-engineered, no schema¹ | — |
 | Gemma 3 / 2 / 1B / 270m | `gemma` | `gemma-3`, `gemma-2` | ✅ | ⚠️ prompt-engineered, no schema¹ | — |
-| Qwen 3 / 3.5 | `hermes` | `qwen3`, `qwen-3` | ✅ | ✅ `<tool_call>` | ✅ `<think>` |
-| Qwen 2.5 | `hermes` | `qwen2.5`, `qwen-2.5`, `qwen2` | ✅ | ✅ `<tool_call>` | — |
+| Qwen 3 / 3.5 | `hermes` | `qwen3`, `qwen-3` | ✅ | ⚠️ best-effort `auto`; `required` unsupported on LiteRT-LM² | ✅ `<think>` |
+| Qwen 2.5 | `hermes` | `qwen2.5`, `qwen-2.5`, `qwen2` | ✅ | ⚠️ best-effort `auto`; `required` unsupported on LiteRT-LM² | — |
 
 ¹ For Gemma 3/3n the engine injects a generic "respond with `tool_call` JSON"
 instruction but does **not** render the tool schemas into the prompt. This
 matches the llama.cpp backend's Gemma 3 behavior — it is a property of the Gemma
 handler, not a LiteRT-LM limitation. Gemma **4** has full native tool calling.
+
+² Hermes/Qwen required-tool rendering depends on grammar-constrained decoding
+to guarantee one declared, schema-valid call. LiteRT-LM's llamadart backend does
+not expose that constraint wiring, so `ToolChoice.required` fails with
+`LlamaUnsupportedException` before generation. On native LiteRT-LM,
+`ToolChoice.auto` remains the best-effort Conversation path;
+`ToolChoice.none` still disables tool parsing and declarations on both native
+and web paths.
 
 Detection is best-effort and based on the bundle filename. If a bundle is
 renamed or its family isn't listed above, pass the template explicitly via
@@ -96,9 +104,16 @@ dart run tool/gguf_chat_features_smoke.dart \
   test/fixtures/image.png
 ```
 
-For native LiteRT-LM, `tool/litert_lm_chat_features_smoke.dart` checks the same
-tool-call path and also requires the model to emit a thinking channel. Use it
-with models that support thinking, such as Qwen 3/3.5 and Gemma 4:
+For native LiteRT-LM, `tool/litert_lm_chat_features_smoke.dart` requires a
+non-empty ordinary response with thinking disabled, plus both a thinking
+channel and visible answer with thinking enabled. For Gemma 4 it also validates
+native `auto` tool history and requires exactly one schema-valid
+`ToolChoice.required` call. For Hermes/Qwen it instead requires the planner's
+actionable unsupported error before generation; empty output or a normal
+`stop` finish still fails. The planner unit matrix separately pins unchanged
+native and rendered routing for `auto` and `none`; the Qwen smoke does not
+promote best-effort `auto` into a guaranteed call. Use it with models that
+support thinking, such as Qwen 3/3.5 and Gemma 4:
 
 ```bash
 dart run tool/litert_lm_chat_features_smoke.dart \
@@ -175,8 +190,10 @@ backend, not the registry:
   Dart-rendered prompt string.
 - **The Dart template path remains the compatibility fallback.** The engine
   still renders prompts in Dart for web LiteRT-LM, custom template inspection
-  through `chatTemplate(...)`, required tool-choice, parallel tool calls, and
-  any backend that does not expose native structured chat generation.
+  through `chatTemplate(...)`, Gemma 4 required tool-choice compatibility,
+  parallel tool calls, and any backend that does not expose native structured
+  chat generation. Hermes/Qwen required tool-choice is rejected before this
+  fallback because dropping its grammar would weaken the public contract.
 
 - **Thinking is reassembled from a channel stream.** The native runtime streams
   reasoning and the answer on separate channels — thought as
@@ -186,12 +203,14 @@ backend, not the registry:
   reasoning tags (`<|channel>thought … <channel|>` for Gemma 4, `<think>…</think>`
   for Qwen/Hermes) so chat-template handlers extract them as reasoning instead
   of leaking raw JSON.
-- **Grammar-constrained decoding is skipped.** Grammar-using handlers (Hermes/Qwen)
-  emit a GBNF grammar for tool calls, which the LiteRT-LM backend rejects.
-  `NativeAutoBackend` forwards `supportsGrammarConstraints == false` from the
-  active delegate, so the engine drops the grammar and tool calls are parsed
-  best-effort from the model output. Gemma 4 emits no grammar, so it is
-  unaffected.
+- **Grammar-constrained decoding is skipped.** Required-tool handlers including
+  Hermes/Qwen and Gemma 4 can emit GBNF tool-call grammars, which the LiteRT-LM
+  backend cannot consume. `NativeAutoBackend` forwards
+  `supportsGrammarConstraints == false` from the active delegate. The planner
+  therefore rejects Hermes/Qwen `ToolChoice.required` before generation rather
+  than dropping its required-call constraint. Gemma 4 keeps its existing,
+  real-model-tested rendered-prompt compatibility path, but its handler grammar
+  is still not applied by LiteRT-LM and must not be reported as grammar support.
 - **Native media parts use LiteRT-LM's conversation message JSON.** When
   `LlamaImageContent` or `LlamaAudioContent` reaches the native LiteRT-LM
   backend, llamadart sends matching `type: image` / `type: audio` message items

--- a/lib/src/backends/litert_lm/litert_lm_service.dart
+++ b/lib/src/backends/litert_lm/litert_lm_service.dart
@@ -238,8 +238,12 @@ class LiteRtLmService {
     }
     if (toolChoice == ToolChoice.required) {
       throw UnsupportedError(
-        'LiteRtLmBackend native chat generation does not support '
-        'ToolChoice.required; use the Dart template path instead.',
+        'LiteRtLmBackend native chat generation does not expose '
+        'ToolChoice.required enforcement. Use LlamaEngine.create so a '
+        'compatible template can select its rendered-prompt fallback. For '
+        'Hermes/Qwen, use ToolChoice.auto only when best-effort tool calling '
+        'is acceptable, or use a grammar-capable backend such as llama.cpp '
+        'for required tool calls.',
       );
     }
     if (parallelToolCalls) {

--- a/lib/src/core/engine/chat_completion_request_planner.dart
+++ b/lib/src/core/engine/chat_completion_request_planner.dart
@@ -8,6 +8,7 @@ import '../models/chat/content_part.dart';
 import '../models/inference/generation_params.dart';
 import '../models/inference/tool_choice.dart';
 import '../models/tools/tool_definition.dart';
+import '../template/chat_format.dart';
 import '../template/chat_template_engine.dart';
 
 /// Prepared generation inputs for a chat-completion request.
@@ -89,6 +90,20 @@ class ChatCompletionRequestPlanner {
         'constraints; '
         'use a grammar-capable backend such as llama.cpp, or omit '
         'responseFormat for best-effort JSON output.',
+      );
+    }
+    if (!backendSupportsGrammarConstraints &&
+        toolChoice == ToolChoice.required &&
+        tools != null &&
+        tools.isNotEmpty &&
+        templateResult.format == ChatFormat.hermes.index) {
+      throw LlamaUnsupportedException(
+        'ToolChoice.required for Hermes/Qwen tool calling requires '
+        'grammar-constrained decoding, but the active backend does not '
+        'support grammar constraints. LiteRT-LM native and web cannot '
+        'currently enforce a declared tool schema before generation; use '
+        'ToolChoice.auto for best-effort tool calling, or use a '
+        'grammar-capable backend such as llama.cpp.',
       );
     }
 

--- a/lib/src/core/engine/chat_completion_request_planner.dart
+++ b/lib/src/core/engine/chat_completion_request_planner.dart
@@ -100,8 +100,8 @@ class ChatCompletionRequestPlanner {
       throw LlamaUnsupportedException(
         'ToolChoice.required for Hermes/Qwen tool calling requires '
         'grammar-constrained decoding, but the active backend does not '
-        'support grammar constraints. LiteRT-LM native and web cannot '
-        'currently enforce a declared tool schema before generation; use '
+        'support grammar constraints. The active backend cannot enforce the '
+        'declared tool schema before generation; use '
         'ToolChoice.auto for best-effort tool calling, or use a '
         'grammar-capable backend such as llama.cpp.',
       );

--- a/test/unit/backends/litert_lm/litert_lm_service_test.dart
+++ b/test/unit/backends/litert_lm/litert_lm_service_test.dart
@@ -18,6 +18,7 @@ import 'package:llamadart/src/core/models/config/log_level.dart';
 import 'package:llamadart/src/core/models/config/lora_config.dart';
 import 'package:llamadart/src/core/models/inference/generation_params.dart';
 import 'package:llamadart/src/core/models/inference/model_params.dart';
+import 'package:llamadart/src/core/models/inference/tool_choice.dart';
 import 'package:llamadart/src/core/models/tools/tool_definition.dart';
 import 'package:llamadart/src/core/models/tools/tool_param.dart';
 import 'package:test/test.dart';
@@ -1836,6 +1837,65 @@ void main() {
       service.dispose();
     }
   });
+
+  test(
+    'rejects native required tool choice before runtime initialization',
+    () async {
+      final fakeClient = _FakeLiteRtLmRuntimeClient();
+      final service = LiteRtLmService(clientFactory: () => fakeClient);
+
+      try {
+        final modelHandle = await service.loadModel(
+          modelFile.path,
+          const ModelParams(preferredBackend: GpuBackend.cpu),
+        );
+        final contextHandle = service.createContext(
+          modelHandle,
+          const ModelParams(preferredBackend: GpuBackend.cpu),
+        );
+
+        await expectLater(
+          service
+              .generateChat(
+                contextHandle,
+                const [
+                  LlamaChatMessage.fromText(
+                    role: LlamaChatRole.user,
+                    text: 'Call get_weather for Seoul.',
+                  ),
+                ],
+                const GenerationParams(maxTokens: 32),
+                tools: [
+                  ToolDefinition(
+                    name: 'get_weather',
+                    description: 'Gets weather.',
+                    parameters: const [],
+                    handler: (_) async => 'sunny',
+                  ).toJson(),
+                ],
+                toolChoice: ToolChoice.required,
+              )
+              .drain<void>(),
+          throwsA(
+            isA<UnsupportedError>().having(
+              (error) => error.message,
+              'message',
+              allOf(
+                contains('ToolChoice.required enforcement'),
+                contains('rendered-prompt fallback'),
+                contains('grammar-capable backend'),
+              ),
+            ),
+          ),
+        );
+        expect(fakeClient.initializeStarted.isCompleted, isFalse);
+        expect(fakeClient.createConversationCount, 0);
+        expect(fakeClient.generateCount, 0);
+      } finally {
+        service.dispose();
+      }
+    },
+  );
 
   test(
     'recreates LiteRT-LM client when speculative decoding changes',

--- a/test/unit/core/engine/chat_completion_request_planner_test.dart
+++ b/test/unit/core/engine/chat_completion_request_planner_test.dart
@@ -97,6 +97,7 @@ void main() {
                 contains('ToolChoice.required'),
                 contains('Hermes/Qwen'),
                 contains('grammar-constrained decoding'),
+                isNot(contains('LiteRT-LM')),
               ),
             ),
           ),

--- a/test/unit/core/engine/chat_completion_request_planner_test.dart
+++ b/test/unit/core/engine/chat_completion_request_planner_test.dart
@@ -8,6 +8,7 @@ import 'package:llamadart/src/core/models/inference/generation_params.dart';
 import 'package:llamadart/src/core/models/inference/tool_choice.dart';
 import 'package:llamadart/src/core/models/tools/tool_definition.dart';
 import 'package:llamadart/src/core/models/tools/tool_param.dart';
+import 'package:llamadart/src/core/template/chat_format.dart';
 import 'package:test/test.dart';
 
 void main() {
@@ -63,6 +64,135 @@ void main() {
         ),
         throwsA(isA<LlamaUnsupportedException>()),
       );
+    });
+
+    test('rejects required Hermes tools on every no-grammar route', () {
+      for (final backend in <LlamaBackend>[
+        _NoGrammarBackend(),
+        _NoGrammarNativeChatBackend(),
+      ]) {
+        expect(
+          () => ChatCompletionRequestPlanner.build(
+            backend: backend,
+            templateResult: LlamaChatTemplateResult(
+              prompt: 'qwen prompt',
+              format: ChatFormat.hermes.index,
+              grammar: 'root ::= tool_call',
+            ),
+            messages: const [
+              LlamaChatMessage.fromText(
+                role: LlamaChatRole.user,
+                text: 'Call get_weather for Seoul.',
+              ),
+            ],
+            tools: [_weatherTool],
+            toolChoice: ToolChoice.required,
+            parallelToolCalls: false,
+          ),
+          throwsA(
+            isA<LlamaUnsupportedException>().having(
+              (error) => error.message,
+              'message',
+              allOf(
+                contains('ToolChoice.required'),
+                contains('Hermes/Qwen'),
+                contains('grammar-constrained decoding'),
+              ),
+            ),
+          ),
+          reason: backend.runtimeType.toString(),
+        );
+      }
+    });
+
+    test('keeps Hermes auto and none usable on every no-grammar route', () {
+      for (final route in <({LlamaBackend backend, bool usesNativeChat})>[
+        (backend: _NoGrammarBackend(), usesNativeChat: false),
+        (backend: _NoGrammarNativeChatBackend(), usesNativeChat: true),
+      ]) {
+        for (final toolChoice in [ToolChoice.auto, ToolChoice.none]) {
+          final plan = ChatCompletionRequestPlanner.build(
+            backend: route.backend,
+            templateResult: LlamaChatTemplateResult(
+              prompt: 'qwen prompt',
+              format: ChatFormat.hermes.index,
+              grammar: toolChoice == ToolChoice.auto
+                  ? 'root ::= tool_call'
+                  : null,
+            ),
+            messages: const [
+              LlamaChatMessage.fromText(
+                role: LlamaChatRole.user,
+                text: 'Hello.',
+              ),
+            ],
+            tools: [_weatherTool],
+            toolChoice: toolChoice,
+            parallelToolCalls: false,
+          );
+
+          final reason = '${route.backend.runtimeType}/${toolChoice.name}';
+          expect(
+            plan.usesNativeChatGeneration,
+            route.usesNativeChat,
+            reason: reason,
+          );
+          expect(plan.generationParams.grammar, isNull, reason: reason);
+          expect(
+            plan.parseToolCallsEnabled,
+            toolChoice == ToolChoice.auto,
+            reason: reason,
+          );
+        }
+      }
+    });
+
+    test('preserves required Hermes grammar on capable backends', () {
+      final plan = ChatCompletionRequestPlanner.build(
+        backend: _NativeChatBackend(),
+        templateResult: LlamaChatTemplateResult(
+          prompt: 'qwen prompt',
+          format: ChatFormat.hermes.index,
+          grammar: 'root ::= tool_call',
+        ),
+        messages: const [
+          LlamaChatMessage.fromText(
+            role: LlamaChatRole.user,
+            text: 'Call get_weather for Seoul.',
+          ),
+        ],
+        tools: [_weatherTool],
+        toolChoice: ToolChoice.required,
+        parallelToolCalls: false,
+      );
+
+      expect(plan.usesNativeChatGeneration, isFalse);
+      expect(plan.generationParams.grammar, 'root ::= tool_call');
+      expect(plan.parseToolCallsEnabled, isTrue);
+    });
+
+    test('preserves Gemma 4 required rendered-prompt compatibility', () {
+      final plan = ChatCompletionRequestPlanner.build(
+        backend: _NoGrammarNativeChatBackend(),
+        templateResult: LlamaChatTemplateResult(
+          prompt: 'gemma prompt',
+          format: ChatFormat.gemma4.index,
+          grammar: 'root ::= tool_call',
+        ),
+        messages: const [
+          LlamaChatMessage.fromText(
+            role: LlamaChatRole.user,
+            text: 'Call get_weather for Seoul.',
+          ),
+        ],
+        tools: [_weatherTool],
+        toolChoice: ToolChoice.required,
+        parallelToolCalls: false,
+      );
+
+      expect(plan.usesNativeChatGeneration, isFalse);
+      expect(plan.generationParams.grammar, isNull);
+      expect(plan.parseToolCallsEnabled, isTrue);
     });
 
     test('resolves omitted thinking-budget tags from the chat template', () {
@@ -123,6 +253,12 @@ class _NativeChatBackend extends _BaseBackend
   @override
   bool get supportsGrammarConstraints => true;
 
+  @override
+  bool get supportsNativeChatGeneration => true;
+}
+
+class _NoGrammarNativeChatBackend extends _NoGrammarBackend
+    implements BackendNativeChatGeneration {
   @override
   bool get supportsNativeChatGeneration => true;
 }

--- a/tool/litert_lm_chat_features_smoke.dart
+++ b/tool/litert_lm_chat_features_smoke.dart
@@ -43,6 +43,19 @@ Future<void> main(List<String> args) async {
       modelParams: ModelParams(contextSize: 2048, liteRtLmBackend: backend),
     );
 
+    final plain = await _runScenario(
+      engine: engine,
+      messages: const [
+        LlamaChatMessage.fromText(
+          role: LlamaChatRole.user,
+          text: 'Reply with one short sentence saying hello.',
+        ),
+      ],
+      tools: const [],
+      enableThinking: false,
+      maxTokens: 64,
+    );
+
     final thinking = await _runScenario(
       engine: engine,
       messages: const [
@@ -58,65 +71,50 @@ Future<void> main(List<String> args) async {
       maxTokens: 256,
     );
 
-    final toolCall = await _runScenario(
-      engine: engine,
-      messages: const [
-        LlamaChatMessage.fromText(
-          role: LlamaChatRole.system,
-          text: 'You must call get_weather. Return only a tool call.',
-        ),
-        LlamaChatMessage.fromText(
-          role: LlamaChatRole.user,
-          text: 'Call get_weather with location Seoul.',
-        ),
-      ],
-      tools: [
-        ToolDefinition(
-          name: 'get_weather',
-          description: 'Returns current weather for a city.',
-          parameters: [ToolParam.string('location', description: 'City name')],
-          handler: (_) async => 'Sunny',
-        ),
-      ],
-      enableThinking: false,
-      maxTokens: 160,
+    final requiredTemplate = await engine.chatTemplate(
+      _requiredToolMessages,
+      tools: [_weatherTool],
       toolChoice: ToolChoice.required,
+      enableThinking: false,
+      includeTokenCount: false,
+    );
+    final requiredUnsupportedExpected =
+        requiredTemplate.format == ChatFormat.hermes.index;
+    final toolCall = await _runRequiredToolScenario(
+      engine: engine,
+      expectUnsupported: requiredUnsupportedExpected,
     );
 
-    final nativeToolHistory = await _runScenario(
-      engine: engine,
-      messages: const [
-        LlamaChatMessage.fromText(
-          role: LlamaChatRole.system,
-          text:
-              'For weather questions, call get_weather with the requested '
-              'city. Do not answer weather questions in text.',
-        ),
-        LlamaChatMessage.fromText(
-          role: LlamaChatRole.user,
-          text: 'Remember this city: Seoul.',
-        ),
-        LlamaChatMessage.fromText(
-          role: LlamaChatRole.assistant,
-          text: 'I will remember Seoul.',
-        ),
-        LlamaChatMessage.fromText(
-          role: LlamaChatRole.user,
-          text: 'What is the weather in the remembered city? Use the tool.',
-        ),
-      ],
-      tools: [
-        ToolDefinition(
-          name: 'get_weather',
-          description: 'Returns current weather for a city.',
-          parameters: [ToolParam.string('location', description: 'City name')],
-          handler: (_) async => 'Sunny',
-        ),
-      ],
-      enableThinking: false,
-      maxTokens: 160,
-      toolChoice: ToolChoice.auto,
-    );
+    final nativeToolHistory = requiredUnsupportedExpected
+        ? null
+        : await _runScenario(
+            engine: engine,
+            messages: const [
+              LlamaChatMessage.fromText(
+                role: LlamaChatRole.system,
+                text:
+                    'For weather questions, call get_weather with the '
+                    'requested city. Do not answer weather questions in text.',
+              ),
+              LlamaChatMessage.fromText(
+                role: LlamaChatRole.user,
+                text: 'Remember this city: Seoul.',
+              ),
+              LlamaChatMessage.fromText(
+                role: LlamaChatRole.assistant,
+                text: 'I will remember Seoul.',
+              ),
+              LlamaChatMessage.fromText(
+                role: LlamaChatRole.user,
+                text:
+                    'What is the weather in the remembered city? Use the tool.',
+              ),
+            ],
+            tools: [_weatherTool],
+            enableThinking: false,
+            maxTokens: 160,
+            toolChoice: ToolChoice.auto,
+          );
 
     final nativeMediaRender = imagePath == null
         ? null
@@ -165,9 +163,18 @@ Future<void> main(List<String> args) async {
     final result = {
       'backendName': await engine.getBackendName(),
       'requestedLiteRtLmBackend': backend.name,
+      'format': requiredTemplate.format,
+      'plain': plain.toJson(),
       'thinking': thinking.toJson(),
       'toolCall': toolCall.toJson(),
-      'nativeToolHistory': nativeToolHistory.toJson(),
+      'nativeToolHistory':
+          nativeToolHistory?.toJson() ??
+          const {
+            'status': 'not_applicable',
+            'reason':
+                'Hermes/Qwen auto tool calls are best-effort and are not '
+                'asserted by this smoke',
+          },
       if (nativeMediaRender != null)
         'nativeMediaRender': nativeMediaRender.toJson(),
       if (multimodal != null) 'multimodal': multimodal.toJson(),
@@ -177,8 +184,10 @@ Future<void> main(List<String> args) async {
       },
     };
     _verifyResult(
+      plain: plain,
       thinking: thinking,
       toolCall: toolCall,
+      requiredUnsupportedExpected: requiredUnsupportedExpected,
       nativeToolHistory: nativeToolHistory,
       multimodal: multimodal,
       audioChat: audioChat,
@@ -191,32 +200,58 @@ Future<void> main(List<String> args) async {
 }
 
 void _verifyResult({
+  required _ScenarioResult plain,
   required _ScenarioResult thinking,
-  required _ScenarioResult toolCall,
-  required _ScenarioResult nativeToolHistory,
+  required _RequiredToolScenarioResult toolCall,
+  required bool requiredUnsupportedExpected,
+  required _ScenarioResult? nativeToolHistory,
   _ScenarioResult? multimodal,
   _ScenarioResult? audioChat,
   String? audioExpectedText,
 }) {
-  if (thinking.thinking.trim().isEmpty) {
-    throw StateError('Gemma 4 thinking scenario produced no thinking delta.');
+  if (plain.content.trim().isEmpty) {
+    throw StateError('LiteRT-LM plain chat produced no visible content.');
   }
-  _verifyWeatherToolCall(
-    toolCall,
-    scenarioName: 'Gemma 4 required tool scenario',
-  );
-  if (nativeToolHistory.content.trim().isNotEmpty) {
+  if (plain.thinking.trim().isNotEmpty) {
     throw StateError(
-      'Gemma 4 native tool/history scenario streamed content: '
-      '${nativeToolHistory.content}',
+      'LiteRT-LM plain chat produced an unexpected thinking delta.',
     );
   }
-  _verifyWeatherToolCall(
-    nativeToolHistory,
-    scenarioName: 'Gemma 4 native tool/history scenario',
-  );
+  if (plain.toolCalls.isNotEmpty) {
+    throw StateError('LiteRT-LM plain chat produced an unexpected tool call.');
+  }
+  if (thinking.thinking.trim().isEmpty) {
+    throw StateError('LiteRT-LM thinking scenario produced no thinking delta.');
+  }
+  if (thinking.content.trim().isEmpty) {
+    throw StateError('LiteRT-LM thinking scenario produced no visible answer.');
+  }
+  if (requiredUnsupportedExpected) {
+    if (!toolCall.isUnsupported) {
+      throw StateError(
+        'Hermes/Qwen required tool choice did not fail explicitly unsupported.',
+      );
+    }
+  } else {
+    _verifyWeatherToolCall(
+      toolCall.scenario!,
+      scenarioName: 'LiteRT-LM required tool scenario',
+    );
+  }
+  if (nativeToolHistory != null) {
+    if (nativeToolHistory.content.trim().isNotEmpty) {
+      throw StateError(
+        'LiteRT-LM native tool/history scenario streamed content: '
+        '${nativeToolHistory.content}',
+      );
+    }
+    _verifyWeatherToolCall(
+      nativeToolHistory,
+      scenarioName: 'LiteRT-LM native tool/history scenario',
+    );
+  }
   if (multimodal != null && multimodal.content.trim().isEmpty) {
-    throw StateError('Gemma 4 multimodal scenario produced no content.');
+    throw StateError('LiteRT-LM multimodal scenario produced no content.');
   }
   if (audioChat != null) {
     verifyExactAudioChatAnswer(
@@ -244,8 +279,55 @@ void _verifyWeatherToolCall(
     throw StateError('$scenarioName did not call get_weather.');
   }
   final arguments = function['arguments'];
-  if (arguments is! String || !arguments.contains('"location":"Seoul"')) {
+  if (arguments is! String) {
+    throw StateError('$scenarioName did not provide JSON string arguments.');
+  }
+  Object? decoded;
+  try {
+    decoded = jsonDecode(arguments);
+  } catch (_) {
+    throw StateError('$scenarioName produced invalid JSON arguments.');
+  }
+  if (decoded is! Map ||
+      decoded.length != 1 ||
+      decoded['location'] != 'Seoul') {
     throw StateError('$scenarioName did not pass the expected location.');
+  }
+}
+
+Future<_RequiredToolScenarioResult> _runRequiredToolScenario({
+  required LlamaEngine engine,
+  required bool expectUnsupported,
+}) async {
+  try {
+    final scenario = await _runScenario(
+      engine: engine,
+      messages: _requiredToolMessages,
+      tools: [_weatherTool],
+      enableThinking: false,
+      maxTokens: 160,
+      toolChoice: ToolChoice.required,
+    );
+    if (expectUnsupported) {
+      throw StateError(
+        'Hermes/Qwen required tool choice reached generation instead of '
+        'failing explicitly unsupported.',
+      );
+    }
+    return _RequiredToolScenarioResult.success(scenario);
+  } on LlamaUnsupportedException catch (error) {
+    if (!expectUnsupported) {
+      rethrow;
+    }
+    if (!error.message.contains('ToolChoice.required') ||
+        !error.message.contains('Hermes/Qwen') ||
+        !error.message.contains('grammar-constrained decoding')) {
+      throw StateError(
+        'Hermes/Qwen required tool choice produced a non-actionable '
+        'unsupported error.',
+      );
+    }
+    return _RequiredToolScenarioResult.unsupported(error.message);
   }
 }
 
@@ -421,6 +503,23 @@ class _ScenarioResult {
   };
 }
 
+class _RequiredToolScenarioResult {
+  const _RequiredToolScenarioResult.success(this.scenario)
+    : unsupportedMessage = null;
+
+  const _RequiredToolScenarioResult.unsupported(this.unsupportedMessage)
+    : scenario = null;
+
+  final _ScenarioResult? scenario;
+  final String? unsupportedMessage;
+
+  bool get isUnsupported => unsupportedMessage != null;
+
+  Map<String, Object?> toJson() =>
+      scenario?.toJson() ??
+      {'status': 'unsupported', 'message': unsupportedMessage};
+}
+
 class _NativeMediaRenderResult {
   const _NativeMediaRenderResult({
     required this.marker,
@@ -445,3 +544,21 @@ String _tail(String value) {
   }
   return value.substring(value.length - 240);
 }
+
+const List<LlamaChatMessage> _requiredToolMessages = [
+  LlamaChatMessage.fromText(
+    role: LlamaChatRole.system,
+    text: 'You must call get_weather. Return only a tool call.',
+  ),
+  LlamaChatMessage.fromText(
+    role: LlamaChatRole.user,
+    text: 'Call get_weather with location Seoul.',
+  ),
+];
+
+final ToolDefinition _weatherTool = ToolDefinition(
+  name: 'get_weather',
+  description: 'Returns current weather for a city.',
+  parameters: [ToolParam.string('location', description: 'City name')],
+  handler: (_) async => 'Sunny',
+);


### PR DESCRIPTION
## Summary

- fail Hermes/Qwen `ToolChoice.required` requests before generation when the active backend cannot enforce the generated grammar
- preserve grammar-capable Hermes/Qwen routing, Gemma 4 required-tool compatibility, and `auto`/`none` behavior
- make LiteRT-LM capability documentation and the physical-model smoke explicit about the unsupported required-tool boundary
- strengthen the smoke with ordinary visible-chat coverage so model/runtime failures cannot hide behind thinking-only output

## Release-qualification finding

Physical-macOS qualification of exact `main` (`a0e35c109da1a587a3e37744fb6660240a67049e`) found that the repository-documented `Qwen3-0.6B.litertlm` bundle reached generation for `ToolChoice.required`, then finished `stop` with zero visible output and zero tool calls on both CPU and GPU. LiteRT-LM does not expose grammar-constrained decoding, so silently dropping the Hermes tool grammar weakened the public contract.

This PR fails that combination with an actionable `LlamaUnsupportedException` before generation instead of pretending the required call can be enforced.

## Production-readiness scope

- Hermes/Qwen required tools on non-grammar backends fail loudly before generation.
- Grammar-capable Hermes/Qwen backends retain their required-call grammar.
- Gemma 4 LiteRT-LM required tools retain the existing rendered-prompt compatibility path.
- Qwen `auto` remains explicitly best-effort; `none` remains supported.
- No public signatures, dependencies, generated bindings, or native runtime artifacts change.

## Verification

- `dart format --output=none --set-exit-if-changed ...` — pass
- `git diff --check` — pass
- `dart analyze` — pass
- focused planner/service tests — 61 pass across VM and Chrome
- template + llama.cpp unit suites — 1,098 pass
- full `dart test` — 2,751 pass, 11 skip
- physical macOS Gemma 4 LiteRT-LM smoke, CPU — pass
- physical macOS Gemma 4 LiteRT-LM smoke, GPU — pass
- physical macOS Qwen3 LiteRT-LM required-boundary smoke before final plain-chat hardening, CPU/GPU — pass with explicit unsupported result
- final hardened Qwen3 LiteRT-LM smoke, CPU/GPU — intentionally reports the separate pre-existing artifact/runtime failure: plain chat produces no visible content. This remains a release-qualification blocker and is not masked by this PR.

## Review notes

- Agy Gemini 3.7 Flash High: rejected before editing because its command request was denied.
- Personal Claude Code Opus 5: reached its bounded turn limit without edits.
- Codex CLI `gpt-5.6-sol`, xhigh: implemented the remediation; a fresh xhigh final audit added plain-chat coverage and fixed capability wording.
- Existing issue/PR search found no dedicated match for this exact LiteRT-LM Qwen required-tool failure.

## Out of scope

- Adding grammar-constrained decoding to LiteRT-LM.
- Claiming guaranteed Qwen `auto` tool selection.
- Repairing or replacing the local Qwen3 LiteRT-LM artifact/runtime path that currently emits no visible plain-chat content.
