### PR TITLE
fix(web): align WebGPU bridge runtime with native llama.cpp

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 ## Unreleased
 
+* Aligned the default WebGPU bridge assets to `v0.1.39` (immutable manifest
+  `b355d01040604f6ae2c5c5fe5bb42b858101a96f03f67e4b27b32fe41ce3b2bf`),
+  restoring Web/native llama.cpp upstream `v0.2.0@bb4caa7540188872173c44d161602d9271386413`
+  parity with native anchor `llamadart-native@v0.2.0-1` while preserving
+  approved Web `@litert-lm/core@0.15.0` packaging.
+
 * Fixed native Qwen3-ASR transcription by applying the model chat template to
   audio turns, while preserving the validated raw-prompt Web bridge contract.
   Empty ASR output now fails explicitly instead of reporting an empty result.

--- a/README.md
+++ b/README.md
@@ -145,7 +145,7 @@ Current default runtime pins:
 | --- | --- |
 | Native llama.cpp / GGUF | `leehack/llamadart-native@v0.2.0-1` |
 | Native LiteRT-LM / `.litertlm` | `leehack/litert-lm-native@v0.16.0-native.2` |
-| Web llama.cpp / GGUF | `leehack/llama-web-bridge-assets@v0.1.37` |
+| Web llama.cpp / GGUF | `leehack/llama-web-bridge-assets@v0.1.39` |
 | Web LiteRT-LM / `.litertlm` | `@litert-lm/core@0.15.0` |
 
 Native overrides accept stable `vMAJOR.MINOR.PATCH` releases and preserve

--- a/doc/webgpu_bridge.md
+++ b/doc/webgpu_bridge.md
@@ -19,13 +19,17 @@ pipelines.
    `https://cdn.jsdelivr.net/gh/leehack/llama-web-bridge-assets@<tag>/llama_webgpu_bridge.js`
 2. Local fallback: `./webgpu_bridge/llama_webgpu_bridge.js`
 
-Default pinned tag in the example is `v0.1.37`.
+Default pinned tag in the example is `v0.1.39`.
 
-That release embeds llama.cpp `b10514`, which now trails the `hook/build.dart`
-native pin (`v0.2.0-1`, built from llama.cpp `v0.2.0`), so Web and native are not
-on the same llama.cpp build. It retains
+That release embeds llama.cpp `v0.2.0`, matching the `hook/build.dart` native pin
+(`v0.2.0-1`, both built from upstream llama.cpp `v0.2.0@bb4caa7540188872173c44d161602d9271386413`)
+even though wrapper release tags differ. Provenance for this immutable consumer
+artifact: release `377534035`, tag commit
+`d14d46a63deeee7a8f8a017e394b74ee112f4dba`, bridge source
+`79b6ef31e394dd2de92a456b7c249f9da377c720`, and manifest SHA-256
+`b355d01040604f6ae2c5c5fe5bb42b858101a96f03f67e4b27b32fe41ce3b2bf`. It retains
 the Qwen3-ASR typed speech-to-text contract introduced in `v0.1.30` and
-provisions the explicit 1 MiB Wasm stack needed for `b10514` memory64 context
+provisions the explicit 1 MiB Wasm stack needed for memory64 context
 construction in direct and worker modes. The chat bootstrap opts
 `SpeechToTextEngine` into that contract from the immutable tag; older or custom
 assets remain disabled unless the host explicitly sets
@@ -43,7 +47,7 @@ model bytes.
 To vendor pinned assets into local app web files:
 
 ```bash
-WEBGPU_BRIDGE_ASSETS_TAG=v0.1.37 ./scripts/fetch_webgpu_bridge_assets.sh
+WEBGPU_BRIDGE_ASSETS_TAG=v0.1.39 ./scripts/fetch_webgpu_bridge_assets.sh
 ```
 
 Optional compatibility env vars:
@@ -124,7 +128,7 @@ You can override CDN source/version before the bridge loader runs:
 ```html
 <script>
   window.__llamadartBridgeAssetsRepo = 'leehack/llama-web-bridge-assets';
-  window.__llamadartBridgeAssetsTag = 'v0.1.37';
+  window.__llamadartBridgeAssetsTag = 'v0.1.39';
 </script>
 ```
 

--- a/example/chat_app/web/index.html
+++ b/example/chat_app/web/index.html
@@ -211,8 +211,8 @@
       typeof configuredRepo === 'string' && configuredRepo.length > 0
         ? configuredRepo
         : 'leehack/llama-web-bridge-assets';
-    const defaultBridgeAssetsTag = 'v0.1.37';
-    const defaultBridgeLlamaCppTag = 'b10514';
+    const defaultBridgeAssetsTag = 'v0.1.39';
+    const defaultBridgeLlamaCppTag = 'v0.2.0';
     const bridgeAssetsTag =
       typeof configuredTag === 'string' && configuredTag.length > 0
         ? configuredTag

--- a/scripts/fetch_webgpu_bridge_assets.sh
+++ b/scripts/fetch_webgpu_bridge_assets.sh
@@ -4,17 +4,24 @@ set -euo pipefail
 ROOT_DIR="$(git rev-parse --show-toplevel)"
 OUT_DIR="${WEBGPU_BRIDGE_OUT_DIR:-$ROOT_DIR/example/chat_app/web/webgpu_bridge}"
 ASSETS_REPO="${WEBGPU_BRIDGE_ASSETS_REPO:-leehack/llama-web-bridge-assets}"
-ASSETS_TAG="${WEBGPU_BRIDGE_ASSETS_TAG:-v0.1.37}"
+ASSETS_TAG="${WEBGPU_BRIDGE_ASSETS_TAG:-v0.1.39}"
 CDN_BASE="${WEBGPU_BRIDGE_CDN_BASE:-https://cdn.jsdelivr.net/gh/${ASSETS_REPO}@${ASSETS_TAG}}"
 PATCH_SAFARI_COMPAT="${WEBGPU_BRIDGE_PATCH_SAFARI_COMPAT:-1}"
 MIN_SAFARI_VERSION="${WEBGPU_BRIDGE_MIN_SAFARI_VERSION:-170400}"
+CURL_DOWNLOAD_ARGS=(
+  --connect-timeout 15
+  --max-time 300
+  --retry 3
+  --retry-delay 1
+  --retry-max-time 600
+)
 
 if [[ "${1:-}" == "--help" || "${1:-}" == "-h" ]]; then
   cat <<'USAGE'
 Downloads prebuilt WebGPU bridge assets into the chat_app web directory.
 
 Default source:
-  https://cdn.jsdelivr.net/gh/leehack/llama-web-bridge-assets@v0.1.37
+  https://cdn.jsdelivr.net/gh/leehack/llama-web-bridge-assets@v0.1.39
 
 Environment variables:
   WEBGPU_BRIDGE_ASSETS_REPO   Asset repo in owner/repo format
@@ -28,7 +35,7 @@ Usage:
   ./scripts/fetch_webgpu_bridge_assets.sh
 
 Examples:
-  WEBGPU_BRIDGE_ASSETS_TAG=v0.1.37 ./scripts/fetch_webgpu_bridge_assets.sh
+  WEBGPU_BRIDGE_ASSETS_TAG=v0.1.39 ./scripts/fetch_webgpu_bridge_assets.sh
   WEBGPU_BRIDGE_ASSETS_REPO=acme/llama-web-bridge-assets WEBGPU_BRIDGE_ASSETS_TAG=v2 ./scripts/fetch_webgpu_bridge_assets.sh
 USAGE
   exit 0
@@ -58,7 +65,7 @@ download_required() {
   local target_path="$OUT_DIR/$file_name"
 
   echo "[webgpu-assets] downloading $source_url"
-  curl -fL --retry 3 --retry-delay 1 "$source_url" -o "$target_path"
+  curl -fL "${CURL_DOWNLOAD_ARGS[@]}" "$source_url" -o "$target_path"
   mark_downloaded "$file_name"
 }
 
@@ -68,9 +75,9 @@ download_optional() {
   local target_path="$OUT_DIR/$file_name"
 
   rm -f "$target_path"
-  if curl -fsI "$source_url" >/dev/null; then
+  if curl -fsI --connect-timeout 15 --max-time 30 "$source_url" >/dev/null; then
     echo "[webgpu-assets] downloading optional $source_url"
-    curl -fL --retry 3 --retry-delay 1 "$source_url" -o "$target_path"
+    curl -fL "${CURL_DOWNLOAD_ARGS[@]}" "$source_url" -o "$target_path"
     mark_downloaded "$file_name"
   fi
 }

--- a/test/unit/tooling/check_webgpu_bridge_tag_test.dart
+++ b/test/unit/tooling/check_webgpu_bridge_tag_test.dart
@@ -1,50 +1,14 @@
 @TestOn('vm')
 library;
 
+import 'dart:async';
+import 'dart:convert';
 import 'dart:io';
 
+import 'package:crypto/crypto.dart';
 import 'package:test/test.dart';
 
 import '../../../tool/testing/check_webgpu_bridge_tag.dart';
-
-List<String> _bridgeCliContractProblems(String source) {
-  final problems = <String>[];
-  final runtimeCheck = RegExp(
-    r'\.\.\.findBridgeRuntimeDrift\(\s*repoRoot,\s*bridgeLlamaCppTag,\s*'
-    r'bridgeLlamaCppDivergence,\s*\),',
-    multiLine: true,
-  ).allMatches(source).toList();
-  final manifestCheck = RegExp(
-    r'if \(verifyManifest\)\s*'
-    r'\.\.\.await verifyManifestLlamaCppTag\('
-    r'expectedTag, bridgeLlamaCppTag\),',
-    multiLine: true,
-  ).allMatches(source).toList();
-  if (runtimeCheck.length != 1) {
-    problems.add(
-      'expected one production Web/native runtime drift check, found '
-      '${runtimeCheck.length}',
-    );
-  }
-  if (manifestCheck.length != 1) {
-    problems.add(
-      'expected one opt-in production manifest check, found '
-      '${manifestCheck.length}',
-    );
-  }
-
-  final errorGuard = source.indexOf('if (problems.isNotEmpty) {');
-  if (runtimeCheck.length == 1 &&
-      manifestCheck.length == 1 &&
-      !(runtimeCheck.single.start < manifestCheck.single.start &&
-          manifestCheck.single.start < errorGuard)) {
-    problems.add(
-      'runtime-drift and manifest checks must run before success can be '
-      'reported',
-    );
-  }
-  return problems;
-}
 
 Directory _fakeRepo(String assetsTag, {Map<String, String> files = const {}}) {
   final root = Directory.systemTemp.createTempSync('bridge_tag_gate');
@@ -62,25 +26,28 @@ Directory _fakeRepo(String assetsTag, {Map<String, String> files = const {}}) {
   return root;
 }
 
-/// Builds a repo whose docs and native pin describe [bridgeTag]/[nativeTag].
+/// Builds a repo whose docs, chat bootstrap and native pin describe
+/// [bridgeTag]/[nativeTag].
 Directory _fakeRuntimeRepo({
   required String bridgeTag,
   required String nativeTag,
-  bool parityWording = false,
+  bool parityWording = true,
 }) {
   final root = Directory.systemTemp.createTempSync('bridge_runtime_gate');
   addTearDown(() => root.deleteSync(recursive: true));
   final entries = <String, String>{
     nativeLlamaCppTagPath: "const _llamaCppTag = '$nativeTag';\n",
+    'example/chat_app/web/index.html':
+        "    const defaultBridgeLlamaCppTag = '$bridgeTag';\n",
     'doc/webgpu_bridge.md': parityWording
         ? 'That release embeds llama.cpp `$bridgeTag`, matching the '
               '`hook/build.dart` native pin\n'
         : 'That release embeds llama.cpp `$bridgeTag`, which now trails the '
               '`hook/build.dart`\n',
     'website/docs/platforms/webgpu-bridge.md': parityWording
-        ? '- `v0.1.37+` bridge assets embed llama.cpp `$bridgeTag`, matching '
+        ? '- `v0.1.39+` bridge assets embed llama.cpp `$bridgeTag`, matching '
               'the native runtime\n'
-        : '- `v0.1.37+` bridge assets embed llama.cpp `$bridgeTag`, which now '
+        : '- `v0.1.39+` bridge assets embed llama.cpp `$bridgeTag`, which now '
               'trails the\n',
   };
   for (final entry in entries.entries) {
@@ -91,48 +58,175 @@ Directory _fakeRuntimeRepo({
   return root;
 }
 
+const String _approvedManifestJson = '''
+{
+  "artifacts": {
+    "llama_webgpu_bridge.d.ts": {
+      "sha256": "f2875193104f9be50a3cdbce2b6b8691354576f2d6ba1bbbb3637eaedd22b507",
+      "size_bytes": 5495
+    },
+    "llama_webgpu_bridge.js": {
+      "sha256": "a704115fe87d3defff4a02c5a2b1d1bf0ab3bc1f00de3f40ed2c9b2d5983fd73",
+      "size_bytes": 210601
+    },
+    "llama_webgpu_bridge_worker.js": {
+      "sha256": "47bbfa0fe897e708455b9497e9aa41d2e94489c329300c33b12936fb3169deca",
+      "size_bytes": 257
+    },
+    "llama_webgpu_core.js": {
+      "sha256": "d282a57d2de9cd3835ecc999374bcc9ef00d6df32da0f47744ea672977c86f32",
+      "size_bytes": 113962
+    },
+    "llama_webgpu_core.wasm": {
+      "sha256": "b1419854bab331278deb513b5cbadb98be364ad5f4b515690dee58edb38cc41e",
+      "size_bytes": 8542117
+    },
+    "llama_webgpu_core_mem64.js": {
+      "sha256": "451ed2bfc99fc33e0de6b09eb96f03914a194c91bcd0bda968048c2d5efa7e2d",
+      "size_bytes": 131045
+    },
+    "llama_webgpu_core_mem64.wasm": {
+      "sha256": "64e8046a6d18e570e50be84665f4a5022a457f70bc53c728298827b4c52bc072",
+      "size_bytes": 8760585
+    }
+  },
+  "assets_repository": "leehack/llama-web-bridge-assets",
+  "bridge_assets_tag": "v0.1.39",
+  "bridge_commit": "79b6ef31e394dd2de92a456b7c249f9da377c720",
+  "bridge_repository": "leehack/llama-web-bridge",
+  "capabilities": {
+    "memory64": true,
+    "multimodal": {
+      "direct": true,
+      "worker": true
+    },
+    "speech_to_text": {
+      "advertised": true,
+      "direct": true,
+      "memory64": true,
+      "wasm32": true,
+      "worker": true
+    },
+    "state_persistence": {
+      "direct": true,
+      "worker": true
+    },
+    "text_to_speech": {
+      "advertised": true,
+      "direct": true,
+      "memory64": true,
+      "wasm32": false,
+      "worker": true
+    },
+    "wasm32": true
+  },
+  "emscripten_version": "6.0.8",
+  "files": {
+    "llama_webgpu_bridge.d.ts": {
+      "sha256": "f2875193104f9be50a3cdbce2b6b8691354576f2d6ba1bbbb3637eaedd22b507",
+      "size_bytes": 5495
+    },
+    "llama_webgpu_bridge.js": {
+      "sha256": "a704115fe87d3defff4a02c5a2b1d1bf0ab3bc1f00de3f40ed2c9b2d5983fd73",
+      "size_bytes": 210601
+    },
+    "llama_webgpu_bridge_worker.js": {
+      "sha256": "47bbfa0fe897e708455b9497e9aa41d2e94489c329300c33b12936fb3169deca",
+      "size_bytes": 257
+    },
+    "llama_webgpu_core.js": {
+      "sha256": "d282a57d2de9cd3835ecc999374bcc9ef00d6df32da0f47744ea672977c86f32",
+      "size_bytes": 113962
+    },
+    "llama_webgpu_core.wasm": {
+      "sha256": "b1419854bab331278deb513b5cbadb98be364ad5f4b515690dee58edb38cc41e",
+      "size_bytes": 8542117
+    },
+    "llama_webgpu_core_mem64.js": {
+      "sha256": "451ed2bfc99fc33e0de6b09eb96f03914a194c91bcd0bda968048c2d5efa7e2d",
+      "size_bytes": 131045
+    },
+    "llama_webgpu_core_mem64.wasm": {
+      "sha256": "64e8046a6d18e570e50be84665f4a5022a457f70bc53c728298827b4c52bc072",
+      "size_bytes": 8760585
+    }
+  },
+  "github_run_id": "33032131594",
+  "github_run_url": "https://github.com/leehack/llama-web-bridge/actions/runs/33032131594",
+  "llama_cpp_commit": "bb4caa7540188872173c44d161602d9271386413",
+  "llama_cpp_tag": "v0.2.0",
+  "native_commit": "e5c240e34b525da953ed98dc743516eef78cb738",
+  "native_manifest_sha256": "2e5d29d7f98f0d71e75d3fa63b7c55f3b2a7933247cc34ea2b1c5e053d142452",
+  "native_release_tag": "v0.2.0-1",
+  "native_repository": "leehack/llamadart-native",
+  "orchestrator_correlation_id": "kanban:t_7f112b91:web-v0.1.39",
+  "qualification_gates": {
+    "multimodal": "passed",
+    "speech_to_text": "required-local-attestation",
+    "state_persistence": "passed",
+    "text_to_speech": "required-local-attestation"
+  },
+  "release_channel": "stable",
+  "release_rebuild": 0,
+  "release_tag": "v0.1.39",
+  "schema_version": 2,
+  "source_commit": "79b6ef31e394dd2de92a456b7c249f9da377c720",
+  "source_repository": "leehack/llama-web-bridge",
+  "unproven_capabilities": {
+    "real_device_intelligibility": "unproven",
+    "real_device_playback": "unproven",
+    "speaker_reference_fidelity": "unproven"
+  },
+  "upstream_commit": "bb4caa7540188872173c44d161602d9271386413",
+  "upstream_repository": "ggml-org/llama.cpp",
+  "upstream_tag": "v0.2.0"
+}
+''';
+
+Future<List<String>> _verifyManifestJson(
+  String manifestJson, {
+  String? expectedManifestSha256,
+}) {
+  final bytes = utf8.encode(manifestJson);
+  return verifyManifest(
+    expectedTag: 'v0.1.39',
+    expectedLlamaCppTag: 'v0.2.0',
+    expectedLlamaCppCommit: 'bb4caa7540188872173c44d161602d9271386413',
+    expectedBridgeCommit: '79b6ef31e394dd2de92a456b7c249f9da377c720',
+    expectedNativeReleaseTag: 'v0.2.0-1',
+    expectedManifestSha256:
+        expectedManifestSha256 ?? sha256.convert(bytes).toString(),
+    fetcher: (_) async => ManifestResponse(HttpStatus.ok, bytes),
+  );
+}
+
+String _unreleasedSection(String path) {
+  final contents = File(path).readAsStringSync();
+  return RegExp(
+    r'^## Unreleased\b(?:(?!^## ).)*',
+    multiLine: true,
+    dotAll: true,
+  ).firstMatch(contents)!.group(0)!;
+}
+
 void main() {
-  test('bridge CLI wires runtime drift and opt-in manifest checks', () {
-    final source = File(
-      'tool/testing/check_webgpu_bridge_tag.dart',
-    ).readAsStringSync();
+  test(
+    'aggregate gate runs offline checks and opt-in byte verification',
+    () async {
+      final bytes = utf8.encode(_approvedManifestJson);
+      final repoRoot = Directory.current;
 
-    expect(_bridgeCliContractProblems(source), isEmpty);
-  });
-
-  test('bridge CLI contract rejects deletion, bypass, and miswiring', () {
-    final source = File(
-      'tool/testing/check_webgpu_bridge_tag.dart',
-    ).readAsStringSync();
-    final wrongRootSource = source.replaceFirst(
-      RegExp(
-        r'repoRoot,\r?\n\s*bridgeLlamaCppTag,\r?\n\s*'
-        r'bridgeLlamaCppDivergence,',
-      ),
-      'Directory.systemTemp,\n'
-      '      bridgeLlamaCppTag,\n'
-      '      bridgeLlamaCppDivergence,',
-    );
-
-    expect(wrongRootSource, isNot(equals(source)));
-
-    expect(
-      _bridgeCliContractProblems(
-        source.replaceFirst(
-          '...findBridgeRuntimeDrift(',
-          '...findBridgeTagDrift(',
+      expect(
+        await findBridgeProblems(
+          repoRoot,
+          readPinnedBridgeTag(repoRoot),
+          verifyPublishedManifest: true,
+          manifestFetcher: (_) async => ManifestResponse(HttpStatus.ok, bytes),
         ),
-      ),
-      isNotEmpty,
-    );
-    expect(_bridgeCliContractProblems(wrongRootSource), isNotEmpty);
-    expect(
-      _bridgeCliContractProblems(
-        source.replaceFirst('if (verifyManifest)', 'if (false)'),
-      ),
-      isNotEmpty,
-    );
-  });
+        isEmpty,
+      );
+    },
+  );
 
   test('the checked-in pins all quote the source of truth', () {
     final repoRoot = Directory.current;
@@ -141,6 +235,36 @@ void main() {
       isEmpty,
     );
   });
+
+  test(
+    'current release notes keep exact Web provenance and LiteRT separation',
+    () {
+      for (final path in const <String>[
+        'CHANGELOG.md',
+        'website/docs/changelog/recent-releases.md',
+      ]) {
+        final unreleased = _unreleasedSection(path);
+        expect(unreleased, contains('`v0.1.39`'), reason: path);
+        expect(unreleased, contains(bridgeManifestSha256), reason: path);
+        expect(
+          unreleased,
+          contains('$bridgeLlamaCppTag@$bridgeLlamaCppCommit'),
+          reason: path,
+        );
+        expect(unreleased, contains(bridgeNativeReleaseTag), reason: path);
+        expect(unreleased, contains('@litert-lm/core@0.15.0'), reason: path);
+      }
+
+      expect(
+        File('example/chat_app/web/index.html').readAsStringSync(),
+        contains('@litert-lm/core@0.15.0/+esm'),
+      );
+      expect(
+        File(nativeLlamaCppTagPath).readAsStringSync(),
+        contains("const _litertLmReleaseTag = 'v0.16.0-native.2';"),
+      );
+    },
+  );
 
   test('a pin quoting a different tag is reported', () {
     final root = _fakeRepo(
@@ -191,6 +315,31 @@ void main() {
       contains(contains('matches 2 lines, expected 1')),
     );
   });
+
+  test(
+    'live changelog pins do not treat frozen release history as current',
+    () {
+      final cases = <String, String>{
+        'CHANGELOG.md':
+            '## Unreleased\n\n'
+            '* Aligned the default WebGPU bridge assets to `v9.9.9`.\n\n'
+            '## 1.0.0\n\n'
+            '* Aligned the default WebGPU bridge assets to `v1.0.0`.\n',
+        'website/docs/changelog/recent-releases.md':
+            '## Unreleased\n\n'
+            '- Aligned default WebGPU bridge assets to `v9.9.9`.\n\n'
+            '## 1.0.0\n\n'
+            '- Aligned default WebGPU bridge assets to `v1.0.0`.\n',
+      };
+
+      for (final entry in cases.entries) {
+        final pin = bridgeTagPins.singleWhere((pin) => pin.path == entry.key);
+        final matches = pin.pattern.allMatches(entry.value).toList();
+        expect(matches, hasLength(1), reason: entry.key);
+        expect(matches.single.group(1), 'v9.9.9', reason: entry.key);
+      }
+    },
+  );
 
   test('every bash assignment form is counted', () {
     const overrides = <String>[
@@ -343,159 +492,429 @@ void main() {
   }, skip: Platform.isWindows ? 'requires POSIX file permissions' : false);
 
   group('Web/native llama.cpp relationship', () {
-    test('the checked-in repo agrees with its recorded divergence', () {
+    test('the checked-in repo agrees on upstream family parity', () {
       expect(
-        findBridgeRuntimeDrift(
-          Directory.current,
-          bridgeLlamaCppTag,
-          bridgeLlamaCppDivergence,
-        ),
+        findBridgeRuntimeDrift(Directory.current, bridgeLlamaCppTag),
         isEmpty,
       );
     });
 
-    test('an unrecorded divergence is reported', () {
-      final root = _fakeRuntimeRepo(bridgeTag: 'b10514', nativeTag: 'b10545');
+    test('normalizes native wrapper rebuild tags to upstream family', () {
+      expect(normalizeNativeLlamaCppTag('v0.2.0-1'), 'v0.2.0');
+      expect(normalizeNativeLlamaCppTag('v0.2.0'), 'v0.2.0');
+      expect(normalizeNativeLlamaCppTag('v1.2.3-45'), 'v1.2.3');
+      expect(normalizeNativeLlamaCppTag('b10514-1'), 'b10514');
+      expect(normalizeNativeLlamaCppTag('b10514-llamadart.1'), 'b10514');
+      expect(normalizeNativeLlamaCppTag('b10514'), 'b10514');
+    });
+
+    test('rejects malformed native tags during normalization', () {
+      expect(normalizeNativeLlamaCppTag('v0.2.0-0'), isNull);
+      expect(normalizeNativeLlamaCppTag('v0.2.0-beta'), isNull);
+      expect(normalizeNativeLlamaCppTag('v0.2.0-custom'), isNull);
+      expect(normalizeNativeLlamaCppTag('v00.2.0-1'), isNull);
+      expect(normalizeNativeLlamaCppTag('v0.2.0-01'), isNull);
+      expect(normalizeNativeLlamaCppTag('b0123'), isNull);
+      expect(normalizeNativeLlamaCppTag('b10514-0'), isNull);
+      expect(normalizeNativeLlamaCppTag('b10514-llamadart.0'), isNull);
+      expect(normalizeNativeLlamaCppTag('v1.2'), isNull);
+      expect(normalizeNativeLlamaCppTag('invalid-tag'), isNull);
+      expect(normalizeNativeLlamaCppTag(''), isNull);
+    });
+
+    test('a malformed native wrapper tag is reported', () {
+      final root = _fakeRuntimeRepo(
+        bridgeTag: 'v0.2.0',
+        nativeTag: 'v0.2.0-custom',
+      );
 
       expect(
-        findBridgeRuntimeDrift(root, 'b10514', null),
+        findBridgeRuntimeDrift(root, 'v0.2.0'),
+        contains(contains('malformed native llama.cpp tag "v0.2.0-custom"')),
+      );
+    });
+
+    test('a wrapper tag cannot masquerade as the upstream bridge tag', () {
+      final root = _fakeRuntimeRepo(bridgeTag: 'v0.2.0', nativeTag: 'v0.2.0-1');
+
+      expect(
+        findBridgeRuntimeDrift(root, 'v0.2.0-1'),
         contains(
-          'bridge assets embed llama.cpp b10514 but $nativeLlamaCppTagPath '
-          'pins b10545 — move the bridge asset pin, or set '
-          'bridgeLlamaCppDivergence and say so in the docs',
+          'bridgeLlamaCppTag v0.2.0-1 is not a canonical upstream llama.cpp '
+          'release tag',
         ),
       );
     });
 
-    test('a recorded divergence permits the mismatch', () {
-      final root = _fakeRuntimeRepo(bridgeTag: 'b10514', nativeTag: 'b10545');
-
-      expect(findBridgeRuntimeDrift(root, 'b10514', 'because'), isEmpty);
-    });
-
-    test('a divergence record left behind after convergence is reported', () {
-      final root = _fakeRuntimeRepo(bridgeTag: 'b10545', nativeTag: 'b10545');
+    test('an upstream-family mismatch is reported', () {
+      final root = _fakeRuntimeRepo(bridgeTag: 'v0.2.0', nativeTag: 'v0.3.0-1');
 
       expect(
-        findBridgeRuntimeDrift(root, 'b10545', 'because'),
+        findBridgeRuntimeDrift(root, 'v0.2.0'),
         contains(
-          'bridgeLlamaCppDivergence records a divergence, but the bridge '
-          'assets and $nativeLlamaCppTagPath both use b10545 — clear the '
-          'record and restore the parity wording in the docs, then update '
-          'the anchored bridgeLlamaCppTagPins patterns with the wording',
+          'bridge assets embed llama.cpp v0.2.0 but $nativeLlamaCppTagPath '
+          'pins v0.3.0-1 (upstream family v0.3.0) — Web and native must share '
+          'the same upstream llama.cpp release',
         ),
       );
     });
 
-    test('stale divergence prose after convergence is reported', () {
-      final root = _fakeRuntimeRepo(bridgeTag: 'b10545', nativeTag: 'b10545');
+    test('a different wrapper in the same family is not the approved anchor', () {
+      final root = _fakeRuntimeRepo(bridgeTag: 'v0.2.0', nativeTag: 'v0.2.0-2');
 
       expect(
-        findBridgeRuntimeDrift(root, 'b10545', null).join('\n'),
+        findBridgeRuntimeDrift(root, 'v0.2.0'),
+        contains(
+          '$nativeLlamaCppTagPath pins v0.2.0-2, expected the bridge-qualified '
+          'native anchor $bridgeNativeReleaseTag',
+        ),
+      );
+    });
+
+    test('stale divergence prose is reported', () {
+      final root = _fakeRuntimeRepo(
+        bridgeTag: 'v0.2.0',
+        nativeTag: 'v0.2.0-1',
+        parityWording: false,
+      );
+
+      expect(
+        findBridgeRuntimeDrift(root, 'v0.2.0').join('\n'),
         contains('matches 0 lines, expected 1'),
       );
     });
 
-    test('parity prose is accepted after convergence', () {
+    test('parity prose is accepted for matching upstream tags', () {
       final root = _fakeRuntimeRepo(
-        bridgeTag: 'b10545',
-        nativeTag: 'b10545',
+        bridgeTag: 'v0.2.0',
+        nativeTag: 'v0.2.0-1',
         parityWording: true,
       );
 
-      expect(findBridgeRuntimeDrift(root, 'b10545', null), isEmpty);
+      expect(findBridgeRuntimeDrift(root, 'v0.2.0'), isEmpty);
     });
 
     test('a doc naming a different bridge build is reported', () {
-      final root = _fakeRuntimeRepo(bridgeTag: 'b9999', nativeTag: 'b10545');
+      final root = _fakeRuntimeRepo(
+        bridgeTag: 'v0.1.0',
+        nativeTag: 'v0.2.0-1',
+        parityWording: true,
+      );
 
       expect(
-        findBridgeRuntimeDrift(root, 'b10514', 'because'),
-        contains('doc/webgpu_bridge.md: states b9999, expected b10514'),
+        findBridgeRuntimeDrift(root, 'v0.2.0'),
+        contains('doc/webgpu_bridge.md: states v0.1.0, expected v0.2.0'),
       );
     });
 
     test('a reworded parity sentence is reported rather than skipped', () {
-      final root = _fakeRuntimeRepo(bridgeTag: 'b10514', nativeTag: 'b10545');
+      final root = _fakeRuntimeRepo(
+        bridgeTag: 'v0.2.0',
+        nativeTag: 'v0.2.0-1',
+        parityWording: true,
+      );
       File('${root.path}/doc/webgpu_bridge.md').writeAsStringSync(
-        'That release embeds llama.cpp `b10514`, matching.\n',
+        'That release embeds llama.cpp `v0.2.0`, matching.\n',
       );
 
       expect(
-        findBridgeRuntimeDrift(root, 'b10514', 'because').join('\n'),
+        findBridgeRuntimeDrift(root, 'v0.2.0').join('\n'),
         contains('matches 0 lines, expected 1'),
       );
     });
 
     test('a missing native pin fails instead of passing vacuously', () {
-      final root = _fakeRuntimeRepo(bridgeTag: 'b10514', nativeTag: 'b10545');
+      final root = _fakeRuntimeRepo(bridgeTag: 'v0.2.0', nativeTag: 'v0.2.0-1');
       File(
         '${root.path}/$nativeLlamaCppTagPath',
       ).writeAsStringSync('// nothing here\n');
 
       expect(
-        findBridgeRuntimeDrift(root, 'b10514', 'because'),
+        findBridgeRuntimeDrift(root, 'v0.2.0'),
         contains(
-          '$nativeLlamaCppTagPath: no _llamaCppTag constant; the gate cannot '
-          'run',
+          '$nativeLlamaCppTagPath: found 0 _llamaCppTag constants, expected '
+          'exactly 1; the gate cannot identify the active native pin',
+        ),
+      );
+    });
+
+    test('duplicate native pin constants fail closed', () {
+      final root = _fakeRuntimeRepo(bridgeTag: 'v0.2.0', nativeTag: 'v0.2.0-1');
+      File('${root.path}/$nativeLlamaCppTagPath').writeAsStringSync(
+        "const _llamaCppTag = 'v0.2.0-1';\n"
+        "const _llamaCppTag = 'v0.3.0-1';\n",
+      );
+
+      expect(
+        findBridgeRuntimeDrift(root, 'v0.2.0'),
+        contains(
+          contains('found 2 _llamaCppTag constants, expected exactly 1'),
         ),
       );
     });
 
     test('an unreadable native pin is reported without throwing', () {
-      final root = _fakeRuntimeRepo(bridgeTag: 'b10514', nativeTag: 'b10545');
+      final root = _fakeRuntimeRepo(bridgeTag: 'v0.2.0', nativeTag: 'v0.2.0-1');
       final file = File('${root.path}/$nativeLlamaCppTagPath');
       expect(Process.runSync('chmod', ['000', file.path]).exitCode, 0);
       addTearDown(() => Process.runSync('chmod', ['600', file.path]));
 
       expect(
-        findBridgeRuntimeDrift(root, 'b10514', 'because'),
+        findBridgeRuntimeDrift(root, 'v0.2.0'),
         contains(contains('$nativeLlamaCppTagPath: could not be read:')),
       );
     }, skip: Platform.isWindows ? 'requires POSIX file permissions' : false);
+
+    test(
+      'a recorded anchor outside the recorded upstream family is reported',
+      () {
+        // bridgeNativeReleaseTag is a constant, so drive the mismatch from the
+        // other side: a tree whose bridge and native pins agree on a family the
+        // checked-in anchor does not belong to.
+        final root = _fakeRuntimeRepo(
+          bridgeTag: 'v0.3.0',
+          nativeTag: 'v0.3.0-1',
+        );
+
+        expect(
+          findBridgeRuntimeDrift(root, 'v0.3.0'),
+          contains(
+            contains(
+              'bridgeNativeReleaseTag $bridgeNativeReleaseTag does not belong to '
+              'the recorded upstream llama.cpp release v0.3.0',
+            ),
+          ),
+        );
+      },
+    );
   });
 
-  test('malformed remote manifest JSON is reported without throwing', () async {
-    final server = await HttpServer.bind(InternetAddress.loopbackIPv4, 0);
-    addTearDown(server.close);
-    server.listen((request) {
-      request.response
-        ..statusCode = HttpStatus.ok
-        ..write('{not-json')
-        ..close();
+  group('Pinned release provenance', () {
+    test('the checked-in docs restate the pinned provenance', () {
+      expect(findBridgeProvenanceDrift(Directory.current), isEmpty);
     });
 
-    final errors = await verifyManifestLlamaCppTag(
-      'v9.9.9',
-      'b10514',
-      manifestUrl: Uri.parse(
-        'http://${server.address.host}:${server.port}/manifest.json',
-      ),
-    );
+    test('immutable release identity stays pinned to the approved release', () {
+      expect(bridgeAssetsReleaseId, '377534035');
+      expect(bridgeAssetsTagCommit, 'd14d46a63deeee7a8f8a017e394b74ee112f4dba');
+    });
 
-    expect(errors, hasLength(1));
-    expect(errors.single, contains('returned invalid manifest JSON'));
+    test('a doc restating a stale provenance value is reported', () {
+      final root = Directory.systemTemp.createTempSync('bridge_provenance');
+      addTearDown(() => root.deleteSync(recursive: true));
+      for (final pin in bridgeProvenancePins) {
+        final source = File(pin.path).readAsStringSync();
+        final passage = pin.pattern.firstMatch(source)!.group(0)!;
+        File('${root.path}/${pin.path}')
+          ..parent.createSync(recursive: true)
+          ..writeAsStringSync(
+            '${passage.replaceFirst(bridgeManifestSha256, 'a' * 64)}\n',
+          );
+      }
+
+      expect(
+        findBridgeProvenanceDrift(root),
+        everyElement(
+          contains(
+            'states manifestSha256 ${'a' * 64}, expected '
+            '$bridgeManifestSha256',
+          ),
+        ),
+      );
+    });
+
+    test('a reworded provenance passage is reported rather than skipped', () {
+      final root = Directory.systemTemp.createTempSync('bridge_provenance');
+      addTearDown(() => root.deleteSync(recursive: true));
+      for (final pin in bridgeProvenancePins) {
+        File('${root.path}/${pin.path}')
+          ..parent.createSync(recursive: true)
+          ..writeAsStringSync('Built from some release, trust us.\n');
+      }
+
+      expect(
+        findBridgeProvenanceDrift(root),
+        everyElement(contains('matches 0 lines, expected 1')),
+      );
+    });
+
+    test('a missing provenance doc fails instead of passing vacuously', () {
+      final root = Directory.systemTemp.createTempSync('bridge_provenance');
+      addTearDown(() => root.deleteSync(recursive: true));
+
+      expect(
+        findBridgeProvenanceDrift(root),
+        everyElement(contains('file is missing')),
+      );
+    });
   });
 
-  test('a stalled remote manifest request times out', () async {
-    final server = await HttpServer.bind(InternetAddress.loopbackIPv4, 0);
-    addTearDown(server.close);
-    server.listen((request) {
-      request.response.statusCode = HttpStatus.ok;
-      request.response.headers.contentType = ContentType.json;
-      request.response.write('{"llama_cpp_tag":"b10514"');
+  group('Remote manifest machine verification', () {
+    test('verifies success for the exact approved manifest', () async {
+      // Deliberately the production constants, not literals: the fixture is
+      // the only offline proof that they describe the approved bytes, and
+      // repeating them here would let a half-finished bump still pass.
+      final bytes = utf8.encode(_approvedManifestJson);
+      final errors = await verifyManifest(
+        expectedTag: readPinnedBridgeTag(Directory.current),
+        expectedLlamaCppTag: bridgeLlamaCppTag,
+        expectedLlamaCppCommit: bridgeLlamaCppCommit,
+        expectedBridgeCommit: bridgeSourceCommit,
+        expectedNativeReleaseTag: bridgeNativeReleaseTag,
+        expectedManifestSha256: bridgeManifestSha256,
+        fetcher: (_) async => ManifestResponse(HttpStatus.ok, bytes),
+      );
+
+      expect(errors, isEmpty);
     });
 
-    final errors = await verifyManifestLlamaCppTag(
-      'v9.9.9',
-      'b10514',
-      manifestUrl: Uri.parse(
-        'http://${server.address.host}:${server.port}/manifest.json',
-      ),
-      timeout: const Duration(milliseconds: 50),
+    test(
+      'an alias-only manifest no longer satisfies the required fields',
+      () async {
+        // The published manifest carries a legacy alias for each of these four
+        // fields; dropping the canonical names must fail rather than fall back.
+        final aliasOnly =
+            jsonDecode(_approvedManifestJson) as Map<String, dynamic>;
+        aliasOnly.remove('release_tag');
+        aliasOnly.remove('upstream_tag');
+        aliasOnly.remove('upstream_commit');
+        aliasOnly.remove('bridge_commit');
+        final manifestJson = jsonEncode(aliasOnly);
+        final errors = await _verifyManifestJson(manifestJson);
+
+        expect(
+          errors,
+          allOf(
+            contains(contains('release_tag is missing or empty')),
+            contains(contains('upstream_tag is missing or empty')),
+            contains(contains('upstream_commit is missing or empty')),
+            contains(contains('bridge_commit is missing or empty')),
+          ),
+        );
+      },
     );
 
-    expect(errors, hasLength(1));
-    expect(errors.single, contains('timed out reading'));
+    test('conflicting legacy provenance aliases fail closed', () async {
+      for (final alias in const <String>[
+        'bridge_assets_tag',
+        'source_repository',
+        'source_commit',
+        'llama_cpp_tag',
+        'llama_cpp_commit',
+      ]) {
+        final manifestJson = jsonEncode(<String, dynamic>{
+          ...jsonDecode(_approvedManifestJson) as Map<String, dynamic>,
+          alias: 'conflict',
+        });
+        final errors = await _verifyManifestJson(manifestJson);
+
+        expect(
+          errors,
+          contains(contains('conflicting provenance aliases')),
+          reason: '$alias conflict was accepted',
+        );
+      }
+    });
+
+    test('reports mismatching manifest SHA-256 hash', () async {
+      final errors = await _verifyManifestJson(
+        _approvedManifestJson,
+        expectedManifestSha256:
+            'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa',
+      );
+
+      expect(errors, hasLength(greaterThanOrEqualTo(1)));
+      expect(errors.first, contains('manifest SHA-256 is'));
+    });
+
+    test('rejects drift in every canonical provenance field', () async {
+      for (final mutation in <String, Object>{
+        'schema_version': 1,
+        'release_tag': 'v0.1.38',
+        'assets_repository': 'fork/llama-web-bridge-assets',
+        'bridge_repository': 'fork/llama-web-bridge',
+        'bridge_commit': '2' * 40,
+        'upstream_repository': 'fork/llama.cpp',
+        'upstream_tag': 'v0.1.9',
+        'upstream_commit': '1' * 40,
+        'native_repository': 'fork/llamadart-native',
+        'native_release_tag': 'v0.1.0-1',
+      }.entries) {
+        final manifestJson = jsonEncode(<String, dynamic>{
+          ...jsonDecode(_approvedManifestJson) as Map<String, dynamic>,
+          mutation.key: mutation.value,
+        });
+        final errors = await _verifyManifestJson(manifestJson);
+
+        expect(
+          errors,
+          contains(contains('reports ${mutation.key} ${mutation.value}')),
+          reason: '${mutation.key} drift was accepted',
+        );
+      }
+    });
+
+    test('HTTP error response is reported without throwing', () async {
+      final errors = await verifyManifest(
+        expectedTag: 'v0.1.39',
+        expectedLlamaCppTag: 'v0.2.0',
+        expectedLlamaCppCommit: 'bb4caa7540188872173c44d161602d9271386413',
+        expectedBridgeCommit: '79b6ef31e394dd2de92a456b7c249f9da377c720',
+        expectedNativeReleaseTag: 'v0.2.0-1',
+        expectedManifestSha256: bridgeManifestSha256,
+        fetcher: (_) async =>
+            const ManifestResponse(HttpStatus.notFound, <int>[]),
+      );
+
+      expect(errors, hasLength(1));
+      expect(errors.single, contains('returned HTTP 404'));
+    });
+
+    test(
+      'malformed remote manifest JSON is reported without throwing',
+      () async {
+        final errors = await _verifyManifestJson(
+          '{not-json',
+          expectedManifestSha256: bridgeManifestSha256,
+        );
+
+        expect(errors, hasLength(greaterThanOrEqualTo(1)));
+        expect(errors.join('\n'), contains('returned invalid manifest JSON'));
+      },
+    );
+
+    test('a stalled remote manifest request times out', () async {
+      final pending = Completer<ManifestResponse>();
+
+      final errors = await verifyManifest(
+        expectedTag: 'v0.1.39',
+        expectedLlamaCppTag: 'v0.2.0',
+        expectedLlamaCppCommit: 'bb4caa7540188872173c44d161602d9271386413',
+        expectedBridgeCommit: '79b6ef31e394dd2de92a456b7c249f9da377c720',
+        expectedNativeReleaseTag: 'v0.2.0-1',
+        expectedManifestSha256: bridgeManifestSha256,
+        fetcher: (_) => pending.future,
+        timeout: const Duration(milliseconds: 50),
+      );
+
+      expect(errors, hasLength(1));
+      expect(errors.single, contains('timed out reading'));
+    });
+
+    test('an oversized manifest response fails before validation', () async {
+      final errors = await verifyManifest(
+        expectedTag: 'v0.1.39',
+        expectedLlamaCppTag: 'v0.2.0',
+        expectedLlamaCppCommit: 'bb4caa7540188872173c44d161602d9271386413',
+        expectedBridgeCommit: '79b6ef31e394dd2de92a456b7c249f9da377c720',
+        expectedNativeReleaseTag: 'v0.2.0-1',
+        expectedManifestSha256: bridgeManifestSha256,
+        maximumBytes: 16,
+        fetcher: (_) async =>
+            ManifestResponse(HttpStatus.ok, List<int>.filled(17, 0)),
+      );
+
+      expect(errors.single, contains('exceeds the 16-byte limit'));
+    });
   });
 }

--- a/test/unit/tooling/check_webgpu_bridge_tag_test.dart
+++ b/test/unit/tooling/check_webgpu_bridge_tag_test.dart
@@ -699,6 +699,24 @@ void main() {
       expect(bridgeAssetsTagCommit, 'd14d46a63deeee7a8f8a017e394b74ee112f4dba');
     });
 
+    test('accepts equivalent CRLF documentation passages', () {
+      final root = Directory.systemTemp.createTempSync(
+        'bridge_provenance_crlf',
+      );
+      addTearDown(() => root.deleteSync(recursive: true));
+      for (final pin in bridgeProvenancePins) {
+        final source = File(pin.path).readAsStringSync();
+        final crlfSource = source
+            .replaceAll('\r\n', '\n')
+            .replaceAll('\n', '\r\n');
+        File('${root.path}/${pin.path}')
+          ..parent.createSync(recursive: true)
+          ..writeAsStringSync(crlfSource);
+      }
+
+      expect(findBridgeProvenanceDrift(root), isEmpty);
+    });
+
     test('a doc restating a stale provenance value is reported', () {
       final root = Directory.systemTemp.createTempSync('bridge_provenance');
       addTearDown(() => root.deleteSync(recursive: true));

--- a/tool/testing/check_webgpu_bridge_tag.dart
+++ b/tool/testing/check_webgpu_bridge_tag.dart
@@ -317,7 +317,7 @@ final List<BridgeTagPin> bridgeLlamaCppParityPins = <BridgeTagPin>[
 /// The provenance values the docs restate for the pinned immutable release.
 ///
 /// Each pattern matches one passage; every named group is checked against
-/// [bridgeProvenanceValues]. The same six values are written out in two docs,
+/// [bridgeProvenanceValues]. The same seven values are written out in two docs,
 /// so without this a partial bump leaves half the tree describing the previous
 /// release with nothing failing.
 final List<BridgeTagPin> bridgeProvenancePins = <BridgeTagPin>[

--- a/tool/testing/check_webgpu_bridge_tag.dart
+++ b/tool/testing/check_webgpu_bridge_tag.dart
@@ -10,6 +10,8 @@ import 'dart:async';
 import 'dart:convert';
 import 'dart:io';
 
+import 'package:crypto/crypto.dart';
+
 /// The file whose default decides what a fresh vendoring run downloads.
 const String bridgeTagSourcePath = 'scripts/fetch_webgpu_bridge_assets.sh';
 
@@ -99,7 +101,10 @@ final List<BridgeTagPin> bridgeTagPins = <BridgeTagPin>[
   ),
   BridgeTagPin(
     'website/docs/platforms/webgpu-bridge.md',
-    RegExp(r'^identified as `(v\d+\.\d+\.\d+)-local-b\d+`\.$', multiLine: true),
+    RegExp(
+      r'^identified as `(v\d+\.\d+\.\d+)-local-[a-zA-Z0-9.-]+`\.$',
+      multiLine: true,
+    ),
   ),
   BridgeTagPin(
     'website/docs/platforms/webgpu-bridge.md',
@@ -118,6 +123,24 @@ final List<BridgeTagPin> bridgeTagPins = <BridgeTagPin>[
   BridgeTagPin(
     'website/docs/guides/text-to-speech.md',
     RegExp(r'^- The chat example pins `(v\d+\.\d+\.\d+)`,', multiLine: true),
+  ),
+  BridgeTagPin(
+    'CHANGELOG.md',
+    RegExp(
+      r'^## Unreleased\b(?:(?!^## ).)*?^\* Aligned the default WebGPU bridge '
+      r'assets to `(v\d+\.\d+\.\d+)`',
+      multiLine: true,
+      dotAll: true,
+    ),
+  ),
+  BridgeTagPin(
+    'website/docs/changelog/recent-releases.md',
+    RegExp(
+      r'^## Unreleased\b(?:(?!^## ).)*?^- Aligned default WebGPU bridge assets '
+      r'to `(v\d+\.\d+\.\d+)`',
+      multiLine: true,
+      dotAll: true,
+    ),
   ),
 ];
 
@@ -187,62 +210,97 @@ List<String> findBridgeTagDrift(Directory repoRoot, String expectedTag) {
   return problems;
 }
 
-/// The llama.cpp build embedded in the pinned bridge assets.
-///
-/// Taken from `llama_cpp_tag` in the `manifest.json` published under the tag
-/// [bridgeTagSourcePath] pins. `--verify-manifest` re-reads the published
-/// manifest and fails when this record no longer matches it.
-const String bridgeLlamaCppTag = 'b10514';
+/// The llama.cpp upstream release tag embedded in the pinned bridge assets.
+const String bridgeLlamaCppTag = 'v0.2.0';
+
+/// The exact upstream llama.cpp commit embedded in the pinned bridge assets.
+const String bridgeLlamaCppCommit = 'bb4caa7540188872173c44d161602d9271386413';
+
+/// The exact bridge source commit used to build the pinned bridge assets.
+const String bridgeSourceCommit = '79b6ef31e394dd2de92a456b7c249f9da377c720';
+
+/// Canonical repository identities recorded in the approved manifest.
+const String bridgeAssetsRepository = 'leehack/llama-web-bridge-assets';
+const String bridgeSourceRepository = 'leehack/llama-web-bridge';
+const String bridgeUpstreamRepository = 'ggml-org/llama.cpp';
+const String bridgeNativeRepository = 'leehack/llamadart-native';
+
+/// The native release tag the pinned bridge assets were qualified against.
+const String bridgeNativeReleaseTag = 'v0.2.0-1';
+
+/// The asset repository release that published the pinned bridge assets.
+const String bridgeAssetsReleaseId = '377534035';
+
+/// The asset repository commit the pinned bridge asset tag points at.
+const String bridgeAssetsTagCommit = 'd14d46a63deeee7a8f8a017e394b74ee112f4dba';
+
+/// SHA-256 hash of the exact approved published manifest.json.
+const String bridgeManifestSha256 =
+    'b355d01040604f6ae2c5c5fe5bb42b858101a96f03f67e4b27b32fe41ce3b2bf';
 
 /// Where the native runtime's llama.cpp build is pinned.
 const String nativeLlamaCppTagPath = 'hook/build.dart';
 
 final RegExp _nativeLlamaCppTag = RegExp(r"const _llamaCppTag = '([^']+)';");
 
-/// Why Web deliberately runs a different llama.cpp build from native, or null
-/// when the two must agree.
-///
-/// Set this only alongside docs that say so; clear it once the bridge assets
-/// catch up. The gate fails both ways: an unrecorded divergence, and a record
-/// left behind after the tags converged. Prose describing the relationship
-/// lives in the [bridgeLlamaCppTagPins] sentences, which move with it.
-String? get bridgeLlamaCppDivergence =>
-    'Bridge assets v0.1.37 embed b10514; the native pin now consumes immutable '
-    'v0.2.0-1 (llama.cpp v0.2.0). Web trails native until the next bridge '
-    'asset release.';
+final RegExp _stableNativeTag = RegExp(
+  r'^v(0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*)$',
+);
+final RegExp _stableWrapperTag = RegExp(
+  r'^v(0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*)-([1-9]\d*)$',
+);
+final RegExp _legacyNativeTag = RegExp(r'^b(0|[1-9]\d*)$');
+final RegExp _nightlyWrapperTag = RegExp(r'^b(0|[1-9]\d*)-([1-9]\d*)$');
+final RegExp _legacyWrapperTag = RegExp(
+  r'^b(0|[1-9]\d*)-llamadart\.([1-9]\d*)$',
+);
 
-/// Doc sentences that state the bridge assets' llama.cpp build.
+/// Normalizes a native release tag (e.g., `v0.2.0-1` or `b10514-1`) to its
+/// upstream llama.cpp release family (e.g., `v0.2.0` or `b10514`).
 ///
-/// Anchored on the surrounding wording so a reworded parity claim fails here
-/// instead of quietly outliving the pin it describes.
-final List<BridgeTagPin> bridgeLlamaCppTagPins = <BridgeTagPin>[
-  BridgeTagPin(
-    'doc/webgpu_bridge.md',
-    RegExp(
-      r'^That release embeds llama\.cpp `(b\d+)`, which now trails the '
-      r'`hook/build\.dart`$',
-      multiLine: true,
-    ),
-  ),
-  BridgeTagPin(
-    'website/docs/platforms/webgpu-bridge.md',
-    RegExp(
-      r'^- `v\d+\.\d+\.\d+\+` bridge assets embed llama\.cpp `(b\d+)`, which now trails the$',
-      multiLine: true,
-    ),
-  ),
-];
+/// Returns null if the tag is malformed or not a recognized native release tag.
+String? normalizeNativeLlamaCppTag(String nativeTag) {
+  final stableWrapperMatch = _stableWrapperTag.firstMatch(nativeTag);
+  if (stableWrapperMatch != null) {
+    return 'v${stableWrapperMatch.group(1)}.${stableWrapperMatch.group(2)}.${stableWrapperMatch.group(3)}';
+  }
+  final stableMatch = _stableNativeTag.firstMatch(nativeTag);
+  if (stableMatch != null) {
+    return nativeTag;
+  }
+  final nightlyWrapperMatch = _nightlyWrapperTag.firstMatch(nativeTag);
+  if (nightlyWrapperMatch != null) {
+    return 'b${nightlyWrapperMatch.group(1)}';
+  }
+  final legacyWrapperMatch = _legacyWrapperTag.firstMatch(nativeTag);
+  if (legacyWrapperMatch != null) {
+    return 'b${legacyWrapperMatch.group(1)}';
+  }
+  final legacyMatch = _legacyNativeTag.firstMatch(nativeTag);
+  if (legacyMatch != null) {
+    return nativeTag;
+  }
+  return null;
+}
 
-/// Doc sentences required once the bridge and native llama.cpp pins converge.
+/// Every site that names the llama.cpp build the bridge assets embed.
 ///
-/// Keeping these separate from [bridgeLlamaCppTagPins] prevents stale
-/// divergence prose from passing merely because both embedded tag values are
-/// current.
+/// The doc sentences are anchored on their parity wording so a reworded claim
+/// fails here instead of outliving the pin it describes. The chat bootstrap
+/// constant is included because it feeds the user-visible local build id, so a
+/// stale value there misreports the running build in every browser console.
 final List<BridgeTagPin> bridgeLlamaCppParityPins = <BridgeTagPin>[
   BridgeTagPin(
+    'example/chat_app/web/index.html',
+    RegExp(
+      r"^\s*const defaultBridgeLlamaCppTag = '(v\d+\.\d+\.\d+|b\d+)';$",
+      multiLine: true,
+    ),
+  ),
+  BridgeTagPin(
     'doc/webgpu_bridge.md',
     RegExp(
-      r'^That release embeds llama\.cpp `(b\d+)`, matching the '
+      r'^That release embeds llama\.cpp `(v\d+\.\d+\.\d+|b\d+)`, matching the '
       r'`hook/build\.dart` native pin$',
       multiLine: true,
     ),
@@ -250,24 +308,65 @@ final List<BridgeTagPin> bridgeLlamaCppParityPins = <BridgeTagPin>[
   BridgeTagPin(
     'website/docs/platforms/webgpu-bridge.md',
     RegExp(
-      r'^- `v\d+\.\d+\.\d+\+` bridge assets embed llama\.cpp `(b\d+)`, matching the native runtime$',
+      r'^- `v\d+\.\d+\.\d+\+` bridge assets embed llama\.cpp `(v\d+\.\d+\.\d+|b\d+)`, matching the native runtime$',
       multiLine: true,
     ),
   ),
 ];
+
+/// The provenance values the docs restate for the pinned immutable release.
+///
+/// Each pattern matches one passage; every named group is checked against
+/// [bridgeProvenanceValues]. The same six values are written out in two docs,
+/// so without this a partial bump leaves half the tree describing the previous
+/// release with nothing failing.
+final List<BridgeTagPin> bridgeProvenancePins = <BridgeTagPin>[
+  BridgeTagPin(
+    'doc/webgpu_bridge.md',
+    RegExp(
+      r'^\(`(?<nativeReleaseTag>[^`]+)`, both built from upstream llama\.cpp '
+      r'`(?<upstreamTag>[^`@]+)@(?<upstreamCommit>[0-9a-f]{40})`\)\n'
+      r'even though wrapper release tags differ\. Provenance for this immutable consumer\n'
+      r'artifact: release `(?<releaseId>\d+)`, tag commit\n'
+      r'`(?<tagCommit>[0-9a-f]{40})`, bridge source\n'
+      r'`(?<bridgeCommit>[0-9a-f]{40})`, and manifest SHA-256\n'
+      r'`(?<manifestSha256>[0-9a-f]{64})`\.',
+      multiLine: true,
+    ),
+  ),
+  BridgeTagPin(
+    'website/docs/platforms/webgpu-bridge.md',
+    RegExp(
+      r'^  \(`(?<nativeReleaseTag>[^`]+)`, both built from upstream '
+      r'`(?<upstreamTag>[^`@]+)@(?<upstreamCommit>[0-9a-f]{40})`\)\n'
+      r'  even though wrapper release tags differ\. Pinned artifact provenance: release\n'
+      r'  `(?<releaseId>\d+)`, tag commit `(?<tagCommit>[0-9a-f]{40})`, bridge\n'
+      r'  source `(?<bridgeCommit>[0-9a-f]{40})`, manifest SHA-256\n'
+      r'  `(?<manifestSha256>[0-9a-f]{64})`\.',
+      multiLine: true,
+    ),
+  ),
+];
+
+/// The expected value behind each [bridgeProvenancePins] group name.
+Map<String, String> get bridgeProvenanceValues => <String, String>{
+  'nativeReleaseTag': bridgeNativeReleaseTag,
+  'upstreamTag': bridgeLlamaCppTag,
+  'upstreamCommit': bridgeLlamaCppCommit,
+  'releaseId': bridgeAssetsReleaseId,
+  'tagCommit': bridgeAssetsTagCommit,
+  'bridgeCommit': bridgeSourceCommit,
+  'manifestSha256': bridgeManifestSha256,
+};
 
 /// Returns one message per problem with the Web/native llama.cpp relationship.
 ///
 /// `hook/build.dart` and the bridge manifest move in different repositories, so
 /// nothing else notices when a native pin bump silently ends Web/native parity
 /// and leaves the docs claiming it.
-/// [bridgeTag] is the llama.cpp tag embedded by the bridge assets, not the
-/// bridge asset release tag itself.
-List<String> findBridgeRuntimeDrift(
-  Directory repoRoot,
-  String bridgeTag,
-  String? divergence,
-) {
+/// [bridgeTag] is the llama.cpp upstream release tag embedded by the bridge
+/// assets, not the bridge asset release tag itself.
+List<String> findBridgeRuntimeDrift(Directory repoRoot, String bridgeTag) {
   final problems = <String>[];
   final file = File('${repoRoot.path}/$nativeLlamaCppTagPath');
   if (!file.existsSync()) {
@@ -275,35 +374,59 @@ List<String> findBridgeRuntimeDrift(
   }
   final nativeContents = _readGateFile(file, nativeLlamaCppTagPath, problems);
   if (nativeContents == null) return problems;
-  final match = _nativeLlamaCppTag.firstMatch(nativeContents);
-  if (match == null) {
+  final matches = _nativeLlamaCppTag.allMatches(nativeContents).toList();
+  if (matches.length != 1) {
     return <String>[
-      '$nativeLlamaCppTagPath: no _llamaCppTag constant; the gate cannot run',
+      '$nativeLlamaCppTagPath: found ${matches.length} _llamaCppTag constants, '
+          'expected exactly 1; the gate cannot identify the active native pin',
     ];
   }
 
-  final nativeTag = match.group(1)!;
-  if (nativeTag == bridgeTag) {
-    if (divergence != null) {
-      problems.add(
-        'bridgeLlamaCppDivergence records a divergence, but the bridge assets '
-        'and $nativeLlamaCppTagPath both use $nativeTag — clear the record and '
-        'restore the parity wording in the docs, then update the anchored '
-        'bridgeLlamaCppTagPins patterns with the wording',
-      );
-    }
-  } else if (divergence == null) {
+  final normalizedBridgeTag = normalizeNativeLlamaCppTag(bridgeTag);
+  if (normalizedBridgeTag != bridgeTag) {
     problems.add(
-      'bridge assets embed llama.cpp $bridgeTag but $nativeLlamaCppTagPath '
-      'pins $nativeTag — move the bridge asset pin, or set '
-      'bridgeLlamaCppDivergence and say so in the docs',
+      'bridgeLlamaCppTag $bridgeTag is not a canonical upstream llama.cpp '
+      'release tag',
     );
   }
 
-  final activeDocPins = divergence == null
-      ? bridgeLlamaCppParityPins
-      : bridgeLlamaCppTagPins;
-  for (final pin in activeDocPins) {
+  // The recorded anchor and the recorded upstream tag are bumped by hand in
+  // separate constants, so a half-finished bump would otherwise pass here and
+  // then be compared against the manifest in its stale form by
+  // --verify-manifest, which would pass too.
+  final normalizedAnchor = normalizeNativeLlamaCppTag(bridgeNativeReleaseTag);
+  if (normalizedAnchor != bridgeTag) {
+    problems.add(
+      'bridgeNativeReleaseTag $bridgeNativeReleaseTag does not belong to the '
+      'recorded upstream llama.cpp release $bridgeTag — the checked-in bridge '
+      'provenance constants disagree with each other',
+    );
+  }
+
+  final nativeTag = matches.single.group(1)!;
+  final normalizedNativeFamily = normalizeNativeLlamaCppTag(nativeTag);
+  if (normalizedNativeFamily == null) {
+    problems.add(
+      '$nativeLlamaCppTagPath: malformed native llama.cpp tag "$nativeTag" — '
+      'expected stable vMAJOR.MINOR.PATCH(-N) or nightly bNNNN(-N|-llamadart.N)',
+    );
+  } else {
+    if (nativeTag != bridgeNativeReleaseTag) {
+      problems.add(
+        '$nativeLlamaCppTagPath pins $nativeTag, expected the bridge-qualified '
+        'native anchor $bridgeNativeReleaseTag',
+      );
+    }
+    if (normalizedNativeFamily != bridgeTag) {
+      problems.add(
+        'bridge assets embed llama.cpp $bridgeTag but $nativeLlamaCppTagPath '
+        'pins $nativeTag (upstream family $normalizedNativeFamily) — Web and '
+        'native must share the same upstream llama.cpp release',
+      );
+    }
+  }
+
+  for (final pin in bridgeLlamaCppParityPins) {
     final doc = File('${repoRoot.path}/${pin.path}');
     if (!doc.existsSync()) {
       problems.add('${pin.path}: file is missing');
@@ -325,6 +448,50 @@ List<String> findBridgeRuntimeDrift(
       problems.add('${pin.path}: states $found, expected $bridgeTag');
     }
   }
+
+  return problems;
+}
+
+/// Returns one message per provenance value a doc states incorrectly.
+///
+/// The bridge assets are consumed as an immutable artifact, so every value in
+/// [bridgeProvenanceValues] identifies bytes that can be re-fetched and
+/// re-hashed. Docs that restate them are pinned rather than trusted.
+List<String> findBridgeProvenanceDrift(Directory repoRoot) {
+  final problems = <String>[];
+  for (final pin in bridgeProvenancePins) {
+    final doc = File('${repoRoot.path}/${pin.path}');
+    if (!doc.existsSync()) {
+      problems.add('${pin.path}: file is missing');
+      continue;
+    }
+    final contents = _readGateFile(doc, pin.path, problems);
+    if (contents == null) continue;
+    final matches = pin.pattern.allMatches(contents).toList();
+    if (matches.length != 1) {
+      problems.add(
+        '${pin.path}: the pinned release provenance passage matches '
+        '${matches.length} lines, expected 1 — it was reworded, removed, or '
+        'duplicated, so this check no longer covers it',
+      );
+      continue;
+    }
+    final match = matches.single;
+    for (final entry in bridgeProvenanceValues.entries) {
+      if (!match.groupNames.contains(entry.key)) {
+        problems.add(
+          '${pin.path}: the provenance passage no longer states ${entry.key}',
+        );
+        continue;
+      }
+      final found = match.namedGroup(entry.key);
+      if (found != entry.value) {
+        problems.add(
+          '${pin.path}: states ${entry.key} $found, expected ${entry.value}',
+        );
+      }
+    }
+  }
   return problems;
 }
 
@@ -339,64 +506,197 @@ String? _readGateFile(File file, String path, List<String> problems) {
   return null;
 }
 
-/// Re-reads the published manifest for [expectedTag] and returns one message
-/// when [bridgeLlamaCppTag] no longer matches it.
+/// Maximum accepted response size for the small release manifest.
+const int maxBridgeManifestBytes = 64 * 1024;
+
+/// The transport result consumed by [verifyManifest].
+class ManifestResponse {
+  /// HTTP status returned by the manifest endpoint.
+  final int statusCode;
+
+  /// Response bytes, empty for a non-success status.
+  final List<int> bytes;
+
+  /// Creates a manifest response.
+  const ManifestResponse(this.statusCode, this.bytes);
+}
+
+/// Fetches one manifest response.
+typedef ManifestFetcher = Future<ManifestResponse> Function(Uri url);
+
+const Map<String, String> _manifestProvenanceAliases = <String, String>{
+  'release_tag': 'bridge_assets_tag',
+  'bridge_repository': 'source_repository',
+  'bridge_commit': 'source_commit',
+  'upstream_tag': 'llama_cpp_tag',
+  'upstream_commit': 'llama_cpp_commit',
+};
+
+Future<ManifestResponse> _fetchManifest(
+  HttpClient client,
+  Uri url,
+  int maximumBytes,
+) async {
+  final request = await client.getUrl(url);
+  final response = await request.close();
+  if (response.statusCode != HttpStatus.ok) {
+    return ManifestResponse(response.statusCode, const <int>[]);
+  }
+  if (response.contentLength > maximumBytes) {
+    throw HttpException(
+      'manifest Content-Length ${response.contentLength} exceeds the '
+      '$maximumBytes-byte limit',
+      uri: url,
+    );
+  }
+
+  final bytes = <int>[];
+  await for (final chunk in response) {
+    if (bytes.length + chunk.length > maximumBytes) {
+      throw HttpException(
+        'manifest body exceeds the $maximumBytes-byte limit',
+        uri: url,
+      );
+    }
+    bytes.addAll(chunk);
+  }
+  return ManifestResponse(response.statusCode, bytes);
+}
+
+/// Verifies exact manifest bytes and their canonical schema-2 provenance.
+List<String> verifyManifestBytes({
+  required List<int> bytes,
+  required Uri source,
+  required String expectedManifestSha256,
+  required Map<String, Object> expectedProvenance,
+}) {
+  final problems = <String>[];
+  final actualHash = sha256.convert(bytes).toString();
+  if (actualHash != expectedManifestSha256) {
+    problems.add(
+      '$source manifest SHA-256 is $actualHash, expected '
+      '$expectedManifestSha256',
+    );
+  }
+
+  final String body;
+  try {
+    body = utf8.decode(bytes);
+  } on FormatException catch (error) {
+    return <String>[
+      ...problems,
+      '$source returned invalid manifest UTF-8 bytes: $error',
+    ];
+  }
+
+  final dynamic decoded;
+  try {
+    decoded = jsonDecode(body);
+  } on FormatException catch (error) {
+    return <String>[
+      ...problems,
+      '$source returned invalid manifest JSON: $error',
+    ];
+  }
+  if (decoded is! Map<String, dynamic>) {
+    return <String>[
+      ...problems,
+      '$source returned invalid manifest JSON: expected an object',
+    ];
+  }
+
+  // Alias fields remain in the published manifest for old consumers. This gate
+  // deliberately reads only the schema-2 canonical names so an alias cannot
+  // hide a missing or conflicting provenance field.
+  for (final expectation in expectedProvenance.entries) {
+    final value = decoded[expectation.key];
+    if (value == null || (value is String && value.isEmpty)) {
+      problems.add(
+        '$source returned invalid manifest JSON: ${expectation.key} is missing '
+        'or empty',
+      );
+      continue;
+    }
+    if (value != expectation.value) {
+      problems.add(
+        '$source reports ${expectation.key} $value, expected '
+        '${expectation.value}',
+      );
+    }
+  }
+  for (final alias in _manifestProvenanceAliases.entries) {
+    final aliasValue = decoded[alias.value];
+    if (aliasValue != null && aliasValue != decoded[alias.key]) {
+      problems.add(
+        '$source has conflicting provenance aliases: ${alias.key} '
+        '${decoded[alias.key]} but ${alias.value} $aliasValue',
+      );
+    }
+  }
+  return problems;
+}
+
+/// Re-reads the published manifest for [expectedTag] and machine-verifies its
+/// exact approved bytes and canonical schema-2 provenance fields.
 ///
 /// Network-dependent, so it is opt-in rather than part of the default run.
-Future<List<String>> verifyManifestLlamaCppTag(
-  String expectedTag,
-  String bridgeTag, {
+Future<List<String>> verifyManifest({
+  required String expectedTag,
+  required String expectedLlamaCppTag,
+  required String expectedLlamaCppCommit,
+  required String expectedBridgeCommit,
+  required String expectedNativeReleaseTag,
+  required String expectedManifestSha256,
   Uri? manifestUrl,
   Duration timeout = const Duration(seconds: 15),
+  int maximumBytes = maxBridgeManifestBytes,
+  ManifestFetcher? fetcher,
 }) async {
   final url =
       manifestUrl ??
       Uri.parse(
-        'https://cdn.jsdelivr.net/gh/leehack/llama-web-bridge-assets@$expectedTag'
+        'https://cdn.jsdelivr.net/gh/$bridgeAssetsRepository@$expectedTag'
         '/manifest.json',
       );
-  final client = HttpClient();
+  final client = fetcher == null ? HttpClient() : null;
   try {
-    Future<List<String>> fetchManifest() async {
-      final request = await client.getUrl(url);
-      final response = await request.close();
-      if (response.statusCode != 200) {
-        return <String>['$url returned HTTP ${response.statusCode}'];
-      }
-      final body = await response.transform(utf8.decoder).join();
-      final decoded = jsonDecode(body);
-      if (decoded is! Map<String, dynamic>) {
-        return <String>[
-          '$url returned invalid manifest JSON: expected an object',
-        ];
-      }
-      final manifestTag = decoded['llama_cpp_tag'];
-      if (manifestTag is! String || manifestTag.isEmpty) {
-        return <String>[
-          '$url returned invalid manifest JSON: llama_cpp_tag must be a '
-              'non-empty string',
-        ];
-      }
-      if (manifestTag != bridgeTag) {
-        return <String>[
-          '$url reports llama_cpp_tag $manifestTag, but bridgeLlamaCppTag is '
-              '$bridgeTag',
-        ];
-      }
-      return <String>[];
+    final response =
+        await (fetcher ?? (url) => _fetchManifest(client!, url, maximumBytes))(
+          url,
+        ).timeout(timeout);
+    if (response.statusCode != HttpStatus.ok) {
+      return <String>['$url returned HTTP ${response.statusCode}'];
     }
-
-    return await fetchManifest().timeout(timeout);
+    if (response.bytes.length > maximumBytes) {
+      return <String>[
+        '$url manifest body exceeds the $maximumBytes-byte limit',
+      ];
+    }
+    return verifyManifestBytes(
+      bytes: response.bytes,
+      source: url,
+      expectedManifestSha256: expectedManifestSha256,
+      expectedProvenance: <String, Object>{
+        'schema_version': 2,
+        'release_tag': expectedTag,
+        'assets_repository': bridgeAssetsRepository,
+        'bridge_repository': bridgeSourceRepository,
+        'bridge_commit': expectedBridgeCommit,
+        'upstream_repository': bridgeUpstreamRepository,
+        'upstream_tag': expectedLlamaCppTag,
+        'upstream_commit': expectedLlamaCppCommit,
+        'native_repository': bridgeNativeRepository,
+        'native_release_tag': expectedNativeReleaseTag,
+      },
+    );
   } on TimeoutException {
     return <String>[
       'timed out reading $url after ${timeout.inMilliseconds} ms',
     ];
   } on IOException catch (error) {
     return <String>['could not read $url: $error'];
-  } on FormatException catch (error) {
-    return <String>['$url returned invalid manifest JSON: $error'];
   } finally {
-    client.close();
+    client?.close(force: true);
   }
 }
 
@@ -419,7 +719,8 @@ const List<String> _selfPaths = <String>[
   'test/unit/tooling/check_webgpu_bridge_tag_test.dart',
 ];
 
-/// Files that record past releases, where an old tag is correct.
+/// Files that record past releases, where an old tag is correct. Current
+/// `Unreleased` claims in these files remain explicit [bridgeTagPins].
 const List<String> tagHistoryFiles = <String>[
   'CHANGELOG.md',
   'website/docs/changelog/recent-releases.md',
@@ -432,7 +733,7 @@ const String versionedDocsPrefix = 'website/versioned_docs/';
 ///
 /// Without this the gate would only protect sites someone remembered to
 /// register, so a newly added pin could go stale while CI stayed green.
-/// Capability floors (`v0.1.37+`) and the release histories are excluded
+/// Capability floors (`v0.1.39+`) and the release histories are excluded
 /// because they legitimately keep their own values.
 List<String> findUnregisteredTagSites(Directory repoRoot, String expectedTag) {
   final listed = Process.runSync('git', <String>[
@@ -507,7 +808,7 @@ class _PinOccurrence {
 }
 
 /// Every pin shape, plus every mention of [expectedTag] that is not a
-/// `v0.1.37+` minimum.
+/// `v0.1.39+` minimum.
 List<_PinOccurrence> _pinOccurrences(String line, String expectedTag) {
   final found = <_PinOccurrence>[];
   for (final shape in bridgeTagPinShapes) {
@@ -528,8 +829,31 @@ List<_PinOccurrence> _pinOccurrences(String line, String expectedTag) {
   return found;
 }
 
+/// Runs every offline drift gate and the optional published-manifest gate.
+Future<List<String>> findBridgeProblems(
+  Directory repoRoot,
+  String expectedTag, {
+  bool verifyPublishedManifest = false,
+  ManifestFetcher? manifestFetcher,
+}) async => <String>[
+  ...findBridgeTagDrift(repoRoot, expectedTag),
+  ...findUnregisteredTagSites(repoRoot, expectedTag),
+  ...findBridgeRuntimeDrift(repoRoot, bridgeLlamaCppTag),
+  ...findBridgeProvenanceDrift(repoRoot),
+  if (verifyPublishedManifest)
+    ...await verifyManifest(
+      expectedTag: expectedTag,
+      expectedLlamaCppTag: bridgeLlamaCppTag,
+      expectedLlamaCppCommit: bridgeLlamaCppCommit,
+      expectedBridgeCommit: bridgeSourceCommit,
+      expectedNativeReleaseTag: bridgeNativeReleaseTag,
+      expectedManifestSha256: bridgeManifestSha256,
+      fetcher: manifestFetcher,
+    ),
+];
+
 Future<void> main(List<String> arguments) async {
-  final verifyManifest = arguments.contains('--verify-manifest');
+  final verifyManifestFlag = arguments.contains('--verify-manifest');
   final unknown = arguments.where(
     (argument) => argument != '--verify-manifest',
   );
@@ -550,17 +874,11 @@ Future<void> main(List<String> arguments) async {
     exit(1);
   }
 
-  final problems = <String>[
-    ...findBridgeTagDrift(repoRoot, expectedTag),
-    ...findUnregisteredTagSites(repoRoot, expectedTag),
-    ...findBridgeRuntimeDrift(
-      repoRoot,
-      bridgeLlamaCppTag,
-      bridgeLlamaCppDivergence,
-    ),
-    if (verifyManifest)
-      ...await verifyManifestLlamaCppTag(expectedTag, bridgeLlamaCppTag),
-  ];
+  final problems = await findBridgeProblems(
+    repoRoot,
+    expectedTag,
+    verifyPublishedManifest: verifyManifestFlag,
+  );
   if (problems.isNotEmpty) {
     stderr.writeln(
       '[webgpu-bridge-tag] $bridgeTagSourcePath pins $expectedTag, but:',
@@ -571,19 +889,15 @@ Future<void> main(List<String> arguments) async {
     exit(1);
   }
 
-  final divergence = bridgeLlamaCppDivergence;
   stdout.writeln(
     '[webgpu-bridge-tag] OK: ${bridgeTagPins.length} pins agree on $expectedTag.',
   );
-  if (divergence == null) {
-    stdout.writeln(
-      '[webgpu-bridge-tag] OK: Web and native both run llama.cpp '
-      '$bridgeLlamaCppTag.',
-    );
-  } else {
-    stdout.writeln(
-      '[webgpu-bridge-tag] Recorded divergence: bridge assets embed '
-      '$bridgeLlamaCppTag. $divergence',
-    );
-  }
+  stdout.writeln(
+    '[webgpu-bridge-tag] OK: Web and native both run upstream llama.cpp '
+    '$bridgeLlamaCppTag.',
+  );
+  stdout.writeln(
+    '[webgpu-bridge-tag] OK: ${bridgeProvenancePins.length} docs restate the '
+    'release $bridgeAssetsReleaseId provenance correctly.',
+  );
 }

--- a/tool/testing/check_webgpu_bridge_tag.dart
+++ b/tool/testing/check_webgpu_bridge_tag.dart
@@ -325,11 +325,11 @@ final List<BridgeTagPin> bridgeProvenancePins = <BridgeTagPin>[
     'doc/webgpu_bridge.md',
     RegExp(
       r'^\(`(?<nativeReleaseTag>[^`]+)`, both built from upstream llama\.cpp '
-      r'`(?<upstreamTag>[^`@]+)@(?<upstreamCommit>[0-9a-f]{40})`\)\n'
-      r'even though wrapper release tags differ\. Provenance for this immutable consumer\n'
-      r'artifact: release `(?<releaseId>\d+)`, tag commit\n'
-      r'`(?<tagCommit>[0-9a-f]{40})`, bridge source\n'
-      r'`(?<bridgeCommit>[0-9a-f]{40})`, and manifest SHA-256\n'
+      r'`(?<upstreamTag>[^`@]+)@(?<upstreamCommit>[0-9a-f]{40})`\)\r?\n'
+      r'even though wrapper release tags differ\. Provenance for this immutable consumer\r?\n'
+      r'artifact: release `(?<releaseId>\d+)`, tag commit\r?\n'
+      r'`(?<tagCommit>[0-9a-f]{40})`, bridge source\r?\n'
+      r'`(?<bridgeCommit>[0-9a-f]{40})`, and manifest SHA-256\r?\n'
       r'`(?<manifestSha256>[0-9a-f]{64})`\.',
       multiLine: true,
     ),
@@ -338,10 +338,10 @@ final List<BridgeTagPin> bridgeProvenancePins = <BridgeTagPin>[
     'website/docs/platforms/webgpu-bridge.md',
     RegExp(
       r'^  \(`(?<nativeReleaseTag>[^`]+)`, both built from upstream '
-      r'`(?<upstreamTag>[^`@]+)@(?<upstreamCommit>[0-9a-f]{40})`\)\n'
-      r'  even though wrapper release tags differ\. Pinned artifact provenance: release\n'
-      r'  `(?<releaseId>\d+)`, tag commit `(?<tagCommit>[0-9a-f]{40})`, bridge\n'
-      r'  source `(?<bridgeCommit>[0-9a-f]{40})`, manifest SHA-256\n'
+      r'`(?<upstreamTag>[^`@]+)@(?<upstreamCommit>[0-9a-f]{40})`\)\r?\n'
+      r'  even though wrapper release tags differ\. Pinned artifact provenance: release\r?\n'
+      r'  `(?<releaseId>\d+)`, tag commit `(?<tagCommit>[0-9a-f]{40})`, bridge\r?\n'
+      r'  source `(?<bridgeCommit>[0-9a-f]{40})`, manifest SHA-256\r?\n'
       r'  `(?<manifestSha256>[0-9a-f]{64})`\.',
       multiLine: true,
     ),

--- a/website/docs/changelog/recent-releases.md
+++ b/website/docs/changelog/recent-releases.md
@@ -9,6 +9,13 @@ For canonical full release notes, use:
 
 ## Unreleased
 
+- Aligned default WebGPU bridge assets to `v0.1.39` (immutable manifest
+  `b355d01040604f6ae2c5c5fe5bb42b858101a96f03f67e4b27b32fe41ce3b2bf`),
+  restoring Web and native llama.cpp upstream
+  `v0.2.0@bb4caa7540188872173c44d161602d9271386413` parity with native
+  anchor `llamadart-native@v0.2.0-1` while preserving Web
+  `@litert-lm/core@0.15.0` packaging.
+
 - Patched the website's vulnerable `nanoid` and `uuid` dependency paths. Until
   Docusaurus replaces its unpatched image parser, automatic local Markdown
   images are rejected; website contributors should use static pathname URLs.

--- a/website/docs/guides/text-to-speech.md
+++ b/website/docs/guides/text-to-speech.md
@@ -172,7 +172,7 @@ memory-constrained mobile devices.
 - Web requires published bridge assets `v0.1.33+`, WebAssembly memory64 for the
   pinned roughly 1.48 GB model/projector pair, and a browser/device with enough
   memory. Older bridge assets fail capability discovery clearly.
-- The chat example pins `v0.1.37`, which retains the `v0.1.34` recovery that
+- The chat example pins `v0.1.39`, which retains the `v0.1.34` recovery that
   retries a worker WebGPU abort or device failure once on CPU using the cached
   model and projector. Recovery is slower and is not a substitute for
   sufficient browser memory. Qwen3-TTS accelerator behavior remains

--- a/website/docs/platforms/webgpu-bridge.md
+++ b/website/docs/platforms/webgpu-bridge.md
@@ -146,13 +146,13 @@ development validation, and CDN-first loading for normal hosted deployments:
 1. On localhost: local asset first, then CDN fallback.
 2. On hosted deployments: CDN asset first, then local fallback.
 
-The example currently pins bridge assets to `v0.1.37`, with local vendored assets
-identified as `v0.1.37-local-b10514`.
+The example currently pins bridge assets to `v0.1.39`, with local vendored assets
+identified as `v0.1.39-local-v0.2.0`.
 
 Fetch pinned local assets with:
 
 ```bash
-WEBGPU_BRIDGE_ASSETS_TAG=v0.1.37 ./scripts/fetch_webgpu_bridge_assets.sh
+WEBGPU_BRIDGE_ASSETS_TAG=v0.1.39 ./scripts/fetch_webgpu_bridge_assets.sh
 ```
 
 To verify the loaded runtime in a browser console, inspect:
@@ -194,12 +194,15 @@ cannot report success before the bridge exposes `prefetchModelToCache(...)`.
 - `v0.1.34+` bridge assets retry a failed worker WebGPU TTS synthesis once in a
   CPU main-thread runtime using the already cached model and projector. This
   recovery is slower than healthy WebGPU synthesis and does not loop.
-- `v0.1.37+` bridge assets embed llama.cpp `b10514`, which now trails the
-  `hook/build.dart` native pin (`v0.2.0-1`, built from llama.cpp `v0.2.0`), so Web
-  and native are not on the same llama.cpp build. The bridge assets provision an
-  explicit 1 MiB stack for both wasm32
-  and memory64, preventing `b10514` graph-parameter growth from overflowing
-  Emscripten's 64 KiB default during memory64 Qwen3-ASR context construction.
+- `v0.1.39+` bridge assets embed llama.cpp `v0.2.0`, matching the native runtime
+  (`v0.2.0-1`, both built from upstream `v0.2.0@bb4caa7540188872173c44d161602d9271386413`)
+  even though wrapper release tags differ. Pinned artifact provenance: release
+  `377534035`, tag commit `d14d46a63deeee7a8f8a017e394b74ee112f4dba`, bridge
+  source `79b6ef31e394dd2de92a456b7c249f9da377c720`, manifest SHA-256
+  `b355d01040604f6ae2c5c5fe5bb42b858101a96f03f67e4b27b32fe41ce3b2bf`. The
+  bridge assets provision an explicit 1 MiB stack for both wasm32 and memory64,
+  preventing graph-parameter growth from overflowing Emscripten's 64 KiB
+  default during memory64 Qwen3-ASR context construction.
 - `v0.1.12+` bridge assets forward native-compatible `ModelParams` load
   tuning fields, including multi-sequence slots, KV cache type, flash attention,
   RoPE overrides, split mode, and main GPU.
@@ -330,7 +333,7 @@ You can override bridge asset source/version before loader startup:
 ```html
 <script>
   window.__llamadartBridgeAssetsRepo = 'leehack/llama-web-bridge-assets';
-  window.__llamadartBridgeAssetsTag = 'v0.1.37';
+  window.__llamadartBridgeAssetsTag = 'v0.1.39';
   // Custom assets stay speech-disabled unless the host has validated them:
   // window.__llamadartBridgeSpeechToTextSupported = true;
   // Prefer local runtime even off localhost:


### PR DESCRIPTION
## Summary
- pin the default WebGPU bridge assets to immutable `leehack/llama-web-bridge-assets@v0.1.39`
- restore Web/native upstream llama.cpp parity at `v0.2.0@bb4caa7540188872173c44d161602d9271386413` while preserving the distinct native wrapper tag `v0.2.0-1`
- fail closed on stale Web/native family claims, native-anchor drift, exact manifest-byte drift, canonical provenance mismatches, oversized responses, and network timeouts
- update current bootstrap/docs/changelog pins while leaving historical and versioned docs untouched
- preserve Web `@litert-lm/core@0.15.0` and native `v0.16.0-native.2` LiteRT-LM pins without adding a false cross-runtime parity rule

## Immutable provenance
- assets release: `377534035`
- assets tag commit: `d14d46a63deeee7a8f8a017e394b74ee112f4dba`
- bridge source: `79b6ef31e394dd2de92a456b7c249f9da377c720`
- manifest SHA-256: `b355d01040604f6ae2c5c5fe5bb42b858101a96f03f67e4b27b32fe41ce3b2bf`
- upstream llama.cpp: `v0.2.0@bb4caa7540188872173c44d161602d9271386413`
- qualified native anchor: `leehack/llamadart-native@v0.2.0-1`

## Validation
- [x] `dart run tool/prepare_workspace.dart`
- [x] `dart format --output=none --set-exit-if-changed .`
- [x] `dart analyze`
- [x] `dart run tool/testing/check_platform_boundaries.dart`
- [x] `dart run tool/testing/verify_release_docs_versions.dart`
- [x] `python3 tool/native/test_sync_native_release_pins.py`
- [x] `dart run tool/testing/check_webgpu_bridge_tag.dart --verify-manifest`
- [x] `dart test -p vm -j 1 test/unit/tooling/check_webgpu_bridge_tag_test.dart` (46 passed)
- [x] `dart test -p vm -j 1 --exclude-tags local-only` (1,778 passed; 77 skipped)
- [x] `dart test -p chrome --exclude-tags local-only` (925 passed)
- [x] `(cd website && npm ci && npm test)` (6 passed)
- [x] `./tool/docs/build_site.sh`
- [x] `./scripts/validate_chat_app_web_build.sh example/chat_app/build/web` (all seven manifest artifacts verified)
- [x] `flutter pub publish --dry-run` (0 warnings)
- [x] real worker/WASM/GGUF wasm32 CPU smoke with commit-pinned Qwen3.5 0.8B: response `2+2 equals 4.`
- [x] real worker/WASM/GGUF mem64 CPU smoke against the same model: response `2+2 equals 4.`, `preferMemory64: true`
- [x] exact-head CI run `33039721711`: all jobs passed, including analyze/lint, docs, VM coverage, Chrome, Web chat contract, macOS/Windows native, companion packages, prompt-reuse parity, publish dry-runs, and Pana
- [x] exact-head PR preview run `33039721838` passed
- [x] exact-head Copilot run `33039759863` recommended approval with no new comments

## Review hardening
- implementation: Agy `gemini-3.7-flash-high`
- first audit/fix: personal Claude Code `claude-opus-5`, high effort
- final audit/fix: Codex CLI `gpt-5.6-sol`, high reasoning
- Copilot's one inline comment was fixed in follow-up commit `4b097a322`; the thread is resolved and outdated
- final review state: 0 unresolved threads, 0 failing or pending checks, clean mergeability
- exact PR head: `4b097a3225d6ea91f3b34775bc0c8e45470e7066`

## Runtime evidence and residual risk
The staged runtime was fetched from the pinned `v0.1.39` publication; its checked manifest hashes to the approved SHA-256 and all packaged artifacts pass checksum validation. A Chromium WebGPU/Metal attempt completed through the runtime automatic CPU fallback (`Active: CPU`), so this consumer run proves the fallback but does not claim hardware WebGPU execution. Parent artifact QA separately exercised memory64 WebGPU against the same immutable assets.

## Existing issue check
No dedicated issue matches this pin/parity correction. It is related to the publication-orchestration work tracked in #400, but does not close that broader issue.
