### PR TITLE
chore: sync llama.cpp v0.3.0 runtimes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,16 @@
+## Unreleased
+
+* Updated the default llama.cpp native runtime pin to
+  `leehack/llamadart-native@v0.3.0`, regenerated matching Dart FFI bindings, refreshed
+  the `llamadart_llama_cpp_flutter` Apple SwiftPM checksum, and
+  aligned current README/website native override docs.
+
+* Aligned the default WebGPU bridge assets to `v0.1.40`, keeping Web/native
+  llama.cpp upstream `v0.3.0@c1d0e7a004015f23bc0233470b747b596f29b264` parity
+  with native anchor `llamadart-native@v0.3.0` while preserving approved Web
+  `@litert-lm/core@0.15.0` packaging. Immutable manifest:
+  `99fc09bb0cc23cf0eb08875a9ea973803fb1d432c5c8ca1b1211af0eb1d20b17`.
+
 ## 0.8.21
 
 * Aligned the default WebGPU bridge assets to `v0.1.39` (immutable manifest

--- a/README.md
+++ b/README.md
@@ -143,9 +143,9 @@ Current default runtime pins:
 
 | Runtime | Pin |
 | --- | --- |
-| Native llama.cpp / GGUF | `leehack/llamadart-native@v0.2.0-1` |
+| Native llama.cpp / GGUF | `leehack/llamadart-native@v0.3.0` |
 | Native LiteRT-LM / `.litertlm` | `leehack/litert-lm-native@v0.16.0-native.2` |
-| Web llama.cpp / GGUF | `leehack/llama-web-bridge-assets@v0.1.39` |
+| Web llama.cpp / GGUF | `leehack/llama-web-bridge-assets@v0.1.40` |
 | Web LiteRT-LM / `.litertlm` | `@litert-lm/core@0.15.0` |
 
 Native overrides accept stable `vMAJOR.MINOR.PATCH` releases and preserve

--- a/doc/webgpu_bridge.md
+++ b/doc/webgpu_bridge.md
@@ -19,15 +19,15 @@ pipelines.
    `https://cdn.jsdelivr.net/gh/leehack/llama-web-bridge-assets@<tag>/llama_webgpu_bridge.js`
 2. Local fallback: `./webgpu_bridge/llama_webgpu_bridge.js`
 
-Default pinned tag in the example is `v0.1.39`.
+Default pinned tag in the example is `v0.1.40`.
 
-That release embeds llama.cpp `v0.2.0`, matching the `hook/build.dart` native pin
-(`v0.2.0-1`, both built from upstream llama.cpp `v0.2.0@bb4caa7540188872173c44d161602d9271386413`)
+That release embeds llama.cpp `v0.3.0`, matching the `hook/build.dart` native pin
+(`v0.3.0`, both built from upstream llama.cpp `v0.3.0@c1d0e7a004015f23bc0233470b747b596f29b264`)
 even though wrapper release tags differ. Provenance for this immutable consumer
-artifact: release `377534035`, tag commit
-`d14d46a63deeee7a8f8a017e394b74ee112f4dba`, bridge source
-`79b6ef31e394dd2de92a456b7c249f9da377c720`, and manifest SHA-256
-`b355d01040604f6ae2c5c5fe5bb42b858101a96f03f67e4b27b32fe41ce3b2bf`. It retains
+artifact: release `379234159`, tag commit
+`a18f1c31835ee722c7750a5c68f22c5b19e4c937`, bridge source
+`0bdc8286fd52b70da27f5b039e1b4278361da0be`, and manifest SHA-256
+`99fc09bb0cc23cf0eb08875a9ea973803fb1d432c5c8ca1b1211af0eb1d20b17`. It retains
 the Qwen3-ASR typed speech-to-text contract introduced in `v0.1.30` and
 provisions the explicit 1 MiB Wasm stack needed for memory64 context
 construction in direct and worker modes. The chat bootstrap opts
@@ -47,7 +47,7 @@ model bytes.
 To vendor pinned assets into local app web files:
 
 ```bash
-WEBGPU_BRIDGE_ASSETS_TAG=v0.1.39 ./scripts/fetch_webgpu_bridge_assets.sh
+WEBGPU_BRIDGE_ASSETS_TAG=v0.1.40 ./scripts/fetch_webgpu_bridge_assets.sh
 ```
 
 Optional compatibility env vars:
@@ -128,7 +128,7 @@ You can override CDN source/version before the bridge loader runs:
 ```html
 <script>
   window.__llamadartBridgeAssetsRepo = 'leehack/llama-web-bridge-assets';
-  window.__llamadartBridgeAssetsTag = 'v0.1.39';
+  window.__llamadartBridgeAssetsTag = 'v0.1.40';
 </script>
 ```
 

--- a/doc/webgpu_bridge.md
+++ b/doc/webgpu_bridge.md
@@ -23,9 +23,9 @@ Default pinned tag in the example is `v0.1.40`.
 
 That release embeds llama.cpp `v0.3.0`, matching the `hook/build.dart` native pin
 (`v0.3.0`, both built from upstream llama.cpp `v0.3.0@c1d0e7a004015f23bc0233470b747b596f29b264`)
-even though wrapper release tags differ. Provenance for this immutable consumer
-artifact: release `379234159`, tag commit
-`a18f1c31835ee722c7750a5c68f22c5b19e4c937`, bridge source
+even though the bridge asset tag `v0.1.40` differs from the native runtime tag
+`v0.3.0`. Provenance for this immutable consumer artifact: release `379234159`,
+tag commit `a18f1c31835ee722c7750a5c68f22c5b19e4c937`, bridge source
 `0bdc8286fd52b70da27f5b039e1b4278361da0be`, and manifest SHA-256
 `99fc09bb0cc23cf0eb08875a9ea973803fb1d432c5c8ca1b1211af0eb1d20b17`. It retains
 the Qwen3-ASR typed speech-to-text contract introduced in `v0.1.30` and

--- a/example/chat_app/web/index.html
+++ b/example/chat_app/web/index.html
@@ -211,8 +211,8 @@
       typeof configuredRepo === 'string' && configuredRepo.length > 0
         ? configuredRepo
         : 'leehack/llama-web-bridge-assets';
-    const defaultBridgeAssetsTag = 'v0.1.39';
-    const defaultBridgeLlamaCppTag = 'v0.2.0';
+    const defaultBridgeAssetsTag = 'v0.1.40';
+    const defaultBridgeLlamaCppTag = 'v0.3.0';
     const bridgeAssetsTag =
       typeof configuredTag === 'string' && configuredTag.length > 0
         ? configuredTag

--- a/hook/build.dart
+++ b/hook/build.dart
@@ -13,7 +13,7 @@ import 'package:path/path.dart' as path;
 
 import 'package:llamadart/src/hook/native_bundle_config.dart';
 
-const _llamaCppTag = 'v0.2.0-1';
+const _llamaCppTag = 'v0.3.0';
 const _nativeRepoSlug = 'leehack/llamadart-native';
 
 const _packageName = 'llamadart';

--- a/lib/src/backends/llama_cpp/bindings.dart
+++ b/lib/src/backends/llama_cpp/bindings.dart
@@ -1306,6 +1306,21 @@ external ffi.Pointer<ggml_tensor> ggml_clamp(
   ffi.Pointer<ggml_tensor> Function(
     ffi.Pointer<ggml_context>,
     ffi.Pointer<ggml_tensor>,
+    ffi.Float,
+    ffi.Float,
+  )
+>()
+external ffi.Pointer<ggml_tensor> ggml_clamp_inplace(
+  ffi.Pointer<ggml_context> ctx,
+  ffi.Pointer<ggml_tensor> a,
+  double min,
+  double max,
+);
+
+@ffi.Native<
+  ffi.Pointer<ggml_tensor> Function(
+    ffi.Pointer<ggml_context>,
+    ffi.Pointer<ggml_tensor>,
     ffi.Int,
     ffi.Int,
     ffi.Int,

--- a/packages/llamadart_llama_cpp_flutter/CHANGELOG.md
+++ b/packages/llamadart_llama_cpp_flutter/CHANGELOG.md
@@ -1,3 +1,7 @@
+## Unreleased
+
+* Updated Apple SwiftPM native pin to `leehack/llamadart-native@v0.3.0`.
+
 ## 0.0.16
 
 * Updated Apple SwiftPM native pin to the immutable

--- a/packages/llamadart_llama_cpp_flutter/README.md
+++ b/packages/llamadart_llama_cpp_flutter/README.md
@@ -16,8 +16,7 @@ dependencies:
 This package has no runtime Dart API of its own. Import `package:llamadart`
 normally from the core package and use `LlamaBackend()` / `LlamaEngine` there.
 
-The Apple SwiftPM manifest pins
-`leehack/llamadart-native@v0.2.0-1`.
+The Apple SwiftPM manifest pins `leehack/llamadart-native@v0.3.0`.
 
 Source for this package lives in
 `packages/llamadart_llama_cpp_flutter` in the

--- a/packages/llamadart_llama_cpp_flutter/darwin/llamadart_llama_cpp_flutter/Package.swift
+++ b/packages/llamadart_llama_cpp_flutter/darwin/llamadart_llama_cpp_flutter/Package.swift
@@ -4,7 +4,7 @@ import PackageDescription
 
 let packageRoot = URL(fileURLWithPath: #filePath).deletingLastPathComponent()
 let artifactsRoot = packageRoot.appendingPathComponent("Artifacts")
-let llamaCppTag = "v0.2.0-1"
+let llamaCppTag = "v0.3.0"
 
 func localArtifactPath(_ name: String) -> String? {
     let path = artifactsRoot.appendingPathComponent(name).path
@@ -47,7 +47,7 @@ let package = Package(
             repository: "leehack/llamadart-native",
             artifactName: "llamadart-native-apple-xcframework-\(llamaCppTag).zip",
             tag: llamaCppTag,
-            checksum: "833144802669b735dc07f66b1f1f6c1ca8409752adff4e09238dbf66635bdd68"
+            checksum: "a3578c392294a9827c38379cf43cfd2ba578432b3f8878685a6bf0cd2d5b9d4a"
         ),
         .target(
             name: "llamadart_llama_cpp_flutter",

--- a/scripts/fetch_webgpu_bridge_assets.sh
+++ b/scripts/fetch_webgpu_bridge_assets.sh
@@ -4,7 +4,7 @@ set -euo pipefail
 ROOT_DIR="$(git rev-parse --show-toplevel)"
 OUT_DIR="${WEBGPU_BRIDGE_OUT_DIR:-$ROOT_DIR/example/chat_app/web/webgpu_bridge}"
 ASSETS_REPO="${WEBGPU_BRIDGE_ASSETS_REPO:-leehack/llama-web-bridge-assets}"
-ASSETS_TAG="${WEBGPU_BRIDGE_ASSETS_TAG:-v0.1.39}"
+ASSETS_TAG="${WEBGPU_BRIDGE_ASSETS_TAG:-v0.1.40}"
 CDN_BASE="${WEBGPU_BRIDGE_CDN_BASE:-https://cdn.jsdelivr.net/gh/${ASSETS_REPO}@${ASSETS_TAG}}"
 PATCH_SAFARI_COMPAT="${WEBGPU_BRIDGE_PATCH_SAFARI_COMPAT:-1}"
 MIN_SAFARI_VERSION="${WEBGPU_BRIDGE_MIN_SAFARI_VERSION:-170400}"
@@ -21,7 +21,7 @@ if [[ "${1:-}" == "--help" || "${1:-}" == "-h" ]]; then
 Downloads prebuilt WebGPU bridge assets into the chat_app web directory.
 
 Default source:
-  https://cdn.jsdelivr.net/gh/leehack/llama-web-bridge-assets@v0.1.39
+  https://cdn.jsdelivr.net/gh/leehack/llama-web-bridge-assets@v0.1.40
 
 Environment variables:
   WEBGPU_BRIDGE_ASSETS_REPO   Asset repo in owner/repo format
@@ -35,7 +35,7 @@ Usage:
   ./scripts/fetch_webgpu_bridge_assets.sh
 
 Examples:
-  WEBGPU_BRIDGE_ASSETS_TAG=v0.1.39 ./scripts/fetch_webgpu_bridge_assets.sh
+  WEBGPU_BRIDGE_ASSETS_TAG=v0.1.40 ./scripts/fetch_webgpu_bridge_assets.sh
   WEBGPU_BRIDGE_ASSETS_REPO=acme/llama-web-bridge-assets WEBGPU_BRIDGE_ASSETS_TAG=v2 ./scripts/fetch_webgpu_bridge_assets.sh
 USAGE
   exit 0

--- a/test/unit/tooling/check_webgpu_bridge_tag_test.dart
+++ b/test/unit/tooling/check_webgpu_bridge_tag_test.dart
@@ -50,9 +50,9 @@ Directory _fakeRuntimeRepo({
         : 'That release embeds llama.cpp `$bridgeTag`, which now trails the '
               '`hook/build.dart`\n',
     'website/docs/platforms/webgpu-bridge.md': parityWording
-        ? '- `v0.1.39+` bridge assets embed llama.cpp `$bridgeTag`, matching '
+        ? '- The pinned `v1.2.3` bridge assets embed llama.cpp `$bridgeTag`, matching '
               'the native runtime\n'
-        : '- `v0.1.39+` bridge assets embed llama.cpp `$bridgeTag`, which now '
+        : '- The pinned `v1.2.3` bridge assets embed llama.cpp `$bridgeTag`, which now '
               'trails the\n',
   };
   for (final entry in entries.entries) {
@@ -79,25 +79,25 @@ const String _approvedManifestJson = '''
       "size_bytes": 257
     },
     "llama_webgpu_core.js": {
-      "sha256": "d282a57d2de9cd3835ecc999374bcc9ef00d6df32da0f47744ea672977c86f32",
+      "sha256": "d98327b43cd30b8ac25523255f53a8873ebd7756de2de96d7f1ea5c279029d96",
       "size_bytes": 113962
     },
     "llama_webgpu_core.wasm": {
-      "sha256": "b1419854bab331278deb513b5cbadb98be364ad5f4b515690dee58edb38cc41e",
-      "size_bytes": 8542117
+      "sha256": "85dee0979f80a41108351b3298c0e96fc79e92db602b2bd2ddbd652fb0f08e20",
+      "size_bytes": 8629961
     },
     "llama_webgpu_core_mem64.js": {
       "sha256": "451ed2bfc99fc33e0de6b09eb96f03914a194c91bcd0bda968048c2d5efa7e2d",
       "size_bytes": 131045
     },
     "llama_webgpu_core_mem64.wasm": {
-      "sha256": "64e8046a6d18e570e50be84665f4a5022a457f70bc53c728298827b4c52bc072",
-      "size_bytes": 8760585
+      "sha256": "31de051ee7dfe8703a54c4ef91d68c59d9a08beb15eec5f0b26d4e344a6b57cd",
+      "size_bytes": 8845657
     }
   },
   "assets_repository": "leehack/llama-web-bridge-assets",
-  "bridge_assets_tag": "v0.1.39",
-  "bridge_commit": "79b6ef31e394dd2de92a456b7c249f9da377c720",
+  "bridge_assets_tag": "v0.1.40",
+  "bridge_commit": "0bdc8286fd52b70da27f5b039e1b4278361da0be",
   "bridge_repository": "leehack/llama-web-bridge",
   "capabilities": {
     "memory64": true,
@@ -140,31 +140,31 @@ const String _approvedManifestJson = '''
       "size_bytes": 257
     },
     "llama_webgpu_core.js": {
-      "sha256": "d282a57d2de9cd3835ecc999374bcc9ef00d6df32da0f47744ea672977c86f32",
+      "sha256": "d98327b43cd30b8ac25523255f53a8873ebd7756de2de96d7f1ea5c279029d96",
       "size_bytes": 113962
     },
     "llama_webgpu_core.wasm": {
-      "sha256": "b1419854bab331278deb513b5cbadb98be364ad5f4b515690dee58edb38cc41e",
-      "size_bytes": 8542117
+      "sha256": "85dee0979f80a41108351b3298c0e96fc79e92db602b2bd2ddbd652fb0f08e20",
+      "size_bytes": 8629961
     },
     "llama_webgpu_core_mem64.js": {
       "sha256": "451ed2bfc99fc33e0de6b09eb96f03914a194c91bcd0bda968048c2d5efa7e2d",
       "size_bytes": 131045
     },
     "llama_webgpu_core_mem64.wasm": {
-      "sha256": "64e8046a6d18e570e50be84665f4a5022a457f70bc53c728298827b4c52bc072",
-      "size_bytes": 8760585
+      "sha256": "31de051ee7dfe8703a54c4ef91d68c59d9a08beb15eec5f0b26d4e344a6b57cd",
+      "size_bytes": 8845657
     }
   },
-  "github_run_id": "33032131594",
-  "github_run_url": "https://github.com/leehack/llama-web-bridge/actions/runs/33032131594",
-  "llama_cpp_commit": "bb4caa7540188872173c44d161602d9271386413",
-  "llama_cpp_tag": "v0.2.0",
-  "native_commit": "e5c240e34b525da953ed98dc743516eef78cb738",
-  "native_manifest_sha256": "2e5d29d7f98f0d71e75d3fa63b7c55f3b2a7933247cc34ea2b1c5e053d142452",
-  "native_release_tag": "v0.2.0-1",
+  "github_run_id": "33225744070",
+  "github_run_url": "https://github.com/leehack/llama-web-bridge/actions/runs/33225744070",
+  "llama_cpp_commit": "c1d0e7a004015f23bc0233470b747b596f29b264",
+  "llama_cpp_tag": "v0.3.0",
+  "native_commit": "28fca14873d4b4c531bef4425b261e2b911bdcce",
+  "native_manifest_sha256": "811fda999e70c3ad2716d1c196688dd38db62cf11a78044855ca94f71fabed45",
+  "native_release_tag": "v0.3.0",
   "native_repository": "leehack/llamadart-native",
-  "orchestrator_correlation_id": "kanban:t_7f112b91:web-v0.1.39",
+  "orchestrator_correlation_id": "auto-stable-v0.3.0-811fda999e70c3ad",
   "qualification_gates": {
     "multimodal": "passed",
     "speech_to_text": "required-local-attestation",
@@ -173,18 +173,18 @@ const String _approvedManifestJson = '''
   },
   "release_channel": "stable",
   "release_rebuild": 0,
-  "release_tag": "v0.1.39",
+  "release_tag": "v0.1.40",
   "schema_version": 2,
-  "source_commit": "79b6ef31e394dd2de92a456b7c249f9da377c720",
+  "source_commit": "0bdc8286fd52b70da27f5b039e1b4278361da0be",
   "source_repository": "leehack/llama-web-bridge",
   "unproven_capabilities": {
     "real_device_intelligibility": "unproven",
     "real_device_playback": "unproven",
     "speaker_reference_fidelity": "unproven"
   },
-  "upstream_commit": "bb4caa7540188872173c44d161602d9271386413",
+  "upstream_commit": "c1d0e7a004015f23bc0233470b747b596f29b264",
   "upstream_repository": "ggml-org/llama.cpp",
-  "upstream_tag": "v0.2.0"
+  "upstream_tag": "v0.3.0"
 }
 ''';
 
@@ -194,11 +194,11 @@ Future<List<String>> _verifyManifestJson(
 }) {
   final bytes = utf8.encode(manifestJson);
   return verifyManifest(
-    expectedTag: 'v0.1.39',
-    expectedLlamaCppTag: 'v0.2.0',
-    expectedLlamaCppCommit: 'bb4caa7540188872173c44d161602d9271386413',
-    expectedBridgeCommit: '79b6ef31e394dd2de92a456b7c249f9da377c720',
-    expectedNativeReleaseTag: 'v0.2.0-1',
+    expectedTag: 'v0.1.40',
+    expectedLlamaCppTag: bridgeLlamaCppTag,
+    expectedLlamaCppCommit: bridgeLlamaCppCommit,
+    expectedBridgeCommit: bridgeSourceCommit,
+    expectedNativeReleaseTag: bridgeNativeReleaseTag,
     expectedManifestSha256:
         expectedManifestSha256 ?? sha256.convert(bytes).toString(),
     fetcher: (_) async => ManifestResponse(HttpStatus.ok, bytes),
@@ -253,7 +253,7 @@ void main() {
         'website/docs/changelog/recent-releases.md',
       ]) {
         final current = _currentReleaseNotes(path);
-        expect(current, contains('`v0.1.39`'), reason: path);
+        expect(current, contains('`v0.1.40`'), reason: path);
         expect(current, contains(bridgeManifestSha256), reason: path);
         expect(
           current,
@@ -683,12 +683,12 @@ void main() {
 
     test('parity prose is accepted for matching upstream tags', () {
       final root = _fakeRuntimeRepo(
-        bridgeTag: 'v0.2.0',
-        nativeTag: 'v0.2.0-1',
+        bridgeTag: 'v0.3.0',
+        nativeTag: 'v0.3.0',
         parityWording: true,
       );
 
-      expect(findBridgeRuntimeDrift(root, 'v0.2.0'), isEmpty);
+      expect(findBridgeRuntimeDrift(root, 'v0.3.0'), isEmpty);
     });
 
     test('a doc naming a different bridge build is reported', () {
@@ -768,17 +768,14 @@ void main() {
         // bridgeNativeReleaseTag is a constant, so drive the mismatch from the
         // other side: a tree whose bridge and native pins agree on a family the
         // checked-in anchor does not belong to.
-        final root = _fakeRuntimeRepo(
-          bridgeTag: 'v0.3.0',
-          nativeTag: 'v0.3.0-1',
-        );
+        final root = _fakeRuntimeRepo(bridgeTag: 'v0.4.0', nativeTag: 'v0.4.0');
 
         expect(
-          findBridgeRuntimeDrift(root, 'v0.3.0'),
+          findBridgeRuntimeDrift(root, 'v0.4.0'),
           contains(
             contains(
               'bridgeNativeReleaseTag $bridgeNativeReleaseTag does not belong to '
-              'the recorded upstream llama.cpp release v0.3.0',
+              'the recorded upstream llama.cpp release v0.4.0',
             ),
           ),
         );
@@ -792,8 +789,8 @@ void main() {
     });
 
     test('immutable release identity stays pinned to the approved release', () {
-      expect(bridgeAssetsReleaseId, '377534035');
-      expect(bridgeAssetsTagCommit, 'd14d46a63deeee7a8f8a017e394b74ee112f4dba');
+      expect(bridgeAssetsReleaseId, '379234159');
+      expect(bridgeAssetsTagCommit, 'a18f1c31835ee722c7750a5c68f22c5b19e4c937');
     });
 
     test('accepts equivalent CRLF documentation passages', () {

--- a/test/unit/tooling/verify_release_docs_companion_pins_test.dart
+++ b/test/unit/tooling/verify_release_docs_companion_pins_test.dart
@@ -291,12 +291,23 @@ void main() {
     }
   });
 
-  test('the checked-in companions are release-ready', () {
-    final errors = <String>[];
+  test(
+    'the checked-in companions keep pending sync separate from release prep',
+    () {
+      final errors = <String>[];
+      final pending = checkCompanionSwiftPins(Directory.current, errors);
 
-    expect(checkCompanionSwiftPins(Directory.current, errors), isEmpty);
-    expect(errors, isEmpty);
-  });
+      expect(
+        pending.map((bump) => bump.toString()),
+        contains(
+          'llamadart_llama_cpp_flutter 0.0.16 publishes v0.2.0-1, but '
+          'Package.swift pins v0.3.0; bump the version and rename '
+          '`## Unreleased` to the new version before releasing.',
+        ),
+      );
+      expect(errors, isEmpty);
+    },
+  );
 
   test('a pin recorded in the released section passes', () {
     final root = _fakeRepo(

--- a/tool/testing/check_webgpu_bridge_tag.dart
+++ b/tool/testing/check_webgpu_bridge_tag.dart
@@ -102,6 +102,13 @@ final List<BridgeTagPin> bridgeTagPins = <BridgeTagPin>[
   BridgeTagPin(
     'website/docs/platforms/webgpu-bridge.md',
     RegExp(
+      r'^- The pinned `(v\d+\.\d+\.\d+)` bridge assets embed llama\.cpp ',
+      multiLine: true,
+    ),
+  ),
+  BridgeTagPin(
+    'website/docs/platforms/webgpu-bridge.md',
+    RegExp(
       r'^identified as `(v\d+\.\d+\.\d+)-local-[a-zA-Z0-9.-]+`\.$',
       multiLine: true,
     ),
@@ -322,13 +329,13 @@ List<String> findCurrentReleaseNotesDrift(
 }
 
 /// The llama.cpp upstream release tag embedded in the pinned bridge assets.
-const String bridgeLlamaCppTag = 'v0.2.0';
+const String bridgeLlamaCppTag = 'v0.3.0';
 
 /// The exact upstream llama.cpp commit embedded in the pinned bridge assets.
-const String bridgeLlamaCppCommit = 'bb4caa7540188872173c44d161602d9271386413';
+const String bridgeLlamaCppCommit = 'c1d0e7a004015f23bc0233470b747b596f29b264';
 
 /// The exact bridge source commit used to build the pinned bridge assets.
-const String bridgeSourceCommit = '79b6ef31e394dd2de92a456b7c249f9da377c720';
+const String bridgeSourceCommit = '0bdc8286fd52b70da27f5b039e1b4278361da0be';
 
 /// Canonical repository identities recorded in the approved manifest.
 const String bridgeAssetsRepository = 'leehack/llama-web-bridge-assets';
@@ -337,17 +344,17 @@ const String bridgeUpstreamRepository = 'ggml-org/llama.cpp';
 const String bridgeNativeRepository = 'leehack/llamadart-native';
 
 /// The native release tag the pinned bridge assets were qualified against.
-const String bridgeNativeReleaseTag = 'v0.2.0-1';
+const String bridgeNativeReleaseTag = 'v0.3.0';
 
 /// The asset repository release that published the pinned bridge assets.
-const String bridgeAssetsReleaseId = '377534035';
+const String bridgeAssetsReleaseId = '379234159';
 
 /// The asset repository commit the pinned bridge asset tag points at.
-const String bridgeAssetsTagCommit = 'd14d46a63deeee7a8f8a017e394b74ee112f4dba';
+const String bridgeAssetsTagCommit = 'a18f1c31835ee722c7750a5c68f22c5b19e4c937';
 
 /// SHA-256 hash of the exact approved published manifest.json.
 const String bridgeManifestSha256 =
-    'b355d01040604f6ae2c5c5fe5bb42b858101a96f03f67e4b27b32fe41ce3b2bf';
+    '99fc09bb0cc23cf0eb08875a9ea973803fb1d432c5c8ca1b1211af0eb1d20b17';
 
 /// Where the native runtime's llama.cpp build is pinned.
 const String nativeLlamaCppTagPath = 'hook/build.dart';
@@ -419,7 +426,7 @@ final List<BridgeTagPin> bridgeLlamaCppParityPins = <BridgeTagPin>[
   BridgeTagPin(
     'website/docs/platforms/webgpu-bridge.md',
     RegExp(
-      r'^- `v\d+\.\d+\.\d+\+` bridge assets embed llama\.cpp `(v\d+\.\d+\.\d+|b\d+)`, matching the native runtime$',
+      r'^- The pinned `v\d+\.\d+\.\d+` bridge assets embed llama\.cpp `(v\d+\.\d+\.\d+|b\d+)`, matching the native runtime$',
       multiLine: true,
     ),
   ),

--- a/tool/testing/check_webgpu_bridge_tag.dart
+++ b/tool/testing/check_webgpu_bridge_tag.dart
@@ -93,9 +93,25 @@ final List<BridgeTagPin> bridgeTagPins = <BridgeTagPin>[
     ),
   ),
   BridgeTagPin(
+    'doc/webgpu_bridge.md',
+    RegExp(
+      r'^even though the bridge asset tag `(v\d+\.\d+\.\d+)` differs from the '
+      r'native runtime tag$',
+      multiLine: true,
+    ),
+  ),
+  BridgeTagPin(
     'website/docs/platforms/webgpu-bridge.md',
     RegExp(
       r'^The example currently pins bridge assets to `(v\d+\.\d+\.\d+)`,',
+      multiLine: true,
+    ),
+  ),
+  BridgeTagPin(
+    'website/docs/platforms/webgpu-bridge.md',
+    RegExp(
+      r'^  even though the bridge asset tag `(v\d+\.\d+\.\d+)` differs from the '
+      r'native runtime tag$',
       multiLine: true,
     ),
   ),
@@ -444,9 +460,11 @@ final List<BridgeTagPin> bridgeProvenancePins = <BridgeTagPin>[
     RegExp(
       r'^\(`(?<nativeReleaseTag>[^`]+)`, both built from upstream llama\.cpp '
       r'`(?<upstreamTag>[^`@]+)@(?<upstreamCommit>[0-9a-f]{40})`\)\r?\n'
-      r'even though wrapper release tags differ\. Provenance for this immutable consumer\r?\n'
-      r'artifact: release `(?<releaseId>\d+)`, tag commit\r?\n'
-      r'`(?<tagCommit>[0-9a-f]{40})`, bridge source\r?\n'
+      r'even though the bridge asset tag `v\d+\.\d+\.\d+` differs from the '
+      r'native runtime tag\r?\n'
+      r'`v\d+\.\d+\.\d+`\. Provenance for this immutable consumer artifact: '
+      r'release `(?<releaseId>\d+)`,\r?\n'
+      r'tag commit `(?<tagCommit>[0-9a-f]{40})`, bridge source\r?\n'
       r'`(?<bridgeCommit>[0-9a-f]{40})`, and manifest SHA-256\r?\n'
       r'`(?<manifestSha256>[0-9a-f]{64})`\.',
       multiLine: true,
@@ -457,9 +475,12 @@ final List<BridgeTagPin> bridgeProvenancePins = <BridgeTagPin>[
     RegExp(
       r'^  \(`(?<nativeReleaseTag>[^`]+)`, both built from upstream '
       r'`(?<upstreamTag>[^`@]+)@(?<upstreamCommit>[0-9a-f]{40})`\)\r?\n'
-      r'  even though wrapper release tags differ\. Pinned artifact provenance: release\r?\n'
-      r'  `(?<releaseId>\d+)`, tag commit `(?<tagCommit>[0-9a-f]{40})`, bridge\r?\n'
-      r'  source `(?<bridgeCommit>[0-9a-f]{40})`, manifest SHA-256\r?\n'
+      r'  even though the bridge asset tag `v\d+\.\d+\.\d+` differs from the '
+      r'native runtime tag\r?\n'
+      r'  `v\d+\.\d+\.\d+`\. Pinned artifact provenance: release '
+      r'`(?<releaseId>\d+)`, tag commit\r?\n'
+      r'  `(?<tagCommit>[0-9a-f]{40})`, bridge source\r?\n'
+      r'  `(?<bridgeCommit>[0-9a-f]{40})`, manifest SHA-256\r?\n'
       r'  `(?<manifestSha256>[0-9a-f]{64})`\.',
       multiLine: true,
     ),

--- a/website/docs/changelog/recent-releases.md
+++ b/website/docs/changelog/recent-releases.md
@@ -7,6 +7,19 @@ For canonical full release notes, use:
 
 - [`CHANGELOG.md`](https://github.com/leehack/llamadart/blob/main/CHANGELOG.md)
 
+## Unreleased
+
+- Updated the default llama.cpp native runtime pin to
+  `leehack/llamadart-native@v0.3.0`, regenerated matching Dart FFI bindings,
+  refreshed the `llamadart_llama_cpp_flutter` Apple SwiftPM checksum, and
+  aligned current README/website native override docs.
+
+- Aligned default WebGPU bridge assets to `v0.1.40`, keeping Web and native
+  llama.cpp upstream `v0.3.0@c1d0e7a004015f23bc0233470b747b596f29b264` parity
+  with native anchor `llamadart-native@v0.3.0` while preserving Web
+  `@litert-lm/core@0.15.0` packaging. Immutable manifest:
+  `99fc09bb0cc23cf0eb08875a9ea973803fb1d432c5c8ca1b1211af0eb1d20b17`.
+
 ## 0.8.21
 
 - Aligned default WebGPU bridge assets to `v0.1.39` (immutable manifest

--- a/website/docs/getting-started/installation.md
+++ b/website/docs/getting-started/installation.md
@@ -79,7 +79,7 @@ hooks:
     llamadart:
       # Optional. Defaults to llamadart's tested native runtime pin.
       # Use a leehack/llamadart-native release tag when testing another build.
-      llamadart_native_tag: v0.2.0-1
+      llamadart_native_tag: v0.3.0
 
       # Optional. GitHub repository slug or github.com URL.
       llamadart_native_repository: leehack/llamadart-native
@@ -106,7 +106,7 @@ per-target module list.
 Native source overrides are for compatibility testing. They do not regenerate
 Dart FFI bindings or symbol lookups, so the selected binary still must be ABI-
 and symbol-compatible with the default
-`leehack/llamadart-native@v0.2.0-1` runtime.
+`leehack/llamadart-native@v0.3.0` runtime.
 
 Available native tags are published on the
 [`leehack/llamadart-native` releases page](https://github.com/leehack/llamadart-native/releases).
@@ -134,7 +134,7 @@ gh release list --repo leehack/llamadart-native --limit 20
 
 Before overriding, confirm the release includes the asset for your target. The
 hook downloads files named `llamadart-native-<bundle>-<tag>.tar.gz`, for example
-`llamadart-native-windows-x64-v0.2.0-1.tar.gz`.
+`llamadart-native-windows-x64-v0.3.0.tar.gz`.
 For local testing, `llamadart_native_path` may point directly at a bundle
 archive, at an extracted bundle directory, or at a directory containing
 `<tag>/<bundle>/`, `<bundle>/`, or the expected archive file.

--- a/website/docs/guides/multimodal.md
+++ b/website/docs/guides/multimodal.md
@@ -99,7 +99,7 @@ on the loaded bridge's runtime capability report.
 Video is not currently consumable through the public Dart generation API.
 `LlamaVideoContent` makes an attempted path/byte request explicit, but
 generation rejects it with `LlamaUnsupportedException`. The published native
-`v0.2.0-1` archive exports upstream video helper symbols, but this release has
+`v0.3.0` archive exports upstream video helper symbols, but this release has
 not been qualified for end-to-end video input; symbol presence is not a
 capability check. A complete implementation still needs companion native builds
 with `LLAMA_SUBPROCESS`/`MTMD_VIDEO`, a cross-platform FFmpeg/ffprobe packaging

--- a/website/docs/guides/performance-tuning.md
+++ b/website/docs/guides/performance-tuning.md
@@ -148,7 +148,7 @@ Guidelines:
 - DSpark is an experimental, opt-in native llama.cpp external draft-model
   strategy. Use `SpeculativeDecodingConfig.draftDspark(draftModelPath: ...)`;
   it is never selected automatically, maps to upstream `draft-dspark`, requires
-  at least the `b10356-llamadart.1` wrapper fix; the package-pinned `v0.2.0-1`
+  at least the `b10356-llamadart.1` wrapper fix; the package-pinned `v0.3.0`
   runtime satisfies that ABI, supports speculators-format checkpoints, and
   adds LFM2 target/draft support. DSpark remains subject to
   target/draft/backend compatibility.

--- a/website/docs/guides/text-to-speech.md
+++ b/website/docs/guides/text-to-speech.md
@@ -172,7 +172,7 @@ memory-constrained mobile devices.
 - Web requires published bridge assets `v0.1.33+`, WebAssembly memory64 for the
   pinned roughly 1.48 GB model/projector pair, and a browser/device with enough
   memory. Older bridge assets fail capability discovery clearly.
-- The chat example pins `v0.1.39`, which retains the `v0.1.34` recovery that
+- The chat example pins `v0.1.40`, which retains the `v0.1.34` recovery that
   retries a worker WebGPU abort or device failure once on CPU using the cached
   model and projector. Recovery is slower and is not a substitute for
   sufficient browser memory. Qwen3-TTS accelerator behavior remains

--- a/website/docs/platforms/support-matrix.md
+++ b/website/docs/platforms/support-matrix.md
@@ -8,7 +8,7 @@ backend-module configuration for
 `llamadart`.
 
 The native-assets hook currently pins `llamadart-native` tag
-`v0.2.0-1` and
+`v0.3.0` and
 `litert-lm-native` release `v0.16.0-native.2` (`hook/build.dart`). Apps can
 override the llama.cpp native GitHub source with
 `hooks.user_defines.llamadart.llamadart_native_tag` and
@@ -117,8 +117,8 @@ bundled:
 - `llama_cpp`: GGUF model support through llama.cpp.
 - `litert_lm`: `.litertlm` model support through LiteRT-LM.
 
-The `v0.2.0-1` native llama.cpp pin (llama.cpp `v0.2.0`) includes BailingMoE3 and
-GraniteSWA/GraniteMoeSWA model loading and adds LFM2 target/draft support for
+The `v0.3.0` native llama.cpp pin (llama.cpp `v0.3.0`) includes BailingMoE3 and
+GraniteSWA/GraniteMoeSWA model loading and LFM2 target/draft support for
 DSpark speculative decoding. These architectures use the existing GGUF APIs;
 LFM2 DSpark uses `SpeculativeDecodingConfig.draftDspark(...)`. No
 model-specific Dart preset is required, but representative target/draft and
@@ -128,7 +128,7 @@ backend validation remains necessary before enabling DSpark in production.
 
 | Runtime path | Public video input | Current evidence |
 | --- | --- | --- |
-| Native llama.cpp / GGUF | Not consumable | The published `v0.2.0-1` archive exports upstream video helper symbols, but this release has not been qualified for end-to-end video input. The companion build does not opt into `LLAMA_SUBPROCESS`/`MTMD_VIDEO` or package FFmpeg/ffprobe; the public Dart path remains unsupported until matching native, packaging, and frame-lifecycle validation exists. |
+| Native llama.cpp / GGUF | Not consumable | The published `v0.3.0` archive exports upstream video helper symbols, but this release has not been qualified for end-to-end video input. The companion build does not opt into `LLAMA_SUBPROCESS`/`MTMD_VIDEO` or package FFmpeg/ffprobe; the public Dart path remains unsupported until matching native, packaging, and frame-lifecycle validation exists. |
 | Native LiteRT-LM | Not consumable | The public direct-media path accepts image/audio content only. |
 | WebGPU / Web LiteRT-LM | Not consumable | No validated public Dart video transport or frame-lifetime contract exists. |
 | Android / iOS | Not consumable | Explicitly unsupported pending native packaging and device validation. |
@@ -264,7 +264,7 @@ device/model bundle, use `cpu` or `gpu` for that artifact.
   a web load failure as a package bug. The [WebGPU Bridge](./webgpu-bridge)
   page has the browser-console probe and Flutter Web smoke-test path.
 
-## Current llama.cpp module availability by bundle (`v0.2.0-1`)
+## Current llama.cpp module availability by bundle (`v0.3.0`)
 
 | Bundle key | Available backend modules in bundle |
 | --- | --- |
@@ -312,7 +312,7 @@ hooks:
   user_defines:
     llamadart:
       # Optional. Defaults to llamadart's tested native runtime pin.
-      llamadart_native_tag: v0.2.0-1
+      llamadart_native_tag: v0.3.0
 
       # Optional. GitHub repository slug or github.com URL.
       llamadart_native_repository: leehack/llamadart-native

--- a/website/docs/platforms/webgpu-bridge.md
+++ b/website/docs/platforms/webgpu-bridge.md
@@ -146,13 +146,13 @@ development validation, and CDN-first loading for normal hosted deployments:
 1. On localhost: local asset first, then CDN fallback.
 2. On hosted deployments: CDN asset first, then local fallback.
 
-The example currently pins bridge assets to `v0.1.39`, with local vendored assets
-identified as `v0.1.39-local-v0.2.0`.
+The example currently pins bridge assets to `v0.1.40`, with local vendored assets
+identified as `v0.1.40-local-v0.3.0`.
 
 Fetch pinned local assets with:
 
 ```bash
-WEBGPU_BRIDGE_ASSETS_TAG=v0.1.39 ./scripts/fetch_webgpu_bridge_assets.sh
+WEBGPU_BRIDGE_ASSETS_TAG=v0.1.40 ./scripts/fetch_webgpu_bridge_assets.sh
 ```
 
 To verify the loaded runtime in a browser console, inspect:
@@ -194,12 +194,13 @@ cannot report success before the bridge exposes `prefetchModelToCache(...)`.
 - `v0.1.34+` bridge assets retry a failed worker WebGPU TTS synthesis once in a
   CPU main-thread runtime using the already cached model and projector. This
   recovery is slower than healthy WebGPU synthesis and does not loop.
-- `v0.1.39+` bridge assets embed llama.cpp `v0.2.0`, matching the native runtime
-  (`v0.2.0-1`, both built from upstream `v0.2.0@bb4caa7540188872173c44d161602d9271386413`)
+- `v0.1.39+` remains the compatibility floor for bridge asset capabilities.
+- The pinned `v0.1.40` bridge assets embed llama.cpp `v0.3.0`, matching the native runtime
+  (`v0.3.0`, both built from upstream `v0.3.0@c1d0e7a004015f23bc0233470b747b596f29b264`)
   even though wrapper release tags differ. Pinned artifact provenance: release
-  `377534035`, tag commit `d14d46a63deeee7a8f8a017e394b74ee112f4dba`, bridge
-  source `79b6ef31e394dd2de92a456b7c249f9da377c720`, manifest SHA-256
-  `b355d01040604f6ae2c5c5fe5bb42b858101a96f03f67e4b27b32fe41ce3b2bf`. The
+  `379234159`, tag commit `a18f1c31835ee722c7750a5c68f22c5b19e4c937`, bridge
+  source `0bdc8286fd52b70da27f5b039e1b4278361da0be`, manifest SHA-256
+  `99fc09bb0cc23cf0eb08875a9ea973803fb1d432c5c8ca1b1211af0eb1d20b17`. The
   bridge assets provision an explicit 1 MiB stack for both wasm32 and memory64,
   preventing graph-parameter growth from overflowing Emscripten's 64 KiB
   default during memory64 Qwen3-ASR context construction.
@@ -333,7 +334,7 @@ You can override bridge asset source/version before loader startup:
 ```html
 <script>
   window.__llamadartBridgeAssetsRepo = 'leehack/llama-web-bridge-assets';
-  window.__llamadartBridgeAssetsTag = 'v0.1.39';
+  window.__llamadartBridgeAssetsTag = 'v0.1.40';
   // Custom assets stay speech-disabled unless the host has validated them:
   // window.__llamadartBridgeSpeechToTextSupported = true;
   // Prefer local runtime even off localhost:

--- a/website/docs/platforms/webgpu-bridge.md
+++ b/website/docs/platforms/webgpu-bridge.md
@@ -197,9 +197,10 @@ cannot report success before the bridge exposes `prefetchModelToCache(...)`.
 - `v0.1.39+` remains the compatibility floor for bridge asset capabilities.
 - The pinned `v0.1.40` bridge assets embed llama.cpp `v0.3.0`, matching the native runtime
   (`v0.3.0`, both built from upstream `v0.3.0@c1d0e7a004015f23bc0233470b747b596f29b264`)
-  even though wrapper release tags differ. Pinned artifact provenance: release
-  `379234159`, tag commit `a18f1c31835ee722c7750a5c68f22c5b19e4c937`, bridge
-  source `0bdc8286fd52b70da27f5b039e1b4278361da0be`, manifest SHA-256
+  even though the bridge asset tag `v0.1.40` differs from the native runtime tag
+  `v0.3.0`. Pinned artifact provenance: release `379234159`, tag commit
+  `a18f1c31835ee722c7750a5c68f22c5b19e4c937`, bridge source
+  `0bdc8286fd52b70da27f5b039e1b4278361da0be`, manifest SHA-256
   `99fc09bb0cc23cf0eb08875a9ea973803fb1d432c5c8ca1b1211af0eb1d20b17`. The
   bridge assets provision an explicit 1 MiB stack for both wasm32 and memory64,
   preventing graph-parameter growth from overflowing Emscripten's 64 KiB


### PR DESCRIPTION
## Summary

- update the default native runtime to `llamadart-native@v0.3.0`
- update WebGPU bridge assets to immutable `v0.1.40`, built from the same upstream llama.cpp `v0.3.0` commit
- regenerate Dart FFI bindings and refresh the Apple XCFramework checksum
- align current runtime documentation and provenance checks

## Compatibility

- no `llama.h` or `mtmd.h` API symbol changes
- generated FFI adds the new raw `ggml_clamp_inplace` symbol
- no llamadart public API implementation changes
- native video remains unsupported because the packaged runtime does not enable `MTMD_VIDEO` or ship FFmpeg

## Verification

- changed-Dart format and affected-file analysis
- `dart analyze lib`
- release-doc and WebGPU manifest provenance verifiers
- native pin, hook, bundle-configuration, symbol, and focused provenance tests
- full default test suite
- native symbol integration — 15 passed
- real Qwen3.5 native chat-template smoke
- staged `v0.1.40` Web asset checksum and JavaScript syntax verification
- browser bridge smoke with worker fallback, projector load, and completion calls
- Swift package description and archive checksum
- root and companion `dart pub publish --dry-run`
- `git diff --check`

## Published inputs

- upstream: `ggml-org/llama.cpp@v0.3.0` (`c1d0e7a004015f23bc0233470b747b596f29b264`)
- native release: `leehack/llamadart-native@v0.3.0` — 26 release jobs passed
- Web assets: `leehack/llama-web-bridge-assets@v0.1.40` — immutable; candidate build/state/multimodal gates passed

No release, package publication, tag, or governance change is included.
