### PR TITLE
chore: prepare coordinated 0.8.22 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 ## Unreleased
 
+* Prepared `llamadart_llama_cpp_flutter` `0.0.17` to package the existing
+  Apple SwiftPM `v0.3.0` runtime pin.
+
 * Updated the default llama.cpp native runtime pin to
   `leehack/llamadart-native@v0.3.0`, regenerated matching Dart FFI bindings, refreshed
   the `llamadart_llama_cpp_flutter` Apple SwiftPM checksum, and

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
-## Unreleased
+## 0.8.22
 
-* Prepared `llamadart_llama_cpp_flutter` `0.0.17` to package the existing
+* Updated `llamadart_llama_cpp_flutter` to `0.0.17` with the
   Apple SwiftPM `v0.3.0` runtime pin.
 
 * Updated the default llama.cpp native runtime pin to

--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ For Dart or Flutter apps:
 
 ```yaml
 dependencies:
-  llamadart: ^0.8.21
+  llamadart: ^0.8.22
 ```
 
 Flutter iOS/macOS apps that should link Apple XCFrameworks through Swift
@@ -63,7 +63,7 @@ Package Manager should also add the runtime companion packages they need:
 
 ```yaml
 dependencies:
-  llamadart: ^0.8.21
+  llamadart: ^0.8.22
   llamadart_llama_cpp_flutter: ^0.0.17 # GGUF / llama.cpp
   llamadart_litert_lm_flutter: ^0.0.10 # Apple .litertlm / LiteRT-LM targets
 ```

--- a/README.md
+++ b/README.md
@@ -64,7 +64,7 @@ Package Manager should also add the runtime companion packages they need:
 ```yaml
 dependencies:
   llamadart: ^0.8.21
-  llamadart_llama_cpp_flutter: ^0.0.16 # GGUF / llama.cpp
+  llamadart_llama_cpp_flutter: ^0.0.17 # GGUF / llama.cpp
   llamadart_litert_lm_flutter: ^0.0.10 # Apple .litertlm / LiteRT-LM targets
 ```
 

--- a/example/chat_app/pubspec.lock
+++ b/example/chat_app/pubspec.lock
@@ -413,7 +413,7 @@ packages:
       path: "../.."
       relative: true
     source: path
-    version: "0.8.21"
+    version: "0.8.22"
   llamadart_litert_lm_flutter:
     dependency: "direct main"
     description:

--- a/example/chat_app/pubspec.lock
+++ b/example/chat_app/pubspec.lock
@@ -427,7 +427,7 @@ packages:
       path: "../../packages/llamadart_llama_cpp_flutter"
       relative: true
     source: path
-    version: "0.0.16"
+    version: "0.0.17"
   logging:
     dependency: transitive
     description:

--- a/packages/llamadart_litert_lm_flutter/README.md
+++ b/packages/llamadart_litert_lm_flutter/README.md
@@ -15,7 +15,7 @@ also request an x86_64 Simulator slice must exclude x86_64 for LiteRT-LM builds.
 
 ```yaml
 dependencies:
-  llamadart: ^0.8.21
+  llamadart: ^0.8.22
   llamadart_litert_lm_flutter: ^0.0.10
 ```
 

--- a/packages/llamadart_llama_cpp_flutter/CHANGELOG.md
+++ b/packages/llamadart_llama_cpp_flutter/CHANGELOG.md
@@ -1,4 +1,4 @@
-## Unreleased
+## 0.0.17
 
 * Updated Apple SwiftPM native pin to `leehack/llamadart-native@v0.3.0`.
 

--- a/packages/llamadart_llama_cpp_flutter/README.md
+++ b/packages/llamadart_llama_cpp_flutter/README.md
@@ -10,7 +10,7 @@ core package's native-assets fallback.
 ```yaml
 dependencies:
   llamadart: ^0.8.21
-  llamadart_llama_cpp_flutter: ^0.0.16
+  llamadart_llama_cpp_flutter: ^0.0.17
 ```
 
 This package has no runtime Dart API of its own. Import `package:llamadart`

--- a/packages/llamadart_llama_cpp_flutter/README.md
+++ b/packages/llamadart_llama_cpp_flutter/README.md
@@ -9,7 +9,7 @@ core package's native-assets fallback.
 
 ```yaml
 dependencies:
-  llamadart: ^0.8.21
+  llamadart: ^0.8.22
   llamadart_llama_cpp_flutter: ^0.0.17
 ```
 

--- a/packages/llamadart_llama_cpp_flutter/pubspec.yaml
+++ b/packages/llamadart_llama_cpp_flutter/pubspec.yaml
@@ -1,6 +1,6 @@
 name: llamadart_llama_cpp_flutter
 description: Flutter Apple SwiftPM runtime companion package for llamadart llama.cpp and GGUF support.
-version: 0.0.16
+version: 0.0.17
 repository: https://github.com/leehack/llamadart/tree/main/packages/llamadart_llama_cpp_flutter
 homepage: https://github.com/leehack/llamadart
 issue_tracker: https://github.com/leehack/llamadart/issues

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: llamadart
 description: Dart and Flutter local LLM inference with llama.cpp GGUF and LiteRT-LM across native platforms and web.
-version: 0.8.21
+version: 0.8.22
 homepage: https://github.com/leehack/llamadart
 repository: https://github.com/leehack/llamadart
 issue_tracker: https://github.com/leehack/llamadart/issues

--- a/test/unit/tooling/verify_release_docs_companion_pins_test.dart
+++ b/test/unit/tooling/verify_release_docs_companion_pins_test.dart
@@ -316,23 +316,13 @@ void main() {
     }
   });
 
-  test(
-    'the checked-in companions keep pending sync separate from release prep',
-    () {
-      final errors = <String>[];
-      final pending = checkCompanionSwiftPins(Directory.current, errors);
+  test('the checked-in companion versions record their SwiftPM pins', () {
+    final errors = <String>[];
+    final pending = checkCompanionSwiftPins(Directory.current, errors);
 
-      expect(
-        pending.map((bump) => bump.toString()),
-        contains(
-          'llamadart_llama_cpp_flutter 0.0.16 publishes v0.2.0-1, but '
-          'Package.swift pins v0.3.0; bump the version and rename '
-          '`## Unreleased` to the new version before releasing.',
-        ),
-      );
-      expect(errors, isEmpty);
-    },
-  );
+    expect(pending, isEmpty);
+    expect(errors, isEmpty);
+  });
 
   test('a pin recorded in the released section passes', () {
     final root = _fakeRepo(

--- a/website/docs/changelog/recent-releases.md
+++ b/website/docs/changelog/recent-releases.md
@@ -9,6 +9,9 @@ For canonical full release notes, use:
 
 ## Unreleased
 
+- Prepared `llamadart_llama_cpp_flutter` `0.0.17` to package the existing
+  Apple SwiftPM `v0.3.0` runtime pin.
+
 - Updated the default llama.cpp native runtime pin to
   `leehack/llamadart-native@v0.3.0`, regenerated matching Dart FFI bindings,
   refreshed the `llamadart_llama_cpp_flutter` Apple SwiftPM checksum, and

--- a/website/docs/changelog/recent-releases.md
+++ b/website/docs/changelog/recent-releases.md
@@ -7,9 +7,9 @@ For canonical full release notes, use:
 
 - [`CHANGELOG.md`](https://github.com/leehack/llamadart/blob/main/CHANGELOG.md)
 
-## Unreleased
+## 0.8.22
 
-- Prepared `llamadart_llama_cpp_flutter` `0.0.17` to package the existing
+- Updated `llamadart_llama_cpp_flutter` to `0.0.17` with the
   Apple SwiftPM `v0.3.0` runtime pin.
 
 - Updated the default llama.cpp native runtime pin to

--- a/website/docs/getting-started/installation.md
+++ b/website/docs/getting-started/installation.md
@@ -36,7 +36,7 @@ Package Manager, also add the runtime companion packages you need:
 ```yaml
 dependencies:
   llamadart: ^0.8.21
-  llamadart_llama_cpp_flutter: ^0.0.16 # GGUF / llama.cpp
+  llamadart_llama_cpp_flutter: ^0.0.17 # GGUF / llama.cpp
   llamadart_litert_lm_flutter: ^0.0.10 # Apple .litertlm / LiteRT-LM targets
 ```
 

--- a/website/docs/getting-started/installation.md
+++ b/website/docs/getting-started/installation.md
@@ -27,7 +27,7 @@ In Xcode, set `IPHONEOS_DEPLOYMENT_TARGET = 16.4` or
 
 ```yaml
 dependencies:
-  llamadart: ^0.8.21
+  llamadart: ^0.8.22
 ```
 
 For Flutter iOS/macOS apps that should link Apple XCFrameworks through Swift
@@ -35,7 +35,7 @@ Package Manager, also add the runtime companion packages you need:
 
 ```yaml
 dependencies:
-  llamadart: ^0.8.21
+  llamadart: ^0.8.22
   llamadart_llama_cpp_flutter: ^0.0.17 # GGUF / llama.cpp
   llamadart_litert_lm_flutter: ^0.0.10 # Apple .litertlm / LiteRT-LM targets
 ```


### PR DESCRIPTION
## Summary
Prepare the coordinated patch release of `llamadart 0.8.22` and `llamadart_llama_cpp_flutter 0.0.17`. Move accumulated core notes into 0.8.22, align current install snippets, regenerate the chat example lock through pub, and require companion pins to have matching versioned changelog entries. LiteRT companion remains 0.0.10.

The release includes the already-merged native v0.3.0 adoption, Web bridge v0.1.41 adoption, and native release-tag grammar consolidation. No breaking public API change was found in the source delta from v0.8.21. This PR changes release metadata/docs and the existing companion consistency assertion; runtime code, native/Web/LiteRT pins, SwiftPM binary URLs and checksums stay unchanged against its base.

Refs #473; keep it open until actual Apple companion publication is verified. Missing physical Android release qualification is tracked in #476.

## Maintainer decision addendum — 2026-09-04

Maintainer instruction for this release:

> I don't have older android device nor nvidia device so we should skip. Except that, everything ready?

For core **0.8.22 / Apple companion 0.0.17** at head `0bed2ff2603ee53b868863a2a801d1d64387a23b`, record:

| Qualification | Current release disposition | Residual evidence boundary |
| --- | --- | --- |
| Older/lower-ISA physical Android arm64, full and compact | **SKIP — maintainer-authorized for this release; accepted missing qualification** | Old-device SIGILL and lower-ISA safety remain unverified. Modern compact does not prove old-device compatibility. |
| NVIDIA CUDA racecheck/synccheck | **SKIP — maintainer-authorized for this release; accepted missing qualification** | CUDA sanitizer qualification remains unverified; the previously identified upstream source patterns remain present. No CUDA correctness clearance. |
| Modern Pixel 9 Pro, full and compact | **PASS — separate independent Sol audit** | Bounded CPU packaging/load/generation/crash/timing evidence only. |

These skips are not PASS and do not change the permanent matrix. #476 stays open for future old-device evidence. The original independent audit and evaluator observations remain preserved; this subsequent maintainer decision changes only the release disposition of the two unavailable hardware qualifications. It does not retroactively change the audit verdict or erase its findings.

Exact Qwen MTP reproduction and checkpoint/replay fallback remain untested and disclosed as existing bounded-evidence limitations. No other required gate is skipped by this instruction.

With these two explicitly accepted skips, **no other known mandatory pre-release blocker remains**: exact head/current base verified, all 15 checks successful, CLEAN/MERGEABLE, zero review threads, clean worktree, release dry-runs and independent preparation/device audits complete. The release is ready for the maintainer's separate publication decision. The PR remains draft; mark-ready, merge/publication, tags, dispatch and settings changes are not authorized by this question. A later approved merge triggers companion-before-core publication and docs release.

## Publication approval boundary
**This is a coordinated release-prep PR. A later approved merge is approval to publish, not merely to merge metadata.** The `release-prep` label makes the neutral existing branch eligible for `release_on_prep_merge.yml`. That workflow validates versions, pushes the missing Apple companion 0.0.17 tag, waits for its pub.dev publication, skips already-published LiteRT companion 0.0.10, and only then pushes core v0.8.22. Core publication creates the GitHub Release; the core tag triggers docs version cut and subsequent docs deployment.

No publication occurs while this PR remains open. No tag, manual dispatch, mark-ready, merge, publication or settings change is authorized in this preparation task. The release-specific qualification skips are recorded above; merge still requires separate explicit publication approval. Current snippets intentionally reference the prepared versions and rely on this companion-before-core sequencing.

Before edits, complete pub.dev version lists showed core latest 0.8.21 and Apple latest 0.0.16, with target 0.8.22 and 0.0.17 absent. Matching GitHub tags were absent. Core patch selection follows the inspected non-breaking release scope.

## Validation
Flutter 3.47.1 / Dart 3.13.1, macOS:
- [x] Clean workspace preparation; only intended path-version lock lines regenerated by pub.
- [x] Repository format/analyze and default/strict release docs version checkers.
- [x] Core clean-state `flutter pub publish --dry-run`: zero warnings.
- [x] Both companions: analyze, tests, SwiftPM manifest validation and CI-shaped temporary-copy publish dry-runs, zero warnings.
- [x] Maintained docs build and link checks.
- [x] `git diff --check`; no incidental analyzer migration committed.
- [x] Full VM: 1,982 passed / 77 skipped; Chrome: 925 passed.
- [x] Independent exact-head Sol QA accepted the coordinated draft scope; 25-test baselines, seven regression mutations, publication ordering and failure-path probes passed.
- [x] All 15 populated checks succeeded on exact head: [full CI](https://github.com/leehack/llamadart/actions/runs/33876869627) and [Linux/Windows native smokes](https://github.com/leehack/llamadart/actions/runs/33876869534), plus preview/advisory. GitHub reports CLEAN/MERGEABLE; PR remains draft.

The initial core dry-run only warned about then-uncommitted metadata and passed after commit. The first VM run encountered a pre-existing writer-policy test scanning a third-party README in ignored website/node_modules. With docs dependencies moved outside the checkout, the targeted 29-test suite passed; the full clean-tree rerun is recorded separately.

## Release-tier evidence and accepted skips
| Row | Result | Evidence / remaining work |
| --- | --- | --- |
| `android-release-device-pool` | **Modern PASS; older-device SKIP for this release** | #476: exact-candidate Pixel 9 Pro full+compact PASS with independent audit; old/lower-ISA physical arm64 full+compact evidence remains missing. Missing old-device evidence is maintainer-accepted for this release under the dated decision above; future evidence still requires the maintained helper plus model load/generation and crash logs. No emulator substitution. |
| `release-companion-pub-gate` | PASS for preparation; publication pending approved merge | Apple 0.0.17 intentionally absent, LiteRT 0.0.10 unchanged; workflow enforces companion publication before core tag. |
| `release-representative-smokes` | Bounded evidence reviewed by independent QA | Native continuation on exact base: public Dart Metal/GLM-OCR MTP cancellation/error/rejection recovery passed; prior Web v0.1.41 direct/worker real-model and deployed app smokes passed. Runtime surface is unchanged by this preparation. |

Modern-device evidence at exact candidate: Pixel 9 Pro/Tensor G4/SDK37, published native v0.3.0 archive SHA256 `74d70e5bf3c191ff02093180c8d758fb1d178adf460e8a5ee97855016d42e4bb`. Full loaded `android_armv9.0_1`; compact loaded `android_armv8.0_1`; each completed two warmups and seven measured 32-token CPU generations with nonempty text and no captured process crash. Median wall times 179 ms full / 241 ms compact support observed full-not-slower, without output-parity or controlled-speedup claims. Independent Sol reviewed APK/native provenance, successful loader diagnostics, raw run records and original-APK restoration. Temporary config/diagnostic overlay changed no selection/inference logic and was removed. This closes only the modern-device rows; #476 remains open for old hardware.

Native qualification does **not** clear CUDA: NVIDIA racecheck/synccheck unavailable, affected upstream source patterns remain present. Exact Qwen MTP reproduction and checkpoint/replay fallback remain untested. Metal pipeline/lifecycle results do not establish general backend/model correctness. These are explicit qualification limits, not invented PR-caused regressions. The maintainer has accepted the old-device and NVIDIA qualification skips for this release; separate publication approval remains pending.

## High-risk regression review
- Classification: artifactConsumer (companion package paths); release metadata.
- Exact head: `0bed2ff2603ee53b868863a2a801d1d64387a23b`.
- Current base: `37b5c521e1544e7a9c3e480149e0e8b87452aa3e`.
- Fresh independent `gpt-5.6-sol` audit: accepted scoped draft preparation; zero blocking implementation findings.
- Positive/negative and mutation evidence: independent 25-test worktree/archive baselines; seven mutations rejected (Apple version/changelog, stale core/LiteRT README versions, strict mode, errors and pending list). Actual production gate accepts exact release-prep label only. Stubbed production publication shell proves Apple-before-core order and blocks core on companion timeout/duplicate tag. Duplicate core tags and Unreleased core headings rejected.
- Known PR-caused P1 regressions: 0, independently reviewed.
- Review threads: 0 total / 0 unresolved, explicitly queried; pagination complete.

Manual repository-local review/evidence establishes readiness under `doc/high_risk_pre_merge_readiness.md`. Intentionally unconfigured external enforcement is not a pending merge requirement; evaluator exit 2 is diagnostic. The separate dated maintainer decision records only this release's two hardware skips; it does not expand native qualification claims.

Keep draft pending the separate publication decision. No other known mandatory pre-release blocker remains after the explicitly accepted hardware skips.

<details>
<summary>Exact-head repository-local readiness evidence</summary>

```json
{
  "schema": "llamadart.high-risk-readiness-evidence",
  "schema_version": "1.0.0",
  "timestamp": "2026-09-04T13:20:38.594869Z",
  "correlation_id": "release822-pr475-0bed2ff2",
  "repository": "leehack/llamadart",
  "pr_number": 475,
  "expected_pr_head_sha": "0bed2ff2603ee53b868863a2a801d1d64387a23b",
  "current_base_sha": "37b5c521e1544e7a9c3e480149e0e8b87452aa3e",
  "pr_author": "leehack",
  "classification": "high-risk",
  "surfaces": [
    "artifactConsumer"
  ],
  "required_matrix_row_ids": [
    "high-risk-exact-head-independent-qa"
  ],
  "matrix_row_evidence": {
    "high-risk-exact-head-independent-qa": {
      "row_id": "high-risk-exact-head-independent-qa",
      "result": "pass",
      "command": "Fresh independent Sol exact-head audit: 25-test worktree/archive baselines, seven mutations, production release gate/validation/ordering positive and negative probes",
      "evidence_notes": "Accepted coordinated draft preparation, zero implementation blockers/P1/threads. Mandatory Android physical old+modern full+compact qualification incomplete (#476); no release-ready claim. Candidate versions unused, exact label gates publication, companion timeout/duplicate tag prevent core tag."
    }
  },
  "independent_audit": {
    "auditor_identity": "codex-adversarial-sol-release822",
    "audit_kind": "codex-adversarial",
    "audit_head_sha": "0bed2ff2603ee53b868863a2a801d1d64387a23b",
    "audit_base_sha": "37b5c521e1544e7a9c3e480149e0e8b87452aa3e",
    "decision": "accepted",
    "unresolved_review_threads": 0,
    "known_pr_caused_p1_regressions": 0,
    "summary": "Fresh /root/sol_release822_qa dispatched gpt-5.6-sol high. Accepted only coordinated draft-preparation scope at exact head/base. Report /private/tmp/release822-sol-qa.md. Physical Android release tier remains blocked; CUDA/exactQwen/checkpoint fallback unqualified. No mark-ready or publication approval."
  },
  "structured_output_evidence": null,
  "affected_test_paths": [
    "test/unit/tooling/verify_release_docs_companion_pins_test.dart"
  ],
  "evaluation": {
    "evaluated_at": "2026-09-04T13:21:04.439400Z",
    "changed_files": [
      {
        "path": "CHANGELOG.md",
        "status": "modified"
      },
      {
        "path": "README.md",
        "status": "modified"
      },
      {
        "path": "example/chat_app/pubspec.lock",
        "status": "modified"
      },
      {
        "path": "packages/llamadart_litert_lm_flutter/README.md",
        "status": "modified"
      },
      {
        "path": "packages/llamadart_llama_cpp_flutter/CHANGELOG.md",
        "status": "modified"
      },
      {
        "path": "packages/llamadart_llama_cpp_flutter/README.md",
        "status": "modified"
      },
      {
        "path": "packages/llamadart_llama_cpp_flutter/pubspec.yaml",
        "status": "modified"
      },
      {
        "path": "pubspec.yaml",
        "status": "modified"
      },
      {
        "path": "test/unit/tooling/verify_release_docs_companion_pins_test.dart",
        "status": "modified"
      },
      {
        "path": "website/docs/changelog/recent-releases.md",
        "status": "modified"
      },
      {
        "path": "website/docs/getting-started/installation.md",
        "status": "modified"
      }
    ],
    "decision": "unverifiedPrerequisites",
    "failure_classification": "externalPrerequisitesUnavailable",
    "message": "Repository-local evidence is internally consistent, but auditor authentication, GitHub App publication, protected-environment provenance, and ruleset enforcement are not available. This is not operational merge readiness.",
    "external_prerequisites": {
      "app_installed": false,
      "protected_environment_configured": false,
      "independent_auditor_authenticated": false,
      "ruleset_enforced": false,
      "diagnostic_message": "No repository-local input can authenticate the dedicated GitHub App, protected environment, independent auditor, or conditional ruleset. See doc/high_risk_pre_merge_readiness.md."
    }
  }
}
```

Local evidence is internally consistent. The external-prerequisite diagnostic is not a pending adopted merge gate. Hardware qualification remains incomplete as evidence; the subsequent dated maintainer addendum accepts the two stated hardware skips for this release. The preserved payload above predates that decision.
</details>
