### PR TITLE
test(ios): complete physical speech qualification

### DIFF
--- a/example/chat_app/integration_test/physical_ios_speech_e2e_test.dart
+++ b/example/chat_app/integration_test/physical_ios_speech_e2e_test.dart
@@ -16,20 +16,53 @@
 /// Fail-closed: never skips, never plays audio, never downloads, and requires
 /// every path, digest, transcript, preset, and duration as a `--dart-define`.
 ///
+/// Each path define is either a safe absolute on-device path or an
+/// `@appcache/<relative>` reference. Installing onto a physical device rotates
+/// the app data-container UUID, so an absolute container path captured before
+/// the install stops resolving; the `@appcache/` form is bound to the runtime
+/// cache directory during preflight, before any artifact is read.
+///
 /// Run with:
 /// ```
-/// cd example/chat_app && flutter test --no-pub --no-uninstall \
-///   --run-skipped -t local-only \
-///   integration_test/physical_ios_speech_e2e_test.dart \
-///   -d "$PHYSICAL_IOS_DEVICE_ID" --dart-define=...
+/// cd example/chat_app && flutter drive --no-pub \
+///   --publish-port \
+///   --no-start-paused --device-vmservice-port="$IOS_SPEECH_DEVICE_VM_PORT" \
+///   --host-vmservice-port="$IOS_SPEECH_HOST_VM_PORT" \
+///   --driver=test_driver/integration_test.dart \
+///   --target=integration_test/physical_ios_speech_e2e_test.dart \
+///   --timeout=21600 -d "$PHYSICAL_IOS_DEVICE_ID" \
+///   --dart-define=IOS_SPEECH_QWEN3_ASR_MODEL_PATH="$IOS_SPEECH_QWEN3_ASR_MODEL_PATH" \
+///   --dart-define=IOS_SPEECH_QWEN3_ASR_MODEL_SHA256="$IOS_SPEECH_QWEN3_ASR_MODEL_SHA256" \
+///   --dart-define=IOS_SPEECH_QWEN3_ASR_MMPROJ_PATH="$IOS_SPEECH_QWEN3_ASR_MMPROJ_PATH" \
+///   --dart-define=IOS_SPEECH_QWEN3_ASR_MMPROJ_SHA256="$IOS_SPEECH_QWEN3_ASR_MMPROJ_SHA256" \
+///   --dart-define=IOS_SPEECH_ASR_AUDIO_PATH="$IOS_SPEECH_ASR_AUDIO_PATH" \
+///   --dart-define=IOS_SPEECH_ASR_AUDIO_SHA256="$IOS_SPEECH_ASR_AUDIO_SHA256" \
+///   --dart-define=IOS_SPEECH_ASR_EXPECTED_TRANSCRIPT="$IOS_SPEECH_ASR_EXPECTED_TRANSCRIPT" \
+///   --dart-define=IOS_SPEECH_MIC_DURATION_SECONDS="$IOS_SPEECH_MIC_DURATION_SECONDS" \
+///   --dart-define=IOS_SPEECH_MIC_EXPECTED_TRANSCRIPT="$IOS_SPEECH_MIC_EXPECTED_TRANSCRIPT" \
+///   --dart-define=IOS_SPEECH_LITERT_ASR_MODEL_PATH="$IOS_SPEECH_LITERT_ASR_MODEL_PATH" \
+///   --dart-define=IOS_SPEECH_LITERT_ASR_MODEL_SHA256="$IOS_SPEECH_LITERT_ASR_MODEL_SHA256" \
+///   --dart-define=IOS_SPEECH_LITERT_ASR_TOKENIZER_PATH="$IOS_SPEECH_LITERT_ASR_TOKENIZER_PATH" \
+///   --dart-define=IOS_SPEECH_LITERT_ASR_TOKENIZER_SHA256="$IOS_SPEECH_LITERT_ASR_TOKENIZER_SHA256" \
+///   --dart-define=IOS_SPEECH_LITERT_ASR_PRESET="$IOS_SPEECH_LITERT_ASR_PRESET" \
+///   --dart-define=IOS_SPEECH_LITERT_ASR_AUDIO_PATH="$IOS_SPEECH_LITERT_ASR_AUDIO_PATH" \
+///   --dart-define=IOS_SPEECH_LITERT_ASR_AUDIO_SHA256="$IOS_SPEECH_LITERT_ASR_AUDIO_SHA256" \
+///   --dart-define=IOS_SPEECH_LITERT_ASR_EXPECTED_TRANSCRIPT="$IOS_SPEECH_LITERT_ASR_EXPECTED_TRANSCRIPT" \
+///   --dart-define=IOS_SPEECH_QWEN3_TTS_MODEL_PATH="$IOS_SPEECH_QWEN3_TTS_MODEL_PATH" \
+///   --dart-define=IOS_SPEECH_QWEN3_TTS_MODEL_SHA256="$IOS_SPEECH_QWEN3_TTS_MODEL_SHA256" \
+///   --dart-define=IOS_SPEECH_QWEN3_TTS_MMPROJ_PATH="$IOS_SPEECH_QWEN3_TTS_MMPROJ_PATH" \
+///   --dart-define=IOS_SPEECH_QWEN3_TTS_MMPROJ_SHA256="$IOS_SPEECH_QWEN3_TTS_MMPROJ_SHA256" \
+///   --dart-define=IOS_SPEECH_TTS_TEXT="$IOS_SPEECH_TTS_TEXT" \
+///   --dart-define=IOS_SPEECH_TTS_OUTPUT_PATH="$IOS_SPEECH_TTS_OUTPUT_PATH" \
+///   --dart-define=IOS_SPEECH_TTS_EXPECTED_TRANSCRIPT="$IOS_SPEECH_TTS_EXPECTED_TRANSCRIPT" \
+///   --dart-define=IOS_SPEECH_LITERT_LM_MODEL_PATH="$IOS_SPEECH_LITERT_LM_MODEL_PATH" \
+///   --dart-define=IOS_SPEECH_LITERT_LM_MODEL_SHA256="$IOS_SPEECH_LITERT_LM_MODEL_SHA256"
 /// ```
 library;
 
 import 'dart:async';
-import 'dart:ffi';
 import 'dart:io';
 
-import 'package:ffi/ffi.dart';
 import 'package:flutter/foundation.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:integration_test/integration_test.dart';
@@ -82,52 +115,41 @@ const ModelParams _metalParams = ModelParams(
   gpuLayers: ModelParams.maxGpuLayers,
 );
 
-typedef _SysctlByNameNative =
-    Int32 Function(
-      Pointer<Utf8>,
-      Pointer<Void>,
-      Pointer<UintPtr>,
-      Pointer<Void>,
-      UintPtr,
-    );
-typedef _SysctlByNameDart =
-    int Function(
-      Pointer<Utf8>,
-      Pointer<Void>,
-      Pointer<UintPtr>,
-      Pointer<Void>,
-      int,
-    );
-
-String _iosHardwareMachineIdentifier() {
-  final sysctl = DynamicLibrary.process()
-      .lookupFunction<_SysctlByNameNative, _SysctlByNameDart>('sysctlbyname');
-  final name = 'hw.machine'.toNativeUtf8();
-  final length = calloc<UintPtr>();
-  try {
-    if (sysctl(name, nullptr, length, nullptr, 0) != 0 ||
-        length.value <= 1 ||
-        length.value > 256) {
-      throw StateError('Unable to query a bounded iOS hardware identifier.');
-    }
-    final value = calloc<Uint8>(length.value);
-    try {
-      if (sysctl(name, value.cast<Void>(), length, nullptr, 0) != 0) {
-        throw StateError('Unable to read the iOS hardware identifier.');
-      }
-      return value.cast<Utf8>().toDartString();
-    } finally {
-      calloc.free(value);
-    }
-  } finally {
-    calloc
-      ..free(length)
-      ..free(name);
-  }
-}
-
 Future<void> _disposeEngine(LlamaEngine engine, String label) =>
     awaitBounded(engine.dispose(), _cleanupTimeout, '$label.dispose');
+
+Future<void> _settleSpeechTask({
+  required void Function() cancel,
+  required Future<Object?> done,
+  required Future<Object?> eventsClosed,
+  required String label,
+}) async {
+  Object? firstError;
+  StackTrace? firstStackTrace;
+
+  Future<void> run(Future<void> Function() action) async {
+    try {
+      await action();
+    } catch (error, stackTrace) {
+      firstError ??= error;
+      firstStackTrace ??= stackTrace;
+    }
+  }
+
+  await run(() async => cancel());
+  await run(() => awaitBounded(done, _cleanupTimeout, '$label.cleanupDone'));
+  await run(
+    () => awaitBounded(
+      eventsClosed,
+      _cleanupTimeout,
+      '$label.cleanupEventsClosed',
+    ),
+  );
+  final cleanupError = firstError;
+  if (cleanupError != null) {
+    Error.throwWithStackTrace(cleanupError, firstStackTrace!);
+  }
+}
 
 Future<Uint8List> _readBoundedFixture(File file, String label) async {
   final length = await awaitBounded(
@@ -217,6 +239,24 @@ Future<LlamaEngine> _loadMetalEngine(
       _modelLoadTimeout,
       '$label.loadMultimodalProjector',
     );
+    final gpuLayers = await awaitBounded(
+      engine.getResolvedGpuLayers(),
+      _cleanupTimeout,
+      '$label.getResolvedGpuLayers',
+    );
+    if (gpuLayers == null || gpuLayers <= 0) {
+      throw StateError(
+        '$label did not resolve Metal GPU offload on physical iOS hardware.',
+      );
+    }
+    requireSpeechBackendIdentity(
+      await awaitBounded(
+        engine.getBackendName(),
+        _cleanupTimeout,
+        '$label.getBackendName',
+      ),
+      SpeechE2EBackendKind.llamaCppMetal,
+    );
     return engine;
   } catch (error, stackTrace) {
     try {
@@ -245,44 +285,56 @@ Future<String> _transcribeExact({
     '$label.start',
   );
   final eventsFuture = collectSpeechEvents(task.events);
-  final completion = await awaitBounded(
-    task.done,
-    _transcribeTimeout,
-    '$label.done',
+  String? fingerprint;
+  await runWithSpeechCleanup(
+    body: () async {
+      final completion = await awaitBounded(
+        task.done,
+        _transcribeTimeout,
+        '$label.done',
+      );
+      final events = await awaitBounded(
+        eventsFuture,
+        _transcribeTimeout,
+        '$label.eventsClosed',
+      );
+      if (completion.state != SpeechToTextCompletionState.completed) {
+        throw StateError(
+          '$label ended in ${completion.state.name} instead of completed'
+          '${completion.error == null ? '' : ': ${safeSpeechErrorDiagnostic(completion.error!)}'}',
+        );
+      }
+      final result = completion.result;
+      if (result == null) {
+        throw StateError('$label completed without a SpeechToTextResult.');
+      }
+      final finalEvents = events.whereType<SpeechToTextFinalEvent>().toList();
+      if (finalEvents.length != 1) {
+        throw StateError(
+          '$label emitted ${finalEvents.length} final events instead of one.',
+        );
+      }
+      final text = result.text;
+      expectExactNormalizedTranscript(
+        actual: text,
+        expected: expectedTranscript,
+        label: label,
+      );
+      expectExactNormalizedTranscript(
+        actual: finalEvents.single.result.text,
+        expected: expectedTranscript,
+        label: '$label.finalEvent',
+      );
+      fingerprint = transcriptFingerprint(text);
+    },
+    cleanup: () => _settleSpeechTask(
+      cancel: task.cancel,
+      done: task.done,
+      eventsClosed: eventsFuture,
+      label: label,
+    ),
   );
-  final events = await awaitBounded(
-    eventsFuture,
-    _transcribeTimeout,
-    '$label.eventsClosed',
-  );
-  if (completion.state != SpeechToTextCompletionState.completed) {
-    throw StateError(
-      '$label ended in ${completion.state.name} instead of completed'
-      '${completion.error == null ? '' : ': ${safeSpeechErrorDiagnostic(completion.error!)}'}',
-    );
-  }
-  final result = completion.result;
-  if (result == null) {
-    throw StateError('$label completed without a SpeechToTextResult.');
-  }
-  final finalEvents = events.whereType<SpeechToTextFinalEvent>().toList();
-  if (finalEvents.length != 1) {
-    throw StateError(
-      '$label emitted ${finalEvents.length} final events instead of one.',
-    );
-  }
-  final text = result.text;
-  expectExactNormalizedTranscript(
-    actual: text,
-    expected: expectedTranscript,
-    label: label,
-  );
-  expectExactNormalizedTranscript(
-    actual: finalEvents.single.result.text,
-    expected: expectedTranscript,
-    label: '$label.finalEvent',
-  );
-  return transcriptFingerprint(text);
+  return fingerprint!;
 }
 
 /// Streams [samples] into [session] in bounded chunks.
@@ -350,10 +402,12 @@ void main() {
           'physical_ios_speech_e2e_test requires the iOS device runtime.',
         );
       }
-      final machine = _iosHardwareMachineIdentifier();
-      if (!isPhysicalIosMachineIdentifier(machine)) {
+      if (!isPhysicalIosApplicationExecutablePath(
+        Platform.resolvedExecutable,
+      )) {
         throw StateError(
-          'physical_ios_speech_e2e_test rejected an iOS simulator.',
+          'physical_ios_speech_e2e_test requires an app installed on physical '
+          'iOS hardware.',
         );
       }
     } catch (error) {
@@ -363,17 +417,24 @@ void main() {
     }
 
     late final PhysicalIosSpeechConfig config;
+    late final Map<String, PhysicalIosSpeechArtifactFailure> artifactFailures;
     try {
-      config = PhysicalIosSpeechConfig.fromEnvironment();
+      // Resolution must precede every artifact read: a device install mints a
+      // fresh data-container UUID, so `@appcache/` defines only name a real
+      // file once bound to the runtime cache directory.
+      config = await canonicalizePhysicalIosSpeechFilesystemLayout(
+        await resolvePhysicalIosSpeechCachePaths(
+          PhysicalIosSpeechConfig.fromEnvironment(),
+        ),
+      );
+      artifactFailures = await config.validateArtifactsCollectingFailures(
+        timeoutPerArtifact: _artifactHashTimeout,
+      );
     } catch (error) {
       _recordPreflightFailure(rowResults, error);
       _emitAndValidateResults(rowResults);
       return;
     }
-
-    final artifactFailures = await config.validateArtifactsCollectingFailures(
-      timeoutPerArtifact: _artifactHashTimeout,
-    );
 
     // =====================================================================
     // ROW 1: llama.cpp Qwen3-ASR
@@ -456,31 +517,43 @@ void main() {
               'row1.cancel.start',
             );
             final cancelEventsFuture = collectSpeechEvents(cancelTask.events);
-            await requireStillActiveBeforeCancellation(
-              cancelTask.done,
-              _activeCancellationObservation,
-              'row1.cancel',
-            );
-            cancelTask.cancel();
-            final cancelCompletion = await awaitBounded(
-              cancelTask.done,
-              _cancelTimeout,
-              'row1.cancel.done',
-            );
-            final cancelEvents = await awaitBounded(
-              cancelEventsFuture,
-              _cancelTimeout,
-              'row1.cancel.eventsClosed',
-            );
-            expect(
-              verifySttCancellation(cancelCompletion),
-              isTrue,
-              reason: 'Cancelled transcription must reach the cancelled state',
-            );
-            expect(
-              cancelEvents.whereType<SpeechToTextFinalEvent>(),
-              isEmpty,
-              reason: 'Cancelled transcription must not emit a final result',
+            await runWithSpeechCleanup(
+              body: () async {
+                await requireStillActiveBeforeCancellation(
+                  cancelTask.done,
+                  _activeCancellationObservation,
+                  'row1.cancel',
+                );
+                cancelTask.cancel();
+                final cancelCompletion = await awaitBounded(
+                  cancelTask.done,
+                  _cancelTimeout,
+                  'row1.cancel.done',
+                );
+                final cancelEvents = await awaitBounded(
+                  cancelEventsFuture,
+                  _cancelTimeout,
+                  'row1.cancel.eventsClosed',
+                );
+                expect(
+                  verifySttCancellation(cancelCompletion),
+                  isTrue,
+                  reason:
+                      'Cancelled transcription must reach the cancelled state',
+                );
+                expect(
+                  cancelEvents.whereType<SpeechToTextFinalEvent>(),
+                  isEmpty,
+                  reason:
+                      'Cancelled transcription must not emit a final result',
+                );
+              },
+              cleanup: () => _settleSpeechTask(
+                cancel: cancelTask.cancel,
+                done: cancelTask.done,
+                eventsClosed: cancelEventsFuture,
+                label: 'row1.cancel',
+              ),
             );
 
             // Physical microphone capture. The recorder is created outside the
@@ -732,7 +805,7 @@ void main() {
             );
             await requireStillActiveBeforeCancellation(
               cancelSession.done,
-              Duration.zero,
+              _activeCancellationObservation,
               'row2.cancel',
             );
             await awaitBounded(
@@ -999,32 +1072,13 @@ void main() {
                 );
 
                 // Export and re-read from disk: never played back.
-                if (await awaitBounded(
-                  outFile.exists(),
-                  _cleanupTimeout,
-                  'row3.output.preexisting',
-                )) {
-                  throw StateError(
-                    'The configured TTS output already exists; refusing to '
-                    'overwrite or delete it.',
-                  );
-                }
+                final wavBytes = synthResult.toWavBytes();
                 await awaitBounded(
-                  outFile.parent.create(recursive: true),
+                  writePhysicalIosSpeechOutputExclusive(config, wavBytes),
                   _cleanupTimeout,
-                  'row3.output.parentCreate',
-                );
-                await awaitBounded(
-                  outFile.create(exclusive: true),
-                  _cleanupTimeout,
-                  'row3.output.createExclusive',
+                  'row3.output.writeExclusive',
                 );
                 ownsOutputFile = true;
-                await awaitBounded(
-                  outFile.writeAsBytes(synthResult.toWavBytes(), flush: true),
-                  _cleanupTimeout,
-                  'row3.output.write',
-                );
                 final wavInfo = validatePcm16Wav(
                   await awaitBounded(
                     outFile.readAsBytes(),
@@ -1222,14 +1276,9 @@ void main() {
             );
           },
           cleanup: () async {
-            if (ownsOutputFile &&
-                await awaitBounded(
-                  outFile.exists(),
-                  _cleanupTimeout,
-                  'row3.output.cleanupExists',
-                )) {
+            if (ownsOutputFile) {
               await awaitBounded(
-                outFile.delete(),
+                deletePhysicalIosSpeechOutput(config),
                 _cleanupTimeout,
                 'row3.output.delete',
               );

--- a/example/chat_app/integration_test/physical_ios_speech_e2e_test.dart
+++ b/example/chat_app/integration_test/physical_ios_speech_e2e_test.dart
@@ -15,6 +15,8 @@
 ///
 /// Fail-closed: never skips, never plays audio, never downloads, and requires
 /// every path, digest, transcript, preset, and duration as a `--dart-define`.
+/// The optional `IOS_SPEECH_ROW` define selects one canonical row for a
+/// missing-row rerun; omit it or use `all` for the complete strict matrix.
 ///
 /// Each path define is either a safe absolute on-device path or an
 /// `@appcache/<relative>` reference. Installing onto a physical device rotates
@@ -109,10 +111,15 @@ const Set<String> _row3ArtifactLabels = <String>{
 };
 const Set<String> _row4ArtifactLabels = <String>{'liteRtLmModel'};
 
-const ModelParams _metalParams = ModelParams(
+const ModelParams _cpuParams = ModelParams(
   contextSize: 4096,
-  preferredBackend: GpuBackend.metal,
-  gpuLayers: ModelParams.maxGpuLayers,
+  preferredBackend: GpuBackend.cpu,
+  gpuLayers: 0,
+);
+
+const String _selectedRowSelection = String.fromEnvironment(
+  PhysicalIosSpeechEnvKeys.rowSelection,
+  defaultValue: physicalIosSpeechAllRows,
 );
 
 Future<void> _disposeEngine(LlamaEngine engine, String label) =>
@@ -197,18 +204,24 @@ Future<void> _cleanupRecorder(
   }
 }
 
-void _emitAndValidateResults(List<SpeechE2ERowResult> rows) {
+void _emitAndValidateResults(
+  List<SpeechE2ERowResult> rows, {
+  required Set<String> expectedIds,
+}) {
   for (final row in rows) {
     debugPrint(row.toResultLine());
   }
   final summary = SpeechE2ESummary(rows);
   debugPrint(summary.toSummaryLine());
-  summary.validateRowIds();
-  summary.validateStrictCounts();
+  summary.validateSelectedRows(expectedIds);
 }
 
-void _recordPreflightFailure(List<SpeechE2ERowResult> results, Object error) {
-  for (final id in speechE2ERowIdsInOrder) {
+void _recordPreflightFailure(
+  List<SpeechE2ERowResult> results,
+  Object error,
+  Iterable<String> rowIds,
+) {
+  for (final id in rowIds) {
     results.add(
       SpeechE2ERowResult(
         id: id,
@@ -221,8 +234,8 @@ void _recordPreflightFailure(List<SpeechE2ERowResult> results, Object error) {
   }
 }
 
-/// Loads a Qwen3 model plus its projector on the Metal backend.
-Future<LlamaEngine> _loadMetalEngine(
+/// Loads a Qwen3 model plus its projector on explicit llama.cpp CPU.
+Future<LlamaEngine> _loadCpuEngine(
   String modelPath,
   String mmprojPath,
   String label,
@@ -230,7 +243,7 @@ Future<LlamaEngine> _loadMetalEngine(
   final engine = LlamaEngine(LlamaBackend());
   try {
     await awaitBounded(
-      engine.loadModel(modelPath, modelParams: _metalParams),
+      engine.loadModel(modelPath, modelParams: _cpuParams),
       _modelLoadTimeout,
       '$label.loadModel',
     );
@@ -244,9 +257,10 @@ Future<LlamaEngine> _loadMetalEngine(
       _cleanupTimeout,
       '$label.getResolvedGpuLayers',
     );
-    if (gpuLayers == null || gpuLayers <= 0) {
+    if (gpuLayers == null || gpuLayers != 0) {
       throw StateError(
-        '$label did not resolve Metal GPU offload on physical iOS hardware.',
+        '$label expected 0 resolved GPU layers for llama.cpp CPU, but resolved '
+        '${gpuLayers ?? 'null'}.',
       );
     }
     requireSpeechBackendIdentity(
@@ -255,7 +269,7 @@ Future<LlamaEngine> _loadMetalEngine(
         _cleanupTimeout,
         '$label.getBackendName',
       ),
-      SpeechE2EBackendKind.llamaCppMetal,
+      SpeechE2EBackendKind.llamaCppCpu,
     );
     return engine;
   } catch (error, stackTrace) {
@@ -392,9 +406,11 @@ Future<void> _recordRow({
 void main() {
   IntegrationTestWidgetsFlutterBinding.ensureInitialized();
 
-  testWidgets('canonical physical-iOS speech E2E validation across all four speech rows', (
+  testWidgets('canonical physical-iOS speech E2E validation', (
     WidgetTester _,
   ) async {
+    final selectedRowIds = selectPhysicalIosSpeechRowIds(_selectedRowSelection);
+    final expectedRowIds = selectedRowIds.toSet();
     final rowResults = <SpeechE2ERowResult>[];
     try {
       if (kIsWeb || !Platform.isIOS) {
@@ -411,8 +427,8 @@ void main() {
         );
       }
     } catch (error) {
-      _recordPreflightFailure(rowResults, error);
-      _emitAndValidateResults(rowResults);
+      _recordPreflightFailure(rowResults, error, selectedRowIds);
+      _emitAndValidateResults(rowResults, expectedIds: expectedRowIds);
       return;
     }
 
@@ -431,1005 +447,1059 @@ void main() {
         timeoutPerArtifact: _artifactHashTimeout,
       );
     } catch (error) {
-      _recordPreflightFailure(rowResults, error);
-      _emitAndValidateResults(rowResults);
+      _recordPreflightFailure(rowResults, error, selectedRowIds);
+      _emitAndValidateResults(rowResults, expectedIds: expectedRowIds);
       return;
     }
 
     // =====================================================================
     // ROW 1: llama.cpp Qwen3-ASR
     // =====================================================================
-    await _recordRow(
-      id: 'llama_cpp_qwen3_asr',
-      results: rowResults,
-      body: (elapsed) async {
-        requireValidSpeechArtifacts(artifactFailures, _row1ArtifactLabels);
-        String? backendName;
-        final engine = await _loadMetalEngine(
-          config.qwen3AsrModelPath,
-          config.qwen3AsrMmprojPath,
-          'row1.engine',
-        );
-        await runWithSpeechCleanup(
-          body: () async {
-            final gpuLayers = await awaitBounded(
-              engine.getResolvedGpuLayers(),
-              _cleanupTimeout,
-              'row1.getResolvedGpuLayers',
-            );
-            if (gpuLayers == null || gpuLayers <= 0) {
-              throw StateError(
-                'Expected Metal GPU offload on a physical iOS device, but the '
-                'runtime resolved ${gpuLayers ?? 'no'} GPU layers.',
-              );
-            }
-
-            final recognizer = SpeechToTextEngine(
-              engine,
-              modelProfile: SpeechToTextModelProfile.qwen3Asr,
-            );
-            final caps = await awaitBounded(
-              recognizer.capabilities,
-              _cleanupTimeout,
-              'row1.capabilities',
-            );
-            expect(
-              caps.isSupported,
-              isTrue,
-              reason: caps.unsupportedReason ?? 'Qwen3-ASR should be supported',
-            );
-            expect(
-              caps.implementation,
-              equals(SpeechToTextImplementation.multimodalPromptAdapter),
-            );
-            expect(caps.supportsCancellation, isTrue);
-            final reportedBackend = caps.backendName;
-            final String resolvedBackend;
-            if (reportedBackend case final String value) {
-              resolvedBackend = value;
-            } else {
-              resolvedBackend = await awaitBounded(
-                engine.getBackendName(),
+    if (selectedRowIds.contains('llama_cpp_qwen3_asr')) {
+      await _recordRow(
+        id: 'llama_cpp_qwen3_asr',
+        results: rowResults,
+        body: (elapsed) async {
+          requireValidSpeechArtifacts(artifactFailures, _row1ArtifactLabels);
+          String? backendName;
+          final engine = await _loadCpuEngine(
+            config.qwen3AsrModelPath,
+            config.qwen3AsrMmprojPath,
+            'row1.engine',
+          );
+          await runWithSpeechCleanup(
+            body: () async {
+              final gpuLayers = await awaitBounded(
+                engine.getResolvedGpuLayers(),
                 _cleanupTimeout,
-                'row1.getBackendName',
+                'row1.getResolvedGpuLayers',
               );
-            }
-            backendName = requireSpeechBackendIdentity(
-              resolvedBackend,
-              SpeechE2EBackendKind.llamaCppMetal,
-            );
+              if (gpuLayers == null || gpuLayers != 0) {
+                throw StateError(
+                  'Expected 0 GPU layers for llama.cpp CPU, but the runtime '
+                  'resolved ${gpuLayers ?? 'null'} GPU layers.',
+                );
+              }
 
-            await _transcribeExact(
-              recognizer: recognizer,
+              final recognizer = SpeechToTextEngine(
+                engine,
+                modelProfile: SpeechToTextModelProfile.qwen3Asr,
+              );
+              final caps = await awaitBounded(
+                recognizer.capabilities,
+                _cleanupTimeout,
+                'row1.capabilities',
+              );
+              expect(
+                caps.isSupported,
+                isTrue,
+                reason:
+                    caps.unsupportedReason ?? 'Qwen3-ASR should be supported',
+              );
+              expect(
+                caps.implementation,
+                equals(SpeechToTextImplementation.multimodalPromptAdapter),
+              );
+              expect(caps.supportsCancellation, isTrue);
+              final reportedBackend = caps.backendName;
+              final String resolvedBackend;
+              if (reportedBackend case final String value) {
+                resolvedBackend = value;
+              } else {
+                resolvedBackend = await awaitBounded(
+                  engine.getBackendName(),
+                  _cleanupTimeout,
+                  'row1.getBackendName',
+                );
+              }
+              backendName = requireSpeechBackendIdentity(
+                resolvedBackend,
+                SpeechE2EBackendKind.llamaCppCpu,
+              );
+
+              await _transcribeExact(
+                recognizer: recognizer,
+                audioPath: config.asrAudioPath,
+                expectedTranscript: config.asrExpectedTranscript,
+                label: 'row1.fixture',
+              );
+
+              final cancelTask = await awaitBounded(
+                recognizer.transcribe(
+                  SpeechToTextRequest(
+                    audio: SpeechAudioFileInput(config.asrAudioPath),
+                    maxOutputTokens: 512,
+                  ),
+                ),
+                _transcribeTimeout,
+                'row1.cancel.start',
+              );
+              final cancelEventsFuture = collectSpeechEvents(cancelTask.events);
+              await runWithSpeechCleanup(
+                body: () async {
+                  await requireStillActiveBeforeCancellation(
+                    cancelTask.done,
+                    _activeCancellationObservation,
+                    'row1.cancel',
+                  );
+                  cancelTask.cancel();
+                  final cancelCompletion = await awaitBounded(
+                    cancelTask.done,
+                    _cancelTimeout,
+                    'row1.cancel.done',
+                  );
+                  final cancelEvents = await awaitBounded(
+                    cancelEventsFuture,
+                    _cancelTimeout,
+                    'row1.cancel.eventsClosed',
+                  );
+                  expect(
+                    verifySttCancellation(cancelCompletion),
+                    isTrue,
+                    reason:
+                        'Cancelled transcription must reach the cancelled state',
+                  );
+                  expect(
+                    cancelEvents.whereType<SpeechToTextFinalEvent>(),
+                    isEmpty,
+                    reason:
+                        'Cancelled transcription must not emit a final result',
+                  );
+                },
+                cleanup: () => _settleSpeechTask(
+                  cancel: cancelTask.cancel,
+                  done: cancelTask.done,
+                  eventsClosed: cancelEventsFuture,
+                  label: 'row1.cancel',
+                ),
+              );
+
+              // Physical microphone capture. The recorder is created outside the
+              // capture try so a failing start() or stop() still disposes it.
+              final recorder = AudioRecordingService();
+              String? micWavPath;
+              await runWithSpeechCleanup(
+                body: () async {
+                  if (!recorder.isSupported) {
+                    throw const AudioRecordingException(
+                      AudioRecordingFailure.unsupported,
+                      'AudioRecordingService reports no recorder on this device.',
+                    );
+                  }
+                  await awaitBounded(
+                    recorder.start(),
+                    _cleanupTimeout,
+                    'row1.mic.start',
+                  );
+                  await Future<void>.delayed(
+                    Duration(seconds: config.micDurationSeconds),
+                  );
+                  final capturedPath = await awaitBounded(
+                    recorder.stop(),
+                    _cleanupTimeout,
+                    'row1.mic.stop',
+                  );
+                  micWavPath = capturedPath;
+
+                  expect(
+                    await awaitBounded(
+                      File(capturedPath).exists(),
+                      _cleanupTimeout,
+                      'row1.mic.exists',
+                    ),
+                    isTrue,
+                  );
+                  final micBytes = await awaitBounded(
+                    recorder.readRecording(capturedPath),
+                    _cleanupTimeout,
+                    'row1.mic.read',
+                  );
+                  final micInfo = validatePcm16Wav(
+                    micBytes,
+                    expectedSampleRate: 16000,
+                    expectedChannels: 1,
+                    requireNonSilent: true,
+                  );
+                  expect(micInfo.sampleFrames, greaterThan(0));
+                  expect(micInfo.durationSeconds, greaterThan(0.0));
+
+                  await _transcribeExact(
+                    recognizer: recognizer,
+                    audioPath: capturedPath,
+                    expectedTranscript: config.micExpectedTranscript,
+                    label: 'row1.microphone',
+                  );
+                },
+                cleanup: () => _cleanupRecorder(recorder, micWavPath),
+              );
+            },
+            cleanup: () => _disposeEngine(engine, 'row1.engine'),
+          );
+
+          // Fresh engine over the same immutable paths proves unload/reload.
+          final reloadEngine = await _loadCpuEngine(
+            config.qwen3AsrModelPath,
+            config.qwen3AsrMmprojPath,
+            'row1.reload',
+          );
+          await runWithSpeechCleanup(
+            body: () => _transcribeExact(
+              recognizer: SpeechToTextEngine(
+                reloadEngine,
+                modelProfile: SpeechToTextModelProfile.qwen3Asr,
+              ),
               audioPath: config.asrAudioPath,
               expectedTranscript: config.asrExpectedTranscript,
-              label: 'row1.fixture',
-            );
-
-            final cancelTask = await awaitBounded(
-              recognizer.transcribe(
-                SpeechToTextRequest(
-                  audio: SpeechAudioFileInput(config.asrAudioPath),
-                  maxOutputTokens: 512,
-                ),
-              ),
-              _transcribeTimeout,
-              'row1.cancel.start',
-            );
-            final cancelEventsFuture = collectSpeechEvents(cancelTask.events);
-            await runWithSpeechCleanup(
-              body: () async {
-                await requireStillActiveBeforeCancellation(
-                  cancelTask.done,
-                  _activeCancellationObservation,
-                  'row1.cancel',
-                );
-                cancelTask.cancel();
-                final cancelCompletion = await awaitBounded(
-                  cancelTask.done,
-                  _cancelTimeout,
-                  'row1.cancel.done',
-                );
-                final cancelEvents = await awaitBounded(
-                  cancelEventsFuture,
-                  _cancelTimeout,
-                  'row1.cancel.eventsClosed',
-                );
-                expect(
-                  verifySttCancellation(cancelCompletion),
-                  isTrue,
-                  reason:
-                      'Cancelled transcription must reach the cancelled state',
-                );
-                expect(
-                  cancelEvents.whereType<SpeechToTextFinalEvent>(),
-                  isEmpty,
-                  reason:
-                      'Cancelled transcription must not emit a final result',
-                );
-              },
-              cleanup: () => _settleSpeechTask(
-                cancel: cancelTask.cancel,
-                done: cancelTask.done,
-                eventsClosed: cancelEventsFuture,
-                label: 'row1.cancel',
-              ),
-            );
-
-            // Physical microphone capture. The recorder is created outside the
-            // capture try so a failing start() or stop() still disposes it.
-            final recorder = AudioRecordingService();
-            String? micWavPath;
-            await runWithSpeechCleanup(
-              body: () async {
-                if (!recorder.isSupported) {
-                  throw const AudioRecordingException(
-                    AudioRecordingFailure.unsupported,
-                    'AudioRecordingService reports no recorder on this device.',
-                  );
-                }
-                await awaitBounded(
-                  recorder.start(),
-                  _cleanupTimeout,
-                  'row1.mic.start',
-                );
-                await Future<void>.delayed(
-                  Duration(seconds: config.micDurationSeconds),
-                );
-                final capturedPath = await awaitBounded(
-                  recorder.stop(),
-                  _cleanupTimeout,
-                  'row1.mic.stop',
-                );
-                micWavPath = capturedPath;
-
-                expect(
-                  await awaitBounded(
-                    File(capturedPath).exists(),
-                    _cleanupTimeout,
-                    'row1.mic.exists',
-                  ),
-                  isTrue,
-                );
-                final micBytes = await awaitBounded(
-                  recorder.readRecording(capturedPath),
-                  _cleanupTimeout,
-                  'row1.mic.read',
-                );
-                final micInfo = validatePcm16Wav(
-                  micBytes,
-                  expectedSampleRate: 16000,
-                  expectedChannels: 1,
-                  requireNonSilent: true,
-                );
-                expect(micInfo.sampleFrames, greaterThan(0));
-                expect(micInfo.durationSeconds, greaterThan(0.0));
-
-                await _transcribeExact(
-                  recognizer: recognizer,
-                  audioPath: capturedPath,
-                  expectedTranscript: config.micExpectedTranscript,
-                  label: 'row1.microphone',
-                );
-              },
-              cleanup: () => _cleanupRecorder(recorder, micWavPath),
-            );
-          },
-          cleanup: () => _disposeEngine(engine, 'row1.engine'),
-        );
-
-        // Fresh engine over the same immutable paths proves unload/reload.
-        final reloadEngine = await _loadMetalEngine(
-          config.qwen3AsrModelPath,
-          config.qwen3AsrMmprojPath,
-          'row1.reload',
-        );
-        await runWithSpeechCleanup(
-          body: () => _transcribeExact(
-            recognizer: SpeechToTextEngine(
-              reloadEngine,
-              modelProfile: SpeechToTextModelProfile.qwen3Asr,
+              label: 'row1.reload.fixture',
             ),
-            audioPath: config.asrAudioPath,
-            expectedTranscript: config.asrExpectedTranscript,
-            label: 'row1.reload.fixture',
-          ),
-          cleanup: () => _disposeEngine(reloadEngine, 'row1.reload'),
-        );
+            cleanup: () => _disposeEngine(reloadEngine, 'row1.reload'),
+          );
 
-        final validatedBackendName = backendName;
-        if (validatedBackendName == null) {
-          throw StateError('row1 did not resolve its runtime backend.');
-        }
-        return SpeechE2ERowResult(
-          id: 'llama_cpp_qwen3_asr',
-          status: SpeechE2ERowStatus.pass,
-          backend: validatedBackendName,
-          duration: elapsed.elapsed,
-          digestIdentifiers: {
-            'model': config.qwen3AsrModelSha256.substring(0, 8),
-            'mmproj': config.qwen3AsrMmprojSha256.substring(0, 8),
-            'fixture': config.asrAudioSha256.substring(0, 8),
-          },
-          assertionSummary:
-              'caps verified, exact fixture transcript, active cancellation, '
-              'physical mic capture with strict mono PCM16 WAV, exact mic '
-              'transcript, cleanup, fresh reload on the same pinned paths',
-        );
-      },
-    );
+          final validatedBackendName = backendName;
+          if (validatedBackendName == null) {
+            throw StateError('row1 did not resolve its runtime backend.');
+          }
+          return SpeechE2ERowResult(
+            id: 'llama_cpp_qwen3_asr',
+            status: SpeechE2ERowStatus.pass,
+            backend: validatedBackendName,
+            duration: elapsed.elapsed,
+            digestIdentifiers: {
+              'model': config.qwen3AsrModelSha256.substring(0, 8),
+              'mmproj': config.qwen3AsrMmprojSha256.substring(0, 8),
+              'fixture': config.asrAudioSha256.substring(0, 8),
+            },
+            assertionSummary:
+                'llama.cpp CPU with 0 GPU layers, caps verified, exact fixture '
+                'transcript, active cancellation, physical mic capture with '
+                'strict mono PCM16 WAV, exact mic transcript, cleanup, fresh CPU '
+                'reload on the same pinned paths',
+          );
+        },
+      );
+    }
 
     // =====================================================================
     // ROW 2: LiteRT-LM dedicated streaming ASR
     // =====================================================================
-    await _recordRow(
-      id: 'litert_lm_streaming_asr',
-      results: rowResults,
-      body: (elapsed) async {
-        requireValidSpeechArtifacts(artifactFailures, _row2ArtifactLabels);
-        final floatSamples = decodePcm16WavToFloat32(
-          await _readBoundedFixture(
-            File(config.liteRtAsrAudioPath),
-            'row2.fixture',
-          ),
-          expectedSampleRate: 16000,
-          expectedChannels: 1,
-          requireNonSilent: true,
-        );
+    if (selectedRowIds.contains('litert_lm_streaming_asr')) {
+      await _recordRow(
+        id: 'litert_lm_streaming_asr',
+        results: rowResults,
+        body: (elapsed) async {
+          requireValidSpeechArtifacts(artifactFailures, _row2ArtifactLabels);
+          final floatSamples = decodePcm16WavToFloat32(
+            await _readBoundedFixture(
+              File(config.liteRtAsrAudioPath),
+              'row2.fixture',
+            ),
+            expectedSampleRate: 16000,
+            expectedChannels: 1,
+            requireNonSilent: true,
+          );
 
-        final runtimeConfig = LiteRtLmAsrRuntimeConfig(
-          modelPath: config.liteRtAsrModelPath,
-          tokenizerPath: config.liteRtAsrTokenizerPath,
-          modelPreset: config.liteRtAsrPreset,
-        );
+          final runtimeConfig = LiteRtLmAsrRuntimeConfig(
+            modelPath: config.liteRtAsrModelPath,
+            tokenizerPath: config.liteRtAsrTokenizerPath,
+            modelPreset: config.liteRtAsrPreset,
+          );
 
-        final liteRtEngine = SpeechToTextEngine.liteRtLm(runtimeConfig);
-        final caps = await awaitBounded(
-          liteRtEngine.capabilities,
-          _cleanupTimeout,
-          'row2.capabilities',
-        );
-        expect(
-          caps.isSupported,
-          isTrue,
-          reason: caps.unsupportedReason ?? 'LiteRT-LM ASR should be supported',
-        );
-        expect(
-          caps.implementation,
-          equals(SpeechToTextImplementation.dedicatedBackend),
-        );
-        expect(caps.supportsPartialResults, isTrue);
-        expect(caps.supportsStreamingInput, isTrue);
-        expect(caps.supportsInputBackpressure, isTrue);
-        expect(caps.supportsCancellation, isTrue);
-        final backendName = requireSpeechBackendIdentity(
-          caps.backendName ?? '',
-          SpeechE2EBackendKind.liteRtLmAsrCpu,
-        );
+          final liteRtEngine = SpeechToTextEngine.liteRtLm(runtimeConfig);
+          final caps = await awaitBounded(
+            liteRtEngine.capabilities,
+            _cleanupTimeout,
+            'row2.capabilities',
+          );
+          expect(
+            caps.isSupported,
+            isTrue,
+            reason:
+                caps.unsupportedReason ?? 'LiteRT-LM ASR should be supported',
+          );
+          expect(
+            caps.implementation,
+            equals(SpeechToTextImplementation.dedicatedBackend),
+          );
+          expect(caps.supportsPartialResults, isTrue);
+          expect(caps.supportsStreamingInput, isTrue);
+          expect(caps.supportsInputBackpressure, isTrue);
+          expect(caps.supportsCancellation, isTrue);
+          final backendName = requireSpeechBackendIdentity(
+            caps.backendName ?? '',
+            SpeechE2EBackendKind.liteRtLmAsrCpu,
+          );
 
-        final session = await awaitBounded(
-          liteRtEngine.startStream(),
-          _streamTimeout,
-          'row2.session.start',
-        );
-        // Subscribe before any PCM is pushed and await stream closure after
-        // terminal completion so the final event cannot race assertions.
-        final eventsFuture = collectSpeechEvents(session.events);
-        var sessionSettled = false;
-        await runWithSpeechCleanup(
-          body: () async {
-            await _pushBoundedPcm(session, floatSamples, 'row2.session');
-            await awaitBounded(
-              session.finish(),
-              _streamTimeout,
-              'row2.session.finish',
-            );
-            final completion = await awaitBounded(
-              session.done,
-              _streamTimeout,
-              'row2.session.done',
-            );
-            final events = await awaitBounded(
-              eventsFuture,
-              _streamTimeout,
-              'row2.session.eventsClosed',
-            );
-            sessionSettled = true;
-            final partialEvents = events
-                .whereType<SpeechToTextPartialEvent>()
-                .toList();
-            final finalEvents = events
-                .whereType<SpeechToTextFinalEvent>()
-                .toList();
-
-            expect(
-              completion.state,
-              equals(SpeechToTextCompletionState.completed),
-            );
-            expect(
-              partialEvents.any((p) => p.text.trim().isNotEmpty),
-              isTrue,
-              reason: 'Expected at least one non-empty partial transcript',
-            );
-            expect(
-              finalEvents,
-              hasLength(1),
-              reason: 'Expected exactly one final event',
-            );
-            final result = completion.result;
-            if (result == null) {
-              throw StateError('row2 completed without a final result.');
-            }
-            expectExactNormalizedTranscript(
-              actual: result.text,
-              expected: config.liteRtAsrExpectedTranscript,
-              label: 'row2.final',
-            );
-            expectExactNormalizedTranscript(
-              actual: finalEvents.single.result.text,
-              expected: config.liteRtAsrExpectedTranscript,
-              label: 'row2.finalEvent',
-            );
-          },
-          cleanup: () async {
-            if (!sessionSettled) {
+          final session = await awaitBounded(
+            liteRtEngine.startStream(),
+            _streamTimeout,
+            'row2.session.start',
+          );
+          // Subscribe before any PCM is pushed and await stream closure after
+          // terminal completion so the final event cannot race assertions.
+          final eventsFuture = collectSpeechEvents(session.events);
+          var sessionSettled = false;
+          await runWithSpeechCleanup(
+            body: () async {
+              await _pushBoundedPcm(session, floatSamples, 'row2.session');
               await awaitBounded(
-                session.cancel(),
-                _cleanupTimeout,
-                'row2.session.cleanupCancel',
+                session.finish(),
+                _streamTimeout,
+                'row2.session.finish',
               );
-              await awaitBounded(
+              final completion = await awaitBounded(
+                session.done,
+                _streamTimeout,
+                'row2.session.done',
+              );
+              final events = await awaitBounded(
                 eventsFuture,
-                _cleanupTimeout,
-                'row2.session.cleanupEventsClosed',
+                _streamTimeout,
+                'row2.session.eventsClosed',
               );
-            }
-          },
-        );
+              sessionSettled = true;
+              final partialEvents = events
+                  .whereType<SpeechToTextPartialEvent>()
+                  .toList();
+              final finalEvents = events
+                  .whereType<SpeechToTextFinalEvent>()
+                  .toList();
 
-        final cancelSession = await awaitBounded(
-          liteRtEngine.startStream(),
-          _streamTimeout,
-          'row2.cancel.start',
-        );
-        final cancelEventsFuture = collectSpeechEvents(cancelSession.events);
-        var cancelSessionSettled = false;
-        await runWithSpeechCleanup(
-          body: () async {
-            await awaitBounded(
-              cancelSession.addPcm(
-                chunkPcmSamples(floatSamples, _pcmChunkSamples).first,
-              ),
-              _streamTimeout,
-              'row2.cancel.addPcm',
-            );
-            await requireStillActiveBeforeCancellation(
-              cancelSession.done,
-              _activeCancellationObservation,
-              'row2.cancel',
-            );
-            await awaitBounded(
-              cancelSession.cancel(),
-              _cancelTimeout,
-              'row2.cancel.cancel',
-            );
-            final cancelCompletion = await awaitBounded(
-              cancelSession.done,
-              _cancelTimeout,
-              'row2.cancel.done',
-            );
-            final cancelEvents = await awaitBounded(
-              cancelEventsFuture,
-              _cancelTimeout,
-              'row2.cancel.eventsClosed',
-            );
-            cancelSessionSettled = true;
-            expect(
-              verifySttCancellation(cancelCompletion),
-              isTrue,
-              reason: 'Cancelled stream session must reach the cancelled state',
-            );
-            expect(
-              cancelEvents.whereType<SpeechToTextFinalEvent>(),
-              isEmpty,
-              reason: 'Cancelled stream session must not emit a final result',
-            );
-          },
-          cleanup: () async {
-            if (!cancelSessionSettled) {
+              expect(
+                completion.state,
+                equals(SpeechToTextCompletionState.completed),
+              );
+              expect(
+                partialEvents.any((p) => p.text.trim().isNotEmpty),
+                isTrue,
+                reason: 'Expected at least one non-empty partial transcript',
+              );
+              expect(
+                finalEvents,
+                hasLength(1),
+                reason: 'Expected exactly one final event',
+              );
+              final result = completion.result;
+              if (result == null) {
+                throw StateError('row2 completed without a final result.');
+              }
+              expectExactNormalizedTranscript(
+                actual: result.text,
+                expected: config.liteRtAsrExpectedTranscript,
+                label: 'row2.final',
+              );
+              expectExactNormalizedTranscript(
+                actual: finalEvents.single.result.text,
+                expected: config.liteRtAsrExpectedTranscript,
+                label: 'row2.finalEvent',
+              );
+            },
+            cleanup: () async {
+              if (!sessionSettled) {
+                await awaitBounded(
+                  session.cancel(),
+                  _cleanupTimeout,
+                  'row2.session.cleanupCancel',
+                );
+                await awaitBounded(
+                  eventsFuture,
+                  _cleanupTimeout,
+                  'row2.session.cleanupEventsClosed',
+                );
+              }
+            },
+          );
+
+          final cancelSession = await awaitBounded(
+            liteRtEngine.startStream(),
+            _streamTimeout,
+            'row2.cancel.start',
+          );
+          final cancelEventsFuture = collectSpeechEvents(cancelSession.events);
+          var cancelSessionSettled = false;
+          await runWithSpeechCleanup(
+            body: () async {
+              await awaitBounded(
+                cancelSession.addPcm(
+                  chunkPcmSamples(floatSamples, _pcmChunkSamples).first,
+                ),
+                _streamTimeout,
+                'row2.cancel.addPcm',
+              );
+              await requireStillActiveBeforeCancellation(
+                cancelSession.done,
+                _activeCancellationObservation,
+                'row2.cancel',
+              );
               await awaitBounded(
                 cancelSession.cancel(),
-                _cleanupTimeout,
-                'row2.cancel.cleanupCancel',
+                _cancelTimeout,
+                'row2.cancel.cancel',
               );
-              await awaitBounded(
+              final cancelCompletion = await awaitBounded(
+                cancelSession.done,
+                _cancelTimeout,
+                'row2.cancel.done',
+              );
+              final cancelEvents = await awaitBounded(
                 cancelEventsFuture,
-                _cleanupTimeout,
-                'row2.cancel.cleanupEventsClosed',
+                _cancelTimeout,
+                'row2.cancel.eventsClosed',
               );
-            }
-          },
-        );
+              cancelSessionSettled = true;
+              expect(
+                verifySttCancellation(cancelCompletion),
+                isTrue,
+                reason:
+                    'Cancelled stream session must reach the cancelled state',
+              );
+              expect(
+                cancelEvents.whereType<SpeechToTextFinalEvent>(),
+                isEmpty,
+                reason: 'Cancelled stream session must not emit a final result',
+              );
+            },
+            cleanup: () async {
+              if (!cancelSessionSettled) {
+                await awaitBounded(
+                  cancelSession.cancel(),
+                  _cleanupTimeout,
+                  'row2.cancel.cleanupCancel',
+                );
+                await awaitBounded(
+                  cancelEventsFuture,
+                  _cleanupTimeout,
+                  'row2.cancel.cleanupEventsClosed',
+                );
+              }
+            },
+          );
 
-        // Fresh recognizer and session over the same pinned files.
-        final reloadEngine = SpeechToTextEngine.liteRtLm(runtimeConfig);
-        final reloadSession = await awaitBounded(
-          reloadEngine.startStream(),
-          _streamTimeout,
-          'row2.reload.start',
-        );
-        final reloadEventsFuture = collectSpeechEvents(reloadSession.events);
-        var reloadSettled = false;
-        await runWithSpeechCleanup(
-          body: () async {
-            await _pushBoundedPcm(reloadSession, floatSamples, 'row2.reload');
-            await awaitBounded(
-              reloadSession.finish(),
-              _streamTimeout,
-              'row2.reload.finish',
-            );
-            final reloadCompletion = await awaitBounded(
-              reloadSession.done,
-              _streamTimeout,
-              'row2.reload.done',
-            );
-            final reloadEvents = await awaitBounded(
-              reloadEventsFuture,
-              _streamTimeout,
-              'row2.reload.eventsClosed',
-            );
-            reloadSettled = true;
-            expect(
-              reloadCompletion.state,
-              equals(SpeechToTextCompletionState.completed),
-            );
-            expect(
-              reloadEvents.whereType<SpeechToTextFinalEvent>(),
-              hasLength(1),
-            );
-            final reloadResult = reloadCompletion.result;
-            if (reloadResult == null) {
-              throw StateError('row2 reload completed without a final result.');
-            }
-            expectExactNormalizedTranscript(
-              actual: reloadResult.text,
-              expected: config.liteRtAsrExpectedTranscript,
-              label: 'row2.reload.final',
-            );
-            final reloadFinalEvent = reloadEvents
-                .whereType<SpeechToTextFinalEvent>()
-                .single;
-            expectExactNormalizedTranscript(
-              actual: reloadFinalEvent.result.text,
-              expected: config.liteRtAsrExpectedTranscript,
-              label: 'row2.reload.finalEvent',
-            );
-          },
-          cleanup: () async {
-            if (!reloadSettled) {
+          // Fresh recognizer and session over the same pinned files.
+          final reloadEngine = SpeechToTextEngine.liteRtLm(runtimeConfig);
+          final reloadSession = await awaitBounded(
+            reloadEngine.startStream(),
+            _streamTimeout,
+            'row2.reload.start',
+          );
+          final reloadEventsFuture = collectSpeechEvents(reloadSession.events);
+          var reloadSettled = false;
+          await runWithSpeechCleanup(
+            body: () async {
+              await _pushBoundedPcm(reloadSession, floatSamples, 'row2.reload');
               await awaitBounded(
-                reloadSession.cancel(),
-                _cleanupTimeout,
-                'row2.reload.cleanupCancel',
+                reloadSession.finish(),
+                _streamTimeout,
+                'row2.reload.finish',
               );
-              await awaitBounded(
+              final reloadCompletion = await awaitBounded(
+                reloadSession.done,
+                _streamTimeout,
+                'row2.reload.done',
+              );
+              final reloadEvents = await awaitBounded(
                 reloadEventsFuture,
-                _cleanupTimeout,
-                'row2.reload.cleanupEventsClosed',
+                _streamTimeout,
+                'row2.reload.eventsClosed',
               );
-            }
-          },
-        );
+              reloadSettled = true;
+              expect(
+                reloadCompletion.state,
+                equals(SpeechToTextCompletionState.completed),
+              );
+              expect(
+                reloadEvents.whereType<SpeechToTextFinalEvent>(),
+                hasLength(1),
+              );
+              final reloadResult = reloadCompletion.result;
+              if (reloadResult == null) {
+                throw StateError(
+                  'row2 reload completed without a final result.',
+                );
+              }
+              expectExactNormalizedTranscript(
+                actual: reloadResult.text,
+                expected: config.liteRtAsrExpectedTranscript,
+                label: 'row2.reload.final',
+              );
+              final reloadFinalEvent = reloadEvents
+                  .whereType<SpeechToTextFinalEvent>()
+                  .single;
+              expectExactNormalizedTranscript(
+                actual: reloadFinalEvent.result.text,
+                expected: config.liteRtAsrExpectedTranscript,
+                label: 'row2.reload.finalEvent',
+              );
+            },
+            cleanup: () async {
+              if (!reloadSettled) {
+                await awaitBounded(
+                  reloadSession.cancel(),
+                  _cleanupTimeout,
+                  'row2.reload.cleanupCancel',
+                );
+                await awaitBounded(
+                  reloadEventsFuture,
+                  _cleanupTimeout,
+                  'row2.reload.cleanupEventsClosed',
+                );
+              }
+            },
+          );
 
-        return SpeechE2ERowResult(
-          id: 'litert_lm_streaming_asr',
-          status: SpeechE2ERowStatus.pass,
-          backend: backendName,
-          duration: elapsed.elapsed,
-          digestIdentifiers: {
-            'model': config.liteRtAsrModelSha256.substring(0, 8),
-            'tokenizer': config.liteRtAsrTokenizerSha256.substring(0, 8),
-            'fixture': config.liteRtAsrAudioSha256.substring(0, 8),
-          },
-          assertionSummary:
-              'dedicated backend caps verified, bounded PCM chunks streamed, '
-              'nonempty partial observed, exactly one final event, exact final '
-              'transcript, deterministic cancellation, bounded-chunk reload',
-        );
-      },
-    );
+          return SpeechE2ERowResult(
+            id: 'litert_lm_streaming_asr',
+            status: SpeechE2ERowStatus.pass,
+            backend: backendName,
+            duration: elapsed.elapsed,
+            digestIdentifiers: {
+              'model': config.liteRtAsrModelSha256.substring(0, 8),
+              'tokenizer': config.liteRtAsrTokenizerSha256.substring(0, 8),
+              'fixture': config.liteRtAsrAudioSha256.substring(0, 8),
+            },
+            assertionSummary:
+                'dedicated backend caps verified, bounded PCM chunks streamed, '
+                'nonempty partial observed, exactly one final event, exact final '
+                'transcript, deterministic cancellation, bounded-chunk reload',
+          );
+        },
+      );
+    }
 
     // =====================================================================
     // ROW 3: llama.cpp Qwen3-TTS
     // =====================================================================
-    await _recordRow(
-      id: 'llama_cpp_qwen3_tts',
-      results: rowResults,
-      body: (elapsed) async {
-        requireValidSpeechArtifacts(artifactFailures, _row3ArtifactLabels);
-        final outFile = File(config.ttsOutputPath);
-        var ownsOutputFile = false;
-        String? backendName;
-        await runWithSpeechCleanup(
-          body: () async {
-            final engine = await _loadMetalEngine(
-              config.qwen3TtsModelPath,
-              config.qwen3TtsMmprojPath,
-              'row3.engine',
-            );
-            await runWithSpeechCleanup(
-              body: () async {
-                final synthesizer = TextToSpeechEngine(
-                  engine,
-                  modelProfile: TextToSpeechModelProfile.qwen3Tts,
-                );
-                final caps = await awaitBounded(
-                  synthesizer.capabilities,
-                  _cleanupTimeout,
-                  'row3.capabilities',
-                );
-                expect(
-                  caps.isSupported,
-                  isTrue,
-                  reason:
-                      caps.unsupportedReason ?? 'Qwen3-TTS should be supported',
-                );
-                expect(
-                  caps.implementation,
-                  equals(TextToSpeechImplementation.nativeAudioGeneration),
-                );
-                expect(caps.sampleRateHz, equals(24000));
-                expect(caps.channelCount, equals(1));
-                expect(caps.supportsCancellation, isTrue);
-                final reportedBackend = caps.backendName;
-                final String resolvedBackend;
-                if (reportedBackend case final String value) {
-                  resolvedBackend = value;
-                } else {
-                  resolvedBackend = await awaitBounded(
-                    engine.getBackendName(),
-                    _cleanupTimeout,
-                    'row3.getBackendName',
+    if (selectedRowIds.contains('llama_cpp_qwen3_tts')) {
+      await _recordRow(
+        id: 'llama_cpp_qwen3_tts',
+        results: rowResults,
+        body: (elapsed) async {
+          requireValidSpeechArtifacts(artifactFailures, _row3ArtifactLabels);
+          final outFile = File(config.ttsOutputPath);
+          var ownsOutputFile = false;
+          String? backendName;
+          await runWithSpeechCleanup(
+            body: () async {
+              final engine = await _loadCpuEngine(
+                config.qwen3TtsModelPath,
+                config.qwen3TtsMmprojPath,
+                'row3.engine',
+              );
+              await runWithSpeechCleanup(
+                body: () async {
+                  final synthesizer = TextToSpeechEngine(
+                    engine,
+                    modelProfile: TextToSpeechModelProfile.qwen3Tts,
                   );
-                }
-                backendName = requireSpeechBackendIdentity(
-                  resolvedBackend,
-                  SpeechE2EBackendKind.llamaCppMetal,
-                );
-
-                final synthTask = await awaitBounded(
-                  synthesizer.synthesize(
-                    TextToSpeechRequest(
-                      text: config.ttsText,
-                      maxFrames: _ttsMaxCodecFrames,
-                      seed: 1,
-                    ),
-                  ),
-                  _synthesizeTimeout,
-                  'row3.synthesis.start',
-                );
-                final synthEventsFuture = collectSpeechEvents(synthTask.events);
-
-                final completion = await awaitBounded(
-                  synthTask.done,
-                  _synthesizeTimeout,
-                  'row3.synthesis.done',
-                );
-                final synthEvents = await awaitBounded(
-                  synthEventsFuture,
-                  _synthesizeTimeout,
-                  'row3.synthesis.eventsClosed',
-                );
-                expect(
-                  completion.state,
-                  equals(TextToSpeechCompletionState.completed),
-                );
-                final progressEvents = synthEvents
-                    .whereType<TextToSpeechProgressEvent>()
-                    .toList();
-                final finalEvents = synthEvents
-                    .whereType<TextToSpeechFinalEvent>()
-                    .toList();
-                expect(
-                  progressEvents,
-                  isNotEmpty,
-                  reason: 'Expected progress events during synthesis',
-                );
-                expect(
-                  finalEvents,
-                  hasLength(1),
-                  reason: 'Expected exactly one final event',
-                );
-                final synthResult = completion.result;
-                if (synthResult == null) {
-                  throw StateError('row3 completed without synthesized PCM.');
-                }
-                expect(finalEvents.single.result, same(synthResult));
-
-                expect(synthResult.samples, isNotEmpty);
-                expect(synthResult.sampleRateHz, equals(24000));
-                expect(synthResult.channelCount, equals(1));
-                expect(
-                  synthResult.samples.every((s) => s.isFinite),
-                  isTrue,
-                  reason: 'Synthesized PCM must be finite',
-                );
-                expect(
-                  synthResult.truncated,
-                  isFalse,
-                  reason:
-                      'Exact round-trip validation requires complete speech',
-                );
-                validateTtsResultPlausibility(
-                  framesGenerated: synthResult.framesGenerated,
-                  maxFrames: _ttsMaxCodecFrames,
-                  sampleFrames:
-                      synthResult.samples.length ~/ synthResult.channelCount,
-                  sampleRateHz: synthResult.sampleRateHz,
-                  channelCount: synthResult.channelCount,
-                  duration: synthResult.duration,
-                  label: 'row3.synthesis',
-                );
-
-                // Export and re-read from disk: never played back.
-                final wavBytes = synthResult.toWavBytes();
-                await awaitBounded(
-                  writePhysicalIosSpeechOutputExclusive(config, wavBytes),
-                  _cleanupTimeout,
-                  'row3.output.writeExclusive',
-                );
-                ownsOutputFile = true;
-                final wavInfo = validatePcm16Wav(
-                  await awaitBounded(
-                    outFile.readAsBytes(),
+                  final caps = await awaitBounded(
+                    synthesizer.capabilities,
                     _cleanupTimeout,
-                    'row3.output.read',
-                  ),
-                  expectedSampleRate: 24000,
-                  expectedChannels: 1,
-                  requireNonSilent: true,
-                );
-                expect(
-                  wavInfo.sampleFrames,
-                  equals(
-                    synthResult.samples.length ~/ synthResult.channelCount,
-                  ),
-                  reason:
-                      'WAV export must preserve every synthesized PCM frame',
-                );
-                expect(wavInfo.peakAmplitude, greaterThan(0));
-                validateTtsResultPlausibility(
-                  framesGenerated: synthResult.framesGenerated,
-                  maxFrames: _ttsMaxCodecFrames,
-                  sampleFrames: wavInfo.sampleFrames,
-                  sampleRateHz: wavInfo.sampleRate,
-                  channelCount: wavInfo.channels,
-                  duration: Duration(
-                    microseconds:
-                        (wavInfo.durationSeconds *
-                                Duration.microsecondsPerSecond)
-                            .round(),
-                  ),
-                  label: 'row3.exportedWav',
-                );
+                    'row3.capabilities',
+                  );
+                  expect(
+                    caps.isSupported,
+                    isTrue,
+                    reason:
+                        caps.unsupportedReason ??
+                        'Qwen3-TTS should be supported',
+                  );
+                  expect(
+                    caps.implementation,
+                    equals(TextToSpeechImplementation.nativeAudioGeneration),
+                  );
+                  expect(caps.sampleRateHz, equals(24000));
+                  expect(caps.channelCount, equals(1));
+                  expect(caps.supportsCancellation, isTrue);
+                  final reportedBackend = caps.backendName;
+                  final String resolvedBackend;
+                  if (reportedBackend case final String value) {
+                    resolvedBackend = value;
+                  } else {
+                    resolvedBackend = await awaitBounded(
+                      engine.getBackendName(),
+                      _cleanupTimeout,
+                      'row3.getBackendName',
+                    );
+                  }
+                  backendName = requireSpeechBackendIdentity(
+                    resolvedBackend,
+                    SpeechE2EBackendKind.llamaCppCpu,
+                  );
 
-                // Cancel only after real audio frames exist.
-                final cancelTask = await awaitBounded(
-                  synthesizer.synthesize(
-                    TextToSpeechRequest(
-                      text: config.ttsText,
-                      maxFrames: _ttsCancelMaxCodecFrames,
-                      seed: 1,
+                  final synthTask = await awaitBounded(
+                    synthesizer.synthesize(
+                      TextToSpeechRequest(
+                        text: config.ttsText,
+                        maxFrames: _ttsMaxCodecFrames,
+                        seed: 1,
+                      ),
                     ),
-                  ),
-                  _synthesizeTimeout,
-                  'row3.cancel.start',
-                );
-                final cancellationTriggered = Completer<void>();
-                final cancelEventsFuture = collectSpeechEvents(
-                  cancelTask.events.map((event) {
-                    if (event is TextToSpeechProgressEvent &&
-                        shouldCancelOnTtsProgress(event) &&
-                        !cancellationTriggered.isCompleted) {
-                      cancellationTriggered.complete();
-                      cancelTask.cancel();
-                    }
-                    return event;
-                  }),
-                );
-                await awaitBounded(
-                  Future.any<void>(<Future<void>>[
-                    cancellationTriggered.future,
-                    cancelTask.done.then<void>((_) {
-                      if (!cancellationTriggered.isCompleted) {
+                    _synthesizeTimeout,
+                    'row3.synthesis.start',
+                  );
+                  final synthEventsFuture = collectSpeechEvents(
+                    synthTask.events,
+                  );
+                  await runWithSpeechCleanup(
+                    body: () async {
+                      final completion = await awaitBounded(
+                        synthTask.done,
+                        _synthesizeTimeout,
+                        'row3.synthesis.done',
+                      );
+                      final synthEvents = await awaitBounded(
+                        synthEventsFuture,
+                        _synthesizeTimeout,
+                        'row3.synthesis.eventsClosed',
+                      );
+                      expect(
+                        completion.state,
+                        equals(TextToSpeechCompletionState.completed),
+                      );
+                      final progressEvents = synthEvents
+                          .whereType<TextToSpeechProgressEvent>()
+                          .toList();
+                      final finalEvents = synthEvents
+                          .whereType<TextToSpeechFinalEvent>()
+                          .toList();
+                      expect(
+                        progressEvents,
+                        isNotEmpty,
+                        reason: 'Expected progress events during synthesis',
+                      );
+                      expect(
+                        finalEvents,
+                        hasLength(1),
+                        reason: 'Expected exactly one final event',
+                      );
+                      final synthResult = completion.result;
+                      if (synthResult == null) {
                         throw StateError(
-                          'row3 synthesis settled before it emitted a positive '
-                          'generated-frame progress event.',
+                          'row3 completed without synthesized PCM.',
                         );
                       }
-                    }),
-                  ]),
-                  _synthesizeTimeout,
-                  'row3.cancel.firstGeneratedFrame',
-                );
-                final cancelCompletion = await awaitBounded(
-                  cancelTask.done,
-                  _cancelTimeout,
-                  'row3.cancel.done',
-                );
-                final cancelEvents = await awaitBounded(
-                  cancelEventsFuture,
-                  _cancelTimeout,
-                  'row3.cancel.eventsClosed',
-                );
-                expect(
-                  cancellationTriggered.isCompleted,
-                  isTrue,
-                  reason: 'Cancellation must follow real generation progress',
-                );
-                expect(
-                  verifyTtsCancellation(cancelCompletion),
-                  isTrue,
-                  reason: 'Cancelled synthesis must reach the cancelled state',
-                );
-                expect(
-                  cancelEvents.whereType<TextToSpeechFinalEvent>(),
-                  isEmpty,
-                  reason: 'Cancelled synthesis must not emit final PCM',
-                );
-              },
-              cleanup: () => _disposeEngine(engine, 'row3.engine'),
-            );
+                      expect(finalEvents.single.result, same(synthResult));
 
-            // Fresh TTS engine on the same immutable paths.
-            final reloadEngine = await _loadMetalEngine(
-              config.qwen3TtsModelPath,
-              config.qwen3TtsMmprojPath,
-              'row3.reload',
-            );
-            await runWithSpeechCleanup(
-              body: () async {
-                final reloadTask = await awaitBounded(
-                  TextToSpeechEngine(
-                    reloadEngine,
-                    modelProfile: TextToSpeechModelProfile.qwen3Tts,
-                  ).synthesize(
-                    TextToSpeechRequest(
-                      text: config.ttsText,
-                      maxFrames: _ttsReloadMaxCodecFrames,
-                      seed: 1,
+                      expect(synthResult.samples, isNotEmpty);
+                      expect(synthResult.sampleRateHz, equals(24000));
+                      expect(synthResult.channelCount, equals(1));
+                      expect(
+                        synthResult.samples.every((s) => s.isFinite),
+                        isTrue,
+                        reason: 'Synthesized PCM must be finite',
+                      );
+                      expect(
+                        synthResult.truncated,
+                        isFalse,
+                        reason:
+                            'Exact round-trip validation requires complete speech',
+                      );
+                      validateTtsResultPlausibility(
+                        framesGenerated: synthResult.framesGenerated,
+                        maxFrames: _ttsMaxCodecFrames,
+                        sampleFrames:
+                            synthResult.samples.length ~/
+                            synthResult.channelCount,
+                        sampleRateHz: synthResult.sampleRateHz,
+                        channelCount: synthResult.channelCount,
+                        duration: synthResult.duration,
+                        label: 'row3.synthesis',
+                      );
+
+                      // Export and re-read from disk: never played back.
+                      final wavBytes = synthResult.toWavBytes();
+                      await awaitBounded(
+                        writePhysicalIosSpeechOutputExclusive(config, wavBytes),
+                        _cleanupTimeout,
+                        'row3.output.writeExclusive',
+                      );
+                      ownsOutputFile = true;
+                      final wavInfo = validatePcm16Wav(
+                        await awaitBounded(
+                          outFile.readAsBytes(),
+                          _cleanupTimeout,
+                          'row3.output.read',
+                        ),
+                        expectedSampleRate: 24000,
+                        expectedChannels: 1,
+                        requireNonSilent: true,
+                      );
+                      expect(
+                        wavInfo.sampleFrames,
+                        equals(
+                          synthResult.samples.length ~/
+                              synthResult.channelCount,
+                        ),
+                        reason:
+                            'WAV export must preserve every synthesized PCM frame',
+                      );
+                      expect(wavInfo.peakAmplitude, greaterThan(0));
+                      validateTtsResultPlausibility(
+                        framesGenerated: synthResult.framesGenerated,
+                        maxFrames: _ttsMaxCodecFrames,
+                        sampleFrames: wavInfo.sampleFrames,
+                        sampleRateHz: wavInfo.sampleRate,
+                        channelCount: wavInfo.channels,
+                        duration: Duration(
+                          microseconds:
+                              (wavInfo.durationSeconds *
+                                      Duration.microsecondsPerSecond)
+                                  .round(),
+                        ),
+                        label: 'row3.exportedWav',
+                      );
+                    },
+                    cleanup: () => _settleSpeechTask(
+                      cancel: synthTask.cancel,
+                      done: synthTask.done,
+                      eventsClosed: synthEventsFuture,
+                      label: 'row3.synthesis',
                     ),
-                  ),
-                  _synthesizeTimeout,
-                  'row3.reload.start',
-                );
-                final reloadEventsFuture = collectSpeechEvents(
-                  reloadTask.events,
-                );
-                final reloadCompletion = await awaitBounded(
-                  reloadTask.done,
-                  _synthesizeTimeout,
-                  'row3.reload.done',
-                );
-                final reloadEvents = await awaitBounded(
-                  reloadEventsFuture,
-                  _synthesizeTimeout,
-                  'row3.reload.eventsClosed',
-                );
-                expect(
-                  reloadCompletion.state,
-                  equals(TextToSpeechCompletionState.completed),
-                );
-                expect(
-                  reloadEvents.whereType<TextToSpeechFinalEvent>(),
-                  hasLength(1),
-                );
-                final reloadResult = reloadCompletion.result;
-                if (reloadResult == null) {
-                  throw StateError('row3 reload completed without PCM.');
-                }
-                expect(
-                  reloadEvents
-                      .whereType<TextToSpeechFinalEvent>()
-                      .single
-                      .result,
-                  same(reloadResult),
-                );
-                expect(reloadResult.samples, isNotEmpty);
-                expect(reloadResult.sampleRateHz, 24000);
-                expect(reloadResult.channelCount, 1);
-                expect(
-                  reloadResult.samples.every((sample) => sample.isFinite),
-                  isTrue,
-                );
-                validateTtsResultPlausibility(
-                  framesGenerated: reloadResult.framesGenerated,
-                  maxFrames: _ttsReloadMaxCodecFrames,
-                  sampleFrames:
-                      reloadResult.samples.length ~/ reloadResult.channelCount,
-                  sampleRateHz: reloadResult.sampleRateHz,
-                  channelCount: reloadResult.channelCount,
-                  duration: reloadResult.duration,
-                  label: 'row3.reload',
-                );
-              },
-              cleanup: () => _disposeEngine(reloadEngine, 'row3.reload'),
-            );
+                  );
 
-            // Non-audible intelligibility: transcribe the exported WAV.
-            final asrEngine = await _loadMetalEngine(
-              config.qwen3AsrModelPath,
-              config.qwen3AsrMmprojPath,
-              'row3.roundTrip',
-            );
-            await runWithSpeechCleanup(
-              body: () => _transcribeExact(
-                recognizer: SpeechToTextEngine(
-                  asrEngine,
-                  modelProfile: SpeechToTextModelProfile.qwen3Asr,
-                ),
-                audioPath: config.ttsOutputPath,
-                expectedTranscript: config.ttsExpectedTranscript,
-                label: 'row3.roundTrip',
-              ),
-              cleanup: () => _disposeEngine(asrEngine, 'row3.roundTrip'),
-            );
-          },
-          cleanup: () async {
-            if (ownsOutputFile) {
-              await awaitBounded(
-                deletePhysicalIosSpeechOutput(config),
-                _cleanupTimeout,
-                'row3.output.delete',
+                  // Cancel only after real audio frames exist.
+                  final cancelTask = await awaitBounded(
+                    synthesizer.synthesize(
+                      TextToSpeechRequest(
+                        text: config.ttsText,
+                        maxFrames: _ttsCancelMaxCodecFrames,
+                        seed: 1,
+                      ),
+                    ),
+                    _synthesizeTimeout,
+                    'row3.cancel.start',
+                  );
+                  final cancellationTriggered = Completer<void>();
+                  final cancelEventsFuture = collectSpeechEvents(
+                    cancelTask.events.map((event) {
+                      if (event is TextToSpeechProgressEvent &&
+                          shouldCancelOnTtsProgress(event) &&
+                          !cancellationTriggered.isCompleted) {
+                        cancellationTriggered.complete();
+                        cancelTask.cancel();
+                      }
+                      return event;
+                    }),
+                  );
+                  await runWithSpeechCleanup(
+                    body: () async {
+                      await awaitBounded(
+                        Future.any<void>(<Future<void>>[
+                          cancellationTriggered.future,
+                          cancelTask.done.then<void>((_) {
+                            if (!cancellationTriggered.isCompleted) {
+                              throw StateError(
+                                'row3 synthesis settled before it emitted a '
+                                'positive generated-frame progress event.',
+                              );
+                            }
+                          }),
+                        ]),
+                        _synthesizeTimeout,
+                        'row3.cancel.firstGeneratedFrame',
+                      );
+                      final cancelCompletion = await awaitBounded(
+                        cancelTask.done,
+                        _cancelTimeout,
+                        'row3.cancel.done',
+                      );
+                      final cancelEvents = await awaitBounded(
+                        cancelEventsFuture,
+                        _cancelTimeout,
+                        'row3.cancel.eventsClosed',
+                      );
+                      expect(
+                        cancellationTriggered.isCompleted,
+                        isTrue,
+                        reason:
+                            'Cancellation must follow real generation progress',
+                      );
+                      expect(
+                        verifyTtsCancellation(cancelCompletion),
+                        isTrue,
+                        reason:
+                            'Cancelled synthesis must reach the cancelled state',
+                      );
+                      expect(
+                        cancelEvents.whereType<TextToSpeechFinalEvent>(),
+                        isEmpty,
+                        reason: 'Cancelled synthesis must not emit final PCM',
+                      );
+                    },
+                    cleanup: () => _settleSpeechTask(
+                      cancel: cancelTask.cancel,
+                      done: cancelTask.done,
+                      eventsClosed: cancelEventsFuture,
+                      label: 'row3.cancel',
+                    ),
+                  );
+                },
+                cleanup: () => _disposeEngine(engine, 'row3.engine'),
               );
-            }
-          },
-        );
 
-        final validatedBackendName = backendName;
-        if (validatedBackendName == null) {
-          throw StateError('row3 did not resolve its runtime backend.');
-        }
-        return SpeechE2ERowResult(
-          id: 'llama_cpp_qwen3_tts',
-          status: SpeechE2ERowStatus.pass,
-          backend: validatedBackendName,
-          duration: elapsed.elapsed,
-          digestIdentifiers: {
-            'model': config.qwen3TtsModelSha256.substring(0, 8),
-            'mmproj': config.qwen3TtsMmprojSha256.substring(0, 8),
-          },
-          assertionSummary:
-              'native 24 kHz mono caps verified, progress and exactly one '
-              'final event, finite nonempty PCM within codec-frame cap, strict '
-              'exported WAV read-back with non-silence, cancellation after '
-              'real frames, fresh reload, non-audible exact ASR '
-              'round-trip, exported WAV removed',
-        );
-      },
-    );
+              // Fresh TTS engine on the same immutable paths.
+              final reloadEngine = await _loadCpuEngine(
+                config.qwen3TtsModelPath,
+                config.qwen3TtsMmprojPath,
+                'row3.reload',
+              );
+              await runWithSpeechCleanup(
+                body: () async {
+                  final reloadTask = await awaitBounded(
+                    TextToSpeechEngine(
+                      reloadEngine,
+                      modelProfile: TextToSpeechModelProfile.qwen3Tts,
+                    ).synthesize(
+                      TextToSpeechRequest(
+                        text: config.ttsText,
+                        maxFrames: _ttsReloadMaxCodecFrames,
+                        seed: 1,
+                      ),
+                    ),
+                    _synthesizeTimeout,
+                    'row3.reload.start',
+                  );
+                  final reloadEventsFuture = collectSpeechEvents(
+                    reloadTask.events,
+                  );
+                  await runWithSpeechCleanup(
+                    body: () async {
+                      final reloadCompletion = await awaitBounded(
+                        reloadTask.done,
+                        _synthesizeTimeout,
+                        'row3.reload.done',
+                      );
+                      final reloadEvents = await awaitBounded(
+                        reloadEventsFuture,
+                        _synthesizeTimeout,
+                        'row3.reload.eventsClosed',
+                      );
+                      expect(
+                        reloadCompletion.state,
+                        equals(TextToSpeechCompletionState.completed),
+                      );
+                      expect(
+                        reloadEvents.whereType<TextToSpeechFinalEvent>(),
+                        hasLength(1),
+                      );
+                      final reloadResult = reloadCompletion.result;
+                      if (reloadResult == null) {
+                        throw StateError('row3 reload completed without PCM.');
+                      }
+                      expect(
+                        reloadEvents
+                            .whereType<TextToSpeechFinalEvent>()
+                            .single
+                            .result,
+                        same(reloadResult),
+                      );
+                      expect(reloadResult.samples, isNotEmpty);
+                      expect(reloadResult.sampleRateHz, 24000);
+                      expect(reloadResult.channelCount, 1);
+                      expect(
+                        reloadResult.samples.every((sample) => sample.isFinite),
+                        isTrue,
+                      );
+                      validateTtsResultPlausibility(
+                        framesGenerated: reloadResult.framesGenerated,
+                        maxFrames: _ttsReloadMaxCodecFrames,
+                        sampleFrames:
+                            reloadResult.samples.length ~/
+                            reloadResult.channelCount,
+                        sampleRateHz: reloadResult.sampleRateHz,
+                        channelCount: reloadResult.channelCount,
+                        duration: reloadResult.duration,
+                        label: 'row3.reload',
+                      );
+                    },
+                    cleanup: () => _settleSpeechTask(
+                      cancel: reloadTask.cancel,
+                      done: reloadTask.done,
+                      eventsClosed: reloadEventsFuture,
+                      label: 'row3.reload',
+                    ),
+                  );
+                },
+                cleanup: () => _disposeEngine(reloadEngine, 'row3.reload'),
+              );
+
+              // Non-audible intelligibility: transcribe the exported WAV.
+              final asrEngine = await _loadCpuEngine(
+                config.qwen3AsrModelPath,
+                config.qwen3AsrMmprojPath,
+                'row3.roundTrip',
+              );
+              await runWithSpeechCleanup(
+                body: () => _transcribeExact(
+                  recognizer: SpeechToTextEngine(
+                    asrEngine,
+                    modelProfile: SpeechToTextModelProfile.qwen3Asr,
+                  ),
+                  audioPath: config.ttsOutputPath,
+                  expectedTranscript: config.ttsExpectedTranscript,
+                  label: 'row3.roundTrip',
+                ),
+                cleanup: () => _disposeEngine(asrEngine, 'row3.roundTrip'),
+              );
+            },
+            cleanup: () async {
+              if (ownsOutputFile) {
+                await awaitBounded(
+                  deletePhysicalIosSpeechOutput(config),
+                  _cleanupTimeout,
+                  'row3.output.delete',
+                );
+              }
+            },
+          );
+
+          final validatedBackendName = backendName;
+          if (validatedBackendName == null) {
+            throw StateError('row3 did not resolve its runtime backend.');
+          }
+          return SpeechE2ERowResult(
+            id: 'llama_cpp_qwen3_tts',
+            status: SpeechE2ERowStatus.pass,
+            backend: validatedBackendName,
+            duration: elapsed.elapsed,
+            digestIdentifiers: {
+              'model': config.qwen3TtsModelSha256.substring(0, 8),
+              'mmproj': config.qwen3TtsMmprojSha256.substring(0, 8),
+              'roundTripAsrModel': config.qwen3AsrModelSha256.substring(0, 8),
+              'roundTripAsrMmproj': config.qwen3AsrMmprojSha256.substring(0, 8),
+            },
+            assertionSummary:
+                'llama.cpp CPU TTS with 0 GPU layers, native 24 kHz mono caps, '
+                'progress and exactly one final event, finite nonempty PCM within '
+                'codec-frame cap, strict exported WAV read-back with non-silence, '
+                'cancellation after real frames, fresh CPU reload, non-audible '
+                'exact llama.cpp CPU ASR round-trip with 0 GPU layers, exported '
+                'WAV removed',
+          );
+        },
+      );
+    }
 
     // =====================================================================
     // ROW 4: LiteRT-LM TTS (expected unsupported)
     // =====================================================================
-    await _recordRow(
-      id: 'litert_lm_tts',
-      results: rowResults,
-      body: (elapsed) async {
-        requireValidSpeechArtifacts(artifactFailures, _row4ArtifactLabels);
-        // The real LiteRT-LM backend, not the llama.cpp router: routing a
-        // .litertlm model through LlamaBackend() would prove nothing about the
-        // LiteRT-LM synthesis path.
-        final engine = LlamaEngine(LiteRtLmBackend());
-        String? backendName;
-        await runWithSpeechCleanup(
-          body: () async {
-            await awaitBounded(
-              engine.loadModel(
-                config.liteRtLmModelPath,
-                modelParams: const ModelParams(contextSize: 2048),
-              ),
-              _modelLoadTimeout,
-              'row4.loadModel',
-            );
-            expect(engine.isReady, isTrue);
-            backendName = requireSpeechBackendIdentity(
+    if (selectedRowIds.contains('litert_lm_tts')) {
+      await _recordRow(
+        id: 'litert_lm_tts',
+        results: rowResults,
+        body: (elapsed) async {
+          requireValidSpeechArtifacts(artifactFailures, _row4ArtifactLabels);
+          // The real LiteRT-LM backend, not the llama.cpp router: routing a
+          // .litertlm model through LlamaBackend() would prove nothing about the
+          // LiteRT-LM synthesis path.
+          final engine = LlamaEngine(LiteRtLmBackend());
+          String? backendName;
+          await runWithSpeechCleanup(
+            body: () async {
               await awaitBounded(
-                engine.getBackendName(),
-                _cleanupTimeout,
-                'row4.getBackendName',
-              ),
-              SpeechE2EBackendKind.liteRtLm,
-            );
-
-            final synthesizer = TextToSpeechEngine(
-              engine,
-              modelProfile: TextToSpeechModelProfile.qwen3Tts,
-            );
-            final caps = await awaitBounded(
-              synthesizer.capabilities,
-              _cleanupTimeout,
-              'row4.capabilities',
-            );
-            expect(
-              classifyLiteRtLmTtsSupport(caps),
-              equals(SpeechE2ERowStatus.unsupported),
-            );
-            expect(caps.unsupportedReason?.trim(), isNotEmpty);
-            expect(
-              requireSpeechBackendIdentity(
-                caps.backendName ?? '',
-                SpeechE2EBackendKind.liteRtLm,
-              ),
-              backendName,
-            );
-
-            Object? thrown;
-            TextToSpeechTask? unexpectedTask;
-            try {
-              unexpectedTask = await awaitBounded(
-                synthesizer.synthesize(
-                  TextToSpeechRequest(text: config.ttsText, maxFrames: 64),
+                engine.loadModel(
+                  config.liteRtLmModelPath,
+                  modelParams: const ModelParams(contextSize: 2048),
                 ),
-                _cancelTimeout,
-                'row4.synthesize',
+                _modelLoadTimeout,
+                'row4.loadModel',
               );
-            } catch (error) {
-              thrown = error;
-            }
-            if (unexpectedTask != null) {
-              final unexpectedEvents = collectSpeechEvents(
-                unexpectedTask.events,
+              expect(engine.isReady, isTrue);
+              backendName = requireSpeechBackendIdentity(
+                await awaitBounded(
+                  engine.getBackendName(),
+                  _cleanupTimeout,
+                  'row4.getBackendName',
+                ),
+                SpeechE2EBackendKind.liteRtLm,
               );
-              unexpectedTask.cancel();
-              await awaitBounded(
-                unexpectedTask.done,
-                _cancelTimeout,
-                'row4.unexpectedTask.done',
-              );
-              await awaitBounded(
-                unexpectedEvents,
-                _cancelTimeout,
-                'row4.unexpectedTask.eventsClosed',
-              );
-              throw StateError(
-                'LiteRT-LM synthesize returned a task instead of throwing '
-                'LlamaUnsupportedException.',
-              );
-            }
-            if (thrown == null) {
-              throw StateError(
-                'LiteRT-LM synthesize reached no observable terminal state.',
-              );
-            }
-            expect(verifyLiteRtLmTtsSynthesisError(thrown), isTrue);
-          },
-          cleanup: () => _disposeEngine(engine, 'row4.engine'),
-        );
 
-        final validatedBackendName = backendName;
-        if (validatedBackendName == null) {
-          throw StateError('row4 did not resolve its runtime backend.');
-        }
-        return SpeechE2ERowResult(
-          id: 'litert_lm_tts',
-          status: SpeechE2ERowStatus.unsupported,
-          backend: validatedBackendName,
-          duration: elapsed.elapsed,
-          digestIdentifiers: {
-            'model': config.liteRtLmModelSha256.substring(0, 8),
-          },
-          assertionSummary:
-              'real LiteRT-LM model and backend identity loaded, typed '
-              'capabilities report isSupported=false with an actionable '
-              'reason, synthesize throws typed LlamaUnsupportedException',
-        );
-      },
-    );
+              final synthesizer = TextToSpeechEngine(
+                engine,
+                modelProfile: TextToSpeechModelProfile.qwen3Tts,
+              );
+              final caps = await awaitBounded(
+                synthesizer.capabilities,
+                _cleanupTimeout,
+                'row4.capabilities',
+              );
+              expect(
+                classifyLiteRtLmTtsSupport(caps),
+                equals(SpeechE2ERowStatus.unsupported),
+              );
+              expect(caps.unsupportedReason?.trim(), isNotEmpty);
+              expect(
+                requireSpeechBackendIdentity(
+                  caps.backendName ?? '',
+                  SpeechE2EBackendKind.liteRtLm,
+                ),
+                backendName,
+              );
+
+              Object? thrown;
+              TextToSpeechTask? unexpectedTask;
+              try {
+                unexpectedTask = await awaitBounded(
+                  synthesizer.synthesize(
+                    TextToSpeechRequest(text: config.ttsText, maxFrames: 64),
+                  ),
+                  _cancelTimeout,
+                  'row4.synthesize',
+                );
+              } catch (error) {
+                thrown = error;
+              }
+              final task = unexpectedTask;
+              if (task != null) {
+                final unexpectedEvents = collectSpeechEvents(task.events);
+                await runWithSpeechCleanup(
+                  body: () async {
+                    throw StateError(
+                      'LiteRT-LM synthesize returned a task instead of throwing '
+                      'LlamaUnsupportedException.',
+                    );
+                  },
+                  cleanup: () => _settleSpeechTask(
+                    cancel: task.cancel,
+                    done: task.done,
+                    eventsClosed: unexpectedEvents,
+                    label: 'row4.unexpectedTask',
+                  ),
+                );
+              }
+              if (thrown == null) {
+                throw StateError(
+                  'LiteRT-LM synthesize reached no observable terminal state.',
+                );
+              }
+              expect(verifyLiteRtLmTtsSynthesisError(thrown), isTrue);
+            },
+            cleanup: () => _disposeEngine(engine, 'row4.engine'),
+          );
+
+          final validatedBackendName = backendName;
+          if (validatedBackendName == null) {
+            throw StateError('row4 did not resolve its runtime backend.');
+          }
+          return SpeechE2ERowResult(
+            id: 'litert_lm_tts',
+            status: SpeechE2ERowStatus.unsupported,
+            backend: validatedBackendName,
+            duration: elapsed.elapsed,
+            digestIdentifiers: {
+              'model': config.liteRtLmModelSha256.substring(0, 8),
+            },
+            assertionSummary:
+                'real LiteRT-LM model and backend identity loaded, typed '
+                'capabilities report isSupported=false with an actionable '
+                'reason, synthesize throws typed LlamaUnsupportedException',
+          );
+        },
+      );
+    }
 
     // =====================================================================
     // Reporting: always emitted, even when a row failed or was unavailable.
     // =====================================================================
-    _emitAndValidateResults(rowResults);
+    _emitAndValidateResults(rowResults, expectedIds: expectedRowIds);
   });
 }

--- a/example/chat_app/integration_test/physical_ios_speech_e2e_test.dart
+++ b/example/chat_app/integration_test/physical_ios_speech_e2e_test.dart
@@ -1,0 +1,1386 @@
+@Tags(['local-only', 'e2e'])
+@Timeout(Duration(hours: 6))
+/// Canonical physical-iOS speech integration test harness.
+///
+/// Validates four rows against real runtimes and checksum-pinned local files:
+/// 1. llama.cpp Qwen3-ASR — capabilities, exact fixture transcript, active
+///    cancellation, real microphone capture, and fresh reload.
+/// 2. LiteRT-LM dedicated streaming ASR — partials, exactly one final event,
+///    exact transcript, deterministic cancellation, fresh recognizer reload.
+/// 3. llama.cpp Qwen3-TTS — 24 kHz mono synthesis, progress, WAV export and
+///    strict read-back, cancellation after real progress, reload, and a
+///    non-audible ASR round-trip.
+/// 4. LiteRT-LM TTS — expected unsupported classification through the real
+///    LiteRT-LM backend with a typed [LlamaUnsupportedException].
+///
+/// Fail-closed: never skips, never plays audio, never downloads, and requires
+/// every path, digest, transcript, preset, and duration as a `--dart-define`.
+///
+/// Run with:
+/// ```
+/// cd example/chat_app && flutter test --no-pub --no-uninstall \
+///   --run-skipped -t local-only \
+///   integration_test/physical_ios_speech_e2e_test.dart \
+///   -d "$PHYSICAL_IOS_DEVICE_ID" --dart-define=...
+/// ```
+library;
+
+import 'dart:async';
+import 'dart:ffi';
+import 'dart:io';
+
+import 'package:ffi/ffi.dart';
+import 'package:flutter/foundation.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:integration_test/integration_test.dart';
+import 'package:llamadart/llamadart.dart';
+
+import 'package:llamadart_chat_example/services/audio_recording_service.dart';
+import 'support/physical_ios_speech_e2e_support.dart';
+
+/// 100 ms of 16 kHz mono PCM per push, so no single call hands the native
+/// session an unbounded buffer.
+const int _pcmChunkSamples = 1600;
+
+const Duration _modelLoadTimeout = Duration(minutes: 8);
+const Duration _transcribeTimeout = Duration(minutes: 6);
+const Duration _streamTimeout = Duration(minutes: 6);
+const Duration _synthesizeTimeout = Duration(minutes: 8);
+const Duration _cancelTimeout = Duration(seconds: 45);
+const Duration _cleanupTimeout = Duration(seconds: 60);
+const Duration _activeCancellationObservation = Duration(milliseconds: 250);
+const Duration _artifactHashTimeout = Duration(minutes: 10);
+
+/// These are audio-codec frame ceilings, not decoded PCM sample ceilings.
+const int _ttsMaxCodecFrames = 2048;
+const int _ttsReloadMaxCodecFrames = 512;
+const int _ttsCancelMaxCodecFrames = 2048;
+
+const int _maxLiteRtAsrFixtureBytes = 64 * 1024 * 1024;
+
+const Set<String> _row1ArtifactLabels = <String>{
+  'qwen3AsrModel',
+  'qwen3AsrMmproj',
+  'asrAudio',
+};
+const Set<String> _row2ArtifactLabels = <String>{
+  'liteRtAsrModel',
+  'liteRtAsrTokenizer',
+  'liteRtAsrAudio',
+};
+const Set<String> _row3ArtifactLabels = <String>{
+  'qwen3TtsModel',
+  'qwen3TtsMmproj',
+  'qwen3AsrModel',
+  'qwen3AsrMmproj',
+};
+const Set<String> _row4ArtifactLabels = <String>{'liteRtLmModel'};
+
+const ModelParams _metalParams = ModelParams(
+  contextSize: 4096,
+  preferredBackend: GpuBackend.metal,
+  gpuLayers: ModelParams.maxGpuLayers,
+);
+
+typedef _SysctlByNameNative =
+    Int32 Function(
+      Pointer<Utf8>,
+      Pointer<Void>,
+      Pointer<UintPtr>,
+      Pointer<Void>,
+      UintPtr,
+    );
+typedef _SysctlByNameDart =
+    int Function(
+      Pointer<Utf8>,
+      Pointer<Void>,
+      Pointer<UintPtr>,
+      Pointer<Void>,
+      int,
+    );
+
+String _iosHardwareMachineIdentifier() {
+  final sysctl = DynamicLibrary.process()
+      .lookupFunction<_SysctlByNameNative, _SysctlByNameDart>('sysctlbyname');
+  final name = 'hw.machine'.toNativeUtf8();
+  final length = calloc<UintPtr>();
+  try {
+    if (sysctl(name, nullptr, length, nullptr, 0) != 0 ||
+        length.value <= 1 ||
+        length.value > 256) {
+      throw StateError('Unable to query a bounded iOS hardware identifier.');
+    }
+    final value = calloc<Uint8>(length.value);
+    try {
+      if (sysctl(name, value.cast<Void>(), length, nullptr, 0) != 0) {
+        throw StateError('Unable to read the iOS hardware identifier.');
+      }
+      return value.cast<Utf8>().toDartString();
+    } finally {
+      calloc.free(value);
+    }
+  } finally {
+    calloc
+      ..free(length)
+      ..free(name);
+  }
+}
+
+Future<void> _disposeEngine(LlamaEngine engine, String label) =>
+    awaitBounded(engine.dispose(), _cleanupTimeout, '$label.dispose');
+
+Future<Uint8List> _readBoundedFixture(File file, String label) async {
+  final length = await awaitBounded(
+    file.length(),
+    _cleanupTimeout,
+    '$label.length',
+  );
+  if (length <= 44 || length > _maxLiteRtAsrFixtureBytes) {
+    throw StateError(
+      '$label must be a nonempty WAV no larger than '
+      '$_maxLiteRtAsrFixtureBytes bytes.',
+    );
+  }
+  return awaitBounded(file.readAsBytes(), _cleanupTimeout, '$label.read');
+}
+
+Future<void> _cleanupRecorder(
+  AudioRecordingService recorder,
+  String? recordingPath,
+) async {
+  Object? cleanupError;
+  StackTrace? cleanupStackTrace;
+  try {
+    if (recordingPath == null) {
+      await awaitBounded(recorder.cancel(), _cleanupTimeout, 'row1.mic.cancel');
+    } else {
+      await awaitBounded(
+        recorder.deleteRecording(recordingPath),
+        _cleanupTimeout,
+        'row1.mic.delete',
+      );
+    }
+  } catch (error, stackTrace) {
+    cleanupError = error;
+    cleanupStackTrace = stackTrace;
+  }
+  try {
+    await awaitBounded(recorder.dispose(), _cleanupTimeout, 'row1.mic.dispose');
+  } catch (error, stackTrace) {
+    cleanupError ??= error;
+    cleanupStackTrace ??= stackTrace;
+  }
+  if (cleanupError != null) {
+    Error.throwWithStackTrace(cleanupError, cleanupStackTrace!);
+  }
+}
+
+void _emitAndValidateResults(List<SpeechE2ERowResult> rows) {
+  for (final row in rows) {
+    debugPrint(row.toResultLine());
+  }
+  final summary = SpeechE2ESummary(rows);
+  debugPrint(summary.toSummaryLine());
+  summary.validateRowIds();
+  summary.validateStrictCounts();
+}
+
+void _recordPreflightFailure(List<SpeechE2ERowResult> results, Object error) {
+  for (final id in speechE2ERowIdsInOrder) {
+    results.add(
+      SpeechE2ERowResult(
+        id: id,
+        status: SpeechE2ERowStatus.fail,
+        backend: unresolvedSpeechBackendForRow(id),
+        duration: Duration.zero,
+        error: error,
+      ),
+    );
+  }
+}
+
+/// Loads a Qwen3 model plus its projector on the Metal backend.
+Future<LlamaEngine> _loadMetalEngine(
+  String modelPath,
+  String mmprojPath,
+  String label,
+) async {
+  final engine = LlamaEngine(LlamaBackend());
+  try {
+    await awaitBounded(
+      engine.loadModel(modelPath, modelParams: _metalParams),
+      _modelLoadTimeout,
+      '$label.loadModel',
+    );
+    await awaitBounded(
+      engine.loadMultimodalProjector(mmprojPath),
+      _modelLoadTimeout,
+      '$label.loadMultimodalProjector',
+    );
+    return engine;
+  } catch (error, stackTrace) {
+    try {
+      await _disposeEngine(engine, label);
+    } catch (_) {
+      // Preserve the model/projector load failure as the authoritative error.
+    }
+    Error.throwWithStackTrace(error, stackTrace);
+  }
+}
+
+Future<String> _transcribeExact({
+  required SpeechToTextEngine recognizer,
+  required String audioPath,
+  required String expectedTranscript,
+  required String label,
+}) async {
+  final task = await awaitBounded(
+    recognizer.transcribe(
+      SpeechToTextRequest(
+        audio: SpeechAudioFileInput(audioPath),
+        maxOutputTokens: 512,
+      ),
+    ),
+    _transcribeTimeout,
+    '$label.start',
+  );
+  final eventsFuture = collectSpeechEvents(task.events);
+  final completion = await awaitBounded(
+    task.done,
+    _transcribeTimeout,
+    '$label.done',
+  );
+  final events = await awaitBounded(
+    eventsFuture,
+    _transcribeTimeout,
+    '$label.eventsClosed',
+  );
+  if (completion.state != SpeechToTextCompletionState.completed) {
+    throw StateError(
+      '$label ended in ${completion.state.name} instead of completed'
+      '${completion.error == null ? '' : ': ${safeSpeechErrorDiagnostic(completion.error!)}'}',
+    );
+  }
+  final result = completion.result;
+  if (result == null) {
+    throw StateError('$label completed without a SpeechToTextResult.');
+  }
+  final finalEvents = events.whereType<SpeechToTextFinalEvent>().toList();
+  if (finalEvents.length != 1) {
+    throw StateError(
+      '$label emitted ${finalEvents.length} final events instead of one.',
+    );
+  }
+  final text = result.text;
+  expectExactNormalizedTranscript(
+    actual: text,
+    expected: expectedTranscript,
+    label: label,
+  );
+  expectExactNormalizedTranscript(
+    actual: finalEvents.single.result.text,
+    expected: expectedTranscript,
+    label: '$label.finalEvent',
+  );
+  return transcriptFingerprint(text);
+}
+
+/// Streams [samples] into [session] in bounded chunks.
+Future<void> _pushBoundedPcm(
+  SpeechToTextStreamingSession session,
+  Float32List samples,
+  String label,
+) async {
+  final elapsed = Stopwatch()..start();
+  var index = 0;
+  for (final chunk in chunkPcmSamples(samples, _pcmChunkSamples)) {
+    final remaining = _streamTimeout - elapsed.elapsed;
+    if (remaining <= Duration.zero) {
+      throw TimeoutException(
+        '$label exceeded the total bounded-PCM push deadline.',
+        _streamTimeout,
+      );
+    }
+    await awaitBounded(
+      session.addPcm(chunk),
+      remaining,
+      '$label.addPcm[$index]',
+    );
+    index++;
+  }
+}
+
+/// Runs one row, always recording a result and never aborting the harness.
+Future<void> _recordRow({
+  required String id,
+  required List<SpeechE2ERowResult> results,
+  required Future<SpeechE2ERowResult> Function(Stopwatch elapsed) body,
+}) async {
+  final stopwatch = Stopwatch()..start();
+  try {
+    final result = await body(stopwatch);
+    if (result.id != id) {
+      throw StateError('Speech row body returned a mismatched row id.');
+    }
+    results.add(result);
+  } catch (error) {
+    results.add(
+      SpeechE2ERowResult(
+        id: id,
+        status: classifySpeechRowFailure(error),
+        backend: unresolvedSpeechBackendForRow(id),
+        duration: stopwatch.elapsed,
+        error: error,
+        actionMarker: speechRowFailureMarker(error),
+      ),
+    );
+  }
+}
+
+void main() {
+  IntegrationTestWidgetsFlutterBinding.ensureInitialized();
+
+  testWidgets('canonical physical-iOS speech E2E validation across all four speech rows', (
+    WidgetTester _,
+  ) async {
+    final rowResults = <SpeechE2ERowResult>[];
+    try {
+      if (kIsWeb || !Platform.isIOS) {
+        throw StateError(
+          'physical_ios_speech_e2e_test requires the iOS device runtime.',
+        );
+      }
+      final machine = _iosHardwareMachineIdentifier();
+      if (!isPhysicalIosMachineIdentifier(machine)) {
+        throw StateError(
+          'physical_ios_speech_e2e_test rejected an iOS simulator.',
+        );
+      }
+    } catch (error) {
+      _recordPreflightFailure(rowResults, error);
+      _emitAndValidateResults(rowResults);
+      return;
+    }
+
+    late final PhysicalIosSpeechConfig config;
+    try {
+      config = PhysicalIosSpeechConfig.fromEnvironment();
+    } catch (error) {
+      _recordPreflightFailure(rowResults, error);
+      _emitAndValidateResults(rowResults);
+      return;
+    }
+
+    final artifactFailures = await config.validateArtifactsCollectingFailures(
+      timeoutPerArtifact: _artifactHashTimeout,
+    );
+
+    // =====================================================================
+    // ROW 1: llama.cpp Qwen3-ASR
+    // =====================================================================
+    await _recordRow(
+      id: 'llama_cpp_qwen3_asr',
+      results: rowResults,
+      body: (elapsed) async {
+        requireValidSpeechArtifacts(artifactFailures, _row1ArtifactLabels);
+        String? backendName;
+        final engine = await _loadMetalEngine(
+          config.qwen3AsrModelPath,
+          config.qwen3AsrMmprojPath,
+          'row1.engine',
+        );
+        await runWithSpeechCleanup(
+          body: () async {
+            final gpuLayers = await awaitBounded(
+              engine.getResolvedGpuLayers(),
+              _cleanupTimeout,
+              'row1.getResolvedGpuLayers',
+            );
+            if (gpuLayers == null || gpuLayers <= 0) {
+              throw StateError(
+                'Expected Metal GPU offload on a physical iOS device, but the '
+                'runtime resolved ${gpuLayers ?? 'no'} GPU layers.',
+              );
+            }
+
+            final recognizer = SpeechToTextEngine(
+              engine,
+              modelProfile: SpeechToTextModelProfile.qwen3Asr,
+            );
+            final caps = await awaitBounded(
+              recognizer.capabilities,
+              _cleanupTimeout,
+              'row1.capabilities',
+            );
+            expect(
+              caps.isSupported,
+              isTrue,
+              reason: caps.unsupportedReason ?? 'Qwen3-ASR should be supported',
+            );
+            expect(
+              caps.implementation,
+              equals(SpeechToTextImplementation.multimodalPromptAdapter),
+            );
+            expect(caps.supportsCancellation, isTrue);
+            final reportedBackend = caps.backendName;
+            final String resolvedBackend;
+            if (reportedBackend case final String value) {
+              resolvedBackend = value;
+            } else {
+              resolvedBackend = await awaitBounded(
+                engine.getBackendName(),
+                _cleanupTimeout,
+                'row1.getBackendName',
+              );
+            }
+            backendName = requireSpeechBackendIdentity(
+              resolvedBackend,
+              SpeechE2EBackendKind.llamaCppMetal,
+            );
+
+            await _transcribeExact(
+              recognizer: recognizer,
+              audioPath: config.asrAudioPath,
+              expectedTranscript: config.asrExpectedTranscript,
+              label: 'row1.fixture',
+            );
+
+            final cancelTask = await awaitBounded(
+              recognizer.transcribe(
+                SpeechToTextRequest(
+                  audio: SpeechAudioFileInput(config.asrAudioPath),
+                  maxOutputTokens: 512,
+                ),
+              ),
+              _transcribeTimeout,
+              'row1.cancel.start',
+            );
+            final cancelEventsFuture = collectSpeechEvents(cancelTask.events);
+            await requireStillActiveBeforeCancellation(
+              cancelTask.done,
+              _activeCancellationObservation,
+              'row1.cancel',
+            );
+            cancelTask.cancel();
+            final cancelCompletion = await awaitBounded(
+              cancelTask.done,
+              _cancelTimeout,
+              'row1.cancel.done',
+            );
+            final cancelEvents = await awaitBounded(
+              cancelEventsFuture,
+              _cancelTimeout,
+              'row1.cancel.eventsClosed',
+            );
+            expect(
+              verifySttCancellation(cancelCompletion),
+              isTrue,
+              reason: 'Cancelled transcription must reach the cancelled state',
+            );
+            expect(
+              cancelEvents.whereType<SpeechToTextFinalEvent>(),
+              isEmpty,
+              reason: 'Cancelled transcription must not emit a final result',
+            );
+
+            // Physical microphone capture. The recorder is created outside the
+            // capture try so a failing start() or stop() still disposes it.
+            final recorder = AudioRecordingService();
+            String? micWavPath;
+            await runWithSpeechCleanup(
+              body: () async {
+                if (!recorder.isSupported) {
+                  throw const AudioRecordingException(
+                    AudioRecordingFailure.unsupported,
+                    'AudioRecordingService reports no recorder on this device.',
+                  );
+                }
+                await awaitBounded(
+                  recorder.start(),
+                  _cleanupTimeout,
+                  'row1.mic.start',
+                );
+                await Future<void>.delayed(
+                  Duration(seconds: config.micDurationSeconds),
+                );
+                final capturedPath = await awaitBounded(
+                  recorder.stop(),
+                  _cleanupTimeout,
+                  'row1.mic.stop',
+                );
+                micWavPath = capturedPath;
+
+                expect(
+                  await awaitBounded(
+                    File(capturedPath).exists(),
+                    _cleanupTimeout,
+                    'row1.mic.exists',
+                  ),
+                  isTrue,
+                );
+                final micBytes = await awaitBounded(
+                  recorder.readRecording(capturedPath),
+                  _cleanupTimeout,
+                  'row1.mic.read',
+                );
+                final micInfo = validatePcm16Wav(
+                  micBytes,
+                  expectedSampleRate: 16000,
+                  expectedChannels: 1,
+                  requireNonSilent: true,
+                );
+                expect(micInfo.sampleFrames, greaterThan(0));
+                expect(micInfo.durationSeconds, greaterThan(0.0));
+
+                await _transcribeExact(
+                  recognizer: recognizer,
+                  audioPath: capturedPath,
+                  expectedTranscript: config.micExpectedTranscript,
+                  label: 'row1.microphone',
+                );
+              },
+              cleanup: () => _cleanupRecorder(recorder, micWavPath),
+            );
+          },
+          cleanup: () => _disposeEngine(engine, 'row1.engine'),
+        );
+
+        // Fresh engine over the same immutable paths proves unload/reload.
+        final reloadEngine = await _loadMetalEngine(
+          config.qwen3AsrModelPath,
+          config.qwen3AsrMmprojPath,
+          'row1.reload',
+        );
+        await runWithSpeechCleanup(
+          body: () => _transcribeExact(
+            recognizer: SpeechToTextEngine(
+              reloadEngine,
+              modelProfile: SpeechToTextModelProfile.qwen3Asr,
+            ),
+            audioPath: config.asrAudioPath,
+            expectedTranscript: config.asrExpectedTranscript,
+            label: 'row1.reload.fixture',
+          ),
+          cleanup: () => _disposeEngine(reloadEngine, 'row1.reload'),
+        );
+
+        final validatedBackendName = backendName;
+        if (validatedBackendName == null) {
+          throw StateError('row1 did not resolve its runtime backend.');
+        }
+        return SpeechE2ERowResult(
+          id: 'llama_cpp_qwen3_asr',
+          status: SpeechE2ERowStatus.pass,
+          backend: validatedBackendName,
+          duration: elapsed.elapsed,
+          digestIdentifiers: {
+            'model': config.qwen3AsrModelSha256.substring(0, 8),
+            'mmproj': config.qwen3AsrMmprojSha256.substring(0, 8),
+            'fixture': config.asrAudioSha256.substring(0, 8),
+          },
+          assertionSummary:
+              'caps verified, exact fixture transcript, active cancellation, '
+              'physical mic capture with strict mono PCM16 WAV, exact mic '
+              'transcript, cleanup, fresh reload on the same pinned paths',
+        );
+      },
+    );
+
+    // =====================================================================
+    // ROW 2: LiteRT-LM dedicated streaming ASR
+    // =====================================================================
+    await _recordRow(
+      id: 'litert_lm_streaming_asr',
+      results: rowResults,
+      body: (elapsed) async {
+        requireValidSpeechArtifacts(artifactFailures, _row2ArtifactLabels);
+        final floatSamples = decodePcm16WavToFloat32(
+          await _readBoundedFixture(
+            File(config.liteRtAsrAudioPath),
+            'row2.fixture',
+          ),
+          expectedSampleRate: 16000,
+          expectedChannels: 1,
+          requireNonSilent: true,
+        );
+
+        final runtimeConfig = LiteRtLmAsrRuntimeConfig(
+          modelPath: config.liteRtAsrModelPath,
+          tokenizerPath: config.liteRtAsrTokenizerPath,
+          modelPreset: config.liteRtAsrPreset,
+        );
+
+        final liteRtEngine = SpeechToTextEngine.liteRtLm(runtimeConfig);
+        final caps = await awaitBounded(
+          liteRtEngine.capabilities,
+          _cleanupTimeout,
+          'row2.capabilities',
+        );
+        expect(
+          caps.isSupported,
+          isTrue,
+          reason: caps.unsupportedReason ?? 'LiteRT-LM ASR should be supported',
+        );
+        expect(
+          caps.implementation,
+          equals(SpeechToTextImplementation.dedicatedBackend),
+        );
+        expect(caps.supportsPartialResults, isTrue);
+        expect(caps.supportsStreamingInput, isTrue);
+        expect(caps.supportsInputBackpressure, isTrue);
+        expect(caps.supportsCancellation, isTrue);
+        final backendName = requireSpeechBackendIdentity(
+          caps.backendName ?? '',
+          SpeechE2EBackendKind.liteRtLmAsrCpu,
+        );
+
+        final session = await awaitBounded(
+          liteRtEngine.startStream(),
+          _streamTimeout,
+          'row2.session.start',
+        );
+        // Subscribe before any PCM is pushed and await stream closure after
+        // terminal completion so the final event cannot race assertions.
+        final eventsFuture = collectSpeechEvents(session.events);
+        var sessionSettled = false;
+        await runWithSpeechCleanup(
+          body: () async {
+            await _pushBoundedPcm(session, floatSamples, 'row2.session');
+            await awaitBounded(
+              session.finish(),
+              _streamTimeout,
+              'row2.session.finish',
+            );
+            final completion = await awaitBounded(
+              session.done,
+              _streamTimeout,
+              'row2.session.done',
+            );
+            final events = await awaitBounded(
+              eventsFuture,
+              _streamTimeout,
+              'row2.session.eventsClosed',
+            );
+            sessionSettled = true;
+            final partialEvents = events
+                .whereType<SpeechToTextPartialEvent>()
+                .toList();
+            final finalEvents = events
+                .whereType<SpeechToTextFinalEvent>()
+                .toList();
+
+            expect(
+              completion.state,
+              equals(SpeechToTextCompletionState.completed),
+            );
+            expect(
+              partialEvents.any((p) => p.text.trim().isNotEmpty),
+              isTrue,
+              reason: 'Expected at least one non-empty partial transcript',
+            );
+            expect(
+              finalEvents,
+              hasLength(1),
+              reason: 'Expected exactly one final event',
+            );
+            final result = completion.result;
+            if (result == null) {
+              throw StateError('row2 completed without a final result.');
+            }
+            expectExactNormalizedTranscript(
+              actual: result.text,
+              expected: config.liteRtAsrExpectedTranscript,
+              label: 'row2.final',
+            );
+            expectExactNormalizedTranscript(
+              actual: finalEvents.single.result.text,
+              expected: config.liteRtAsrExpectedTranscript,
+              label: 'row2.finalEvent',
+            );
+          },
+          cleanup: () async {
+            if (!sessionSettled) {
+              await awaitBounded(
+                session.cancel(),
+                _cleanupTimeout,
+                'row2.session.cleanupCancel',
+              );
+              await awaitBounded(
+                eventsFuture,
+                _cleanupTimeout,
+                'row2.session.cleanupEventsClosed',
+              );
+            }
+          },
+        );
+
+        final cancelSession = await awaitBounded(
+          liteRtEngine.startStream(),
+          _streamTimeout,
+          'row2.cancel.start',
+        );
+        final cancelEventsFuture = collectSpeechEvents(cancelSession.events);
+        var cancelSessionSettled = false;
+        await runWithSpeechCleanup(
+          body: () async {
+            await awaitBounded(
+              cancelSession.addPcm(
+                chunkPcmSamples(floatSamples, _pcmChunkSamples).first,
+              ),
+              _streamTimeout,
+              'row2.cancel.addPcm',
+            );
+            await requireStillActiveBeforeCancellation(
+              cancelSession.done,
+              Duration.zero,
+              'row2.cancel',
+            );
+            await awaitBounded(
+              cancelSession.cancel(),
+              _cancelTimeout,
+              'row2.cancel.cancel',
+            );
+            final cancelCompletion = await awaitBounded(
+              cancelSession.done,
+              _cancelTimeout,
+              'row2.cancel.done',
+            );
+            final cancelEvents = await awaitBounded(
+              cancelEventsFuture,
+              _cancelTimeout,
+              'row2.cancel.eventsClosed',
+            );
+            cancelSessionSettled = true;
+            expect(
+              verifySttCancellation(cancelCompletion),
+              isTrue,
+              reason: 'Cancelled stream session must reach the cancelled state',
+            );
+            expect(
+              cancelEvents.whereType<SpeechToTextFinalEvent>(),
+              isEmpty,
+              reason: 'Cancelled stream session must not emit a final result',
+            );
+          },
+          cleanup: () async {
+            if (!cancelSessionSettled) {
+              await awaitBounded(
+                cancelSession.cancel(),
+                _cleanupTimeout,
+                'row2.cancel.cleanupCancel',
+              );
+              await awaitBounded(
+                cancelEventsFuture,
+                _cleanupTimeout,
+                'row2.cancel.cleanupEventsClosed',
+              );
+            }
+          },
+        );
+
+        // Fresh recognizer and session over the same pinned files.
+        final reloadEngine = SpeechToTextEngine.liteRtLm(runtimeConfig);
+        final reloadSession = await awaitBounded(
+          reloadEngine.startStream(),
+          _streamTimeout,
+          'row2.reload.start',
+        );
+        final reloadEventsFuture = collectSpeechEvents(reloadSession.events);
+        var reloadSettled = false;
+        await runWithSpeechCleanup(
+          body: () async {
+            await _pushBoundedPcm(reloadSession, floatSamples, 'row2.reload');
+            await awaitBounded(
+              reloadSession.finish(),
+              _streamTimeout,
+              'row2.reload.finish',
+            );
+            final reloadCompletion = await awaitBounded(
+              reloadSession.done,
+              _streamTimeout,
+              'row2.reload.done',
+            );
+            final reloadEvents = await awaitBounded(
+              reloadEventsFuture,
+              _streamTimeout,
+              'row2.reload.eventsClosed',
+            );
+            reloadSettled = true;
+            expect(
+              reloadCompletion.state,
+              equals(SpeechToTextCompletionState.completed),
+            );
+            expect(
+              reloadEvents.whereType<SpeechToTextFinalEvent>(),
+              hasLength(1),
+            );
+            final reloadResult = reloadCompletion.result;
+            if (reloadResult == null) {
+              throw StateError('row2 reload completed without a final result.');
+            }
+            expectExactNormalizedTranscript(
+              actual: reloadResult.text,
+              expected: config.liteRtAsrExpectedTranscript,
+              label: 'row2.reload.final',
+            );
+            final reloadFinalEvent = reloadEvents
+                .whereType<SpeechToTextFinalEvent>()
+                .single;
+            expectExactNormalizedTranscript(
+              actual: reloadFinalEvent.result.text,
+              expected: config.liteRtAsrExpectedTranscript,
+              label: 'row2.reload.finalEvent',
+            );
+          },
+          cleanup: () async {
+            if (!reloadSettled) {
+              await awaitBounded(
+                reloadSession.cancel(),
+                _cleanupTimeout,
+                'row2.reload.cleanupCancel',
+              );
+              await awaitBounded(
+                reloadEventsFuture,
+                _cleanupTimeout,
+                'row2.reload.cleanupEventsClosed',
+              );
+            }
+          },
+        );
+
+        return SpeechE2ERowResult(
+          id: 'litert_lm_streaming_asr',
+          status: SpeechE2ERowStatus.pass,
+          backend: backendName,
+          duration: elapsed.elapsed,
+          digestIdentifiers: {
+            'model': config.liteRtAsrModelSha256.substring(0, 8),
+            'tokenizer': config.liteRtAsrTokenizerSha256.substring(0, 8),
+            'fixture': config.liteRtAsrAudioSha256.substring(0, 8),
+          },
+          assertionSummary:
+              'dedicated backend caps verified, bounded PCM chunks streamed, '
+              'nonempty partial observed, exactly one final event, exact final '
+              'transcript, deterministic cancellation, bounded-chunk reload',
+        );
+      },
+    );
+
+    // =====================================================================
+    // ROW 3: llama.cpp Qwen3-TTS
+    // =====================================================================
+    await _recordRow(
+      id: 'llama_cpp_qwen3_tts',
+      results: rowResults,
+      body: (elapsed) async {
+        requireValidSpeechArtifacts(artifactFailures, _row3ArtifactLabels);
+        final outFile = File(config.ttsOutputPath);
+        var ownsOutputFile = false;
+        String? backendName;
+        await runWithSpeechCleanup(
+          body: () async {
+            final engine = await _loadMetalEngine(
+              config.qwen3TtsModelPath,
+              config.qwen3TtsMmprojPath,
+              'row3.engine',
+            );
+            await runWithSpeechCleanup(
+              body: () async {
+                final synthesizer = TextToSpeechEngine(
+                  engine,
+                  modelProfile: TextToSpeechModelProfile.qwen3Tts,
+                );
+                final caps = await awaitBounded(
+                  synthesizer.capabilities,
+                  _cleanupTimeout,
+                  'row3.capabilities',
+                );
+                expect(
+                  caps.isSupported,
+                  isTrue,
+                  reason:
+                      caps.unsupportedReason ?? 'Qwen3-TTS should be supported',
+                );
+                expect(
+                  caps.implementation,
+                  equals(TextToSpeechImplementation.nativeAudioGeneration),
+                );
+                expect(caps.sampleRateHz, equals(24000));
+                expect(caps.channelCount, equals(1));
+                expect(caps.supportsCancellation, isTrue);
+                final reportedBackend = caps.backendName;
+                final String resolvedBackend;
+                if (reportedBackend case final String value) {
+                  resolvedBackend = value;
+                } else {
+                  resolvedBackend = await awaitBounded(
+                    engine.getBackendName(),
+                    _cleanupTimeout,
+                    'row3.getBackendName',
+                  );
+                }
+                backendName = requireSpeechBackendIdentity(
+                  resolvedBackend,
+                  SpeechE2EBackendKind.llamaCppMetal,
+                );
+
+                final synthTask = await awaitBounded(
+                  synthesizer.synthesize(
+                    TextToSpeechRequest(
+                      text: config.ttsText,
+                      maxFrames: _ttsMaxCodecFrames,
+                      seed: 1,
+                    ),
+                  ),
+                  _synthesizeTimeout,
+                  'row3.synthesis.start',
+                );
+                final synthEventsFuture = collectSpeechEvents(synthTask.events);
+
+                final completion = await awaitBounded(
+                  synthTask.done,
+                  _synthesizeTimeout,
+                  'row3.synthesis.done',
+                );
+                final synthEvents = await awaitBounded(
+                  synthEventsFuture,
+                  _synthesizeTimeout,
+                  'row3.synthesis.eventsClosed',
+                );
+                expect(
+                  completion.state,
+                  equals(TextToSpeechCompletionState.completed),
+                );
+                final progressEvents = synthEvents
+                    .whereType<TextToSpeechProgressEvent>()
+                    .toList();
+                final finalEvents = synthEvents
+                    .whereType<TextToSpeechFinalEvent>()
+                    .toList();
+                expect(
+                  progressEvents,
+                  isNotEmpty,
+                  reason: 'Expected progress events during synthesis',
+                );
+                expect(
+                  finalEvents,
+                  hasLength(1),
+                  reason: 'Expected exactly one final event',
+                );
+                final synthResult = completion.result;
+                if (synthResult == null) {
+                  throw StateError('row3 completed without synthesized PCM.');
+                }
+                expect(finalEvents.single.result, same(synthResult));
+
+                expect(synthResult.samples, isNotEmpty);
+                expect(synthResult.sampleRateHz, equals(24000));
+                expect(synthResult.channelCount, equals(1));
+                expect(
+                  synthResult.samples.every((s) => s.isFinite),
+                  isTrue,
+                  reason: 'Synthesized PCM must be finite',
+                );
+                expect(
+                  synthResult.truncated,
+                  isFalse,
+                  reason:
+                      'Exact round-trip validation requires complete speech',
+                );
+                validateTtsResultPlausibility(
+                  framesGenerated: synthResult.framesGenerated,
+                  maxFrames: _ttsMaxCodecFrames,
+                  sampleFrames:
+                      synthResult.samples.length ~/ synthResult.channelCount,
+                  sampleRateHz: synthResult.sampleRateHz,
+                  channelCount: synthResult.channelCount,
+                  duration: synthResult.duration,
+                  label: 'row3.synthesis',
+                );
+
+                // Export and re-read from disk: never played back.
+                if (await awaitBounded(
+                  outFile.exists(),
+                  _cleanupTimeout,
+                  'row3.output.preexisting',
+                )) {
+                  throw StateError(
+                    'The configured TTS output already exists; refusing to '
+                    'overwrite or delete it.',
+                  );
+                }
+                await awaitBounded(
+                  outFile.parent.create(recursive: true),
+                  _cleanupTimeout,
+                  'row3.output.parentCreate',
+                );
+                await awaitBounded(
+                  outFile.create(exclusive: true),
+                  _cleanupTimeout,
+                  'row3.output.createExclusive',
+                );
+                ownsOutputFile = true;
+                await awaitBounded(
+                  outFile.writeAsBytes(synthResult.toWavBytes(), flush: true),
+                  _cleanupTimeout,
+                  'row3.output.write',
+                );
+                final wavInfo = validatePcm16Wav(
+                  await awaitBounded(
+                    outFile.readAsBytes(),
+                    _cleanupTimeout,
+                    'row3.output.read',
+                  ),
+                  expectedSampleRate: 24000,
+                  expectedChannels: 1,
+                  requireNonSilent: true,
+                );
+                expect(
+                  wavInfo.sampleFrames,
+                  equals(
+                    synthResult.samples.length ~/ synthResult.channelCount,
+                  ),
+                  reason:
+                      'WAV export must preserve every synthesized PCM frame',
+                );
+                expect(wavInfo.peakAmplitude, greaterThan(0));
+                validateTtsResultPlausibility(
+                  framesGenerated: synthResult.framesGenerated,
+                  maxFrames: _ttsMaxCodecFrames,
+                  sampleFrames: wavInfo.sampleFrames,
+                  sampleRateHz: wavInfo.sampleRate,
+                  channelCount: wavInfo.channels,
+                  duration: Duration(
+                    microseconds:
+                        (wavInfo.durationSeconds *
+                                Duration.microsecondsPerSecond)
+                            .round(),
+                  ),
+                  label: 'row3.exportedWav',
+                );
+
+                // Cancel only after real audio frames exist.
+                final cancelTask = await awaitBounded(
+                  synthesizer.synthesize(
+                    TextToSpeechRequest(
+                      text: config.ttsText,
+                      maxFrames: _ttsCancelMaxCodecFrames,
+                      seed: 1,
+                    ),
+                  ),
+                  _synthesizeTimeout,
+                  'row3.cancel.start',
+                );
+                final cancellationTriggered = Completer<void>();
+                final cancelEventsFuture = collectSpeechEvents(
+                  cancelTask.events.map((event) {
+                    if (event is TextToSpeechProgressEvent &&
+                        shouldCancelOnTtsProgress(event) &&
+                        !cancellationTriggered.isCompleted) {
+                      cancellationTriggered.complete();
+                      cancelTask.cancel();
+                    }
+                    return event;
+                  }),
+                );
+                await awaitBounded(
+                  Future.any<void>(<Future<void>>[
+                    cancellationTriggered.future,
+                    cancelTask.done.then<void>((_) {
+                      if (!cancellationTriggered.isCompleted) {
+                        throw StateError(
+                          'row3 synthesis settled before it emitted a positive '
+                          'generated-frame progress event.',
+                        );
+                      }
+                    }),
+                  ]),
+                  _synthesizeTimeout,
+                  'row3.cancel.firstGeneratedFrame',
+                );
+                final cancelCompletion = await awaitBounded(
+                  cancelTask.done,
+                  _cancelTimeout,
+                  'row3.cancel.done',
+                );
+                final cancelEvents = await awaitBounded(
+                  cancelEventsFuture,
+                  _cancelTimeout,
+                  'row3.cancel.eventsClosed',
+                );
+                expect(
+                  cancellationTriggered.isCompleted,
+                  isTrue,
+                  reason: 'Cancellation must follow real generation progress',
+                );
+                expect(
+                  verifyTtsCancellation(cancelCompletion),
+                  isTrue,
+                  reason: 'Cancelled synthesis must reach the cancelled state',
+                );
+                expect(
+                  cancelEvents.whereType<TextToSpeechFinalEvent>(),
+                  isEmpty,
+                  reason: 'Cancelled synthesis must not emit final PCM',
+                );
+              },
+              cleanup: () => _disposeEngine(engine, 'row3.engine'),
+            );
+
+            // Fresh TTS engine on the same immutable paths.
+            final reloadEngine = await _loadMetalEngine(
+              config.qwen3TtsModelPath,
+              config.qwen3TtsMmprojPath,
+              'row3.reload',
+            );
+            await runWithSpeechCleanup(
+              body: () async {
+                final reloadTask = await awaitBounded(
+                  TextToSpeechEngine(
+                    reloadEngine,
+                    modelProfile: TextToSpeechModelProfile.qwen3Tts,
+                  ).synthesize(
+                    TextToSpeechRequest(
+                      text: config.ttsText,
+                      maxFrames: _ttsReloadMaxCodecFrames,
+                      seed: 1,
+                    ),
+                  ),
+                  _synthesizeTimeout,
+                  'row3.reload.start',
+                );
+                final reloadEventsFuture = collectSpeechEvents(
+                  reloadTask.events,
+                );
+                final reloadCompletion = await awaitBounded(
+                  reloadTask.done,
+                  _synthesizeTimeout,
+                  'row3.reload.done',
+                );
+                final reloadEvents = await awaitBounded(
+                  reloadEventsFuture,
+                  _synthesizeTimeout,
+                  'row3.reload.eventsClosed',
+                );
+                expect(
+                  reloadCompletion.state,
+                  equals(TextToSpeechCompletionState.completed),
+                );
+                expect(
+                  reloadEvents.whereType<TextToSpeechFinalEvent>(),
+                  hasLength(1),
+                );
+                final reloadResult = reloadCompletion.result;
+                if (reloadResult == null) {
+                  throw StateError('row3 reload completed without PCM.');
+                }
+                expect(
+                  reloadEvents
+                      .whereType<TextToSpeechFinalEvent>()
+                      .single
+                      .result,
+                  same(reloadResult),
+                );
+                expect(reloadResult.samples, isNotEmpty);
+                expect(reloadResult.sampleRateHz, 24000);
+                expect(reloadResult.channelCount, 1);
+                expect(
+                  reloadResult.samples.every((sample) => sample.isFinite),
+                  isTrue,
+                );
+                validateTtsResultPlausibility(
+                  framesGenerated: reloadResult.framesGenerated,
+                  maxFrames: _ttsReloadMaxCodecFrames,
+                  sampleFrames:
+                      reloadResult.samples.length ~/ reloadResult.channelCount,
+                  sampleRateHz: reloadResult.sampleRateHz,
+                  channelCount: reloadResult.channelCount,
+                  duration: reloadResult.duration,
+                  label: 'row3.reload',
+                );
+              },
+              cleanup: () => _disposeEngine(reloadEngine, 'row3.reload'),
+            );
+
+            // Non-audible intelligibility: transcribe the exported WAV.
+            final asrEngine = await _loadMetalEngine(
+              config.qwen3AsrModelPath,
+              config.qwen3AsrMmprojPath,
+              'row3.roundTrip',
+            );
+            await runWithSpeechCleanup(
+              body: () => _transcribeExact(
+                recognizer: SpeechToTextEngine(
+                  asrEngine,
+                  modelProfile: SpeechToTextModelProfile.qwen3Asr,
+                ),
+                audioPath: config.ttsOutputPath,
+                expectedTranscript: config.ttsExpectedTranscript,
+                label: 'row3.roundTrip',
+              ),
+              cleanup: () => _disposeEngine(asrEngine, 'row3.roundTrip'),
+            );
+          },
+          cleanup: () async {
+            if (ownsOutputFile &&
+                await awaitBounded(
+                  outFile.exists(),
+                  _cleanupTimeout,
+                  'row3.output.cleanupExists',
+                )) {
+              await awaitBounded(
+                outFile.delete(),
+                _cleanupTimeout,
+                'row3.output.delete',
+              );
+            }
+          },
+        );
+
+        final validatedBackendName = backendName;
+        if (validatedBackendName == null) {
+          throw StateError('row3 did not resolve its runtime backend.');
+        }
+        return SpeechE2ERowResult(
+          id: 'llama_cpp_qwen3_tts',
+          status: SpeechE2ERowStatus.pass,
+          backend: validatedBackendName,
+          duration: elapsed.elapsed,
+          digestIdentifiers: {
+            'model': config.qwen3TtsModelSha256.substring(0, 8),
+            'mmproj': config.qwen3TtsMmprojSha256.substring(0, 8),
+          },
+          assertionSummary:
+              'native 24 kHz mono caps verified, progress and exactly one '
+              'final event, finite nonempty PCM within codec-frame cap, strict '
+              'exported WAV read-back with non-silence, cancellation after '
+              'real frames, fresh reload, non-audible exact ASR '
+              'round-trip, exported WAV removed',
+        );
+      },
+    );
+
+    // =====================================================================
+    // ROW 4: LiteRT-LM TTS (expected unsupported)
+    // =====================================================================
+    await _recordRow(
+      id: 'litert_lm_tts',
+      results: rowResults,
+      body: (elapsed) async {
+        requireValidSpeechArtifacts(artifactFailures, _row4ArtifactLabels);
+        // The real LiteRT-LM backend, not the llama.cpp router: routing a
+        // .litertlm model through LlamaBackend() would prove nothing about the
+        // LiteRT-LM synthesis path.
+        final engine = LlamaEngine(LiteRtLmBackend());
+        String? backendName;
+        await runWithSpeechCleanup(
+          body: () async {
+            await awaitBounded(
+              engine.loadModel(
+                config.liteRtLmModelPath,
+                modelParams: const ModelParams(contextSize: 2048),
+              ),
+              _modelLoadTimeout,
+              'row4.loadModel',
+            );
+            expect(engine.isReady, isTrue);
+            backendName = requireSpeechBackendIdentity(
+              await awaitBounded(
+                engine.getBackendName(),
+                _cleanupTimeout,
+                'row4.getBackendName',
+              ),
+              SpeechE2EBackendKind.liteRtLm,
+            );
+
+            final synthesizer = TextToSpeechEngine(
+              engine,
+              modelProfile: TextToSpeechModelProfile.qwen3Tts,
+            );
+            final caps = await awaitBounded(
+              synthesizer.capabilities,
+              _cleanupTimeout,
+              'row4.capabilities',
+            );
+            expect(
+              classifyLiteRtLmTtsSupport(caps),
+              equals(SpeechE2ERowStatus.unsupported),
+            );
+            expect(caps.unsupportedReason?.trim(), isNotEmpty);
+            expect(
+              requireSpeechBackendIdentity(
+                caps.backendName ?? '',
+                SpeechE2EBackendKind.liteRtLm,
+              ),
+              backendName,
+            );
+
+            Object? thrown;
+            TextToSpeechTask? unexpectedTask;
+            try {
+              unexpectedTask = await awaitBounded(
+                synthesizer.synthesize(
+                  TextToSpeechRequest(text: config.ttsText, maxFrames: 64),
+                ),
+                _cancelTimeout,
+                'row4.synthesize',
+              );
+            } catch (error) {
+              thrown = error;
+            }
+            if (unexpectedTask != null) {
+              final unexpectedEvents = collectSpeechEvents(
+                unexpectedTask.events,
+              );
+              unexpectedTask.cancel();
+              await awaitBounded(
+                unexpectedTask.done,
+                _cancelTimeout,
+                'row4.unexpectedTask.done',
+              );
+              await awaitBounded(
+                unexpectedEvents,
+                _cancelTimeout,
+                'row4.unexpectedTask.eventsClosed',
+              );
+              throw StateError(
+                'LiteRT-LM synthesize returned a task instead of throwing '
+                'LlamaUnsupportedException.',
+              );
+            }
+            if (thrown == null) {
+              throw StateError(
+                'LiteRT-LM synthesize reached no observable terminal state.',
+              );
+            }
+            expect(verifyLiteRtLmTtsSynthesisError(thrown), isTrue);
+          },
+          cleanup: () => _disposeEngine(engine, 'row4.engine'),
+        );
+
+        final validatedBackendName = backendName;
+        if (validatedBackendName == null) {
+          throw StateError('row4 did not resolve its runtime backend.');
+        }
+        return SpeechE2ERowResult(
+          id: 'litert_lm_tts',
+          status: SpeechE2ERowStatus.unsupported,
+          backend: validatedBackendName,
+          duration: elapsed.elapsed,
+          digestIdentifiers: {
+            'model': config.liteRtLmModelSha256.substring(0, 8),
+          },
+          assertionSummary:
+              'real LiteRT-LM model and backend identity loaded, typed '
+              'capabilities report isSupported=false with an actionable '
+              'reason, synthesize throws typed LlamaUnsupportedException',
+        );
+      },
+    );
+
+    // =====================================================================
+    // Reporting: always emitted, even when a row failed or was unavailable.
+    // =====================================================================
+    _emitAndValidateResults(rowResults);
+  });
+}

--- a/example/chat_app/integration_test/support/physical_ios_speech_e2e_support.dart
+++ b/example/chat_app/integration_test/support/physical_ios_speech_e2e_support.dart
@@ -7,6 +7,8 @@ import 'dart:typed_data';
 import 'package:crypto/crypto.dart';
 import 'package:llamadart/llamadart.dart';
 import 'package:llamadart_chat_example/services/audio_recording_service.dart';
+import 'package:path/path.dart' as path;
+import 'package:path_provider/path_provider.dart';
 
 /// Compile-time define names for physical iOS speech integration testing.
 abstract final class PhysicalIosSpeechEnvKeys {
@@ -163,16 +165,200 @@ final _hexDigestPattern = RegExp(r'^[0-9a-f]{64}$');
 final _positiveIntegerPattern = RegExp(r'^[0-9]+$');
 final _whitespaceRun = RegExp(r'\s+');
 final _controlCharacters = RegExp(r'[\x00-\x1f\x7f]');
-final _physicalIosMachinePattern = RegExp(r'^(?:iPhone|iPad|iPod)\d+,\d+$');
+const List<String> _physicalIosApplicationRoots = <String>[
+  '/private/var/containers/Bundle/Application/',
+  '/var/containers/Bundle/Application/',
+];
 
 const int _maximumMicrophoneDurationSeconds = 30;
+
+/// Marker for a path expressed relative to the on-device app cache directory.
+///
+/// Installing onto a physical device rotates the app data-container UUID, so an
+/// absolute container path captured before the install no longer resolves.
+/// Defines written as `@appcache/<relative>` are bound to the real directory at
+/// runtime through `getApplicationCacheDirectory` instead.
+const String appCachePathPrefix = '@appcache/';
+
+/// Matches the marker in any casing so a near-miss fails loudly instead of
+/// being reinterpreted as a relative path.
+final _appCacheMarkerProbe = RegExp(r'^@appcache(?=/|$)', caseSensitive: false);
+final _rejectedPathCharacters = RegExp(r'[\\:?#]');
+
+/// Whether [value] is an app-cache-relative path reference.
+bool isAppCachePathReference(String value) =>
+    value.startsWith(appCachePathPrefix);
+
+void _requireSafePathSegments(String segments, String key, String value) {
+  for (final segment in segments.split('/')) {
+    if (segment.isEmpty) {
+      throw ArgumentError.value(
+        value,
+        key,
+        'Path contains an empty segment. Leading, trailing, and duplicated '
+        '"/" separators are not allowed.',
+      );
+    }
+    if (segment == '.' || segment == '..') {
+      throw ArgumentError.value(
+        value,
+        key,
+        'Path contains a "." or ".." traversal segment.',
+      );
+    }
+    if (segment.startsWith('~')) {
+      throw ArgumentError.value(
+        value,
+        key,
+        'Path contains a "~" home-expansion segment.',
+      );
+    }
+    if (_rejectedPathCharacters.hasMatch(segment)) {
+      throw ArgumentError.value(
+        value,
+        key,
+        r'Path contains "\", ":", "?", or "#". Backslash separators, '
+        'drive-qualified values, URL queries, and URL fragments are not '
+        'allowed.',
+      );
+    }
+    if (_controlCharacters.hasMatch(segment) || segment.trim() != segment) {
+      throw ArgumentError.value(
+        value,
+        key,
+        'Path segments must not contain control characters or leading and '
+        'trailing whitespace.',
+      );
+    }
+  }
+}
+
+/// Validates one configured path spec and returns it unchanged.
+///
+/// Accepts either a safe absolute on-device path or an [appCachePathPrefix]
+/// reference. Traversal, dot, empty or duplicated separators, backslashes,
+/// URL-like values, the bare filesystem root, tilde expansion, and a
+/// differently cased marker are all rejected.
+String requireSafeSpeechPathSpec(String value, String key) {
+  if (_appCacheMarkerProbe.hasMatch(value)) {
+    if (!isAppCachePathReference(value)) {
+      throw ArgumentError.value(
+        value,
+        key,
+        'The app-cache marker must be spelled exactly "$appCachePathPrefix". '
+        'Case variants are rejected because the on-device container may fold '
+        'case.',
+      );
+    }
+    final relative = value.substring(appCachePathPrefix.length);
+    if (relative.isEmpty) {
+      throw ArgumentError.value(
+        value,
+        key,
+        'An $appCachePathPrefix reference must name a file below the app cache '
+        'directory.',
+      );
+    }
+    _requireSafePathSegments(relative, key, value);
+    return value;
+  }
+
+  final uri = Uri.tryParse(value);
+  if (!value.startsWith('/') || (uri?.hasScheme ?? false)) {
+    throw ArgumentError.value(
+      value,
+      key,
+      'Expected an absolute local on-device path or an $appCachePathPrefix '
+      'reference. URLs and relative paths are not allowed.',
+    );
+  }
+  final absoluteSegments = value.substring(1);
+  if (absoluteSegments.isEmpty) {
+    throw ArgumentError.value(
+      value,
+      key,
+      'The filesystem root is not a usable artifact path.',
+    );
+  }
+  _requireSafePathSegments(absoluteSegments, key, value);
+  return value;
+}
+
+String _requireUsableCacheDirectory(String rawDirectory) {
+  const key = 'applicationCacheDirectory';
+  if (rawDirectory.trim().isEmpty) {
+    throw ArgumentError.value(
+      rawDirectory,
+      key,
+      'The platform reported an empty application cache directory.',
+    );
+  }
+  if (rawDirectory.trim() != rawDirectory) {
+    throw ArgumentError.value(
+      rawDirectory,
+      key,
+      'The application cache directory must not have surrounding whitespace.',
+    );
+  }
+  final directory = rawDirectory;
+  final normalized = directory.length > 1 && directory.endsWith('/')
+      ? directory.substring(0, directory.length - 1)
+      : directory;
+  requireSafeSpeechPathSpec(normalized, key);
+  if (isAppCachePathReference(normalized)) {
+    throw ArgumentError.value(
+      rawDirectory,
+      key,
+      'The application cache directory must itself be an absolute path.',
+    );
+  }
+  return normalized;
+}
+
+/// Rejects duplicate immutable inputs and a TTS output that aliases an input.
+///
+/// Comparison folds case because the on-device container may treat two
+/// differently cased names as one file. Filesystem-level canonical and inode
+/// checks run later, after every path exists on the installed app container.
+void _requireUnambiguousSpeechPaths(
+  String outputPath,
+  Map<String, String> inputPaths,
+) {
+  final labelsByFoldedPath = <String, String>{};
+  for (final entry in inputPaths.entries) {
+    final folded = entry.value.toLowerCase();
+    final previousLabel = labelsByFoldedPath[folded];
+    if (previousLabel != null) {
+      throw ArgumentError.value(
+        entry.value,
+        entry.key,
+        'Immutable input path collides with $previousLabel, ignoring case.',
+      );
+    }
+    labelsByFoldedPath[folded] = entry.key;
+  }
+
+  final foldedOutput = outputPath.toLowerCase();
+  if (labelsByFoldedPath.containsKey(foldedOutput)) {
+    throw ArgumentError.value(
+      outputPath,
+      PhysicalIosSpeechEnvKeys.ttsOutputPath,
+      'The disposable TTS output path must not equal any immutable input '
+      'artifact path, ignoring case.',
+    );
+  }
+}
 
 /// One checksum-pinned immutable input file.
 class PhysicalIosSpeechArtifact {
   /// Stable identifier used in diagnostics and result digests.
   final String label;
 
-  /// Absolute on-device path supplied through a compile-time define.
+  /// Configured path spec.
+  ///
+  /// This may still be an [appCachePathPrefix] reference until the config is
+  /// resolved. Callers must use [PhysicalIosSpeechConfig.requireResolvedPaths]
+  /// before any filesystem access.
   final String path;
 
   /// Expected canonical lowercase SHA-256 digest.
@@ -233,6 +419,13 @@ class PhysicalIosSpeechConfig {
   final String liteRtLmModelPath;
   final String liteRtLmModelSha256;
 
+  /// Canonical cache root used to resolve [appCachePathPrefix] references.
+  ///
+  /// This stays null for an all-absolute configuration. Once set, every
+  /// resolved cache-relative path is required to remain below this directory
+  /// after symbolic-link resolution.
+  final String? resolvedAppCacheDirectoryPath;
+
   const PhysicalIosSpeechConfig({
     required this.qwen3AsrModelPath,
     required this.qwen3AsrModelSha256,
@@ -260,6 +453,7 @@ class PhysicalIosSpeechConfig {
     required this.ttsExpectedTranscript,
     required this.liteRtLmModelPath,
     required this.liteRtLmModelSha256,
+    this.resolvedAppCacheDirectoryPath,
   });
 
   /// Loads configuration from `--dart-define` values only.
@@ -297,18 +491,12 @@ class PhysicalIosSpeechConfig {
       return value;
     }
 
-    String requireAbsoluteLocalPath(String key) {
-      final value = require(key);
-      final uri = Uri.tryParse(value);
-      if (!value.startsWith('/') || (uri?.hasScheme ?? false)) {
-        throw ArgumentError.value(
-          value,
-          key,
-          'Expected an absolute local on-device path. URLs and relative paths '
-          'are not allowed.',
-        );
+    String requirePathSpec(String key) {
+      final raw = map[key] ?? '';
+      if (raw.trim().isEmpty) {
+        return requireSafeSpeechPathSpec(require(key), key);
       }
-      return value;
+      return requireSafeSpeechPathSpec(raw, key);
     }
 
     final micDurationStr = require(PhysicalIosSpeechEnvKeys.micDurationSeconds);
@@ -327,55 +515,47 @@ class PhysicalIosSpeechConfig {
       );
     }
 
-    final qwen3AsrModelPath = requireAbsoluteLocalPath(
+    final qwen3AsrModelPath = requirePathSpec(
       PhysicalIosSpeechEnvKeys.qwen3AsrModelPath,
     );
-    final qwen3AsrMmprojPath = requireAbsoluteLocalPath(
+    final qwen3AsrMmprojPath = requirePathSpec(
       PhysicalIosSpeechEnvKeys.qwen3AsrMmprojPath,
     );
-    final asrAudioPath = requireAbsoluteLocalPath(
-      PhysicalIosSpeechEnvKeys.asrAudioPath,
-    );
-    final liteRtAsrModelPath = requireAbsoluteLocalPath(
+    final asrAudioPath = requirePathSpec(PhysicalIosSpeechEnvKeys.asrAudioPath);
+    final liteRtAsrModelPath = requirePathSpec(
       PhysicalIosSpeechEnvKeys.liteRtAsrModelPath,
     );
-    final liteRtAsrTokenizerPath = requireAbsoluteLocalPath(
+    final liteRtAsrTokenizerPath = requirePathSpec(
       PhysicalIosSpeechEnvKeys.liteRtAsrTokenizerPath,
     );
-    final liteRtAsrAudioPath = requireAbsoluteLocalPath(
+    final liteRtAsrAudioPath = requirePathSpec(
       PhysicalIosSpeechEnvKeys.liteRtAsrAudioPath,
     );
-    final qwen3TtsModelPath = requireAbsoluteLocalPath(
+    final qwen3TtsModelPath = requirePathSpec(
       PhysicalIosSpeechEnvKeys.qwen3TtsModelPath,
     );
-    final qwen3TtsMmprojPath = requireAbsoluteLocalPath(
+    final qwen3TtsMmprojPath = requirePathSpec(
       PhysicalIosSpeechEnvKeys.qwen3TtsMmprojPath,
     );
-    final ttsOutputPath = requireAbsoluteLocalPath(
+    final ttsOutputPath = requirePathSpec(
       PhysicalIosSpeechEnvKeys.ttsOutputPath,
     );
-    final liteRtLmModelPath = requireAbsoluteLocalPath(
+    final liteRtLmModelPath = requirePathSpec(
       PhysicalIosSpeechEnvKeys.liteRtLmModelPath,
     );
-    final inputPaths = <String>{
-      qwen3AsrModelPath,
-      qwen3AsrMmprojPath,
-      asrAudioPath,
-      liteRtAsrModelPath,
-      liteRtAsrTokenizerPath,
-      liteRtAsrAudioPath,
-      qwen3TtsModelPath,
-      qwen3TtsMmprojPath,
-      liteRtLmModelPath,
-    };
-    if (inputPaths.contains(ttsOutputPath)) {
-      throw ArgumentError.value(
-        ttsOutputPath,
-        PhysicalIosSpeechEnvKeys.ttsOutputPath,
-        'The disposable TTS output path must not equal any immutable input '
-        'artifact path.',
-      );
-    }
+    // Collisions are re-checked after resolution, because an absolute path and
+    // an `@appcache/` reference can only be compared once both are bound.
+    _requireUnambiguousSpeechPaths(ttsOutputPath, <String, String>{
+      'qwen3AsrModel': qwen3AsrModelPath,
+      'qwen3AsrMmproj': qwen3AsrMmprojPath,
+      'asrAudio': asrAudioPath,
+      'liteRtAsrModel': liteRtAsrModelPath,
+      'liteRtAsrTokenizer': liteRtAsrTokenizerPath,
+      'liteRtAsrAudio': liteRtAsrAudioPath,
+      'qwen3TtsModel': qwen3TtsModelPath,
+      'qwen3TtsMmproj': qwen3TtsMmprojPath,
+      'liteRtLmModel': liteRtLmModelPath,
+    });
 
     return PhysicalIosSpeechConfig(
       qwen3AsrModelPath: qwen3AsrModelPath,
@@ -464,6 +644,150 @@ class PhysicalIosSpeechConfig {
     }
   }
 
+  /// Whether any configured path still needs app-cache resolution.
+  bool get usesAppCachePaths =>
+      _configuredPaths.any(isAppCachePathReference) ||
+      isAppCachePathReference(ttsOutputPath);
+
+  List<String> get _configuredPaths => <String>[
+    qwen3AsrModelPath,
+    qwen3AsrMmprojPath,
+    asrAudioPath,
+    liteRtAsrModelPath,
+    liteRtAsrTokenizerPath,
+    liteRtAsrAudioPath,
+    qwen3TtsModelPath,
+    qwen3TtsMmprojPath,
+    liteRtLmModelPath,
+  ];
+
+  /// Binds every [appCachePathPrefix] reference to [cacheDirectoryPath].
+  ///
+  /// Safe absolute paths are returned unchanged. Every path is re-validated
+  /// here so a directly constructed config cannot smuggle an unsafe path past
+  /// [PhysicalIosSpeechConfig.fromMap].
+  PhysicalIosSpeechConfig resolveAppCachePaths(String cacheDirectoryPath) {
+    final base = _requireUsableCacheDirectory(cacheDirectoryPath);
+
+    String resolve(String value, String key) {
+      final spec = requireSafeSpeechPathSpec(value, key);
+      if (!isAppCachePathReference(spec)) {
+        return spec;
+      }
+      return '$base/${spec.substring(appCachePathPrefix.length)}';
+    }
+
+    final resolvedQwen3AsrModelPath = resolve(
+      qwen3AsrModelPath,
+      PhysicalIosSpeechEnvKeys.qwen3AsrModelPath,
+    );
+    final resolvedQwen3AsrMmprojPath = resolve(
+      qwen3AsrMmprojPath,
+      PhysicalIosSpeechEnvKeys.qwen3AsrMmprojPath,
+    );
+    final resolvedAsrAudioPath = resolve(
+      asrAudioPath,
+      PhysicalIosSpeechEnvKeys.asrAudioPath,
+    );
+    final resolvedLiteRtAsrModelPath = resolve(
+      liteRtAsrModelPath,
+      PhysicalIosSpeechEnvKeys.liteRtAsrModelPath,
+    );
+    final resolvedLiteRtAsrTokenizerPath = resolve(
+      liteRtAsrTokenizerPath,
+      PhysicalIosSpeechEnvKeys.liteRtAsrTokenizerPath,
+    );
+    final resolvedLiteRtAsrAudioPath = resolve(
+      liteRtAsrAudioPath,
+      PhysicalIosSpeechEnvKeys.liteRtAsrAudioPath,
+    );
+    final resolvedQwen3TtsModelPath = resolve(
+      qwen3TtsModelPath,
+      PhysicalIosSpeechEnvKeys.qwen3TtsModelPath,
+    );
+    final resolvedQwen3TtsMmprojPath = resolve(
+      qwen3TtsMmprojPath,
+      PhysicalIosSpeechEnvKeys.qwen3TtsMmprojPath,
+    );
+    final resolvedLiteRtLmModelPath = resolve(
+      liteRtLmModelPath,
+      PhysicalIosSpeechEnvKeys.liteRtLmModelPath,
+    );
+    final resolvedTtsOutputPath = resolve(
+      ttsOutputPath,
+      PhysicalIosSpeechEnvKeys.ttsOutputPath,
+    );
+    _requireUnambiguousSpeechPaths(resolvedTtsOutputPath, <String, String>{
+      'qwen3AsrModel': resolvedQwen3AsrModelPath,
+      'qwen3AsrMmproj': resolvedQwen3AsrMmprojPath,
+      'asrAudio': resolvedAsrAudioPath,
+      'liteRtAsrModel': resolvedLiteRtAsrModelPath,
+      'liteRtAsrTokenizer': resolvedLiteRtAsrTokenizerPath,
+      'liteRtAsrAudio': resolvedLiteRtAsrAudioPath,
+      'qwen3TtsModel': resolvedQwen3TtsModelPath,
+      'qwen3TtsMmproj': resolvedQwen3TtsMmprojPath,
+      'liteRtLmModel': resolvedLiteRtLmModelPath,
+    });
+
+    return PhysicalIosSpeechConfig(
+      qwen3AsrModelPath: resolvedQwen3AsrModelPath,
+      qwen3AsrModelSha256: qwen3AsrModelSha256,
+      qwen3AsrMmprojPath: resolvedQwen3AsrMmprojPath,
+      qwen3AsrMmprojSha256: qwen3AsrMmprojSha256,
+      asrAudioPath: resolvedAsrAudioPath,
+      asrAudioSha256: asrAudioSha256,
+      asrExpectedTranscript: asrExpectedTranscript,
+      micDurationSeconds: micDurationSeconds,
+      micExpectedTranscript: micExpectedTranscript,
+      liteRtAsrModelPath: resolvedLiteRtAsrModelPath,
+      liteRtAsrModelSha256: liteRtAsrModelSha256,
+      liteRtAsrTokenizerPath: resolvedLiteRtAsrTokenizerPath,
+      liteRtAsrTokenizerSha256: liteRtAsrTokenizerSha256,
+      liteRtAsrPreset: liteRtAsrPreset,
+      liteRtAsrAudioPath: resolvedLiteRtAsrAudioPath,
+      liteRtAsrAudioSha256: liteRtAsrAudioSha256,
+      liteRtAsrExpectedTranscript: liteRtAsrExpectedTranscript,
+      qwen3TtsModelPath: resolvedQwen3TtsModelPath,
+      qwen3TtsModelSha256: qwen3TtsModelSha256,
+      qwen3TtsMmprojPath: resolvedQwen3TtsMmprojPath,
+      qwen3TtsMmprojSha256: qwen3TtsMmprojSha256,
+      ttsText: ttsText,
+      ttsOutputPath: resolvedTtsOutputPath,
+      ttsExpectedTranscript: ttsExpectedTranscript,
+      liteRtLmModelPath: resolvedLiteRtLmModelPath,
+      liteRtLmModelSha256: liteRtLmModelSha256,
+      resolvedAppCacheDirectoryPath: base,
+    );
+  }
+
+  /// Fails closed unless every path is safe, resolved, and collision-free.
+  void requireResolvedPaths() {
+    final configuredArtifacts = artifacts;
+    final unresolved = <String>[
+      for (final artifact in configuredArtifacts)
+        if (isAppCachePathReference(
+          requireSafeSpeechPathSpec(artifact.path, artifact.label),
+        ))
+          artifact.label,
+      if (isAppCachePathReference(
+        requireSafeSpeechPathSpec(
+          ttsOutputPath,
+          PhysicalIosSpeechEnvKeys.ttsOutputPath,
+        ),
+      ))
+        'ttsOutput',
+    ]..sort();
+    if (unresolved.isNotEmpty) {
+      throw StateError(
+        'Path access was attempted before $appCachePathPrefix references were '
+        'resolved: ${unresolved.join(', ')}.',
+      );
+    }
+    _requireUnambiguousSpeechPaths(ttsOutputPath, <String, String>{
+      for (final artifact in configuredArtifacts) artifact.label: artifact.path,
+    });
+  }
+
   /// Every checksum-pinned immutable artifact, in verification order.
   List<PhysicalIosSpeechArtifact> get artifacts => <PhysicalIosSpeechArtifact>[
     PhysicalIosSpeechArtifact(
@@ -520,6 +844,7 @@ class PhysicalIosSpeechConfig {
   Future<void> validateArtifacts({
     Future<void> Function(PhysicalIosSpeechArtifact artifact)? verify,
   }) async {
+    requireResolvedPaths();
     final check =
         verify ??
         (PhysicalIosSpeechArtifact artifact) =>
@@ -539,6 +864,7 @@ class PhysicalIosSpeechConfig {
     Future<void> Function(PhysicalIosSpeechArtifact artifact)? verify,
     Duration? timeoutPerArtifact,
   }) async {
+    requireResolvedPaths();
     final check =
         verify ??
         (PhysicalIosSpeechArtifact artifact) => validateFileChecksum(
@@ -561,6 +887,458 @@ class PhysicalIosSpeechConfig {
   }
 }
 
+/// Resolves [appCachePathPrefix] references against the real app cache
+/// directory, so paths survive the data-container UUID a device install mints.
+///
+/// [cacheDirectory] exists so host tests can bind a temporary directory; the
+/// device harness always uses `getApplicationCacheDirectory`. The lookup is
+/// skipped entirely when no define uses the marker, keeping an all-absolute
+/// configuration independent of the plugin.
+Future<PhysicalIosSpeechConfig> resolvePhysicalIosSpeechCachePaths(
+  PhysicalIosSpeechConfig config, {
+  Future<Directory> Function()? cacheDirectory,
+}) async {
+  if (!config.usesAppCachePaths) {
+    config.requireResolvedPaths();
+    return config;
+  }
+  final directory = await (cacheDirectory ?? getApplicationCacheDirectory)();
+  final resolved = config.resolveAppCachePaths(directory.path);
+  resolved.requireResolvedPaths();
+  return resolved;
+}
+
+bool _isWithinDirectory(String root, String candidate) {
+  final normalizedRoot = path.normalize(root);
+  final normalizedCandidate = path.normalize(candidate);
+  return path.equals(normalizedRoot, normalizedCandidate) ||
+      path.isWithin(normalizedRoot, normalizedCandidate);
+}
+
+Future<FileSystemEntityType> _safeEntityType(
+  String entityPath,
+  String label,
+) async {
+  try {
+    return await FileSystemEntity.type(entityPath, followLinks: false);
+  } on FileSystemException {
+    throw FileSystemException('Unable to inspect $label safely.');
+  }
+}
+
+Future<String> _safeResolveDirectory(String directoryPath, String label) async {
+  if (await _safeEntityType(directoryPath, label) !=
+      FileSystemEntityType.directory) {
+    throw FileSystemException('$label is not an existing directory.');
+  }
+  try {
+    return path.normalize(
+      await Directory(directoryPath).resolveSymbolicLinks(),
+    );
+  } on FileSystemException {
+    throw FileSystemException('Unable to canonicalize $label safely.');
+  }
+}
+
+Future<void> _requireNoLinksBelowRoot({
+  required String root,
+  required String candidate,
+  required String label,
+  required bool allowMissing,
+}) async {
+  if (!_isWithinDirectory(root, candidate) || path.equals(root, candidate)) {
+    throw StateError('$label escaped the runtime application cache.');
+  }
+  var current = path.normalize(root);
+  final relative = path.relative(path.normalize(candidate), from: current);
+  for (final segment in path.split(relative)) {
+    current = path.join(current, segment);
+    final type = await _safeEntityType(current, label);
+    if (type == FileSystemEntityType.link) {
+      throw StateError('$label contains a symbolic-link component.');
+    }
+    if (type == FileSystemEntityType.notFound) {
+      if (allowMissing) {
+        return;
+      }
+      throw FileSystemException('$label does not exist.');
+    }
+  }
+}
+
+Future<String?> _canonicalizeInputArtifact(
+  PhysicalIosSpeechArtifact artifact, {
+  required String? configuredCacheRoot,
+  required String? canonicalCacheRoot,
+}) async {
+  var candidate = path.normalize(artifact.path);
+  if (configuredCacheRoot != null &&
+      canonicalCacheRoot != null &&
+      _isWithinDirectory(configuredCacheRoot, candidate)) {
+    final relative = path.relative(candidate, from: configuredCacheRoot);
+    candidate = path.join(canonicalCacheRoot, relative);
+    await _requireNoLinksBelowRoot(
+      root: canonicalCacheRoot,
+      candidate: candidate,
+      label: artifact.label,
+      allowMissing: true,
+    );
+  }
+
+  final type = await _safeEntityType(candidate, artifact.label);
+  if (type == FileSystemEntityType.notFound) {
+    // Preserve the path so checksum validation can classify this failure only
+    // against rows that depend on the missing artifact.
+    return null;
+  }
+  if (type == FileSystemEntityType.link) {
+    throw StateError('${artifact.label} must not be a symbolic link.');
+  }
+  if (type != FileSystemEntityType.file) {
+    return null;
+  }
+  try {
+    final canonical = path.normalize(
+      await File(candidate).resolveSymbolicLinks(),
+    );
+    if (canonicalCacheRoot != null &&
+        _isWithinDirectory(canonicalCacheRoot, candidate) &&
+        !_isWithinDirectory(canonicalCacheRoot, canonical)) {
+      throw StateError(
+        '${artifact.label} escaped the runtime application cache.',
+      );
+    }
+    return canonical;
+  } on FileSystemException {
+    throw FileSystemException(
+      'Unable to canonicalize ${artifact.label} safely.',
+    );
+  }
+}
+
+Future<String> _canonicalizePlannedOutputPath(
+  String outputPath, {
+  required String? configuredCacheRoot,
+  required String? canonicalCacheRoot,
+}) async {
+  final normalizedOutput = path.normalize(outputPath);
+  if (configuredCacheRoot != null &&
+      canonicalCacheRoot != null &&
+      _isWithinDirectory(configuredCacheRoot, normalizedOutput)) {
+    final relative = path.relative(normalizedOutput, from: configuredCacheRoot);
+    final canonicalOutput = path.join(canonicalCacheRoot, relative);
+    await _requireNoLinksBelowRoot(
+      root: canonicalCacheRoot,
+      candidate: canonicalOutput,
+      label: 'ttsOutput',
+      allowMissing: true,
+    );
+    return canonicalOutput;
+  }
+
+  var existingAncestor = path.dirname(normalizedOutput);
+  final missingSegments = <String>[];
+  while (true) {
+    final type = await _safeEntityType(existingAncestor, 'ttsOutputParent');
+    if (type == FileSystemEntityType.directory ||
+        type == FileSystemEntityType.link) {
+      break;
+    }
+    if (type != FileSystemEntityType.notFound) {
+      throw StateError('The TTS output parent is not a directory.');
+    }
+    final parent = path.dirname(existingAncestor);
+    if (path.equals(parent, existingAncestor)) {
+      throw StateError('The TTS output path has no usable parent directory.');
+    }
+    missingSegments.add(path.basename(existingAncestor));
+    existingAncestor = parent;
+  }
+  var canonicalParent = path.normalize(
+    await Directory(existingAncestor).resolveSymbolicLinks(),
+  );
+  for (final segment in missingSegments.reversed) {
+    canonicalParent = path.join(canonicalParent, segment);
+  }
+  return path.join(canonicalParent, path.basename(normalizedOutput));
+}
+
+PhysicalIosSpeechConfig _copyConfigWithCanonicalPaths(
+  PhysicalIosSpeechConfig source,
+  Map<String, String> canonicalInputs,
+  String canonicalOutput,
+  String? canonicalCacheRoot,
+) {
+  return PhysicalIosSpeechConfig(
+    qwen3AsrModelPath:
+        canonicalInputs['qwen3AsrModel'] ?? source.qwen3AsrModelPath,
+    qwen3AsrModelSha256: source.qwen3AsrModelSha256,
+    qwen3AsrMmprojPath:
+        canonicalInputs['qwen3AsrMmproj'] ?? source.qwen3AsrMmprojPath,
+    qwen3AsrMmprojSha256: source.qwen3AsrMmprojSha256,
+    asrAudioPath: canonicalInputs['asrAudio'] ?? source.asrAudioPath,
+    asrAudioSha256: source.asrAudioSha256,
+    asrExpectedTranscript: source.asrExpectedTranscript,
+    micDurationSeconds: source.micDurationSeconds,
+    micExpectedTranscript: source.micExpectedTranscript,
+    liteRtAsrModelPath:
+        canonicalInputs['liteRtAsrModel'] ?? source.liteRtAsrModelPath,
+    liteRtAsrModelSha256: source.liteRtAsrModelSha256,
+    liteRtAsrTokenizerPath:
+        canonicalInputs['liteRtAsrTokenizer'] ?? source.liteRtAsrTokenizerPath,
+    liteRtAsrTokenizerSha256: source.liteRtAsrTokenizerSha256,
+    liteRtAsrPreset: source.liteRtAsrPreset,
+    liteRtAsrAudioPath:
+        canonicalInputs['liteRtAsrAudio'] ?? source.liteRtAsrAudioPath,
+    liteRtAsrAudioSha256: source.liteRtAsrAudioSha256,
+    liteRtAsrExpectedTranscript: source.liteRtAsrExpectedTranscript,
+    qwen3TtsModelPath:
+        canonicalInputs['qwen3TtsModel'] ?? source.qwen3TtsModelPath,
+    qwen3TtsModelSha256: source.qwen3TtsModelSha256,
+    qwen3TtsMmprojPath:
+        canonicalInputs['qwen3TtsMmproj'] ?? source.qwen3TtsMmprojPath,
+    qwen3TtsMmprojSha256: source.qwen3TtsMmprojSha256,
+    ttsText: source.ttsText,
+    ttsOutputPath: canonicalOutput,
+    ttsExpectedTranscript: source.ttsExpectedTranscript,
+    liteRtLmModelPath:
+        canonicalInputs['liteRtLmModel'] ?? source.liteRtLmModelPath,
+    liteRtLmModelSha256: source.liteRtLmModelSha256,
+    resolvedAppCacheDirectoryPath: canonicalCacheRoot,
+  );
+}
+
+/// Canonicalizes runtime paths and rejects symlink or inode aliases.
+///
+/// This runs only after app launch and [resolvePhysicalIosSpeechCachePaths], so
+/// an install-time data-container rotation cannot leave stale absolute cache
+/// paths in the runtime APIs. Missing inputs stay available for the later
+/// row-specific checksum ledger; unsafe symlinks and canonical collisions fail
+/// the whole preflight because the configured artifact identities are
+/// ambiguous.
+Future<PhysicalIosSpeechConfig> canonicalizePhysicalIosSpeechFilesystemLayout(
+  PhysicalIosSpeechConfig config,
+) async {
+  config.requireResolvedPaths();
+  final configuredCacheRoot = config.resolvedAppCacheDirectoryPath;
+  final canonicalCacheRoot = configuredCacheRoot == null
+      ? null
+      : await _safeResolveDirectory(
+          configuredCacheRoot,
+          'applicationCacheDirectory',
+        );
+
+  final canonicalInputs = <String, String>{};
+  final canonicalArtifacts = <PhysicalIosSpeechArtifact>[];
+  for (final artifact in config.artifacts) {
+    final canonical = await _canonicalizeInputArtifact(
+      artifact,
+      configuredCacheRoot: configuredCacheRoot,
+      canonicalCacheRoot: canonicalCacheRoot,
+    );
+    if (canonical == null) {
+      continue;
+    }
+    canonicalInputs[artifact.label] = canonical;
+    canonicalArtifacts.add(
+      PhysicalIosSpeechArtifact(
+        label: artifact.label,
+        path: canonical,
+        sha256: artifact.sha256,
+      ),
+    );
+  }
+
+  for (var i = 0; i < canonicalArtifacts.length; i++) {
+    for (var j = i + 1; j < canonicalArtifacts.length; j++) {
+      final left = canonicalArtifacts[i];
+      final right = canonicalArtifacts[j];
+      final collidesByName =
+          left.path.toLowerCase() == right.path.toLowerCase();
+      bool collidesByIdentity;
+      try {
+        collidesByIdentity = await FileSystemEntity.identical(
+          left.path,
+          right.path,
+        );
+      } on FileSystemException {
+        throw const FileSystemException(
+          'Unable to compare immutable artifact identities safely.',
+        );
+      }
+      if (collidesByName || collidesByIdentity) {
+        throw StateError(
+          'Immutable artifact identities collide: ${left.label}, '
+          '${right.label}.',
+        );
+      }
+    }
+  }
+
+  final canonicalOutput = await _canonicalizePlannedOutputPath(
+    config.ttsOutputPath,
+    configuredCacheRoot: configuredCacheRoot,
+    canonicalCacheRoot: canonicalCacheRoot,
+  );
+  final outputType = await _safeEntityType(canonicalOutput, 'ttsOutput');
+  if (outputType != FileSystemEntityType.notFound) {
+    throw StateError(
+      'The configured TTS output already exists; refusing to overwrite or '
+      'delete it.',
+    );
+  }
+  if (canonicalArtifacts.any(
+    (artifact) => artifact.path.toLowerCase() == canonicalOutput.toLowerCase(),
+  )) {
+    throw StateError('The TTS output aliases an immutable input artifact.');
+  }
+
+  return _copyConfigWithCanonicalPaths(
+    config,
+    canonicalInputs,
+    canonicalOutput,
+    canonicalCacheRoot,
+  );
+}
+
+Future<void> _createOutputParentSafely(
+  String outputPath,
+  String? canonicalCacheRoot,
+) async {
+  final parent = path.dirname(outputPath);
+  if (canonicalCacheRoot != null &&
+      _isWithinDirectory(canonicalCacheRoot, outputPath)) {
+    var current = canonicalCacheRoot;
+    final relative = path.relative(parent, from: canonicalCacheRoot);
+    for (final segment in path.split(relative)) {
+      if (segment == '.') {
+        continue;
+      }
+      current = path.join(current, segment);
+      final type = await _safeEntityType(current, 'ttsOutputParent');
+      if (type == FileSystemEntityType.link) {
+        throw StateError('The TTS output parent contains a symbolic link.');
+      }
+      if (type == FileSystemEntityType.notFound) {
+        try {
+          await Directory(current).create();
+        } on FileSystemException {
+          throw const FileSystemException(
+            'Unable to create the TTS output parent safely.',
+          );
+        }
+      } else if (type != FileSystemEntityType.directory) {
+        throw StateError('The TTS output parent is not a directory.');
+      }
+    }
+    return;
+  }
+
+  try {
+    await Directory(parent).create(recursive: true);
+  } on FileSystemException {
+    throw const FileSystemException(
+      'Unable to create the TTS output parent safely.',
+    );
+  }
+  final canonicalParent = await _safeResolveDirectory(
+    parent,
+    'ttsOutputParent',
+  );
+  if (!path.equals(canonicalParent, parent)) {
+    throw StateError('The TTS output parent changed after canonicalization.');
+  }
+}
+
+/// Creates and writes the disposable WAV without following an existing link.
+Future<File> writePhysicalIosSpeechOutputExclusive(
+  PhysicalIosSpeechConfig config,
+  Uint8List bytes,
+) async {
+  config.requireResolvedPaths();
+  final outputPath = path.normalize(config.ttsOutputPath);
+  await _createOutputParentSafely(
+    outputPath,
+    config.resolvedAppCacheDirectoryPath,
+  );
+  if (await _safeEntityType(outputPath, 'ttsOutput') !=
+      FileSystemEntityType.notFound) {
+    throw StateError(
+      'The configured TTS output already exists; refusing to overwrite or '
+      'delete it.',
+    );
+  }
+
+  final output = File(outputPath);
+  var created = false;
+  RandomAccessFile? handle;
+  Object? firstError;
+  StackTrace? firstStackTrace;
+  try {
+    await output.create(exclusive: true);
+    created = true;
+    if (await _safeEntityType(outputPath, 'ttsOutput') !=
+        FileSystemEntityType.file) {
+      throw StateError('The newly created TTS output is not a regular file.');
+    }
+    final canonical = path.normalize(await output.resolveSymbolicLinks());
+    if (!path.equals(canonical, outputPath)) {
+      throw StateError('The TTS output changed after exclusive creation.');
+    }
+    handle = await output.open(mode: FileMode.writeOnly);
+    await handle.writeFrom(bytes);
+    await handle.flush();
+  } catch (error, stackTrace) {
+    firstError = error;
+    firstStackTrace = stackTrace;
+  }
+  try {
+    await handle?.close();
+  } catch (error, stackTrace) {
+    firstError ??= error;
+    firstStackTrace ??= stackTrace;
+  }
+  if (firstError != null) {
+    if (created &&
+        await _safeEntityType(outputPath, 'ttsOutput') ==
+            FileSystemEntityType.file) {
+      try {
+        final canonical = path.normalize(await output.resolveSymbolicLinks());
+        if (path.equals(canonical, outputPath)) {
+          await output.delete();
+        }
+      } on FileSystemException {
+        // Preserve the write failure. A later run will fail closed on the
+        // pre-existing output instead of overwriting it.
+      }
+    }
+    Error.throwWithStackTrace(firstError, firstStackTrace!);
+  }
+  return output;
+}
+
+/// Deletes only the exact canonical regular file created by this harness.
+Future<void> deletePhysicalIosSpeechOutput(
+  PhysicalIosSpeechConfig config,
+) async {
+  final outputPath = path.normalize(config.ttsOutputPath);
+  if (await _safeEntityType(outputPath, 'ttsOutput') !=
+      FileSystemEntityType.file) {
+    throw StateError('Refusing to delete a non-regular TTS output.');
+  }
+  final canonical = path.normalize(
+    await File(outputPath).resolveSymbolicLinks(),
+  );
+  if (!path.equals(canonical, outputPath)) {
+    throw StateError('Refusing to delete a replaced TTS output.');
+  }
+  try {
+    await File(outputPath).delete();
+  } on FileSystemException {
+    throw const FileSystemException('Unable to delete the TTS output safely.');
+  }
+}
+
 /// Fails one row when any of its immutable input labels failed preflight.
 void requireValidSpeechArtifacts(
   Map<String, PhysicalIosSpeechArtifactFailure> failures,
@@ -578,7 +1356,7 @@ void requireValidSpeechArtifacts(
   );
 }
 
-/// Computes SHA-256 sequentially in fixed-size reads, never buffering it all.
+/// Computes SHA-256 sequentially from a cancellable file stream.
 Future<String> computeFileSha256(String path, {Duration? timeout}) async {
   final file = File(path);
   final stopwatch = Stopwatch()..start();
@@ -603,33 +1381,130 @@ Future<String> computeFileSha256(String path, {Duration? timeout}) async {
     );
   }
 
-  RandomAccessFile? inputFile;
   final digestSink = _SpeechDigestSink();
   var digestSinkClosed = false;
   final inputSink = sha256.startChunkedConversion(digestSink);
-  try {
-    final openedFile = await withinDeadline(file.open);
-    inputFile = openedFile;
-    while (true) {
-      final chunk = await withinDeadline(() => openedFile.read(1024 * 1024));
-      if (chunk.isEmpty) {
-        break;
-      }
-      inputSink.add(chunk);
-    }
-    inputSink.close();
-    digestSinkClosed = true;
-  } on FileSystemException {
-    throw const FileSystemException(
-      'Artifact file cannot be read for SHA-256 verification.',
-    );
-  } finally {
+  StreamSubscription<List<int>>? subscription;
+  Timer? deadlineTimer;
+  Object? firstError;
+  StackTrace? firstStackTrace;
+
+  void closeDigestSink() {
     if (!digestSinkClosed) {
       inputSink.close();
+      digestSinkClosed = true;
     }
-    if (inputFile != null) {
-      await inputFile.close();
+  }
+
+  try {
+    final initialType = await withinDeadline(
+      () => FileSystemEntity.type(path, followLinks: false),
+    );
+    if (initialType != FileSystemEntityType.file) {
+      throw const FileSystemException('Artifact path is not a regular file.');
     }
+    final initialCanonicalPath = await withinDeadline(
+      file.resolveSymbolicLinks,
+    );
+    final initialStat = await withinDeadline(file.stat);
+    final streamDone = Completer<void>();
+
+    void completeStreamError(Object error, StackTrace stackTrace) {
+      if (!streamDone.isCompleted) {
+        streamDone.completeError(error, stackTrace);
+      }
+    }
+
+    subscription = file.openRead().listen(
+      (chunk) {
+        try {
+          inputSink.add(chunk);
+        } catch (error, stackTrace) {
+          completeStreamError(error, stackTrace);
+          unawaited(subscription?.cancel());
+        }
+      },
+      onError: completeStreamError,
+      onDone: () {
+        if (streamDone.isCompleted) {
+          return;
+        }
+        try {
+          closeDigestSink();
+          streamDone.complete();
+        } catch (error, stackTrace) {
+          completeStreamError(error, stackTrace);
+        }
+      },
+      cancelOnError: true,
+    );
+    final bound = timeout;
+    if (bound != null) {
+      final remaining = bound - stopwatch.elapsed;
+      if (remaining <= Duration.zero) {
+        throw TimeoutException(
+          'Artifact SHA-256 verification timed out.',
+          bound,
+        );
+      }
+      deadlineTimer = Timer(remaining, () {
+        completeStreamError(
+          TimeoutException('Artifact SHA-256 verification timed out.', bound),
+          StackTrace.current,
+        );
+        unawaited(subscription?.cancel());
+      });
+    }
+    await streamDone.future;
+
+    final finalType = await withinDeadline(
+      () => FileSystemEntity.type(path, followLinks: false),
+    );
+    final finalCanonicalPath = await withinDeadline(file.resolveSymbolicLinks);
+    final finalStat = await withinDeadline(file.stat);
+    if (finalType != FileSystemEntityType.file ||
+        finalCanonicalPath != initialCanonicalPath ||
+        finalStat.type != initialStat.type ||
+        finalStat.size != initialStat.size ||
+        finalStat.modified != initialStat.modified ||
+        finalStat.changed != initialStat.changed) {
+      throw StateError(
+        'Artifact identity changed during SHA-256 verification.',
+      );
+    }
+  } catch (error, stackTrace) {
+    firstError = error;
+    firstStackTrace = stackTrace;
+  }
+
+  deadlineTimer?.cancel();
+  try {
+    await subscription?.cancel().timeout(
+      const Duration(seconds: 5),
+      onTimeout: () => throw TimeoutException(
+        'Artifact SHA-256 stream cleanup timed out.',
+        const Duration(seconds: 5),
+      ),
+    );
+  } catch (error, stackTrace) {
+    firstError ??= error;
+    firstStackTrace ??= stackTrace;
+  }
+  try {
+    closeDigestSink();
+  } catch (error, stackTrace) {
+    firstError ??= error;
+    firstStackTrace ??= stackTrace;
+  }
+
+  final error = firstError;
+  if (error != null) {
+    if (error is FileSystemException) {
+      throw const FileSystemException(
+        'Artifact file cannot be read for SHA-256 verification.',
+      );
+    }
+    Error.throwWithStackTrace(error, firstStackTrace!);
   }
   return digestSink.digest.toString().toLowerCase();
 }
@@ -791,9 +1666,31 @@ Future<void> requireStillActiveBeforeCancellation<T>(
   }
 }
 
-/// Whether an Apple hardware machine string proves this is not a simulator.
-bool isPhysicalIosMachineIdentifier(String machine) =>
-    _physicalIosMachinePattern.hasMatch(machine.trim());
+/// Whether [path] has the public executable-path shape of a physical iOS app.
+///
+/// Simulator executables live on the macOS host. Physical app executables live
+/// below the iOS bundle-installation root. This is deliberately a lexical,
+/// fail-closed check over [Platform.resolvedExecutable], with no private FFI or
+/// device identifier in diagnostics.
+bool isPhysicalIosApplicationExecutablePath(String path) {
+  final root = _physicalIosApplicationRoots.where(path.startsWith).firstOrNull;
+  if (root == null) {
+    return false;
+  }
+  final segments = path.substring(root.length).split('/');
+  return segments.length >= 3 &&
+      segments.every(
+        (segment) =>
+            segment.isNotEmpty &&
+            segment != '.' &&
+            segment != '..' &&
+            !_rejectedPathCharacters.hasMatch(segment) &&
+            !_controlCharacters.hasMatch(segment) &&
+            segment.trim() == segment,
+      ) &&
+      segments[1].length > '.app'.length &&
+      segments[1].endsWith('.app');
+}
 
 /// Backend family expected by one physical speech row.
 enum SpeechE2EBackendKind { llamaCppMetal, liteRtLmAsrCpu, liteRtLm }

--- a/example/chat_app/integration_test/support/physical_ios_speech_e2e_support.dart
+++ b/example/chat_app/integration_test/support/physical_ios_speech_e2e_support.dart
@@ -44,6 +44,10 @@ abstract final class PhysicalIosSpeechEnvKeys {
 
   static const liteRtLmModelPath = 'IOS_SPEECH_LITERT_LM_MODEL_PATH';
   static const liteRtLmModelSha256 = 'IOS_SPEECH_LITERT_LM_MODEL_SHA256';
+
+  /// Optional selector used to execute one matrix row without changing the
+  /// immutable artifact configuration.
+  static const rowSelection = 'IOS_SPEECH_ROW';
 }
 
 /// Every define this harness requires, in declaration order.
@@ -315,25 +319,68 @@ String _requireUsableCacheDirectory(String rawDirectory) {
   return normalized;
 }
 
+bool _isAsrAudioAliasPair(String firstLabel, String secondLabel) =>
+    (firstLabel == 'asrAudio' && secondLabel == 'liteRtAsrAudio') ||
+    (firstLabel == 'liteRtAsrAudio' && secondLabel == 'asrAudio');
+
+bool _isCanonicalDigest(String digest) =>
+    digest.length == 64 && _hexDigestPattern.hasMatch(digest);
+
+bool _hasEqualCanonicalDigest(String firstDigest, String secondDigest) =>
+    _isCanonicalDigest(firstDigest) &&
+    _isCanonicalDigest(secondDigest) &&
+    firstDigest == secondDigest;
+
+String _requireCanonicalDigest(String? digest, String key) {
+  if (digest == null || !_isCanonicalDigest(digest)) {
+    throw ArgumentError.value(
+      digest,
+      key,
+      'Expected a canonical lowercase 64-hex SHA-256 digest.',
+    );
+  }
+  return digest;
+}
+
 /// Rejects duplicate immutable inputs and a TTS output that aliases an input.
 ///
-/// Comparison folds case because the on-device container may treat two
-/// differently cased names as one file. Filesystem-level canonical and inode
-/// checks run later, after every path exists on the installed app container.
+/// Permits aliasing only between `asrAudio` and `liteRtAsrAudio` when their
+/// expected SHA-256 digests are identical. Comparison folds case because the
+/// on-device container may treat two differently cased names as one file.
+/// Filesystem-level canonical and inode checks run later, after every path
+/// exists on the installed app container.
 void _requireUnambiguousSpeechPaths(
   String outputPath,
-  Map<String, String> inputPaths,
-) {
+  Map<String, String> inputPaths, {
+  required Map<String, String> inputDigests,
+}) {
+  final canonicalDigests = <String, String>{
+    for (final label in inputPaths.keys)
+      label: _requireCanonicalDigest(inputDigests[label], '$label.sha256'),
+  };
   final labelsByFoldedPath = <String, String>{};
   for (final entry in inputPaths.entries) {
     final folded = entry.value.toLowerCase();
     final previousLabel = labelsByFoldedPath[folded];
     if (previousLabel != null) {
-      throw ArgumentError.value(
-        entry.value,
-        entry.key,
-        'Immutable input path collides with $previousLabel, ignoring case.',
-      );
+      if (!_isAsrAudioAliasPair(entry.key, previousLabel)) {
+        throw ArgumentError.value(
+          entry.value,
+          entry.key,
+          'Immutable input path collides with $previousLabel, ignoring case.',
+        );
+      }
+      if (!_hasEqualCanonicalDigest(
+        canonicalDigests[entry.key]!,
+        canonicalDigests[previousLabel]!,
+      )) {
+        throw ArgumentError.value(
+          entry.value,
+          entry.key,
+          'Shared ASR fixture paths require one identical canonical '
+          'lowercase SHA-256 digest.',
+        );
+      }
     }
     labelsByFoldedPath[folded] = entry.key;
   }
@@ -479,17 +526,7 @@ class PhysicalIosSpeechConfig {
       return trimmed;
     }
 
-    String requireDigest(String key) {
-      final value = require(key);
-      if (!_hexDigestPattern.hasMatch(value)) {
-        throw ArgumentError.value(
-          value,
-          key,
-          'Expected canonical 64 lowercase hex characters for $key.',
-        );
-      }
-      return value;
-    }
+    String requireDigest(String key) => _requireCanonicalDigest(map[key], key);
 
     String requirePathSpec(String key) {
       final raw = map[key] ?? '';
@@ -543,31 +580,69 @@ class PhysicalIosSpeechConfig {
     final liteRtLmModelPath = requirePathSpec(
       PhysicalIosSpeechEnvKeys.liteRtLmModelPath,
     );
+    final qwen3AsrModelSha256 = requireDigest(
+      PhysicalIosSpeechEnvKeys.qwen3AsrModelSha256,
+    );
+    final qwen3AsrMmprojSha256 = requireDigest(
+      PhysicalIosSpeechEnvKeys.qwen3AsrMmprojSha256,
+    );
+    final asrAudioSha256 = requireDigest(
+      PhysicalIosSpeechEnvKeys.asrAudioSha256,
+    );
+    final liteRtAsrModelSha256 = requireDigest(
+      PhysicalIosSpeechEnvKeys.liteRtAsrModelSha256,
+    );
+    final liteRtAsrTokenizerSha256 = requireDigest(
+      PhysicalIosSpeechEnvKeys.liteRtAsrTokenizerSha256,
+    );
+    final liteRtAsrAudioSha256 = requireDigest(
+      PhysicalIosSpeechEnvKeys.liteRtAsrAudioSha256,
+    );
+    final qwen3TtsModelSha256 = requireDigest(
+      PhysicalIosSpeechEnvKeys.qwen3TtsModelSha256,
+    );
+    final qwen3TtsMmprojSha256 = requireDigest(
+      PhysicalIosSpeechEnvKeys.qwen3TtsMmprojSha256,
+    );
+    final liteRtLmModelSha256 = requireDigest(
+      PhysicalIosSpeechEnvKeys.liteRtLmModelSha256,
+    );
+
     // Collisions are re-checked after resolution, because an absolute path and
     // an `@appcache/` reference can only be compared once both are bound.
-    _requireUnambiguousSpeechPaths(ttsOutputPath, <String, String>{
-      'qwen3AsrModel': qwen3AsrModelPath,
-      'qwen3AsrMmproj': qwen3AsrMmprojPath,
-      'asrAudio': asrAudioPath,
-      'liteRtAsrModel': liteRtAsrModelPath,
-      'liteRtAsrTokenizer': liteRtAsrTokenizerPath,
-      'liteRtAsrAudio': liteRtAsrAudioPath,
-      'qwen3TtsModel': qwen3TtsModelPath,
-      'qwen3TtsMmproj': qwen3TtsMmprojPath,
-      'liteRtLmModel': liteRtLmModelPath,
-    });
+    _requireUnambiguousSpeechPaths(
+      ttsOutputPath,
+      <String, String>{
+        'qwen3AsrModel': qwen3AsrModelPath,
+        'qwen3AsrMmproj': qwen3AsrMmprojPath,
+        'asrAudio': asrAudioPath,
+        'liteRtAsrModel': liteRtAsrModelPath,
+        'liteRtAsrTokenizer': liteRtAsrTokenizerPath,
+        'liteRtAsrAudio': liteRtAsrAudioPath,
+        'qwen3TtsModel': qwen3TtsModelPath,
+        'qwen3TtsMmproj': qwen3TtsMmprojPath,
+        'liteRtLmModel': liteRtLmModelPath,
+      },
+      inputDigests: <String, String>{
+        'qwen3AsrModel': qwen3AsrModelSha256,
+        'qwen3AsrMmproj': qwen3AsrMmprojSha256,
+        'asrAudio': asrAudioSha256,
+        'liteRtAsrModel': liteRtAsrModelSha256,
+        'liteRtAsrTokenizer': liteRtAsrTokenizerSha256,
+        'liteRtAsrAudio': liteRtAsrAudioSha256,
+        'qwen3TtsModel': qwen3TtsModelSha256,
+        'qwen3TtsMmproj': qwen3TtsMmprojSha256,
+        'liteRtLmModel': liteRtLmModelSha256,
+      },
+    );
 
     return PhysicalIosSpeechConfig(
       qwen3AsrModelPath: qwen3AsrModelPath,
-      qwen3AsrModelSha256: requireDigest(
-        PhysicalIosSpeechEnvKeys.qwen3AsrModelSha256,
-      ),
+      qwen3AsrModelSha256: qwen3AsrModelSha256,
       qwen3AsrMmprojPath: qwen3AsrMmprojPath,
-      qwen3AsrMmprojSha256: requireDigest(
-        PhysicalIosSpeechEnvKeys.qwen3AsrMmprojSha256,
-      ),
+      qwen3AsrMmprojSha256: qwen3AsrMmprojSha256,
       asrAudioPath: asrAudioPath,
-      asrAudioSha256: requireDigest(PhysicalIosSpeechEnvKeys.asrAudioSha256),
+      asrAudioSha256: asrAudioSha256,
       asrExpectedTranscript: require(
         PhysicalIosSpeechEnvKeys.asrExpectedTranscript,
       ),
@@ -576,40 +651,28 @@ class PhysicalIosSpeechConfig {
         PhysicalIosSpeechEnvKeys.micExpectedTranscript,
       ),
       liteRtAsrModelPath: liteRtAsrModelPath,
-      liteRtAsrModelSha256: requireDigest(
-        PhysicalIosSpeechEnvKeys.liteRtAsrModelSha256,
-      ),
+      liteRtAsrModelSha256: liteRtAsrModelSha256,
       liteRtAsrTokenizerPath: liteRtAsrTokenizerPath,
-      liteRtAsrTokenizerSha256: requireDigest(
-        PhysicalIosSpeechEnvKeys.liteRtAsrTokenizerSha256,
-      ),
+      liteRtAsrTokenizerSha256: liteRtAsrTokenizerSha256,
       liteRtAsrPreset: _parsePreset(
         require(PhysicalIosSpeechEnvKeys.liteRtAsrPreset),
       ),
       liteRtAsrAudioPath: liteRtAsrAudioPath,
-      liteRtAsrAudioSha256: requireDigest(
-        PhysicalIosSpeechEnvKeys.liteRtAsrAudioSha256,
-      ),
+      liteRtAsrAudioSha256: liteRtAsrAudioSha256,
       liteRtAsrExpectedTranscript: require(
         PhysicalIosSpeechEnvKeys.liteRtAsrExpectedTranscript,
       ),
       qwen3TtsModelPath: qwen3TtsModelPath,
-      qwen3TtsModelSha256: requireDigest(
-        PhysicalIosSpeechEnvKeys.qwen3TtsModelSha256,
-      ),
+      qwen3TtsModelSha256: qwen3TtsModelSha256,
       qwen3TtsMmprojPath: qwen3TtsMmprojPath,
-      qwen3TtsMmprojSha256: requireDigest(
-        PhysicalIosSpeechEnvKeys.qwen3TtsMmprojSha256,
-      ),
+      qwen3TtsMmprojSha256: qwen3TtsMmprojSha256,
       ttsText: require(PhysicalIosSpeechEnvKeys.ttsText),
       ttsOutputPath: ttsOutputPath,
       ttsExpectedTranscript: require(
         PhysicalIosSpeechEnvKeys.ttsExpectedTranscript,
       ),
       liteRtLmModelPath: liteRtLmModelPath,
-      liteRtLmModelSha256: requireDigest(
-        PhysicalIosSpeechEnvKeys.liteRtLmModelSha256,
-      ),
+      liteRtLmModelSha256: liteRtLmModelSha256,
     );
   }
 
@@ -717,17 +780,31 @@ class PhysicalIosSpeechConfig {
       ttsOutputPath,
       PhysicalIosSpeechEnvKeys.ttsOutputPath,
     );
-    _requireUnambiguousSpeechPaths(resolvedTtsOutputPath, <String, String>{
-      'qwen3AsrModel': resolvedQwen3AsrModelPath,
-      'qwen3AsrMmproj': resolvedQwen3AsrMmprojPath,
-      'asrAudio': resolvedAsrAudioPath,
-      'liteRtAsrModel': resolvedLiteRtAsrModelPath,
-      'liteRtAsrTokenizer': resolvedLiteRtAsrTokenizerPath,
-      'liteRtAsrAudio': resolvedLiteRtAsrAudioPath,
-      'qwen3TtsModel': resolvedQwen3TtsModelPath,
-      'qwen3TtsMmproj': resolvedQwen3TtsMmprojPath,
-      'liteRtLmModel': resolvedLiteRtLmModelPath,
-    });
+    _requireUnambiguousSpeechPaths(
+      resolvedTtsOutputPath,
+      <String, String>{
+        'qwen3AsrModel': resolvedQwen3AsrModelPath,
+        'qwen3AsrMmproj': resolvedQwen3AsrMmprojPath,
+        'asrAudio': resolvedAsrAudioPath,
+        'liteRtAsrModel': resolvedLiteRtAsrModelPath,
+        'liteRtAsrTokenizer': resolvedLiteRtAsrTokenizerPath,
+        'liteRtAsrAudio': resolvedLiteRtAsrAudioPath,
+        'qwen3TtsModel': resolvedQwen3TtsModelPath,
+        'qwen3TtsMmproj': resolvedQwen3TtsMmprojPath,
+        'liteRtLmModel': resolvedLiteRtLmModelPath,
+      },
+      inputDigests: <String, String>{
+        'qwen3AsrModel': qwen3AsrModelSha256,
+        'qwen3AsrMmproj': qwen3AsrMmprojSha256,
+        'asrAudio': asrAudioSha256,
+        'liteRtAsrModel': liteRtAsrModelSha256,
+        'liteRtAsrTokenizer': liteRtAsrTokenizerSha256,
+        'liteRtAsrAudio': liteRtAsrAudioSha256,
+        'qwen3TtsModel': qwen3TtsModelSha256,
+        'qwen3TtsMmproj': qwen3TtsMmprojSha256,
+        'liteRtLmModel': liteRtLmModelSha256,
+      },
+    );
 
     return PhysicalIosSpeechConfig(
       qwen3AsrModelPath: resolvedQwen3AsrModelPath,
@@ -760,7 +837,7 @@ class PhysicalIosSpeechConfig {
     );
   }
 
-  /// Fails closed unless every path is safe, resolved, and collision-free.
+  /// Fails closed unless every digest and path is canonical and unambiguous.
   void requireResolvedPaths() {
     final configuredArtifacts = artifacts;
     final unresolved = <String>[
@@ -783,9 +860,17 @@ class PhysicalIosSpeechConfig {
         'resolved: ${unresolved.join(', ')}.',
       );
     }
-    _requireUnambiguousSpeechPaths(ttsOutputPath, <String, String>{
-      for (final artifact in configuredArtifacts) artifact.label: artifact.path,
-    });
+    _requireUnambiguousSpeechPaths(
+      ttsOutputPath,
+      <String, String>{
+        for (final artifact in configuredArtifacts)
+          artifact.label: artifact.path,
+      },
+      inputDigests: <String, String>{
+        for (final artifact in configuredArtifacts)
+          artifact.label: artifact.sha256,
+      },
+    );
   }
 
   /// Every checksum-pinned immutable artifact, in verification order.
@@ -1167,10 +1252,15 @@ Future<PhysicalIosSpeechConfig> canonicalizePhysicalIosSpeechFilesystemLayout(
         );
       }
       if (collidesByName || collidesByIdentity) {
-        throw StateError(
-          'Immutable artifact identities collide: ${left.label}, '
-          '${right.label}.',
-        );
+        final isPermittedAsrAlias =
+            _isAsrAudioAliasPair(left.label, right.label) &&
+            _hasEqualCanonicalDigest(left.sha256, right.sha256);
+        if (!isPermittedAsrAlias) {
+          throw StateError(
+            'Immutable artifact identities collide: ${left.label}, '
+            '${right.label}.',
+          );
+        }
       }
     }
   }
@@ -1693,7 +1783,7 @@ bool isPhysicalIosApplicationExecutablePath(String path) {
 }
 
 /// Backend family expected by one physical speech row.
-enum SpeechE2EBackendKind { llamaCppMetal, liteRtLmAsrCpu, liteRtLm }
+enum SpeechE2EBackendKind { llamaCppCpu, liteRtLmAsrCpu, liteRtLm }
 
 /// Validates backend identity and returns a stable, sanitized report label.
 String requireSpeechBackendIdentity(
@@ -1702,8 +1792,7 @@ String requireSpeechBackendIdentity(
 ) {
   final normalized = actual.trim().toLowerCase();
   final matches = switch (expected) {
-    SpeechE2EBackendKind.llamaCppMetal =>
-      normalized.contains('metal') && !normalized.contains('litert'),
+    SpeechE2EBackendKind.llamaCppCpu => actual == 'CPU',
     SpeechE2EBackendKind.liteRtLmAsrCpu =>
       normalized.contains('litert-lm') &&
           normalized.contains('asr') &&
@@ -1718,7 +1807,7 @@ String requireSpeechBackendIdentity(
     );
   }
   return switch (expected) {
-    SpeechE2EBackendKind.llamaCppMetal => 'llama.cpp Metal',
+    SpeechE2EBackendKind.llamaCppCpu => 'llama.cpp CPU',
     SpeechE2EBackendKind.liteRtLmAsrCpu => 'LiteRT-LM ASR CPU',
     SpeechE2EBackendKind.liteRtLm => 'LiteRT-LM',
   };
@@ -2101,9 +2190,41 @@ const List<String> speechE2ERowIdsInOrder = <String>[
 /// Canonical identifiers for set-based validation.
 const Set<String> speechE2ERowIds = <String>{...speechE2ERowIdsInOrder};
 
+/// Selector value that runs the complete physical-iOS speech matrix.
+const String physicalIosSpeechAllRows = 'all';
+
+/// Parses the optional row selector while preserving canonical row ordering.
+///
+/// The selector is intentionally exact and case-sensitive. An omitted
+/// `IOS_SPEECH_ROW` define is supplied as [physicalIosSpeechAllRows] by the
+/// integration target; an explicit invalid value fails closed rather than
+/// silently running a different subset.
+List<String> selectPhysicalIosSpeechRowIds(String rawSelection) {
+  if (rawSelection.isEmpty || rawSelection != rawSelection.trim()) {
+    throw ArgumentError.value(
+      rawSelection,
+      PhysicalIosSpeechEnvKeys.rowSelection,
+      'Expected "$physicalIosSpeechAllRows" or one canonical speech row id '
+      'without surrounding whitespace.',
+    );
+  }
+  if (rawSelection == physicalIosSpeechAllRows) {
+    return List<String>.unmodifiable(speechE2ERowIdsInOrder);
+  }
+  if (!speechE2ERowIds.contains(rawSelection)) {
+    throw ArgumentError.value(
+      rawSelection,
+      PhysicalIosSpeechEnvKeys.rowSelection,
+      'Expected "$physicalIosSpeechAllRows" or one of '
+      '${speechE2ERowIdsInOrder.join(', ')}.',
+    );
+  }
+  return <String>[rawSelection];
+}
+
 /// Stable sanitized backend label used before a row resolves its live backend.
 String unresolvedSpeechBackendForRow(String id) => switch (id) {
-  'llama_cpp_qwen3_asr' || 'llama_cpp_qwen3_tts' => 'llama.cpp Metal',
+  'llama_cpp_qwen3_asr' || 'llama_cpp_qwen3_tts' => 'llama.cpp CPU',
   'litert_lm_streaming_asr' => 'LiteRT-LM ASR CPU',
   'litert_lm_tts' => 'LiteRT-LM',
   _ => '<unresolved>',
@@ -2239,6 +2360,23 @@ class SpeechE2ESummary {
         'Unexpected: ${unexpected.isEmpty ? '<none>' : (unexpected.toList()..sort()).join(', ')}.',
       );
     }
+  }
+
+  /// Validates the exact row set and strict statuses for a full or selected
+  /// physical-iOS speech run.
+  void validateSelectedRows(Set<String> expectedIds) {
+    if (expectedIds.isEmpty || !speechE2ERowIds.containsAll(expectedIds)) {
+      throw StateError(
+        'Expected one or more canonical physical-iOS speech row ids.',
+      );
+    }
+    validateRowIds(expectedIds: expectedIds);
+    final expectedUnsupported = expectedIds.contains('litert_lm_tts') ? 1 : 0;
+    validateStrictCounts(
+      expectedTotal: expectedIds.length,
+      expectedPass: expectedIds.length - expectedUnsupported,
+      expectedUnsupported: expectedUnsupported,
+    );
   }
 
   void validateStrictCounts({

--- a/example/chat_app/integration_test/support/physical_ios_speech_e2e_support.dart
+++ b/example/chat_app/integration_test/support/physical_ios_speech_e2e_support.dart
@@ -1,0 +1,1418 @@
+import 'dart:async';
+import 'dart:convert';
+import 'dart:io';
+import 'dart:math' as math;
+import 'dart:typed_data';
+
+import 'package:crypto/crypto.dart';
+import 'package:llamadart/llamadart.dart';
+import 'package:llamadart_chat_example/services/audio_recording_service.dart';
+
+/// Compile-time define names for physical iOS speech integration testing.
+abstract final class PhysicalIosSpeechEnvKeys {
+  static const qwen3AsrModelPath = 'IOS_SPEECH_QWEN3_ASR_MODEL_PATH';
+  static const qwen3AsrModelSha256 = 'IOS_SPEECH_QWEN3_ASR_MODEL_SHA256';
+  static const qwen3AsrMmprojPath = 'IOS_SPEECH_QWEN3_ASR_MMPROJ_PATH';
+  static const qwen3AsrMmprojSha256 = 'IOS_SPEECH_QWEN3_ASR_MMPROJ_SHA256';
+  static const asrAudioPath = 'IOS_SPEECH_ASR_AUDIO_PATH';
+  static const asrAudioSha256 = 'IOS_SPEECH_ASR_AUDIO_SHA256';
+  static const asrExpectedTranscript = 'IOS_SPEECH_ASR_EXPECTED_TRANSCRIPT';
+
+  static const micDurationSeconds = 'IOS_SPEECH_MIC_DURATION_SECONDS';
+  static const micExpectedTranscript = 'IOS_SPEECH_MIC_EXPECTED_TRANSCRIPT';
+
+  static const liteRtAsrModelPath = 'IOS_SPEECH_LITERT_ASR_MODEL_PATH';
+  static const liteRtAsrModelSha256 = 'IOS_SPEECH_LITERT_ASR_MODEL_SHA256';
+  static const liteRtAsrTokenizerPath = 'IOS_SPEECH_LITERT_ASR_TOKENIZER_PATH';
+  static const liteRtAsrTokenizerSha256 =
+      'IOS_SPEECH_LITERT_ASR_TOKENIZER_SHA256';
+  static const liteRtAsrPreset = 'IOS_SPEECH_LITERT_ASR_PRESET';
+  static const liteRtAsrAudioPath = 'IOS_SPEECH_LITERT_ASR_AUDIO_PATH';
+  static const liteRtAsrAudioSha256 = 'IOS_SPEECH_LITERT_ASR_AUDIO_SHA256';
+  static const liteRtAsrExpectedTranscript =
+      'IOS_SPEECH_LITERT_ASR_EXPECTED_TRANSCRIPT';
+
+  static const qwen3TtsModelPath = 'IOS_SPEECH_QWEN3_TTS_MODEL_PATH';
+  static const qwen3TtsModelSha256 = 'IOS_SPEECH_QWEN3_TTS_MODEL_SHA256';
+  static const qwen3TtsMmprojPath = 'IOS_SPEECH_QWEN3_TTS_MMPROJ_PATH';
+  static const qwen3TtsMmprojSha256 = 'IOS_SPEECH_QWEN3_TTS_MMPROJ_SHA256';
+  static const ttsText = 'IOS_SPEECH_TTS_TEXT';
+  static const ttsOutputPath = 'IOS_SPEECH_TTS_OUTPUT_PATH';
+  static const ttsExpectedTranscript = 'IOS_SPEECH_TTS_EXPECTED_TRANSCRIPT';
+
+  static const liteRtLmModelPath = 'IOS_SPEECH_LITERT_LM_MODEL_PATH';
+  static const liteRtLmModelSha256 = 'IOS_SPEECH_LITERT_LM_MODEL_SHA256';
+}
+
+/// Every define this harness requires, in declaration order.
+const List<String> physicalIosSpeechDefineKeys = <String>[
+  PhysicalIosSpeechEnvKeys.qwen3AsrModelPath,
+  PhysicalIosSpeechEnvKeys.qwen3AsrModelSha256,
+  PhysicalIosSpeechEnvKeys.qwen3AsrMmprojPath,
+  PhysicalIosSpeechEnvKeys.qwen3AsrMmprojSha256,
+  PhysicalIosSpeechEnvKeys.asrAudioPath,
+  PhysicalIosSpeechEnvKeys.asrAudioSha256,
+  PhysicalIosSpeechEnvKeys.asrExpectedTranscript,
+  PhysicalIosSpeechEnvKeys.micDurationSeconds,
+  PhysicalIosSpeechEnvKeys.micExpectedTranscript,
+  PhysicalIosSpeechEnvKeys.liteRtAsrModelPath,
+  PhysicalIosSpeechEnvKeys.liteRtAsrModelSha256,
+  PhysicalIosSpeechEnvKeys.liteRtAsrTokenizerPath,
+  PhysicalIosSpeechEnvKeys.liteRtAsrTokenizerSha256,
+  PhysicalIosSpeechEnvKeys.liteRtAsrPreset,
+  PhysicalIosSpeechEnvKeys.liteRtAsrAudioPath,
+  PhysicalIosSpeechEnvKeys.liteRtAsrAudioSha256,
+  PhysicalIosSpeechEnvKeys.liteRtAsrExpectedTranscript,
+  PhysicalIosSpeechEnvKeys.qwen3TtsModelPath,
+  PhysicalIosSpeechEnvKeys.qwen3TtsModelSha256,
+  PhysicalIosSpeechEnvKeys.qwen3TtsMmprojPath,
+  PhysicalIosSpeechEnvKeys.qwen3TtsMmprojSha256,
+  PhysicalIosSpeechEnvKeys.ttsText,
+  PhysicalIosSpeechEnvKeys.ttsOutputPath,
+  PhysicalIosSpeechEnvKeys.ttsExpectedTranscript,
+  PhysicalIosSpeechEnvKeys.liteRtLmModelPath,
+  PhysicalIosSpeechEnvKeys.liteRtLmModelSha256,
+];
+
+/// Values supplied through `--dart-define` at compile time.
+///
+/// Every lookup uses a string literal because `String.fromEnvironment` is only
+/// resolved by the compiler in a constant context; a dynamic key silently
+/// yields the default and would let the harness run unconfigured.
+const Map<String, String> physicalIosSpeechCompileTimeDefines =
+    <String, String>{
+      'IOS_SPEECH_QWEN3_ASR_MODEL_PATH': String.fromEnvironment(
+        'IOS_SPEECH_QWEN3_ASR_MODEL_PATH',
+      ),
+      'IOS_SPEECH_QWEN3_ASR_MODEL_SHA256': String.fromEnvironment(
+        'IOS_SPEECH_QWEN3_ASR_MODEL_SHA256',
+      ),
+      'IOS_SPEECH_QWEN3_ASR_MMPROJ_PATH': String.fromEnvironment(
+        'IOS_SPEECH_QWEN3_ASR_MMPROJ_PATH',
+      ),
+      'IOS_SPEECH_QWEN3_ASR_MMPROJ_SHA256': String.fromEnvironment(
+        'IOS_SPEECH_QWEN3_ASR_MMPROJ_SHA256',
+      ),
+      'IOS_SPEECH_ASR_AUDIO_PATH': String.fromEnvironment(
+        'IOS_SPEECH_ASR_AUDIO_PATH',
+      ),
+      'IOS_SPEECH_ASR_AUDIO_SHA256': String.fromEnvironment(
+        'IOS_SPEECH_ASR_AUDIO_SHA256',
+      ),
+      'IOS_SPEECH_ASR_EXPECTED_TRANSCRIPT': String.fromEnvironment(
+        'IOS_SPEECH_ASR_EXPECTED_TRANSCRIPT',
+      ),
+      'IOS_SPEECH_MIC_DURATION_SECONDS': String.fromEnvironment(
+        'IOS_SPEECH_MIC_DURATION_SECONDS',
+      ),
+      'IOS_SPEECH_MIC_EXPECTED_TRANSCRIPT': String.fromEnvironment(
+        'IOS_SPEECH_MIC_EXPECTED_TRANSCRIPT',
+      ),
+      'IOS_SPEECH_LITERT_ASR_MODEL_PATH': String.fromEnvironment(
+        'IOS_SPEECH_LITERT_ASR_MODEL_PATH',
+      ),
+      'IOS_SPEECH_LITERT_ASR_MODEL_SHA256': String.fromEnvironment(
+        'IOS_SPEECH_LITERT_ASR_MODEL_SHA256',
+      ),
+      'IOS_SPEECH_LITERT_ASR_TOKENIZER_PATH': String.fromEnvironment(
+        'IOS_SPEECH_LITERT_ASR_TOKENIZER_PATH',
+      ),
+      'IOS_SPEECH_LITERT_ASR_TOKENIZER_SHA256': String.fromEnvironment(
+        'IOS_SPEECH_LITERT_ASR_TOKENIZER_SHA256',
+      ),
+      'IOS_SPEECH_LITERT_ASR_PRESET': String.fromEnvironment(
+        'IOS_SPEECH_LITERT_ASR_PRESET',
+      ),
+      'IOS_SPEECH_LITERT_ASR_AUDIO_PATH': String.fromEnvironment(
+        'IOS_SPEECH_LITERT_ASR_AUDIO_PATH',
+      ),
+      'IOS_SPEECH_LITERT_ASR_AUDIO_SHA256': String.fromEnvironment(
+        'IOS_SPEECH_LITERT_ASR_AUDIO_SHA256',
+      ),
+      'IOS_SPEECH_LITERT_ASR_EXPECTED_TRANSCRIPT': String.fromEnvironment(
+        'IOS_SPEECH_LITERT_ASR_EXPECTED_TRANSCRIPT',
+      ),
+      'IOS_SPEECH_QWEN3_TTS_MODEL_PATH': String.fromEnvironment(
+        'IOS_SPEECH_QWEN3_TTS_MODEL_PATH',
+      ),
+      'IOS_SPEECH_QWEN3_TTS_MODEL_SHA256': String.fromEnvironment(
+        'IOS_SPEECH_QWEN3_TTS_MODEL_SHA256',
+      ),
+      'IOS_SPEECH_QWEN3_TTS_MMPROJ_PATH': String.fromEnvironment(
+        'IOS_SPEECH_QWEN3_TTS_MMPROJ_PATH',
+      ),
+      'IOS_SPEECH_QWEN3_TTS_MMPROJ_SHA256': String.fromEnvironment(
+        'IOS_SPEECH_QWEN3_TTS_MMPROJ_SHA256',
+      ),
+      'IOS_SPEECH_TTS_TEXT': String.fromEnvironment('IOS_SPEECH_TTS_TEXT'),
+      'IOS_SPEECH_TTS_OUTPUT_PATH': String.fromEnvironment(
+        'IOS_SPEECH_TTS_OUTPUT_PATH',
+      ),
+      'IOS_SPEECH_TTS_EXPECTED_TRANSCRIPT': String.fromEnvironment(
+        'IOS_SPEECH_TTS_EXPECTED_TRANSCRIPT',
+      ),
+      'IOS_SPEECH_LITERT_LM_MODEL_PATH': String.fromEnvironment(
+        'IOS_SPEECH_LITERT_LM_MODEL_PATH',
+      ),
+      'IOS_SPEECH_LITERT_LM_MODEL_SHA256': String.fromEnvironment(
+        'IOS_SPEECH_LITERT_LM_MODEL_SHA256',
+      ),
+    };
+
+final _hexDigestPattern = RegExp(r'^[0-9a-f]{64}$');
+final _positiveIntegerPattern = RegExp(r'^[0-9]+$');
+final _whitespaceRun = RegExp(r'\s+');
+final _controlCharacters = RegExp(r'[\x00-\x1f\x7f]');
+final _physicalIosMachinePattern = RegExp(r'^(?:iPhone|iPad|iPod)\d+,\d+$');
+
+const int _maximumMicrophoneDurationSeconds = 30;
+
+/// One checksum-pinned immutable input file.
+class PhysicalIosSpeechArtifact {
+  /// Stable identifier used in diagnostics and result digests.
+  final String label;
+
+  /// Absolute on-device path supplied through a compile-time define.
+  final String path;
+
+  /// Expected canonical lowercase SHA-256 digest.
+  final String sha256;
+
+  const PhysicalIosSpeechArtifact({
+    required this.label,
+    required this.path,
+    required this.sha256,
+  });
+}
+
+/// Sanitized failure for one immutable artifact verification.
+class PhysicalIosSpeechArtifactFailure implements Exception {
+  /// Stable artifact label. The filesystem path is deliberately excluded.
+  final String label;
+
+  /// Fingerprinted underlying failure suitable for logs.
+  final String diagnostic;
+
+  PhysicalIosSpeechArtifactFailure(this.label, Object error)
+    : diagnostic = safeSpeechErrorDiagnostic(error);
+
+  @override
+  String toString() => 'artifact:$label:$diagnostic';
+}
+
+/// Strict, immutable configuration for the physical iOS speech integration test.
+class PhysicalIosSpeechConfig {
+  final String qwen3AsrModelPath;
+  final String qwen3AsrModelSha256;
+  final String qwen3AsrMmprojPath;
+  final String qwen3AsrMmprojSha256;
+  final String asrAudioPath;
+  final String asrAudioSha256;
+  final String asrExpectedTranscript;
+
+  final int micDurationSeconds;
+  final String micExpectedTranscript;
+
+  final String liteRtAsrModelPath;
+  final String liteRtAsrModelSha256;
+  final String liteRtAsrTokenizerPath;
+  final String liteRtAsrTokenizerSha256;
+  final LiteRtLmAsrModelPreset liteRtAsrPreset;
+  final String liteRtAsrAudioPath;
+  final String liteRtAsrAudioSha256;
+  final String liteRtAsrExpectedTranscript;
+
+  final String qwen3TtsModelPath;
+  final String qwen3TtsModelSha256;
+  final String qwen3TtsMmprojPath;
+  final String qwen3TtsMmprojSha256;
+  final String ttsText;
+  final String ttsOutputPath;
+  final String ttsExpectedTranscript;
+
+  final String liteRtLmModelPath;
+  final String liteRtLmModelSha256;
+
+  const PhysicalIosSpeechConfig({
+    required this.qwen3AsrModelPath,
+    required this.qwen3AsrModelSha256,
+    required this.qwen3AsrMmprojPath,
+    required this.qwen3AsrMmprojSha256,
+    required this.asrAudioPath,
+    required this.asrAudioSha256,
+    required this.asrExpectedTranscript,
+    required this.micDurationSeconds,
+    required this.micExpectedTranscript,
+    required this.liteRtAsrModelPath,
+    required this.liteRtAsrModelSha256,
+    required this.liteRtAsrTokenizerPath,
+    required this.liteRtAsrTokenizerSha256,
+    required this.liteRtAsrPreset,
+    required this.liteRtAsrAudioPath,
+    required this.liteRtAsrAudioSha256,
+    required this.liteRtAsrExpectedTranscript,
+    required this.qwen3TtsModelPath,
+    required this.qwen3TtsModelSha256,
+    required this.qwen3TtsMmprojPath,
+    required this.qwen3TtsMmprojSha256,
+    required this.ttsText,
+    required this.ttsOutputPath,
+    required this.ttsExpectedTranscript,
+    required this.liteRtLmModelPath,
+    required this.liteRtLmModelSha256,
+  });
+
+  /// Loads configuration from `--dart-define` values only.
+  ///
+  /// The process environment is deliberately never consulted: on device it is
+  /// not the channel the harness is configured through, and reading it would
+  /// let an unrelated variable satisfy a required pin.
+  factory PhysicalIosSpeechConfig.fromEnvironment() =>
+      PhysicalIosSpeechConfig.fromMap(physicalIosSpeechCompileTimeDefines);
+
+  /// Parses and validates all parameters from [map].
+  factory PhysicalIosSpeechConfig.fromMap(Map<String, String> map) {
+    String require(String key) {
+      final trimmed = (map[key] ?? '').trim();
+      if (trimmed.isEmpty) {
+        throw ArgumentError.value(
+          map[key],
+          key,
+          'Required dart define $key is missing or empty. Pass '
+          '--dart-define=$key=<value>.',
+        );
+      }
+      return trimmed;
+    }
+
+    String requireDigest(String key) {
+      final value = require(key);
+      if (!_hexDigestPattern.hasMatch(value)) {
+        throw ArgumentError.value(
+          value,
+          key,
+          'Expected canonical 64 lowercase hex characters for $key.',
+        );
+      }
+      return value;
+    }
+
+    String requireAbsoluteLocalPath(String key) {
+      final value = require(key);
+      final uri = Uri.tryParse(value);
+      if (!value.startsWith('/') || (uri?.hasScheme ?? false)) {
+        throw ArgumentError.value(
+          value,
+          key,
+          'Expected an absolute local on-device path. URLs and relative paths '
+          'are not allowed.',
+        );
+      }
+      return value;
+    }
+
+    final micDurationStr = require(PhysicalIosSpeechEnvKeys.micDurationSeconds);
+    final micDuration = _positiveIntegerPattern.hasMatch(micDurationStr)
+        ? int.tryParse(micDurationStr)
+        : null;
+    if (micDuration == null ||
+        micDuration <= 0 ||
+        micDuration > _maximumMicrophoneDurationSeconds) {
+      throw ArgumentError.value(
+        micDurationStr,
+        PhysicalIosSpeechEnvKeys.micDurationSeconds,
+        'Expected a whole number from 1 through '
+        '$_maximumMicrophoneDurationSeconds seconds for microphone '
+        'capture.',
+      );
+    }
+
+    final qwen3AsrModelPath = requireAbsoluteLocalPath(
+      PhysicalIosSpeechEnvKeys.qwen3AsrModelPath,
+    );
+    final qwen3AsrMmprojPath = requireAbsoluteLocalPath(
+      PhysicalIosSpeechEnvKeys.qwen3AsrMmprojPath,
+    );
+    final asrAudioPath = requireAbsoluteLocalPath(
+      PhysicalIosSpeechEnvKeys.asrAudioPath,
+    );
+    final liteRtAsrModelPath = requireAbsoluteLocalPath(
+      PhysicalIosSpeechEnvKeys.liteRtAsrModelPath,
+    );
+    final liteRtAsrTokenizerPath = requireAbsoluteLocalPath(
+      PhysicalIosSpeechEnvKeys.liteRtAsrTokenizerPath,
+    );
+    final liteRtAsrAudioPath = requireAbsoluteLocalPath(
+      PhysicalIosSpeechEnvKeys.liteRtAsrAudioPath,
+    );
+    final qwen3TtsModelPath = requireAbsoluteLocalPath(
+      PhysicalIosSpeechEnvKeys.qwen3TtsModelPath,
+    );
+    final qwen3TtsMmprojPath = requireAbsoluteLocalPath(
+      PhysicalIosSpeechEnvKeys.qwen3TtsMmprojPath,
+    );
+    final ttsOutputPath = requireAbsoluteLocalPath(
+      PhysicalIosSpeechEnvKeys.ttsOutputPath,
+    );
+    final liteRtLmModelPath = requireAbsoluteLocalPath(
+      PhysicalIosSpeechEnvKeys.liteRtLmModelPath,
+    );
+    final inputPaths = <String>{
+      qwen3AsrModelPath,
+      qwen3AsrMmprojPath,
+      asrAudioPath,
+      liteRtAsrModelPath,
+      liteRtAsrTokenizerPath,
+      liteRtAsrAudioPath,
+      qwen3TtsModelPath,
+      qwen3TtsMmprojPath,
+      liteRtLmModelPath,
+    };
+    if (inputPaths.contains(ttsOutputPath)) {
+      throw ArgumentError.value(
+        ttsOutputPath,
+        PhysicalIosSpeechEnvKeys.ttsOutputPath,
+        'The disposable TTS output path must not equal any immutable input '
+        'artifact path.',
+      );
+    }
+
+    return PhysicalIosSpeechConfig(
+      qwen3AsrModelPath: qwen3AsrModelPath,
+      qwen3AsrModelSha256: requireDigest(
+        PhysicalIosSpeechEnvKeys.qwen3AsrModelSha256,
+      ),
+      qwen3AsrMmprojPath: qwen3AsrMmprojPath,
+      qwen3AsrMmprojSha256: requireDigest(
+        PhysicalIosSpeechEnvKeys.qwen3AsrMmprojSha256,
+      ),
+      asrAudioPath: asrAudioPath,
+      asrAudioSha256: requireDigest(PhysicalIosSpeechEnvKeys.asrAudioSha256),
+      asrExpectedTranscript: require(
+        PhysicalIosSpeechEnvKeys.asrExpectedTranscript,
+      ),
+      micDurationSeconds: micDuration,
+      micExpectedTranscript: require(
+        PhysicalIosSpeechEnvKeys.micExpectedTranscript,
+      ),
+      liteRtAsrModelPath: liteRtAsrModelPath,
+      liteRtAsrModelSha256: requireDigest(
+        PhysicalIosSpeechEnvKeys.liteRtAsrModelSha256,
+      ),
+      liteRtAsrTokenizerPath: liteRtAsrTokenizerPath,
+      liteRtAsrTokenizerSha256: requireDigest(
+        PhysicalIosSpeechEnvKeys.liteRtAsrTokenizerSha256,
+      ),
+      liteRtAsrPreset: _parsePreset(
+        require(PhysicalIosSpeechEnvKeys.liteRtAsrPreset),
+      ),
+      liteRtAsrAudioPath: liteRtAsrAudioPath,
+      liteRtAsrAudioSha256: requireDigest(
+        PhysicalIosSpeechEnvKeys.liteRtAsrAudioSha256,
+      ),
+      liteRtAsrExpectedTranscript: require(
+        PhysicalIosSpeechEnvKeys.liteRtAsrExpectedTranscript,
+      ),
+      qwen3TtsModelPath: qwen3TtsModelPath,
+      qwen3TtsModelSha256: requireDigest(
+        PhysicalIosSpeechEnvKeys.qwen3TtsModelSha256,
+      ),
+      qwen3TtsMmprojPath: qwen3TtsMmprojPath,
+      qwen3TtsMmprojSha256: requireDigest(
+        PhysicalIosSpeechEnvKeys.qwen3TtsMmprojSha256,
+      ),
+      ttsText: require(PhysicalIosSpeechEnvKeys.ttsText),
+      ttsOutputPath: ttsOutputPath,
+      ttsExpectedTranscript: require(
+        PhysicalIosSpeechEnvKeys.ttsExpectedTranscript,
+      ),
+      liteRtLmModelPath: liteRtLmModelPath,
+      liteRtLmModelSha256: requireDigest(
+        PhysicalIosSpeechEnvKeys.liteRtLmModelSha256,
+      ),
+    );
+  }
+
+  static LiteRtLmAsrModelPreset _parsePreset(String name) {
+    final normalized = name.trim().toLowerCase().replaceAll('_', '-');
+    switch (normalized) {
+      case 'moonshine-tiny':
+        return LiteRtLmAsrModelPreset.moonshineTiny;
+      case 'parakeet-tdt':
+      case 'parakeet-tdt-0.6b-v3':
+      case 'parakeet-tdt-0-6b-v3':
+      case 'parakeettdt0-6bv3':
+        return LiteRtLmAsrModelPreset.parakeetTdt0_6bV3;
+      case 'parakeet-ctc':
+      case 'parakeet-ctc-0.6b':
+      case 'parakeet-ctc-0-6b':
+      case 'parakeetctc0-6b':
+        return LiteRtLmAsrModelPreset.parakeetCtc0_6b;
+      case 'whisper-tiny':
+        return LiteRtLmAsrModelPreset.whisperTiny;
+      case 'qwen3-asr-0.6b':
+      case 'qwen3-asr-0-6b':
+      case 'qwen3asr0-6b':
+        return LiteRtLmAsrModelPreset.qwen3Asr0_6b;
+      default:
+        throw ArgumentError.value(
+          name,
+          PhysicalIosSpeechEnvKeys.liteRtAsrPreset,
+          'Unknown LiteRT-LM ASR preset. Supported: moonshine-tiny, '
+          'parakeet-tdt, parakeet-ctc, whisper-tiny, qwen3-asr-0.6b.',
+        );
+    }
+  }
+
+  /// Every checksum-pinned immutable artifact, in verification order.
+  List<PhysicalIosSpeechArtifact> get artifacts => <PhysicalIosSpeechArtifact>[
+    PhysicalIosSpeechArtifact(
+      label: 'qwen3AsrModel',
+      path: qwen3AsrModelPath,
+      sha256: qwen3AsrModelSha256,
+    ),
+    PhysicalIosSpeechArtifact(
+      label: 'qwen3AsrMmproj',
+      path: qwen3AsrMmprojPath,
+      sha256: qwen3AsrMmprojSha256,
+    ),
+    PhysicalIosSpeechArtifact(
+      label: 'asrAudio',
+      path: asrAudioPath,
+      sha256: asrAudioSha256,
+    ),
+    PhysicalIosSpeechArtifact(
+      label: 'liteRtAsrModel',
+      path: liteRtAsrModelPath,
+      sha256: liteRtAsrModelSha256,
+    ),
+    PhysicalIosSpeechArtifact(
+      label: 'liteRtAsrTokenizer',
+      path: liteRtAsrTokenizerPath,
+      sha256: liteRtAsrTokenizerSha256,
+    ),
+    PhysicalIosSpeechArtifact(
+      label: 'liteRtAsrAudio',
+      path: liteRtAsrAudioPath,
+      sha256: liteRtAsrAudioSha256,
+    ),
+    PhysicalIosSpeechArtifact(
+      label: 'qwen3TtsModel',
+      path: qwen3TtsModelPath,
+      sha256: qwen3TtsModelSha256,
+    ),
+    PhysicalIosSpeechArtifact(
+      label: 'qwen3TtsMmproj',
+      path: qwen3TtsMmprojPath,
+      sha256: qwen3TtsMmprojSha256,
+    ),
+    PhysicalIosSpeechArtifact(
+      label: 'liteRtLmModel',
+      path: liteRtLmModelPath,
+      sha256: liteRtLmModelSha256,
+    ),
+  ];
+
+  /// Verifies existence and streamed SHA-256 for all immutable artifacts.
+  ///
+  /// Artifacts are hashed strictly one at a time: several of these files are
+  /// multi-gigabyte, and hashing them concurrently saturates device I/O.
+  Future<void> validateArtifacts({
+    Future<void> Function(PhysicalIosSpeechArtifact artifact)? verify,
+  }) async {
+    final check =
+        verify ??
+        (PhysicalIosSpeechArtifact artifact) =>
+            validateFileChecksum(artifact.path, artifact.sha256);
+    for (final artifact in artifacts) {
+      await check(artifact);
+    }
+  }
+
+  /// Verifies every artifact sequentially and collects sanitized failures.
+  ///
+  /// Unlike [validateArtifacts], this does not stop after the first bad pin.
+  /// The physical-device harness uses the resulting ledger so one bad input
+  /// marks only its dependent rows and all four rows are still reported.
+  Future<Map<String, PhysicalIosSpeechArtifactFailure>>
+  validateArtifactsCollectingFailures({
+    Future<void> Function(PhysicalIosSpeechArtifact artifact)? verify,
+    Duration? timeoutPerArtifact,
+  }) async {
+    final check =
+        verify ??
+        (PhysicalIosSpeechArtifact artifact) => validateFileChecksum(
+          artifact.path,
+          artifact.sha256,
+          timeout: timeoutPerArtifact,
+        );
+    final failures = <String, PhysicalIosSpeechArtifactFailure>{};
+    for (final artifact in artifacts) {
+      try {
+        await check(artifact);
+      } catch (error) {
+        failures[artifact.label] = PhysicalIosSpeechArtifactFailure(
+          artifact.label,
+          error,
+        );
+      }
+    }
+    return Map<String, PhysicalIosSpeechArtifactFailure>.unmodifiable(failures);
+  }
+}
+
+/// Fails one row when any of its immutable input labels failed preflight.
+void requireValidSpeechArtifacts(
+  Map<String, PhysicalIosSpeechArtifactFailure> failures,
+  Set<String> requiredLabels,
+) {
+  final failedLabels =
+      requiredLabels.where(failures.containsKey).toList(growable: false)
+        ..sort();
+  if (failedLabels.isEmpty) {
+    return;
+  }
+  throw StateError(
+    'Immutable artifact validation failed for labels: '
+    '${failedLabels.join(', ')}.',
+  );
+}
+
+/// Computes SHA-256 sequentially in fixed-size reads, never buffering it all.
+Future<String> computeFileSha256(String path, {Duration? timeout}) async {
+  final file = File(path);
+  final stopwatch = Stopwatch()..start();
+
+  Future<T> withinDeadline<T>(Future<T> Function() operation) {
+    final bound = timeout;
+    if (bound == null) {
+      return operation();
+    }
+    final remaining = bound - stopwatch.elapsed;
+    if (remaining <= Duration.zero) {
+      return Future<T>.error(
+        TimeoutException('Artifact SHA-256 verification timed out.', bound),
+      );
+    }
+    return operation().timeout(
+      remaining,
+      onTimeout: () => throw TimeoutException(
+        'Artifact SHA-256 verification timed out.',
+        bound,
+      ),
+    );
+  }
+
+  RandomAccessFile? inputFile;
+  final digestSink = _SpeechDigestSink();
+  var digestSinkClosed = false;
+  final inputSink = sha256.startChunkedConversion(digestSink);
+  try {
+    final openedFile = await withinDeadline(file.open);
+    inputFile = openedFile;
+    while (true) {
+      final chunk = await withinDeadline(() => openedFile.read(1024 * 1024));
+      if (chunk.isEmpty) {
+        break;
+      }
+      inputSink.add(chunk);
+    }
+    inputSink.close();
+    digestSinkClosed = true;
+  } on FileSystemException {
+    throw const FileSystemException(
+      'Artifact file cannot be read for SHA-256 verification.',
+    );
+  } finally {
+    if (!digestSinkClosed) {
+      inputSink.close();
+    }
+    if (inputFile != null) {
+      await inputFile.close();
+    }
+  }
+  return digestSink.digest.toString().toLowerCase();
+}
+
+class _SpeechDigestSink implements Sink<Digest> {
+  Digest? _digest;
+
+  Digest get digest =>
+      _digest ?? (throw StateError('SHA-256 conversion did not complete.'));
+
+  @override
+  void add(Digest data) => _digest = data;
+
+  @override
+  void close() {}
+}
+
+/// Verifies that [path] exists and its SHA-256 matches [expectedSha256].
+Future<void> validateFileChecksum(
+  String path,
+  String expectedSha256, {
+  Duration? timeout,
+}) async {
+  final actual = await computeFileSha256(path, timeout: timeout);
+  if (actual != expectedSha256.toLowerCase()) {
+    throw StateError('Checksum mismatch for immutable artifact.');
+  }
+}
+
+/// Normalizes transcript text by trimming, lowercasing, and collapsing runs of
+/// whitespace. No other transformation is applied.
+String normalizeSpeechTranscript(String raw) =>
+    raw.trim().toLowerCase().replaceAll(_whitespaceRun, ' ');
+
+/// A short content-addressed fingerprint of a transcript.
+///
+/// Diagnostics reference transcripts by fingerprint so a failing device run
+/// never prints captured speech into logs or result records.
+String transcriptFingerprint(String raw) => sha256
+    .convert(utf8.encode(normalizeSpeechTranscript(raw)))
+    .toString()
+    .substring(0, 12);
+
+/// Asserts exact normalized transcript equality without echoing either value.
+void expectExactNormalizedTranscript({
+  required String actual,
+  required String expected,
+  required String label,
+}) {
+  final normalizedActual = normalizeSpeechTranscript(actual);
+  final normalizedExpected = normalizeSpeechTranscript(expected);
+  if (normalizedActual == normalizedExpected) {
+    return;
+  }
+  throw StateError(
+    'Transcript mismatch at $label: '
+    'actualSha=${transcriptFingerprint(actual)} '
+    'actualChars=${normalizedActual.length} '
+    'expectedSha=${transcriptFingerprint(expected)} '
+    'expectedChars=${normalizedExpected.length}',
+  );
+}
+
+/// Reduces free-form error text to a single safe, bounded log field.
+String sanitizeSpeechDiagnostic(String raw, {int maxLength = 240}) {
+  final collapsed = raw
+      .replaceAll(_controlCharacters, ' ')
+      .replaceAll(_whitespaceRun, ' ')
+      .trim();
+  if (collapsed.isEmpty) {
+    return '<empty>';
+  }
+  if (collapsed.length <= maxLength) {
+    return collapsed;
+  }
+  return '${collapsed.substring(0, math.max(0, maxLength - 3))}...';
+}
+
+/// Produces a bounded error code without echoing paths, URLs, prompts, or
+/// transcripts from an exception message.
+String safeSpeechErrorDiagnostic(Object error) {
+  if (error is AudioRecordingException) {
+    return '${error.runtimeType}:${error.failure.name}';
+  }
+  final type = error.runtimeType.toString().replaceAll(
+    RegExp(r'[^A-Za-z0-9_]'),
+    '_',
+  );
+  final fingerprint = sha256
+      .convert(utf8.encode(error.toString()))
+      .toString()
+      .substring(0, 12);
+  return '$type#$fingerprint';
+}
+
+/// Awaits [future] with an actionable timeout naming [what].
+Future<T> awaitBounded<T>(Future<T> future, Duration timeout, String what) {
+  return future.timeout(
+    timeout,
+    onTimeout: () => throw TimeoutException(
+      '$what did not settle within ${timeout.inMilliseconds} ms. Re-run on the '
+      'physical device with the pinned artifacts, or raise the bound if the '
+      'model legitimately needs longer.',
+      timeout,
+    ),
+  );
+}
+
+/// Subscribes immediately and marks stream errors handled while preserving
+/// them for the caller that later awaits the returned future.
+Future<List<T>> collectSpeechEvents<T>(Stream<T> events) {
+  final collected = events.toList();
+  unawaited(collected.then<void>((_) {}, onError: (Object _, StackTrace _) {}));
+  return collected;
+}
+
+/// Always runs [cleanup] and preserves a failure from [body] over cleanup.
+Future<void> runWithSpeechCleanup({
+  required Future<void> Function() body,
+  required Future<void> Function() cleanup,
+}) async {
+  Object? firstError;
+  StackTrace? firstStackTrace;
+  try {
+    await body();
+  } catch (error, stackTrace) {
+    firstError = error;
+    firstStackTrace = stackTrace;
+  }
+  try {
+    await cleanup();
+  } catch (error, stackTrace) {
+    firstError ??= error;
+    firstStackTrace ??= stackTrace;
+  }
+  if (firstError != null) {
+    Error.throwWithStackTrace(firstError, firstStackTrace!);
+  }
+}
+
+/// Proves [done] has not already settled before active cancellation is issued.
+Future<void> requireStillActiveBeforeCancellation<T>(
+  Future<T> done,
+  Duration observationWindow,
+  String label,
+) async {
+  var settled = false;
+  unawaited(
+    done.then<void>(
+      (_) => settled = true,
+      onError: (Object _, StackTrace _) => settled = true,
+    ),
+  );
+  await Future<void>.delayed(observationWindow);
+  if (settled) {
+    throw StateError(
+      '$label settled before the active-cancellation observation point.',
+    );
+  }
+}
+
+/// Whether an Apple hardware machine string proves this is not a simulator.
+bool isPhysicalIosMachineIdentifier(String machine) =>
+    _physicalIosMachinePattern.hasMatch(machine.trim());
+
+/// Backend family expected by one physical speech row.
+enum SpeechE2EBackendKind { llamaCppMetal, liteRtLmAsrCpu, liteRtLm }
+
+/// Validates backend identity and returns a stable, sanitized report label.
+String requireSpeechBackendIdentity(
+  String actual,
+  SpeechE2EBackendKind expected,
+) {
+  final normalized = actual.trim().toLowerCase();
+  final matches = switch (expected) {
+    SpeechE2EBackendKind.llamaCppMetal =>
+      normalized.contains('metal') && !normalized.contains('litert'),
+    SpeechE2EBackendKind.liteRtLmAsrCpu =>
+      normalized.contains('litert-lm') &&
+          normalized.contains('asr') &&
+          normalized.contains('cpu'),
+    SpeechE2EBackendKind.liteRtLm =>
+      normalized.contains('litert-lm') && !normalized.contains('asr'),
+  };
+  if (!matches) {
+    throw StateError(
+      'Runtime backend identity did not match ${expected.name}: '
+      'actualSha=${transcriptFingerprint(actual)}.',
+    );
+  }
+  return switch (expected) {
+    SpeechE2EBackendKind.llamaCppMetal => 'llama.cpp Metal',
+    SpeechE2EBackendKind.liteRtLmAsrCpu => 'LiteRT-LM ASR CPU',
+    SpeechE2EBackendKind.liteRtLm => 'LiteRT-LM',
+  };
+}
+
+/// Splits [samples] into bounded chunks so no single push carries the whole
+/// fixture into the native session queue.
+Iterable<Float32List> chunkPcmSamples(
+  Float32List samples,
+  int chunkSize,
+) sync* {
+  if (chunkSize <= 0) {
+    throw ArgumentError.value(chunkSize, 'chunkSize', 'Must be positive.');
+  }
+  if (samples.isEmpty) {
+    throw ArgumentError.value(
+      samples.length,
+      'samples',
+      'Refusing to stream an empty PCM buffer.',
+    );
+  }
+  for (var offset = 0; offset < samples.length; offset += chunkSize) {
+    final end = math.min(offset + chunkSize, samples.length);
+    yield Float32List.sublistView(samples, offset, end);
+  }
+}
+
+/// Extracted PCM16 signal metrics from a WAV file.
+class WavPcm16Info {
+  final int sampleRate;
+  final int channels;
+  final int sampleFrames;
+  final int peakAmplitude;
+  final double rmsAmplitude;
+  final double durationSeconds;
+  final int dataOffset;
+  final int dataLength;
+
+  const WavPcm16Info({
+    required this.sampleRate,
+    required this.channels,
+    required this.sampleFrames,
+    required this.peakAmplitude,
+    required this.rmsAmplitude,
+    required this.durationSeconds,
+    required this.dataOffset,
+    required this.dataLength,
+  });
+}
+
+/// Creates a standard PCM16 WAV byte buffer.
+Uint8List createPcm16WavBytes({
+  required List<int> samples,
+  required int sampleRate,
+  required int channels,
+}) {
+  const bytesPerSample = 2;
+  if (sampleRate <= 0) {
+    throw ArgumentError.value(sampleRate, 'sampleRate', 'Must be positive.');
+  }
+  if (channels <= 0) {
+    throw ArgumentError.value(channels, 'channels', 'Must be positive.');
+  }
+  if (samples.isEmpty || samples.length % channels != 0) {
+    throw ArgumentError.value(
+      samples.length,
+      'samples',
+      'Must contain at least one whole interleaved PCM frame.',
+    );
+  }
+  if (samples.any((sample) => sample < -32768 || sample > 32767)) {
+    throw ArgumentError.value(
+      samples.length,
+      'samples',
+      'Every PCM16 sample must be between -32768 and 32767.',
+    );
+  }
+  final dataLength = samples.length * bytesPerSample;
+  final byteRate = sampleRate * channels * bytesPerSample;
+  final blockAlign = channels * bytesPerSample;
+  if (sampleRate > 0xffffffff ||
+      channels > 0xffff ||
+      byteRate > 0xffffffff ||
+      blockAlign > 0xffff ||
+      dataLength > 0xffffffff - 36) {
+    throw ArgumentError(
+      'PCM metadata exceeds the canonical RIFF/WAV integer fields.',
+    );
+  }
+  final bytes = Uint8List(44 + dataLength);
+  final data = ByteData.sublistView(bytes);
+
+  void writeAscii(int offset, String value) {
+    for (var i = 0; i < value.length; i++) {
+      bytes[offset + i] = value.codeUnitAt(i);
+    }
+  }
+
+  writeAscii(0, 'RIFF');
+  data.setUint32(4, 36 + dataLength, Endian.little);
+  writeAscii(8, 'WAVE');
+  writeAscii(12, 'fmt ');
+  data.setUint32(16, 16, Endian.little);
+  data.setUint16(20, 1, Endian.little); // PCM format
+  data.setUint16(22, channels, Endian.little);
+  data.setUint32(24, sampleRate, Endian.little);
+  data.setUint32(28, byteRate, Endian.little);
+  data.setUint16(32, blockAlign, Endian.little);
+  data.setUint16(34, 16, Endian.little); // bits per sample
+  writeAscii(36, 'data');
+  data.setUint32(40, dataLength, Endian.little);
+
+  for (var i = 0; i < samples.length; i++) {
+    data.setInt16(44 + i * bytesPerSample, samples[i], Endian.little);
+  }
+  return bytes;
+}
+
+/// Parses and strictly validates a PCM16 WAV byte array.
+///
+/// Every structural field is cross-checked, because a partially written or
+/// re-encoded capture must fail here rather than silently degrade a transcript.
+WavPcm16Info validatePcm16Wav(
+  Uint8List bytes, {
+  int? expectedSampleRate,
+  int? expectedChannels,
+  bool requireNonSilent = true,
+}) {
+  const bytesPerSample = 2;
+  final fileLength = bytes.length;
+  if (fileLength < 44 ||
+      bytes[0] != 0x52 ||
+      bytes[1] != 0x49 ||
+      bytes[2] != 0x46 ||
+      bytes[3] != 0x46 ||
+      bytes[8] != 0x57 ||
+      bytes[9] != 0x41 ||
+      bytes[10] != 0x56 ||
+      bytes[11] != 0x45) {
+    throw const FormatException('Invalid or incomplete RIFF/WAVE header.');
+  }
+
+  final data = ByteData.sublistView(bytes);
+  final riffSize = data.getUint32(4, Endian.little);
+  if (riffSize != fileLength - 8) {
+    throw FormatException(
+      'RIFF size field ($riffSize) disagrees with the file length '
+      '(${fileLength - 8}).',
+    );
+  }
+
+  int? sampleRate;
+  int? channels;
+  int? dataOffset;
+  int? dataLength;
+  var sawFmt = false;
+  var sawData = false;
+  var offset = 12;
+
+  while (offset + 8 <= fileLength) {
+    final chunkSize = data.getUint32(offset + 4, Endian.little);
+    final payloadOffset = offset + 8;
+    final payloadEnd = payloadOffset + chunkSize;
+    final paddedEnd = payloadEnd + (chunkSize.isOdd ? 1 : 0);
+    if (payloadEnd > fileLength) {
+      throw const FormatException('WAV chunk exceeds file length boundary.');
+    }
+    if (paddedEnd > fileLength) {
+      throw const FormatException(
+        'Odd-sized WAV chunk is missing its pad byte.',
+      );
+    }
+
+    final chunkId = String.fromCharCodes(bytes.sublist(offset, offset + 4));
+    if (chunkId == 'fmt ') {
+      if (sawFmt) {
+        throw const FormatException('Duplicate fmt chunk in WAV file.');
+      }
+      sawFmt = true;
+      if (chunkSize < 16) {
+        throw const FormatException('fmt chunk too small.');
+      }
+      final audioFormat = data.getUint16(payloadOffset, Endian.little);
+      if (audioFormat != 1) {
+        throw FormatException(
+          'WAV is not uncompressed PCM (format $audioFormat).',
+        );
+      }
+      final bitsPerSample = data.getUint16(payloadOffset + 14, Endian.little);
+      if (bitsPerSample != 16) {
+        throw FormatException('WAV is not 16-bit PCM ($bitsPerSample bits).');
+      }
+      channels = data.getUint16(payloadOffset + 2, Endian.little);
+      if (channels < 1) {
+        throw const FormatException('WAV declares zero channels.');
+      }
+      sampleRate = data.getUint32(payloadOffset + 4, Endian.little);
+      if (sampleRate < 1) {
+        throw const FormatException('WAV declares a zero sample rate.');
+      }
+      final byteRate = data.getUint32(payloadOffset + 8, Endian.little);
+      final expectedByteRate = sampleRate * channels * bytesPerSample;
+      if (byteRate != expectedByteRate) {
+        throw FormatException(
+          'WAV byte rate ($byteRate) disagrees with rate * channels * 2 '
+          '($expectedByteRate).',
+        );
+      }
+      final blockAlign = data.getUint16(payloadOffset + 12, Endian.little);
+      final expectedBlockAlign = channels * bytesPerSample;
+      if (blockAlign != expectedBlockAlign) {
+        throw FormatException(
+          'WAV block align ($blockAlign) disagrees with channels * 2 '
+          '($expectedBlockAlign).',
+        );
+      }
+    } else if (chunkId == 'data') {
+      if (sawData) {
+        throw const FormatException('Duplicate data chunk in WAV file.');
+      }
+      if (!sawFmt) {
+        throw const FormatException('WAV data chunk appears before fmt chunk.');
+      }
+      sawData = true;
+      dataOffset = payloadOffset;
+      dataLength = chunkSize;
+    }
+
+    offset = paddedEnd;
+  }
+
+  if (offset != fileLength) {
+    throw const FormatException('Unclaimed trailing bytes after final chunk.');
+  }
+  if (!sawFmt || !sawData) {
+    throw const FormatException('Missing fmt or data chunk in WAV file.');
+  }
+
+  final resolvedRate = sampleRate!;
+  final resolvedChannels = channels!;
+  final resolvedOffset = dataOffset!;
+  final resolvedLength = dataLength!;
+
+  if (resolvedLength == 0) {
+    throw const FormatException('WAV data chunk is empty.');
+  }
+  if (resolvedLength.isOdd) {
+    throw FormatException(
+      'WAV data length ($resolvedLength) is not a whole number of 16-bit '
+      'samples.',
+    );
+  }
+  final frameBytes = resolvedChannels * bytesPerSample;
+  if (resolvedLength % frameBytes != 0) {
+    throw FormatException(
+      'WAV data length ($resolvedLength) is not a whole number of '
+      '$resolvedChannels-channel frames.',
+    );
+  }
+
+  if (expectedSampleRate != null && resolvedRate != expectedSampleRate) {
+    throw FormatException(
+      'WAV sample rate mismatch: expected $expectedSampleRate Hz, got '
+      '$resolvedRate Hz.',
+    );
+  }
+  if (expectedChannels != null && resolvedChannels != expectedChannels) {
+    throw FormatException(
+      'WAV channel count mismatch: expected $expectedChannels, got '
+      '$resolvedChannels.',
+    );
+  }
+
+  final sampleCount = resolvedLength ~/ bytesPerSample;
+  var peak = 0;
+  var sumSquares = 0.0;
+  for (var i = 0; i < sampleCount; i++) {
+    final sample = data.getInt16(
+      resolvedOffset + i * bytesPerSample,
+      Endian.little,
+    );
+    final mag = sample.abs();
+    if (mag > peak) {
+      peak = mag;
+    }
+    sumSquares += sample * sample;
+  }
+
+  final rms = math.sqrt(sumSquares / sampleCount);
+  if (requireNonSilent && (peak == 0 || rms == 0.0)) {
+    throw const FormatException('WAV audio contains only silent samples.');
+  }
+
+  return WavPcm16Info(
+    sampleRate: resolvedRate,
+    channels: resolvedChannels,
+    sampleFrames: sampleCount ~/ resolvedChannels,
+    peakAmplitude: peak,
+    rmsAmplitude: rms,
+    durationSeconds: (sampleCount ~/ resolvedChannels) / resolvedRate,
+    dataOffset: resolvedOffset,
+    dataLength: resolvedLength,
+  );
+}
+
+/// Parses a PCM16 WAV file and returns normalized [-1.0, 1.0] float samples.
+Float32List decodePcm16WavToFloat32(
+  Uint8List bytes, {
+  int? expectedSampleRate,
+  int? expectedChannels,
+  bool requireNonSilent = true,
+}) {
+  final info = validatePcm16Wav(
+    bytes,
+    expectedSampleRate: expectedSampleRate,
+    expectedChannels: expectedChannels,
+    requireNonSilent: requireNonSilent,
+  );
+
+  final data = ByteData.sublistView(bytes);
+  final sampleCount = info.dataLength ~/ 2;
+  final floatSamples = Float32List(sampleCount);
+  for (var i = 0; i < sampleCount; i++) {
+    floatSamples[i] =
+        data.getInt16(info.dataOffset + i * 2, Endian.little) / 32768.0;
+  }
+  return floatSamples;
+}
+
+/// Asserts that a synthesis result's frame, sample, and duration values agree.
+void validateTtsResultPlausibility({
+  required int framesGenerated,
+  required int maxFrames,
+  required int sampleFrames,
+  required int sampleRateHz,
+  required int channelCount,
+  required Duration duration,
+  required String label,
+}) {
+  void fail(String reason) => throw StateError('$label: $reason');
+
+  if (sampleRateHz <= 0) {
+    fail('sample rate must be positive, got $sampleRateHz.');
+  }
+  if (channelCount <= 0) {
+    fail('channel count must be positive, got $channelCount.');
+  }
+  if (framesGenerated <= 0) {
+    fail('expected a positive frame count, got $framesGenerated.');
+  }
+  if (framesGenerated > maxFrames) {
+    fail('generated $framesGenerated frames beyond the cap of $maxFrames.');
+  }
+  if (sampleFrames <= 0) {
+    fail('decoded audio is empty ($sampleFrames frames).');
+  }
+  final expectedSeconds = sampleFrames / sampleRateHz;
+  final actualSeconds =
+      duration.inMicroseconds / Duration.microsecondsPerSecond;
+  if ((actualSeconds - expectedSeconds).abs() > 0.01) {
+    fail(
+      'duration ${actualSeconds.toStringAsFixed(3)}s contradicts $sampleFrames '
+      'frames at $sampleRateHz Hz '
+      '(${expectedSeconds.toStringAsFixed(3)}s).',
+    );
+  }
+  if (!actualSeconds.isFinite || actualSeconds <= 0) {
+    fail('duration must be finite and positive, got $actualSeconds s.');
+  }
+}
+
+/// Canonical identifiers for the four validated speech rows.
+const List<String> speechE2ERowIdsInOrder = <String>[
+  'llama_cpp_qwen3_asr',
+  'litert_lm_streaming_asr',
+  'llama_cpp_qwen3_tts',
+  'litert_lm_tts',
+];
+
+/// Canonical identifiers for set-based validation.
+const Set<String> speechE2ERowIds = <String>{...speechE2ERowIdsInOrder};
+
+/// Stable sanitized backend label used before a row resolves its live backend.
+String unresolvedSpeechBackendForRow(String id) => switch (id) {
+  'llama_cpp_qwen3_asr' || 'llama_cpp_qwen3_tts' => 'llama.cpp Metal',
+  'litert_lm_streaming_asr' => 'LiteRT-LM ASR CPU',
+  'litert_lm_tts' => 'LiteRT-LM',
+  _ => '<unresolved>',
+};
+
+/// Marker that tells the operator a run was blocked by device permissions
+/// rather than by a defect in the library.
+const String microphonePermissionActionMarker =
+    'ACTION_REQUIRED_MICROPHONE_PERMISSION';
+
+/// Marker for a runtime that has no microphone recorder at all.
+const String microphoneUnavailableActionMarker =
+    'ACTION_REQUIRED_MICROPHONE_UNAVAILABLE';
+
+/// Status classification for an integration test row.
+enum SpeechE2ERowStatus { pass, fail, unsupported, unavailable }
+
+/// Classifies a row failure as an environment gap or a genuine defect.
+SpeechE2ERowStatus classifySpeechRowFailure(Object error) {
+  if (error is AudioRecordingException) {
+    switch (error.failure) {
+      case AudioRecordingFailure.permissionDenied:
+      case AudioRecordingFailure.unsupported:
+        return SpeechE2ERowStatus.unavailable;
+      case AudioRecordingFailure.startFailed:
+      case AudioRecordingFailure.stopFailed:
+      case AudioRecordingFailure.readFailed:
+        return SpeechE2ERowStatus.fail;
+    }
+  }
+  return SpeechE2ERowStatus.fail;
+}
+
+/// Returns the operator-facing action marker for [error], when one applies.
+String? speechRowFailureMarker(Object error) {
+  if (error is AudioRecordingException) {
+    switch (error.failure) {
+      case AudioRecordingFailure.permissionDenied:
+        return microphonePermissionActionMarker;
+      case AudioRecordingFailure.unsupported:
+        return microphoneUnavailableActionMarker;
+      case AudioRecordingFailure.startFailed:
+      case AudioRecordingFailure.stopFailed:
+      case AudioRecordingFailure.readFailed:
+        return null;
+    }
+  }
+  return null;
+}
+
+/// A recorded row result with machine-readable serialization.
+class SpeechE2ERowResult {
+  final String id;
+  final SpeechE2ERowStatus status;
+  final String backend;
+  final Duration duration;
+  final Map<String, String> digestIdentifiers;
+  final String assertionSummary;
+  final Object? error;
+  final String? actionMarker;
+
+  SpeechE2ERowResult({
+    required this.id,
+    required this.status,
+    required this.backend,
+    required this.duration,
+    this.digestIdentifiers = const <String, String>{},
+    this.assertionSummary = '',
+    this.error,
+    this.actionMarker,
+  });
+
+  /// Emits one JSON record so backend labels and errors containing spaces or
+  /// quotes stay parseable.
+  String toResultLine() {
+    final rawError = this.error;
+    final error = rawError == null ? null : safeSpeechErrorDiagnostic(rawError);
+    final record = <String, Object?>{
+      'id': id,
+      'status': status.name.toUpperCase(),
+      'backend': sanitizeSpeechDiagnostic(backend, maxLength: 120),
+      'elapsedMs': duration.inMilliseconds,
+      'digests': digestIdentifiers,
+      'assertions': sanitizeSpeechDiagnostic(assertionSummary, maxLength: 400),
+      'error': ?error,
+      'action': ?actionMarker,
+    };
+    return 'RESULT physical_ios_speech ${jsonEncode(record)}';
+  }
+}
+
+/// Aggregate summary of all speech E2E rows.
+class SpeechE2ESummary {
+  final List<SpeechE2ERowResult> rows;
+
+  SpeechE2ESummary(this.rows);
+
+  int get total => rows.length;
+  int get passCount => _count(SpeechE2ERowStatus.pass);
+  int get failCount => _count(SpeechE2ERowStatus.fail);
+  int get unsupportedCount => _count(SpeechE2ERowStatus.unsupported);
+  int get unavailableCount => _count(SpeechE2ERowStatus.unavailable);
+
+  int _count(SpeechE2ERowStatus status) =>
+      rows.where((r) => r.status == status).length;
+
+  String toSummaryLine() =>
+      'SUMMARY physical_ios_speech total=$total pass=$passCount '
+      'unsupported=$unsupportedCount fail=$failCount '
+      'unavailable=$unavailableCount';
+
+  /// Verifies each canonical row was recorded exactly once and nothing else was.
+  void validateRowIds({Set<String> expectedIds = speechE2ERowIds}) {
+    final seen = <String>{};
+    final duplicates = <String>{};
+    for (final row in rows) {
+      if (!seen.add(row.id)) {
+        duplicates.add(row.id);
+      }
+    }
+    if (duplicates.isNotEmpty) {
+      throw StateError(
+        'Duplicate speech E2E row ids recorded: '
+        '${(duplicates.toList()..sort()).join(', ')}',
+      );
+    }
+    final missing = expectedIds.difference(seen);
+    final unexpected = seen.difference(expectedIds);
+    if (missing.isNotEmpty || unexpected.isNotEmpty) {
+      throw StateError(
+        'Speech E2E row id validation failed. '
+        'Missing: ${missing.isEmpty ? '<none>' : (missing.toList()..sort()).join(', ')}. '
+        'Unexpected: ${unexpected.isEmpty ? '<none>' : (unexpected.toList()..sort()).join(', ')}.',
+      );
+    }
+  }
+
+  void validateStrictCounts({
+    int expectedTotal = 4,
+    int expectedPass = 3,
+    int expectedUnsupported = 1,
+    int expectedFail = 0,
+    int expectedUnavailable = 0,
+  }) {
+    if (total != expectedTotal ||
+        passCount != expectedPass ||
+        unsupportedCount != expectedUnsupported ||
+        failCount != expectedFail ||
+        unavailableCount != expectedUnavailable) {
+      throw StateError(
+        'Speech E2E count validation failed. Expected total=$expectedTotal, '
+        'pass=$expectedPass, unsupported=$expectedUnsupported, '
+        'fail=$expectedFail, unavailable=$expectedUnavailable. '
+        'Actual: total=$total, pass=$passCount, '
+        'unsupported=$unsupportedCount, fail=$failCount, '
+        'unavailable=$unavailableCount',
+      );
+    }
+  }
+}
+
+/// Validates that an STT task ended in cancelled state.
+bool verifySttCancellation(SpeechToTextCompletion completion) =>
+    completion.state == SpeechToTextCompletionState.cancelled;
+
+/// Validates that a TTS task ended in cancelled state.
+bool verifyTtsCancellation(TextToSpeechCompletion completion) =>
+    completion.state == TextToSpeechCompletionState.cancelled;
+
+/// Whether [event] proves synthesis has produced real audio, so cancelling now
+/// exercises an in-flight generation rather than the prompt prefill.
+bool shouldCancelOnTtsProgress(TextToSpeechProgressEvent event) =>
+    event.phase == TextToSpeechProgressPhase.generating &&
+    event.framesGenerated > 0;
+
+/// Evaluates LiteRT-LM TTS capabilities for expected unsupported status.
+SpeechE2ERowStatus classifyLiteRtLmTtsSupport(
+  TextToSpeechCapabilities capabilities,
+) {
+  requireSpeechBackendIdentity(
+    capabilities.backendName ?? '',
+    SpeechE2EBackendKind.liteRtLm,
+  );
+  if (capabilities.isSupported) {
+    throw StateError(
+      'LiteRT-LM TTS was unexpectedly supported by the runtime. Reclassify the '
+      'row instead of recording a misleading UNSUPPORTED result.',
+    );
+  }
+  final reason = capabilities.unsupportedReason?.trim();
+  if (reason == null || reason.isEmpty) {
+    throw StateError(
+      'LiteRT-LM TTS reported isSupported=false without an actionable '
+      'unsupportedReason.',
+    );
+  }
+  return SpeechE2ERowStatus.unsupported;
+}
+
+/// Verifies that LiteRT-LM TTS synthesis threw [LlamaUnsupportedException].
+bool verifyLiteRtLmTtsSynthesisError(Object error) {
+  if (error is LlamaUnsupportedException) {
+    return true;
+  }
+  throw StateError(
+    'Expected LlamaUnsupportedException for LiteRT-LM TTS synthesis, but '
+    'received ${safeSpeechErrorDiagnostic(error)}.',
+  );
+}

--- a/example/chat_app/test/physical_ios_speech_e2e_support_test.dart
+++ b/example/chat_app/test/physical_ios_speech_e2e_support_test.dart
@@ -56,15 +56,22 @@ Map<String, String> _validEnv() {
 PhysicalIosSpeechConfig _copyConfigWithPaths(
   PhysicalIosSpeechConfig source, {
   String? qwen3AsrModelPath,
+  String? qwen3AsrModelSha256,
+  String? asrAudioPath,
+  String? asrAudioSha256,
+  String? liteRtAsrAudioPath,
+  String? liteRtAsrAudioSha256,
+  String? liteRtLmModelPath,
+  String? liteRtLmModelSha256,
   String? ttsOutputPath,
 }) {
   return PhysicalIosSpeechConfig(
     qwen3AsrModelPath: qwen3AsrModelPath ?? source.qwen3AsrModelPath,
-    qwen3AsrModelSha256: source.qwen3AsrModelSha256,
+    qwen3AsrModelSha256: qwen3AsrModelSha256 ?? source.qwen3AsrModelSha256,
     qwen3AsrMmprojPath: source.qwen3AsrMmprojPath,
     qwen3AsrMmprojSha256: source.qwen3AsrMmprojSha256,
-    asrAudioPath: source.asrAudioPath,
-    asrAudioSha256: source.asrAudioSha256,
+    asrAudioPath: asrAudioPath ?? source.asrAudioPath,
+    asrAudioSha256: asrAudioSha256 ?? source.asrAudioSha256,
     asrExpectedTranscript: source.asrExpectedTranscript,
     micDurationSeconds: source.micDurationSeconds,
     micExpectedTranscript: source.micExpectedTranscript,
@@ -73,8 +80,8 @@ PhysicalIosSpeechConfig _copyConfigWithPaths(
     liteRtAsrTokenizerPath: source.liteRtAsrTokenizerPath,
     liteRtAsrTokenizerSha256: source.liteRtAsrTokenizerSha256,
     liteRtAsrPreset: source.liteRtAsrPreset,
-    liteRtAsrAudioPath: source.liteRtAsrAudioPath,
-    liteRtAsrAudioSha256: source.liteRtAsrAudioSha256,
+    liteRtAsrAudioPath: liteRtAsrAudioPath ?? source.liteRtAsrAudioPath,
+    liteRtAsrAudioSha256: liteRtAsrAudioSha256 ?? source.liteRtAsrAudioSha256,
     liteRtAsrExpectedTranscript: source.liteRtAsrExpectedTranscript,
     qwen3TtsModelPath: source.qwen3TtsModelPath,
     qwen3TtsModelSha256: source.qwen3TtsModelSha256,
@@ -83,8 +90,8 @@ PhysicalIosSpeechConfig _copyConfigWithPaths(
     ttsText: source.ttsText,
     ttsOutputPath: ttsOutputPath ?? source.ttsOutputPath,
     ttsExpectedTranscript: source.ttsExpectedTranscript,
-    liteRtLmModelPath: source.liteRtLmModelPath,
-    liteRtLmModelSha256: source.liteRtLmModelSha256,
+    liteRtLmModelPath: liteRtLmModelPath ?? source.liteRtLmModelPath,
+    liteRtLmModelSha256: liteRtLmModelSha256 ?? source.liteRtLmModelSha256,
     resolvedAppCacheDirectoryPath: source.resolvedAppCacheDirectoryPath,
   );
 }
@@ -119,6 +126,20 @@ Future<PhysicalIosSpeechConfig> _createResolvedAppCacheConfig(
   return resolved;
 }
 
+Future<void> _replaceWithHardLink(File source, File destination) async {
+  await destination.delete();
+  final result = await Process.run('ln', <String>[
+    source.path,
+    destination.path,
+  ]);
+  expect(result.exitCode, isZero);
+  expect(
+    await FileSystemEntity.identical(source.path, destination.path),
+    isTrue,
+    reason: 'The test fixture must identify one inode through two paths.',
+  );
+}
+
 /// Rebuilds a WAV buffer with one header field overwritten so malformed
 /// metadata cases can be asserted precisely.
 Uint8List _withUint32(Uint8List source, int offset, int value) {
@@ -140,6 +161,45 @@ Map<String, Object?> _decodeResultLine(String line) {
 }
 
 void main() {
+  group('Physical iOS speech row selection', () {
+    test('defaults and preserves canonical order for the full matrix', () {
+      expect(PhysicalIosSpeechEnvKeys.rowSelection, 'IOS_SPEECH_ROW');
+      expect(
+        selectPhysicalIosSpeechRowIds(physicalIosSpeechAllRows),
+        equals(speechE2ERowIdsInOrder),
+      );
+    });
+
+    test('selects one canonical row for missing-row reruns', () {
+      for (final id in speechE2ERowIdsInOrder) {
+        expect(selectPhysicalIosSpeechRowIds(id), equals(<String>[id]));
+      }
+    });
+
+    test('rejects empty, padded, case-variant, and unknown selectors', () {
+      for (final invalid in <String>[
+        '',
+        ' all',
+        'all ',
+        'ALL',
+        'llama_cpp_qwen3_asr ',
+        'unknown_row',
+      ]) {
+        expect(
+          () => selectPhysicalIosSpeechRowIds(invalid),
+          throwsA(
+            isA<ArgumentError>().having(
+              (error) => error.name,
+              'name',
+              PhysicalIosSpeechEnvKeys.rowSelection,
+            ),
+          ),
+          reason: 'Selector should fail closed: "$invalid"',
+        );
+      }
+    });
+  });
+
   group('PhysicalIosSpeechConfig', () {
     test('parses valid full configuration successfully', () {
       final config = PhysicalIosSpeechConfig.fromMap(_validEnv());
@@ -189,6 +249,9 @@ void main() {
         '0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0',
         '0123456789ABCDEF0123456789abcdef0123456789abcdef0123456789abcdef',
         '0123456789xyzdef0123456789abcdef0123456789abcdef0123456789abcdef',
+        ' 0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef',
+        '0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef ',
+        '0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef\n',
       ];
 
       for (final badDigest in invalidDigests) {
@@ -491,6 +554,185 @@ void main() {
       );
     });
 
+    test(
+      'accepts identical path and digest for asrAudio and liteRtAsrAudio',
+      () {
+        final env = _validEnv()
+          ..['IOS_SPEECH_ASR_AUDIO_PATH'] = '/fixtures/shared_speech.wav'
+          ..['IOS_SPEECH_LITERT_ASR_AUDIO_PATH'] = '/fixtures/shared_speech.wav'
+          ..['IOS_SPEECH_ASR_AUDIO_SHA256'] =
+              '1111111111111111111111111111111111111111111111111111111111111111'
+          ..['IOS_SPEECH_LITERT_ASR_AUDIO_SHA256'] =
+              '1111111111111111111111111111111111111111111111111111111111111111';
+
+        final config = PhysicalIosSpeechConfig.fromMap(env);
+        expect(config.asrAudioPath, equals('/fixtures/shared_speech.wav'));
+        expect(
+          config.liteRtAsrAudioPath,
+          equals('/fixtures/shared_speech.wav'),
+        );
+        expect(config.asrAudioSha256, equals(config.liteRtAsrAudioSha256));
+      },
+    );
+
+    test(
+      'accepts case-folded identical path for asrAudio and liteRtAsrAudio when digests match',
+      () {
+        final env = _validEnv()
+          ..['IOS_SPEECH_ASR_AUDIO_PATH'] = '/fixtures/SHARED_speech.wav'
+          ..['IOS_SPEECH_LITERT_ASR_AUDIO_PATH'] = '/fixtures/shared_SPEECH.wav'
+          ..['IOS_SPEECH_ASR_AUDIO_SHA256'] =
+              '1111111111111111111111111111111111111111111111111111111111111111'
+          ..['IOS_SPEECH_LITERT_ASR_AUDIO_SHA256'] =
+              '1111111111111111111111111111111111111111111111111111111111111111';
+
+        expect(() => PhysicalIosSpeechConfig.fromMap(env), returnsNormally);
+      },
+    );
+
+    test(
+      'rejects a three-way collision containing the permitted ASR fixture pair',
+      () {
+        const sharedPath = '/fixtures/shared_speech.wav';
+        const sharedDigest =
+            '1111111111111111111111111111111111111111111111111111111111111111';
+        final env = _validEnv()
+          ..['IOS_SPEECH_ASR_AUDIO_PATH'] = sharedPath
+          ..['IOS_SPEECH_LITERT_ASR_AUDIO_PATH'] = sharedPath
+          ..['IOS_SPEECH_QWEN3_TTS_MODEL_PATH'] = sharedPath
+          ..['IOS_SPEECH_ASR_AUDIO_SHA256'] = sharedDigest
+          ..['IOS_SPEECH_LITERT_ASR_AUDIO_SHA256'] = sharedDigest
+          ..['IOS_SPEECH_QWEN3_TTS_MODEL_SHA256'] = sharedDigest;
+
+        expect(
+          () => PhysicalIosSpeechConfig.fromMap(env),
+          throwsA(
+            isA<ArgumentError>()
+                .having((error) => error.name, 'name', 'qwen3TtsModel')
+                .having(
+                  (error) => error.message.toString(),
+                  'message',
+                  contains('collides'),
+                ),
+          ),
+          reason:
+              'The ASR fixture exception must not authorize a third artifact.',
+        );
+      },
+    );
+
+    test(
+      'rejects shared asrAudio and liteRtAsrAudio path when digests conflict',
+      () {
+        final env = _validEnv()
+          ..['IOS_SPEECH_ASR_AUDIO_PATH'] = '/fixtures/shared_speech.wav'
+          ..['IOS_SPEECH_LITERT_ASR_AUDIO_PATH'] = '/fixtures/shared_speech.wav'
+          ..['IOS_SPEECH_ASR_AUDIO_SHA256'] =
+              '1111111111111111111111111111111111111111111111111111111111111111'
+          ..['IOS_SPEECH_LITERT_ASR_AUDIO_SHA256'] =
+              '4444444444444444444444444444444444444444444444444444444444444444';
+
+        expect(
+          () => PhysicalIosSpeechConfig.fromMap(env),
+          throwsA(
+            isA<ArgumentError>().having(
+              (e) => e.message.toString(),
+              'message',
+              contains('SHA-256 digest'),
+            ),
+          ),
+        );
+      },
+    );
+
+    test(
+      'retains alias rejection for unrelated input pairs even with matching digests',
+      () {
+        final env1 = _validEnv()
+          ..['IOS_SPEECH_QWEN3_ASR_MODEL_PATH'] = '/models/same.gguf'
+          ..['IOS_SPEECH_QWEN3_ASR_MMPROJ_PATH'] = '/models/same.gguf'
+          ..['IOS_SPEECH_QWEN3_ASR_MODEL_SHA256'] =
+              '0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef'
+          ..['IOS_SPEECH_QWEN3_ASR_MMPROJ_SHA256'] =
+              '0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef';
+
+        expect(
+          () => PhysicalIosSpeechConfig.fromMap(env1),
+          throwsA(isA<ArgumentError>()),
+        );
+
+        final env2 = _validEnv()
+          ..['IOS_SPEECH_ASR_AUDIO_PATH'] = '/models/shared.bin'
+          ..['IOS_SPEECH_QWEN3_ASR_MODEL_PATH'] = '/models/shared.bin'
+          ..['IOS_SPEECH_ASR_AUDIO_SHA256'] =
+              '0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef'
+          ..['IOS_SPEECH_QWEN3_ASR_MODEL_SHA256'] =
+              '0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef';
+
+        expect(
+          () => PhysicalIosSpeechConfig.fromMap(env2),
+          throwsA(isA<ArgumentError>()),
+        );
+
+        final env3 = _validEnv()
+          ..['IOS_SPEECH_LITERT_ASR_AUDIO_PATH'] = '/models/shared.bin'
+          ..['IOS_SPEECH_LITERT_LM_MODEL_PATH'] = '/models/shared.bin'
+          ..['IOS_SPEECH_LITERT_ASR_AUDIO_SHA256'] =
+              '7777777777777777777777777777777777777777777777777777777777777777'
+          ..['IOS_SPEECH_LITERT_LM_MODEL_SHA256'] =
+              '7777777777777777777777777777777777777777777777777777777777777777';
+
+        expect(
+          () => PhysicalIosSpeechConfig.fromMap(env3),
+          throwsA(isA<ArgumentError>()),
+        );
+      },
+    );
+
+    test('rejects TTS output colliding with shared ASR fixture path', () {
+      final env = _validEnv()
+        ..['IOS_SPEECH_ASR_AUDIO_PATH'] = '/fixtures/shared_speech.wav'
+        ..['IOS_SPEECH_LITERT_ASR_AUDIO_PATH'] = '/fixtures/shared_speech.wav'
+        ..['IOS_SPEECH_ASR_AUDIO_SHA256'] =
+            '1111111111111111111111111111111111111111111111111111111111111111'
+        ..['IOS_SPEECH_LITERT_ASR_AUDIO_SHA256'] =
+            '1111111111111111111111111111111111111111111111111111111111111111'
+        ..['IOS_SPEECH_TTS_OUTPUT_PATH'] = '/fixtures/SHARED_SPEECH.WAV';
+
+      expect(
+        () => PhysicalIosSpeechConfig.fromMap(env),
+        throwsA(isA<ArgumentError>()),
+      );
+    });
+
+    test(
+      'resolves shared @appcache ASR fixtures with matching digest',
+      () async {
+        final env = _validEnv()
+          ..['IOS_SPEECH_ASR_AUDIO_PATH'] = '@appcache/fixtures/speech.wav'
+          ..['IOS_SPEECH_LITERT_ASR_AUDIO_PATH'] =
+              '@appcache/fixtures/speech.wav'
+          ..['IOS_SPEECH_ASR_AUDIO_SHA256'] =
+              '1111111111111111111111111111111111111111111111111111111111111111'
+          ..['IOS_SPEECH_LITERT_ASR_AUDIO_SHA256'] =
+              '1111111111111111111111111111111111111111111111111111111111111111';
+
+        final resolved = await resolvePhysicalIosSpeechCachePaths(
+          PhysicalIosSpeechConfig.fromMap(env),
+          cacheDirectory: () async => Directory('/var/mobile/Containers/Cache'),
+        );
+
+        expect(
+          resolved.asrAudioPath,
+          equals('/var/mobile/Containers/Cache/fixtures/speech.wav'),
+        );
+        expect(
+          resolved.liteRtAsrAudioPath,
+          equals('/var/mobile/Containers/Cache/fixtures/speech.wav'),
+        );
+      },
+    );
+
     test('refuses artifact access before resolution', () async {
       final config = PhysicalIosSpeechConfig.fromMap(
         _validEnv()
@@ -523,38 +765,74 @@ void main() {
       );
     });
 
-    test(
-      'direct construction cannot bypass path and collision checks',
-      () async {
-        final valid = PhysicalIosSpeechConfig.fromMap(_validEnv());
-        final invalidConfigs = <PhysicalIosSpeechConfig>[
-          _copyConfigWithPaths(
-            valid,
-            qwen3AsrModelPath: '/models/../private/input.gguf',
-          ),
-          _copyConfigWithPaths(
-            valid,
-            qwen3AsrModelPath: '@AppCache/models/input.gguf',
-          ),
-          _copyConfigWithPaths(valid, ttsOutputPath: '/MODELS/QWEN3_ASR.GGUF'),
-        ];
+    test('direct construction cannot bypass path and collision checks', () async {
+      final valid = PhysicalIosSpeechConfig.fromMap(_validEnv());
+      final nonCanonicalDigest = valid.qwen3AsrModelSha256.toUpperCase();
+      final invalidConfigs = <PhysicalIosSpeechConfig>[
+        _copyConfigWithPaths(
+          valid,
+          qwen3AsrModelPath: '/models/../private/input.gguf',
+        ),
+        _copyConfigWithPaths(
+          valid,
+          qwen3AsrModelPath: '@AppCache/models/input.gguf',
+        ),
+        _copyConfigWithPaths(valid, ttsOutputPath: '/MODELS/QWEN3_ASR.GGUF'),
+        _copyConfigWithPaths(valid, qwen3AsrModelSha256: nonCanonicalDigest),
+        _copyConfigWithPaths(
+          valid,
+          qwen3AsrModelPath: '/models/shared.bin',
+          liteRtLmModelPath: '/models/shared.bin',
+          liteRtLmModelSha256: valid.qwen3AsrModelSha256,
+        ),
+        _copyConfigWithPaths(
+          valid,
+          asrAudioPath: '/fixtures/shared.wav',
+          liteRtAsrAudioPath: '/fixtures/shared.wav',
+          asrAudioSha256:
+              '1111111111111111111111111111111111111111111111111111111111111111',
+          liteRtAsrAudioSha256:
+              '4444444444444444444444444444444444444444444444444444444444444444',
+        ),
+        _copyConfigWithPaths(
+          valid,
+          asrAudioPath: '/fixtures/shared.wav',
+          liteRtAsrAudioPath: '/fixtures/shared.wav',
+          asrAudioSha256: nonCanonicalDigest,
+          liteRtAsrAudioSha256: nonCanonicalDigest,
+        ),
+        _copyConfigWithPaths(
+          valid,
+          asrAudioPath: '/fixtures/shared.wav',
+          liteRtAsrAudioPath: '/fixtures/shared.wav',
+          asrAudioSha256: '',
+          liteRtAsrAudioSha256: '',
+        ),
+      ];
 
-        for (final config in invalidConfigs) {
-          final visited = <String>[];
-          await expectLater(
-            config.validateArtifacts(
-              verify: (artifact) async => visited.add(artifact.label),
-            ),
-            throwsA(anyOf(isA<ArgumentError>(), isA<StateError>())),
-          );
-          expect(
-            visited,
-            isEmpty,
-            reason: 'Every path check must finish before the first file read.',
-          );
-        }
-      },
-    );
+      for (final config in invalidConfigs) {
+        final visited = <String>[];
+        await expectLater(
+          config.validateArtifacts(
+            verify: (artifact) async => visited.add(artifact.label),
+          ),
+          throwsA(anyOf(isA<ArgumentError>(), isA<StateError>())),
+        );
+        expect(
+          visited,
+          isEmpty,
+          reason: 'Every configuration check must finish before file reads.',
+        );
+      }
+
+      final validSharedConfig = _copyConfigWithPaths(
+        valid,
+        asrAudioPath: '/fixtures/shared.wav',
+        liteRtAsrAudioPath: '/fixtures/shared.wav',
+        liteRtAsrAudioSha256: valid.asrAudioSha256,
+      );
+      expect(() => validSharedConfig.requireResolvedPaths(), returnsNormally);
+    });
   });
 
   group('Canonical speech filesystem layout', () {
@@ -664,6 +942,105 @@ void main() {
         expect(await target.exists(), isTrue);
       },
       skip: Platform.isWindows ? 'Symlink privileges are not portable.' : false,
+    );
+
+    test(
+      'canonicalizes layout when asrAudio and liteRtAsrAudio share the same file and digest',
+      () async {
+        final resolved = await _createResolvedAppCacheConfig(cacheDir);
+        final sharedFixtureConfig = _copyConfigWithPaths(
+          resolved,
+          liteRtAsrAudioPath: resolved.asrAudioPath,
+          liteRtAsrAudioSha256: resolved.asrAudioSha256,
+        );
+
+        final canonical = await canonicalizePhysicalIosSpeechFilesystemLayout(
+          sharedFixtureConfig,
+        );
+        final canonicalRoot = await cacheDir.resolveSymbolicLinks();
+
+        expect(canonical.asrAudioPath, '$canonicalRoot/inputs/asr.wav');
+        expect(canonical.liteRtAsrAudioPath, '$canonicalRoot/inputs/asr.wav');
+      },
+    );
+
+    test(
+      'accepts distinct paths identifying the same inode for asrAudio and liteRtAsrAudio when digests match',
+      () async {
+        final resolved = await _createResolvedAppCacheConfig(cacheDir);
+        final asrFile = File(resolved.asrAudioPath);
+        final liteRtAsrFile = File(resolved.liteRtAsrAudioPath);
+
+        await _replaceWithHardLink(asrFile, liteRtAsrFile);
+
+        final sharedDigestConfig = _copyConfigWithPaths(
+          resolved,
+          liteRtAsrAudioSha256: resolved.asrAudioSha256,
+        );
+
+        final canonical = await canonicalizePhysicalIosSpeechFilesystemLayout(
+          sharedDigestConfig,
+        );
+        expect(
+          await FileSystemEntity.identical(
+            canonical.asrAudioPath,
+            canonical.liteRtAsrAudioPath,
+          ),
+          isTrue,
+        );
+      },
+      skip: Platform.isWindows ? 'Hardlinks require unix ln tool.' : false,
+    );
+
+    test(
+      'rejects distinct paths identifying the same inode for asrAudio and liteRtAsrAudio when digests conflict',
+      () async {
+        final resolved = await _createResolvedAppCacheConfig(cacheDir);
+        final asrFile = File(resolved.asrAudioPath);
+        final liteRtAsrFile = File(resolved.liteRtAsrAudioPath);
+
+        await _replaceWithHardLink(asrFile, liteRtAsrFile);
+
+        await expectLater(
+          canonicalizePhysicalIosSpeechFilesystemLayout(resolved),
+          throwsA(
+            isA<StateError>().having(
+              (error) => error.message,
+              'message',
+              allOf(contains('asrAudio'), contains('liteRtAsrAudio')),
+            ),
+          ),
+        );
+      },
+      skip: Platform.isWindows ? 'Hardlinks require unix ln tool.' : false,
+    );
+
+    test(
+      'rejects unrelated artifacts identifying the same inode even with identical digests',
+      () async {
+        final resolved = await _createResolvedAppCacheConfig(cacheDir);
+        final modelFile = File(resolved.qwen3AsrModelPath);
+        final lmFile = File(resolved.liteRtLmModelPath);
+
+        await _replaceWithHardLink(modelFile, lmFile);
+
+        final matchingDigestConfig = _copyConfigWithPaths(
+          resolved,
+          liteRtLmModelSha256: resolved.qwen3AsrModelSha256,
+        );
+
+        await expectLater(
+          canonicalizePhysicalIosSpeechFilesystemLayout(matchingDigestConfig),
+          throwsA(
+            isA<StateError>().having(
+              (error) => error.message,
+              'message',
+              allOf(contains('qwen3AsrModel'), contains('liteRtLmModel')),
+            ),
+          ),
+        );
+      },
+      skip: Platform.isWindows ? 'Hardlinks require unix ln tool.' : false,
     );
   });
 
@@ -1595,7 +1972,7 @@ void main() {
       final row = SpeechE2ERowResult(
         id: 'llama_cpp_qwen3_asr',
         status: SpeechE2ERowStatus.pass,
-        backend: 'llama.cpp Metal',
+        backend: 'llama.cpp CPU',
         duration: const Duration(milliseconds: 1250),
         digestIdentifiers: {'model': '01234567', 'mmproj': '89abcdef'},
         assertionSummary: 'verified caps, transcribed fixture, verified mic',
@@ -1604,7 +1981,7 @@ void main() {
       final decoded = _decodeResultLine(row.toResultLine());
       expect(decoded['id'], equals('llama_cpp_qwen3_asr'));
       expect(decoded['status'], equals('PASS'));
-      expect(decoded['backend'], equals('llama.cpp Metal'));
+      expect(decoded['backend'], equals('llama.cpp CPU'));
       expect(decoded['elapsedMs'], equals(1250));
       expect(
         decoded['digests'],
@@ -1651,7 +2028,7 @@ void main() {
         SpeechE2ERowResult(
           id: 'llama_cpp_qwen3_asr',
           status: SpeechE2ERowStatus.pass,
-          backend: 'llama.cpp Metal',
+          backend: 'llama.cpp CPU',
           duration: const Duration(seconds: 2),
         ),
         SpeechE2ERowResult(
@@ -1663,7 +2040,7 @@ void main() {
         SpeechE2ERowResult(
           id: 'llama_cpp_qwen3_tts',
           status: SpeechE2ERowStatus.pass,
-          backend: 'llama.cpp Metal',
+          backend: 'llama.cpp CPU',
           duration: const Duration(seconds: 3),
         ),
         SpeechE2ERowResult(
@@ -1683,6 +2060,10 @@ void main() {
 
       expect(() => summary.validateRowIds(), returnsNormally);
       expect(() => summary.validateStrictCounts(), returnsNormally);
+      expect(
+        () => summary.validateSelectedRows(speechE2ERowIds),
+        returnsNormally,
+      );
 
       expect(
         summary.toSummaryLine(),
@@ -1805,6 +2186,70 @@ void main() {
         ]),
       );
     });
+
+    test('validates strict status counts for every selector value', () {
+      for (final selection in <String>[
+        physicalIosSpeechAllRows,
+        ...speechE2ERowIdsInOrder,
+      ]) {
+        final expectedIds = selectPhysicalIosSpeechRowIds(selection).toSet();
+        final rows = <SpeechE2ERowResult>[
+          for (final id in speechE2ERowIdsInOrder)
+            if (expectedIds.contains(id))
+              SpeechE2ERowResult(
+                id: id,
+                status: id == 'litert_lm_tts'
+                    ? SpeechE2ERowStatus.unsupported
+                    : SpeechE2ERowStatus.pass,
+                backend: unresolvedSpeechBackendForRow(id),
+                duration: Duration.zero,
+              ),
+        ];
+
+        expect(
+          () => SpeechE2ESummary(rows).validateSelectedRows(expectedIds),
+          returnsNormally,
+          reason: 'Selector should validate its exact row set: $selection',
+        );
+      }
+    });
+
+    test('selected-row validation rejects extra rows and wrong statuses', () {
+      final selectedIds = selectPhysicalIosSpeechRowIds(
+        'llama_cpp_qwen3_asr',
+      ).toSet();
+      final extraRow = SpeechE2ESummary(<SpeechE2ERowResult>[
+        SpeechE2ERowResult(
+          id: 'llama_cpp_qwen3_asr',
+          status: SpeechE2ERowStatus.pass,
+          backend: 'llama.cpp CPU',
+          duration: Duration.zero,
+        ),
+        SpeechE2ERowResult(
+          id: 'llama_cpp_qwen3_tts',
+          status: SpeechE2ERowStatus.pass,
+          backend: 'llama.cpp CPU',
+          duration: Duration.zero,
+        ),
+      ]);
+      expect(
+        () => extraRow.validateSelectedRows(selectedIds),
+        throwsA(isA<StateError>()),
+      );
+
+      final wrongStatus = SpeechE2ESummary(<SpeechE2ERowResult>[
+        SpeechE2ERowResult(
+          id: 'llama_cpp_qwen3_asr',
+          status: SpeechE2ERowStatus.unsupported,
+          backend: 'llama.cpp CPU',
+          duration: Duration.zero,
+        ),
+      ]);
+      expect(
+        () => wrongStatus.validateSelectedRows(selectedIds),
+        throwsA(isA<StateError>()),
+      );
+    });
   });
 
   group('Cancellation and Classification Helpers', () {
@@ -1847,11 +2292,8 @@ void main() {
       'requires exact runtime backend families and canonicalizes labels',
       () {
         expect(
-          requireSpeechBackendIdentity(
-            'Metal',
-            SpeechE2EBackendKind.llamaCppMetal,
-          ),
-          'llama.cpp Metal',
+          requireSpeechBackendIdentity('CPU', SpeechE2EBackendKind.llamaCppCpu),
+          'llama.cpp CPU',
         );
         expect(
           requireSpeechBackendIdentity(
@@ -1868,12 +2310,71 @@ void main() {
           'LiteRT-LM',
         );
         expect(
+          requireSpeechBackendIdentity(
+            'LiteRT-LM',
+            SpeechE2EBackendKind.liteRtLm,
+          ),
+          'LiteRT-LM',
+        );
+
+        for (final value in <String>[
+          'cpu',
+          ' CPU',
+          'CPU ',
+          'llama.cpp CPU',
+          'CPU fallback',
+          'not CPU',
+        ]) {
+          expect(
+            () => requireSpeechBackendIdentity(
+              value,
+              SpeechE2EBackendKind.llamaCppCpu,
+            ),
+            throwsA(isA<StateError>()),
+            reason: 'llama.cpp CPU must reject non-runtime label "$value".',
+          );
+        }
+
+        // Reject Metal for CPU.
+        expect(
           () => requireSpeechBackendIdentity(
-            'LiteRT-LM Metal',
-            SpeechE2EBackendKind.llamaCppMetal,
+            'Metal',
+            SpeechE2EBackendKind.llamaCppCpu,
           ),
           throwsA(isA<StateError>()),
         );
+        expect(
+          () => requireSpeechBackendIdentity(
+            'llama.cpp Metal',
+            SpeechE2EBackendKind.llamaCppCpu,
+          ),
+          throwsA(isA<StateError>()),
+        );
+
+        // Reject LiteRT for CPU.
+        expect(
+          () => requireSpeechBackendIdentity(
+            'LiteRT-LM CPU',
+            SpeechE2EBackendKind.llamaCppCpu,
+          ),
+          throwsA(isA<StateError>()),
+        );
+        expect(
+          () => requireSpeechBackendIdentity(
+            'LiteRT-LM ASR CPU',
+            SpeechE2EBackendKind.llamaCppCpu,
+          ),
+          throwsA(isA<StateError>()),
+        );
+        expect(
+          () => requireSpeechBackendIdentity(
+            'LiteRT-LM',
+            SpeechE2EBackendKind.llamaCppCpu,
+          ),
+          throwsA(isA<StateError>()),
+        );
+
+        // Reject Metal for LiteRT.
         expect(
           () => requireSpeechBackendIdentity(
             'Metal',
@@ -1881,6 +2382,49 @@ void main() {
           ),
           throwsA(isA<StateError>()),
         );
+        expect(
+          () => requireSpeechBackendIdentity(
+            'Metal',
+            SpeechE2EBackendKind.liteRtLmAsrCpu,
+          ),
+          throwsA(isA<StateError>()),
+        );
+
+        // Reject CPU for LiteRT.
+        expect(
+          () => requireSpeechBackendIdentity(
+            'CPU',
+            SpeechE2EBackendKind.liteRtLmAsrCpu,
+          ),
+          throwsA(isA<StateError>()),
+        );
+        expect(
+          () => requireSpeechBackendIdentity(
+            'CPU',
+            SpeechE2EBackendKind.liteRtLm,
+          ),
+          throwsA(isA<StateError>()),
+        );
+      },
+    );
+
+    test(
+      'resolves expected fallback backend labels before live resolution',
+      () {
+        expect(
+          unresolvedSpeechBackendForRow('llama_cpp_qwen3_asr'),
+          'llama.cpp CPU',
+        );
+        expect(
+          unresolvedSpeechBackendForRow('llama_cpp_qwen3_tts'),
+          'llama.cpp CPU',
+        );
+        expect(
+          unresolvedSpeechBackendForRow('litert_lm_streaming_asr'),
+          'LiteRT-LM ASR CPU',
+        );
+        expect(unresolvedSpeechBackendForRow('litert_lm_tts'), 'LiteRT-LM');
+        expect(unresolvedSpeechBackendForRow('unknown_row'), '<unresolved>');
       },
     );
 

--- a/example/chat_app/test/physical_ios_speech_e2e_support_test.dart
+++ b/example/chat_app/test/physical_ios_speech_e2e_support_test.dart
@@ -53,6 +53,72 @@ Map<String, String> _validEnv() {
   };
 }
 
+PhysicalIosSpeechConfig _copyConfigWithPaths(
+  PhysicalIosSpeechConfig source, {
+  String? qwen3AsrModelPath,
+  String? ttsOutputPath,
+}) {
+  return PhysicalIosSpeechConfig(
+    qwen3AsrModelPath: qwen3AsrModelPath ?? source.qwen3AsrModelPath,
+    qwen3AsrModelSha256: source.qwen3AsrModelSha256,
+    qwen3AsrMmprojPath: source.qwen3AsrMmprojPath,
+    qwen3AsrMmprojSha256: source.qwen3AsrMmprojSha256,
+    asrAudioPath: source.asrAudioPath,
+    asrAudioSha256: source.asrAudioSha256,
+    asrExpectedTranscript: source.asrExpectedTranscript,
+    micDurationSeconds: source.micDurationSeconds,
+    micExpectedTranscript: source.micExpectedTranscript,
+    liteRtAsrModelPath: source.liteRtAsrModelPath,
+    liteRtAsrModelSha256: source.liteRtAsrModelSha256,
+    liteRtAsrTokenizerPath: source.liteRtAsrTokenizerPath,
+    liteRtAsrTokenizerSha256: source.liteRtAsrTokenizerSha256,
+    liteRtAsrPreset: source.liteRtAsrPreset,
+    liteRtAsrAudioPath: source.liteRtAsrAudioPath,
+    liteRtAsrAudioSha256: source.liteRtAsrAudioSha256,
+    liteRtAsrExpectedTranscript: source.liteRtAsrExpectedTranscript,
+    qwen3TtsModelPath: source.qwen3TtsModelPath,
+    qwen3TtsModelSha256: source.qwen3TtsModelSha256,
+    qwen3TtsMmprojPath: source.qwen3TtsMmprojPath,
+    qwen3TtsMmprojSha256: source.qwen3TtsMmprojSha256,
+    ttsText: source.ttsText,
+    ttsOutputPath: ttsOutputPath ?? source.ttsOutputPath,
+    ttsExpectedTranscript: source.ttsExpectedTranscript,
+    liteRtLmModelPath: source.liteRtLmModelPath,
+    liteRtLmModelSha256: source.liteRtLmModelSha256,
+    resolvedAppCacheDirectoryPath: source.resolvedAppCacheDirectoryPath,
+  );
+}
+
+Future<PhysicalIosSpeechConfig> _createResolvedAppCacheConfig(
+  Directory cacheDirectory,
+) async {
+  final env = _validEnv()
+    ..['IOS_SPEECH_QWEN3_ASR_MODEL_PATH'] = '@appcache/inputs/qwen3_asr.gguf'
+    ..['IOS_SPEECH_QWEN3_ASR_MMPROJ_PATH'] =
+        '@appcache/inputs/qwen3_asr_mmproj.gguf'
+    ..['IOS_SPEECH_ASR_AUDIO_PATH'] = '@appcache/inputs/asr.wav'
+    ..['IOS_SPEECH_LITERT_ASR_MODEL_PATH'] =
+        '@appcache/inputs/litert_asr.tflite'
+    ..['IOS_SPEECH_LITERT_ASR_TOKENIZER_PATH'] =
+        '@appcache/inputs/tokenizer.json'
+    ..['IOS_SPEECH_LITERT_ASR_AUDIO_PATH'] = '@appcache/inputs/litert_asr.wav'
+    ..['IOS_SPEECH_QWEN3_TTS_MODEL_PATH'] = '@appcache/inputs/qwen3_tts.gguf'
+    ..['IOS_SPEECH_QWEN3_TTS_MMPROJ_PATH'] =
+        '@appcache/inputs/qwen3_tts_mmproj.gguf'
+    ..['IOS_SPEECH_LITERT_LM_MODEL_PATH'] = '@appcache/inputs/chat.litertlm'
+    ..['IOS_SPEECH_TTS_OUTPUT_PATH'] = '@appcache/output/tts.wav';
+  final resolved = await resolvePhysicalIosSpeechCachePaths(
+    PhysicalIosSpeechConfig.fromMap(env),
+    cacheDirectory: () async => cacheDirectory,
+  );
+  for (final artifact in resolved.artifacts) {
+    final file = File(artifact.path);
+    await file.parent.create(recursive: true);
+    await file.writeAsString(artifact.label, flush: true);
+  }
+  return resolved;
+}
+
 /// Rebuilds a WAV buffer with one header field overwritten so malformed
 /// metadata cases can be asserted precisely.
 Uint8List _withUint32(Uint8List source, int offset, int value) {
@@ -186,6 +252,419 @@ void main() {
         throwsA(isA<ArgumentError>()),
       );
     });
+  });
+
+  group('App-cache relative path defines', () {
+    test('accepts @appcache references alongside absolute paths', () {
+      final env = _validEnv()
+        ..['IOS_SPEECH_QWEN3_ASR_MODEL_PATH'] = '@appcache/models/asr.gguf'
+        ..['IOS_SPEECH_TTS_OUTPUT_PATH'] = '@appcache/out/tts.wav';
+
+      final config = PhysicalIosSpeechConfig.fromMap(env);
+      expect(config.qwen3AsrModelPath, equals('@appcache/models/asr.gguf'));
+      expect(config.usesAppCachePaths, isTrue);
+      expect(
+        PhysicalIosSpeechConfig.fromMap(_validEnv()).usesAppCachePaths,
+        isFalse,
+      );
+    });
+
+    test('rejects unsafe @appcache relative paths', () {
+      const unsafe = <String>[
+        '@appcache/../escape.gguf',
+        '@appcache/models/../../escape.gguf',
+        '@appcache/./model.gguf',
+        '@appcache/models/./model.gguf',
+        '@appcache/',
+        '@appcache',
+        '@appcache//model.gguf',
+        '@appcache/models//model.gguf',
+        '@appcache/models/',
+        '@appcache/models\\model.gguf',
+        '@appcache/https://example.invalid/model.gguf',
+        '@appcache/models/model.gguf?download=1',
+        '@appcache/models/model.gguf#fragment',
+        '@appcache//',
+        '@appcache/~/model.gguf',
+        '@appcache/~root/model.gguf',
+        ' @appcache/models/model.gguf',
+        '@appcache/models/model.gguf ',
+        '@appcache/ models/model.gguf',
+        '@appcache/models /model.gguf',
+      ];
+
+      for (final badPath in unsafe) {
+        final env = _validEnv()..['IOS_SPEECH_QWEN3_ASR_MODEL_PATH'] = badPath;
+        expect(
+          () => PhysicalIosSpeechConfig.fromMap(env),
+          throwsA(isA<ArgumentError>()),
+          reason: 'Should reject app-cache path: "$badPath"',
+        );
+      }
+    });
+
+    test('rejects a differently cased app-cache marker', () {
+      for (final marker in <String>[
+        '@AppCache/models/asr.gguf',
+        '@APPCACHE/models/asr.gguf',
+        '@Appcache/models/asr.gguf',
+      ]) {
+        final env = _validEnv()..['IOS_SPEECH_QWEN3_ASR_MODEL_PATH'] = marker;
+        expect(
+          () => PhysicalIosSpeechConfig.fromMap(env),
+          throwsA(
+            isA<ArgumentError>().having(
+              (e) => e.message.toString(),
+              'message',
+              contains('@appcache/'),
+            ),
+          ),
+          reason: 'Ambiguous marker casing must fail closed: "$marker"',
+        );
+      }
+    });
+
+    test('rejects unsafe absolute paths', () {
+      const unsafe = <String>[
+        '/',
+        '/models/../../etc/passwd',
+        '/models/./asr.gguf',
+        '/models//asr.gguf',
+        '/models/',
+        r'/models\asr.gguf',
+        '/~/models/asr.gguf',
+        '/models/asr:stream.gguf',
+        '/models/asr.gguf?download=1',
+        '/models/asr.gguf#fragment',
+        ' /models/asr.gguf',
+        '/models/asr.gguf ',
+        'file:///models/asr.gguf',
+      ];
+
+      for (final badPath in unsafe) {
+        final env = _validEnv()..['IOS_SPEECH_QWEN3_ASR_MODEL_PATH'] = badPath;
+        expect(
+          () => PhysicalIosSpeechConfig.fromMap(env),
+          throwsA(isA<ArgumentError>()),
+          reason: 'Should reject absolute path: "$badPath"',
+        );
+      }
+    });
+
+    test('resolves references against the runtime cache directory', () async {
+      final env = _validEnv()
+        ..['IOS_SPEECH_QWEN3_ASR_MODEL_PATH'] = '@appcache/models/asr.gguf'
+        ..['IOS_SPEECH_LITERT_LM_MODEL_PATH'] = '@appcache/dummy.litertlm'
+        ..['IOS_SPEECH_TTS_OUTPUT_PATH'] = '@appcache/out/tts.wav';
+
+      final resolved = await resolvePhysicalIosSpeechCachePaths(
+        PhysicalIosSpeechConfig.fromMap(env),
+        cacheDirectory: () async =>
+            Directory('/var/mobile/Containers/Data/Application/NEW-UUID/Cache'),
+      );
+
+      expect(
+        resolved.qwen3AsrModelPath,
+        equals(
+          '/var/mobile/Containers/Data/Application/NEW-UUID/Cache/models/'
+          'asr.gguf',
+        ),
+      );
+      expect(
+        resolved.liteRtLmModelPath,
+        equals(
+          '/var/mobile/Containers/Data/Application/NEW-UUID/Cache/'
+          'dummy.litertlm',
+        ),
+      );
+      expect(
+        resolved.ttsOutputPath,
+        equals(
+          '/var/mobile/Containers/Data/Application/NEW-UUID/Cache/out/tts.wav',
+        ),
+      );
+      expect(
+        resolved.qwen3AsrMmprojPath,
+        equals('/models/qwen3_asr_mmproj.gguf'),
+        reason: 'Safe absolute paths must survive resolution unchanged.',
+      );
+      expect(resolved.usesAppCachePaths, isFalse);
+      expect(resolved.micDurationSeconds, equals(3));
+      expect(
+        resolved.liteRtAsrPreset,
+        equals(LiteRtLmAsrModelPreset.moonshineTiny),
+      );
+    });
+
+    test('never consults path_provider for an all-absolute config', () async {
+      var lookups = 0;
+      final resolved = await resolvePhysicalIosSpeechCachePaths(
+        PhysicalIosSpeechConfig.fromMap(_validEnv()),
+        cacheDirectory: () async {
+          lookups++;
+          return Directory('/unused');
+        },
+      );
+
+      expect(lookups, isZero);
+      expect(resolved.ttsOutputPath, equals('/tmp/output_tts.wav'));
+    });
+
+    test('rejects an unusable runtime cache directory', () async {
+      final config = PhysicalIosSpeechConfig.fromMap(
+        _validEnv()..['IOS_SPEECH_TTS_OUTPUT_PATH'] = '@appcache/out/tts.wav',
+      );
+
+      for (final directory in <String>[
+        '',
+        '   ',
+        'relative/cache',
+        '/',
+        '/var/../root/cache',
+        '/var/cache//app',
+        ' /var/cache/app',
+        '/var/cache/app ',
+        '@appcache/nested',
+      ]) {
+        await expectLater(
+          resolvePhysicalIosSpeechCachePaths(
+            config,
+            cacheDirectory: () async => Directory(directory),
+          ),
+          throwsA(isA<ArgumentError>()),
+          reason: 'Should reject cache directory: "$directory"',
+        );
+      }
+    });
+
+    test('tolerates a trailing separator on the cache directory', () async {
+      final resolved = await resolvePhysicalIosSpeechCachePaths(
+        PhysicalIosSpeechConfig.fromMap(
+          _validEnv()..['IOS_SPEECH_TTS_OUTPUT_PATH'] = '@appcache/out/tts.wav',
+        ),
+        cacheDirectory: () async => Directory('/Containers/Cache/'),
+      );
+
+      expect(resolved.ttsOutputPath, equals('/Containers/Cache/out/tts.wav'));
+    });
+
+    test('rejects an output that collides only after resolution', () async {
+      final env = _validEnv()
+        ..['IOS_SPEECH_QWEN3_TTS_MODEL_PATH'] = '/Containers/Cache/TTS.wav'
+        ..['IOS_SPEECH_TTS_OUTPUT_PATH'] = '@appcache/tts.wav';
+
+      // The two specs differ textually, so only post-resolution comparison can
+      // stop the harness from deleting a pinned input during cleanup.
+      final config = PhysicalIosSpeechConfig.fromMap(env);
+
+      await expectLater(
+        resolvePhysicalIosSpeechCachePaths(
+          config,
+          cacheDirectory: () async => Directory('/Containers/Cache'),
+        ),
+        throwsA(isA<ArgumentError>()),
+        reason: 'Post-resolution comparison must ignore path casing.',
+      );
+    });
+
+    test('rejects an input/output collision that differs only by case', () {
+      final env = _validEnv()
+        ..['IOS_SPEECH_TTS_OUTPUT_PATH'] = '/models/QWEN3_TTS.gguf'
+        ..['IOS_SPEECH_QWEN3_TTS_MODEL_PATH'] = '/models/qwen3_tts.gguf';
+
+      expect(
+        () => PhysicalIosSpeechConfig.fromMap(env),
+        throwsA(isA<ArgumentError>()),
+        reason: 'The on-device container may fold case into one file.',
+      );
+    });
+
+    test('rejects duplicate immutable input paths ignoring case', () {
+      final env = _validEnv()
+        ..['IOS_SPEECH_QWEN3_ASR_MODEL_PATH'] = '/models/shared.gguf'
+        ..['IOS_SPEECH_QWEN3_ASR_MMPROJ_PATH'] = '/MODELS/SHARED.GGUF';
+
+      expect(
+        () => PhysicalIosSpeechConfig.fromMap(env),
+        throwsA(isA<ArgumentError>()),
+        reason: 'Every checksum pin must identify one unambiguous input file.',
+      );
+    });
+
+    test('refuses artifact access before resolution', () async {
+      final config = PhysicalIosSpeechConfig.fromMap(
+        _validEnv()
+          ..['IOS_SPEECH_ASR_AUDIO_PATH'] = '@appcache/fixtures/speech.wav',
+      );
+      final visited = <String>[];
+
+      await expectLater(
+        config.validateArtifacts(
+          verify: (artifact) async => visited.add(artifact.label),
+        ),
+        throwsA(
+          isA<StateError>().having(
+            (e) => e.message,
+            'message',
+            allOf(contains('asrAudio'), contains('@appcache/')),
+          ),
+        ),
+      );
+      await expectLater(
+        config.validateArtifactsCollectingFailures(
+          verify: (artifact) async => visited.add(artifact.label),
+        ),
+        throwsA(isA<StateError>()),
+      );
+      expect(
+        visited,
+        isEmpty,
+        reason: 'No artifact may be opened while a path is unresolved.',
+      );
+    });
+
+    test(
+      'direct construction cannot bypass path and collision checks',
+      () async {
+        final valid = PhysicalIosSpeechConfig.fromMap(_validEnv());
+        final invalidConfigs = <PhysicalIosSpeechConfig>[
+          _copyConfigWithPaths(
+            valid,
+            qwen3AsrModelPath: '/models/../private/input.gguf',
+          ),
+          _copyConfigWithPaths(
+            valid,
+            qwen3AsrModelPath: '@AppCache/models/input.gguf',
+          ),
+          _copyConfigWithPaths(valid, ttsOutputPath: '/MODELS/QWEN3_ASR.GGUF'),
+        ];
+
+        for (final config in invalidConfigs) {
+          final visited = <String>[];
+          await expectLater(
+            config.validateArtifacts(
+              verify: (artifact) async => visited.add(artifact.label),
+            ),
+            throwsA(anyOf(isA<ArgumentError>(), isA<StateError>())),
+          );
+          expect(
+            visited,
+            isEmpty,
+            reason: 'Every path check must finish before the first file read.',
+          );
+        }
+      },
+    );
+  });
+
+  group('Canonical speech filesystem layout', () {
+    late Directory tempDir;
+    late Directory cacheDir;
+
+    setUp(() async {
+      tempDir = await Directory.systemTemp.createTemp(
+        'speech_e2e_layout_test_',
+      );
+      cacheDir = Directory('${tempDir.path}/cache');
+      await cacheDir.create();
+    });
+
+    tearDown(() async {
+      if (await tempDir.exists()) {
+        await tempDir.delete(recursive: true);
+      }
+    });
+
+    test('canonicalizes cache paths after runtime resolution', () async {
+      final resolved = await _createResolvedAppCacheConfig(cacheDir);
+
+      final canonical = await canonicalizePhysicalIosSpeechFilesystemLayout(
+        resolved,
+      );
+      final canonicalRoot = await cacheDir.resolveSymbolicLinks();
+
+      expect(canonical.resolvedAppCacheDirectoryPath, canonicalRoot);
+      expect(canonical.qwen3AsrModelPath, startsWith('$canonicalRoot/'));
+      expect(canonical.ttsOutputPath, '$canonicalRoot/output/tts.wav');
+      expect(await File(canonical.ttsOutputPath).exists(), isFalse);
+    });
+
+    test(
+      'rejects an input symlink that escapes the runtime cache',
+      () async {
+        final resolved = await _createResolvedAppCacheConfig(cacheDir);
+        final model = File(resolved.qwen3AsrModelPath);
+        final outside = File('${tempDir.path}/outside.gguf');
+        await outside.writeAsString('outside', flush: true);
+        await model.delete();
+        await Link(model.path).create(outside.path);
+
+        await expectLater(
+          canonicalizePhysicalIosSpeechFilesystemLayout(resolved),
+          throwsA(isA<StateError>()),
+        );
+      },
+      skip: Platform.isWindows
+          ? 'Creating symbolic links requires additional Windows privileges.'
+          : false,
+    );
+
+    test(
+      'rejects a symlinked output parent below the cache root',
+      () async {
+        final resolved = await _createResolvedAppCacheConfig(cacheDir);
+        final outside = Directory('${tempDir.path}/outside')..createSync();
+        await Link('${cacheDir.path}/output').create(outside.path);
+
+        await expectLater(
+          canonicalizePhysicalIosSpeechFilesystemLayout(resolved),
+          throwsA(isA<StateError>()),
+        );
+      },
+      skip: Platform.isWindows ? 'Symlink privileges are not portable.' : false,
+    );
+
+    test('writes exclusively and deletes only the canonical output', () async {
+      final resolved = await _createResolvedAppCacheConfig(cacheDir);
+      final canonical = await canonicalizePhysicalIosSpeechFilesystemLayout(
+        resolved,
+      );
+      final bytes = Uint8List.fromList(<int>[1, 2, 3, 4]);
+
+      final output = await writePhysicalIosSpeechOutputExclusive(
+        canonical,
+        bytes,
+      );
+      expect(await output.readAsBytes(), bytes);
+      await expectLater(
+        writePhysicalIosSpeechOutputExclusive(canonical, bytes),
+        throwsA(isA<StateError>()),
+      );
+
+      await deletePhysicalIosSpeechOutput(canonical);
+      expect(await output.exists(), isFalse);
+    });
+
+    test(
+      'refuses to delete an output replaced by a symbolic link',
+      () async {
+        final resolved = await _createResolvedAppCacheConfig(cacheDir);
+        final canonical = await canonicalizePhysicalIosSpeechFilesystemLayout(
+          resolved,
+        );
+        final target = File('${tempDir.path}/do_not_delete.wav');
+        await target.writeAsBytes(<int>[9], flush: true);
+        await Directory(canonical.ttsOutputPath).parent.create(recursive: true);
+        await Link(canonical.ttsOutputPath).create(target.path);
+
+        await expectLater(
+          deletePhysicalIosSpeechOutput(canonical),
+          throwsA(isA<StateError>()),
+        );
+        expect(await target.exists(), isTrue);
+      },
+      skip: Platform.isWindows ? 'Symlink privileges are not portable.' : false,
+    );
   });
 
   group('Compile-time define map', () {
@@ -619,6 +1098,23 @@ void main() {
         throwsA(isA<FileSystemException>()),
       );
     });
+
+    test(
+      'refuses to hash through an artifact symlink',
+      () async {
+        final target = File('${tempDir.path}/target.bin');
+        await target.writeAsBytes(<int>[1, 2, 3], flush: true);
+        final link = Link('${tempDir.path}/artifact.bin');
+        await link.create(target.path);
+
+        await expectLater(
+          computeFileSha256(link.path),
+          throwsA(isA<FileSystemException>()),
+        );
+        expect(await target.exists(), isTrue);
+      },
+      skip: Platform.isWindows ? 'Symlink privileges are not portable.' : false,
+    );
   });
 
   group('PCM16 WAV Parsing and Validation', () {
@@ -1312,14 +1808,39 @@ void main() {
   });
 
   group('Cancellation and Classification Helpers', () {
-    test('distinguishes physical iOS hardware from simulator machines', () {
-      expect(isPhysicalIosMachineIdentifier('iPhone17,2'), isTrue);
-      expect(isPhysicalIosMachineIdentifier('iPad14,6'), isTrue);
-      expect(isPhysicalIosMachineIdentifier('iPod9,1'), isTrue);
-      expect(isPhysicalIosMachineIdentifier('arm64'), isFalse);
-      expect(isPhysicalIosMachineIdentifier('x86_64'), isFalse);
-      expect(isPhysicalIosMachineIdentifier('iPhone Simulator'), isFalse);
-      expect(isPhysicalIosMachineIdentifier(''), isFalse);
+    test('distinguishes physical iOS app paths without private FFI', () {
+      expect(
+        isPhysicalIosApplicationExecutablePath(
+          '/private/var/containers/Bundle/Application/INSTALL-ID/'
+          'Runner.app/Runner',
+        ),
+        isTrue,
+      );
+      expect(
+        isPhysicalIosApplicationExecutablePath(
+          '/var/containers/Bundle/Application/INSTALL-ID/'
+          'Runner.app/Frameworks/App.framework/App',
+        ),
+        isTrue,
+      );
+      for (final path in <String>[
+        '/Users/test/Library/Developer/CoreSimulator/Devices/DEVICE/data/'
+            'Containers/Bundle/Application/INSTALL-ID/Runner.app/Runner',
+        '/private/var/mobile/Containers/Data/Application/INSTALL-ID/Runner',
+        '/private/var/containers/Bundle/Application/INSTALL-ID/Runner',
+        '/private/var/containers/Bundle/Application/INSTALL-ID/Runner.app',
+        '/private/var/containers/Bundle/Application//Runner.app/Runner',
+        '/private/var/containers/Bundle/Application/INSTALL-ID/'
+            'Runner.app/../Runner',
+        '/private/var/containers/Bundle/Application/INSTALL-ID/.app/Runner',
+        '',
+      ]) {
+        expect(
+          isPhysicalIosApplicationExecutablePath(path),
+          isFalse,
+          reason: 'Must reject non-device executable path: "$path"',
+        );
+      }
     });
 
     test(

--- a/example/chat_app/test/physical_ios_speech_e2e_support_test.dart
+++ b/example/chat_app/test/physical_ios_speech_e2e_support_test.dart
@@ -1,0 +1,1570 @@
+import 'dart:async';
+import 'dart:convert';
+import 'dart:io';
+import 'dart:math' as math;
+import 'dart:typed_data';
+
+import 'package:crypto/crypto.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:llamadart/llamadart.dart';
+import 'package:llamadart_chat_example/services/audio_recording_service.dart';
+
+import '../integration_test/support/physical_ios_speech_e2e_support.dart';
+
+Map<String, String> _validEnv() {
+  return <String, String>{
+    'IOS_SPEECH_QWEN3_ASR_MODEL_PATH': '/models/qwen3_asr.gguf',
+    'IOS_SPEECH_QWEN3_ASR_MODEL_SHA256':
+        '0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef',
+    'IOS_SPEECH_QWEN3_ASR_MMPROJ_PATH': '/models/qwen3_asr_mmproj.gguf',
+    'IOS_SPEECH_QWEN3_ASR_MMPROJ_SHA256':
+        'abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789',
+    'IOS_SPEECH_ASR_AUDIO_PATH': '/fixtures/speech.wav',
+    'IOS_SPEECH_ASR_AUDIO_SHA256':
+        '1111111111111111111111111111111111111111111111111111111111111111',
+    'IOS_SPEECH_ASR_EXPECTED_TRANSCRIPT': 'hello world from speech test',
+    'IOS_SPEECH_MIC_DURATION_SECONDS': '3',
+    'IOS_SPEECH_MIC_EXPECTED_TRANSCRIPT': 'testing microphone input',
+    'IOS_SPEECH_LITERT_ASR_MODEL_PATH': '/models/moonshine_tiny.tflite',
+    'IOS_SPEECH_LITERT_ASR_MODEL_SHA256':
+        '2222222222222222222222222222222222222222222222222222222222222222',
+    'IOS_SPEECH_LITERT_ASR_TOKENIZER_PATH': '/models/tokenizer.json',
+    'IOS_SPEECH_LITERT_ASR_TOKENIZER_SHA256':
+        '3333333333333333333333333333333333333333333333333333333333333333',
+    'IOS_SPEECH_LITERT_ASR_PRESET': 'moonshine-tiny',
+    'IOS_SPEECH_LITERT_ASR_AUDIO_PATH': '/fixtures/litert_speech.wav',
+    'IOS_SPEECH_LITERT_ASR_AUDIO_SHA256':
+        '4444444444444444444444444444444444444444444444444444444444444444',
+    'IOS_SPEECH_LITERT_ASR_EXPECTED_TRANSCRIPT':
+        'litert streaming speech recognition',
+    'IOS_SPEECH_QWEN3_TTS_MODEL_PATH': '/models/qwen3_tts.gguf',
+    'IOS_SPEECH_QWEN3_TTS_MODEL_SHA256':
+        '5555555555555555555555555555555555555555555555555555555555555555',
+    'IOS_SPEECH_QWEN3_TTS_MMPROJ_PATH': '/models/qwen3_tts_mmproj.gguf',
+    'IOS_SPEECH_QWEN3_TTS_MMPROJ_SHA256':
+        '6666666666666666666666666666666666666666666666666666666666666666',
+    'IOS_SPEECH_TTS_TEXT': 'Hello from physical iOS speech synthesis test.',
+    'IOS_SPEECH_TTS_OUTPUT_PATH': '/tmp/output_tts.wav',
+    'IOS_SPEECH_TTS_EXPECTED_TRANSCRIPT':
+        'hello from physical ios speech synthesis test',
+    'IOS_SPEECH_LITERT_LM_MODEL_PATH': '/models/dummy.litertlm',
+    'IOS_SPEECH_LITERT_LM_MODEL_SHA256':
+        '7777777777777777777777777777777777777777777777777777777777777777',
+  };
+}
+
+/// Rebuilds a WAV buffer with one header field overwritten so malformed
+/// metadata cases can be asserted precisely.
+Uint8List _withUint32(Uint8List source, int offset, int value) {
+  final copy = Uint8List.fromList(source);
+  ByteData.sublistView(copy).setUint32(offset, value, Endian.little);
+  return copy;
+}
+
+Uint8List _withUint16(Uint8List source, int offset, int value) {
+  final copy = Uint8List.fromList(source);
+  ByteData.sublistView(copy).setUint16(offset, value, Endian.little);
+  return copy;
+}
+
+Map<String, Object?> _decodeResultLine(String line) {
+  const prefix = 'RESULT physical_ios_speech ';
+  expect(line, startsWith(prefix));
+  return jsonDecode(line.substring(prefix.length)) as Map<String, Object?>;
+}
+
+void main() {
+  group('PhysicalIosSpeechConfig', () {
+    test('parses valid full configuration successfully', () {
+      final config = PhysicalIosSpeechConfig.fromMap(_validEnv());
+      expect(config.qwen3AsrModelPath, equals('/models/qwen3_asr.gguf'));
+      expect(config.micDurationSeconds, equals(3));
+      expect(
+        config.liteRtAsrPreset,
+        equals(LiteRtLmAsrModelPreset.moonshineTiny),
+      );
+      expect(
+        config.ttsText,
+        equals('Hello from physical iOS speech synthesis test.'),
+      );
+    });
+
+    test('rejects missing required configuration key', () {
+      final env = _validEnv()..remove('IOS_SPEECH_QWEN3_ASR_MODEL_PATH');
+      expect(
+        () => PhysicalIosSpeechConfig.fromMap(env),
+        throwsA(
+          isA<ArgumentError>().having(
+            (e) => e.message.toString(),
+            'message',
+            contains('IOS_SPEECH_QWEN3_ASR_MODEL_PATH'),
+          ),
+        ),
+      );
+    });
+
+    test('rejects empty configuration value', () {
+      final env = _validEnv()..['IOS_SPEECH_TTS_TEXT'] = '   ';
+      expect(
+        () => PhysicalIosSpeechConfig.fromMap(env),
+        throwsA(
+          isA<ArgumentError>().having(
+            (e) => e.message.toString(),
+            'message',
+            contains('IOS_SPEECH_TTS_TEXT'),
+          ),
+        ),
+      );
+    });
+
+    test('rejects invalid hex SHA-256 digest format', () {
+      final invalidDigests = [
+        '0123456789abcdef',
+        '0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0',
+        '0123456789ABCDEF0123456789abcdef0123456789abcdef0123456789abcdef',
+        '0123456789xyzdef0123456789abcdef0123456789abcdef0123456789abcdef',
+      ];
+
+      for (final badDigest in invalidDigests) {
+        final env = _validEnv()
+          ..['IOS_SPEECH_QWEN3_ASR_MODEL_SHA256'] = badDigest;
+        expect(
+          () => PhysicalIosSpeechConfig.fromMap(env),
+          throwsA(isA<ArgumentError>()),
+          reason: 'Should reject digest: $badDigest',
+        );
+      }
+    });
+
+    test('rejects non-positive and non-numeric mic duration', () {
+      for (final bad in <String>['0', '-5', 'three', '2.5', '']) {
+        final env = _validEnv()..['IOS_SPEECH_MIC_DURATION_SECONDS'] = bad;
+        expect(
+          () => PhysicalIosSpeechConfig.fromMap(env),
+          throwsA(isA<ArgumentError>()),
+          reason: 'Should reject mic duration: "$bad"',
+        );
+      }
+    });
+
+    test('rejects unknown LiteRT ASR preset name', () {
+      final env = _validEnv()
+        ..['IOS_SPEECH_LITERT_ASR_PRESET'] = 'whisper-large';
+      expect(
+        () => PhysicalIosSpeechConfig.fromMap(env),
+        throwsA(isA<ArgumentError>()),
+      );
+    });
+
+    test('rejects remote, relative, colliding, and unsafe output paths', () {
+      for (final badPath in <String>[
+        'https://example.invalid/model.gguf',
+        'relative/model.gguf',
+      ]) {
+        final env = _validEnv()..['IOS_SPEECH_QWEN3_ASR_MODEL_PATH'] = badPath;
+        expect(
+          () => PhysicalIosSpeechConfig.fromMap(env),
+          throwsA(isA<ArgumentError>()),
+          reason: 'Only absolute local on-device paths are valid: $badPath',
+        );
+      }
+
+      final colliding = _validEnv()
+        ..['IOS_SPEECH_TTS_OUTPUT_PATH'] =
+            _validEnv()['IOS_SPEECH_QWEN3_TTS_MODEL_PATH']!;
+      expect(
+        () => PhysicalIosSpeechConfig.fromMap(colliding),
+        throwsA(isA<ArgumentError>()),
+        reason: 'The disposable WAV output must never overwrite an input.',
+      );
+    });
+
+    test('caps microphone capture duration', () {
+      final env = _validEnv()..['IOS_SPEECH_MIC_DURATION_SECONDS'] = '31';
+      expect(
+        () => PhysicalIosSpeechConfig.fromMap(env),
+        throwsA(isA<ArgumentError>()),
+      );
+    });
+  });
+
+  group('Compile-time define map', () {
+    test('exposes exactly the declared keys', () {
+      expect(
+        physicalIosSpeechCompileTimeDefines.keys.toSet(),
+        equals(physicalIosSpeechDefineKeys.toSet()),
+      );
+      expect(
+        physicalIosSpeechCompileTimeDefines,
+        hasLength(physicalIosSpeechDefineKeys.length),
+      );
+      expect(physicalIosSpeechDefineKeys, hasLength(26));
+      for (final key in physicalIosSpeechDefineKeys) {
+        expect(key, startsWith('IOS_SPEECH_'));
+      }
+    });
+
+    test('fails closed when no --dart-define values were supplied', () {
+      expect(
+        () => PhysicalIosSpeechConfig.fromEnvironment(),
+        throwsA(
+          isA<ArgumentError>().having(
+            (e) => e.message.toString(),
+            'message',
+            contains('IOS_SPEECH_'),
+          ),
+        ),
+      );
+    });
+  });
+
+  group('Artifact checksum verification', () {
+    test('enumerates every immutable artifact exactly once', () {
+      final config = PhysicalIosSpeechConfig.fromMap(_validEnv());
+      final artifacts = config.artifacts;
+      expect(artifacts, hasLength(9));
+      expect(
+        artifacts.map((a) => a.label).toSet(),
+        equals(<String>{
+          'qwen3AsrModel',
+          'qwen3AsrMmproj',
+          'asrAudio',
+          'liteRtAsrModel',
+          'liteRtAsrTokenizer',
+          'liteRtAsrAudio',
+          'qwen3TtsModel',
+          'qwen3TtsMmproj',
+          'liteRtLmModel',
+        }),
+      );
+      expect(artifacts.map((a) => a.path).toSet(), hasLength(9));
+    });
+
+    test('streams hashes strictly sequentially, never concurrently', () async {
+      final config = PhysicalIosSpeechConfig.fromMap(_validEnv());
+      final order = <String>[];
+      var inFlight = 0;
+      var maxInFlight = 0;
+
+      await config.validateArtifacts(
+        verify: (artifact) async {
+          inFlight++;
+          if (inFlight > maxInFlight) {
+            maxInFlight = inFlight;
+          }
+          order.add(artifact.label);
+          await Future<void>.delayed(Duration.zero);
+          inFlight--;
+        },
+      );
+
+      expect(
+        maxInFlight,
+        equals(1),
+        reason: 'Multi-GB artifacts must not be hashed concurrently.',
+      );
+      expect(order, hasLength(9));
+      expect(order.first, equals('qwen3AsrModel'));
+    });
+
+    test('stops at the first failing artifact and names it', () async {
+      final config = PhysicalIosSpeechConfig.fromMap(_validEnv());
+      final visited = <String>[];
+
+      await expectLater(
+        config.validateArtifacts(
+          verify: (artifact) async {
+            visited.add(artifact.label);
+            if (artifact.label == 'asrAudio') {
+              throw StateError('Checksum mismatch for "${artifact.path}"');
+            }
+          },
+        ),
+        throwsA(isA<StateError>()),
+      );
+
+      expect(visited, equals(['qwen3AsrModel', 'qwen3AsrMmproj', 'asrAudio']));
+    });
+
+    test(
+      'collects every artifact failure while remaining sequential',
+      () async {
+        final config = PhysicalIosSpeechConfig.fromMap(_validEnv());
+        final visited = <String>[];
+        var inFlight = 0;
+        var maxInFlight = 0;
+
+        final failures = await config.validateArtifactsCollectingFailures(
+          verify: (artifact) async {
+            inFlight++;
+            maxInFlight = math.max(maxInFlight, inFlight);
+            visited.add(artifact.label);
+            await Future<void>.delayed(Duration.zero);
+            inFlight--;
+            if (artifact.label == 'asrAudio' ||
+                artifact.label == 'liteRtLmModel') {
+              throw StateError('secret path ${artifact.path}');
+            }
+          },
+        );
+
+        expect(visited, hasLength(9));
+        expect(maxInFlight, 1);
+        expect(failures.keys, {'asrAudio', 'liteRtLmModel'});
+        expect(failures.values.join(' '), isNot(contains('/fixtures/')));
+        expect(failures.values.join(' '), isNot(contains('/models/')));
+        expect(
+          () => requireValidSpeechArtifacts(failures, const {'asrAudio'}),
+          throwsA(isA<StateError>()),
+        );
+        expect(
+          () => requireValidSpeechArtifacts(failures, const {'qwen3TtsModel'}),
+          returnsNormally,
+        );
+      },
+    );
+  });
+
+  group('Transcript Normalization', () {
+    test('normalizes whitespace, casing, and trimming exactly', () {
+      expect(
+        normalizeSpeechTranscript('  Hello   World  \n\t from   Dart  '),
+        equals('hello world from dart'),
+      );
+      expect(
+        normalizeSpeechTranscript('TESTING  1  2  3'),
+        equals('testing 1 2 3'),
+      );
+      expect(normalizeSpeechTranscript(''), equals(''));
+      expect(normalizeSpeechTranscript('   \n\t  '), equals(''));
+      expect(
+        normalizeSpeechTranscript('  Exact   Punctuation, Preserved!  '),
+        equals('exact punctuation, preserved!'),
+      );
+    });
+
+    test('does not use substring or contains matching', () {
+      final actual = normalizeSpeechTranscript('hello world');
+      final expected = normalizeSpeechTranscript('hello');
+      expect(actual == expected, isFalse);
+    });
+
+    test('exact comparison accepts only normalized equality', () {
+      expect(
+        () => expectExactNormalizedTranscript(
+          actual: '  Hello   World ',
+          expected: 'hello world',
+          label: 'row1.fixture',
+        ),
+        returnsNormally,
+      );
+      expect(
+        () => expectExactNormalizedTranscript(
+          actual: 'hello world!',
+          expected: 'hello world',
+          label: 'row1.fixture',
+        ),
+        throwsA(isA<StateError>()),
+      );
+      expect(
+        () => expectExactNormalizedTranscript(
+          actual: 'hello world extra',
+          expected: 'hello world',
+          label: 'row1.fixture',
+        ),
+        throwsA(isA<StateError>()),
+      );
+    });
+
+    test('mismatch diagnostics never leak transcript content', () {
+      Object? captured;
+      try {
+        expectExactNormalizedTranscript(
+          actual: 'the launch codes are alpha bravo',
+          expected: 'entirely different phrase',
+          label: 'row1.fixture',
+        );
+      } catch (error) {
+        captured = error;
+      }
+
+      expect(captured, isA<StateError>());
+      final message = (captured! as StateError).message;
+      expect(message, contains('row1.fixture'));
+      expect(message, contains('actualSha'));
+      expect(message, contains('expectedSha'));
+      for (final word in <String>[
+        'launch',
+        'codes',
+        'alpha',
+        'bravo',
+        'entirely',
+        'different',
+        'phrase',
+      ]) {
+        expect(
+          message.toLowerCase(),
+          isNot(contains(word)),
+          reason: 'Diagnostic must not echo transcript token "$word".',
+        );
+      }
+    });
+
+    test('fingerprints are stable, short, and normalization-insensitive', () {
+      final a = transcriptFingerprint('  Hello   World  ');
+      final b = transcriptFingerprint('hello world');
+      expect(a, equals(b));
+      expect(a, hasLength(12));
+      expect(a, matches(RegExp(r'^[0-9a-f]{12}$')));
+      expect(a, isNot(equals(transcriptFingerprint('hello worlds'))));
+    });
+  });
+
+  group('Diagnostic sanitization', () {
+    test('collapses whitespace, strips control characters, and truncates', () {
+      final sanitized = sanitizeSpeechDiagnostic(
+        'line one\nline\ttwo   spaced',
+      );
+      expect(sanitized, equals('line one line two spaced'));
+
+      final long = sanitizeSpeechDiagnostic('x' * 400, maxLength: 32);
+      expect(long, hasLength(32));
+      expect(long, endsWith('...'));
+    });
+
+    test('produces a non-empty placeholder for blank input', () {
+      expect(sanitizeSpeechDiagnostic('   \n  '), equals('<empty>'));
+    });
+
+    test('error diagnostics fingerprint rather than echo sensitive text', () {
+      final diagnostic = safeSpeechErrorDiagnostic(
+        StateError(
+          'https://user:secret@example.invalid/private/model.gguf '
+          'the launch phrase is never printable',
+        ),
+      );
+
+      expect(diagnostic, startsWith('StateError#'));
+      expect(diagnostic, matches(RegExp(r'^[A-Za-z0-9_]+#[0-9a-f]{12}$')));
+      expect(diagnostic, isNot(contains('https://')));
+      expect(diagnostic, isNot(contains('secret')));
+      expect(diagnostic, isNot(contains('launch')));
+    });
+  });
+
+  group('Bounded awaits', () {
+    test('event collection remains awaitable after a stream error', () async {
+      final events = collectSpeechEvents<int>(
+        Stream<int>.error(StateError('event failure')),
+      );
+
+      await expectLater(events, throwsA(isA<StateError>()));
+    });
+
+    test('returns the value when the future settles in time', () async {
+      final value = await awaitBounded(
+        Future<int>.value(7),
+        const Duration(seconds: 5),
+        'unit value',
+      );
+      expect(value, equals(7));
+    });
+
+    test(
+      'throws an actionable TimeoutException naming the operation',
+      () async {
+        await expectLater(
+          awaitBounded(
+            Completer<void>().future,
+            const Duration(milliseconds: 20),
+            'row2.session.done',
+          ),
+          throwsA(
+            isA<TimeoutException>().having(
+              (e) => e.message ?? '',
+              'message',
+              allOf(contains('row2.session.done'), contains('20')),
+            ),
+          ),
+        );
+      },
+    );
+
+    test(
+      'requires an operation to remain active before cancellation',
+      () async {
+        final completer = Completer<void>();
+        await expectLater(
+          requireStillActiveBeforeCancellation(
+            completer.future,
+            Duration.zero,
+            'row1.cancel',
+          ),
+          completes,
+        );
+
+        await expectLater(
+          requireStillActiveBeforeCancellation(
+            Future<void>.value(),
+            Duration.zero,
+            'row1.cancel',
+          ),
+          throwsA(isA<StateError>()),
+        );
+      },
+    );
+
+    test('cleanup always runs without masking the primary failure', () async {
+      var cleanupRan = false;
+      await expectLater(
+        runWithSpeechCleanup(
+          body: () async => throw const AudioRecordingException(
+            AudioRecordingFailure.permissionDenied,
+            'permission denied',
+          ),
+          cleanup: () async {
+            cleanupRan = true;
+            throw StateError('cleanup failed');
+          },
+        ),
+        throwsA(
+          isA<AudioRecordingException>().having(
+            (error) => error.failure,
+            'failure',
+            AudioRecordingFailure.permissionDenied,
+          ),
+        ),
+      );
+      expect(cleanupRan, isTrue);
+
+      await expectLater(
+        runWithSpeechCleanup(
+          body: () async {},
+          cleanup: () async => throw StateError('cleanup failed'),
+        ),
+        throwsA(isA<StateError>()),
+      );
+    });
+  });
+
+  group('Streaming SHA-256 Verification', () {
+    late Directory tempDir;
+
+    setUp(() {
+      tempDir = Directory.systemTemp.createTempSync('speech_e2e_sha_test_');
+    });
+
+    tearDown(() {
+      tempDir.deleteSync(recursive: true);
+    });
+
+    test('computes exact streaming SHA-256 for a file', () async {
+      final testFile = File('${tempDir.path}/test.bin');
+      final bytes = Uint8List.fromList([1, 2, 3, 4, 5, 6, 7, 8, 9, 10]);
+      testFile.writeAsBytesSync(bytes, flush: true);
+
+      final expectedDigest = sha256.convert(bytes).toString();
+      final computed = await computeFileSha256(testFile.path);
+
+      expect(computed, equals(expectedDigest));
+    });
+
+    test('validates file checksum successfully on match', () async {
+      final testFile = File('${tempDir.path}/match.bin');
+      final bytes = Uint8List.fromList([10, 20, 30, 40]);
+      testFile.writeAsBytesSync(bytes, flush: true);
+
+      final expectedDigest = sha256.convert(bytes).toString();
+      await expectLater(
+        validateFileChecksum(testFile.path, expectedDigest),
+        completes,
+      );
+    });
+
+    test('bounds hashing without leaving the artifact locked', () async {
+      final testFile = File('${tempDir.path}/timeout.bin');
+      testFile.writeAsBytesSync(List<int>.filled(1024, 7), flush: true);
+
+      await expectLater(
+        computeFileSha256(testFile.path, timeout: Duration.zero),
+        throwsA(isA<TimeoutException>()),
+      );
+      await expectLater(testFile.delete(), completes);
+    });
+
+    test('throws on checksum mismatch', () async {
+      final testFile = File('${tempDir.path}/mismatch.bin');
+      testFile.writeAsBytesSync([1, 2, 3], flush: true);
+
+      const wrongDigest =
+          '0000000000000000000000000000000000000000000000000000000000000000';
+      await expectLater(
+        validateFileChecksum(testFile.path, wrongDigest),
+        throwsA(
+          isA<StateError>().having(
+            (e) => e.message,
+            'message',
+            contains('Checksum mismatch'),
+          ),
+        ),
+      );
+    });
+
+    test('throws when file does not exist', () async {
+      await expectLater(
+        validateFileChecksum(
+          '${tempDir.path}/nonexistent.bin',
+          '0000000000000000000000000000000000000000000000000000000000000000',
+        ),
+        throwsA(isA<FileSystemException>()),
+      );
+    });
+  });
+
+  group('PCM16 WAV Parsing and Validation', () {
+    test('WAV creation rejects invalid metadata and ragged frames', () {
+      expect(
+        () => createPcm16WavBytes(
+          samples: const <int>[1],
+          sampleRate: 0,
+          channels: 1,
+        ),
+        throwsA(isA<ArgumentError>()),
+      );
+      expect(
+        () => createPcm16WavBytes(
+          samples: const <int>[1],
+          sampleRate: 16000,
+          channels: 0,
+        ),
+        throwsA(isA<ArgumentError>()),
+      );
+      expect(
+        () => createPcm16WavBytes(
+          samples: const <int>[1, 2, 3],
+          sampleRate: 16000,
+          channels: 2,
+        ),
+        throwsA(isA<ArgumentError>()),
+      );
+      expect(
+        () => createPcm16WavBytes(
+          samples: const <int>[40000],
+          sampleRate: 16000,
+          channels: 1,
+        ),
+        throwsA(isA<ArgumentError>()),
+        reason: 'PCM16 creation must not silently wrap out-of-range samples.',
+      );
+    });
+
+    test('validates 16 kHz mono PCM16 WAV and decodes to Float32List', () {
+      final samples = <int>[100, -100, 200, -200, 300, -300];
+      final wav = createPcm16WavBytes(
+        samples: samples,
+        sampleRate: 16000,
+        channels: 1,
+      );
+
+      final info = validatePcm16Wav(
+        wav,
+        expectedSampleRate: 16000,
+        expectedChannels: 1,
+      );
+
+      expect(info.sampleRate, equals(16000));
+      expect(info.channels, equals(1));
+      expect(info.sampleFrames, equals(6));
+      expect(info.peakAmplitude, equals(300));
+      expect(info.durationSeconds, closeTo(6 / 16000, 0.00001));
+
+      final floatSamples = decodePcm16WavToFloat32(
+        wav,
+        expectedSampleRate: 16000,
+        expectedChannels: 1,
+      );
+
+      expect(floatSamples.length, equals(6));
+      expect(floatSamples[0], closeTo(100 / 32768.0, 0.0001));
+      expect(floatSamples[1], closeTo(-100 / 32768.0, 0.0001));
+      expect(floatSamples[4], closeTo(300 / 32768.0, 0.0001));
+    });
+
+    test('validates 24 kHz mono PCM16 TTS WAV format and signal', () {
+      final samples = List<int>.generate(2400, (i) => ((i % 100) * 100) - 5000);
+      final wav = createPcm16WavBytes(
+        samples: samples,
+        sampleRate: 24000,
+        channels: 1,
+      );
+
+      final info = validatePcm16Wav(
+        wav,
+        expectedSampleRate: 24000,
+        expectedChannels: 1,
+      );
+
+      expect(info.sampleRate, equals(24000));
+      expect(info.channels, equals(1));
+      expect(info.sampleFrames, equals(2400));
+      expect(info.durationSeconds, closeTo(0.1, 0.0001));
+      expect(info.peakAmplitude, greaterThan(0));
+      expect(info.rmsAmplitude, greaterThan(0));
+    });
+
+    test('rejects silent WAV when requireNonSilent is true', () {
+      final silentWav = createPcm16WavBytes(
+        samples: List<int>.filled(1600, 0),
+        sampleRate: 16000,
+        channels: 1,
+      );
+
+      expect(
+        () => validatePcm16Wav(
+          silentWav,
+          expectedSampleRate: 16000,
+          expectedChannels: 1,
+          requireNonSilent: true,
+        ),
+        throwsA(isA<FormatException>()),
+      );
+    });
+
+    test('rejects invalid sample rate and channel count', () {
+      final wav = createPcm16WavBytes(
+        samples: [100, 200],
+        sampleRate: 44100,
+        channels: 2,
+      );
+
+      expect(
+        () => validatePcm16Wav(
+          wav,
+          expectedSampleRate: 16000,
+          expectedChannels: 1,
+        ),
+        throwsA(isA<FormatException>()),
+      );
+    });
+
+    test('rejects malformed, empty, and truncated WAV files', () {
+      expect(
+        () => validatePcm16Wav(Uint8List.fromList('not a wav file'.codeUnits)),
+        throwsA(isA<FormatException>()),
+      );
+
+      final validWav = createPcm16WavBytes(
+        samples: [100, 200, 300],
+        sampleRate: 16000,
+        channels: 1,
+      );
+      expect(
+        () => validatePcm16Wav(validWav.sublist(0, 30)),
+        throwsA(isA<FormatException>()),
+      );
+      expect(
+        () => validatePcm16Wav(Uint8List(0)),
+        throwsA(isA<FormatException>()),
+      );
+    });
+
+    test('rejects a RIFF size field inconsistent with the file length', () {
+      final wav = createPcm16WavBytes(
+        samples: [100, 200, 300, 400],
+        sampleRate: 16000,
+        channels: 1,
+      );
+
+      expect(
+        () => validatePcm16Wav(_withUint32(wav, 4, wav.length + 512)),
+        throwsA(isA<FormatException>()),
+        reason: 'Oversized RIFF size must be rejected.',
+      );
+      expect(
+        () => validatePcm16Wav(_withUint32(wav, 4, 8)),
+        throwsA(isA<FormatException>()),
+        reason: 'Undersized RIFF size must be rejected.',
+      );
+    });
+
+    test('rejects a data chunk whose declared length is inconsistent', () {
+      final wav = createPcm16WavBytes(
+        samples: [100, 200, 300, 400],
+        sampleRate: 16000,
+        channels: 1,
+      );
+
+      expect(
+        () => validatePcm16Wav(_withUint32(wav, 40, 0)),
+        throwsA(isA<FormatException>()),
+        reason: 'Empty data chunk must be rejected.',
+      );
+      expect(
+        () => validatePcm16Wav(_withUint32(wav, 40, 7)),
+        throwsA(isA<FormatException>()),
+        reason: 'Odd data length cannot hold whole PCM16 samples.',
+      );
+      expect(
+        () => validatePcm16Wav(_withUint32(wav, 40, wav.length)),
+        throwsA(isA<FormatException>()),
+        reason: 'Data chunk overrunning the file must be rejected.',
+      );
+    });
+
+    test('rejects a data length that is not a whole number of frames', () {
+      final stereo = createPcm16WavBytes(
+        samples: [100, 200, 300, 400],
+        sampleRate: 16000,
+        channels: 2,
+      );
+      // 6 bytes = 3 samples = 1.5 stereo frames.
+      final ragged = _withUint32(_withUint32(stereo, 4, 42), 40, 6);
+
+      expect(
+        () => validatePcm16Wav(ragged, expectedChannels: 2),
+        throwsA(isA<FormatException>()),
+      );
+    });
+
+    test('rejects inconsistent fmt metadata', () {
+      final wav = createPcm16WavBytes(
+        samples: [100, 200, 300, 400],
+        sampleRate: 16000,
+        channels: 1,
+      );
+
+      expect(
+        () => validatePcm16Wav(_withUint16(wav, 22, 0)),
+        throwsA(isA<FormatException>()),
+        reason: 'Zero channels must be rejected before any division.',
+      );
+      expect(
+        () => validatePcm16Wav(_withUint32(wav, 24, 0)),
+        throwsA(isA<FormatException>()),
+        reason: 'Zero sample rate must be rejected before duration math.',
+      );
+      expect(
+        () => validatePcm16Wav(_withUint32(wav, 28, 12345)),
+        throwsA(isA<FormatException>()),
+        reason: 'byteRate must agree with rate * channels * bytesPerSample.',
+      );
+      expect(
+        () => validatePcm16Wav(_withUint16(wav, 32, 9)),
+        throwsA(isA<FormatException>()),
+        reason: 'blockAlign must agree with channels * bytesPerSample.',
+      );
+      expect(
+        () => validatePcm16Wav(_withUint16(wav, 34, 24)),
+        throwsA(isA<FormatException>()),
+        reason: 'Only 16-bit PCM is accepted.',
+      );
+      expect(
+        () => validatePcm16Wav(_withUint16(wav, 20, 3)),
+        throwsA(isA<FormatException>()),
+        reason: 'Only uncompressed PCM format 1 is accepted.',
+      );
+    });
+
+    test('rejects trailing bytes after the final chunk', () {
+      final wav = createPcm16WavBytes(
+        samples: [100, 200, 300, 400],
+        sampleRate: 16000,
+        channels: 1,
+      );
+      final padded = Uint8List(wav.length + 3)..setRange(0, wav.length, wav);
+      final withRiffSize = _withUint32(padded, 4, padded.length - 8);
+
+      expect(
+        () => validatePcm16Wav(withRiffSize),
+        throwsA(isA<FormatException>()),
+      );
+    });
+
+    test('rejects data before fmt and a missing odd-chunk pad byte', () {
+      final wav = createPcm16WavBytes(
+        samples: [100, 200, 300, 400],
+        sampleRate: 16000,
+        channels: 1,
+      );
+      final reordered = Uint8List(wav.length)
+        ..setRange(0, 12, wav)
+        ..setRange(12, wav.length - 24, wav, 36)
+        ..setRange(wav.length - 24, wav.length, wav, 12);
+      expect(
+        () => validatePcm16Wav(reordered),
+        throwsA(isA<FormatException>()),
+        reason: 'Strict PCM WAV requires fmt before the audio data chunk.',
+      );
+
+      final missingPad = Uint8List(wav.length + 9)
+        ..setRange(0, wav.length, wav)
+        ..setRange(wav.length, wav.length + 4, 'JUNK'.codeUnits);
+      final missingPadData = ByteData.sublistView(missingPad)
+        ..setUint32(wav.length + 4, 1, Endian.little)
+        ..setUint8(wav.length + 8, 7)
+        ..setUint32(4, missingPad.length - 8, Endian.little);
+      expect(missingPadData.getUint8(wav.length + 8), 7);
+      expect(
+        () => validatePcm16Wav(missingPad),
+        throwsA(isA<FormatException>()),
+        reason: 'Odd-sized RIFF chunks require a physical pad byte.',
+      );
+    });
+
+    test('rejects a WAV that declares no data chunk at all', () {
+      final wav = createPcm16WavBytes(
+        samples: [100, 200],
+        sampleRate: 16000,
+        channels: 1,
+      );
+      final headerOnly = Uint8List.fromList(wav.sublist(0, 36));
+      final fixed = _withUint32(headerOnly, 4, headerOnly.length - 8);
+
+      expect(() => validatePcm16Wav(fixed), throwsA(isA<FormatException>()));
+    });
+
+    test('decoding also enforces strict metadata and non-silence', () {
+      final wav = createPcm16WavBytes(
+        samples: [100, 200, 300, 400],
+        sampleRate: 16000,
+        channels: 1,
+      );
+
+      expect(
+        () => decodePcm16WavToFloat32(_withUint32(wav, 40, 7)),
+        throwsA(isA<FormatException>()),
+      );
+      expect(
+        () => decodePcm16WavToFloat32(
+          createPcm16WavBytes(
+            samples: List<int>.filled(64, 0),
+            sampleRate: 16000,
+            channels: 1,
+          ),
+        ),
+        throwsA(isA<FormatException>()),
+        reason: 'A silent ASR fixture is not usable input.',
+      );
+    });
+  });
+
+  group('Bounded PCM chunking', () {
+    test('splits samples into bounded chunks covering every sample', () {
+      final samples = Float32List.fromList(
+        List<double>.generate(4001, (i) => i / 4001.0),
+      );
+      final chunks = chunkPcmSamples(samples, 1600).toList();
+
+      expect(chunks, hasLength(3));
+      expect(chunks[0], hasLength(1600));
+      expect(chunks[1], hasLength(1600));
+      expect(chunks[2], hasLength(801));
+      expect(
+        chunks.fold<int>(0, (sum, c) => sum + c.length),
+        equals(samples.length),
+      );
+      expect(chunks.every((c) => c.length <= 1600), isTrue);
+    });
+
+    test('rejects an empty buffer and a non-positive chunk size', () {
+      expect(
+        () => chunkPcmSamples(Float32List(0), 1600).toList(),
+        throwsA(isA<ArgumentError>()),
+      );
+      expect(
+        () => chunkPcmSamples(Float32List(10), 0).toList(),
+        throwsA(isA<ArgumentError>()),
+      );
+    });
+  });
+
+  group('TTS result plausibility', () {
+    test('accepts a coherent frame, sample, and duration relation', () {
+      expect(
+        () => validateTtsResultPlausibility(
+          framesGenerated: 24000,
+          maxFrames: 48000,
+          sampleFrames: 24000,
+          sampleRateHz: 24000,
+          channelCount: 1,
+          duration: const Duration(seconds: 1),
+          label: 'row3.synthesis',
+        ),
+        returnsNormally,
+      );
+    });
+
+    test('rejects zero frames and frames beyond the configured maximum', () {
+      expect(
+        () => validateTtsResultPlausibility(
+          framesGenerated: 0,
+          maxFrames: 48000,
+          sampleFrames: 0,
+          sampleRateHz: 24000,
+          channelCount: 1,
+          duration: Duration.zero,
+          label: 'row3.synthesis',
+        ),
+        throwsA(isA<StateError>()),
+      );
+      expect(
+        () => validateTtsResultPlausibility(
+          framesGenerated: 48001,
+          maxFrames: 48000,
+          sampleFrames: 48001,
+          sampleRateHz: 24000,
+          channelCount: 1,
+          duration: const Duration(seconds: 2),
+          label: 'row3.synthesis',
+        ),
+        throwsA(isA<StateError>()),
+      );
+    });
+
+    test('rejects a duration that contradicts the sample count', () {
+      expect(
+        () => validateTtsResultPlausibility(
+          framesGenerated: 24000,
+          maxFrames: 48000,
+          sampleFrames: 24000,
+          sampleRateHz: 24000,
+          channelCount: 1,
+          duration: const Duration(seconds: 9),
+          label: 'row3.synthesis',
+        ),
+        throwsA(isA<StateError>()),
+      );
+    });
+
+    test('does not confuse codec frames with decoded PCM sample frames', () {
+      expect(
+        () => validateTtsResultPlausibility(
+          framesGenerated: 512,
+          maxFrames: 512,
+          sampleFrames: 240000,
+          sampleRateHz: 24000,
+          channelCount: 1,
+          duration: const Duration(seconds: 10),
+          label: 'row3.synthesis',
+        ),
+        returnsNormally,
+        reason:
+            'TextToSpeechResult.framesGenerated counts audio-codec frames, '
+            'not decoded PCM sample frames.',
+      );
+    });
+
+    test('rejects degenerate rate, channel, and sample values', () {
+      expect(
+        () => validateTtsResultPlausibility(
+          framesGenerated: 10,
+          maxFrames: 100,
+          sampleFrames: 10,
+          sampleRateHz: 0,
+          channelCount: 1,
+          duration: const Duration(milliseconds: 1),
+          label: 'row3.synthesis',
+        ),
+        throwsA(isA<StateError>()),
+      );
+      expect(
+        () => validateTtsResultPlausibility(
+          framesGenerated: 10,
+          maxFrames: 100,
+          sampleFrames: 0,
+          sampleRateHz: 24000,
+          channelCount: 1,
+          duration: const Duration(milliseconds: 1),
+          label: 'row3.synthesis',
+        ),
+        throwsA(isA<StateError>()),
+      );
+      expect(
+        () => validateTtsResultPlausibility(
+          framesGenerated: 10,
+          maxFrames: 100,
+          sampleFrames: 10,
+          sampleRateHz: 24000,
+          channelCount: 0,
+          duration: const Duration(milliseconds: 1),
+          label: 'row3.synthesis',
+        ),
+        throwsA(isA<StateError>()),
+      );
+    });
+  });
+
+  group('Result Reporting and Count Validation', () {
+    test('emits one machine-readable JSON RESULT record', () {
+      final row = SpeechE2ERowResult(
+        id: 'llama_cpp_qwen3_asr',
+        status: SpeechE2ERowStatus.pass,
+        backend: 'llama.cpp Metal',
+        duration: const Duration(milliseconds: 1250),
+        digestIdentifiers: {'model': '01234567', 'mmproj': '89abcdef'},
+        assertionSummary: 'verified caps, transcribed fixture, verified mic',
+      );
+
+      final decoded = _decodeResultLine(row.toResultLine());
+      expect(decoded['id'], equals('llama_cpp_qwen3_asr'));
+      expect(decoded['status'], equals('PASS'));
+      expect(decoded['backend'], equals('llama.cpp Metal'));
+      expect(decoded['elapsedMs'], equals(1250));
+      expect(
+        decoded['digests'],
+        equals({'model': '01234567', 'mmproj': '89abcdef'}),
+      );
+      expect(
+        decoded['assertions'],
+        equals('verified caps, transcribed fixture, verified mic'),
+      );
+      expect(decoded.containsKey('error'), isFalse);
+      expect(decoded.containsKey('action'), isFalse);
+    });
+
+    test('serializes fingerprinted errors and action markers', () {
+      final row = SpeechE2ERowResult(
+        id: 'litert_lm_streaming_asr',
+        status: SpeechE2ERowStatus.unavailable,
+        backend: 'LiteRT-LM "CPU" backend',
+        duration: const Duration(milliseconds: 40),
+        error: const AudioRecordingException(
+          AudioRecordingFailure.permissionDenied,
+          'Microphone "access" denied\nby the user at /private/path.',
+        ),
+        actionMarker: microphonePermissionActionMarker,
+      );
+
+      final line = row.toResultLine();
+      expect(line, isNot(contains('\n')));
+
+      final decoded = _decodeResultLine(line);
+      expect(decoded['status'], equals('UNAVAILABLE'));
+      expect(decoded['backend'], equals('LiteRT-LM "CPU" backend'));
+      expect(
+        decoded['error'],
+        equals('AudioRecordingException:permissionDenied'),
+      );
+      expect(line, isNot(contains('/private/path')));
+      expect(line, isNot(contains('access')));
+      expect(decoded['action'], equals(microphonePermissionActionMarker));
+    });
+
+    test('validates strict summary counts on expected 3 PASS, 1 UNSUPPORTED', () {
+      final rows = [
+        SpeechE2ERowResult(
+          id: 'llama_cpp_qwen3_asr',
+          status: SpeechE2ERowStatus.pass,
+          backend: 'llama.cpp Metal',
+          duration: const Duration(seconds: 2),
+        ),
+        SpeechE2ERowResult(
+          id: 'litert_lm_streaming_asr',
+          status: SpeechE2ERowStatus.pass,
+          backend: 'LiteRT-LM ASR CPU',
+          duration: const Duration(seconds: 1),
+        ),
+        SpeechE2ERowResult(
+          id: 'llama_cpp_qwen3_tts',
+          status: SpeechE2ERowStatus.pass,
+          backend: 'llama.cpp Metal',
+          duration: const Duration(seconds: 3),
+        ),
+        SpeechE2ERowResult(
+          id: 'litert_lm_tts',
+          status: SpeechE2ERowStatus.unsupported,
+          backend: 'LiteRT-LM',
+          duration: const Duration(milliseconds: 50),
+        ),
+      ];
+
+      final summary = SpeechE2ESummary(rows);
+      expect(summary.total, equals(4));
+      expect(summary.passCount, equals(3));
+      expect(summary.unsupportedCount, equals(1));
+      expect(summary.failCount, equals(0));
+      expect(summary.unavailableCount, equals(0));
+
+      expect(() => summary.validateRowIds(), returnsNormally);
+      expect(() => summary.validateStrictCounts(), returnsNormally);
+
+      expect(
+        summary.toSummaryLine(),
+        equals(
+          'SUMMARY physical_ios_speech total=4 pass=3 unsupported=1 fail=0 unavailable=0',
+        ),
+      );
+    });
+
+    test(
+      'rejects summary when counts do not match expected strict standard',
+      () {
+        final failureRows = [
+          SpeechE2ERowResult(
+            id: 'llama_cpp_qwen3_asr',
+            status: SpeechE2ERowStatus.pass,
+            backend: 'backend1',
+            duration: Duration.zero,
+          ),
+          SpeechE2ERowResult(
+            id: 'litert_lm_streaming_asr',
+            status: SpeechE2ERowStatus.fail,
+            backend: 'backend2',
+            duration: Duration.zero,
+          ),
+          SpeechE2ERowResult(
+            id: 'litert_lm_tts',
+            status: SpeechE2ERowStatus.unsupported,
+            backend: 'backend3',
+            duration: Duration.zero,
+          ),
+        ];
+
+        final summary = SpeechE2ESummary(failureRows);
+        expect(
+          () => summary.validateStrictCounts(),
+          throwsA(isA<StateError>()),
+        );
+      },
+    );
+
+    test('rejects duplicate row identifiers', () {
+      final summary = SpeechE2ESummary([
+        for (final id in <String>[
+          'llama_cpp_qwen3_asr',
+          'llama_cpp_qwen3_asr',
+          'llama_cpp_qwen3_tts',
+          'litert_lm_tts',
+        ])
+          SpeechE2ERowResult(
+            id: id,
+            status: SpeechE2ERowStatus.pass,
+            backend: 'b',
+            duration: Duration.zero,
+          ),
+      ]);
+
+      expect(
+        () => summary.validateRowIds(),
+        throwsA(
+          isA<StateError>().having(
+            (e) => e.message,
+            'message',
+            allOf(contains('Duplicate'), contains('llama_cpp_qwen3_asr')),
+          ),
+        ),
+      );
+    });
+
+    test('rejects missing and unknown row identifiers', () {
+      final missing = SpeechE2ESummary([
+        SpeechE2ERowResult(
+          id: 'llama_cpp_qwen3_asr',
+          status: SpeechE2ERowStatus.pass,
+          backend: 'b',
+          duration: Duration.zero,
+        ),
+      ]);
+      expect(
+        () => missing.validateRowIds(),
+        throwsA(
+          isA<StateError>().having(
+            (e) => e.message,
+            'message',
+            contains('Missing'),
+          ),
+        ),
+      );
+
+      final unknown = SpeechE2ESummary([
+        for (final id in <String>[...speechE2ERowIds, 'rogue_row'])
+          SpeechE2ERowResult(
+            id: id,
+            status: SpeechE2ERowStatus.pass,
+            backend: 'b',
+            duration: Duration.zero,
+          ),
+      ]);
+      expect(
+        () => unknown.validateRowIds(),
+        throwsA(
+          isA<StateError>().having(
+            (e) => e.message,
+            'message',
+            contains('rogue_row'),
+          ),
+        ),
+      );
+    });
+
+    test('declares exactly the four canonical row identifiers', () {
+      expect(speechE2ERowIds, hasLength(4));
+      expect(
+        speechE2ERowIds,
+        containsAll(<String>[
+          'llama_cpp_qwen3_asr',
+          'litert_lm_streaming_asr',
+          'llama_cpp_qwen3_tts',
+          'litert_lm_tts',
+        ]),
+      );
+    });
+  });
+
+  group('Cancellation and Classification Helpers', () {
+    test('distinguishes physical iOS hardware from simulator machines', () {
+      expect(isPhysicalIosMachineIdentifier('iPhone17,2'), isTrue);
+      expect(isPhysicalIosMachineIdentifier('iPad14,6'), isTrue);
+      expect(isPhysicalIosMachineIdentifier('iPod9,1'), isTrue);
+      expect(isPhysicalIosMachineIdentifier('arm64'), isFalse);
+      expect(isPhysicalIosMachineIdentifier('x86_64'), isFalse);
+      expect(isPhysicalIosMachineIdentifier('iPhone Simulator'), isFalse);
+      expect(isPhysicalIosMachineIdentifier(''), isFalse);
+    });
+
+    test(
+      'requires exact runtime backend families and canonicalizes labels',
+      () {
+        expect(
+          requireSpeechBackendIdentity(
+            'Metal',
+            SpeechE2EBackendKind.llamaCppMetal,
+          ),
+          'llama.cpp Metal',
+        );
+        expect(
+          requireSpeechBackendIdentity(
+            'LiteRT-LM ASR CPU',
+            SpeechE2EBackendKind.liteRtLmAsrCpu,
+          ),
+          'LiteRT-LM ASR CPU',
+        );
+        expect(
+          requireSpeechBackendIdentity(
+            'LiteRT-LM CPU',
+            SpeechE2EBackendKind.liteRtLm,
+          ),
+          'LiteRT-LM',
+        );
+        expect(
+          () => requireSpeechBackendIdentity(
+            'LiteRT-LM Metal',
+            SpeechE2EBackendKind.llamaCppMetal,
+          ),
+          throwsA(isA<StateError>()),
+        );
+        expect(
+          () => requireSpeechBackendIdentity(
+            'Metal',
+            SpeechE2EBackendKind.liteRtLm,
+          ),
+          throwsA(isA<StateError>()),
+        );
+      },
+    );
+
+    test('verifies STT and TTS cancellation terminal states', () {
+      const sttCancelled = SpeechToTextCompletion.cancelled();
+      expect(verifySttCancellation(sttCancelled), isTrue);
+
+      final sttCompleted = SpeechToTextCompletion.completed(
+        const SpeechToTextResult(text: 'test'),
+      );
+      expect(verifySttCancellation(sttCompleted), isFalse);
+
+      const ttsCancelled = TextToSpeechCompletion.cancelled();
+      expect(verifyTtsCancellation(ttsCancelled), isTrue);
+
+      final ttsCompleted = TextToSpeechCompletion.completed(
+        TextToSpeechResult(
+          samples: Float32List(0),
+          sampleRateHz: 24000,
+          channelCount: 1,
+          framesGenerated: 0,
+          truncated: false,
+        ),
+      );
+      expect(verifyTtsCancellation(ttsCompleted), isFalse);
+    });
+
+    test('requires real generation progress before cancelling', () {
+      expect(
+        shouldCancelOnTtsProgress(
+          const TextToSpeechProgressEvent(
+            phase: TextToSpeechProgressPhase.processingPrompt,
+            promptTokensRemaining: 12,
+            framesGenerated: 0,
+            truncated: false,
+          ),
+        ),
+        isFalse,
+        reason: 'Prompt-phase progress is not evidence of real synthesis.',
+      );
+      expect(
+        shouldCancelOnTtsProgress(
+          const TextToSpeechProgressEvent(
+            phase: TextToSpeechProgressPhase.generating,
+            promptTokensRemaining: 0,
+            framesGenerated: 0,
+            truncated: false,
+          ),
+        ),
+        isFalse,
+        reason: 'Generation phase without frames is not real progress yet.',
+      );
+      expect(
+        shouldCancelOnTtsProgress(
+          const TextToSpeechProgressEvent(
+            phase: TextToSpeechProgressPhase.generating,
+            promptTokensRemaining: 0,
+            framesGenerated: 128,
+            truncated: false,
+          ),
+        ),
+        isTrue,
+      );
+    });
+
+    test('classifies LiteRT-LM unsupported TTS capabilities correctly', () {
+      const unsupportedCaps = TextToSpeechCapabilities(
+        isSupported: false,
+        unsupportedReason:
+            'The active backend does not expose dedicated text-to-speech.',
+        backendName: 'LiteRT-LM',
+      );
+
+      final status = classifyLiteRtLmTtsSupport(unsupportedCaps);
+      expect(status, equals(SpeechE2ERowStatus.unsupported));
+
+      const unexpectedlySupported = TextToSpeechCapabilities(
+        isSupported: true,
+        backendName: 'LiteRT-LM',
+      );
+      expect(
+        () => classifyLiteRtLmTtsSupport(unexpectedlySupported),
+        throwsA(
+          isA<StateError>().having(
+            (e) => e.message,
+            'message',
+            contains('unexpectedly supported'),
+          ),
+        ),
+      );
+
+      const blankReason = TextToSpeechCapabilities(
+        isSupported: false,
+        unsupportedReason: '   ',
+        backendName: 'LiteRT-LM',
+      );
+      expect(
+        () => classifyLiteRtLmTtsSupport(blankReason),
+        throwsA(isA<StateError>()),
+      );
+
+      const wrongBackend = TextToSpeechCapabilities(
+        isSupported: false,
+        unsupportedReason: 'No TTS implementation.',
+        backendName: 'Metal',
+      );
+      expect(
+        () => classifyLiteRtLmTtsSupport(wrongBackend),
+        throwsA(isA<StateError>()),
+        reason: 'An unsupported llama.cpp route is not LiteRT-LM evidence.',
+      );
+    });
+
+    test('verifies typed LiteRT-LM TTS synthesis error', () {
+      final unsupportedException = LlamaUnsupportedException('TTS unsupported');
+      expect(verifyLiteRtLmTtsSynthesisError(unsupportedException), isTrue);
+
+      expect(
+        () => verifyLiteRtLmTtsSynthesisError(Exception('Generic failure')),
+        throwsA(isA<StateError>()),
+      );
+      Object? sanitizedFailure;
+      try {
+        verifyLiteRtLmTtsSynthesisError(
+          Exception(
+            'https://user:token@example.invalid/model '
+            'private transcript words',
+          ),
+        );
+      } catch (error) {
+        sanitizedFailure = error;
+      }
+      expect(sanitizedFailure, isA<StateError>());
+      expect(sanitizedFailure.toString(), isNot(contains('https://')));
+      expect(sanitizedFailure.toString(), isNot(contains('token')));
+      expect(sanitizedFailure.toString(), isNot(contains('transcript words')));
+      expect(
+        () => verifyLiteRtLmTtsSynthesisError(
+          LlamaStateException('Load a projector first.'),
+        ),
+        throwsA(isA<StateError>()),
+        reason: 'A state error is a defect, not an unsupported classification.',
+      );
+    });
+
+    test('classifies microphone permission denial as UNAVAILABLE', () {
+      const denied = AudioRecordingException(
+        AudioRecordingFailure.permissionDenied,
+        'Microphone permission was denied.',
+      );
+
+      expect(
+        classifySpeechRowFailure(denied),
+        equals(SpeechE2ERowStatus.unavailable),
+      );
+      expect(
+        speechRowFailureMarker(denied),
+        equals(microphonePermissionActionMarker),
+      );
+    });
+
+    test('classifies an unsupported recorder as UNAVAILABLE', () {
+      const unsupported = AudioRecordingException(
+        AudioRecordingFailure.unsupported,
+        'No recorder on this runtime.',
+      );
+
+      expect(
+        classifySpeechRowFailure(unsupported),
+        equals(SpeechE2ERowStatus.unavailable),
+      );
+      expect(speechRowFailureMarker(unsupported), isNotNull);
+    });
+
+    test('classifies semantic, backend, and config defects as FAIL', () {
+      const startFailed = AudioRecordingException(
+        AudioRecordingFailure.startFailed,
+        'Recorder could not start.',
+      );
+      expect(
+        classifySpeechRowFailure(startFailed),
+        equals(SpeechE2ERowStatus.fail),
+      );
+      expect(speechRowFailureMarker(startFailed), isNull);
+
+      expect(
+        classifySpeechRowFailure(StateError('transcript mismatch')),
+        equals(SpeechE2ERowStatus.fail),
+      );
+      expect(
+        classifySpeechRowFailure(
+          ArgumentError.value('', 'IOS_SPEECH_TTS_TEXT', 'missing'),
+        ),
+        equals(SpeechE2ERowStatus.fail),
+      );
+      expect(
+        classifySpeechRowFailure(
+          TimeoutException('row1.fixture.done exceeded 600s'),
+        ),
+        equals(SpeechE2ERowStatus.fail),
+      );
+      expect(
+        classifySpeechRowFailure(LlamaUnsupportedException('nope')),
+        equals(SpeechE2ERowStatus.fail),
+      );
+    });
+  });
+}

--- a/lib/src/backends/llama_cpp/llama_cpp_backend.dart
+++ b/lib/src/backends/llama_cpp/llama_cpp_backend.dart
@@ -52,7 +52,7 @@ class NativeLlamaBackend
   NativeLlamaBackend({
     SendPort? initialSendPort,
     LlamaWorkerEntrypoint workerEntrypoint = llamaWorkerEntry,
-    Duration workerStartupTimeout = const Duration(seconds: 5),
+    Duration workerStartupTimeout = const Duration(seconds: 30),
   }) : _workerEntrypoint = workerEntrypoint,
        _workerStartupTimeout = workerStartupTimeout {
     if (initialSendPort != null) {

--- a/test/unit/backends/llama_cpp/llama_cpp_backend_test.dart
+++ b/test/unit/backends/llama_cpp/llama_cpp_backend_test.dart
@@ -774,6 +774,22 @@ void main() {
       }
     });
 
+    test('default startup timeout permits a slow native cold start', () async {
+      final backend = NativeLlamaBackend(
+        workerEntrypoint: _slowReusableWorkerEntry,
+      );
+
+      try {
+        final handle = await backend
+            .modelLoad('slow.gguf', const ModelParams())
+            .timeout(const Duration(seconds: 10));
+        expect(handle, 42);
+        expect(backend.isReady, isTrue);
+      } finally {
+        await backend.dispose().timeout(const Duration(seconds: 2));
+      }
+    });
+
     test('unexpected handshake response reports version skew', () async {
       final backend = NativeLlamaBackend(
         workerEntrypoint: _incompatibleHandshakeWorkerEntry,
@@ -854,6 +870,24 @@ void _delayedReusableWorkerEntry(SendPort initialSendPort) {
     switch (message) {
       case WorkerHandshake():
         await Future<void>.delayed(const Duration(milliseconds: 50));
+        message.sendPort.send(DoneResponse());
+      case ModelLoadRequest():
+        message.sendPort.send(HandleResponse(42));
+      case DisposeRequest():
+        message.sendPort.send(null);
+        receivePort.close();
+        Isolate.exit();
+    }
+  });
+}
+
+void _slowReusableWorkerEntry(SendPort initialSendPort) {
+  final receivePort = ReceivePort();
+  initialSendPort.send(receivePort.sendPort);
+  receivePort.listen((message) async {
+    switch (message) {
+      case WorkerHandshake():
+        await Future<void>.delayed(const Duration(milliseconds: 5200));
         message.sendPort.send(DoneResponse());
       case ModelLoadRequest():
         message.sendPort.send(HandleResponse(42));

--- a/test/unit/tooling/test_matrix_test.dart
+++ b/test/unit/tooling/test_matrix_test.dart
@@ -73,19 +73,59 @@ void main() {
       );
     });
 
-    test('physical iOS speech row runs the local-only tagged target', () {
+    test('physical iOS speech row uses wireless-capable Flutter drive', () {
       final row = testMatrixRows.singleWhere(
         (row) => row.id == 'physical-ios-speech-e2e',
       );
 
-      // The chat-app dart_test.yaml marks local-only as `skip`, so omitting
-      // these flags silently passes the harness without running it.
-      expect(row.command, contains('--run-skipped'));
-      expect(row.command, contains('-t local-only'));
+      // `flutter test` cannot start a wirelessly tethered physical iOS app.
+      // Drive publishes a VM-service port and runs the integration driver.
       expect(row.command, contains('--no-pub'));
-      expect(row.command, contains('--no-uninstall'));
+      expect(row.command, contains('--publish-port'));
+      expect(row.command, contains('--no-start-paused'));
+      expect(
+        row.command,
+        contains(r'--device-vmservice-port="$IOS_SPEECH_DEVICE_VM_PORT"'),
+      );
+      expect(
+        row.command,
+        contains(r'--host-vmservice-port="$IOS_SPEECH_HOST_VM_PORT"'),
+      );
+      expect(
+        row.command,
+        contains('--driver=test_driver/integration_test.dart'),
+      );
+      expect(
+        row.command,
+        contains('--target=integration_test/physical_ios_speech_e2e_test.dart'),
+      );
+      expect(
+        row.command,
+        contains('--timeout=21600'),
+        reason: 'The drive host must allow the target\'s six-hour timeout.',
+      );
       expect(row.command, contains('cd example/chat_app'));
-      expect(row.command, contains('flutter test'));
+      expect(row.command, contains('flutter drive'));
+      expect(row.command, isNot(contains('flutter test')));
+      expect(row.command, isNot(contains('--run-skipped')));
+      expect(row.command, isNot(contains(' --no-uninstall ')));
+      expect(
+        row.command,
+        isNot(contains('--no-uninstall-first')),
+        reason: '`uninstall-first` is a flutter run flag, not a drive flag.',
+      );
+    });
+
+    test('physical iOS speech row documents app-cache relative paths', () {
+      final row = testMatrixRows.singleWhere(
+        (row) => row.id == 'physical-ios-speech-e2e',
+      );
+
+      // Installing rotates the data-container UUID, so an operator who pins
+      // absolute container paths gets unreadable artifacts.
+      expect(row.useWhen, contains('@appcache/'));
+      expect(row.useWhen, contains('data-container UUID'));
+      expect(row.useWhen, contains('absolute'));
     });
 
     test('physical iOS speech row targets a physical device only', () {
@@ -101,6 +141,19 @@ void main() {
       expect(row.command.toLowerCase(), isNot(contains('https://')));
       expect(row.command.toLowerCase(), isNot(contains('playback')));
       expect(row.command.toLowerCase(), isNot(contains('--run-skipped-if')));
+      expect(row.command, isNot(contains('/Containers/Data/Application/')));
+      expect(
+        row.command,
+        isNot(
+          matches(
+            RegExp(
+              r'[0-9A-Fa-f]{8}-[0-9A-Fa-f]{4}-[0-9A-Fa-f]{4}-'
+              r'[0-9A-Fa-f]{4}-[0-9A-Fa-f]{12}',
+            ),
+          ),
+        ),
+        reason: 'The command must never pin an install-specific container ID.',
+      );
       expect(row.covers.toLowerCase(), isNot(contains('simulator')));
     });
 

--- a/test/unit/tooling/test_matrix_test.dart
+++ b/test/unit/tooling/test_matrix_test.dart
@@ -51,6 +51,110 @@ void main() {
       expect(ids, contains('web-real-model-smoke'));
       expect(ids, contains('webgpu-multimodal-regression'));
       expect(ids, contains('gemma4-webgpu-mem64'));
+      expect(ids, contains('physical-ios-speech-e2e'));
+    });
+
+    test('includes targeted physical iOS speech E2E row', () {
+      final row = testMatrixRows.singleWhere(
+        (row) => row.id == 'physical-ios-speech-e2e',
+      );
+      expect(row.tier, equals('targeted'));
+      expect(row.mode, contains('device'));
+      expect(row.covers, contains('physical iOS'));
+      expect(row.covers, contains('immutable local artifacts'));
+      expect(row.covers, contains('no audio playback'));
+      expect(row.covers, contains('llama.cpp Qwen3-ASR'));
+      expect(row.covers, contains('LiteRT-LM streaming ASR'));
+      expect(row.covers, contains('llama.cpp Qwen3-TTS'));
+      expect(row.covers, contains('LiteRT-LM TTS'));
+      expect(
+        row.command,
+        contains('integration_test/physical_ios_speech_e2e_test.dart'),
+      );
+    });
+
+    test('physical iOS speech row runs the local-only tagged target', () {
+      final row = testMatrixRows.singleWhere(
+        (row) => row.id == 'physical-ios-speech-e2e',
+      );
+
+      // The chat-app dart_test.yaml marks local-only as `skip`, so omitting
+      // these flags silently passes the harness without running it.
+      expect(row.command, contains('--run-skipped'));
+      expect(row.command, contains('-t local-only'));
+      expect(row.command, contains('--no-pub'));
+      expect(row.command, contains('--no-uninstall'));
+      expect(row.command, contains('cd example/chat_app'));
+      expect(row.command, contains('flutter test'));
+    });
+
+    test('physical iOS speech row targets a physical device only', () {
+      final row = testMatrixRows.singleWhere(
+        (row) => row.id == 'physical-ios-speech-e2e',
+      );
+
+      expect(row.command, contains(r'-d "$PHYSICAL_IOS_DEVICE_ID"'));
+      expect(row.command, isNot(contains('<physical-ios-device-id>')));
+      expect(row.command, isNot(matches(RegExp(r'(^|\s)<[^>]+>'))));
+      expect(row.command.toLowerCase(), isNot(contains('simulator')));
+      expect(row.command.toLowerCase(), isNot(contains('http://')));
+      expect(row.command.toLowerCase(), isNot(contains('https://')));
+      expect(row.command.toLowerCase(), isNot(contains('playback')));
+      expect(row.command.toLowerCase(), isNot(contains('--run-skipped-if')));
+      expect(row.covers.toLowerCase(), isNot(contains('simulator')));
+    });
+
+    test('physical iOS speech row passes every required dart define', () {
+      final row = testMatrixRows.singleWhere(
+        (row) => row.id == 'physical-ios-speech-e2e',
+      );
+
+      const requiredDefines = <String>[
+        'IOS_SPEECH_QWEN3_ASR_MODEL_PATH',
+        'IOS_SPEECH_QWEN3_ASR_MODEL_SHA256',
+        'IOS_SPEECH_QWEN3_ASR_MMPROJ_PATH',
+        'IOS_SPEECH_QWEN3_ASR_MMPROJ_SHA256',
+        'IOS_SPEECH_ASR_AUDIO_PATH',
+        'IOS_SPEECH_ASR_AUDIO_SHA256',
+        'IOS_SPEECH_ASR_EXPECTED_TRANSCRIPT',
+        'IOS_SPEECH_MIC_DURATION_SECONDS',
+        'IOS_SPEECH_MIC_EXPECTED_TRANSCRIPT',
+        'IOS_SPEECH_LITERT_ASR_MODEL_PATH',
+        'IOS_SPEECH_LITERT_ASR_MODEL_SHA256',
+        'IOS_SPEECH_LITERT_ASR_TOKENIZER_PATH',
+        'IOS_SPEECH_LITERT_ASR_TOKENIZER_SHA256',
+        'IOS_SPEECH_LITERT_ASR_PRESET',
+        'IOS_SPEECH_LITERT_ASR_AUDIO_PATH',
+        'IOS_SPEECH_LITERT_ASR_AUDIO_SHA256',
+        'IOS_SPEECH_LITERT_ASR_EXPECTED_TRANSCRIPT',
+        'IOS_SPEECH_QWEN3_TTS_MODEL_PATH',
+        'IOS_SPEECH_QWEN3_TTS_MODEL_SHA256',
+        'IOS_SPEECH_QWEN3_TTS_MMPROJ_PATH',
+        'IOS_SPEECH_QWEN3_TTS_MMPROJ_SHA256',
+        'IOS_SPEECH_TTS_TEXT',
+        'IOS_SPEECH_TTS_OUTPUT_PATH',
+        'IOS_SPEECH_TTS_EXPECTED_TRANSCRIPT',
+        'IOS_SPEECH_LITERT_LM_MODEL_PATH',
+        'IOS_SPEECH_LITERT_LM_MODEL_SHA256',
+      ];
+
+      for (final define in requiredDefines) {
+        expect(
+          row.command,
+          contains('--dart-define=$define='),
+          reason: 'Command must pass $define.',
+        );
+        expect(
+          row.command,
+          contains('--dart-define=$define="\$$define"'),
+          reason: 'Command must quote the operator-provided value for $define.',
+        );
+      }
+      expect(
+        '--dart-define='.allMatches(row.command).length,
+        equals(requiredDefines.length),
+        reason: 'Command must not pass unknown or duplicated defines.',
+      );
     });
 
     test('includes explicit platform coverage rows', () {

--- a/tool/testing/test_matrix.dart
+++ b/tool/testing/test_matrix.dart
@@ -387,10 +387,13 @@ const List<TestMatrixRow> testMatrixRows = <TestMatrixRow>[
         'ASR round-trip intelligibility, and LiteRT-LM TTS unsupported '
         'classification across immutable local artifacts with no audio playback',
     command:
-        r'cd example/chat_app && flutter test --no-pub --no-uninstall '
-        r'--run-skipped -t local-only '
-        r'integration_test/physical_ios_speech_e2e_test.dart '
-        r'-d "$PHYSICAL_IOS_DEVICE_ID" '
+        r'cd example/chat_app && flutter drive --no-pub '
+        r'--publish-port --no-start-paused '
+        r'--device-vmservice-port="$IOS_SPEECH_DEVICE_VM_PORT" '
+        r'--host-vmservice-port="$IOS_SPEECH_HOST_VM_PORT" '
+        r'--driver=test_driver/integration_test.dart '
+        r'--target=integration_test/physical_ios_speech_e2e_test.dart '
+        r'--timeout=21600 -d "$PHYSICAL_IOS_DEVICE_ID" '
         r'--dart-define=IOS_SPEECH_QWEN3_ASR_MODEL_PATH="$IOS_SPEECH_QWEN3_ASR_MODEL_PATH" '
         r'--dart-define=IOS_SPEECH_QWEN3_ASR_MODEL_SHA256="$IOS_SPEECH_QWEN3_ASR_MODEL_SHA256" '
         r'--dart-define=IOS_SPEECH_QWEN3_ASR_MMPROJ_PATH="$IOS_SPEECH_QWEN3_ASR_MMPROJ_PATH" '
@@ -419,7 +422,11 @@ const List<TestMatrixRow> testMatrixRows = <TestMatrixRow>[
         r'--dart-define=IOS_SPEECH_LITERT_LM_MODEL_SHA256="$IOS_SPEECH_LITERT_LM_MODEL_SHA256"',
     useWhen:
         'Physical iOS speech validation across Qwen3-ASR, LiteRT-LM streaming '
-        'ASR, Qwen3-TTS, microphone capture, and typed speech API contracts.',
+        'ASR, Qwen3-TTS, microphone capture, and typed speech API contracts. '
+        'Each _PATH define takes a safe absolute device path or an '
+        '@appcache/ relative reference; prefer @appcache/ because installing '
+        'rotates the app data-container UUID and invalidates absolute '
+        'pre-install container paths.',
   ),
   TestMatrixRow(
     id: 'chat-app-live-speech-smoke',

--- a/tool/testing/test_matrix.dart
+++ b/tool/testing/test_matrix.dart
@@ -377,6 +377,51 @@ const List<TestMatrixRow> testMatrixRows = <TestMatrixRow>[
         'temporary-audio handling changes.',
   ),
   TestMatrixRow(
+    id: 'physical-ios-speech-e2e',
+    tier: 'targeted',
+    mode: 'manual/device',
+    covers:
+        'physical iOS real microphone WAV capture, llama.cpp Qwen3-ASR with '
+        'cancellation and reload, LiteRT-LM streaming ASR with partials and '
+        'cancellation, llama.cpp Qwen3-TTS with 24 kHz WAV export, non-audible '
+        'ASR round-trip intelligibility, and LiteRT-LM TTS unsupported '
+        'classification across immutable local artifacts with no audio playback',
+    command:
+        r'cd example/chat_app && flutter test --no-pub --no-uninstall '
+        r'--run-skipped -t local-only '
+        r'integration_test/physical_ios_speech_e2e_test.dart '
+        r'-d "$PHYSICAL_IOS_DEVICE_ID" '
+        r'--dart-define=IOS_SPEECH_QWEN3_ASR_MODEL_PATH="$IOS_SPEECH_QWEN3_ASR_MODEL_PATH" '
+        r'--dart-define=IOS_SPEECH_QWEN3_ASR_MODEL_SHA256="$IOS_SPEECH_QWEN3_ASR_MODEL_SHA256" '
+        r'--dart-define=IOS_SPEECH_QWEN3_ASR_MMPROJ_PATH="$IOS_SPEECH_QWEN3_ASR_MMPROJ_PATH" '
+        r'--dart-define=IOS_SPEECH_QWEN3_ASR_MMPROJ_SHA256="$IOS_SPEECH_QWEN3_ASR_MMPROJ_SHA256" '
+        r'--dart-define=IOS_SPEECH_ASR_AUDIO_PATH="$IOS_SPEECH_ASR_AUDIO_PATH" '
+        r'--dart-define=IOS_SPEECH_ASR_AUDIO_SHA256="$IOS_SPEECH_ASR_AUDIO_SHA256" '
+        r'--dart-define=IOS_SPEECH_ASR_EXPECTED_TRANSCRIPT="$IOS_SPEECH_ASR_EXPECTED_TRANSCRIPT" '
+        r'--dart-define=IOS_SPEECH_MIC_DURATION_SECONDS="$IOS_SPEECH_MIC_DURATION_SECONDS" '
+        r'--dart-define=IOS_SPEECH_MIC_EXPECTED_TRANSCRIPT="$IOS_SPEECH_MIC_EXPECTED_TRANSCRIPT" '
+        r'--dart-define=IOS_SPEECH_LITERT_ASR_MODEL_PATH="$IOS_SPEECH_LITERT_ASR_MODEL_PATH" '
+        r'--dart-define=IOS_SPEECH_LITERT_ASR_MODEL_SHA256="$IOS_SPEECH_LITERT_ASR_MODEL_SHA256" '
+        r'--dart-define=IOS_SPEECH_LITERT_ASR_TOKENIZER_PATH="$IOS_SPEECH_LITERT_ASR_TOKENIZER_PATH" '
+        r'--dart-define=IOS_SPEECH_LITERT_ASR_TOKENIZER_SHA256="$IOS_SPEECH_LITERT_ASR_TOKENIZER_SHA256" '
+        r'--dart-define=IOS_SPEECH_LITERT_ASR_PRESET="$IOS_SPEECH_LITERT_ASR_PRESET" '
+        r'--dart-define=IOS_SPEECH_LITERT_ASR_AUDIO_PATH="$IOS_SPEECH_LITERT_ASR_AUDIO_PATH" '
+        r'--dart-define=IOS_SPEECH_LITERT_ASR_AUDIO_SHA256="$IOS_SPEECH_LITERT_ASR_AUDIO_SHA256" '
+        r'--dart-define=IOS_SPEECH_LITERT_ASR_EXPECTED_TRANSCRIPT="$IOS_SPEECH_LITERT_ASR_EXPECTED_TRANSCRIPT" '
+        r'--dart-define=IOS_SPEECH_QWEN3_TTS_MODEL_PATH="$IOS_SPEECH_QWEN3_TTS_MODEL_PATH" '
+        r'--dart-define=IOS_SPEECH_QWEN3_TTS_MODEL_SHA256="$IOS_SPEECH_QWEN3_TTS_MODEL_SHA256" '
+        r'--dart-define=IOS_SPEECH_QWEN3_TTS_MMPROJ_PATH="$IOS_SPEECH_QWEN3_TTS_MMPROJ_PATH" '
+        r'--dart-define=IOS_SPEECH_QWEN3_TTS_MMPROJ_SHA256="$IOS_SPEECH_QWEN3_TTS_MMPROJ_SHA256" '
+        r'--dart-define=IOS_SPEECH_TTS_TEXT="$IOS_SPEECH_TTS_TEXT" '
+        r'--dart-define=IOS_SPEECH_TTS_OUTPUT_PATH="$IOS_SPEECH_TTS_OUTPUT_PATH" '
+        r'--dart-define=IOS_SPEECH_TTS_EXPECTED_TRANSCRIPT="$IOS_SPEECH_TTS_EXPECTED_TRANSCRIPT" '
+        r'--dart-define=IOS_SPEECH_LITERT_LM_MODEL_PATH="$IOS_SPEECH_LITERT_LM_MODEL_PATH" '
+        r'--dart-define=IOS_SPEECH_LITERT_LM_MODEL_SHA256="$IOS_SPEECH_LITERT_LM_MODEL_SHA256"',
+    useWhen:
+        'Physical iOS speech validation across Qwen3-ASR, LiteRT-LM streaming '
+        'ASR, Qwen3-TTS, microphone capture, and typed speech API contracts.',
+  ),
+  TestMatrixRow(
     id: 'chat-app-live-speech-smoke',
     tier: 'targeted',
     mode: 'manual/device',


### PR DESCRIPTION
## Summary

- add and harden the checksum-pinned physical-iOS speech qualification matrix
- support fail-closed missing-row selection while preserving strict full-matrix accounting
- qualify Qwen3-ASR and Qwen3-TTS on explicit llama.cpp CPU (`gpuLayers: 0`)
- permit one shared ASR fixture only when both canonical SHA-256 digests match, while continuing to reject every other path/inode collision
- make speech task cleanup preserve primary failures and settle active streams reliably
- raise the native llama.cpp worker startup timeout from 5 seconds to 30 seconds, with a 5.2-second cold-start regression test

## Physical iPad qualification

Final product matrix:

- Qwen3-ASR llama.cpp CPU: **PASS**
  - deterministic file-input transcript passed on the physical iPad
  - foreground microphone `Stop & transcribe` passed in a standalone Profile-mode Chat App, manually validated by the user
- LiteRT-LM streaming ASR CPU: **PASS**
- Qwen3-TTS llama.cpp CPU: **PASS**
  - 24 kHz mono synthesis, cancellation, reload, WAV validation, and non-audible Qwen3-ASR round trip
- LiteRT-LM TTS: **typed UNSUPPORTED**

The automated host-speaker-to-iPad-microphone attempt was not treated as product-failure evidence because the acoustic playback did not reliably reach the recorded input. File-input ASR and the real Chat App microphone path were validated separately.

## Exact-head verification

- `flutter test test/physical_ios_speech_e2e_support_test.dart` — **105 passed**
- `dart test --platform vm test/unit/backends/llama_cpp/llama_cpp_backend_test.dart` — **33 passed**
- targeted `dart analyze` for all five final changed files — **no issues**
- `dart format --output=none --set-exit-if-changed ...` — **0 changed**
- `git diff --check` — **passed**

No merge or release action is included in this PR creation step.
