### PR TITLE
chore: prepare v0.8.21 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-## Unreleased
+## 0.8.21
 
 * Aligned the default WebGPU bridge assets to `v0.1.39` (immutable manifest
   `b355d01040604f6ae2c5c5fe5bb42b858101a96f03f67e4b27b32fe41ce3b2bf`),

--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ For Dart or Flutter apps:
 
 ```yaml
 dependencies:
-  llamadart: ^0.8.20
+  llamadart: ^0.8.21
 ```
 
 Flutter iOS/macOS apps that should link Apple XCFrameworks through Swift
@@ -63,7 +63,7 @@ Package Manager should also add the runtime companion packages they need:
 
 ```yaml
 dependencies:
-  llamadart: ^0.8.20
+  llamadart: ^0.8.21
   llamadart_llama_cpp_flutter: ^0.0.16 # GGUF / llama.cpp
   llamadart_litert_lm_flutter: ^0.0.10 # Apple .litertlm / LiteRT-LM targets
 ```

--- a/example/chat_app/pubspec.lock
+++ b/example/chat_app/pubspec.lock
@@ -413,7 +413,7 @@ packages:
       path: "../.."
       relative: true
     source: path
-    version: "0.8.20"
+    version: "0.8.21"
   llamadart_litert_lm_flutter:
     dependency: "direct main"
     description:

--- a/packages/llamadart_litert_lm_flutter/README.md
+++ b/packages/llamadart_litert_lm_flutter/README.md
@@ -15,7 +15,7 @@ also request an x86_64 Simulator slice must exclude x86_64 for LiteRT-LM builds.
 
 ```yaml
 dependencies:
-  llamadart: ^0.8.20
+  llamadart: ^0.8.21
   llamadart_litert_lm_flutter: ^0.0.10
 ```
 

--- a/packages/llamadart_llama_cpp_flutter/README.md
+++ b/packages/llamadart_llama_cpp_flutter/README.md
@@ -9,7 +9,7 @@ core package's native-assets fallback.
 
 ```yaml
 dependencies:
-  llamadart: ^0.8.20
+  llamadart: ^0.8.21
   llamadart_llama_cpp_flutter: ^0.0.16
 ```
 

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: llamadart
 description: Dart and Flutter local LLM inference with llama.cpp GGUF and LiteRT-LM across native platforms and web.
-version: 0.8.20
+version: 0.8.21
 homepage: https://github.com/leehack/llamadart
 repository: https://github.com/leehack/llamadart
 issue_tracker: https://github.com/leehack/llamadart/issues

--- a/test/unit/tooling/check_webgpu_bridge_tag_test.dart
+++ b/test/unit/tooling/check_webgpu_bridge_tag_test.dart
@@ -10,12 +10,17 @@ import 'package:test/test.dart';
 
 import '../../../tool/testing/check_webgpu_bridge_tag.dart';
 
-Directory _fakeRepo(String assetsTag, {Map<String, String> files = const {}}) {
+Directory _fakeRepo(
+  String assetsTag, {
+  String version = '1.2.3',
+  Map<String, String> files = const {},
+}) {
   final root = Directory.systemTemp.createTempSync('bridge_tag_gate');
   addTearDown(() => root.deleteSync(recursive: true));
   final entries = <String, String>{
     bridgeTagSourcePath:
         'ASSETS_TAG="\${WEBGPU_BRIDGE_ASSETS_TAG:-$assetsTag}"\n',
+    rootPubspecPath: 'name: llamadart\nversion: $version\n',
     ...files,
   };
   for (final entry in entries.entries) {
@@ -200,13 +205,17 @@ Future<List<String>> _verifyManifestJson(
   );
 }
 
-String _unreleasedSection(String path) {
-  final contents = File(path).readAsStringSync();
-  return RegExp(
-    r'^## Unreleased\b(?:(?!^## ).)*',
-    multiLine: true,
-    dotAll: true,
-  ).firstMatch(contents)!.group(0)!;
+String _currentReleaseNotes(String path) {
+  final section = currentReleaseNotesSection(
+    File(path).readAsStringSync(),
+    readRootPackageVersion(Directory.current),
+  );
+  expect(
+    section,
+    isNotNull,
+    reason: '$path has no current release-notes section',
+  );
+  return section!;
 }
 
 void main() {
@@ -243,16 +252,16 @@ void main() {
         'CHANGELOG.md',
         'website/docs/changelog/recent-releases.md',
       ]) {
-        final unreleased = _unreleasedSection(path);
-        expect(unreleased, contains('`v0.1.39`'), reason: path);
-        expect(unreleased, contains(bridgeManifestSha256), reason: path);
+        final current = _currentReleaseNotes(path);
+        expect(current, contains('`v0.1.39`'), reason: path);
+        expect(current, contains(bridgeManifestSha256), reason: path);
         expect(
-          unreleased,
+          current,
           contains('$bridgeLlamaCppTag@$bridgeLlamaCppCommit'),
           reason: path,
         );
-        expect(unreleased, contains(bridgeNativeReleaseTag), reason: path);
-        expect(unreleased, contains('@litert-lm/core@0.15.0'), reason: path);
+        expect(current, contains(bridgeNativeReleaseTag), reason: path);
+        expect(current, contains('@litert-lm/core@0.15.0'), reason: path);
       }
 
       expect(
@@ -316,30 +325,118 @@ void main() {
     );
   });
 
-  test(
-    'live changelog pins do not treat frozen release history as current',
-    () {
-      final cases = <String, String>{
+  group('current release-notes section', () {
+    /// A repo whose top release-notes section is headed [heading] and claims
+    /// [currentTag], over a frozen `## 1.0.0` section claiming `v1.0.0`.
+    Directory releaseNotesRepo(
+      String heading, {
+      String currentTag = 'v9.9.9',
+      String currentClaim = 'Aligned the default WebGPU bridge assets to',
+      String websiteClaim = 'Aligned default WebGPU bridge assets to',
+    }) => _fakeRepo(
+      'v9.9.9',
+      files: <String, String>{
         'CHANGELOG.md':
-            '## Unreleased\n\n'
-            '* Aligned the default WebGPU bridge assets to `v9.9.9`.\n\n'
+            '## $heading\n\n'
+            '* $currentClaim `$currentTag`.\n\n'
             '## 1.0.0\n\n'
             '* Aligned the default WebGPU bridge assets to `v1.0.0`.\n',
         'website/docs/changelog/recent-releases.md':
-            '## Unreleased\n\n'
-            '- Aligned default WebGPU bridge assets to `v9.9.9`.\n\n'
+            '## $heading\n\n'
+            '- $websiteClaim `$currentTag`.\n\n'
             '## 1.0.0\n\n'
             '- Aligned default WebGPU bridge assets to `v1.0.0`.\n',
-      };
+      },
+    );
 
-      for (final entry in cases.entries) {
-        final pin = bridgeTagPins.singleWhere((pin) => pin.path == entry.key);
-        final matches = pin.pattern.allMatches(entry.value).toList();
-        expect(matches, hasLength(1), reason: entry.key);
-        expect(matches.single.group(1), 'v9.9.9', reason: entry.key);
+    test('accepts `## Unreleased` and ignores frozen release history', () {
+      expect(
+        findCurrentReleaseNotesDrift(releaseNotesRepo('Unreleased'), 'v9.9.9'),
+        isEmpty,
+      );
+    });
+
+    test('accepts the promoted `## <pubspec version>` heading', () {
+      expect(
+        findCurrentReleaseNotesDrift(releaseNotesRepo('1.2.3'), 'v9.9.9'),
+        isEmpty,
+      );
+    });
+
+    test('a heading naming another version is reported', () {
+      expect(
+        findCurrentReleaseNotesDrift(releaseNotesRepo('1.2.4'), 'v9.9.9'),
+        everyElement(
+          contains('the top section is neither `## Unreleased` nor `## 1.2.3`'),
+        ),
+      );
+    });
+
+    test('a stale tag in the current section is reported', () {
+      expect(
+        findCurrentReleaseNotesDrift(
+          releaseNotesRepo('1.2.3', currentTag: 'v0.0.1'),
+          'v9.9.9',
+        ),
+        everyElement(contains('pins v0.0.1, expected v9.9.9')),
+      );
+    });
+
+    test('frozen history cannot satisfy a reworded current claim', () {
+      expect(
+        findCurrentReleaseNotesDrift(
+          releaseNotesRepo(
+            '1.2.3',
+            currentClaim: 'Moved the WebGPU bridge assets to',
+            websiteClaim: 'Moved the WebGPU bridge assets to',
+          ),
+          'v9.9.9',
+        ),
+        everyElement(
+          contains(
+            'matches 0 lines in the current release-notes section, expected 1',
+          ),
+        ),
+      );
+    });
+
+    test('a duplicated claim in the current section is reported', () {
+      final root = releaseNotesRepo('1.2.3');
+      for (final pin in releaseNotesPins) {
+        final file = File('${root.path}/${pin.path}');
+        final line = pin.pattern.firstMatch(file.readAsStringSync())!.group(0)!;
+        file.writeAsStringSync(
+          file.readAsStringSync().replaceFirst(line, '$line\n$line'),
+        );
       }
-    },
-  );
+
+      expect(
+        findCurrentReleaseNotesDrift(root, 'v9.9.9'),
+        everyElement(
+          contains(
+            'matches 2 lines in the current release-notes section, expected 1',
+          ),
+        ),
+      );
+    });
+
+    test('a missing release-notes file fails instead of passing vacuously', () {
+      expect(
+        findCurrentReleaseNotesDrift(_fakeRepo('v9.9.9'), 'v9.9.9'),
+        everyElement(contains('file is missing')),
+      );
+    });
+
+    test('a missing root pubspec version fails closed', () {
+      final root = releaseNotesRepo('Unreleased');
+      File('${root.path}/$rootPubspecPath').writeAsStringSync('name: x\n');
+
+      expect(
+        findCurrentReleaseNotesDrift(root, 'v9.9.9'),
+        contains(contains('Expected exactly one version field')),
+      );
+    });
+  });
 
   test('every bash assignment form is counted', () {
     const overrides = <String>[

--- a/tool/testing/check_webgpu_bridge_tag.dart
+++ b/tool/testing/check_webgpu_bridge_tag.dart
@@ -124,25 +124,84 @@ final List<BridgeTagPin> bridgeTagPins = <BridgeTagPin>[
     'website/docs/guides/text-to-speech.md',
     RegExp(r'^- The chat example pins `(v\d+\.\d+\.\d+)`,', multiLine: true),
   ),
+];
+
+/// Release-notes files whose current section restates the pinned tag.
+///
+/// The patterns are matched against [currentReleaseNotesSection] alone, so the
+/// frozen sections below it keep the tags their releases shipped.
+final List<BridgeTagPin> releaseNotesPins = <BridgeTagPin>[
   BridgeTagPin(
     'CHANGELOG.md',
     RegExp(
-      r'^## Unreleased\b(?:(?!^## ).)*?^\* Aligned the default WebGPU bridge '
-      r'assets to `(v\d+\.\d+\.\d+)`',
+      r'^\* Aligned the default WebGPU bridge assets to `(v\d+\.\d+\.\d+)`',
       multiLine: true,
-      dotAll: true,
     ),
   ),
   BridgeTagPin(
     'website/docs/changelog/recent-releases.md',
     RegExp(
-      r'^## Unreleased\b(?:(?!^## ).)*?^- Aligned default WebGPU bridge assets '
-      r'to `(v\d+\.\d+\.\d+)`',
+      r'^- Aligned default WebGPU bridge assets to `(v\d+\.\d+\.\d+)`',
       multiLine: true,
-      dotAll: true,
     ),
   ),
 ];
+
+/// The pubspec whose version names the section a release-prep tree promotes.
+const String rootPubspecPath = 'pubspec.yaml';
+
+final RegExp _rootPubspecVersion = RegExp(
+  r'^version:\s*(\S+)\s*$',
+  multiLine: true,
+);
+
+final RegExp _topReleaseNotesSection = RegExp(
+  r'^## (?<heading>.*?)\s*$(?<body>(?:(?!^## ).)*)',
+  multiLine: true,
+  dotAll: true,
+);
+
+/// Reads the version the root package will publish.
+///
+/// Throws [FormatException] when it is missing or duplicated, so the gate
+/// cannot fall back to accepting any release-notes heading it finds.
+String readRootPackageVersion(Directory repoRoot) {
+  final file = File('${repoRoot.path}/$rootPubspecPath');
+  if (!file.existsSync()) {
+    throw FormatException('Missing $rootPubspecPath');
+  }
+  final String source;
+  try {
+    source = file.readAsStringSync();
+  } on FileSystemException catch (error) {
+    throw FormatException('$rootPubspecPath could not be read: $error');
+  } on FormatException catch (error) {
+    throw FormatException('$rootPubspecPath could not be decoded: $error');
+  }
+  final matches = _rootPubspecVersion.allMatches(source).toList();
+  if (matches.length != 1) {
+    throw FormatException(
+      'Expected exactly one version field in $rootPubspecPath, found '
+      '${matches.length}; the gate cannot identify the current release-notes '
+      'section.',
+    );
+  }
+  return matches.single.group(1)!;
+}
+
+/// The body of the top `## ` section of [contents] when it is the current one.
+///
+/// Ordinary development leaves the top section headed `## Unreleased`; a
+/// release-prep change promotes that same section to `## $releaseVersion`.
+/// Returns null for any other heading, so a gate reading this never mistakes a
+/// frozen historical section for the current release notes.
+String? currentReleaseNotesSection(String contents, String releaseVersion) {
+  final match = _topReleaseNotesSection.firstMatch(contents);
+  if (match == null) return null;
+  final heading = match.namedGroup('heading');
+  if (heading != 'Unreleased' && heading != releaseVersion) return null;
+  return match.namedGroup('body');
+}
 
 /// Reads the tag every pin must quote.
 ///
@@ -199,6 +258,58 @@ List<String> findBridgeTagDrift(Directory repoRoot, String expectedTag) {
         '${pin.path}: ${pin.pattern.pattern} matches ${matches.length} lines, '
         'expected 1 — the pin moved, was reworded, or was duplicated, so this '
         'check no longer covers exactly one site',
+      );
+      continue;
+    }
+    final found = matches.single.group(1)!;
+    if (found != expectedTag) {
+      problems.add('${pin.path}: pins $found, expected $expectedTag');
+    }
+  }
+  return <String>[
+    ...problems,
+    ...findCurrentReleaseNotesDrift(repoRoot, expectedTag),
+  ];
+}
+
+/// Returns one message per [releaseNotesPins] site whose current section
+/// drifted, lost its claim, or sits under an unrecognized heading.
+List<String> findCurrentReleaseNotesDrift(
+  Directory repoRoot,
+  String expectedTag,
+) {
+  final String releaseVersion;
+  try {
+    releaseVersion = readRootPackageVersion(repoRoot);
+  } on FormatException catch (error) {
+    return <String>[error.message];
+  }
+
+  final problems = <String>[];
+  for (final pin in releaseNotesPins) {
+    final file = File('${repoRoot.path}/${pin.path}');
+    if (!file.existsSync()) {
+      problems.add('${pin.path}: file is missing');
+      continue;
+    }
+    final contents = _readGateFile(file, pin.path, problems);
+    if (contents == null) continue;
+    final section = currentReleaseNotesSection(contents, releaseVersion);
+    if (section == null) {
+      problems.add(
+        '${pin.path}: the top section is neither `## Unreleased` nor '
+        '`## $releaseVersion`, so the gate cannot tell the current release '
+        'notes from frozen history',
+      );
+      continue;
+    }
+    final matches = pin.pattern.allMatches(section).toList();
+    if (matches.length != 1) {
+      problems.add(
+        '${pin.path}: ${pin.pattern.pattern} matches ${matches.length} lines in '
+        'the current release-notes section, expected 1 — the pin moved, was '
+        'reworded, or was duplicated, so this check no longer covers exactly '
+        'one site',
       );
       continue;
     }
@@ -719,8 +830,8 @@ const List<String> _selfPaths = <String>[
   'test/unit/tooling/check_webgpu_bridge_tag_test.dart',
 ];
 
-/// Files that record past releases, where an old tag is correct. Current
-/// `Unreleased` claims in these files remain explicit [bridgeTagPins].
+/// Files that record past releases, where an old tag is correct. The current
+/// release-notes claims in these files remain explicit [releaseNotesPins].
 const List<String> tagHistoryFiles = <String>[
   'CHANGELOG.md',
   'website/docs/changelog/recent-releases.md',
@@ -890,7 +1001,9 @@ Future<void> main(List<String> arguments) async {
   }
 
   stdout.writeln(
-    '[webgpu-bridge-tag] OK: ${bridgeTagPins.length} pins agree on $expectedTag.',
+    '[webgpu-bridge-tag] OK: '
+    '${bridgeTagPins.length + releaseNotesPins.length} pins agree on '
+    '$expectedTag.',
   );
   stdout.writeln(
     '[webgpu-bridge-tag] OK: Web and native both run upstream llama.cpp '

--- a/website/docs/changelog/recent-releases.md
+++ b/website/docs/changelog/recent-releases.md
@@ -7,7 +7,7 @@ For canonical full release notes, use:
 
 - [`CHANGELOG.md`](https://github.com/leehack/llamadart/blob/main/CHANGELOG.md)
 
-## Unreleased
+## 0.8.21
 
 - Aligned default WebGPU bridge assets to `v0.1.39` (immutable manifest
   `b355d01040604f6ae2c5c5fe5bb42b858101a96f03f67e4b27b32fe41ce3b2bf`),
@@ -15,6 +15,22 @@ For canonical full release notes, use:
   `v0.2.0@bb4caa7540188872173c44d161602d9271386413` parity with native
   anchor `llamadart-native@v0.2.0-1` while preserving Web
   `@litert-lm/core@0.15.0` packaging.
+
+- Fixed native Qwen3-ASR transcription by applying the model chat template to
+  audio turns, while preserving the validated raw-prompt Web bridge contract.
+  Empty ASR output now fails explicitly instead of reporting an empty result.
+
+- Fixed Qwen 2.5/3 LiteRT-LM `ToolChoice.required` requests silently running
+  without their required-call grammar and finishing with no call. They now fail
+  with an actionable `LlamaUnsupportedException` before generation when the
+  backend cannot enforce the declared tool schema; Gemma 4 compatibility and
+  `auto`/`none` tool routing are unchanged.
+
+- Fixed Gemma 4 thinking-budget output so split channel controls and tool-call
+  envelopes stay out of visible assistant content while preserving ordinary
+  whitespace. The chat example now also validates custom tool declarations,
+  executes declared host handlers exactly once, appends tool results, and
+  performs a bounded continuation for both llama.cpp and LiteRT-LM backends.
 
 - Patched the website's vulnerable `nanoid` and `uuid` dependency paths. Until
   Docusaurus replaces its unpatched image parser, automatic local Markdown

--- a/website/docs/getting-started/installation.md
+++ b/website/docs/getting-started/installation.md
@@ -27,7 +27,7 @@ In Xcode, set `IPHONEOS_DEPLOYMENT_TARGET = 16.4` or
 
 ```yaml
 dependencies:
-  llamadart: ^0.8.20
+  llamadart: ^0.8.21
 ```
 
 For Flutter iOS/macOS apps that should link Apple XCFrameworks through Swift
@@ -35,7 +35,7 @@ Package Manager, also add the runtime companion packages you need:
 
 ```yaml
 dependencies:
-  llamadart: ^0.8.20
+  llamadart: ^0.8.21
   llamadart_llama_cpp_flutter: ^0.0.16 # GGUF / llama.cpp
   llamadart_litert_lm_flutter: ^0.0.10 # Apple .litertlm / LiteRT-LM targets
 ```


### PR DESCRIPTION
## Summary

- prepare `llamadart` 0.8.21 release metadata and current install documentation
- promote the accumulated `Unreleased` notes to `0.8.21`
- keep the qualified runtime pins unchanged (`llamadart-native@v0.2.0-1`, Web bridge assets `v0.1.39`, LiteRT-LM native `v0.16.0-native.2`, Web LiteRT-LM `0.15.0`)
- make the Web bridge provenance gate understand both an active `Unreleased` section and a promoted top-level release section matching the root package version, without accepting frozen historical sections

## Release qualification

- automated Qwen3-ASR qualification uses deterministic file input, exact transcript, backend/model identity, cancellation, and reload/lifecycle evidence
- physical microphone capture is intentionally outside automated qualification; the signed Release Chat App microphone product path was validated separately on a physical iPad
- existing Web qualification remains 12/12 PASS
- `llamadart-native v0.3.0` consumption is intentionally deferred; this release preserves the qualified `v0.2.0-1` pin

## Verification

- [x] `dart format --output=none --set-exit-if-changed .`
- [x] `dart analyze`
- [x] `dart test` — 2717 passed, 85 skipped, 0 failed
- [x] `dart test --chain-stack-traces test/unit/tooling/check_webgpu_bridge_tag_test.dart` — 53 passed
- [x] `dart run tool/testing/check_webgpu_bridge_tag.dart`
- [x] `dart run tool/testing/verify_release_docs_versions.dart --release-prep`
- [x] `python3 tool/native/test_sync_native_release_pins.py` — 21 passed
- [x] companion package analyze/tests
- [x] Docusaurus build and link validation
- [x] clean temporary-copy publish dry-run for `llamadart 0.8.21` — 0 warnings
- [x] clean temporary-copy publish dry-run for `llamadart_llama_cpp_flutter 0.0.16` — 0 warnings, one non-blocking skipped-version hint because pub.dev currently has 0.0.14
- [x] clean temporary-copy publish dry-run for `llamadart_litert_lm_flutter 0.0.10` — 0 warnings
- [x] `git diff --check`
- [x] independent `codex review --uncommitted` — no actionable findings

## Publication boundary

Merging this release-prep PR is publication-sensitive because `release_on_prep_merge.yml` can publish missing companion versions before tagging and publishing the core package. Do not merge without explicit maintainer approval bound to the final reviewed head.
