### PR TITLE
ci: make high-risk readiness check advisory

### DIFF
--- a/.github/workflows/high_risk_readiness.yml
+++ b/.github/workflows/high_risk_readiness.yml
@@ -1,11 +1,11 @@
-name: High-Risk Readiness Prerequisite Diagnostic
+name: High-Risk Readiness Advisory
 
 on:
   pull_request_target:
     types: [opened, synchronize, reopened, ready_for_review]
 
 concurrency:
-  group: high-risk-readiness-diagnostic-${{ github.repository }}-${{ github.event.pull_request.number }}
+  group: high-risk-readiness-advisory-${{ github.repository }}-${{ github.event.pull_request.number }}
   cancel-in-progress: true
 
 permissions:
@@ -14,7 +14,7 @@ permissions:
 
 jobs:
   inspect:
-    name: Read-only diagnostic (not a required readiness check)
+    name: Read-only advisory (not a required readiness check)
     runs-on: ubuntu-latest
     timeout-minutes: 10
 
@@ -106,26 +106,26 @@ jobs:
             echo "is_high_risk=false" >> "$GITHUB_OUTPUT"
           fi
 
-      - name: Report standard-risk diagnostic
+      - name: Report standard-risk advisory
         if: steps.classify.outputs.is_high_risk == 'false'
         run: |
           {
-            echo '### High-risk readiness prerequisite diagnostic'
+            echo '### High-risk readiness advisory'
             echo
             echo 'The trusted default-branch classifier found no high-risk surface.'
-            echo 'This workflow is diagnostic only and must not be configured as a required readiness check.'
+            echo 'This workflow is advisory only and must not be configured as a required readiness check.'
           } >> "$GITHUB_STEP_SUMMARY"
 
-      - name: Fail closed while privileged readiness publisher is unavailable
+      - name: Report high-risk advisory
         if: steps.classify.outputs.is_high_risk == 'true'
         run: |
           {
-            echo '### High-risk readiness prerequisite diagnostic'
+            echo '### High-risk readiness advisory'
             echo
             echo 'High-risk paths were detected.'
-            echo 'No protected GitHub App evidence publisher or conditional ruleset is configured.'
+            echo 'No protected GitHub App evidence publisher or conditional ruleset is configured, so this advisory cannot verify readiness and does not gate the merge.'
             echo 'PR comments, PR-authored files, workflow artifacts, and environment variables are not trusted readiness evidence.'
-            echo 'Operational readiness therefore remains unavailable and fails closed.'
+            echo 'Complete the repository-local review manually: run tool/testing/high_risk_readiness.dart with independently observed repository, PR, author, head, and base values, obtain an independent blocking audit, and fill the PR template high-risk block.'
+            echo 'See doc/high_risk_pre_merge_readiness.md.'
           } >> "$GITHUB_STEP_SUMMARY"
-          echo "::error::High-risk readiness publication is not operationally configured."
-          exit 1
+          echo "::warning::High-risk paths detected; readiness must be reviewed manually in the repository."

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -342,8 +342,10 @@ Security-sensitive required-check publication and repository settings are
 governed by `doc/high_risk_pre_merge_readiness.md`; checkout-local verification
 can return only an unverified-prerequisites result and fails closed until the
 dedicated GitHub App, authenticated auditor boundary, and conditional ruleset
-enforcement are separately implemented and configured. Do not configure the
-default-branch diagnostic workflow as a required readiness check.
+enforcement are separately implemented and configured. The default-branch
+workflow is a non-required advisory: it warns on high-risk paths instead of
+failing, so high-risk readiness must be established by the repository-local
+review and evidence. Do not configure it as a required readiness check.
 
 For docs-only PRs, state that runtime behavior is unchanged and list docs
 validation. If implementation scope changed, reduce and state the scope rather

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -315,7 +315,8 @@ of an independent operator-owned or fresh Codex adversarial audit identity.
 The local evaluator derives the changed-file inventory from Git and never emits
 operational readiness. Until the separately reviewed GitHub App, auditor
 authentication, and conditional ruleset boundary exist, a valid high-risk run
-is explicitly unverified and the default-branch workflow is diagnostic only.
+is explicitly unverified and the default-branch workflow is a non-required
+advisory that warns rather than fails.
 
 ### PR type examples
 

--- a/doc/high_risk_pre_merge_readiness.md
+++ b/doc/high_risk_pre_merge_readiness.md
@@ -14,7 +14,7 @@ The repository currently provides:
 - a Git-derived name-status inventory that preserves deletions and both sides
   of renames;
 - candidate-tree checks for changed production tests;
-- a trusted-default-branch GitHub Actions diagnostic.
+- a trusted-default-branch GitHub Actions advisory.
 
 It does **not** provide an authenticated GitHub App publisher, protected
 environment provenance, conditional ruleset enforcement, or an authenticated
@@ -24,8 +24,15 @@ independent-auditor identity. Consequently:
   `unverifiedPrerequisites` and exits 2;
 - no local JSON field, command-line flag, process environment variable, or
   credential-shaped value can produce an operational-ready result;
-- the diagnostic workflow must not be selected as a required status check;
-- issue #419 is not operationally complete.
+- the advisory workflow reports that limitation instead of enforcing it, and
+  must not be selected as a required status check;
+- high-risk merge readiness is established by manual repository-local review and
+  evidence, which is how issue #419 was closed as completed.
+
+Protected external enforcement is intentionally unconfigured and is not a
+pending merge requirement. Adopting it would need a separate approved
+governance change satisfying the boundary in
+[Missing external prerequisites](#missing-external-prerequisites).
 
 ## Threat model
 
@@ -149,7 +156,7 @@ Exit codes:
 `--schema` prints the schema. There is deliberately no App credential,
 environment trust, supplied changed-file inventory, or `ready` option.
 
-## Trusted-default-branch diagnostic workflow
+## Trusted-default-branch advisory workflow
 
 `.github/workflows/high_risk_readiness.yml` runs under
 `pull_request_target` but checks out only the immutable `github.sha`
@@ -163,15 +170,21 @@ classifies both current and previous rename paths.
 It does not check out or execute the PR branch and does not consume PR comments,
 PR-authored evidence files, workflow artifacts, or PR-authored workflows.
 
-- Standard-risk changes receive a successful, explicitly non-required
-  diagnostic.
-- High-risk changes fail nonzero because the protected publisher is absent.
-- No failure is hidden with `|| true`, and no diagnostic evidence payload is
+- Standard-risk changes receive a successful, explicitly non-required advisory.
+- High-risk changes succeed with a `::warning` and a job summary stating that
+  the protected publisher is absent, so readiness must be established by the
+  repository-local review, evaluator run, and independent audit described above.
+- Invalid PR metadata, GitHub API failures, incomplete or ambiguous file
+  inventories, head/base/changed-file drift, and classifier failures still exit
+  nonzero.
+- No failure is hidden with `|| true`, and no advisory evidence payload is
   fabricated.
 
-The workflow name and job name intentionally say `diagnostic`. Configuring it
-as a required check would make high-risk PRs permanently fail and could make
-standard-risk PRs depend on a gate that is not intended for them.
+The workflow name and job name intentionally say `advisory`. It is not a
+required check, so it deliberately does not fail merely because the protected
+publisher was never adopted; that absence is reported, not enforced.
+Configuring it as a required check could make standard-risk PRs depend on a
+gate that is not intended for them.
 
 ## Missing external prerequisites
 

--- a/doc/testing_matrix.md
+++ b/doc/testing_matrix.md
@@ -107,7 +107,8 @@ The readiness evaluator validates the repository-local portion of these rules;
 it never emits operational readiness. External auditor authentication, GitHub
 App status publication, protected-environment provenance, and conditional
 ruleset enforcement remain unavailable and fail closed. The default-branch
-workflow is a non-required diagnostic. See
+workflow is a non-required advisory that warns on high-risk paths instead of
+failing. See
 `doc/high_risk_pre_merge_readiness.md`.
 
 The structured-output requirements encode the regression classes found after

--- a/test/unit/tooling/high_risk_review_policy_test.dart
+++ b/test/unit/tooling/high_risk_review_policy_test.dart
@@ -127,7 +127,7 @@ void main() {
           ),
         );
         expect(workflow, contains('persist-credentials: false'));
-        expect(workflow, contains('Read-only diagnostic'));
+        expect(workflow, contains('Read-only advisory'));
         expect(workflow, contains('observed_head'));
         expect(workflow, contains('current_head'));
         expect(workflow, contains('observed_base'));
@@ -141,10 +141,61 @@ void main() {
         expect(workflow, contains('exit 1'));
         expect(workflow, isNot(contains('|| true')));
         expect(workflow, isNot(contains('PRIVATE_KEY')));
-        expect(runbook, contains('issue #419 is not operationally complete'));
+        expect(runbook, contains('manual repository-local review'));
+        expect(
+          runbook,
+          contains(
+            'Protected external enforcement is intentionally '
+            'unconfigured',
+          ),
+        );
+        expect(
+          runbook,
+          contains('must not add credentials or a required check until'),
+        );
         expect(runbook, contains('must not be selected as a required'));
       },
     );
+
+    test('high-risk advisory warns instead of failing the check', () {
+      final workflow = read('.github/workflows/high_risk_readiness.yml');
+      final steps = workflow
+          .split(RegExp(r'^      - name: ', multiLine: true))
+          .skip(1)
+          .toList();
+      final advisory = steps.singleWhere(
+        (step) => step.contains("is_high_risk == 'true'"),
+      );
+
+      expect(advisory, contains('::warning::'));
+      expect(advisory, isNot(contains('::error::')));
+      expect(advisory, isNot(contains('exit 1')));
+      expect(advisory, contains('High-risk readiness advisory'));
+      expect(advisory, contains('tool/testing/high_risk_readiness.dart'));
+      expect(advisory, contains('doc/high_risk_pre_merge_readiness.md'));
+      expect(workflow, isNot(contains('Fail closed')));
+    });
+
+    test('advisory still fails on malformed or unsafe diagnostic input', () {
+      final workflow = read('.github/workflows/high_risk_readiness.yml');
+      final classify = workflow
+          .split(RegExp(r'^      - name: ', multiLine: true))
+          .singleWhere((step) => step.contains('id: classify'));
+
+      expect(classify, contains('set -euo pipefail'));
+      expect(classify, contains('::error::Invalid pull request number.'));
+      expect(classify, contains('exit 64'));
+      expect(classify, contains('exit 65'));
+      expect(
+        classify,
+        contains(
+          '::error::PR head, base, or changed-file count changed while the '
+          'inventory was read.',
+        ),
+      );
+      expect(classify, contains('exit 1'));
+      expect(classify, contains('jq -e --argjson expected'));
+    });
 
     test('schema makes evaluator decisions computed and enum-complete', () {
       final schema = read(


### PR DESCRIPTION
## Summary

- rename the trusted default-branch workflow to `High-Risk Readiness Advisory`
- report expected high-risk classification with a warning and successful advisory check
- preserve failures for malformed metadata, unsafe/incomplete inventory, API/classifier errors, and head/base drift
- align current policy docs and static contracts with the completed #419 practical-policy decision

## Rationale

The workflow is explicitly non-required, and the protected App/publisher/ruleset path was intentionally not adopted. Intentionally failing every high-risk PR adds a permanent red status without enforcing a merge boundary. Manual repository-local review, exact-head evidence, independent audit, required CI, and zero unresolved threads remain the readiness contract.

This PR does not add a GitHub App, environment, ruleset, required check, secret, manual approval, release, or publication setting.

## Verification

- `actionlint -color=false .github/workflows/high_risk_readiness.yml`
- changed-Dart format and analysis
- high-risk policy and evaluator tests — 68 passed
- classifier tests — 9 passed
- `git diff --check`

## Current-check note

This PR itself may still show the old red diagnostic because `pull_request_target` executes the current default-branch workflow. After this change lands, future high-risk PRs will receive the advisory warning without an intentional failure.
