### PR TITLE
fix(native): make header sync atomic and actionable

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -51,6 +51,12 @@ jobs:
       - name: Verify native release pin policy
         run: python3 tool/native/test_sync_native_release_pins.py
 
+      - name: Verify native header archive staging
+        run: python3 tool/native/test_native_header_archive.py
+
+      - name: Verify native header sync atomicity
+        run: python3 tool/native/test_sync_native_headers_and_bindings.py
+
       - name: Pub Publish Dry Run
         run: flutter pub publish --dry-run
 

--- a/tool/native/native_header_archive.py
+++ b/tool/native/native_header_archive.py
@@ -1,0 +1,220 @@
+#!/usr/bin/env python3
+"""Validate a llamadart-native header archive and stage a complete header root."""
+
+from __future__ import annotations
+
+import argparse
+import shutil
+import sys
+import tarfile
+from pathlib import Path, PurePosixPath
+from typing import NamedTuple
+
+
+class ArchiveError(RuntimeError):
+    pass
+
+
+class HeaderLayout(NamedTuple):
+    llama_include: Path
+    ggml_include: Path
+    mtmd_dir: Path
+    wrapper_header: Path
+
+
+MTMD_HEADERS = ("mtmd.h", "mtmd-helper.h")
+
+
+def required_sources(layout: HeaderLayout) -> dict[str, Path]:
+    """Map each required staged header path to its archive source."""
+    return {
+        "llama_cpp/include/llama.h": layout.llama_include / "llama.h",
+        "llama_cpp/ggml/include/ggml.h": layout.ggml_include / "ggml.h",
+        "llama_cpp/ggml/include/ggml-backend.h": (
+            layout.ggml_include / "ggml-backend.h"
+        ),
+        **{
+            f"llama_cpp/tools/mtmd/{name}": layout.mtmd_dir / name
+            for name in MTMD_HEADERS
+        },
+        "libllamadart/llama_dart_wrapper.h": layout.wrapper_header,
+    }
+
+
+def member_relative_path(name: str) -> PurePosixPath:
+    if name.startswith("/"):
+        raise ArchiveError(f"archive entry {name!r} uses an absolute path")
+    parts = [part for part in PurePosixPath(name).parts if part != "."]
+    if any(part == ".." for part in parts):
+        raise ArchiveError(f"archive entry {name!r} escapes the archive root")
+    if not parts:
+        raise ArchiveError(f"archive entry {name!r} has an empty path")
+    return PurePosixPath(*parts)
+
+
+def validate_member(member: tarfile.TarInfo) -> PurePosixPath:
+    if member.issym() or member.islnk():
+        raise ArchiveError(f"archive entry {member.name!r} is a link entry")
+    if not (member.isfile() or member.isdir()):
+        raise ArchiveError(
+            f"archive entry {member.name!r} is neither a regular file nor a "
+            "directory"
+        )
+    if getattr(member, "sparse", None) is not None:
+        raise ArchiveError(f"archive entry {member.name!r} is sparse")
+    return member_relative_path(member.name)
+
+
+def validate_members(
+    members: list[tarfile.TarInfo],
+) -> list[tuple[tarfile.TarInfo, PurePosixPath]]:
+    validated: list[tuple[tarfile.TarInfo, PurePosixPath]] = []
+    by_path: dict[PurePosixPath, tarfile.TarInfo] = {}
+    for member in members:
+        relative = validate_member(member)
+        if relative in by_path:
+            raise ArchiveError(f"archive entry {member.name!r} is duplicated")
+        by_path[relative] = member
+        validated.append((member, relative))
+    for member, relative in validated:
+        for parent in relative.parents:
+            parent_member = by_path.get(parent)
+            if parent_member is not None and not parent_member.isdir():
+                raise ArchiveError(
+                    f"archive entry {member.name!r} is nested below a file"
+                )
+    return validated
+
+
+def extract_archive(archive_path: Path, destination: Path) -> None:
+    """Extract validated regular files and directories only.
+
+    Every member is checked before any byte is written so a hostile or
+    malformed archive cannot place files outside ``destination``.
+    """
+    if destination.is_symlink() or (
+        destination.exists()
+        and (not destination.is_dir() or any(destination.iterdir()))
+    ):
+        raise ArchiveError(
+            f"Extraction path is not an empty directory: {destination}"
+        )
+    destination.mkdir(parents=True, exist_ok=True)
+    resolved_destination = destination.resolve()
+    try:
+        with tarfile.open(archive_path, "r:gz") as archive:
+            validated = validate_members(archive.getmembers())
+            for member, relative in validated:
+                target = destination / relative
+                if not target.resolve().is_relative_to(resolved_destination):
+                    raise ArchiveError(
+                        f"archive entry {member.name!r} escapes the archive root"
+                    )
+                if member.isdir():
+                    target.mkdir(parents=True, exist_ok=True)
+                    continue
+                target.parent.mkdir(parents=True, exist_ok=True)
+                source = archive.extractfile(member)
+                if source is None:
+                    raise ArchiveError(
+                        f"archive entry {member.name!r} has no readable content"
+                    )
+                with source, open(target, "xb") as output:
+                    shutil.copyfileobj(source, output)
+    except ArchiveError:
+        raise
+    except (tarfile.TarError, OSError, EOFError) as error:
+        raise ArchiveError(
+            f"Header archive {archive_path.name} could not be extracted: {error}"
+        ) from error
+
+
+def resolve_layout(extract_root: Path) -> HeaderLayout:
+    if (extract_root / "llama_cpp" / "include").is_dir():
+        return HeaderLayout(
+            extract_root / "llama_cpp" / "include",
+            extract_root / "llama_cpp" / "ggml" / "include",
+            extract_root / "llama_cpp" / "tools" / "mtmd",
+            extract_root / "libllamadart" / "llama_dart_wrapper.h",
+        )
+    # Retained for historical llamadart-native header bundles.
+    if (extract_root / "include" / "llama.cpp").is_dir():
+        return HeaderLayout(
+            extract_root / "include" / "llama.cpp",
+            extract_root / "include" / "ggml",
+            extract_root / "include" / "llama.cpp",
+            extract_root / "include" / "llama_dart_wrapper.h",
+        )
+    raise ArchiveError("Unsupported header archive layout")
+
+
+def stage_header_root(extract_root: Path, staging_root: Path) -> None:
+    layout = resolve_layout(extract_root)
+    sources = required_sources(layout)
+    missing = sorted(name for name, path in sources.items() if not path.is_file())
+    if missing:
+        raise ArchiveError(
+            "Header archive is missing required header(s): " + ", ".join(missing)
+        )
+    if staging_root.exists() or staging_root.is_symlink():
+        raise ArchiveError(f"Staging path already exists: {staging_root.name}")
+    try:
+        shutil.copytree(
+            layout.llama_include,
+            staging_root / "llama_cpp" / "include",
+            symlinks=False,
+        )
+        shutil.copytree(
+            layout.ggml_include,
+            staging_root / "llama_cpp" / "ggml" / "include",
+            symlinks=False,
+        )
+        mtmd_root = staging_root / "llama_cpp" / "tools" / "mtmd"
+        mtmd_root.mkdir(parents=True, exist_ok=True)
+        for name in MTMD_HEADERS:
+            shutil.copyfile(layout.mtmd_dir / name, mtmd_root / name)
+        wrapper = staging_root / "libllamadart" / "llama_dart_wrapper.h"
+        wrapper.parent.mkdir(parents=True, exist_ok=True)
+        shutil.copyfile(layout.wrapper_header, wrapper)
+    except (OSError, shutil.Error) as error:
+        shutil.rmtree(staging_root, ignore_errors=True)
+        raise ArchiveError(f"Failed to stage header root: {error}") from error
+
+
+def prepare_header_root(
+    archive_path: Path, extract_root: Path, staging_root: Path
+) -> None:
+    extract_archive(archive_path, extract_root)
+    stage_header_root(extract_root, staging_root)
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description=(
+            "Validate a llamadart-native header archive and stage a complete "
+            "header root without touching the live header root."
+        )
+    )
+    parser.add_argument("--archive", required=True)
+    parser.add_argument("--extract-dir", required=True)
+    parser.add_argument("--staging", required=True)
+    return parser.parse_args()
+
+
+def main() -> int:
+    args = parse_args()
+    prepare_header_root(
+        Path(args.archive), Path(args.extract_dir), Path(args.staging)
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    try:
+        raise SystemExit(main())
+    except ArchiveError as error:
+        print(f"error: {error}", file=sys.stderr)
+        raise SystemExit(1)
+    except (OSError, shutil.Error, tarfile.TarError):
+        print("error: Could not prepare the staged header root", file=sys.stderr)
+        raise SystemExit(1)

--- a/tool/native/sync_native_headers_and_bindings.sh
+++ b/tool/native/sync_native_headers_and_bindings.sh
@@ -86,13 +86,29 @@ if [[ "${tag_input}" != "latest" && -n "${tag_input}" ]] &&
     "bNNNN-N, or legacy wrapper artifact bNNNN-llamadart.N." >&2
   exit 1
 fi
+if [[ ! "${native_repo}" =~ ^[A-Za-z0-9_.-]+/[A-Za-z0-9_.-]+$ ]]; then
+  echo "Invalid native repository slug." >&2
+  exit 1
+fi
 
-curl_headers=(
+curl_opts=(
+  -fsSL
+  --retry 2
+  --retry-connrefused
+  --retry-delay 2
+  --retry-max-time 300
+  --connect-timeout 15
+  --max-time 100
   -H "Accept: application/vnd.github+json"
   -H "X-GitHub-Api-Version: 2022-11-28"
 )
+tmp_dir="$(mktemp -d "${TMPDIR:-/tmp}/llamadart-native-sync.XXXXXX")"
+trap 'rm -rf "${tmp_dir}"' EXIT
 if [[ -n "${GH_TOKEN:-}" ]]; then
-  curl_headers+=(-H "Authorization: Bearer ${GH_TOKEN}")
+  auth_config="${tmp_dir}/curl.conf"
+  (umask 077 && printf 'header = "Authorization: Bearer %s"\n' \
+    "${GH_TOKEN}" > "${auth_config}")
+  curl_opts+=(--config "${auth_config}")
 fi
 
 if [[ "${tag_input}" == "latest" || -z "${tag_input}" ]]; then
@@ -101,16 +117,28 @@ else
   release_api_url="https://api.github.com/repos/${native_repo}/releases/tags/${tag_input}"
 fi
 
-release_json="$(
-  curl -fsSL "${curl_headers[@]}" "${release_api_url}"
-)"
+if ! release_json="$(curl "${curl_opts[@]}" "${release_api_url}" 2>/dev/null)"; then
+  echo "Failed to fetch llamadart-native release metadata for" \
+    "${native_repo}@${tag_input}." >&2
+  exit 1
+fi
 
-resolved_tag="$(
-  python3 -c "import json,sys; print(json.load(sys.stdin)['tag_name'])" <<<"${release_json}"
-)"
+if ! resolved_tag="$(
+  python3 -c 'import json, sys
+data = json.load(sys.stdin)
+tag = data.get("tag_name") if isinstance(data, dict) else None
+if not isinstance(tag, str) or not tag:
+    raise SystemExit(1)
+print(tag)' <<<"${release_json}" 2>/dev/null
+)"; then
+  echo "Release metadata for ${native_repo}@${tag_input} is not JSON with a" \
+    "non-empty tag_name." >&2
+  exit 1
+fi
 
 if ! is_supported_native_tag "${resolved_tag}"; then
-  echo "Release metadata resolved unsupported tag: ${resolved_tag}" >&2
+  echo "Release metadata resolved unsupported tag for" \
+    "${native_repo}@${tag_input}." >&2
   exit 1
 fi
 if [[ "${tag_input}" == "latest" ]] && ! is_latest_eligible_tag "${resolved_tag}"; then
@@ -127,29 +155,104 @@ if [[ "${tag_input}" != "latest" && -n "${tag_input}" ]] &&
 fi
 
 asset_name="llamadart-native-headers-${resolved_tag}.tar.gz"
-asset_url="$(
-  python3 -c "import json,sys; name=sys.argv[1]; data=json.load(sys.stdin); print(next((a.get('browser_download_url','') for a in data.get('assets',[]) if a.get('name')==name),''))" \
-    "${asset_name}" <<<"${release_json}"
-)"
+if ! asset_fields="$(
+  python3 -c 'import json, re, sys
+from urllib.parse import urlsplit
+name = sys.argv[1]
+data = json.load(sys.stdin)
+assets = data.get("assets") if isinstance(data, dict) else None
+if not isinstance(assets, list) or any(not isinstance(a, dict) for a in assets):
+    raise SystemExit("release asset inventory is not a list of objects")
+matching = [a for a in assets if a.get("name") == name]
+if not matching:
+    raise SystemExit(f"Could not find release asset: {name}")
+if len(matching) != 1:
+    raise SystemExit(f"release asset inventory duplicates {name}")
+asset = matching[0]
+url = asset.get("browser_download_url")
+if not isinstance(url, str) or not url:
+    raise SystemExit(f"asset {name} has no download URL")
+parsed = urlsplit(url)
+if (
+    parsed.scheme != "https"
+    or parsed.hostname != "github.com"
+    or parsed.username is not None
+    or parsed.password is not None
+    or any(character.isspace() for character in url)
+    or any(character in url for character in ("\\", "\""))
+):
+    raise SystemExit(f"asset {name} has an invalid download URL")
+digest = asset.get("digest") or ""
+if not isinstance(digest, str) or (
+    digest and not re.fullmatch(r"sha256:[0-9a-f]{64}", digest)
+):
+    raise SystemExit(f"asset {name} has an invalid SHA-256 digest")
+print(url)
+print(digest)' "${asset_name}" <<<"${release_json}"
+)"; then
+  echo "Unusable release metadata for ${native_repo}@${resolved_tag}." >&2
+  exit 1
+fi
+{
+  IFS= read -r asset_url
+  IFS= read -r asset_digest || asset_digest=""
+} <<<"${asset_fields}"
+asset_config="${tmp_dir}/asset.curl.conf"
+(umask 077 && printf 'url = "%s"\n' "${asset_url}" > "${asset_config}")
 
-if [[ -z "${asset_url}" ]]; then
-  echo "Could not find release asset: ${asset_name}" >&2
+header_root_parent="$(dirname "${header_root}")"
+mkdir -p "${header_root_parent}"
+header_root_name="$(basename "${header_root}")"
+header_root="$(cd "${header_root_parent}" && pwd)/${header_root_name}"
+if [[ "${header_root_name}" == "." || "${header_root_name}" == ".." ||
+  "${header_root}" == "/" || "${header_root}" == "${repo_root}" ]]; then
+  echo "Refusing unsafe generated-header root: ${header_root}." >&2
   exit 1
 fi
 
-asset_digest="$(
-  python3 -c "import json,sys; name=sys.argv[1]; data=json.load(sys.stdin); print(next((a.get('digest','') for a in data.get('assets',[]) if a.get('name')==name),''))" \
-    "${asset_name}" <<<"${release_json}"
-)"
-
-tmp_dir="${TMPDIR:-/tmp}/llamadart-native-headers-${resolved_tag}-$$"
 archive_path="${tmp_dir}/${asset_name}"
 extract_dir="${tmp_dir}/extract"
-trap 'rm -rf "${tmp_dir}"' EXIT
+transaction_root="$(mktemp -d \
+  "${header_root_parent}/.${header_root_name}.sync.XXXXXX")"
+staging_root="${transaction_root}/staging"
+backup_root="${transaction_root}/backup"
+restore_backup=0
+published=0
+
+cleanup() {
+  local status=$?
+  trap - EXIT
+  set +e
+  if [[ "${restore_backup}" == "1" ]]; then
+    if rm -rf -- "${header_root}" &&
+      [[ ! -e "${header_root}" && ! -L "${header_root}" ]] &&
+      mv -- "${backup_root}" "${header_root}"; then
+      echo "Restored the previous header root at ${header_root}." >&2
+      restore_backup=0
+    else
+      echo "Could not restore ${header_root}; preserved its backup at" \
+        "${backup_root}." >&2
+      status=1
+    fi
+  elif [[ "${published}" == "1" ]]; then
+    rm -rf -- "${header_root}" || status=1
+  fi
+  if [[ "${restore_backup}" == "0" ]]; then
+    rm -rf -- "${transaction_root}"
+  fi
+  rm -rf -- "${tmp_dir}"
+  exit "${status}"
+}
+trap cleanup EXIT
 
 mkdir -p "${extract_dir}"
 echo "Downloading ${asset_name} from ${native_repo} (${resolved_tag})..."
-curl -fsSL "${curl_headers[@]}" "${asset_url}" -o "${archive_path}"
+if ! curl "${curl_opts[@]}" --config "${asset_config}" \
+  -o "${archive_path}" 2>/dev/null; then
+  echo "Failed to download ${asset_name} from ${native_repo}" \
+    "(${resolved_tag})." >&2
+  exit 1
+fi
 if [[ "${asset_digest}" == sha256:* ]]; then
   expected_sha256="${asset_digest#sha256:}"
   if command -v shasum >/dev/null 2>&1; then
@@ -161,8 +264,8 @@ if [[ "${asset_digest}" == sha256:* ]]; then
     exit 1
   fi
   if [[ "${actual_sha256}" != "${expected_sha256}" ]]; then
-    echo "Header archive checksum mismatch for ${asset_name}: expected" \
-      "${expected_sha256}, got ${actual_sha256}." >&2
+    echo "Header archive checksum mismatch for ${native_repo}@${resolved_tag}:" \
+      "expected ${expected_sha256}, got ${actual_sha256}." >&2
     exit 1
   fi
 elif is_stable_upstream_tag "${resolved_tag}"; then
@@ -172,47 +275,40 @@ else
   echo "Warning: historical release ${resolved_tag} has no GitHub SHA-256" \
     "digest for ${asset_name}." >&2
 fi
-tar -xzf "${archive_path}" -C "${extract_dir}"
-
-llama_include_src=""
-ggml_include_src=""
-mtmd_src=""
-wrapper_header_src=""
-
-if [[ -d "${extract_dir}/llama_cpp/include" ]]; then
-  llama_include_src="${extract_dir}/llama_cpp/include"
-  ggml_include_src="${extract_dir}/llama_cpp/ggml/include"
-  mtmd_src="${extract_dir}/llama_cpp/tools/mtmd"
-  wrapper_header_src="${extract_dir}/libllamadart/llama_dart_wrapper.h"
-elif [[ -d "${extract_dir}/include/llama.cpp" ]]; then
-  # Backward compatibility for earlier archive layout.
-  llama_include_src="${extract_dir}/include/llama.cpp"
-  ggml_include_src="${extract_dir}/include/ggml"
-  mtmd_src="${extract_dir}/include/llama.cpp"
-  wrapper_header_src="${extract_dir}/include/llama_dart_wrapper.h"
-else
-  echo "Unsupported header archive layout in ${asset_name}" >&2
+if ! python3 "${repo_root}/tool/native/native_header_archive.py" \
+  --archive "${archive_path}" \
+  --extract-dir "${extract_dir}" \
+  --staging "${staging_root}"; then
+  echo "Rejected header archive ${asset_name} from ${native_repo}" \
+    "(${resolved_tag}); left ${header_root} unchanged." >&2
   exit 1
 fi
 
-rm -rf "${header_root}"
-mkdir -p "${header_root}/llama_cpp/include"
-mkdir -p "${header_root}/llama_cpp/ggml/include"
-mkdir -p "${header_root}/llama_cpp/tools/mtmd"
-mkdir -p "${header_root}/libllamadart"
-
-rsync -a --delete "${llama_include_src}/" "${header_root}/llama_cpp/include/"
-rsync -a --delete "${ggml_include_src}/" "${header_root}/llama_cpp/ggml/include/"
-cp "${mtmd_src}/mtmd.h" "${header_root}/llama_cpp/tools/mtmd/mtmd.h"
-cp "${mtmd_src}/mtmd-helper.h" "${header_root}/llama_cpp/tools/mtmd/mtmd-helper.h"
-cp "${wrapper_header_src}" "${header_root}/libllamadart/llama_dart_wrapper.h"
+if [[ -e "${header_root}" || -L "${header_root}" ]]; then
+  restore_backup=1
+  if ! mv -- "${header_root}" "${backup_root}"; then
+    restore_backup=0
+    echo "Failed to preserve the previous header root at ${header_root}." >&2
+    exit 1
+  fi
+fi
+published=1
+if ! mv -- "${staging_root}" "${header_root}"; then
+  echo "Failed to publish the staged header root at ${header_root}." >&2
+  exit 1
+fi
 
 echo "Synced headers to ${header_root}"
 
 if [[ "${run_ffigen}" == "1" ]]; then
   echo "Running ffigen..."
-  dart run ffigen --config ffigen.yaml
+  if ! dart run ffigen --config ffigen.yaml; then
+    echo "ffigen failed for ${native_repo} (${resolved_tag})." >&2
+    exit 1
+  fi
 fi
+restore_backup=0
+published=0
 
 if [[ -n "${GITHUB_OUTPUT:-}" ]]; then
   echo "resolved_tag=${resolved_tag}" >> "${GITHUB_OUTPUT}"

--- a/tool/native/sync_native_release_pins.py
+++ b/tool/native/sync_native_release_pins.py
@@ -5,14 +5,18 @@ from __future__ import annotations
 
 import argparse
 import hashlib
+import http.client
 import json
 import os
 import re
 import shutil
+import socket
 import sys
 import tempfile
+import time
 import urllib.error
 import urllib.request
+from collections.abc import Callable, Iterator
 from pathlib import Path
 from typing import Any, NamedTuple
 
@@ -206,6 +210,134 @@ LITERT_ALLOWED_ACCELERATORS = {"gpu", "metal", "opencl", "webgpu"}
 
 class ReleaseError(RuntimeError):
     pass
+
+
+HTTP_SOCKET_TIMEOUT_SECONDS = 15.0
+HTTP_TOTAL_TIMEOUT_SECONDS = 300.0
+HTTP_MAX_ATTEMPTS = 3
+HTTP_RETRY_DELAY_SECONDS = 2.0
+HTTP_CHUNK_BYTES = 1024 * 1024
+RETRYABLE_HTTP_STATUS = frozenset({408, 425, 429, 500, 502, 503, 504})
+
+
+def describe_transport_error(error: BaseException) -> str:
+    """Summarize a transport failure without echoing URLs or credentials."""
+    if isinstance(error, urllib.error.HTTPError):
+        return f"HTTP {error.code}"
+    if isinstance(error, http.client.IncompleteRead):
+        return "interrupted download"
+    if isinstance(error, ValueError):
+        return "invalid download URL"
+    reason = error.reason if isinstance(error, urllib.error.URLError) else error
+    if isinstance(reason, (TimeoutError, socket.timeout)):
+        return (
+            f"timed out (socket {HTTP_SOCKET_TIMEOUT_SECONDS:g}s, "
+            f"total {HTTP_TOTAL_TIMEOUT_SECONDS:g}s)"
+        )
+    if isinstance(reason, socket.gaierror):
+        return "DNS lookup failed"
+    if isinstance(reason, ConnectionError):
+        return "connection failed"
+    if isinstance(reason, http.client.HTTPException):
+        return "HTTP protocol error"
+    return "network error"
+
+
+def is_retryable_transport_error(error: BaseException) -> bool:
+    if isinstance(error, ValueError):
+        return False
+    if isinstance(error, urllib.error.HTTPError):
+        return error.code in RETRYABLE_HTTP_STATUS
+    reason = error.reason if isinstance(error, urllib.error.URLError) else error
+    return isinstance(
+        reason,
+        (
+            TimeoutError,
+            socket.timeout,
+            socket.gaierror,
+            ConnectionError,
+            http.client.HTTPException,
+        ),
+    )
+
+
+def response_chunks(response: Any, deadline: float) -> Iterator[bytes]:
+    while True:
+        if time.monotonic() > deadline:
+            raise TimeoutError("release download exceeded the overall timeout")
+        chunk = response.read(HTTP_CHUNK_BYTES)
+        if time.monotonic() > deadline:
+            raise TimeoutError("release download exceeded the overall timeout")
+        if not chunk:
+            return
+        yield chunk
+
+
+def read_release_url(
+    url: str,
+    *,
+    context: str,
+    headers: dict[str, str] | None = None,
+    consume: Callable[[Iterator[bytes]], Any] = b"".join,
+) -> Any:
+    """Read a release URL with a 15s socket and 300s overall deadline.
+
+    Transport failures and 408, 425, 429, and selected 5xx responses get at
+    most three total attempts. Permanent HTTP failures are not retried. Errors
+    omit the URL because release URLs may carry short-lived credentials.
+    """
+    deadline = time.monotonic() + HTTP_TOTAL_TIMEOUT_SECONDS
+    for attempt in range(1, HTTP_MAX_ATTEMPTS + 1):
+        try:
+            remaining = deadline - time.monotonic()
+            if remaining <= 0:
+                raise TimeoutError("release download exceeded the overall timeout")
+            request = urllib.request.Request(url, headers=headers or {})
+            with urllib.request.urlopen(
+                request, timeout=min(HTTP_SOCKET_TIMEOUT_SECONDS, remaining)
+            ) as response:
+                return consume(response_chunks(response, deadline))
+        except (OSError, ValueError, http.client.HTTPException) as error:
+            reason = describe_transport_error(error)
+            retryable = (
+                attempt < HTTP_MAX_ATTEMPTS
+                and is_retryable_transport_error(error)
+                and time.monotonic() < deadline
+            )
+            if not retryable:
+                raise ReleaseError(f"{context}: {reason}") from error
+            delay = min(
+                HTTP_RETRY_DELAY_SECONDS * attempt,
+                max(0.0, deadline - time.monotonic()),
+            )
+            if delay:
+                time.sleep(delay)
+    raise ReleaseError(f"{context}: network error")
+
+
+def read_release_fixture(path: Path, context: str) -> bytes:
+    try:
+        return path.read_bytes()
+    except OSError as error:
+        raise ReleaseError(f"{context}: cannot read fixture") from error
+
+
+def github_api_headers() -> dict[str, str]:
+    return {
+        "Accept": "application/vnd.github+json",
+        "X-GitHub-Api-Version": "2022-11-28",
+        **github_auth_header(),
+    }
+
+
+def release_asset_context(
+    release: dict[str, Any], asset_name: str, kind: str, repo: str = ""
+) -> str:
+    tag = release.get("tag_name")
+    if not isinstance(tag, str) or not tag:
+        tag = "<unknown>"
+    identity = f"{repo}@{tag}" if repo else tag
+    return f"Failed to read release {kind} {asset_name} ({identity})"
 
 
 def _litert_compatibility_version(compatibility_tag: str) -> tuple[int, ...]:
@@ -471,7 +603,9 @@ def validate_litert_release_sha256_sums(
         tag=tag,
         release_json_dir=release_json_dir,
     )
-    expected_asset_digest = release_asset_checksum(release, "SHA256SUMS")
+    expected_asset_digest = release_asset_checksum(
+        release, "SHA256SUMS", repo=repo
+    )
     actual_asset_digest = hashlib.sha256(checksum_bytes).hexdigest()
     if actual_asset_digest != expected_asset_digest:
         raise ReleaseError(
@@ -508,6 +642,7 @@ def validate_litert_spm_release_asset_digests(
     release: dict[str, Any],
     manifest: dict[str, Any],
     *,
+    repo: str,
     release_tag: str,
 ) -> None:
     upstream = manifest.get("upstream")
@@ -530,7 +665,7 @@ def validate_litert_spm_release_asset_digests(
     )
     for path in sorted(spm_paths):
         asset_name = Path(path).name
-        release_digest = release_asset_checksum(release, asset_name)
+        release_digest = release_asset_checksum(release, asset_name, repo=repo)
         manifest_digest = require_sha256(
             artifacts_by_path[path].get("sha256"),
             f"SPM artifact {path} digest",
@@ -579,7 +714,11 @@ def main() -> int:
             current_tag=read_hook_native_tag(hook_text),
             allow_legacy_tag=args.allow_legacy_tag,
         )
-        validate_native_release_manifest(release, resolved_llama_cpp_tag)
+        validate_native_release_manifest(
+            release,
+            resolved_llama_cpp_tag,
+            repo=args.llamadart_native_repo,
+        )
         hook_text = replace_one(
             hook_text,
             r"const _llamaCppTag = '[^']+';",
@@ -590,6 +729,7 @@ def main() -> int:
             checksum = release_asset_checksum(
                 release,
                 f"llamadart-native-apple-xcframework-{resolved_llama_cpp_tag}.zip",
+                repo=args.llamadart_native_repo,
             )
             original_swift_text = llama_cpp_package_swift_path.read_text(
                 encoding="utf-8"
@@ -726,6 +866,7 @@ def main() -> int:
             checksum = release_asset_checksum(
                 release,
                 f"litert-lm-native-runtime-{bundle}-{resolved_litert_lm_tag}.tar.gz",
+                repo=args.litert_lm_native_repo,
             )
             hook_text = replace_litert_lm_bundle_checksum(
                 hook_text,
@@ -749,6 +890,7 @@ def main() -> int:
                 release=release,
                 manifest=litert_lm_manifest,
                 resolved_tag=resolved_litert_lm_tag,
+                repo=args.litert_lm_native_repo,
             )
             pending_writes[litert_lm_package_swift_path] = swift_text
             package_root = companion_package_root(litert_lm_package_swift_path)
@@ -924,35 +1066,20 @@ def parse_args() -> argparse.Namespace:
 
 
 def fetch_release(repo: str, tag: str, release_json_dir: str = "") -> dict[str, Any]:
-    try:
-        if release_json_dir:
-            path = Path(release_json_dir) / f"{repo.replace('/', '__')}__{tag}.json"
-            payload: Any = json.loads(path.read_text(encoding="utf-8"))
+    context = f"Failed to fetch release {repo}@{tag}"
+    if release_json_dir:
+        path = Path(release_json_dir) / f"{repo.replace('/', '__')}__{tag}.json"
+        raw = read_release_fixture(path, context)
+    else:
+        if tag == "latest":
+            url = f"https://api.github.com/repos/{repo}/releases/latest"
         else:
-            if tag == "latest":
-                url = f"https://api.github.com/repos/{repo}/releases/latest"
-            else:
-                url = f"https://api.github.com/repos/{repo}/releases/tags/{tag}"
-            request = urllib.request.Request(
-                url,
-                headers={
-                    "Accept": "application/vnd.github+json",
-                    "X-GitHub-Api-Version": "2022-11-28",
-                    **github_auth_header(),
-                },
-            )
-            with urllib.request.urlopen(request) as response:
-                payload = json.loads(response.read().decode("utf-8"))
-    except (
-        OSError,
-        urllib.error.HTTPError,
-        urllib.error.URLError,
-        UnicodeDecodeError,
-        json.JSONDecodeError,
-    ) as error:
-        raise ReleaseError(
-            f"Failed to fetch release {repo}@{tag}: {error}"
-        ) from error
+            url = f"https://api.github.com/repos/{repo}/releases/tags/{tag}"
+        raw = read_release_url(url, context=context, headers=github_api_headers())
+    try:
+        payload: Any = json.loads(raw.decode("utf-8"))
+    except (UnicodeDecodeError, json.JSONDecodeError) as error:
+        raise ReleaseError(f"{context}: invalid UTF-8 or JSON") from error
     if not isinstance(payload, dict):
         raise ReleaseError(f"Release {repo}@{tag} must be a JSON object")
     resolved_tag = payload.get("tag_name")
@@ -970,7 +1097,9 @@ def github_auth_header() -> dict[str, str]:
     return {"Authorization": f"Bearer {token}"} if token else {}
 
 
-def release_asset_checksum(release: dict[str, Any], asset_name: str) -> str:
+def release_asset_checksum(
+    release: dict[str, Any], asset_name: str, *, repo: str = ""
+) -> str:
     asset = find_release_asset(release, asset_name)
     if asset is not None:
         digest = asset.get("digest")
@@ -978,17 +1107,21 @@ def release_asset_checksum(release: dict[str, Any], asset_name: str) -> str:
             raise ReleaseError(
                 f"Asset {asset_name} has a non-string GitHub SHA-256 digest"
             )
-        if isinstance(digest, str) and digest.startswith("sha256:"):
-            checksum = digest.removeprefix("sha256:")
-            if not SHA256_RE.fullmatch(checksum):
+        if isinstance(digest, str) and digest:
+            if re.fullmatch(r"sha256:[0-9a-f]{64}", digest) is None:
                 raise ReleaseError(
                     f"Asset {asset_name} has an invalid GitHub SHA-256 digest"
                 )
-            return checksum
+            return digest.removeprefix("sha256:")
         download_url = asset.get("browser_download_url")
         if not isinstance(download_url, str) or not download_url:
             raise ReleaseError(f"Asset {asset_name} has no download URL")
-        return sha256_url(download_url)
+        return sha256_url(
+            download_url,
+            context=release_asset_context(
+                release, asset_name, "asset", repo=repo
+            ),
+        )
     tag = release.get("tag_name", "<unknown>")
     names = ", ".join(
         sorted(str(asset.get("name", "")) for asset in release_assets(release))
@@ -999,16 +1132,19 @@ def release_asset_checksum(release: dict[str, Any], asset_name: str) -> str:
     )
 
 
-def sha256_url(url: str) -> str:
-    request = urllib.request.Request(url, headers=github_auth_header())
-    digest = hashlib.sha256()
-    with urllib.request.urlopen(request) as response:
-        while True:
-            chunk = response.read(1024 * 1024)
-            if not chunk:
-                break
+def sha256_url(url: str, *, context: str) -> str:
+    def hash_chunks(chunks: Iterator[bytes]) -> str:
+        digest = hashlib.sha256()
+        for chunk in chunks:
             digest.update(chunk)
-    return digest.hexdigest()
+        return digest.hexdigest()
+
+    return read_release_url(
+        url,
+        context=context,
+        headers=github_auth_header(),
+        consume=hash_chunks,
+    )
 
 
 def normalize_release_tag(tag: str) -> str:
@@ -1173,12 +1309,21 @@ def release_assets(release: dict[str, Any]) -> list[dict[str, Any]]:
     assets = release.get("assets", [])
     if not isinstance(assets, list):
         raise ReleaseError("Native release metadata assets must be a list")
+    names: set[str] = set()
     for index, asset in enumerate(assets):
         if not isinstance(asset, dict):
             raise ReleaseError(
                 "Native release metadata asset list contains a non-object "
                 f"entry at index {index}"
             )
+        name = asset.get("name")
+        if not isinstance(name, str) or not name:
+            raise ReleaseError(
+                f"Native release metadata asset at index {index} has no valid name"
+            )
+        if name in names:
+            raise ReleaseError(f"Native release metadata duplicates asset {name}")
+        names.add(name)
     return assets
 
 
@@ -1197,7 +1342,7 @@ def require_github_sha256_digest(
 
 
 def release_asset_json(
-    release: dict[str, Any], asset_name: str
+    release: dict[str, Any], asset_name: str, *, repo: str = ""
 ) -> dict[str, Any]:
     asset = find_release_asset(release, asset_name)
     if asset is None:
@@ -1206,32 +1351,31 @@ def release_asset_json(
             f"Release {tag} does not contain required asset {asset_name}"
         )
 
-    fixture_json = asset.get("fixture_json")
-    if isinstance(fixture_json, dict):
+    if "fixture_json" in asset:
+        fixture_json = asset["fixture_json"]
+        if not isinstance(fixture_json, dict):
+            raise ReleaseError(f"Release manifest {asset_name} must be a JSON object")
         return fixture_json
 
     download_url = asset.get("browser_download_url")
     if not isinstance(download_url, str) or not download_url:
         raise ReleaseError(f"Asset {asset_name} has no download URL")
-    request = urllib.request.Request(download_url, headers=github_auth_header())
+    context = release_asset_context(release, asset_name, "manifest", repo=repo)
+    raw = read_release_url(
+        download_url, context=context, headers=github_auth_header()
+    )
     try:
-        with urllib.request.urlopen(request) as response:
-            payload = json.loads(response.read().decode("utf-8"))
-    except (
-        urllib.error.HTTPError,
-        urllib.error.URLError,
-        json.JSONDecodeError,
-        UnicodeDecodeError,
-    ) as error:
-        raise ReleaseError(
-            f"Failed to read release manifest {asset_name}: {error}"
-        ) from error
+        payload = json.loads(raw.decode("utf-8"))
+    except (UnicodeDecodeError, json.JSONDecodeError) as error:
+        raise ReleaseError(f"{context}: invalid UTF-8 or JSON") from error
     if not isinstance(payload, dict):
         raise ReleaseError(f"Release manifest {asset_name} must be a JSON object")
     return payload
 
 
-def release_asset_text(release: dict[str, Any], asset_name: str) -> str:
+def release_asset_text(
+    release: dict[str, Any], asset_name: str, *, repo: str = ""
+) -> str:
     asset = find_release_asset(release, asset_name)
     if asset is None:
         tag = release.get("tag_name", "<unknown>")
@@ -1239,21 +1383,25 @@ def release_asset_text(release: dict[str, Any], asset_name: str) -> str:
             f"Release {tag} does not contain required asset {asset_name}"
         )
 
-    fixture_text = asset.get("fixture_text")
-    if isinstance(fixture_text, str):
+    if "fixture_text" in asset:
+        fixture_text = asset["fixture_text"]
+        if not isinstance(fixture_text, str):
+            raise ReleaseError(f"Release checksum file {asset_name} must be text")
         return fixture_text
 
     download_url = asset.get("browser_download_url")
     if not isinstance(download_url, str) or not download_url:
         raise ReleaseError(f"Asset {asset_name} has no download URL")
-    request = urllib.request.Request(download_url, headers=github_auth_header())
+    context = release_asset_context(
+        release, asset_name, "checksum file", repo=repo
+    )
+    raw = read_release_url(
+        download_url, context=context, headers=github_auth_header()
+    )
     try:
-        with urllib.request.urlopen(request) as response:
-            return response.read().decode("utf-8")
-    except (urllib.error.HTTPError, urllib.error.URLError, UnicodeDecodeError) as error:
-        raise ReleaseError(
-            f"Failed to read release checksum file {asset_name}: {error}"
-        ) from error
+        return raw.decode("utf-8")
+    except UnicodeDecodeError as error:
+        raise ReleaseError(f"{context}: invalid UTF-8") from error
 
 
 def release_asset_bytes(
@@ -1269,28 +1417,19 @@ def release_asset_bytes(
         raise ReleaseError(
             f"Release {tag} does not contain required asset {asset_name}"
         )
+    context = f"Failed to read release asset {asset_name} ({repo}@{tag})"
     if release_json_dir:
         fixture = (
             Path(release_json_dir)
             / f"{repo.replace('/', '__')}__{tag}__{asset_name}"
         )
-        try:
-            return fixture.read_bytes()
-        except OSError as error:
-            raise ReleaseError(
-                f"Failed to read release asset fixture {fixture}: {error}"
-            ) from error
+        return read_release_fixture(fixture, context)
     download_url = asset.get("browser_download_url")
     if not isinstance(download_url, str) or not download_url:
         raise ReleaseError(f"Asset {asset_name} has no download URL")
-    request = urllib.request.Request(download_url, headers=github_auth_header())
-    try:
-        with urllib.request.urlopen(request) as response:
-            return response.read()
-    except (urllib.error.HTTPError, urllib.error.URLError, OSError) as error:
-        raise ReleaseError(
-            f"Failed to read release asset {asset_name}: {error}"
-        ) from error
+    return read_release_url(
+        download_url, context=context, headers=github_auth_header()
+    )
 
 
 def parse_sha256_sums(checksum_text: str, release_tag: str) -> dict[str, str]:
@@ -1314,7 +1453,10 @@ def parse_sha256_sums(checksum_text: str, release_tag: str) -> dict[str, str]:
 
 
 def validate_native_release_manifest(
-    release: dict[str, Any], release_tag: str
+    release: dict[str, Any],
+    release_tag: str,
+    *,
+    repo: str = DEFAULT_LLAMADART_NATIVE_REPO,
 ) -> None:
     release_version = parse_native_release_tag(release_tag)
     is_new_wrapper_form = bool(
@@ -1336,7 +1478,7 @@ def validate_native_release_manifest(
             "assets.json",
         )
 
-    manifest = release_asset_json(release, "assets.json")
+    manifest = release_asset_json(release, "assets.json", repo=repo)
     native_release_tag = manifest.get("native_release_tag")
     legacy_release_tag = manifest.get("tag")
     for field_name, value in (
@@ -1492,7 +1634,7 @@ def validate_native_release_manifest(
             "SHA256SUMS",
         )
         published_checksums = parse_sha256_sums(
-            release_asset_text(release, "SHA256SUMS"),
+            release_asset_text(release, "SHA256SUMS", repo=repo),
             release_tag,
         )
         for file_name, checksum in manifest_checksums.items():
@@ -1673,7 +1815,9 @@ def validate_litert_lm_release_manifest(
             f"Release {repo}@{tag} has no immutable manifest.json evidence"
         )
     manifest, manifest_digest = manifest_result
-    release_manifest_digest = release_asset_checksum(release, "manifest.json")
+    release_manifest_digest = release_asset_checksum(
+        release, "manifest.json", repo=repo
+    )
     if release_manifest_digest != manifest_digest:
         raise ReleaseError(
             "LiteRT-LM manifest bytes do not match the GitHub release digest"
@@ -2361,6 +2505,7 @@ def validate_litert_lm_release_manifest(
     validate_litert_spm_release_asset_digests(
         release,
         manifest,
+        repo=repo,
         release_tag=tag,
     )
     return manifest
@@ -2383,35 +2528,24 @@ def fetch_litert_lm_release_manifest(
     )
     if manifest_asset is None:
         return None
+    context = f"Failed to read release manifest {repo}@{tag}"
+    if release_json_dir:
+        fixture = (
+            Path(release_json_dir)
+            / f"{repo.replace('/', '__')}__{tag}__manifest.json"
+        )
+        payload = read_release_fixture(fixture, context)
+    else:
+        url = manifest_asset.get("browser_download_url")
+        if not isinstance(url, str) or not url:
+            raise ReleaseError(f"Release {repo}@{tag} manifest has no download URL")
+        payload = read_release_url(
+            url, context=context, headers=github_auth_header()
+        )
     try:
-        if release_json_dir:
-            fixture = (
-                Path(release_json_dir)
-                / f"{repo.replace('/', '__')}__{tag}__manifest.json"
-            )
-            payload = fixture.read_bytes()
-        else:
-            url = manifest_asset.get("browser_download_url")
-            if not isinstance(url, str) or not url:
-                raise ReleaseError(
-                    f"Release {repo}@{tag} manifest has no download URL"
-                )
-            request = urllib.request.Request(url, headers=github_auth_header())
-            with urllib.request.urlopen(request) as response:
-                payload = response.read()
         manifest = json.loads(payload.decode("utf-8"))
-    except ReleaseError:
-        raise
-    except (
-        OSError,
-        urllib.error.HTTPError,
-        urllib.error.URLError,
-        UnicodeDecodeError,
-        json.JSONDecodeError,
-    ) as error:
-        raise ReleaseError(
-            f"Failed to read release manifest {repo}@{tag}: {error}"
-        ) from error
+    except (UnicodeDecodeError, json.JSONDecodeError) as error:
+        raise ReleaseError(f"{context}: invalid UTF-8 or JSON") from error
     if not isinstance(manifest, dict):
         raise ReleaseError(f"Release {repo}@{tag} manifest is not a JSON object")
     return manifest, hashlib.sha256(payload).hexdigest()
@@ -2442,28 +2576,16 @@ def fetch_ref_commit(
                 f"Failed to resolve exact commit for {repo}@{ref}: {error}"
             ) from error
     else:
-        url = f"https://api.github.com/repos/{repo}/commits/{ref}"
-        request = urllib.request.Request(
-            url,
-            headers={
-                "Accept": "application/vnd.github+json",
-                "X-GitHub-Api-Version": "2022-11-28",
-                **github_auth_header(),
-            },
+        context = f"Failed to resolve exact commit for {repo}@{ref}"
+        raw = read_release_url(
+            f"https://api.github.com/repos/{repo}/commits/{ref}",
+            context=context,
+            headers=github_api_headers(),
         )
         try:
-            with urllib.request.urlopen(request) as response:
-                payload = json.loads(response.read().decode("utf-8"))
-        except (
-            OSError,
-            urllib.error.HTTPError,
-            urllib.error.URLError,
-            UnicodeDecodeError,
-            json.JSONDecodeError,
-        ) as error:
-            raise ReleaseError(
-                f"Failed to resolve exact commit for {repo}@{ref}: {error}"
-            ) from error
+            payload = json.loads(raw.decode("utf-8"))
+        except (UnicodeDecodeError, json.JSONDecodeError) as error:
+            raise ReleaseError(f"{context}: invalid UTF-8 or JSON") from error
     if not isinstance(payload, dict):
         raise ReleaseError(f"Commit response for {repo}@{ref} must be a JSON object")
     commit = payload.get("sha")
@@ -2936,6 +3058,7 @@ def prepare_litert_lm_package_swift(
     release: dict[str, Any],
     manifest: dict[str, Any],
     resolved_tag: str,
+    repo: str = DEFAULT_LITERT_LM_NATIVE_REPO,
 ) -> str:
     original_tag = swift_variable_value(
         original_swift_text,
@@ -3010,6 +3133,7 @@ def prepare_litert_lm_package_swift(
         checksum = release_asset_checksum(
             release,
             asset_template.format(tag=resolved_tag),
+            repo=repo,
         )
         swift_text = replace_swift_binary_target_checksum(
             swift_text,

--- a/tool/native/test_native_header_archive.py
+++ b/tool/native/test_native_header_archive.py
@@ -1,0 +1,279 @@
+from __future__ import annotations
+
+import io
+import subprocess
+import sys
+import tarfile
+import tempfile
+import unittest
+from pathlib import Path
+from unittest.mock import patch
+
+
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+
+from native_header_archive import (  # noqa: E402
+    ArchiveError,
+    extract_archive,
+    member_relative_path,
+    prepare_header_root,
+    stage_header_root,
+)
+
+
+MODULE_PATH = Path(__file__).resolve().parent / "native_header_archive.py"
+REQUIRED_HEADERS = (
+    "llama_cpp/include/llama.h",
+    "llama_cpp/ggml/include/ggml.h",
+    "llama_cpp/ggml/include/ggml-backend.h",
+    "llama_cpp/tools/mtmd/mtmd.h",
+    "llama_cpp/tools/mtmd/mtmd-helper.h",
+    "libllamadart/llama_dart_wrapper.h",
+)
+CURRENT_LAYOUT_FILES = {
+    "llama_cpp/include/llama.h": "// llama\n",
+    "llama_cpp/include/llama-cpp.h": "// llama-cpp\n",
+    "llama_cpp/ggml/include/ggml.h": "// ggml\n",
+    "llama_cpp/ggml/include/ggml-backend.h": "// ggml-backend\n",
+    "llama_cpp/tools/mtmd/mtmd.h": "// mtmd\n",
+    "llama_cpp/tools/mtmd/mtmd-helper.h": "// mtmd-helper\n",
+    "libllamadart/llama_dart_wrapper.h": "// wrapper\n",
+}
+LEGACY_LAYOUT_FILES = {
+    "include/llama.cpp/llama.h": "// llama\n",
+    "include/llama.cpp/mtmd.h": "// mtmd\n",
+    "include/llama.cpp/mtmd-helper.h": "// mtmd-helper\n",
+    "include/ggml/ggml.h": "// ggml\n",
+    "include/ggml/ggml-backend.h": "// ggml-backend\n",
+    "include/llama_dart_wrapper.h": "// wrapper\n",
+}
+
+
+def _write_archive(path: Path, files: dict[str, str]) -> Path:
+    with tarfile.open(path, "w:gz") as archive:
+        for name, content in files.items():
+            payload = content.encode("utf-8")
+            info = tarfile.TarInfo(name)
+            info.size = len(payload)
+            archive.addfile(info, io.BytesIO(payload))
+    return path
+
+
+def _archive_with_extra_member(path: Path, info: tarfile.TarInfo) -> Path:
+    with tarfile.open(path, "w:gz") as archive:
+        for name, content in CURRENT_LAYOUT_FILES.items():
+            payload = content.encode("utf-8")
+            member = tarfile.TarInfo(name)
+            member.size = len(payload)
+            archive.addfile(member, io.BytesIO(payload))
+        archive.addfile(info)
+    return path
+
+
+class MemberPathTest(unittest.TestCase):
+    def test_rejects_absolute_and_traversing_member_paths(self) -> None:
+        for name in (
+            "/etc/passwd",
+            "//etc/passwd",
+            "../outside.h",
+            "llama_cpp/../../outside.h",
+            ".",
+        ):
+            with self.subTest(name=name):
+                with self.assertRaises(ArchiveError):
+                    member_relative_path(name)
+
+    def test_accepts_normal_member_paths(self) -> None:
+        self.assertEqual(
+            str(member_relative_path("./llama_cpp/include/llama.h")),
+            "llama_cpp/include/llama.h",
+        )
+
+
+class ExtractArchiveTest(unittest.TestCase):
+    def test_rejects_link_device_and_traversing_members(self) -> None:
+        symlink = tarfile.TarInfo("llama_cpp/include/evil.h")
+        symlink.type = tarfile.SYMTYPE
+        symlink.linkname = "/etc/passwd"
+        hardlink = tarfile.TarInfo("llama_cpp/include/evil-hard.h")
+        hardlink.type = tarfile.LNKTYPE
+        hardlink.linkname = "llama_cpp/include/llama.h"
+        device = tarfile.TarInfo("llama_cpp/include/evil-dev")
+        device.type = tarfile.CHRTYPE
+        fifo = tarfile.TarInfo("llama_cpp/include/evil-fifo")
+        fifo.type = tarfile.FIFOTYPE
+        sparse = tarfile.TarInfo("llama_cpp/include/evil-sparse.h")
+        sparse.type = tarfile.GNUTYPE_SPARSE
+        traversal = tarfile.TarInfo("../escaped.h")
+        traversal.size = 0
+
+        expectations = {
+            "symlink": (symlink, "link entry"),
+            "hardlink": (hardlink, "link entry"),
+            "device": (device, "neither a regular file nor a directory"),
+            "fifo": (fifo, "neither a regular file nor a directory"),
+            "sparse": (sparse, "sparse"),
+            "traversal": (traversal, "escapes the archive root"),
+        }
+        for label, (info, message) in expectations.items():
+            with self.subTest(entry=label), tempfile.TemporaryDirectory() as temp:
+                root = Path(temp)
+                archive = _archive_with_extra_member(root / "headers.tar.gz", info)
+                destination = root / "extract"
+                with self.assertRaisesRegex(ArchiveError, message):
+                    extract_archive(archive, destination)
+                self.assertFalse((root / "escaped.h").exists())
+                self.assertFalse(
+                    (destination / "llama_cpp" / "include" / "evil.h").exists()
+                )
+
+    def test_rejects_duplicate_normalized_paths_before_extraction(self) -> None:
+        with tempfile.TemporaryDirectory() as temp:
+            root = Path(temp)
+            archive_path = root / "headers.tar.gz"
+            with tarfile.open(archive_path, "w:gz") as archive:
+                for name in ("headers/value.h", "./headers//value.h"):
+                    payload = name.encode("utf-8")
+                    member = tarfile.TarInfo(name)
+                    member.size = len(payload)
+                    archive.addfile(member, io.BytesIO(payload))
+            destination = root / "extract"
+            with self.assertRaisesRegex(ArchiveError, "duplicated"):
+                extract_archive(archive_path, destination)
+            self.assertEqual(list(destination.iterdir()), [])
+
+    def test_rejects_nonempty_or_symlink_extraction_roots(self) -> None:
+        with tempfile.TemporaryDirectory() as temp:
+            root = Path(temp)
+            archive = _write_archive(root / "headers.tar.gz", CURRENT_LAYOUT_FILES)
+            nonempty = root / "nonempty"
+            nonempty.mkdir()
+            (nonempty / "marker").write_text("keep", encoding="utf-8")
+            with self.assertRaisesRegex(ArchiveError, "not an empty directory"):
+                extract_archive(archive, nonempty)
+            target = root / "target"
+            target.mkdir()
+            symlink = root / "symlink"
+            symlink.symlink_to(target, target_is_directory=True)
+            with self.assertRaisesRegex(ArchiveError, "not an empty directory"):
+                extract_archive(archive, symlink)
+
+    def test_rejects_corrupt_archive(self) -> None:
+        with tempfile.TemporaryDirectory() as temp:
+            root = Path(temp)
+            archive = root / "headers.tar.gz"
+            archive.write_bytes(b"not a gzip archive")
+            with self.assertRaisesRegex(ArchiveError, "could not be extracted"):
+                extract_archive(archive, root / "extract")
+
+    def test_rejects_truncated_archive(self) -> None:
+        with tempfile.TemporaryDirectory() as temp:
+            root = Path(temp)
+            archive = _write_archive(root / "headers.tar.gz", CURRENT_LAYOUT_FILES)
+            payload = archive.read_bytes()
+            archive.write_bytes(payload[: len(payload) // 2])
+            with self.assertRaisesRegex(ArchiveError, "could not be extracted"):
+                extract_archive(archive, root / "extract")
+
+
+class StageHeaderRootTest(unittest.TestCase):
+    def _stage(self, files: dict[str, str], temp: str) -> Path:
+        root = Path(temp)
+        archive = _write_archive(root / "headers.tar.gz", files)
+        staging = root / "ffigen_headers.staging"
+        prepare_header_root(archive, root / "extract", staging)
+        return staging
+
+    def test_stages_every_required_header_for_the_current_layout(self) -> None:
+        with tempfile.TemporaryDirectory() as temp:
+            staging = self._stage(CURRENT_LAYOUT_FILES, temp)
+            for header in REQUIRED_HEADERS:
+                self.assertTrue((staging / header).is_file(), header)
+            self.assertTrue(
+                (staging / "llama_cpp/include/llama-cpp.h").is_file(),
+                "sibling headers are copied with the include tree",
+            )
+
+    def test_stages_every_required_header_for_the_legacy_layout(self) -> None:
+        with tempfile.TemporaryDirectory() as temp:
+            staging = self._stage(LEGACY_LAYOUT_FILES, temp)
+            for header in REQUIRED_HEADERS:
+                self.assertTrue((staging / header).is_file(), header)
+
+    def test_rejects_unsupported_layout(self) -> None:
+        with tempfile.TemporaryDirectory() as temp:
+            with self.assertRaisesRegex(ArchiveError, "Unsupported header archive"):
+                self._stage({"headers/llama.h": "// llama\n"}, temp)
+
+    def test_rejects_missing_required_headers_without_creating_staging(self) -> None:
+        for missing in (
+            "llama_cpp/tools/mtmd/mtmd-helper.h",
+            "libllamadart/llama_dart_wrapper.h",
+            "llama_cpp/ggml/include/ggml-backend.h",
+        ):
+            files = dict(CURRENT_LAYOUT_FILES)
+            files.pop(missing)
+            with self.subTest(missing=missing), tempfile.TemporaryDirectory() as temp:
+                with self.assertRaisesRegex(ArchiveError, f"missing.*{missing}"):
+                    self._stage(files, temp)
+                self.assertFalse((Path(temp) / "ffigen_headers.staging").exists())
+
+    def test_reports_copy_failure_and_removes_partial_staging(self) -> None:
+        with tempfile.TemporaryDirectory() as temp:
+            root = Path(temp)
+            archive = _write_archive(root / "headers.tar.gz", CURRENT_LAYOUT_FILES)
+            extract_root = root / "extract"
+            extract_archive(archive, extract_root)
+            staging = root / "ffigen_headers.staging"
+            with patch(
+                "native_header_archive.shutil.copytree",
+                side_effect=OSError("injected copy failure"),
+            ):
+                with self.assertRaisesRegex(
+                    ArchiveError, "Failed to stage header root"
+                ):
+                    stage_header_root(extract_root, staging)
+            self.assertFalse(staging.exists())
+
+
+class CommandLineTest(unittest.TestCase):
+    def _run(self, archive: Path, extract: Path, staging: Path):
+        return subprocess.run(
+            [
+                sys.executable,
+                str(MODULE_PATH),
+                "--archive",
+                str(archive),
+                "--extract-dir",
+                str(extract),
+                "--staging",
+                str(staging),
+            ],
+            capture_output=True,
+            text=True,
+            check=False,
+        )
+
+    def test_reports_concise_error_without_traceback(self) -> None:
+        with tempfile.TemporaryDirectory() as temp:
+            root = Path(temp)
+            archive = root / "headers.tar.gz"
+            archive.write_bytes(b"not a gzip archive")
+            result = self._run(archive, root / "extract", root / "staging")
+            self.assertEqual(result.returncode, 1)
+            self.assertIn("error: Header archive", result.stderr)
+            self.assertNotIn("Traceback", result.stderr)
+
+    def test_stages_a_valid_archive(self) -> None:
+        with tempfile.TemporaryDirectory() as temp:
+            root = Path(temp)
+            archive = _write_archive(root / "headers.tar.gz", CURRENT_LAYOUT_FILES)
+            staging = root / "staging"
+            result = self._run(archive, root / "extract", staging)
+            self.assertEqual(result.returncode, 0, result.stderr)
+            for header in REQUIRED_HEADERS:
+                self.assertTrue((staging / header).is_file(), header)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tool/native/test_sync_native_headers_and_bindings.py
+++ b/tool/native/test_sync_native_headers_and_bindings.py
@@ -4,10 +4,13 @@ import hashlib
 import io
 import json
 import os
+import shutil
 import subprocess
 import tarfile
 import tempfile
+import threading
 import unittest
+from http.server import BaseHTTPRequestHandler, HTTPServer
 from pathlib import Path
 
 
@@ -58,6 +61,7 @@ class NativeHeaderSyncIntegrationTest(unittest.TestCase):
         token: str = "",
         stale_paths: bool = False,
         duplicate_asset: bool = False,
+        config_capture: str = "",
     ) -> tuple[subprocess.CompletedProcess[str], Path]:
         temp = tempfile.TemporaryDirectory()
         self.addCleanup(temp.cleanup)
@@ -95,6 +99,13 @@ import sys
 
 args = sys.argv[1:]
 mode = os.environ.get("FAKE_CURL_MODE", "ok")
+capture = os.environ.get("FAKE_CONFIG_CAPTURE", "")
+if capture:
+    for index, arg in enumerate(args[:-1]):
+        if arg == "--config":
+            text = Path(args[index + 1]).read_text(encoding="utf-8")
+            if text.startswith('header = "Authorization:'):
+                Path(capture).write_text(text, encoding="utf-8")
 token = os.environ.get("FAKE_EXPECT_TOKEN", "")
 if token:
     if any(token in arg for arg in args):
@@ -185,6 +196,7 @@ exit 0
                 "LLAMADART_FFIGEN_HEADER_ROOT": str(live),
                 "GH_TOKEN": token,
                 "FAKE_EXPECT_TOKEN": token,
+                "FAKE_CONFIG_CAPTURE": config_capture,
                 "FAKE_EXPECT_URL": asset_url
                 or f"https://github.com/owner/repo/releases/download/{TAG}/{ASSET_NAME}",
             }
@@ -388,6 +400,60 @@ exit 0
         )
         self.assertEqual(result.returncode, 0, result.stderr)
         self.assertNotIn(secret, result.stdout + result.stderr)
+
+    def _serve_authorization_probe(self) -> tuple[str, list[str | None]]:
+        seen: list[str | None] = []
+
+        class Handler(BaseHTTPRequestHandler):
+            def do_GET(self) -> None:
+                seen.append(self.headers.get("Authorization"))
+                self.send_response(200)
+                self.send_header("Content-Length", "2")
+                self.end_headers()
+                self.wfile.write(b"{}")
+
+            def log_message(self, *args: object) -> None:
+                return
+
+        server = HTTPServer(("127.0.0.1", 0), Handler)
+        thread = threading.Thread(target=server.serve_forever, daemon=True)
+        thread.start()
+        self.addCleanup(server.server_close)
+        self.addCleanup(thread.join)
+        self.addCleanup(server.shutdown)
+        return f"http://127.0.0.1:{server.server_address[1]}/release", seen
+
+    @unittest.skipUnless(shutil.which("curl"), "requires curl")
+    def test_written_curl_config_authenticates_a_real_request(self) -> None:
+        archive_path = self._temp_archive_path()
+        self._write_archive(archive_path, CURRENT_LAYOUT_FILES)
+        secret = "ghp-llamadart-transport-probe-9f2c4e"
+        capture_dir = tempfile.TemporaryDirectory()
+        self.addCleanup(capture_dir.cleanup)
+        capture = Path(capture_dir.name) / "curl.conf"
+
+        result, _ = self._run_sync(
+            archive_bytes=archive_path.read_bytes(),
+            token=secret,
+            config_capture=str(capture),
+        )
+        self.assertEqual(result.returncode, 0, result.stderr)
+        self.assertEqual(
+            capture.read_text(encoding="utf-8"),
+            f'header = "Authorization: Bearer {secret}"\n',
+        )
+
+        url, seen = self._serve_authorization_probe()
+        probe = subprocess.run(
+            ["curl", "-fsS", "--config", str(capture), url],
+            capture_output=True,
+            text=True,
+            check=False,
+        )
+        self.assertEqual(probe.returncode, 0, probe.stderr)
+        self.assertEqual(seen, [f"Bearer {secret}"])
+        self.assertNotIn(secret, result.stdout + result.stderr)
+        self.assertNotIn(secret, probe.stdout + probe.stderr)
 
     def test_token_and_credential_url_are_not_reported(self) -> None:
         secret = "test-secret-token"

--- a/tool/native/test_sync_native_headers_and_bindings.py
+++ b/tool/native/test_sync_native_headers_and_bindings.py
@@ -1,0 +1,437 @@
+from __future__ import annotations
+
+import hashlib
+import io
+import json
+import os
+import subprocess
+import tarfile
+import tempfile
+import unittest
+from pathlib import Path
+
+
+SCRIPT_PATH = Path(__file__).resolve().parent / "sync_native_headers_and_bindings.sh"
+TAG = "v0.16.0"
+ASSET_NAME = f"llamadart-native-headers-{TAG}.tar.gz"
+CURRENT_LAYOUT_FILES = {
+    "llama_cpp/include/llama.h": "// new llama\n",
+    "llama_cpp/ggml/include/ggml.h": "// new ggml\n",
+    "llama_cpp/ggml/include/ggml-backend.h": "// new ggml backend\n",
+    "llama_cpp/tools/mtmd/mtmd.h": "// new mtmd\n",
+    "llama_cpp/tools/mtmd/mtmd-helper.h": "// new mtmd helper\n",
+    "libllamadart/llama_dart_wrapper.h": "// new wrapper\n",
+}
+
+
+class NativeHeaderSyncIntegrationTest(unittest.TestCase):
+    def _temp_archive_path(self) -> Path:
+        descriptor, name = tempfile.mkstemp(suffix=".tar.gz")
+        os.close(descriptor)
+        path = Path(name)
+        self.addCleanup(lambda: path.unlink(missing_ok=True))
+        return path
+
+    def _write_archive(self, path: Path, files: dict[str, str]) -> None:
+        with tarfile.open(path, "w:gz") as archive:
+            for name, content in files.items():
+                payload = content.encode("utf-8")
+                info = tarfile.TarInfo(name)
+                info.size = len(payload)
+                archive.addfile(info, io.BytesIO(payload))
+
+    def _write_executable(self, path: Path, content: str) -> None:
+        path.write_text(content, encoding="utf-8")
+        path.chmod(0o755)
+
+    def _run_sync(
+        self,
+        *,
+        archive_bytes: bytes,
+        curl_mode: str = "ok",
+        mv_mode: str = "ok",
+        dart_mode: str = "ok",
+        skip_ffigen: bool = True,
+        live_kind: str = "directory",
+        asset_url: str | None = None,
+        digest: str | None = None,
+        token: str = "",
+        stale_paths: bool = False,
+        duplicate_asset: bool = False,
+    ) -> tuple[subprocess.CompletedProcess[str], Path]:
+        temp = tempfile.TemporaryDirectory()
+        self.addCleanup(temp.cleanup)
+        root = Path(temp.name)
+        bin_dir = root / "bin"
+        bin_dir.mkdir()
+        archive = root / "headers.tar.gz"
+        archive.write_bytes(archive_bytes)
+        release = root / "release.json"
+        asset = {
+            "name": ASSET_NAME,
+            "browser_download_url": asset_url
+            or f"https://github.com/owner/repo/releases/download/{TAG}/{ASSET_NAME}",
+            "digest": (
+                digest
+                if digest is not None
+                else f"sha256:{hashlib.sha256(archive_bytes).hexdigest()}"
+            ),
+        }
+        release.write_text(
+            json.dumps(
+                {
+                    "tag_name": TAG,
+                    "assets": [asset, dict(asset)] if duplicate_asset else [asset],
+                }
+            ),
+            encoding="utf-8",
+        )
+        self._write_executable(
+            bin_dir / "curl",
+            """#!/usr/bin/env python3
+import os
+from pathlib import Path
+import sys
+
+args = sys.argv[1:]
+mode = os.environ.get("FAKE_CURL_MODE", "ok")
+token = os.environ.get("FAKE_EXPECT_TOKEN", "")
+if token:
+    if any(token in arg for arg in args):
+        raise SystemExit(90)
+    configs = [
+        Path(args[index + 1])
+        for index, arg in enumerate(args[:-1])
+        if arg == "--config"
+    ]
+    auth = [path for path in configs if token in path.read_text(encoding="utf-8")]
+    if len(auth) != 1 or (auth[0].stat().st_mode & 0o777) != 0o600:
+        raise SystemExit(91)
+if "-o" in args:
+    expected_url = os.environ.get("FAKE_EXPECT_URL", "")
+    if expected_url and any(expected_url in arg for arg in args):
+        raise SystemExit(92)
+    configs = [
+        Path(args[index + 1])
+        for index, arg in enumerate(args[:-1])
+        if arg == "--config"
+    ]
+    if expected_url and not any(
+        expected_url in path.read_text(encoding="utf-8") for path in configs
+    ):
+        raise SystemExit(93)
+    if mode == "asset-failure":
+        Path(args[args.index("-o") + 1]).write_bytes(b"partial")
+        raise SystemExit(22)
+    Path(args[args.index("-o") + 1]).write_bytes(
+        Path(os.environ["FAKE_ARCHIVE"]).read_bytes()
+    )
+    raise SystemExit(0)
+if mode == "metadata-failure":
+    raise SystemExit(22)
+sys.stdout.write(Path(os.environ["FAKE_RELEASE"]).read_text(encoding="utf-8"))
+""",
+        )
+        self._write_executable(
+            bin_dir / "mv",
+            """#!/bin/sh
+if [ "${1:-}" = "--" ]; then shift; fi
+case "${FAKE_MV_MODE:-ok}:$1" in
+  publish-failure:*/staging|swap-failure:*/staging) exit 42 ;;
+  preserve-failure:*/ffigen_headers) exit 43 ;;
+  restore-failure:*/backup) exit 44 ;;
+esac
+exec /bin/mv "$@"
+""",
+        )
+        self._write_executable(
+            bin_dir / "dart",
+            """#!/bin/sh
+if [ "${FAKE_DART_MODE:-ok}" = "ffigen-failure" ]; then exit 41; fi
+exit 0
+""",
+        )
+
+        live = root / "ffigen_headers"
+        if live_kind == "directory":
+            (live / "llama_cpp/include").mkdir(parents=True)
+            (live / "llama_cpp/include/llama.h").write_text(
+                "// old llama\n", encoding="utf-8"
+            )
+            (live / "old-marker.txt").write_text("old root\n", encoding="utf-8")
+        elif live_kind == "file":
+            live.write_text("old file\n", encoding="utf-8")
+        elif live_kind == "symlink":
+            target = root / "old-target"
+            target.mkdir()
+            (target / "old-marker.txt").write_text("old link\n", encoding="utf-8")
+            live.symlink_to(target, target_is_directory=True)
+        elif live_kind != "missing":
+            raise AssertionError(f"unsupported live kind: {live_kind}")
+        if stale_paths:
+            for suffix in ("staging.123", "backup.123"):
+                stale = live.parent / f"{live.name}.{suffix}"
+                stale.mkdir()
+                (stale / "marker").write_text("stale", encoding="utf-8")
+        env = os.environ.copy()
+        env.update(
+            {
+                "FAKE_ARCHIVE": str(archive),
+                "FAKE_RELEASE": str(release),
+                "FAKE_CURL_MODE": curl_mode,
+                "FAKE_MV_MODE": mv_mode,
+                "FAKE_DART_MODE": dart_mode,
+                "PATH": f"{bin_dir}{os.pathsep}{env['PATH']}",
+                "LLAMADART_FFIGEN_HEADER_ROOT": str(live),
+                "GH_TOKEN": token,
+                "FAKE_EXPECT_TOKEN": token,
+                "FAKE_EXPECT_URL": asset_url
+                or f"https://github.com/owner/repo/releases/download/{TAG}/{ASSET_NAME}",
+            }
+        )
+        command = [str(SCRIPT_PATH), "--tag", TAG]
+        if skip_ffigen:
+            command.append("--skip-ffigen")
+        result = subprocess.run(
+            command,
+            cwd=SCRIPT_PATH.parents[2],
+            env=env,
+            capture_output=True,
+            text=True,
+            check=False,
+        )
+        return result, live
+
+    def _assert_previous_root(self, live: Path) -> None:
+        self.assertEqual(
+            (live / "old-marker.txt").read_text(encoding="utf-8"), "old root\n"
+        )
+        self.assertEqual(
+            (live / "llama_cpp/include/llama.h").read_text(encoding="utf-8"),
+            "// old llama\n",
+        )
+        self.assertEqual(list(live.parent.glob(f"{live.name}.*")), [])
+
+    def test_successful_replacement_swaps_complete_root(self) -> None:
+        archive_path = self._temp_archive_path()
+        self._write_archive(archive_path, CURRENT_LAYOUT_FILES)
+        result, live = self._run_sync(archive_bytes=archive_path.read_bytes())
+
+        self.assertEqual(result.returncode, 0, result.stderr)
+        self.assertFalse((live / "old-marker.txt").exists())
+        for relative, content in CURRENT_LAYOUT_FILES.items():
+            self.assertEqual((live / relative).read_text(encoding="utf-8"), content)
+        self.assertEqual(list(live.parent.glob(f"{live.name}.*")), [])
+
+    def test_missing_required_header_preserves_previous_root(self) -> None:
+        files = dict(CURRENT_LAYOUT_FILES)
+        files.pop("llama_cpp/tools/mtmd/mtmd-helper.h")
+        archive_path = self._temp_archive_path()
+        self._write_archive(archive_path, files)
+        result, live = self._run_sync(archive_bytes=archive_path.read_bytes())
+
+        self.assertNotEqual(result.returncode, 0)
+        self.assertIn("left", result.stderr)
+        self._assert_previous_root(live)
+
+    def test_corrupt_archive_preserves_previous_root(self) -> None:
+        result, live = self._run_sync(archive_bytes=b"not a gzip archive")
+
+        self.assertNotEqual(result.returncode, 0)
+        self.assertIn("left", result.stderr)
+        self._assert_previous_root(live)
+
+    def test_unsafe_archive_entry_preserves_previous_root(self) -> None:
+        archive_path = self._temp_archive_path()
+        with tarfile.open(archive_path, "w:gz") as archive:
+            for name, content in CURRENT_LAYOUT_FILES.items():
+                payload = content.encode("utf-8")
+                info = tarfile.TarInfo(name)
+                info.size = len(payload)
+                archive.addfile(info, io.BytesIO(payload))
+            link = tarfile.TarInfo("llama_cpp/include/unsafe.h")
+            link.type = tarfile.SYMTYPE
+            link.linkname = "/etc/passwd"
+            archive.addfile(link)
+        result, live = self._run_sync(archive_bytes=archive_path.read_bytes())
+
+        self.assertNotEqual(result.returncode, 0)
+        self.assertIn("left", result.stderr)
+        self._assert_previous_root(live)
+
+    def test_swap_failure_restores_previous_root(self) -> None:
+        archive_path = self._temp_archive_path()
+        self._write_archive(archive_path, CURRENT_LAYOUT_FILES)
+        result, live = self._run_sync(
+            archive_bytes=archive_path.read_bytes(), mv_mode="publish-failure"
+        )
+
+        self.assertNotEqual(result.returncode, 0)
+        self.assertIn("Restored the previous header root", result.stderr)
+        self._assert_previous_root(live)
+
+    def test_backup_rename_failure_leaves_previous_root_in_place(self) -> None:
+        archive_path = self._temp_archive_path()
+        self._write_archive(archive_path, CURRENT_LAYOUT_FILES)
+        result, live = self._run_sync(
+            archive_bytes=archive_path.read_bytes(), mv_mode="preserve-failure"
+        )
+        self.assertNotEqual(result.returncode, 0)
+        self.assertIn("Failed to preserve", result.stderr)
+        self._assert_previous_root(live)
+
+    def test_restore_failure_preserves_the_backup(self) -> None:
+        archive_path = self._temp_archive_path()
+        self._write_archive(archive_path, CURRENT_LAYOUT_FILES)
+        result, live = self._run_sync(
+            archive_bytes=archive_path.read_bytes(),
+            mv_mode="restore-failure",
+            dart_mode="ffigen-failure",
+            skip_ffigen=False,
+        )
+
+        self.assertNotEqual(result.returncode, 0)
+        self.assertIn("preserved its backup", result.stderr)
+        backups = list(live.parent.glob(f".{live.name}.sync.*/backup"))
+        self.assertEqual(len(backups), 1)
+        self.assertEqual(
+            (backups[0] / "old-marker.txt").read_text(encoding="utf-8"),
+            "old root\n",
+        )
+
+    def test_ffigen_failure_without_previous_root_removes_publication(self) -> None:
+        archive_path = self._temp_archive_path()
+        self._write_archive(archive_path, CURRENT_LAYOUT_FILES)
+        result, live = self._run_sync(
+            archive_bytes=archive_path.read_bytes(),
+            dart_mode="ffigen-failure",
+            skip_ffigen=False,
+            live_kind="missing",
+        )
+
+        self.assertNotEqual(result.returncode, 0)
+        self.assertFalse(live.exists())
+        self.assertEqual(list(live.parent.glob(f".{live.name}.sync.*")), [])
+
+    def test_ffigen_failure_restores_file_and_symlink_roots(self) -> None:
+        archive_path = self._temp_archive_path()
+        self._write_archive(archive_path, CURRENT_LAYOUT_FILES)
+        payload = archive_path.read_bytes()
+        for live_kind in ("file", "symlink"):
+            with self.subTest(live_kind=live_kind):
+                result, live = self._run_sync(
+                    archive_bytes=payload,
+                    dart_mode="ffigen-failure",
+                    skip_ffigen=False,
+                    live_kind=live_kind,
+                )
+                self.assertNotEqual(result.returncode, 0)
+                if live_kind == "file":
+                    self.assertTrue(live.is_file())
+                    self.assertEqual(live.read_text(encoding="utf-8"), "old file\n")
+                else:
+                    self.assertTrue(live.is_symlink())
+                    self.assertEqual(
+                        (live / "old-marker.txt").read_text(encoding="utf-8"),
+                        "old link\n",
+                    )
+
+    def test_stale_pid_paths_are_not_used_or_removed(self) -> None:
+        archive_path = self._temp_archive_path()
+        self._write_archive(archive_path, CURRENT_LAYOUT_FILES)
+        result, live = self._run_sync(
+            archive_bytes=archive_path.read_bytes(), stale_paths=True
+        )
+        self.assertEqual(result.returncode, 0, result.stderr)
+        for suffix in ("staging.123", "backup.123"):
+            self.assertEqual(
+                (live.parent / f"{live.name}.{suffix}" / "marker").read_text(
+                    encoding="utf-8"
+                ),
+                "stale",
+            )
+
+    def test_digest_failure_preserves_previous_root(self) -> None:
+        archive_path = self._temp_archive_path()
+        self._write_archive(archive_path, CURRENT_LAYOUT_FILES)
+        result, live = self._run_sync(
+            archive_bytes=archive_path.read_bytes(), digest=f"sha256:{'0' * 64}"
+        )
+        self.assertNotEqual(result.returncode, 0)
+        self.assertIn("checksum mismatch", result.stderr)
+        self._assert_previous_root(live)
+
+    def test_missing_stable_digest_preserves_previous_root(self) -> None:
+        archive_path = self._temp_archive_path()
+        self._write_archive(archive_path, CURRENT_LAYOUT_FILES)
+        result, live = self._run_sync(
+            archive_bytes=archive_path.read_bytes(), digest=""
+        )
+        self.assertNotEqual(result.returncode, 0)
+        self.assertIn("does not publish", result.stderr)
+        self._assert_previous_root(live)
+
+    def test_duplicate_asset_inventory_preserves_previous_root(self) -> None:
+        result, live = self._run_sync(
+            archive_bytes=b"unused", duplicate_asset=True
+        )
+        self.assertNotEqual(result.returncode, 0)
+        self.assertIn("duplicates", result.stderr)
+        self._assert_previous_root(live)
+
+    def test_token_and_asset_url_stay_out_of_curl_arguments(self) -> None:
+        archive_path = self._temp_archive_path()
+        self._write_archive(archive_path, CURRENT_LAYOUT_FILES)
+        secret = "test-secret-token"
+        result, _ = self._run_sync(
+            archive_bytes=archive_path.read_bytes(), token=secret
+        )
+        self.assertEqual(result.returncode, 0, result.stderr)
+        self.assertNotIn(secret, result.stdout + result.stderr)
+
+    def test_token_and_credential_url_are_not_reported(self) -> None:
+        secret = "test-secret-token"
+        result, live = self._run_sync(
+            archive_bytes=b"unused",
+            asset_url="https://user:password@github.com/owner/repo/archive?token=secret",
+            token=secret,
+        )
+        self.assertNotEqual(result.returncode, 0)
+        self.assertNotIn(secret, result.stdout + result.stderr)
+        self.assertNotIn("password", result.stdout + result.stderr)
+        self._assert_previous_root(live)
+
+    def test_ffigen_failure_restores_previous_root(self) -> None:
+        archive_path = self._temp_archive_path()
+        self._write_archive(archive_path, CURRENT_LAYOUT_FILES)
+        result, live = self._run_sync(
+            archive_bytes=archive_path.read_bytes(),
+            dart_mode="ffigen-failure",
+            skip_ffigen=False,
+        )
+
+        self.assertNotEqual(result.returncode, 0)
+        self.assertIn("Restored the previous header root", result.stderr)
+        self._assert_previous_root(live)
+
+    def test_interrupted_asset_download_preserves_previous_root(self) -> None:
+        result, live = self._run_sync(
+            archive_bytes=b"partial archive", curl_mode="asset-failure"
+        )
+
+        self.assertNotEqual(result.returncode, 0)
+        self.assertIn("Failed to download", result.stderr)
+        self._assert_previous_root(live)
+
+    def test_release_metadata_failure_preserves_previous_root(self) -> None:
+        result, live = self._run_sync(
+            archive_bytes=b"unused", curl_mode="metadata-failure"
+        )
+
+        self.assertNotEqual(result.returncode, 0)
+        self.assertIn("Failed to fetch", result.stderr)
+        self._assert_previous_root(live)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tool/native/test_sync_native_release_pins.py
+++ b/tool/native/test_sync_native_release_pins.py
@@ -10,7 +10,9 @@ import socket
 import subprocess
 import sys
 import tempfile
+import threading
 import urllib.error
+from http.server import BaseHTTPRequestHandler, HTTPServer
 from pathlib import Path
 from unittest.mock import patch
 import unittest
@@ -72,6 +74,90 @@ def _release_with_asset(asset_name: str, tag: str = "v0.16.0") -> dict:
             {"name": asset_name, "browser_download_url": SIGNED_URL},
         ],
     }
+
+
+PROBE_TOKEN = "ghp-llamadart-transport-probe-9f2c4e"
+
+
+class GithubAuthTransportTest(unittest.TestCase):
+    """The real token must reach GitHub while staying out of every diagnostic."""
+
+    def setUp(self) -> None:
+        self.seen: list[str | None] = []
+        self.status = 200
+        test = self
+
+        class Handler(BaseHTTPRequestHandler):
+            def do_GET(self) -> None:
+                test.seen.append(self.headers.get("Authorization"))
+                body = json.dumps({"tag_name": "v0.16.0", "assets": []}).encode()
+                self.send_response(test.status)
+                self.send_header("Content-Length", str(len(body)))
+                self.end_headers()
+                self.wfile.write(body)
+
+            def log_message(self, *args: object) -> None:
+                return
+
+        server = HTTPServer(("127.0.0.1", 0), Handler)
+        thread = threading.Thread(target=server.serve_forever, daemon=True)
+        thread.start()
+        self.addCleanup(server.server_close)
+        self.addCleanup(thread.join)
+        self.addCleanup(server.shutdown)
+        self.url = f"http://127.0.0.1:{server.server_address[1]}/release.json"
+
+    def _env(self, name: str = "") -> dict[str, str]:
+        env = {
+            k: v
+            for k, v in os.environ.items()
+            if k not in ("GH_TOKEN", "GITHUB_TOKEN")
+        }
+        if name:
+            env[name] = PROBE_TOKEN
+        return env
+
+    def test_auth_header_carries_the_real_token(self) -> None:
+        for name in ("GH_TOKEN", "GITHUB_TOKEN"):
+            with self.subTest(variable=name), patch.dict(
+                os.environ, self._env(name), clear=True
+            ):
+                self.assertEqual(
+                    pins.github_auth_header(),
+                    {"Authorization": f"Bearer {PROBE_TOKEN}"},
+                )
+                self.assertEqual(
+                    pins.github_api_headers()["Authorization"],
+                    f"Bearer {PROBE_TOKEN}",
+                )
+
+    def test_no_auth_header_without_a_token(self) -> None:
+        with patch.dict(os.environ, self._env(), clear=True):
+            self.assertEqual(pins.github_auth_header(), {})
+
+    def test_transport_sends_the_real_token(self) -> None:
+        with patch.dict(os.environ, self._env("GH_TOKEN"), clear=True):
+            payload = pins.read_release_url(
+                self.url, context="probe", headers=pins.github_api_headers()
+            )
+        self.assertEqual(self.seen, [f"Bearer {PROBE_TOKEN}"])
+        self.assertEqual(json.loads(payload)["tag_name"], "v0.16.0")
+
+    def test_failures_never_echo_the_token(self) -> None:
+        self.status = 404
+        with patch.dict(os.environ, self._env("GH_TOKEN"), clear=True):
+            with self.assertRaises(ReleaseError) as raised:
+                pins.read_release_url(
+                    self.url, context="probe", headers=pins.github_api_headers()
+                )
+        self.assertEqual(self.seen, [f"Bearer {PROBE_TOKEN}"])
+        cause = raised.exception.__cause__
+        message = f"{raised.exception}{cause}"
+        if isinstance(cause, urllib.error.HTTPError):
+            cause.close()
+        self.assertIn("HTTP 404", message)
+        self.assertNotIn(PROBE_TOKEN, message)
+        self.assertNotIn(self.url, str(raised.exception))
 
 
 class ReleaseTransportFailureTest(unittest.TestCase):

--- a/tool/native/test_sync_native_release_pins.py
+++ b/tool/native/test_sync_native_release_pins.py
@@ -1,19 +1,24 @@
 from __future__ import annotations
 
 import hashlib
+import http.client
 import json
 import os
 import re
 import shutil
+import socket
 import subprocess
 import sys
 import tempfile
+import urllib.error
 from pathlib import Path
+from unittest.mock import patch
 import unittest
 
 
 sys.path.insert(0, str(Path(__file__).resolve().parent))
 
+import sync_native_release_pins as pins  # noqa: E402
 from sync_native_release_pins import (  # noqa: E402
     ReleaseError,
     LEGACY_SCHEMA1_RELEASES,
@@ -36,6 +41,248 @@ from sync_native_release_pins import (  # noqa: E402
 UPSTREAM_COMMIT = "ba82499873945908bf8bcfc96e955d0677eb1fa1"
 NATIVE_COMMIT = "451ba0ce7c366972b4dc0e58f08ffe590958f943"
 DEVELOPMENT_TAG = "gba8249987394"
+
+SIGNED_URL = "https://objects.example.invalid/asset?token=super-secret"
+
+
+class _FakeResponse:
+    def __init__(
+        self, payload: bytes = b"", read_error: BaseException | None = None
+    ) -> None:
+        self._payload = payload
+        self._read_error = read_error
+
+    def __enter__(self) -> _FakeResponse:
+        return self
+
+    def __exit__(self, *args: object) -> None:
+        return None
+
+    def read(self, *args: object) -> bytes:
+        if self._read_error is not None:
+            raise self._read_error
+        payload, self._payload = self._payload, b""
+        return payload
+
+
+def _release_with_asset(asset_name: str, tag: str = "v0.16.0") -> dict:
+    return {
+        "tag_name": tag,
+        "assets": [
+            {"name": asset_name, "browser_download_url": SIGNED_URL},
+        ],
+    }
+
+
+class ReleaseTransportFailureTest(unittest.TestCase):
+    def setUp(self) -> None:
+        for name, value in (
+            ("HTTP_RETRY_DELAY_SECONDS", 0.0),
+            ("HTTP_SOCKET_TIMEOUT_SECONDS", 0.25),
+        ):
+            patcher = patch.object(pins, name, value)
+            patcher.start()
+            self.addCleanup(patcher.stop)
+
+    def _http_error(self, code: int) -> urllib.error.HTTPError:
+        error = urllib.error.HTTPError(SIGNED_URL, code, SIGNED_URL, {}, None)
+        self.addCleanup(error.close)
+        return error
+
+    def _assert_actionable(self, message: str, *expected: str) -> None:
+        for fragment in expected:
+            self.assertIn(fragment, message)
+        self.assertNotIn("Traceback", message)
+        self.assertNotIn("objects.example.invalid", message)
+        self.assertNotIn("super-secret", message)
+
+    def test_dns_failure_is_retried_and_reported_without_the_url(self) -> None:
+        error = urllib.error.URLError(socket.gaierror(SIGNED_URL))
+        with patch.object(
+            pins.urllib.request, "urlopen", side_effect=error
+        ) as urlopen:
+            with self.assertRaises(ReleaseError) as raised:
+                fetch_release("owner/repo", "v0.16.0")
+
+        self._assert_actionable(
+            str(raised.exception),
+            "Failed to fetch release owner/repo@v0.16.0",
+            "DNS lookup failed",
+        )
+        self.assertEqual(urlopen.call_count, pins.HTTP_MAX_ATTEMPTS)
+        self.assertEqual(
+            {call.kwargs["timeout"] for call in urlopen.call_args_list},
+            {pins.HTTP_SOCKET_TIMEOUT_SECONDS},
+        )
+
+    def test_permanent_http_error_is_not_retried(self) -> None:
+        error = self._http_error(404)
+        with patch.object(
+            pins.urllib.request, "urlopen", side_effect=error
+        ) as urlopen:
+            with self.assertRaises(ReleaseError) as raised:
+                fetch_release("owner/repo", "v0.16.0")
+
+        self._assert_actionable(
+            str(raised.exception), "owner/repo@v0.16.0", "HTTP 404"
+        )
+        urlopen.assert_called_once()
+
+    def test_transient_http_error_is_retried_then_reported(self) -> None:
+        error = self._http_error(503)
+        with patch.object(
+            pins.urllib.request, "urlopen", side_effect=error
+        ) as urlopen:
+            with self.assertRaises(ReleaseError) as raised:
+                fetch_release("owner/repo", "v0.16.0")
+
+        self._assert_actionable(str(raised.exception), "HTTP 503")
+        self.assertEqual(urlopen.call_count, pins.HTTP_MAX_ATTEMPTS)
+
+    def test_nontransient_os_error_is_not_retried(self) -> None:
+        with patch.object(
+            pins.urllib.request, "urlopen", side_effect=OSError(SIGNED_URL)
+        ) as urlopen:
+            with self.assertRaises(ReleaseError) as raised:
+                fetch_release("owner/repo", "v0.16.0")
+        self._assert_actionable(str(raised.exception), "network error")
+        urlopen.assert_called_once()
+
+    def test_connection_timeout_is_reported_with_the_bound(self) -> None:
+        with patch.object(
+            pins.urllib.request, "urlopen", side_effect=TimeoutError(SIGNED_URL)
+        ):
+            with self.assertRaises(ReleaseError) as raised:
+                fetch_release("owner/repo", "v0.16.0")
+
+        self._assert_actionable(
+            str(raised.exception),
+            f"timed out (socket {pins.HTTP_SOCKET_TIMEOUT_SECONDS:g}s, "
+            f"total {pins.HTTP_TOTAL_TIMEOUT_SECONDS:g}s)",
+        )
+
+    def test_interrupted_asset_download_is_reported(self) -> None:
+        with patch.object(
+            pins.urllib.request,
+            "urlopen",
+            side_effect=lambda *a, **k: _FakeResponse(
+                read_error=http.client.IncompleteRead(b"partial")
+            ),
+        ) as urlopen:
+            with self.assertRaises(ReleaseError) as raised:
+                pins.release_asset_bytes(
+                    _release_with_asset("bundle.tar.gz"),
+                    "bundle.tar.gz",
+                    repo="owner/repo",
+                    tag="v0.16.0",
+                    release_json_dir="",
+                )
+
+        self._assert_actionable(
+            str(raised.exception),
+            "Failed to read release asset bundle.tar.gz (owner/repo@v0.16.0)",
+            "interrupted download",
+        )
+        self.assertEqual(urlopen.call_count, pins.HTTP_MAX_ATTEMPTS)
+
+    def test_invalid_manifest_payloads_are_release_errors(self) -> None:
+        for payload in (b"{not json", b"\xff\xfe", b'"a string"'):
+            with self.subTest(payload=payload), patch.object(
+                pins.urllib.request,
+                "urlopen",
+                return_value=_FakeResponse(payload),
+            ):
+                with self.assertRaises(ReleaseError) as raised:
+                    pins.release_asset_json(
+                        _release_with_asset("assets.json"), "assets.json"
+                    )
+                self._assert_actionable(str(raised.exception), "assets.json")
+
+        release = _release_with_asset("assets.json")
+        release["assets"][0]["fixture_json"] = []
+        with self.assertRaisesRegex(ReleaseError, "must be a JSON object"):
+            pins.release_asset_json(release, "assets.json")
+
+    def test_checksum_fallback_download_failure_names_the_asset(self) -> None:
+        error = self._http_error(403)
+        with patch.object(pins.urllib.request, "urlopen", side_effect=error):
+            with self.assertRaises(ReleaseError) as raised:
+                pins.release_asset_checksum(
+                    _release_with_asset("SHA256SUMS"),
+                    "SHA256SUMS",
+                    repo="owner/repo",
+                )
+
+        self._assert_actionable(
+            str(raised.exception),
+            "Failed to read release asset SHA256SUMS (owner/repo@v0.16.0)",
+            "HTTP 403",
+        )
+
+    def test_missing_fixture_is_actionable(self) -> None:
+        with tempfile.TemporaryDirectory() as temp:
+            with self.assertRaises(ReleaseError) as raised:
+                fetch_release("owner/repo", "v0.16.0", temp)
+
+        self._assert_actionable(
+            str(raised.exception),
+            "Failed to fetch release owner/repo@v0.16.0",
+            "cannot read fixture",
+        )
+
+    def test_transient_failure_recovers_on_retry(self) -> None:
+        payload = json.dumps({"tag_name": "v0.16.0", "assets": []}).encode("utf-8")
+        with patch.object(
+            pins.urllib.request,
+            "urlopen",
+            side_effect=[
+                urllib.error.URLError(ConnectionResetError("reset")),
+                _FakeResponse(payload),
+            ],
+        ) as urlopen:
+            release = fetch_release("owner/repo", "v0.16.0")
+
+        self.assertEqual(release["tag_name"], "v0.16.0")
+        self.assertEqual(urlopen.call_count, 2)
+
+    def test_invalid_url_is_typed_and_redacted(self) -> None:
+        secret_url = "not-a-url?token=super-secret"
+        with self.assertRaises(ReleaseError) as raised:
+            pins.read_release_url(secret_url, context="Failed to read asset")
+        self._assert_actionable(
+            str(raised.exception), "Failed to read asset", "invalid download URL"
+        )
+
+    def test_streaming_read_cannot_exceed_the_overall_deadline(self) -> None:
+        with patch.object(
+            pins.time,
+            "monotonic",
+            side_effect=[
+                0.0,
+                0.0,
+                0.0,
+                pins.HTTP_TOTAL_TIMEOUT_SECONDS + 1,
+                pins.HTTP_TOTAL_TIMEOUT_SECONDS + 1,
+            ],
+        ), patch.object(
+            pins.urllib.request, "urlopen", return_value=_FakeResponse(b"payload")
+        ) as urlopen:
+            with self.assertRaises(ReleaseError) as raised:
+                pins.read_release_url(SIGNED_URL, context="Failed to read asset")
+
+        self._assert_actionable(str(raised.exception), "timed out")
+        urlopen.assert_called_once()
+
+    def test_invalid_digest_and_asset_inventory_are_rejected(self) -> None:
+        release = _release_with_asset("bundle.tar.gz")
+        release["assets"][0]["digest"] = "sha512:abcd"
+        with self.assertRaisesRegex(ReleaseError, "invalid GitHub SHA-256 digest"):
+            pins.release_asset_checksum(release, "bundle.tar.gz")
+
+        duplicate = _release_with_asset("bundle.tar.gz")
+        duplicate["assets"].append(dict(duplicate["assets"][0]))
+        with self.assertRaisesRegex(ReleaseError, "duplicates asset"):
+            pins.release_asset_checksum(duplicate, "bundle.tar.gz")
 
 
 def _schema2_fixture_payloads() -> tuple[dict, dict]:


### PR DESCRIPTION
## Summary

- stage and validate native header archives before replacing the active header tree
- restore the previous headers when publication or `ffigen` fails
- add bounded retries, timeouts, redacted transport diagnostics, and traceback-free metadata errors
- run archive and atomic-sync regressions in CI

Fixes #401
Fixes #403

## Verification

- `bash -n tool/native/sync_native_headers_and_bindings.sh`
- Python compile checks for all changed native tooling
- `python3 -m unittest discover -s tool/native -p 'test_*.py'` — 71 passed
- `dart test test/unit/tooling/sync_native_release_pins_script_test.dart` — 22 passed, 3 Windows-only skipped
- `actionlint -color=false .github/workflows/ci.yml`
- live staging of published `v0.3.0` and historical `v0.2.0-1` header archives — 27 files each
- authenticated local transport probes prove the real token reaches curl/urllib while remaining absent from argv, output, exceptions, and URLs
- `git diff --check`

## Review

A fresh writable Codex high-reasoning audit fixed transaction collisions, rollback failure handling, archive path and duplicate validation, conservative retry deadlines, and transport redaction. Final verdict: PASS with no material findings remaining.

Copilot later flagged the authentication headers as redacted placeholders. Direct transport probes and mutation checks proved both implementations already carry the real token; regressions now lock that behavior in without changing production code.

No runtime pins, generated bindings, dependency versions, release artifacts, or publication settings changed.
