### PR TITLE
fix(ci): prevent stale PR-head rewinds

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -4,6 +4,7 @@
 .github/pull_request_template.md @leehack
 .github/workflows/ @leehack
 AGENTS.md @leehack
+CONTRIBUTING.md @leehack
 scripts/build_chat_app_web.sh @leehack
 scripts/validate_chat_app_web_build.sh @leehack
 scripts/verify_chat_app_web_deployment.sh @leehack
@@ -12,6 +13,7 @@ scripts/verify_chat_app_web_deployment.sh @leehack
 pubspec.yaml @leehack
 CHANGELOG.md @leehack
 doc/testing_matrix.md @leehack
+doc/pr_branch_writer_inventory.md @leehack
 hook/build.dart @leehack
 tool/testing/test_matrix.dart @leehack
 tool/testing/classify_high_risk_changes.dart @leehack
@@ -24,6 +26,9 @@ tool/litert_lm_templates/ @leehack
 test/integration/core/grammar/generated_tool_schema_grammar_test.dart @leehack
 test/e2e/template/specialized_tool_grammar_validation_e2e_test.dart @leehack
 test/unit/tooling/high_risk_review_policy_test.dart @leehack
+tool/git/safe_pr_head_update.dart @leehack
+tool/git/pr_head_update_evidence.schema.json @leehack
+test/unit/tooling/safe_pr_head_update_test.dart @leehack
 tool/testing/verify_release_docs_versions.dart @leehack
 tool/testing/check_webgpu_bridge_tag.dart @leehack
 tool/native/sync_native_release_pins.py @leehack

--- a/.github/workflows/sync_native_bindings.yml
+++ b/.github/workflows/sync_native_bindings.yml
@@ -36,6 +36,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
+        with:
+          ref: main
+          fetch-depth: 0
 
       - name: Setup Flutter
         uses: subosito/flutter-action@v2
@@ -118,49 +121,167 @@ jobs:
             --litert-lm-tag "${LITERT_LM_TAG}" \
             "${transition_args[@]}"
 
-      - name: Create pull request
-        uses: peter-evans/create-pull-request@v8
-        with:
-          token: ${{ secrets.GITHUB_TOKEN }}
-          commit-message: "chore(native): sync native release ${{ steps.sync_headers.outputs.resolved_tag }}"
-          title: "chore(native): sync native release ${{ steps.sync_headers.outputs.resolved_tag }}"
-          body: |
-            Automated sync from `leehack/llamadart-native` release `${{ steps.sync_headers.outputs.resolved_tag }}`.
+      - name: Prepare fast-forward automation head
+        id: prepare_pr_head
+        env:
+          RESOLVED_NATIVE_TAG: ${{ steps.sync_headers.outputs.resolved_tag }}
+        run: |
+          set -euo pipefail
+          zero_oid="0000000000000000000000000000000000000000"
+          branch="automation/native-sync-${RESOLVED_NATIVE_TAG}"
+          target_ref="refs/heads/${branch}"
+          git check-ref-format --branch "${branch}" >/dev/null
 
-            Changes:
-            - Updates `hook/build.dart` native release pins.
-            - Syncs headers from the matching `llamadart-native` release header bundle.
-            - Regenerates `lib/src/backends/llama_cpp/bindings.dart` via ffigen.
-            - Updates LiteRT-LM Dart runtime version and archive checksums when `litert_lm_tag` is not `keep`.
-            - Updates Apple SPM companion `Package.swift` binary target pins in `packages/`.
-            - Does not bump companion package versions unless the sync script is run with an explicit version-bump option outside this default workflow.
-            - Updates current README/website native pin docs and the core changelog when the llama.cpp native pin changes.
-
-            Native version checklist:
-            - [ ] If `allow_nightly_channel` was enabled, confirm the stable-to-nightly switch was intentional and record the compatibility reason.
-            - [ ] Confirm `leehack/llamadart-native` release `${{ steps.sync_headers.outputs.resolved_tag }}` includes the required native-assets archives.
-            - [ ] If LiteRT-LM sync was requested (`litert_lm_tag` is not `keep`), confirm `leehack/litert-lm-native` release `${{ steps.sync_pins.outputs.resolved_litert_lm_tag }}` includes the required runtime archives.
-            - [ ] Confirm a schema 2 LiteRT-LM manifest has exact upstream/native commits, ABI/capabilities, all platform bundles, SHA-256 artifact digests, and Linux/Windows real-model evidence. Schema 1 is legacy-only compatibility.
-            - [ ] Confirm matching Apple SPM pins changed under `packages/` when Apple XCFramework releases changed.
-            - [ ] Confirm current README/website native pin docs and `CHANGELOG.md` describe the new default pin.
-            - [ ] Do not tag or publish companion/core packages from this PR. Companion/core publication is owned by a later release-prep PR and `release_on_prep_merge.yml`.
-          branch: "automation/native-sync-${{ steps.sync_headers.outputs.resolved_tag }}"
-          labels: automation/native-sync
-          add-paths: |
-            hook/build.dart
-            packages/llamadart_llama_cpp_flutter/darwin/llamadart_llama_cpp_flutter/Package.swift
-            packages/llamadart_llama_cpp_flutter/pubspec.yaml
-            packages/llamadart_llama_cpp_flutter/CHANGELOG.md
-            packages/llamadart_llama_cpp_flutter/README.md
-            packages/llamadart_litert_lm_flutter/darwin/llamadart_litert_lm_flutter/Package.swift
-            packages/llamadart_litert_lm_flutter/pubspec.yaml
-            packages/llamadart_litert_lm_flutter/CHANGELOG.md
-            packages/llamadart_litert_lm_flutter/README.md
-            lib/src/backends/litert_lm/litert_lm_runtime.dart
-            tool/macos_litert_lm_prepare_app.sh
-            lib/src/backends/llama_cpp/bindings.dart
-            CHANGELOG.md
-            README.md
-            website/docs/getting-started/installation.md
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git add -- \
+            hook/build.dart \
+            packages/llamadart_llama_cpp_flutter/darwin/llamadart_llama_cpp_flutter/Package.swift \
+            packages/llamadart_llama_cpp_flutter/pubspec.yaml \
+            packages/llamadart_llama_cpp_flutter/CHANGELOG.md \
+            packages/llamadart_llama_cpp_flutter/README.md \
+            packages/llamadart_litert_lm_flutter/darwin/llamadart_litert_lm_flutter/Package.swift \
+            packages/llamadart_litert_lm_flutter/pubspec.yaml \
+            packages/llamadart_litert_lm_flutter/CHANGELOG.md \
+            packages/llamadart_litert_lm_flutter/README.md \
+            lib/src/backends/litert_lm/litert_lm_runtime.dart \
+            tool/macos_litert_lm_prepare_app.sh \
+            lib/src/backends/llama_cpp/bindings.dart \
+            CHANGELOG.md \
+            README.md \
+            website/docs/getting-started/installation.md \
             website/docs/platforms/support-matrix.md
-          delete-branch: true
+
+          if git diff --cached --quiet; then
+            has_changes=false
+            candidate="$(git rev-parse HEAD)"
+          else
+            has_changes=true
+            git commit -m "chore(native): sync native release ${RESOLVED_NATIVE_TAG}"
+            candidate="$(git rev-parse HEAD)"
+          fi
+
+          remote_line="$(git ls-remote --refs origin "${target_ref}")"
+          if [[ -z "${remote_line}" ]]; then
+            expected="${zero_oid}"
+          else
+            if [[ "$(wc -l <<<"${remote_line}")" -ne 1 ]]; then
+              echo "Exact automation ref lookup returned multiple rows." >&2
+              exit 1
+            fi
+            read -r expected observed_ref <<<"${remote_line}"
+            if [[ "${observed_ref}" != "${target_ref}" || ! "${expected}" =~ ^[0-9a-f]{40}$ ]]; then
+              echo "Exact automation ref lookup returned an invalid row." >&2
+              exit 1
+            fi
+            git fetch --quiet --no-tags origin "${target_ref}"
+            fetched="$(git rev-parse FETCH_HEAD)"
+            if [[ "${fetched}" != "${expected}" ]]; then
+              echo "Automation ref moved while preparing the candidate; rerun required." >&2
+              exit 1
+            fi
+          fi
+
+          if [[ "${expected}" == "${zero_oid}" ]]; then
+            proposed="${candidate}"
+            should_update="${has_changes}"
+          elif git merge-base --is-ancestor "${expected}" "${candidate}"; then
+            proposed="${candidate}"
+            should_update=true
+          elif git merge-base --is-ancestor "${candidate}" "${expected}"; then
+            proposed="${expected}"
+            should_update=true
+          else
+            git checkout --quiet --detach "${expected}"
+            git merge --no-ff --no-edit "${candidate}"
+            proposed="$(git rev-parse HEAD)"
+            read -r reconciled parent_one parent_two extra <<<"$(
+              git rev-list --parents -n 1 "${proposed}"
+            )"
+            if [[ "${reconciled}" != "${proposed}" || \
+                  "${parent_one}" != "${expected}" || \
+                  "${parent_two}" != "${candidate}" || \
+                  -n "${extra:-}" ]]; then
+              echo "Reconciliation commit did not retain the exact expected parents." >&2
+              exit 1
+            fi
+            should_update=true
+          fi
+
+          if [[ "${expected}" != "${zero_oid}" ]] && \
+             ! git merge-base --is-ancestor "${expected}" "${proposed}"; then
+            echo "Prepared head does not retain the expected automation history." >&2
+            exit 1
+          fi
+          if ! git merge-base --is-ancestor "${candidate}" "${proposed}"; then
+            echo "Prepared head does not retain the exact current-main candidate." >&2
+            exit 1
+          fi
+
+          {
+            echo "branch=${branch}"
+            echo "expected_sha=${expected}"
+            echo "proposed_sha=${proposed}"
+            echo "has_changes=${has_changes}"
+            echo "should_update=${should_update}"
+          } >> "${GITHUB_OUTPUT}"
+
+      - name: Update automation branch with expected-head CAS
+        if: steps.prepare_pr_head.outputs.should_update == 'true'
+        env:
+          BRANCH: ${{ steps.prepare_pr_head.outputs.branch }}
+          EXPECTED_SHA: ${{ steps.prepare_pr_head.outputs.expected_sha }}
+          PROPOSED_SHA: ${{ steps.prepare_pr_head.outputs.proposed_sha }}
+        run: |
+          set -euo pipefail
+          dart run tool/git/safe_pr_head_update.dart \
+            --remote origin \
+            --branch "${BRANCH}" \
+            --expected-sha "${EXPECTED_SHA}" \
+            --proposed-sha "${PROPOSED_SHA}" \
+            --writer github-actions-native-sync \
+            --correlation-id "native-sync-${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}" \
+            | tee "${RUNNER_TEMP}/pr-head-update-evidence.json"
+
+      - name: Create, update, or close pull request
+        if: steps.prepare_pr_head.outputs.should_update == 'true'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          BRANCH: ${{ steps.prepare_pr_head.outputs.branch }}
+          HAS_CHANGES: ${{ steps.prepare_pr_head.outputs.has_changes }}
+          RESOLVED_NATIVE_TAG: ${{ steps.sync_headers.outputs.resolved_tag }}
+          RESOLVED_LITERT_LM_TAG: ${{ steps.sync_pins.outputs.resolved_litert_lm_tag }}
+        run: |
+          set -euo pipefail
+          open_pr="$(gh pr list --state open --base main --head "${BRANCH}" \
+            --json number --jq '.[0].number // empty')"
+          if [[ "${HAS_CHANGES}" != "true" ]]; then
+            if [[ -n "${open_pr}" ]]; then
+              gh pr close "${open_pr}" \
+                --comment "The generated native sync now matches current main. The automation branch was reconciled with expected-head CAS and retained for auditable reuse."
+            fi
+            exit 0
+          fi
+
+          body_file="${RUNNER_TEMP}/native-sync-pr-body.md"
+          printf '%s\n' \
+            "Automated sync from \`leehack/llamadart-native\` release \`${RESOLVED_NATIVE_TAG}\`." \
+            "" \
+            "Changes:" \
+            "- Updates native release pins, headers, generated bindings, runtime checksums, Apple SPM pins, and current docs when applicable." \
+            "- Does not bump, tag, or publish companion/core packages." \
+            "" \
+            "Native version checklist:" \
+            "- [ ] Confirm the native release includes all required native-assets archives." \
+            "- [ ] If LiteRT-LM sync was requested, confirm release \`${RESOLVED_LITERT_LM_TAG}\` includes all required runtime archives." \
+            "- [ ] Confirm manifest provenance, ABI/capabilities, bundle coverage, checksums, and real-model evidence." \
+            "- [ ] Confirm Apple SPM pins and current README/website/changelog surfaces are aligned." \
+            > "${body_file}"
+          title="chore(native): sync native release ${RESOLVED_NATIVE_TAG}"
+          if [[ -n "${open_pr}" ]]; then
+            gh pr edit "${open_pr}" --title "${title}" --body-file "${body_file}" \
+              --add-label automation/native-sync
+          else
+            gh pr create --base main --head "${BRANCH}" --title "${title}" \
+              --body-file "${body_file}" --label automation/native-sync
+          fi

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -339,6 +339,28 @@ For docs-only PRs, state that runtime behavior is unchanged and list docs
 validation. If implementation scope changed, reduce and state the scope rather
 than merging incomplete behavior.
 
+### PR Branch Integrity and Mutation Contract
+
+- Repository-local mutations to open PR branches must enforce an expected-head
+  compare-and-swap (CAS) plus fast-forward-only contract (`tool/git/safe_pr_head_update.dart`).
+  Immediately before mutation, the remote head must match the caller's expected
+  head, and the proposed new head must equal that head for an idempotent retry or
+  descend from it.
+- The helper uses a normal push guarded by the remote OID advertised to a
+  one-shot `pre-push` hook. Stale ancestor restorations, force options,
+  `+refspec` updates, and blind overwrites are strictly rejected. Read the exact
+  target ref back before claiming success.
+- Consequence of unexpected transitions (#434 incident): Any unexpected
+  branch-head transition invalidates prior CI runs, review approvals, and
+  independent QA evidence recorded against that head. If the remote head moves,
+  all validation and QA blocks must be re-executed against the exact new head.
+- Residual governance boundaries: checkout-local tooling governs only writers
+  that invoke it. It cannot govern GitHub web UI updates, Dependabot, installed
+  apps, or other server-side writers. The repository relies on branch protection
+  and rulesets to block force pushes and enforce linear history, status checks,
+  and CODEOWNERS reviews across those paths. See the bounded writer inventory
+  and incident evidence in `doc/pr_branch_writer_inventory.md`.
+
 ## AGENTS.md Maintenance
 
 - Update this file when a task reveals a durable workflow rule, command,

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -267,6 +267,12 @@ If you need to build binaries for a new release:
 4.  Push to your fork and submit a Pull Request.
 5.  Complete the production-readiness sections in the pull request template.
 
+For the initial branch publication, `tool/git/safe_pr_head_update.dart` accepts
+the all-zero expected SHA only while the fork ref is absent. After the pull
+request opens, use the helper with the exact observed fork-branch head for every
+update; blind or force pushes are not authorized open-PR update paths. See
+`doc/pr_branch_writer_inventory.md` for the repository-local writer boundary.
+
 ### Production-readiness expectations
 
 `main` should remain production-ready. A pull request may reduce its scope, but

--- a/doc/pr_branch_writer_inventory.md
+++ b/doc/pr_branch_writer_inventory.md
@@ -1,0 +1,74 @@
+# PR Branch Writer Inventory
+
+This inventory bounds tracked repository-local paths at
+`b6af5a8b5d1973bc72d4e5283f1c7d728a679cb7` plus the integrity changes in this
+worktree. It covers workflow files with either `.yml` or `.yaml`, tracked
+non-test executable-source and task-manifest files throughout the repository,
+repository bot configuration, and all tracked Markdown instructions. Static
+regression tests keep those surfaces free of an unregistered direct PR-ref push
+or ref-update API; the helper's own bare-repository tests mutate only temporary
+local fixtures.
+
+| Path | Principal | Trigger | Expected old SHA | Update mechanism |
+| --- | --- | --- | --- | --- |
+| `tool/git/safe_pr_head_update.dart` | Caller-supplied, validated `writer` identifier | Explicit CLI invocation | Required full SHA; all-zero means the ref must be absent | Validates exact ref and ancestry, then performs a normal push with an in-connection advertised-OID guard and exact-ref read-back |
+| `.github/workflows/sync_native_bindings.yml` | `github-actions-native-sync` using `GITHUB_TOKEN` | Maintainer `workflow_dispatch` | Exact automation ref from `git ls-remote`, rechecked by the helper | Builds on current `main`; fast-forwards either line when already integrated or performs a real merge that retains both lines and fails on conflicts, then invokes the guarded helper before using `gh pr` |
+| `AGENTS.md` and `doc/testing_matrix.md` | Maintainer, contributor, or authorized agent named in `writer` | Manual PR creation or follow-up task | Exact verified PR head at the start of the mutation | Required to invoke the guarded helper; ordinary blind `git push` is not an authorized open-PR update path |
+| `CONTRIBUTING.md` | Contributor named in `writer`, using a credentialed fork remote | Initial fork-branch publication, then any update after the PR opens | All-zero for initial branch creation; exact verified fork-branch head for an open PR | Initial publication may invoke the helper with the all-zero expectation; every later open-PR update must invoke the helper with the observed full SHA |
+| `.github/dependabot.yml` | GitHub Dependabot | Weekly GitHub-managed schedule | Managed inside GitHub; not exposed to checkout-local code | Server-side creation/update of Dependabot PR branches; bounded but not enforced by the local helper |
+
+The repository also contains a direct HEAD-to-main push in
+`.github/workflows/docs_version_cut.yml`, tag creation in release automation,
+historical companion tag-push examples under `website/versioned_docs/`, a
+forced local detached checkout for an upstream test fixture, `codesign --force`,
+and `pub publish --force`. None writes an open PR head ref. The static test
+distinguishes these from remote `refs/heads/*` mutation rather than banning
+unrelated uses of the word `force`.
+
+## PR #434 evidence and consequence
+
+Verified local facts:
+
+- `git show 00f93916e6dcc51d3233580aea044d5cf476981b` identifies the merged change as
+  `fix: restore a self-consistent chat app lockfile SDK bound (#434)`.
+- The local reflog for `fix/chat-app-lockfile-sdk-bound` records head
+  `781285446177670c9a83204efc79771f070a0d87`, then a reset to ancestor
+  `135e0957198499e6577ad859b344655583c67864`, followed by rebuilt heads
+  `60ec278c529c646b66e8e08b762c830f4939347c` and
+  `818e6cad15ef7248ef3564ff449fa3d4dc49be7b`.
+- `781285446177670c9a83204efc79771f070a0d87` and
+  `60ec278c529c646b66e8e08b762c830f4939347c` have the same tree
+  `49368f297e580fa81a3ac81005f8e5c3cd60a3cb` but different parents. The latter
+  no longer descends from the former.
+
+Inference, explicitly not established by the retained local evidence: the
+reflog proves a local stale-ancestor reset and replacement history, but does not
+identify which actor or API, if any, applied the corresponding remote branch
+transition. If a validated PR head changes in that way, CI, approvals, and
+independent QA attached to the former SHA no longer qualify the new head and
+must be rerun.
+
+## Residual server-side boundary
+
+The helper's normal Git push is a server-side ref transaction for that one
+invocation: the pre-push guard checks the server-advertised old OID, and the
+receive side rejects a ref race after advertisement. This does not make all
+GitHub writers atomic with the helper. GitHub web UI update-branch operations,
+Dependabot, installed or third-party GitHub Apps, merges, and direct pushes that
+bypass this checkout remain outside local enforcement.
+Untracked checkout-local hooks, aliases, and tools are likewise outside the
+tracked inventory. The helper preserves the configured `pre-push` hook and
+classifies its rejection, but cannot authorize or constrain separate mutations
+that hook performs.
+
+The native-sync workflow deliberately grants its job-scoped `GITHUB_TOKEN` only
+`contents: write` and `pull-requests: write`. GitHub may leave the resulting
+`pull_request` workflow runs awaiting maintainer approval; creating or updating
+the PR is therefore not evidence that its CI started or passed.
+
+Repository owners must enforce that residual boundary with GitHub branch
+protection or rulesets that block force pushes, require linear history and
+required checks, require CODEOWNERS review where applicable, and dismiss or
+renew stale approvals after a head change. Those settings are privileged
+external state and are not asserted merely because this repository documents
+them.

--- a/doc/testing_matrix.md
+++ b/doc/testing_matrix.md
@@ -381,3 +381,7 @@ When an agent creates or updates a PR:
    `test/unit/`, `test/integration/`, or `test/e2e/`; wire heavyweight manual
    checks through `tool/testing/run_local_e2e.dart` and
    `tool/testing/test_matrix.dart`.
+6. When updating an open PR branch, enforce expected-head CAS and fast-forward
+   ancestry with `tool/git/safe_pr_head_update.dart` to prevent stale head
+   rewinds. Consult `doc/pr_branch_writer_inventory.md` for writer scope and the
+   remaining GitHub-managed governance boundary.

--- a/test/unit/tooling/classify_high_risk_changes_test.dart
+++ b/test/unit/tooling/classify_high_risk_changes_test.dart
@@ -70,6 +70,11 @@ void main() {
       final assessment = assessHighRiskFiles([
         '.github/workflows/release_on_prep_merge.yml',
         '.github/pull_request_template.md',
+        'CONTRIBUTING.md',
+        'tool/git/safe_pr_head_update.dart',
+        'tool/git/pr_head_update_evidence.schema.json',
+        'test/unit/tooling/safe_pr_head_update_test.dart',
+        'doc/pr_branch_writer_inventory.md',
       ]);
 
       expect(

--- a/test/unit/tooling/high_risk_review_policy_test.dart
+++ b/test/unit/tooling/high_risk_review_policy_test.dart
@@ -55,7 +55,9 @@ void main() {
 
       for (final path in [
         'AGENTS.md',
+        'CONTRIBUTING.md',
         'doc/testing_matrix.md',
+        'doc/pr_branch_writer_inventory.md',
         'tool/testing/test_matrix.dart',
         'tool/testing/classify_high_risk_changes.dart',
         'tool/testing/run_template_parity_suites.sh',
@@ -69,6 +71,9 @@ void main() {
         'test/e2e/template/'
             'specialized_tool_grammar_validation_e2e_test.dart',
         'test/unit/tooling/high_risk_review_policy_test.dart',
+        'tool/git/safe_pr_head_update.dart',
+        'tool/git/pr_head_update_evidence.schema.json',
+        'test/unit/tooling/safe_pr_head_update_test.dart',
       ]) {
         final rule = path.endsWith(' @leehack') ? path : '$path @leehack';
         expect(codeowners, contains(rule), reason: path);

--- a/test/unit/tooling/safe_pr_head_update_test.dart
+++ b/test/unit/tooling/safe_pr_head_update_test.dart
@@ -257,6 +257,120 @@ void main() {
       },
     );
 
+    test(
+      'injected runner accepts valid SSH URI push remote and sanitizes credential-bearing SSH push remote',
+      () async {
+        const commitA = '388dbc289abdb19b75225bcd3cee47cf72d83cd5';
+        const commitB = '25ef554283a667e3cf7e37a5cfd31605caafbd08';
+
+        ProcessResult mockGit(String pushUrl, List<String> args) {
+          if (args.length >= 2 && args[0] == 'remote' && args[1] == 'get-url') {
+            return ProcessResult(0, 0, '$pushUrl\n', '');
+          }
+          if (args.length >= 2 && args[0] == 'cat-file' && args[1] == '-t') {
+            return ProcessResult(0, 0, 'commit\n', '');
+          }
+          if (args.isNotEmpty && args[0] == 'ls-remote') {
+            return ProcessResult(
+              0,
+              0,
+              '$commitA\trefs/heads/feature/ssh-remote\n',
+              '',
+            );
+          }
+          if (args.contains('merge-base') && args.contains('--is-ancestor')) {
+            final isForward = args.indexOf(commitA) < args.indexOf(commitB);
+            return ProcessResult(0, isForward ? 0 : 1, '', '');
+          }
+          return ProcessResult(0, 0, '', '');
+        }
+
+        for (final validUrl in <String>[
+          'ssh://git@github.com/owner/repo.git',
+          'ssh://github.com/owner/repo.git',
+          'git@github.com:owner/repo.git',
+          'https://github.com/owner/repo.git',
+        ]) {
+          final accepted =
+              await SafePrHeadUpdate(
+                gitRunner: (args, {workingDirectory}) async =>
+                    mockGit(validUrl, args),
+              ).updatePrHead(
+                remote: 'origin',
+                branch: 'feature/ssh-remote',
+                expectedHeadSha: commitA,
+                proposedHeadSha: commitB,
+                writer: 'ssh-writer',
+                dryRun: true,
+              );
+          expect(
+            accepted.decision,
+            PrHeadUpdateDecision.validated,
+            reason: validUrl,
+          );
+          expect(
+            accepted.failureClassification,
+            PrHeadUpdateFailureClassification.none,
+            reason: validUrl,
+          );
+          expectEvidenceMatchesLocalSchema(accepted);
+        }
+
+        for (final (invalidUrl, secret) in <(String, String)>[
+          (
+            'ssh://git:sshSecretPass@github.com/owner/repo.git',
+            'sshSecretPass',
+          ),
+          ('ssh://:sshSecretPass@github.com/owner/repo.git', 'sshSecretPass'),
+          (
+            'ssh://git@github.com/owner/repo.git?token=sshSecretQuery',
+            'sshSecretQuery',
+          ),
+          (
+            'ssh://git@github.com/owner/repo.git#sshSecretFrag',
+            'sshSecretFrag',
+          ),
+          (
+            'https://user:httpsSecretPass@github.com/owner/repo.git',
+            'httpsSecretPass',
+          ),
+          (
+            'https://httpsSecretUser@github.com/owner/repo.git',
+            'httpsSecretUser',
+          ),
+        ]) {
+          final rejected =
+              await SafePrHeadUpdate(
+                gitRunner: (args, {workingDirectory}) async =>
+                    mockGit(invalidUrl, args),
+              ).updatePrHead(
+                remote: 'origin',
+                branch: 'feature/ssh-remote',
+                expectedHeadSha: commitA,
+                proposedHeadSha: commitB,
+                writer: 'ssh-writer',
+                dryRun: true,
+              );
+          expect(
+            rejected.decision,
+            PrHeadUpdateDecision.rejected,
+            reason: invalidUrl,
+          );
+          expect(
+            rejected.failureClassification,
+            PrHeadUpdateFailureClassification.invalidRemoteConfiguration,
+            reason: invalidUrl,
+          );
+          expect(
+            rejected.toFormattedJson(),
+            isNot(contains(secret)),
+            reason: invalidUrl,
+          );
+          expectEvidenceMatchesLocalSchema(rejected);
+        }
+      },
+    );
+
     test('process exceptions become sanitized structured evidence', () async {
       final result =
           await SafePrHeadUpdate(
@@ -974,8 +1088,18 @@ void main() {
           reconciled,
         ], work)).stdout.toString().trim().split(' ');
         expect(parents, <String>[reconciled, commitD, commitC]);
-        expect(File('${work.path}/diverged.txt').readAsStringSync(), 'D\n');
-        expect(File('${work.path}/feature.txt').readAsStringSync(), 'C\n');
+        expect(
+          File(
+            '${work.path}/diverged.txt',
+          ).readAsStringSync().replaceAll('\r\n', '\n'),
+          'D\n',
+        );
+        expect(
+          File(
+            '${work.path}/feature.txt',
+          ).readAsStringSync().replaceAll('\r\n', '\n'),
+          'C\n',
+        );
         for (final parent in <String>[commitD, commitC]) {
           expect(
             (await git(<String>[
@@ -993,8 +1117,12 @@ void main() {
 
   group('static repository writer contracts', () {
     test('all executable and task sources exclude bypass writers', () {
-      String repoPath(File file) =>
-          file.path.startsWith('./') ? file.path.substring(2) : file.path;
+      String repoPath(File file) {
+        final normalized = file.path.replaceAll('\\', '/');
+        return normalized.startsWith('./')
+            ? normalized.substring(2)
+            : normalized;
+      }
 
       final sourceFiles = Directory('.')
           .listSync(recursive: true, followLinks: false)
@@ -1077,15 +1205,18 @@ void main() {
       final markdownFiles = Directory('.')
           .listSync(recursive: true)
           .whereType<File>()
-          .where(
-            (file) =>
-                file.path.endsWith('.md') && !file.path.contains('/.git/'),
-          );
+          .where((file) {
+            final path = repoPath(file);
+            return path.endsWith('.md') &&
+                !path.startsWith('.git/') &&
+                !path.contains('/.git/');
+          });
       for (final file in markdownFiles) {
+        final path = repoPath(file);
         final content = file.readAsStringSync();
         for (final line in content.split('\n')) {
           if (!RegExp(r'\bgit\s+push\b').hasMatch(line)) continue;
-          if (file.path == './doc/pr_branch_writer_inventory.md') {
+          if (path == 'doc/pr_branch_writer_inventory.md') {
             expect(
               line,
               contains(
@@ -1095,13 +1226,13 @@ void main() {
             continue;
           }
           expect(
-            file.path,
+            path,
             matches(
               RegExp(
-                r'^\./website/versioned_docs/version-[^/]+/maintainers/release-workflow\.md$',
+                r'^website/versioned_docs/version-[^/]+/maintainers/release-workflow\.md$',
               ),
             ),
-            reason: '${file.path} documents an unregistered push',
+            reason: '$path documents an unregistered push',
           );
           expect(
             line.trim(),
@@ -1110,7 +1241,7 @@ void main() {
                 r'^git push origin llamadart_[a-z0-9_]+-v[0-9]+\.[0-9]+\.[0-9]+$',
               ),
             ),
-            reason: '${file.path} must remain a tag-only push example',
+            reason: '$path must remain a tag-only push example',
           );
         }
       }
@@ -1119,7 +1250,7 @@ void main() {
     test('the only workflow open-PR writer invokes the guarded helper', () {
       final workflow = File(
         '.github/workflows/sync_native_bindings.yml',
-      ).readAsStringSync();
+      ).readAsStringSync().replaceAll('\r\n', '\n');
       expect(workflowWriterContractViolations(workflow), isEmpty);
       expect(workflow, contains('tool/git/safe_pr_head_update.dart'));
       expect(workflow, contains('ref: main'));
@@ -1166,7 +1297,7 @@ void main() {
     test('workflow contract rejects guard deletion and mutation bypasses', () {
       final workflow = File(
         '.github/workflows/sync_native_bindings.yml',
-      ).readAsStringSync();
+      ).readAsStringSync().replaceAll('\r\n', '\n');
       expect(workflowWriterContractViolations(workflow), isEmpty);
 
       final deletedGuard = workflow.replaceFirst(

--- a/test/unit/tooling/safe_pr_head_update_test.dart
+++ b/test/unit/tooling/safe_pr_head_update_test.dart
@@ -415,6 +415,33 @@ void main() {
         PrHeadUpdateFailureClassification.invalidInput.name,
       );
     });
+
+    test('help and no-argument CLI invocations print usage block', () async {
+      for (final args in <List<String>>[
+        <String>[],
+        <String>['--help'],
+        <String>['-h'],
+      ]) {
+        final process = await Process.run(Platform.resolvedExecutable, <String>[
+          'tool/git/safe_pr_head_update.dart',
+          ...args,
+        ]);
+        expect(process.exitCode, 0, reason: '$args');
+        expect(process.stderr.toString(), isEmpty, reason: '$args');
+        expect(
+          process.stdout.toString(),
+          contains('Usage: dart run tool/git/safe_pr_head_update.dart'),
+          reason: '$args',
+        );
+        expect(
+          process.stdout.toString(),
+          contains(
+            'Update attempts and\ninvalid-argument invocations emit JSON evidence on stdout.',
+          ),
+          reason: '$args',
+        );
+      }
+    });
   });
 
   group('bare remote integration', () {

--- a/test/unit/tooling/safe_pr_head_update_test.dart
+++ b/test/unit/tooling/safe_pr_head_update_test.dart
@@ -1,0 +1,1232 @@
+@TestOn('vm')
+library;
+
+import 'dart:convert';
+import 'dart:io';
+
+import 'package:test/test.dart';
+
+import '../../../tool/git/safe_pr_head_update.dart';
+
+const zeroOid = '0000000000000000000000000000000000000000';
+
+Future<ProcessResult> git(List<String> args, Directory cwd) {
+  return Process.run('git', args, workingDirectory: cwd.path);
+}
+
+Future<String> commitFile(
+  Directory repo,
+  String filename,
+  String content,
+  String message,
+) async {
+  final file = File('${repo.path}/$filename');
+  await file.parent.create(recursive: true);
+  await file.writeAsString(content);
+  expect((await git(<String>['add', filename], repo)).exitCode, 0);
+  expect(
+    (await git(<String>[
+      '-c',
+      'user.name=Test Writer',
+      '-c',
+      'user.email=test@example.com',
+      'commit',
+      '--quiet',
+      '-m',
+      message,
+    ], repo)).exitCode,
+    0,
+  );
+  return (await git(<String>[
+    'rev-parse',
+    'HEAD',
+  ], repo)).stdout.toString().trim();
+}
+
+Future<String?> remoteHead(Directory repo, String branch) async {
+  final result = await git(<String>[
+    'ls-remote',
+    '--refs',
+    'origin',
+    'refs/heads/$branch',
+  ], repo);
+  final output = result.stdout.toString().trim();
+  return output.isEmpty ? null : output.split(RegExp(r'\s+')).first;
+}
+
+void expectEvidenceMatchesLocalSchema(PrHeadUpdateResult result) {
+  final schema =
+      jsonDecode(
+            File(
+              'tool/git/pr_head_update_evidence.schema.json',
+            ).readAsStringSync(),
+          )
+          as Map<String, dynamic>;
+  final properties = schema['properties'] as Map<String, dynamic>;
+  final required = (schema['required'] as List<dynamic>).cast<String>().toSet();
+  final evidence = result.toJson();
+
+  expect(schema[r'$id'], 'urn:llamadart:pr-head-update-evidence:1.0.0');
+  expect(schema['additionalProperties'], isFalse);
+  expect(required, properties.keys.toSet());
+  expect(evidence.keys.toSet(), properties.keys.toSet());
+  expect(evidence['schema'], PrHeadUpdateResult.schema);
+  expect(evidence['schema_version'], PrHeadUpdateResult.schemaVersion);
+  expect(DateTime.tryParse(evidence['timestamp']! as String), isNotNull);
+  expect(evidence['correlation_id'], isA<String>());
+  expect(evidence['writer'], isA<String>());
+  expect(evidence['target_ref'], isA<String>());
+  expect(evidence['remote'], isA<String>());
+  for (final key in <String>[
+    'expected_head_sha',
+    'remote_head_before',
+    'remote_head_after',
+  ]) {
+    final value = evidence[key];
+    expect(
+      value == null || RegExp(r'^[0-9a-f]{40}$').hasMatch(value as String),
+      isTrue,
+    );
+  }
+  expect(evidence['proposed_head_sha'], matches(RegExp(r'^[0-9a-f]{40}$')));
+  expect(
+    ((properties['decision'] as Map<String, dynamic>)['enum'] as List<dynamic>)
+        .toSet(),
+    PrHeadUpdateDecision.values.map((value) => value.name).toSet(),
+  );
+  expect(
+    ((properties['failure_classification'] as Map<String, dynamic>)['enum']
+            as List<dynamic>)
+        .toSet(),
+    PrHeadUpdateFailureClassification.values.map((value) => value.name).toSet(),
+  );
+  expect(evidence['decision'], result.decision.name);
+  expect(evidence['failure_classification'], result.failureClassification.name);
+  expect(evidence['message'], isA<String>());
+}
+
+List<String> workflowWriterContractViolations(String workflow) {
+  final violations = <String>[];
+  final guardedInvocation = RegExp(
+    r'''^\s+dart run tool/git/safe_pr_head_update\.dart \\\s*\n'''
+    r'''\s+--remote origin \\\s*\n'''
+    r'''\s+--branch "\$\{BRANCH\}" \\\s*\n'''
+    r'''\s+--expected-sha "\$\{EXPECTED_SHA\}" \\\s*\n'''
+    r'''\s+--proposed-sha "\$\{PROPOSED_SHA\}" \\\s*\n'''
+    r'''\s+--writer github-actions-native-sync \\\s*\n'''
+    r'''\s+--correlation-id "native-sync-\$\{GITHUB_RUN_ID\}-\$\{GITHUB_RUN_ATTEMPT\}" \\\s*\n'''
+    r'''\s+\| tee "\$\{RUNNER_TEMP\}/pr-head-update-evidence\.json"\s*$''',
+    multiLine: true,
+  );
+  final guardedInvocationCount = guardedInvocation.allMatches(workflow).length;
+  if (guardedInvocationCount != 1) {
+    violations.add('expected exactly one executable guarded-helper invocation');
+  }
+  for (final argument in <String>[
+    '--remote origin',
+    '--branch "\${BRANCH}"',
+    '--expected-sha "\${EXPECTED_SHA}"',
+    '--proposed-sha "\${PROPOSED_SHA}"',
+    '--writer github-actions-native-sync',
+    '--correlation-id "native-sync-\${GITHUB_RUN_ID}-\${GITHUB_RUN_ATTEMPT}"',
+  ]) {
+    if (!workflow.contains(argument)) {
+      violations.add('guarded helper is missing $argument');
+    }
+  }
+  for (final bypass in <RegExp>[
+    RegExp(r'peter-evans/create-pull-request'),
+    RegExp(r'^\s*git\b[^\n]*\bpush\b', multiLine: true),
+    RegExp(r'\b(?:createRef|updateRef|deleteRef)\s*\('),
+    RegExp(r'\bgithub\.rest\.git\.(?:createRef|updateRef|deleteRef)\b'),
+    RegExp(r'\b(?:gh\s+api|curl\b)[^\n]*git/refs/heads'),
+  ]) {
+    if (bypass.hasMatch(workflow)) {
+      violations.add('workflow contains a direct PR-ref mutation bypass');
+    }
+  }
+  final guardIndex = workflow.indexOf(
+    'dart run tool/git/safe_pr_head_update.dart',
+  );
+  for (final command in <String>['gh pr close', 'gh pr edit', 'gh pr create']) {
+    final commandIndex = workflow.indexOf(command);
+    if (guardIndex < 0 || commandIndex < 0 || guardIndex >= commandIndex) {
+      violations.add('$command must follow the guarded ref update');
+    }
+  }
+  return violations;
+}
+
+void main() {
+  group('input and evidence contracts', () {
+    test('validates branch, remote, and full object IDs', () {
+      expect(isValidBranchName('feature/fix-434'), isTrue);
+      expect(
+        isValidBranchName('refs/heads/automation/native-sync-v0.3.0'),
+        isTrue,
+      );
+      for (final value in <String>[
+        '',
+        '--force',
+        '+refs/heads/main',
+        'refs/tags/v1',
+        'feature/../main',
+        'feature//main',
+        '.hidden',
+        'feature/.hidden',
+        'feature/topic.lock/next',
+        'feature name',
+        'feature.lock',
+      ]) {
+        expect(isValidBranchName(value), isFalse, reason: value);
+      }
+
+      expect(isValidRemoteName('origin'), isTrue);
+      expect(isValidRemoteName('maintainer/upstream'), isTrue);
+      for (final value in <String>[
+        '--upload-pack=evil',
+        'https://example.test/repo.git',
+        'origin?token=secret',
+        '../origin',
+      ]) {
+        expect(isValidRemoteName(value), isFalse, reason: value);
+      }
+
+      expect(
+        isValidCommitSha('388dbc289abdb19b75225bcd3cee47cf72d83cd5'),
+        isTrue,
+      );
+      expect(isValidCommitSha(zeroOid), isFalse);
+      expect(isValidCommitSha(zeroOid, allowZero: true), isTrue);
+      expect(isValidCommitSha('HEAD'), isFalse);
+    });
+
+    test('all invalid inputs are sanitized before any rejection', () async {
+      final result = await const SafePrHeadUpdate().updatePrHead(
+        remote:
+            'https://user:remoteSecret@example.test/repo.git?token=remoteSecret',
+        branch: 'feature?branchSecret',
+        expectedHeadSha: 'expectedSecret',
+        proposedHeadSha: 'proposedSecret',
+        writer: 'writer?writerSecret',
+        correlationId: 'correlation?correlationSecret',
+      );
+      final encoded = result.toFormattedJson();
+      expect(
+        result.failureClassification,
+        PrHeadUpdateFailureClassification.invalidInput,
+      );
+      for (final secret in <String>[
+        'remoteSecret',
+        'branchSecret',
+        'expectedSecret',
+        'proposedSecret',
+        'writerSecret',
+        'correlationSecret',
+      ]) {
+        expect(encoded, isNot(contains(secret)));
+      }
+      expect(result.remote, '<invalid>');
+      expect(result.targetRef, '<invalid>');
+      expect(result.writer, '<invalid>');
+      expect(result.correlationId, '<invalid>');
+      expect(result.expectedHeadSha, zeroOid);
+      expect(result.proposedHeadSha, zeroOid);
+      expectEvidenceMatchesLocalSchema(result);
+    });
+
+    test(
+      'local schema exactly accepts every emitted field and stable enum',
+      () {
+        expectEvidenceMatchesLocalSchema(
+          PrHeadUpdateResult(
+            timestamp: DateTime.utc(2026, 8, 28),
+            correlationId: 'schema-check',
+            writer: 'schema-writer',
+            targetRef: 'refs/heads/schema-check',
+            remote: 'origin',
+            expectedHeadSha: zeroOid,
+            remoteHeadBefore: null,
+            proposedHeadSha: '388dbc289abdb19b75225bcd3cee47cf72d83cd5',
+            remoteHeadAfter: '388dbc289abdb19b75225bcd3cee47cf72d83cd5',
+            decision: PrHeadUpdateDecision.accepted,
+            failureClassification: PrHeadUpdateFailureClassification.none,
+            message: 'Schema validation fixture.',
+          ),
+        );
+      },
+    );
+
+    test('process exceptions become sanitized structured evidence', () async {
+      final result =
+          await SafePrHeadUpdate(
+            gitRunner: (args, {workingDirectory}) {
+              throw ProcessException('git', <String>['sensitive-argument']);
+            },
+          ).updatePrHead(
+            remote: 'origin',
+            branch: 'feature/process-failure',
+            expectedHeadSha: zeroOid,
+            proposedHeadSha: '388dbc289abdb19b75225bcd3cee47cf72d83cd5',
+            writer: 'process-writer',
+          );
+      expect(result.decision, PrHeadUpdateDecision.rejected);
+      expect(
+        result.failureClassification,
+        PrHeadUpdateFailureClassification.gitExecutionError,
+      );
+      expect(result.toFormattedJson(), isNot(contains('sensitive-argument')));
+      expectEvidenceMatchesLocalSchema(result);
+    });
+
+    test('malformed CLI input emits sanitized schema evidence', () async {
+      final process = await Process.run(Platform.resolvedExecutable, <String>[
+        'tool/git/safe_pr_head_update.dart',
+        '--unknown=cliSecret',
+      ]);
+      expect(process.exitCode, 64);
+      expect(process.stderr.toString(), isEmpty);
+      expect(process.stdout.toString(), isNot(contains('cliSecret')));
+      final evidence =
+          jsonDecode(process.stdout.toString()) as Map<String, dynamic>;
+      expect(evidence['schema'], PrHeadUpdateResult.schema);
+      expect(evidence['writer'], '<invalid>');
+      expect(evidence['target_ref'], '<invalid>');
+      expect(evidence['remote'], '<invalid>');
+      expect(evidence['expected_head_sha'], zeroOid);
+      expect(evidence['proposed_head_sha'], zeroOid);
+      expect(evidence['decision'], PrHeadUpdateDecision.rejected.name);
+      expect(
+        evidence['failure_classification'],
+        PrHeadUpdateFailureClassification.invalidInput.name,
+      );
+    });
+  });
+
+  group('bare remote integration', () {
+    late Directory root;
+    late Directory remote;
+    late Directory work;
+    late String commitA;
+    late String commitB;
+    late String commitC;
+    late String commitD;
+
+    setUp(() async {
+      root = await Directory.systemTemp.createTemp('safe_pr_head_update_test_');
+      remote = Directory('${root.path}/remote.git')..createSync();
+      work = Directory('${root.path}/work')..createSync();
+      expect(
+        (await git(<String>['init', '--bare', '--quiet'], remote)).exitCode,
+        0,
+      );
+      expect((await git(<String>['init', '--quiet'], work)).exitCode, 0);
+      expect(
+        (await git(<String>[
+          'remote',
+          'add',
+          'origin',
+          remote.path,
+        ], work)).exitCode,
+        0,
+      );
+      commitA = await commitFile(work, 'base.txt', 'A\n', 'A');
+      expect(
+        (await git(<String>[
+          'push',
+          '--quiet',
+          'origin',
+          '$commitA:refs/heads/pr-test',
+        ], work)).exitCode,
+        0,
+      );
+      commitB = await commitFile(work, 'feature.txt', 'B\n', 'B');
+      commitC = await commitFile(work, 'feature.txt', 'C\n', 'C');
+      expect(
+        (await git(<String>[
+          'checkout',
+          '--quiet',
+          '--detach',
+          commitA,
+        ], work)).exitCode,
+        0,
+      );
+      commitD = await commitFile(work, 'diverged.txt', 'D\n', 'D');
+      expect(
+        (await git(<String>[
+          'checkout',
+          '--quiet',
+          '--detach',
+          commitC,
+        ], work)).exitCode,
+        0,
+      );
+    });
+
+    tearDown(() => root.delete(recursive: true));
+
+    test(
+      'normal fast-forward succeeds with no force option and exact read-back',
+      () async {
+        expect(
+          (await git(<String>[
+            '-c',
+            'user.name=Test Writer',
+            '-c',
+            'user.email=test@example.com',
+            'tag',
+            '-a',
+            'must-not-follow',
+            '-m',
+            'must not follow',
+            commitB,
+          ], work)).exitCode,
+          0,
+        );
+        expect(
+          (await git(<String>[
+            'config',
+            'push.followTags',
+            'true',
+          ], work)).exitCode,
+          0,
+        );
+        expect(
+          (await git(<String>[
+            'config',
+            'remote.origin.mirror',
+            'true',
+          ], work)).exitCode,
+          0,
+        );
+        final contributorHookMarker = File('${root.path}/contributor-hook-ran');
+        final contributorHookDirectory = Directory(
+          '${work.path}/.custom-hooks',
+        );
+        await contributorHookDirectory.create();
+        expect(
+          (await git(<String>[
+            'config',
+            'core.hooksPath',
+            '.custom-hooks',
+          ], work)).exitCode,
+          0,
+        );
+        final contributorHook = File(
+          '${contributorHookDirectory.path}/pre-push',
+        );
+        await contributorHook.writeAsString(
+          '#!/bin/sh\n: > "${contributorHookMarker.path}"\n',
+        );
+        expect(
+          (await Process.run('chmod', <String>[
+            '700',
+            contributorHook.path,
+          ])).exitCode,
+          0,
+        );
+        final invocations = <List<String>>[];
+        final updater = SafePrHeadUpdate(
+          gitRunner: (args, {workingDirectory}) {
+            invocations.add(List<String>.of(args));
+            return defaultGitCommandRunner(
+              args,
+              workingDirectory: workingDirectory,
+            );
+          },
+        );
+        final result = await updater.updatePrHead(
+          remote: 'origin',
+          branch: 'pr-test',
+          expectedHeadSha: commitA,
+          proposedHeadSha: commitB,
+          writer: 'test-writer',
+          correlationId: 'normal-forward',
+          workingDirectory: work.path,
+        );
+        expect(
+          result.decision,
+          PrHeadUpdateDecision.accepted,
+          reason: result.toFormattedJson(),
+        );
+        expect(result.remoteHeadBefore, commitA);
+        expect(result.remoteHeadAfter, commitB);
+        expectEvidenceMatchesLocalSchema(result);
+        expect(await remoteHead(work, 'pr-test'), commitB);
+        expect(
+          (await git(<String>[
+            'ls-remote',
+            '--tags',
+            'origin',
+          ], work)).stdout.toString().trim(),
+          isEmpty,
+        );
+        expect(await contributorHookMarker.exists(), isTrue);
+        final push = invocations.singleWhere((args) => args.contains('push'));
+        expect(push, contains('--porcelain'));
+        expect(push, contains('remote.origin.mirror=false'));
+        expect(
+          push,
+          containsAll(<String>[
+            '--no-mirror',
+            '--no-tags',
+            '--no-follow-tags',
+            '--verify',
+          ]),
+        );
+        expect(push.any((arg) => arg.startsWith('--force')), isFalse);
+        expect(push.any((arg) => arg.startsWith('+')), isFalse);
+        final oneShotHookConfig = push.singleWhere(
+          (argument) => argument.startsWith('core.hooksPath='),
+        );
+        final oneShotHookDirectory = Directory(
+          oneShotHookConfig.substring('core.hooksPath='.length),
+        );
+        expect(oneShotHookDirectory.existsSync(), isFalse);
+      },
+    );
+
+    test('configured pre-push rejection is preserved and classified', () async {
+      final contributorHook = File('${work.path}/.git/hooks/pre-push');
+      const hookContents = '#!/bin/sh\nexit 23\n';
+      await contributorHook.writeAsString(hookContents);
+      expect(
+        (await Process.run('chmod', <String>[
+          '700',
+          contributorHook.path,
+        ])).exitCode,
+        0,
+      );
+      final result = await const SafePrHeadUpdate().updatePrHead(
+        remote: 'origin',
+        branch: 'pr-test',
+        expectedHeadSha: commitA,
+        proposedHeadSha: commitB,
+        writer: 'hook-policy-writer',
+        workingDirectory: work.path,
+      );
+      expect(result.decision, PrHeadUpdateDecision.rejected);
+      expect(
+        result.failureClassification,
+        PrHeadUpdateFailureClassification.prePushHookRejected,
+      );
+      expect(await remoteHead(work, 'pr-test'), commitA);
+      expect(await contributorHook.readAsString(), hookContents);
+    });
+
+    test(
+      'expected-head mismatch rejects and leaves the exact ref untouched',
+      () async {
+        final result = await const SafePrHeadUpdate().updatePrHead(
+          remote: 'origin',
+          branch: 'pr-test',
+          expectedHeadSha: commitB,
+          proposedHeadSha: commitC,
+          writer: 'stale-writer',
+          workingDirectory: work.path,
+        );
+        expect(
+          result.failureClassification,
+          PrHeadUpdateFailureClassification.expectedHeadMismatch,
+        );
+        expect(await remoteHead(work, 'pr-test'), commitA);
+      },
+    );
+
+    test('force-style refspec input is rejected without mutation', () async {
+      final result = await const SafePrHeadUpdate().updatePrHead(
+        remote: 'origin',
+        branch: '+refs/heads/pr-test',
+        expectedHeadSha: commitA,
+        proposedHeadSha: commitB,
+        writer: 'force-refspec-writer',
+        workingDirectory: work.path,
+      );
+      expect(
+        result.failureClassification,
+        PrHeadUpdateFailureClassification.invalidInput,
+      );
+      expect(await remoteHead(work, 'pr-test'), commitA);
+    });
+
+    test(
+      'credential-bearing configured push URL is rejected and redacted',
+      () async {
+        expect(
+          (await git(<String>[
+            'config',
+            'remote.origin.pushurl',
+            'https://user:pushSecret@example.test/repo.git',
+          ], work)).exitCode,
+          0,
+        );
+        final result = await const SafePrHeadUpdate().updatePrHead(
+          remote: 'origin',
+          branch: 'pr-test',
+          expectedHeadSha: commitA,
+          proposedHeadSha: commitB,
+          writer: 'redacted-url-writer',
+          workingDirectory: work.path,
+        );
+        expect(
+          result.failureClassification,
+          PrHeadUpdateFailureClassification.invalidRemoteConfiguration,
+        );
+        expect(result.toFormattedJson(), isNot(contains('pushSecret')));
+        expect(
+          (await git(<String>[
+            '--git-dir=${remote.path}',
+            'rev-parse',
+            'refs/heads/pr-test',
+          ], root)).stdout.toString().trim(),
+          commitA,
+        );
+      },
+    );
+
+    test('non-descendant history is rejected', () async {
+      expect(
+        (await git(<String>[
+          'push',
+          'origin',
+          '$commitB:refs/heads/pr-test',
+        ], work)).exitCode,
+        0,
+      );
+      final result = await const SafePrHeadUpdate().updatePrHead(
+        remote: 'origin',
+        branch: 'pr-test',
+        expectedHeadSha: commitB,
+        proposedHeadSha: commitD,
+        writer: 'diverged-writer',
+        workingDirectory: work.path,
+      );
+      expect(
+        result.failureClassification,
+        PrHeadUpdateFailureClassification.nonDescendantHistory,
+      );
+      expect(await remoteHead(work, 'pr-test'), commitB);
+    });
+
+    test('local replacement refs cannot bypass ancestry rejection', () async {
+      expect(
+        (await git(<String>[
+          'push',
+          'origin',
+          '$commitB:refs/heads/pr-test',
+        ], work)).exitCode,
+        0,
+      );
+      expect(
+        (await git(<String>['replace', commitD, commitC], work)).exitCode,
+        0,
+      );
+      expect(
+        (await git(<String>[
+          'merge-base',
+          '--is-ancestor',
+          commitB,
+          commitD,
+        ], work)).exitCode,
+        0,
+        reason:
+            'the fixture replacement must make the divergent head look safe',
+      );
+      final result = await const SafePrHeadUpdate().updatePrHead(
+        remote: 'origin',
+        branch: 'pr-test',
+        expectedHeadSha: commitB,
+        proposedHeadSha: commitD,
+        writer: 'replace-ref-writer',
+        workingDirectory: work.path,
+      );
+      expect(
+        result.failureClassification,
+        PrHeadUpdateFailureClassification.nonDescendantHistory,
+      );
+      expect(await remoteHead(work, 'pr-test'), commitB);
+    });
+
+    test('stale ancestor rewind is rejected', () async {
+      expect(
+        (await git(<String>[
+          'push',
+          'origin',
+          '$commitC:refs/heads/pr-test',
+        ], work)).exitCode,
+        0,
+      );
+      final result = await const SafePrHeadUpdate().updatePrHead(
+        remote: 'origin',
+        branch: 'pr-test',
+        expectedHeadSha: commitC,
+        proposedHeadSha: commitA,
+        writer: 'rewind-writer',
+        workingDirectory: work.path,
+      );
+      expect(
+        result.failureClassification,
+        PrHeadUpdateFailureClassification.staleAncestorRewind,
+      );
+      expect(await remoteHead(work, 'pr-test'), commitC);
+    });
+
+    test(
+      'retry is idempotent when expected and proposed equal the remote',
+      () async {
+        const updater = SafePrHeadUpdate();
+        final first = await updater.updatePrHead(
+          remote: 'origin',
+          branch: 'pr-test',
+          expectedHeadSha: commitA,
+          proposedHeadSha: commitB,
+          writer: 'retry-writer',
+          workingDirectory: work.path,
+        );
+        expect(first.decision, PrHeadUpdateDecision.accepted);
+        final result = await updater.updatePrHead(
+          remote: 'origin',
+          branch: 'pr-test',
+          expectedHeadSha: commitB,
+          proposedHeadSha: commitB,
+          writer: 'retry-writer',
+          workingDirectory: work.path,
+        );
+        expect(result.decision, PrHeadUpdateDecision.noOp);
+        expect(result.remoteHeadAfter, commitB);
+      },
+    );
+
+    test('all-zero expectation creates only an absent branch', () async {
+      final result = await const SafePrHeadUpdate().updatePrHead(
+        remote: 'origin',
+        branch: 'new-pr',
+        expectedHeadSha: zeroOid,
+        proposedHeadSha: commitB,
+        writer: 'automation-writer',
+        workingDirectory: work.path,
+      );
+      expect(result.decision, PrHeadUpdateDecision.accepted);
+      expect(result.remoteHeadBefore, isNull);
+      expect(result.remoteHeadAfter, commitB);
+      expect(await remoteHead(work, 'new-pr'), commitB);
+    });
+
+    test(
+      'an annotated tag object cannot be used as a proposed branch head',
+      () async {
+        expect(
+          (await git(<String>[
+            '-c',
+            'user.name=Test Writer',
+            '-c',
+            'user.email=test@example.com',
+            'tag',
+            '-a',
+            'tag-object-proposal',
+            '-m',
+            'tag object proposal',
+            commitB,
+          ], work)).exitCode,
+          0,
+        );
+        final tagObject = (await git(<String>[
+          'rev-parse',
+          'tag-object-proposal^{tag}',
+        ], work)).stdout.toString().trim();
+        final result = await const SafePrHeadUpdate().updatePrHead(
+          remote: 'origin',
+          branch: 'pr-test',
+          expectedHeadSha: commitA,
+          proposedHeadSha: tagObject,
+          writer: 'tag-object-writer',
+          workingDirectory: work.path,
+        );
+        expect(
+          result.failureClassification,
+          PrHeadUpdateFailureClassification.commitObjectMissing,
+        );
+        expect(await remoteHead(work, 'pr-test'), commitA);
+      },
+    );
+
+    test(
+      'dry-run reports the observed ref rather than an optimistic after SHA',
+      () async {
+        final result = await const SafePrHeadUpdate().updatePrHead(
+          remote: 'origin',
+          branch: 'pr-test',
+          expectedHeadSha: commitA,
+          proposedHeadSha: commitB,
+          writer: 'dry-runner',
+          dryRun: true,
+          workingDirectory: work.path,
+        );
+        expect(result.decision, PrHeadUpdateDecision.validated);
+        expect(result.remoteHeadAfter, commitA);
+        expect(await remoteHead(work, 'pr-test'), commitA);
+      },
+    );
+
+    test(
+      'concurrent winner advances after precheck and stale writer is rejected by in-push CAS',
+      () async {
+        var injectedWinner = false;
+        final updater = SafePrHeadUpdate(
+          gitRunner: (args, {workingDirectory}) async {
+            if (!injectedWinner && args.contains('push')) {
+              injectedWinner = true;
+              final winner = await git(<String>[
+                'push',
+                'origin',
+                '$commitB:refs/heads/pr-test',
+              ], work);
+              expect(winner.exitCode, 0);
+            }
+            return defaultGitCommandRunner(
+              args,
+              workingDirectory: workingDirectory,
+            );
+          },
+        );
+        final stale = await updater.updatePrHead(
+          remote: 'origin',
+          branch: 'pr-test',
+          expectedHeadSha: commitA,
+          proposedHeadSha: commitC,
+          writer: 'stale-concurrent-writer',
+          correlationId: 'deterministic-race',
+          workingDirectory: work.path,
+        );
+        expect(injectedWinner, isTrue);
+        expect(stale.decision, PrHeadUpdateDecision.rejected);
+        expect(
+          stale.failureClassification,
+          PrHeadUpdateFailureClassification.expectedHeadMismatch,
+        );
+        expect(stale.remoteHeadAfter, commitB);
+        expect(await remoteHead(work, 'pr-test'), commitB);
+      },
+    );
+
+    test(
+      'receive-pack rejects a post-advertisement race even when the stale proposal descends from the winner',
+      () async {
+        expect(
+          (await git(<String>[
+            'merge-base',
+            '--is-ancestor',
+            commitB,
+            commitC,
+          ], work)).exitCode,
+          0,
+        );
+        expect(
+          (await git(<String>[
+            'push',
+            '--quiet',
+            'origin',
+            '$commitC:refs/race-fixtures/commit-c',
+          ], work)).exitCode,
+          0,
+        );
+        final contributorHook = File('${work.path}/.git/hooks/pre-push');
+        await contributorHook.writeAsString(
+          '#!/bin/sh\n'
+          "git --git-dir='${remote.path}' update-ref "
+          "refs/heads/pr-test '$commitB' '$commitA'\n",
+        );
+        expect(
+          (await Process.run('chmod', <String>[
+            '700',
+            contributorHook.path,
+          ])).exitCode,
+          0,
+        );
+        final result = await const SafePrHeadUpdate().updatePrHead(
+          remote: 'origin',
+          branch: 'pr-test',
+          expectedHeadSha: commitA,
+          proposedHeadSha: commitC,
+          writer: 'post-advertisement-writer',
+          correlationId: 'receive-pack-old-oid-race',
+          workingDirectory: work.path,
+        );
+        expect(result.decision, PrHeadUpdateDecision.rejected);
+        expect(
+          result.failureClassification,
+          PrHeadUpdateFailureClassification.expectedHeadMismatch,
+        );
+        expect(result.remoteHeadBefore, commitA);
+        expect(result.remoteHeadAfter, commitB);
+        expect(await remoteHead(work, 'pr-test'), commitB);
+      },
+    );
+
+    test(
+      'success is rejected if the exact ref read-back moved again',
+      () async {
+        var remoteReads = 0;
+        final updater = SafePrHeadUpdate(
+          gitRunner: (args, {workingDirectory}) async {
+            if (args.contains('ls-remote')) {
+              remoteReads++;
+              if (remoteReads == 2) {
+                final next = await git(<String>[
+                  'push',
+                  'origin',
+                  '$commitC:refs/heads/pr-test',
+                ], work);
+                expect(next.exitCode, 0);
+              }
+            }
+            return defaultGitCommandRunner(
+              args,
+              workingDirectory: workingDirectory,
+            );
+          },
+        );
+        final result = await updater.updatePrHead(
+          remote: 'origin',
+          branch: 'pr-test',
+          expectedHeadSha: commitA,
+          proposedHeadSha: commitB,
+          writer: 'readback-writer',
+          workingDirectory: work.path,
+        );
+        expect(
+          result.failureClassification,
+          PrHeadUpdateFailureClassification.postMutationVerificationFailed,
+        );
+        expect(result.remoteHeadAfter, commitC);
+      },
+    );
+
+    test(
+      'read-back exception never reports an optimistic after head',
+      () async {
+        var remoteReads = 0;
+        final updater = SafePrHeadUpdate(
+          gitRunner: (args, {workingDirectory}) {
+            if (args.contains('ls-remote') && ++remoteReads == 2) {
+              throw ProcessException('git', <String>['secret-readback-arg']);
+            }
+            return defaultGitCommandRunner(
+              args,
+              workingDirectory: workingDirectory,
+            );
+          },
+        );
+        final result = await updater.updatePrHead(
+          remote: 'origin',
+          branch: 'pr-test',
+          expectedHeadSha: commitA,
+          proposedHeadSha: commitB,
+          writer: 'readback-exception-writer',
+          workingDirectory: work.path,
+        );
+        expect(
+          result.failureClassification,
+          PrHeadUpdateFailureClassification.gitExecutionError,
+        );
+        expect(result.remoteHeadBefore, commitA);
+        expect(result.remoteHeadAfter, isNull);
+        expect(
+          result.toFormattedJson(),
+          isNot(contains('secret-readback-arg')),
+        );
+        expect(await remoteHead(work, 'pr-test'), commitB);
+      },
+    );
+
+    test(
+      'workflow reconciliation merges both lines without dropping newer content',
+      () async {
+        expect(
+          (await git(<String>[
+            'checkout',
+            '--quiet',
+            '--detach',
+            commitD,
+          ], work)).exitCode,
+          0,
+        );
+        final reconciledResult = await git(<String>[
+          '-c',
+          'user.name=Test Writer',
+          '-c',
+          'user.email=test@example.com',
+          'merge',
+          '--no-ff',
+          '--no-edit',
+          commitC,
+        ], work);
+        expect(reconciledResult.exitCode, 0);
+        final reconciled = (await git(<String>[
+          'rev-parse',
+          'HEAD',
+        ], work)).stdout.toString().trim();
+        final parents = (await git(<String>[
+          'rev-list',
+          '--parents',
+          '-n',
+          '1',
+          reconciled,
+        ], work)).stdout.toString().trim().split(' ');
+        expect(parents, <String>[reconciled, commitD, commitC]);
+        expect(File('${work.path}/diverged.txt').readAsStringSync(), 'D\n');
+        expect(File('${work.path}/feature.txt').readAsStringSync(), 'C\n');
+        for (final parent in <String>[commitD, commitC]) {
+          expect(
+            (await git(<String>[
+              'merge-base',
+              '--is-ancestor',
+              parent,
+              reconciled,
+            ], work)).exitCode,
+            0,
+          );
+        }
+      },
+    );
+  });
+
+  group('static repository writer contracts', () {
+    test('all executable and task sources exclude bypass writers', () {
+      String repoPath(File file) =>
+          file.path.startsWith('./') ? file.path.substring(2) : file.path;
+
+      final sourceFiles = Directory('.')
+          .listSync(recursive: true, followLinks: false)
+          .whereType<File>()
+          .where((file) {
+            final path = repoPath(file);
+            if (path.startsWith('.git/') ||
+                path.startsWith('build/') ||
+                path.startsWith('.dart_tool/') ||
+                path.startsWith('node_modules/') ||
+                path.contains('/.dart_tool/') ||
+                path.contains('/node_modules/') ||
+                path.startsWith('test/')) {
+              return false;
+            }
+            return RegExp(
+                  r'\.(dart|py|sh|bash|zsh|fish|ps1|cmd|bat|js|ts)$',
+                ).hasMatch(path) ||
+                RegExp(r'\.ya?ml$').hasMatch(path) ||
+                path.endsWith('/package.json') ||
+                path == 'package.json' ||
+                path.endsWith('/Makefile') ||
+                path == 'Makefile';
+          });
+      for (final file in sourceFiles) {
+        final path = repoPath(file);
+        final content = file.readAsStringSync();
+        expect(
+          content,
+          isNot(contains('peter-evans/create-pull-request')),
+          reason: path,
+        );
+        expect(
+          content,
+          isNot(
+            matches(
+              RegExp(
+                r'(git\s*\.\s*(createRef|updateRef|deleteRef)|git/refs/heads|\b(createRef|updateRef|deleteRef)\s*\(|git\s+push\s+[^\n]*(--force|\+refs/heads))',
+                caseSensitive: false,
+              ),
+            ),
+          ),
+          reason: path,
+        );
+        if (path == '.github/workflows/docs_version_cut.yml') {
+          expect(content, contains('git push origin HEAD:main'));
+          expect(RegExp(r'\bgit\s+push\b').allMatches(content).length, 1);
+        } else {
+          expect(
+            content,
+            isNot(matches(RegExp(r'\bgit\s+push\b'))),
+            reason: '$path contains an unregistered direct push',
+          );
+        }
+        if (path != 'tool/git/safe_pr_head_update.dart') {
+          expect(
+            content,
+            isNot(
+              matches(
+                RegExp(
+                  r'''['"]git['"][\s\S]{0,160}['"]push['"]|['"]push['"]\s*,[\s\S]{0,160}refs/heads/''',
+                ),
+              ),
+            ),
+            reason: path,
+          );
+        }
+        if (path == '.github/workflows/release_on_prep_merge.yml') {
+          expect(content, contains('"ref=refs/tags/\$tag"'));
+          expect(RegExp(r'git/refs').allMatches(content).length, 1);
+        } else {
+          expect(
+            content,
+            isNot(matches(RegExp(r'git/refs'))),
+            reason: '$path contains an unregistered GitHub ref API',
+          );
+        }
+      }
+
+      final markdownFiles = Directory('.')
+          .listSync(recursive: true)
+          .whereType<File>()
+          .where(
+            (file) =>
+                file.path.endsWith('.md') && !file.path.contains('/.git/'),
+          );
+      for (final file in markdownFiles) {
+        final content = file.readAsStringSync();
+        for (final line in content.split('\n')) {
+          if (!RegExp(r'\bgit\s+push\b').hasMatch(line)) continue;
+          if (file.path == './doc/pr_branch_writer_inventory.md') {
+            expect(
+              line,
+              contains(
+                'ordinary blind `git push` is not an authorized open-PR update path',
+              ),
+            );
+            continue;
+          }
+          expect(
+            file.path,
+            matches(
+              RegExp(
+                r'^\./website/versioned_docs/version-[^/]+/maintainers/release-workflow\.md$',
+              ),
+            ),
+            reason: '${file.path} documents an unregistered push',
+          );
+          expect(
+            line.trim(),
+            matches(
+              RegExp(
+                r'^git push origin llamadart_[a-z0-9_]+-v[0-9]+\.[0-9]+\.[0-9]+$',
+              ),
+            ),
+            reason: '${file.path} must remain a tag-only push example',
+          );
+        }
+      }
+    });
+
+    test('the only workflow open-PR writer invokes the guarded helper', () {
+      final workflow = File(
+        '.github/workflows/sync_native_bindings.yml',
+      ).readAsStringSync();
+      expect(workflowWriterContractViolations(workflow), isEmpty);
+      expect(workflow, contains('tool/git/safe_pr_head_update.dart'));
+      expect(workflow, contains('ref: main'));
+      expect(workflow, contains('target_ref="refs/heads/\${branch}"'));
+      expect(workflow, contains('--expected-sha'));
+      expect(workflow, contains('--proposed-sha'));
+      expect(workflow, contains('--writer github-actions-native-sync'));
+      expect(workflow, contains('git fetch --quiet --no-tags origin'));
+      expect(workflow, contains('if [[ "\${fetched}" != "\${expected}" ]]'));
+      expect(
+        workflow,
+        contains('git merge-base --is-ancestor "\${candidate}" "\${expected}"'),
+      );
+      expect(workflow, contains('git merge --no-ff --no-edit "\${candidate}"'));
+      expect(workflow, contains('git rev-list --parents -n 1 "\${proposed}"'));
+      expect(
+        workflow,
+        contains('git merge-base --is-ancestor "\${expected}" "\${proposed}"'),
+      );
+      expect(
+        workflow,
+        contains('git merge-base --is-ancestor "\${candidate}" "\${proposed}"'),
+      );
+      expect(workflow, contains('should_update="\${has_changes}"'));
+      expect(workflow, contains('if [[ "\${HAS_CHANGES}" != "true" ]]'));
+      expect(workflow, contains('gh pr close'));
+      expect(workflow, contains('gh pr edit'));
+      expect(workflow, contains('gh pr create'));
+      expect(
+        workflow.indexOf('tool/git/safe_pr_head_update.dart'),
+        lessThan(workflow.indexOf('gh pr close')),
+      );
+      expect(
+        workflow.indexOf('tool/git/safe_pr_head_update.dart'),
+        lessThan(workflow.indexOf('gh pr edit')),
+      );
+      expect(
+        workflow.indexOf('tool/git/safe_pr_head_update.dart'),
+        lessThan(workflow.indexOf('gh pr create')),
+      );
+      expect(workflow, isNot(contains('create-pull-request')));
+    });
+
+    test('workflow contract rejects guard deletion and mutation bypasses', () {
+      final workflow = File(
+        '.github/workflows/sync_native_bindings.yml',
+      ).readAsStringSync();
+      expect(workflowWriterContractViolations(workflow), isEmpty);
+
+      final deletedGuard = workflow.replaceFirst(
+        '          dart run tool/git/safe_pr_head_update.dart \\\n',
+        '',
+      );
+      expect(workflowWriterContractViolations(deletedGuard), isNotEmpty);
+
+      final mentionedButNotExecuted = workflow.replaceFirst(
+        '          dart run tool/git/safe_pr_head_update.dart \\\n',
+        '          echo tool/git/safe_pr_head_update.dart \\\n',
+      );
+      expect(
+        workflowWriterContractViolations(mentionedButNotExecuted),
+        isNotEmpty,
+      );
+
+      for (final bypass in <String>[
+        '          git push --force origin HEAD:refs/heads/bypass\n',
+        "          gh api graphql -f query='mutation { updateRef(input: {}) }'\n",
+        '          gh api -X PATCH repos/example/repo/git/refs/heads/bypass\n',
+      ]) {
+        final bypassed = workflow.replaceFirst(
+          '          set -euo pipefail\n',
+          '          set -euo pipefail\n$bypass',
+        );
+        expect(
+          workflowWriterContractViolations(bypassed),
+          isNotEmpty,
+          reason: bypass.trim(),
+        );
+      }
+
+      final missingExpected = workflow.replaceFirst(
+        '            --expected-sha "\${EXPECTED_SHA}" \\\n',
+        '',
+      );
+      expect(workflowWriterContractViolations(missingExpected), isNotEmpty);
+    });
+
+    test('docs bind contributors to the inventory and residual boundary', () {
+      final agents = File('AGENTS.md').readAsStringSync();
+      final contributing = File('CONTRIBUTING.md').readAsStringSync();
+      final testingMatrix = File('doc/testing_matrix.md').readAsStringSync();
+      final inventory = File(
+        'doc/pr_branch_writer_inventory.md',
+      ).readAsStringSync();
+      expect(agents, contains('doc/pr_branch_writer_inventory.md'));
+      expect(agents, contains('tool/git/safe_pr_head_update.dart'));
+      expect(contributing, contains('tool/git/safe_pr_head_update.dart'));
+      expect(contributing, contains('exact observed fork-branch head'));
+      expect(testingMatrix, contains('tool/git/safe_pr_head_update.dart'));
+      expect(inventory, contains('GitHub web UI'));
+      expect(inventory, contains('third-party'));
+      expect(inventory, contains('protection or rulesets'));
+      expect(inventory, contains('b6af5a8b5d1973bc72d4e5283f1c7d728a679cb7'));
+      expect(inventory, contains('facts'));
+      expect(inventory, contains('Inference'));
+      expect(inventory, contains('.github/dependabot.yml'));
+      expect(inventory, contains('CONTRIBUTING.md'));
+    });
+  });
+}

--- a/test/unit/tooling/safe_pr_head_update_test.dart
+++ b/test/unit/tooling/safe_pr_head_update_test.dart
@@ -600,6 +600,70 @@ void main() {
       },
     );
 
+    test(
+      'slash-containing remote name executes guarded update without invalid config keys',
+      () async {
+        expect(
+          (await git(<String>[
+            'remote',
+            'add',
+            'maintainer/upstream',
+            remote.path,
+          ], work)).exitCode,
+          0,
+        );
+        final invocations = <List<String>>[];
+        final updater = SafePrHeadUpdate(
+          gitRunner: (args, {workingDirectory}) {
+            invocations.add(List<String>.of(args));
+            return defaultGitCommandRunner(
+              args,
+              workingDirectory: workingDirectory,
+            );
+          },
+        );
+        final result = await updater.updatePrHead(
+          remote: 'maintainer/upstream',
+          branch: 'pr-test',
+          expectedHeadSha: commitA,
+          proposedHeadSha: commitB,
+          writer: 'slash-remote-writer',
+          workingDirectory: work.path,
+        );
+        expect(
+          result.decision,
+          PrHeadUpdateDecision.accepted,
+          reason: result.toFormattedJson(),
+        );
+        expect(result.remote, 'maintainer/upstream');
+        expect(result.remoteHeadBefore, commitA);
+        expect(result.remoteHeadAfter, commitB);
+        expectEvidenceMatchesLocalSchema(result);
+
+        final push = invocations.singleWhere((args) => args.contains('push'));
+        expect(push, contains('--porcelain'));
+        expect(push, contains('--no-mirror'));
+        expect(push, contains('--no-tags'));
+        expect(push, contains('--no-follow-tags'));
+        expect(push, contains('--verify'));
+        expect(push, contains('maintainer/upstream'));
+        expect(
+          push.any((arg) => arg.contains('maintainer/upstream.mirror')),
+          isFalse,
+        );
+        expect(push.any((arg) => arg.startsWith('--force')), isFalse);
+        expect(push.any((arg) => arg.startsWith('+')), isFalse);
+        expect(
+          (await git(<String>[
+            '--git-dir=${remote.path}',
+            'rev-parse',
+            'refs/heads/pr-test',
+          ], root)).stdout.toString().trim(),
+          commitB,
+        );
+      },
+    );
+
     test('configured pre-push rejection is preserved and classified', () async {
       final contributorHook = File('${work.path}/.git/hooks/pre-push');
       const hookContents = '#!/bin/sh\nexit 23\n';

--- a/tool/git/pr_head_update_evidence.schema.json
+++ b/tool/git/pr_head_update_evidence.schema.json
@@ -1,0 +1,65 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "urn:llamadart:pr-head-update-evidence:1.0.0",
+  "title": "llamadart PR head update evidence",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "schema",
+    "schema_version",
+    "timestamp",
+    "correlation_id",
+    "writer",
+    "target_ref",
+    "remote",
+    "expected_head_sha",
+    "remote_head_before",
+    "proposed_head_sha",
+    "remote_head_after",
+    "decision",
+    "failure_classification",
+    "message"
+  ],
+  "properties": {
+    "schema": { "const": "llamadart.pr-head-update-evidence" },
+    "schema_version": { "const": "1.0.0" },
+    "timestamp": { "type": "string", "format": "date-time" },
+    "correlation_id": { "type": "string", "minLength": 1 },
+    "writer": { "type": "string", "minLength": 1 },
+    "target_ref": { "type": "string", "minLength": 1 },
+    "remote": { "type": "string", "minLength": 1 },
+    "expected_head_sha": { "$ref": "#/$defs/nullableSha" },
+    "remote_head_before": { "$ref": "#/$defs/nullableSha" },
+    "proposed_head_sha": { "$ref": "#/$defs/sha" },
+    "remote_head_after": { "$ref": "#/$defs/nullableSha" },
+    "decision": {
+      "enum": ["accepted", "rejected", "noOp", "validated"]
+    },
+    "failure_classification": {
+      "enum": [
+        "none",
+        "expectedHeadMismatch",
+        "nonDescendantHistory",
+        "staleAncestorRewind",
+        "invalidInput",
+        "invalidRemoteConfiguration",
+        "commitObjectMissing",
+        "remoteRefMissing",
+        "gitExecutionError",
+        "remoteMutationFailed",
+        "postMutationVerificationFailed",
+        "prePushHookRejected"
+      ]
+    },
+    "message": { "type": "string", "minLength": 1 }
+  },
+  "$defs": {
+    "sha": { "type": "string", "pattern": "^[0-9a-f]{40}$" },
+    "nullableSha": {
+      "oneOf": [
+        { "$ref": "#/$defs/sha" },
+        { "type": "null" }
+      ]
+    }
+  }
+}

--- a/tool/git/safe_pr_head_update.dart
+++ b/tool/git/safe_pr_head_update.dart
@@ -152,12 +152,17 @@ bool _isSafePushUrl(String value) {
     return true;
   }
   final uri = Uri.tryParse(value);
-  return uri != null &&
-      <String>{'https', 'ssh'}.contains(uri.scheme) &&
-      uri.host.isNotEmpty &&
-      uri.userInfo.isEmpty &&
-      !uri.hasQuery &&
-      !uri.hasFragment;
+  if (uri == null || uri.host.isEmpty || uri.hasQuery || uri.hasFragment) {
+    return false;
+  }
+  if (uri.scheme == 'https') {
+    return uri.userInfo.isEmpty;
+  }
+  if (uri.scheme == 'ssh') {
+    return uri.userInfo.isEmpty ||
+        RegExp(r'^[A-Za-z0-9._-]+$').hasMatch(uri.userInfo);
+  }
+  return false;
 }
 
 String? _parseExactRemoteHead(String output, String targetRef) {

--- a/tool/git/safe_pr_head_update.dart
+++ b/tool/git/safe_pr_head_update.dart
@@ -707,8 +707,8 @@ Usage: dart run tool/git/safe_pr_head_update.dart
   --branch <branch> --expected-sha <sha> --proposed-sha <sha>
   --writer <principal> [--remote origin] [--correlation-id <id>] [--dry-run]
 
-Use the all-zero expected SHA to create an absent branch. Evidence is always
-emitted as JSON on stdout.
+Use the all-zero expected SHA to create an absent branch. Update attempts and
+invalid-argument invocations emit JSON evidence on stdout.
 ''');
 }
 

--- a/tool/git/safe_pr_head_update.dart
+++ b/tool/git/safe_pr_head_update.dart
@@ -533,8 +533,10 @@ class SafePrHeadUpdate {
         final push = await gitRunner(<String>[
           '-c',
           'core.hooksPath=${hookDirectory.path}',
-          '-c',
-          'remote.$safeRemote.mirror=false',
+          if (!safeRemote.contains('/')) ...<String>[
+            '-c',
+            'remote.$safeRemote.mirror=false',
+          ],
           'push',
           '--porcelain',
           '--no-mirror',

--- a/tool/git/safe_pr_head_update.dart
+++ b/tool/git/safe_pr_head_update.dart
@@ -1,0 +1,782 @@
+#!/usr/bin/env dart
+
+import 'dart:convert';
+import 'dart:io';
+
+/// Decision reached while evaluating a PR head update.
+enum PrHeadUpdateDecision { accepted, rejected, noOp, validated }
+
+/// Stable failure classes emitted in PR head update evidence.
+enum PrHeadUpdateFailureClassification {
+  none,
+  expectedHeadMismatch,
+  nonDescendantHistory,
+  staleAncestorRewind,
+  invalidInput,
+  invalidRemoteConfiguration,
+  commitObjectMissing,
+  remoteRefMissing,
+  gitExecutionError,
+  remoteMutationFailed,
+  postMutationVerificationFailed,
+  prePushHookRejected,
+}
+
+/// Structured, sanitized audit evidence for one update attempt.
+class PrHeadUpdateResult {
+  const PrHeadUpdateResult({
+    required this.timestamp,
+    required this.correlationId,
+    required this.writer,
+    required this.targetRef,
+    required this.remote,
+    required this.expectedHeadSha,
+    required this.remoteHeadBefore,
+    required this.proposedHeadSha,
+    required this.remoteHeadAfter,
+    required this.decision,
+    required this.failureClassification,
+    required this.message,
+  });
+
+  static const String schema = 'llamadart.pr-head-update-evidence';
+  static const String schemaVersion = '1.0.0';
+
+  final DateTime timestamp;
+  final String correlationId;
+  final String writer;
+  final String targetRef;
+  final String remote;
+  final String? expectedHeadSha;
+  final String? remoteHeadBefore;
+  final String proposedHeadSha;
+  final String? remoteHeadAfter;
+  final PrHeadUpdateDecision decision;
+  final PrHeadUpdateFailureClassification failureClassification;
+  final String message;
+
+  bool get isSuccess => decision != PrHeadUpdateDecision.rejected;
+
+  Map<String, Object?> toJson() => <String, Object?>{
+    'schema': schema,
+    'schema_version': schemaVersion,
+    'timestamp': timestamp.toUtc().toIso8601String(),
+    'correlation_id': correlationId,
+    'writer': writer,
+    'target_ref': targetRef,
+    'remote': remote,
+    'expected_head_sha': expectedHeadSha,
+    'remote_head_before': remoteHeadBefore,
+    'proposed_head_sha': proposedHeadSha,
+    'remote_head_after': remoteHeadAfter,
+    'decision': decision.name,
+    'failure_classification': failureClassification.name,
+    'message': message,
+  };
+
+  String toFormattedJson() =>
+      const JsonEncoder.withIndent('  ').convert(toJson());
+}
+
+/// Process abstraction used by deterministic tests.
+typedef GitCommandRunner =
+    Future<ProcessResult> Function(
+      List<String> args, {
+      String? workingDirectory,
+    });
+
+/// Runs Git without invoking a shell.
+Future<ProcessResult> defaultGitCommandRunner(
+  List<String> args, {
+  String? workingDirectory,
+}) {
+  return Process.run('git', args, workingDirectory: workingDirectory);
+}
+
+const String _zeroOid = '0000000000000000000000000000000000000000';
+
+bool _isValidIdentifier(String value) =>
+    RegExp(r'^[A-Za-z0-9][A-Za-z0-9._:@/-]{0,127}$').hasMatch(value);
+
+/// Returns whether [branch] is in the safe subset accepted by this tool.
+bool isValidBranchName(String branch) {
+  if (branch.isEmpty || branch.length > 255) return false;
+  if (branch.startsWith('refs/') && !branch.startsWith('refs/heads/')) {
+    return false;
+  }
+  final name = branch.startsWith('refs/heads/')
+      ? branch.substring('refs/heads/'.length)
+      : branch;
+  final components = name.split('/');
+  return name.isNotEmpty &&
+      !name.startsWith('-') &&
+      RegExp(r'^[A-Za-z0-9][A-Za-z0-9._/-]*$').hasMatch(name) &&
+      components.every(
+        (component) =>
+            component.isNotEmpty &&
+            !component.startsWith('.') &&
+            !component.endsWith('.lock'),
+      ) &&
+      !name.endsWith('/') &&
+      !name.endsWith('.') &&
+      !name.contains('..') &&
+      !name.contains('//');
+}
+
+/// Returns whether [remote] is a safe configured remote name, never a URL.
+bool isValidRemoteName(String remote) =>
+    RegExp(r'^[A-Za-z0-9][A-Za-z0-9._/-]{0,127}$').hasMatch(remote) &&
+    !remote.contains('//') &&
+    !remote.contains('..');
+
+/// Returns whether [sha] is a full hexadecimal object ID.
+bool isValidCommitSha(String sha, {bool allowZero = false}) {
+  final value = sha.trim().toLowerCase();
+  return RegExp(r'^[0-9a-f]{40}$').hasMatch(value) &&
+      (allowZero || value != _zeroOid);
+}
+
+bool _isSafePushUrl(String value) {
+  if (value.isEmpty || value.contains('\n') || value.contains('\r')) {
+    return false;
+  }
+  if (value.startsWith('/') ||
+      value.startsWith('./') ||
+      value.startsWith('../')) {
+    return true;
+  }
+  if (RegExp(r'^[A-Za-z]:[\\/]').hasMatch(value)) return true;
+  if (RegExp(
+    r'^[A-Za-z0-9._-]+@[A-Za-z0-9.-]+:[A-Za-z0-9._/~+-]+$',
+  ).hasMatch(value)) {
+    return true;
+  }
+  final uri = Uri.tryParse(value);
+  return uri != null &&
+      <String>{'https', 'ssh'}.contains(uri.scheme) &&
+      uri.host.isNotEmpty &&
+      uri.userInfo.isEmpty &&
+      !uri.hasQuery &&
+      !uri.hasFragment;
+}
+
+String? _parseExactRemoteHead(String output, String targetRef) {
+  String? found;
+  for (final line in const LineSplitter().convert(output.trim())) {
+    final fields = line.trim().split(RegExp(r'\s+'));
+    if (fields.length != 2 || fields[1] != targetRef) continue;
+    final sha = fields[0].toLowerCase();
+    if (!isValidCommitSha(sha) || found != null) return null;
+    found = sha;
+  }
+  return found;
+}
+
+PrHeadUpdateResult _evidence({
+  required DateTime timestamp,
+  required String correlationId,
+  required String writer,
+  required String targetRef,
+  required String remote,
+  required String? expected,
+  required String? before,
+  required String proposed,
+  required String? after,
+  required PrHeadUpdateDecision decision,
+  required PrHeadUpdateFailureClassification classification,
+  required String message,
+}) {
+  return PrHeadUpdateResult(
+    timestamp: timestamp,
+    correlationId: correlationId,
+    writer: writer,
+    targetRef: targetRef,
+    remote: remote,
+    expectedHeadSha: expected,
+    remoteHeadBefore: before,
+    proposedHeadSha: proposed,
+    remoteHeadAfter: after,
+    decision: decision,
+    failureClassification: classification,
+    message: message,
+  );
+}
+
+/// Enforces expected-head CAS and strict fast-forward ancestry for a PR ref.
+class SafePrHeadUpdate {
+  const SafePrHeadUpdate({this.gitRunner = defaultGitCommandRunner});
+
+  final GitCommandRunner gitRunner;
+
+  Future<PrHeadUpdateResult> updatePrHead({
+    required String remote,
+    required String branch,
+    required String expectedHeadSha,
+    required String proposedHeadSha,
+    required String writer,
+    String? correlationId,
+    bool dryRun = false,
+    String? workingDirectory,
+  }) async {
+    final timestamp = DateTime.now();
+    final safeRemote = remote.trim();
+    final safeBranch = branch.trim();
+    final expected = expectedHeadSha.trim().toLowerCase();
+    final proposed = proposedHeadSha.trim().toLowerCase();
+    final safeWriter = writer.trim();
+    final safeCorrelation =
+        correlationId?.trim() ??
+        'pr-head-update-${timestamp.microsecondsSinceEpoch}';
+    final writerIsValid = _isValidIdentifier(safeWriter);
+    final correlationIsValid = _isValidIdentifier(safeCorrelation);
+    final remoteIsValid = isValidRemoteName(safeRemote);
+    final branchIsValid = isValidBranchName(safeBranch);
+    final expectedIsValid = isValidCommitSha(expected, allowZero: true);
+    final proposedIsValid = isValidCommitSha(proposed);
+    final targetRef = branchIsValid
+        ? (safeBranch.startsWith('refs/heads/')
+              ? safeBranch
+              : 'refs/heads/$safeBranch')
+        : '<invalid>';
+    final evidenceWriter = writerIsValid ? safeWriter : '<invalid>';
+    final evidenceCorrelation = correlationIsValid
+        ? safeCorrelation
+        : '<invalid>';
+    final evidenceRemote = remoteIsValid ? safeRemote : '<invalid>';
+    final evidenceExpected = expectedIsValid ? expected : _zeroOid;
+    final evidenceProposed = proposedIsValid ? proposed : _zeroOid;
+
+    PrHeadUpdateResult reject(
+      PrHeadUpdateFailureClassification classification,
+      String message, {
+      String? before,
+      String? after,
+      String? overrideRemote,
+      String? overrideWriter,
+      String? overrideCorrelation,
+      String? overrideTarget,
+      String? overrideExpected,
+      String? overrideProposed,
+    }) => _evidence(
+      timestamp: timestamp,
+      correlationId: overrideCorrelation ?? evidenceCorrelation,
+      writer: overrideWriter ?? evidenceWriter,
+      targetRef: overrideTarget ?? targetRef,
+      remote: overrideRemote ?? evidenceRemote,
+      expected: overrideExpected ?? evidenceExpected,
+      before: before,
+      proposed: overrideProposed ?? evidenceProposed,
+      after: after,
+      decision: PrHeadUpdateDecision.rejected,
+      classification: classification,
+      message: message,
+    );
+
+    if (!writerIsValid) {
+      return reject(
+        PrHeadUpdateFailureClassification.invalidInput,
+        'Writer identity must use the supported identifier character set.',
+      );
+    }
+    if (!correlationIsValid) {
+      return reject(
+        PrHeadUpdateFailureClassification.invalidInput,
+        'Correlation ID must use the supported identifier character set.',
+      );
+    }
+    if (!remoteIsValid) {
+      return reject(
+        PrHeadUpdateFailureClassification.invalidInput,
+        'Remote must be a configured remote name, not a URL or option.',
+      );
+    }
+    if (!branchIsValid) {
+      return reject(
+        PrHeadUpdateFailureClassification.invalidInput,
+        'Branch must be a safe branch name under refs/heads.',
+      );
+    }
+    if (!expectedIsValid) {
+      return reject(
+        PrHeadUpdateFailureClassification.invalidInput,
+        'Expected head must be a full hexadecimal object ID.',
+      );
+    }
+    if (!proposedIsValid) {
+      return reject(
+        PrHeadUpdateFailureClassification.invalidInput,
+        'Proposed head must be a nonzero full hexadecimal object ID.',
+      );
+    }
+
+    String? initialRemoteHead;
+    String? postMutationRemoteHead;
+    var mutationAttempted = false;
+    try {
+      final remoteResult = await gitRunner(<String>[
+        'remote',
+        'get-url',
+        '--push',
+        '--all',
+        safeRemote,
+      ], workingDirectory: workingDirectory);
+      final pushUrls = const LineSplitter()
+          .convert(remoteResult.stdout.toString().trim())
+          .where((line) => line.isNotEmpty)
+          .toList(growable: false);
+      if (remoteResult.exitCode != 0 ||
+          pushUrls.length != 1 ||
+          !_isSafePushUrl(pushUrls.single)) {
+        return reject(
+          PrHeadUpdateFailureClassification.invalidRemoteConfiguration,
+          'Remote must resolve to exactly one credential-free HTTPS, SSH, or local push URL.',
+        );
+      }
+
+      final proposedObject = await gitRunner(<String>[
+        'cat-file',
+        '-t',
+        proposed,
+      ], workingDirectory: workingDirectory);
+      if (proposedObject.exitCode != 0 ||
+          proposedObject.stdout.toString().trim() != 'commit') {
+        return reject(
+          PrHeadUpdateFailureClassification.commitObjectMissing,
+          'The proposed object is not an exact local commit object.',
+        );
+      }
+
+      final observed = await _readRemoteHead(
+        safeRemote,
+        targetRef,
+        workingDirectory,
+      );
+      initialRemoteHead = observed.sha;
+      if (observed.commandFailed) {
+        return reject(
+          PrHeadUpdateFailureClassification.gitExecutionError,
+          'Git could not query the exact remote ref.',
+        );
+      }
+      final before = observed.sha ?? _zeroOid;
+      if (before != expected) {
+        return reject(
+          observed.sha == null
+              ? PrHeadUpdateFailureClassification.remoteRefMissing
+              : PrHeadUpdateFailureClassification.expectedHeadMismatch,
+          observed.sha == null
+              ? 'The target ref does not exist at the expected head.'
+              : 'The exact remote head does not match the expected head.',
+          before: observed.sha,
+          after: observed.sha,
+        );
+      }
+
+      if (expected != _zeroOid) {
+        final expectedObject = await gitRunner(<String>[
+          'cat-file',
+          '-t',
+          expected,
+        ], workingDirectory: workingDirectory);
+        if (expectedObject.exitCode != 0 ||
+            expectedObject.stdout.toString().trim() != 'commit') {
+          return reject(
+            PrHeadUpdateFailureClassification.commitObjectMissing,
+            'The expected remote object is not an exact local commit object.',
+            before: before,
+            after: before,
+          );
+        }
+        if (proposed == expected) {
+          return _evidence(
+            timestamp: timestamp,
+            correlationId: safeCorrelation,
+            writer: safeWriter,
+            targetRef: targetRef,
+            remote: safeRemote,
+            expected: expected,
+            before: before,
+            proposed: proposed,
+            after: before,
+            decision: PrHeadUpdateDecision.noOp,
+            classification: PrHeadUpdateFailureClassification.none,
+            message: 'The exact remote ref is already at the proposed head.',
+          );
+        }
+
+        final stale = await gitRunner(<String>[
+          '--no-replace-objects',
+          'merge-base',
+          '--is-ancestor',
+          proposed,
+          expected,
+        ], workingDirectory: workingDirectory);
+        if (stale.exitCode == 0) {
+          return reject(
+            PrHeadUpdateFailureClassification.staleAncestorRewind,
+            'The proposed head is an ancestor of the expected head.',
+            before: before,
+            after: before,
+          );
+        }
+        if (stale.exitCode > 1) {
+          return reject(
+            PrHeadUpdateFailureClassification.gitExecutionError,
+            'Git could not evaluate stale-ancestor ancestry.',
+            before: before,
+            after: before,
+          );
+        }
+        final forward = await gitRunner(<String>[
+          '--no-replace-objects',
+          'merge-base',
+          '--is-ancestor',
+          expected,
+          proposed,
+        ], workingDirectory: workingDirectory);
+        if (forward.exitCode == 1) {
+          return reject(
+            PrHeadUpdateFailureClassification.nonDescendantHistory,
+            'The proposed head does not descend from the expected head.',
+            before: before,
+            after: before,
+          );
+        }
+        if (forward.exitCode != 0) {
+          return reject(
+            PrHeadUpdateFailureClassification.gitExecutionError,
+            'Git could not evaluate fast-forward ancestry.',
+            before: before,
+            after: before,
+          );
+        }
+      }
+
+      if (dryRun) {
+        return _evidence(
+          timestamp: timestamp,
+          correlationId: safeCorrelation,
+          writer: safeWriter,
+          targetRef: targetRef,
+          remote: safeRemote,
+          expected: expected,
+          before: observed.sha,
+          proposed: proposed,
+          after: observed.sha,
+          decision: PrHeadUpdateDecision.validated,
+          classification: PrHeadUpdateFailureClassification.none,
+          message:
+              'Expected-head and fast-forward checks passed without mutation.',
+        );
+      }
+
+      final configuredHook = await gitRunner(<String>[
+        'rev-parse',
+        '--git-path',
+        'hooks/pre-push',
+      ], workingDirectory: workingDirectory);
+      final configuredHookOutput = configuredHook.stdout.toString().trim();
+      if (configuredHook.exitCode != 0 ||
+          configuredHookOutput.isEmpty ||
+          configuredHookOutput.contains('\n') ||
+          configuredHookOutput.contains('\r')) {
+        return reject(
+          PrHeadUpdateFailureClassification.gitExecutionError,
+          'Git could not resolve the configured pre-push hook path.',
+          before: observed.sha,
+          after: observed.sha,
+        );
+      }
+      final configuredHookPath = File(configuredHookOutput).isAbsolute
+          ? configuredHookOutput
+          : '${workingDirectory ?? Directory.current.path}/$configuredHookOutput';
+
+      final hookDirectory = await Directory.systemTemp.createTemp(
+        'llamadart_pr_head_cas_',
+      );
+      final mismatchMarker = File(
+        '${hookDirectory.path}/expected-head-mismatch',
+      );
+      final configuredHookRejectedMarker = File(
+        '${hookDirectory.path}/configured-hook-rejected',
+      );
+      final hookInput = File('${hookDirectory.path}/pre-push-input');
+      final hook = File('${hookDirectory.path}/pre-push');
+      try {
+        await hook.writeAsString(
+          _prePushHook(
+            targetRef: targetRef,
+            expectedHead: expected,
+            markerPath: mismatchMarker.path,
+            configuredHookRejectedMarkerPath: configuredHookRejectedMarker.path,
+            inputPath: hookInput.path,
+            configuredHookPath: configuredHookPath,
+          ),
+        );
+        if (!Platform.isWindows) {
+          final chmod = await Process.run('chmod', <String>['700', hook.path]);
+          if (chmod.exitCode != 0) {
+            return reject(
+              PrHeadUpdateFailureClassification.gitExecutionError,
+              'The one-shot expected-head guard could not be prepared.',
+              before: observed.sha,
+              after: observed.sha,
+            );
+          }
+        }
+        mutationAttempted = true;
+        final push = await gitRunner(<String>[
+          '-c',
+          'core.hooksPath=${hookDirectory.path}',
+          '-c',
+          'remote.$safeRemote.mirror=false',
+          'push',
+          '--porcelain',
+          '--no-mirror',
+          '--no-tags',
+          '--no-follow-tags',
+          '--verify',
+          safeRemote,
+          '$proposed:$targetRef',
+        ], workingDirectory: workingDirectory);
+        if (push.exitCode != 0) {
+          final afterFailure = await _readRemoteHead(
+            safeRemote,
+            targetRef,
+            workingDirectory,
+          );
+          if (!afterFailure.commandFailed) {
+            postMutationRemoteHead = afterFailure.sha;
+          }
+          final raced =
+              await mismatchMarker.exists() ||
+              (!afterFailure.commandFailed && afterFailure.sha != observed.sha);
+          final configuredHookRejected = await configuredHookRejectedMarker
+              .exists();
+          return reject(
+            raced
+                ? PrHeadUpdateFailureClassification.expectedHeadMismatch
+                : configuredHookRejected
+                ? PrHeadUpdateFailureClassification.prePushHookRejected
+                : PrHeadUpdateFailureClassification.remoteMutationFailed,
+            raced
+                ? 'The remote head changed after validation; the guarded push rejected the stale writer.'
+                : configuredHookRejected
+                ? 'The configured pre-push hook rejected the update.'
+                : 'The server rejected the normal fast-forward-only push.',
+            before: observed.sha,
+            after: afterFailure.sha,
+          );
+        }
+      } finally {
+        try {
+          await hookDirectory.delete(recursive: true);
+        } on FileSystemException {
+          // Cleanup is best-effort. The directory contains no credentials, and
+          // read-back still determines whether the remote mutation succeeded.
+        }
+      }
+
+      final verified = await _readRemoteHead(
+        safeRemote,
+        targetRef,
+        workingDirectory,
+      );
+      if (!verified.commandFailed) {
+        postMutationRemoteHead = verified.sha;
+      }
+      if (verified.commandFailed || verified.sha != proposed) {
+        return reject(
+          PrHeadUpdateFailureClassification.postMutationVerificationFailed,
+          'The exact remote ref did not read back at the proposed head.',
+          before: observed.sha,
+          after: verified.sha,
+        );
+      }
+      return _evidence(
+        timestamp: timestamp,
+        correlationId: safeCorrelation,
+        writer: safeWriter,
+        targetRef: targetRef,
+        remote: safeRemote,
+        expected: expected,
+        before: observed.sha,
+        proposed: proposed,
+        after: verified.sha,
+        decision: PrHeadUpdateDecision.accepted,
+        classification: PrHeadUpdateFailureClassification.none,
+        message:
+            'The exact remote ref was advanced and read back successfully.',
+      );
+    } on ProcessException {
+      return reject(
+        PrHeadUpdateFailureClassification.gitExecutionError,
+        'A local process could not execute the guarded update.',
+        before: initialRemoteHead,
+        after: mutationAttempted ? postMutationRemoteHead : initialRemoteHead,
+      );
+    } on FileSystemException {
+      return reject(
+        PrHeadUpdateFailureClassification.gitExecutionError,
+        'A local filesystem operation could not prepare the guarded update.',
+        before: initialRemoteHead,
+        after: mutationAttempted ? postMutationRemoteHead : initialRemoteHead,
+      );
+    }
+  }
+
+  Future<_RemoteHead> _readRemoteHead(
+    String remote,
+    String targetRef,
+    String? workingDirectory,
+  ) async {
+    final result = await gitRunner(<String>[
+      'ls-remote',
+      '--quiet',
+      '--refs',
+      remote,
+      targetRef,
+    ], workingDirectory: workingDirectory);
+    if (result.exitCode != 0) return const _RemoteHead(commandFailed: true);
+    final output = result.stdout.toString().trim();
+    if (output.isEmpty) return const _RemoteHead();
+    final sha = _parseExactRemoteHead(output, targetRef);
+    return _RemoteHead(sha: sha, commandFailed: sha == null);
+  }
+}
+
+class _RemoteHead {
+  const _RemoteHead({this.sha, this.commandFailed = false});
+  final String? sha;
+  final bool commandFailed;
+}
+
+String _quote(String value) => "'${value.replaceAll("'", "'\"'\"'")}'";
+
+String _prePushHook({
+  required String targetRef,
+  required String expectedHead,
+  required String markerPath,
+  required String configuredHookRejectedMarkerPath,
+  required String inputPath,
+  required String configuredHookPath,
+}) =>
+    '''#!/bin/sh
+target_ref=${_quote(targetRef)}
+expected_head=${_quote(expectedHead)}
+mismatch_marker=${_quote(markerPath)}
+configured_hook_rejected_marker=${_quote(configuredHookRejectedMarkerPath)}
+input_file=${_quote(inputPath)}
+configured_hook=${_quote(configuredHookPath)}
+matched=0
+cat > "\$input_file"
+while read -r local_ref local_oid remote_ref remote_oid
+do
+  if [ "\$remote_ref" = "\$target_ref" ]; then
+    matched=\$((matched + 1))
+    if [ "\$remote_oid" != "\$expected_head" ]; then
+      : > "\$mismatch_marker"
+      exit 1
+    fi
+  fi
+done < "\$input_file"
+if [ "\$matched" -ne 1 ]; then
+  : > "\$mismatch_marker"
+  exit 1
+fi
+if [ -x "\$configured_hook" ]; then
+  "\$configured_hook" "\$@" < "\$input_file" || {
+    status=\$?
+    : > "\$configured_hook_rejected_marker"
+    exit "\$status"
+  }
+fi
+exit 0
+''';
+
+void _printUsage() {
+  stdout.writeln('''
+Usage: dart run tool/git/safe_pr_head_update.dart
+  --branch <branch> --expected-sha <sha> --proposed-sha <sha>
+  --writer <principal> [--remote origin] [--correlation-id <id>] [--dry-run]
+
+Use the all-zero expected SHA to create an absent branch. Evidence is always
+emitted as JSON on stdout.
+''');
+}
+
+void _emitInvalidCliArguments() {
+  final timestamp = DateTime.now();
+  final result = PrHeadUpdateResult(
+    timestamp: timestamp,
+    correlationId: 'invalid-cli-${timestamp.microsecondsSinceEpoch}',
+    writer: '<invalid>',
+    targetRef: '<invalid>',
+    remote: '<invalid>',
+    expectedHeadSha: _zeroOid,
+    remoteHeadBefore: null,
+    proposedHeadSha: _zeroOid,
+    remoteHeadAfter: null,
+    decision: PrHeadUpdateDecision.rejected,
+    failureClassification: PrHeadUpdateFailureClassification.invalidInput,
+    message: 'Command-line arguments are invalid or incomplete.',
+  );
+  stdout.writeln(result.toFormattedJson());
+  exitCode = 64;
+}
+
+Future<void> main(List<String> args) async {
+  if (args.isEmpty || args.contains('--help') || args.contains('-h')) {
+    _printUsage();
+    return;
+  }
+  final values = <String, String>{};
+  var dryRun = false;
+  for (var index = 0; index < args.length; index++) {
+    final argument = args[index];
+    if (argument == '--dry-run') {
+      dryRun = true;
+      continue;
+    }
+    final names = <String, String>{
+      '--branch': 'branch',
+      '-b': 'branch',
+      '--expected-sha': 'expected',
+      '-e': 'expected',
+      '--proposed-sha': 'proposed',
+      '-p': 'proposed',
+      '--writer': 'writer',
+      '-w': 'writer',
+      '--remote': 'remote',
+      '-r': 'remote',
+      '--correlation-id': 'correlation',
+      '-c': 'correlation',
+    };
+    final key = names[argument];
+    if (key == null || index + 1 >= args.length) {
+      _emitInvalidCliArguments();
+      return;
+    }
+    values[key] = args[++index];
+  }
+  if (!<String>{
+    'branch',
+    'expected',
+    'proposed',
+    'writer',
+  }.every(values.containsKey)) {
+    _emitInvalidCliArguments();
+    return;
+  }
+  final result = await const SafePrHeadUpdate().updatePrHead(
+    remote: values['remote'] ?? 'origin',
+    branch: values['branch']!,
+    expectedHeadSha: values['expected']!,
+    proposedHeadSha: values['proposed']!,
+    writer: values['writer']!,
+    correlationId: values['correlation'],
+    dryRun: dryRun,
+  );
+  stdout.writeln(result.toFormattedJson());
+  exitCode = result.isSuccess ? 0 : 1;
+}

--- a/tool/testing/classify_high_risk_changes.dart
+++ b/tool/testing/classify_high_risk_changes.dart
@@ -155,15 +155,20 @@ bool _isReleaseAutomation(String path) {
 
 bool _isRegressionPolicy(String path) {
   return path == 'AGENTS.md' ||
+      path == 'CONTRIBUTING.md' ||
       path == '.github/CODEOWNERS' ||
       path == '.github/pull_request_template.md' ||
       path.startsWith('.github/workflows/') ||
       path == 'doc/testing_matrix.md' ||
+      path == 'doc/pr_branch_writer_inventory.md' ||
       path == 'tool/testing/test_matrix.dart' ||
       path == 'tool/testing/classify_high_risk_changes.dart' ||
       path == 'test/unit/tooling/test_matrix_test.dart' ||
       path == 'test/unit/tooling/classify_high_risk_changes_test.dart' ||
-      path == 'test/unit/tooling/high_risk_review_policy_test.dart';
+      path == 'test/unit/tooling/high_risk_review_policy_test.dart' ||
+      path == 'tool/git/safe_pr_head_update.dart' ||
+      path == 'tool/git/pr_head_update_evidence.schema.json' ||
+      path == 'test/unit/tooling/safe_pr_head_update_test.dart';
 }
 
 /// Formats the contributor-facing classification result.


### PR DESCRIPTION
Fixes #441

## Summary
- Replace the native-sync workflow's blind PR updater with a repository-local expected-head compare-and-swap and fast-forward-only contract.
- Add sanitized, schema-backed update evidence with writer, correlation ID, exact before/proposed/after heads, decision, and failure classification.
- Inventory repository-local open-PR writers and document the remaining GitHub-managed governance boundary.
- Add deterministic bare-repository race, ancestry, retry/idempotency, read-back, sanitization, workflow-contract, and deletion/bypass regressions.

## PR Branch Integrity Contract
- `tool/git/safe_pr_head_update.dart` validates a single configured credential-free push URL, exact full object IDs, commit object type, expected remote head, and strict ancestry before mutation.
- Mutation uses a normal non-force push with a one-shot pre-push guard bound to the advertised remote OID; force options, `+refspec` updates, stale ancestor rewinds, and non-descendant transitions are rejected.
- Credential-free URI-form SSH remotes with a username are accepted, while password/query/fragment-bearing forms remain rejected.
- Slash-containing configured remote names avoid an invalid `git -c remote.<name>.mirror=false` key while retaining explicit `--no-mirror` and all other push guards.
- The exact target ref is read back after mutation. A remote transition invalidates CI, review, and QA evidence tied to the previous head and requires revalidation at the new exact head.
- The native-sync workflow checks out current `main`, preserves current-main and existing automation history through fast-forward or an explicit merge reconciliation, invokes the guarded helper before any `gh pr` mutation, and no longer uses `peter-evans/create-pull-request`.
- Checkout-local enforcement cannot constrain GitHub web UI update-branch operations, Dependabot, installed apps, or direct writers that bypass the helper. The inventory records that residual boundary and the branch-protection/ruleset requirements without claiming those privileged settings were changed here.

## Production-readiness scope
- Supported paths: the repository's native-sync workflow and documented contributor/automation paths that invoke the guarded helper.
- Unsupported/bypassing paths: direct or force updates of an open PR branch, stale ancestor restoration, non-descendant proposals, and remote-head mismatches; these fail closed without changing the target ref.
- The existing native synchronization flow remains responsible for generating the candidate and opening/updating the PR only after the guarded ref update.
- No package publication, release/tag, merge, governance/settings, environment, secret, or cross-repository mutation is included.

## Verification
- Base: `b6af5a8b5d1973bc72d4e5283f1c7d728a679cb7` (`origin/main` and merge-base).
- Candidate: `f0cb32c26eedc93bde8facf467492fa0f77e7541`.
- `dart format --output=none --set-exit-if-changed` on changed Dart files: passed, 0 changed.
- Targeted `dart analyze`: passed, no issues.
- Focused safe PR-head updater suite after review remediation: 28 passed.
- Targeted tooling suites from the initial candidate: 39 passed.
- Protected-main affected download-manager IO suite: 67 passed.
- Full VM suite excluding `local-only`: 1,824 passed, 77 skipped.
- `actionlint -color=false .github/workflows/sync_native_bindings.yml`: passed.
- `jq empty tool/git/pr_head_update_evidence.schema.json`: passed.
- `git diff --check`: passed.
- `./tool/docs/validate_links.sh`: unavailable locally because `website/node_modules` is absent; no dependencies were installed. The changed guidance uses repository paths and contains no new external links.

## Review notes
- Independent writable Codex Sol audit was run against the initial exact candidate and corrected a concrete invalid workflow-contract RegExp; Hermes independently reran all required gates above.
- Copilot's first review found that valid credential-free `ssh://user@host/...` remotes were rejected; Agy Flash remediation in `841761420c3f917427f56acaa71045d7a26ad1a4` added the acceptance path and deterministic security coverage. The thread was replied to and resolved.
- Copilot's subsequent suppressed review found that slash-containing remote names made `remote.<name>.mirror=false` invalid. Agy Flash remediation in `0f859abc421d74edff22b8a02096d77cd0062b89` conditionally omits that override for slash-containing names, preserves `--no-mirror`, and adds a bare-repository integration regression.
- The Windows CI portability regressions found on the prior candidate were fixed in the follow-up: CRLF fixture normalization, platform-independent repository paths, and normalized workflow text for mutation tests.
- Copilot's final review found that the CLI usage text overstated JSON output for `--help` and no-argument invocations. Commit `f0cb32c26eedc93bde8facf467492fa0f77e7541` scopes the wording to update attempts and invalid-argument invocations and adds a CLI regression test.
- The local reflog evidence for #434 establishes a stale local ancestor reset/replacement history but does not identify a remote actor; the inventory preserves that distinction.
- Final exact-head CI, Copilot review/thread state, and mergeability are rechecked after the latest push; no merge is requested by this PR.
