### PR TITLE
feat(native): prepare llama.cpp v0.4.0 adoption

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,12 @@
   the `llamadart_llama_cpp_flutter` Apple SwiftPM checksum, and
   aligned current README/website native override docs. Updated multimodal calls
   for the matching ABI. Saved native sessions from older runtimes must be
-  regenerated; Web and LiteRT runtime pins are unchanged.
+  regenerated. Prepared Apple companion `0.0.18` for the matching native runtime.
+
+* Aligned the default WebGPU bridge assets to `v0.1.43` for Web/native
+  llama.cpp `v0.4.0@5266f24da75dc449bd56cbed7addb9c8e4a6a73e` parity.
+  Web `@litert-lm/core@0.15.0` and native LiteRT pins are unchanged. Immutable
+  manifest: `111eefc3588842cebfe665b363378edca34924764610263e1eda5280dfcfaa27`.
 
 ## 0.8.22
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,12 @@
+## Unreleased
+
+* Updated the default llama.cpp native runtime pin to
+  `leehack/llamadart-native@v0.4.0`, regenerated matching Dart FFI bindings, refreshed
+  the `llamadart_llama_cpp_flutter` Apple SwiftPM checksum, and
+  aligned current README/website native override docs. Updated multimodal calls
+  for the matching ABI. Saved native sessions from older runtimes must be
+  regenerated; Web and LiteRT runtime pins are unchanged.
+
 ## 0.8.22
 
 * Updated `llamadart_llama_cpp_flutter` to `0.0.17` with the

--- a/README.md
+++ b/README.md
@@ -143,7 +143,7 @@ Current default runtime pins:
 
 | Runtime | Pin |
 | --- | --- |
-| Native llama.cpp / GGUF | `leehack/llamadart-native@v0.3.0` |
+| Native llama.cpp / GGUF | `leehack/llamadart-native@v0.4.0` |
 | Native LiteRT-LM / `.litertlm` | `leehack/litert-lm-native@v0.16.0-native.2` |
 | Web llama.cpp / GGUF | `leehack/llama-web-bridge-assets@v0.1.41` |
 | Web LiteRT-LM / `.litertlm` | `@litert-lm/core@0.15.0` |

--- a/README.md
+++ b/README.md
@@ -64,7 +64,7 @@ Package Manager should also add the runtime companion packages they need:
 ```yaml
 dependencies:
   llamadart: ^0.8.22
-  llamadart_llama_cpp_flutter: ^0.0.17 # GGUF / llama.cpp
+  llamadart_llama_cpp_flutter: ^0.0.18 # GGUF / llama.cpp
   llamadart_litert_lm_flutter: ^0.0.10 # Apple .litertlm / LiteRT-LM targets
 ```
 
@@ -145,7 +145,7 @@ Current default runtime pins:
 | --- | --- |
 | Native llama.cpp / GGUF | `leehack/llamadart-native@v0.4.0` |
 | Native LiteRT-LM / `.litertlm` | `leehack/litert-lm-native@v0.16.0-native.2` |
-| Web llama.cpp / GGUF | `leehack/llama-web-bridge-assets@v0.1.41` |
+| Web llama.cpp / GGUF | `leehack/llama-web-bridge-assets@v0.1.43` |
 | Web LiteRT-LM / `.litertlm` | `@litert-lm/core@0.15.0` |
 
 Native overrides accept stable `vMAJOR.MINOR.PATCH` releases and preserve

--- a/README.md
+++ b/README.md
@@ -61,11 +61,24 @@ dependencies:
 Flutter iOS/macOS apps that should link Apple XCFrameworks through Swift
 Package Manager should also add the runtime companion packages they need:
 
+**Unreleased coordinated upgrade:** companion `0.0.18` requires the matching
+llama.cpp v0.4.0 core bindings; it is not compatible with published core
+`0.8.22`. For published packages, keep core `0.8.22` with companion `0.0.17`.
+The development example below requires both path overrides to the same checkout.
+Publish companion `0.0.18` only with the matching next core release, and replace
+these temporary overrides/version constraints during that coordinated release.
+
 ```yaml
 dependencies:
   llamadart: ^0.8.22
   llamadart_llama_cpp_flutter: ^0.0.18 # GGUF / llama.cpp
   llamadart_litert_lm_flutter: ^0.0.10 # Apple .litertlm / LiteRT-LM targets
+
+dependency_overrides:
+  llamadart:
+    path: /path/to/llamadart
+  llamadart_llama_cpp_flutter:
+    path: /path/to/llamadart/packages/llamadart_llama_cpp_flutter
 ```
 
 The LiteRT-LM companion manifest includes the complete iOS SwiftPM runtime

--- a/doc/webgpu_bridge.md
+++ b/doc/webgpu_bridge.md
@@ -19,15 +19,15 @@ pipelines.
    `https://cdn.jsdelivr.net/gh/leehack/llama-web-bridge-assets@<tag>/llama_webgpu_bridge.js`
 2. Local fallback: `./webgpu_bridge/llama_webgpu_bridge.js`
 
-Default pinned tag in the example is `v0.1.41`.
+Default pinned tag in the example is `v0.1.43`.
 
-That release embeds llama.cpp `v0.3.0`, matching the `hook/build.dart` native pin
-(`v0.3.0`, both built from upstream llama.cpp `v0.3.0@c1d0e7a004015f23bc0233470b747b596f29b264`)
-even though the bridge asset tag `v0.1.41` differs from the native runtime tag
-`v0.3.0`. Provenance for this immutable consumer artifact: release `381873266`,
-tag commit `dca41da58a689697f3b532f09da5aa1672e24e93`, bridge source
-`646037ac816c066d3f7d9e357139ca20800dc7ee`, and manifest SHA-256
-`fe97604daabaad6aefa223a8637d5fd9dcac09dd4a61b2ef19cd6aabb39392b9`. It retains
+That release embeds llama.cpp `v0.4.0`, matching the `hook/build.dart` native pin
+(`v0.4.0`, both built from upstream llama.cpp `v0.4.0@5266f24da75dc449bd56cbed7addb9c8e4a6a73e`)
+even though the bridge asset tag `v0.1.43` differs from the native runtime tag
+`v0.4.0`. Provenance for this immutable consumer artifact: release `384042112`,
+tag commit `78be0c8c628cd8cbc6a1268b1a9758c3d6d052a6`, bridge source
+`89178be67c3c84300bc1b129182bd5bc5a8e21fc`, and manifest SHA-256
+`111eefc3588842cebfe665b363378edca34924764610263e1eda5280dfcfaa27`. It retains
 the Qwen3-ASR typed speech-to-text contract introduced in `v0.1.30` and
 provisions the explicit 1 MiB Wasm stack needed for memory64 context
 construction in direct and worker modes. The chat bootstrap opts
@@ -47,7 +47,7 @@ model bytes.
 To vendor pinned assets into local app web files:
 
 ```bash
-WEBGPU_BRIDGE_ASSETS_TAG=v0.1.41 ./scripts/fetch_webgpu_bridge_assets.sh
+WEBGPU_BRIDGE_ASSETS_TAG=v0.1.43 ./scripts/fetch_webgpu_bridge_assets.sh
 ```
 
 Optional compatibility env vars:
@@ -128,7 +128,7 @@ You can override CDN source/version before the bridge loader runs:
 ```html
 <script>
   window.__llamadartBridgeAssetsRepo = 'leehack/llama-web-bridge-assets';
-  window.__llamadartBridgeAssetsTag = 'v0.1.41';
+  window.__llamadartBridgeAssetsTag = 'v0.1.43';
 </script>
 ```
 

--- a/example/chat_app/pubspec.lock
+++ b/example/chat_app/pubspec.lock
@@ -427,7 +427,7 @@ packages:
       path: "../../packages/llamadart_llama_cpp_flutter"
       relative: true
     source: path
-    version: "0.0.17"
+    version: "0.0.18"
   logging:
     dependency: transitive
     description:

--- a/example/chat_app/web/index.html
+++ b/example/chat_app/web/index.html
@@ -211,8 +211,8 @@
       typeof configuredRepo === 'string' && configuredRepo.length > 0
         ? configuredRepo
         : 'leehack/llama-web-bridge-assets';
-    const defaultBridgeAssetsTag = 'v0.1.41';
-    const defaultBridgeLlamaCppTag = 'v0.3.0';
+    const defaultBridgeAssetsTag = 'v0.1.43';
+    const defaultBridgeLlamaCppTag = 'v0.4.0';
     const bridgeAssetsTag =
       typeof configuredTag === 'string' && configuredTag.length > 0
         ? configuredTag

--- a/hook/build.dart
+++ b/hook/build.dart
@@ -13,7 +13,7 @@ import 'package:path/path.dart' as path;
 
 import 'package:llamadart/src/hook/native_bundle_config.dart';
 
-const _llamaCppTag = 'v0.3.0';
+const _llamaCppTag = 'v0.4.0';
 const _nativeRepoSlug = 'leehack/llamadart-native';
 
 const _packageName = 'llamadart';

--- a/lib/src/backends/llama_cpp/bindings.dart
+++ b/lib/src/backends/llama_cpp/bindings.dart
@@ -2225,6 +2225,12 @@ ggml_prec ggml_flash_attn_ext_get_prec(ffi.Pointer<ggml_tensor> a) {
   return ggml_prec.fromValue(_ggml_flash_attn_ext_get_prec(a));
 }
 
+@ffi.Native<ffi.Void Function(ffi.Pointer<ggml_tensor>, ffi.Int32)>()
+external void ggml_flash_attn_ext_set_n_kv_max(
+  ffi.Pointer<ggml_tensor> a,
+  int n_kv_max,
+);
+
 @ffi.Native<ffi.Void Function(ffi.Pointer<ggml_tensor>, ffi.UnsignedInt)>(
   symbol: 'ggml_flash_attn_ext_set_prec',
 )
@@ -5278,6 +5284,21 @@ external ffi.Pointer<ggml_tensor> ggml_swiglu(
     ffi.Pointer<ggml_tensor>,
     ffi.Pointer<ggml_tensor>,
     ffi.Float,
+  )
+>()
+external ffi.Pointer<ggml_tensor> ggml_swiglu_clamp(
+  ffi.Pointer<ggml_context> ctx,
+  ffi.Pointer<ggml_tensor> a,
+  ffi.Pointer<ggml_tensor> b,
+  double limit,
+);
+
+@ffi.Native<
+  ffi.Pointer<ggml_tensor> Function(
+    ffi.Pointer<ggml_context>,
+    ffi.Pointer<ggml_tensor>,
+    ffi.Pointer<ggml_tensor>,
+    ffi.Float,
     ffi.Float,
   )
 >()
@@ -8217,6 +8238,7 @@ external ffi.Pointer<ffi.Float> mtmd_get_output_embd(
     ffi.Pointer<ffi.UnsignedChar>,
     ffi.Size,
     ffi.Bool,
+    mtmd_helper_init_opt,
   )
 >()
 external mtmd_helper_bitmap_wrapper mtmd_helper_bitmap_init_from_buf(
@@ -8224,6 +8246,7 @@ external mtmd_helper_bitmap_wrapper mtmd_helper_bitmap_init_from_buf(
   ffi.Pointer<ffi.UnsignedChar> buf,
   int len,
   bool placeholder,
+  mtmd_helper_init_opt opt,
 );
 
 @ffi.Native<
@@ -8231,12 +8254,14 @@ external mtmd_helper_bitmap_wrapper mtmd_helper_bitmap_init_from_buf(
     ffi.Pointer<mtmd_context>,
     ffi.Pointer<ffi.Char>,
     ffi.Bool,
+    mtmd_helper_init_opt,
   )
 >()
 external mtmd_helper_bitmap_wrapper mtmd_helper_bitmap_init_from_file(
   ffi.Pointer<mtmd_context> ctx,
   ffi.Pointer<ffi.Char> fname,
   bool placeholder,
+  mtmd_helper_init_opt opt,
 );
 
 @ffi.Native<
@@ -8402,6 +8427,9 @@ external void mtmd_helper_image_get_decoder_pos(
   int pos_0,
   ffi.Pointer<mtmd_decoder_pos> out_pos,
 );
+
+@ffi.Native<mtmd_helper_init_opt Function()>()
+external mtmd_helper_init_opt mtmd_helper_init_opt_default();
 
 @ffi.Native<ffi.Void Function(ggml_log_callback, ffi.Pointer<ffi.Void>)>()
 external void mtmd_helper_log_set(
@@ -8654,6 +8682,23 @@ external int mtmd_tokenize(
   int n_bitmaps,
 );
 
+@ffi.Native<
+  ffi.Int32 Function(
+    ffi.Pointer<mtmd_context>,
+    ffi.Pointer<mtmd_input_chunks>,
+    ffi.Pointer<ffi.Pointer<mtmd_input_part>>,
+    ffi.Size,
+    ffi.Bool,
+  )
+>()
+external int mtmd_tokenize_from_parts(
+  ffi.Pointer<mtmd_context> ctx,
+  ffi.Pointer<mtmd_input_chunks> output,
+  ffi.Pointer<ffi.Pointer<mtmd_input_part>> parts,
+  int n_parts,
+  bool add_special,
+);
+
 typedef FILE = __sFILE;
 
 const int GGML_BACKEND_META_MAX_DEVICES = 16;
@@ -8716,7 +8761,7 @@ const int LLAMA_FILE_MAGIC_GGSQ = 1734833009;
 
 const int LLAMA_SESSION_MAGIC = 1734833006;
 
-const int LLAMA_SESSION_VERSION = 9;
+const int LLAMA_SESSION_VERSION = 10;
 
 const int LLAMA_STATE_SEQ_FLAGS_NONE = 0;
 
@@ -8728,7 +8773,7 @@ const int LLAMA_STATE_SEQ_FLAGS_SWA_ONLY = 1;
 
 const int LLAMA_STATE_SEQ_MAGIC = 1734833009;
 
-const int LLAMA_STATE_SEQ_VERSION = 2;
+const int LLAMA_STATE_SEQ_VERSION = 3;
 
 const int LLAMA_TOKEN_NULL = -1;
 
@@ -9381,7 +9426,8 @@ enum ggml_glu_op {
   GGML_GLU_OP_SWIGLU_OAI(3),
   GGML_GLU_OP_GEGLU_ERF(4),
   GGML_GLU_OP_GEGLU_QUICK(5),
-  GGML_GLU_OP_COUNT(6);
+  GGML_GLU_OP_SWIGLU_CLAMP(6),
+  GGML_GLU_OP_COUNT(7);
 
   final int value;
   const ggml_glu_op(this.value);
@@ -9393,7 +9439,8 @@ enum ggml_glu_op {
     3 => GGML_GLU_OP_SWIGLU_OAI,
     4 => GGML_GLU_OP_GEGLU_ERF,
     5 => GGML_GLU_OP_GEGLU_QUICK,
-    6 => GGML_GLU_OP_COUNT,
+    6 => GGML_GLU_OP_SWIGLU_CLAMP,
+    7 => GGML_GLU_OP_COUNT,
     _ => throw ArgumentError('Unknown value for ggml_glu_op: $value'),
   };
 }
@@ -10929,6 +10976,22 @@ enum llama_ftype {
   };
 }
 
+enum llama_lazy_mode {
+  LLAMA_LAZY_MODE_OFF(0),
+  LLAMA_LAZY_MODE_AUTO(1),
+  LLAMA_LAZY_MODE_ON(2);
+
+  final int value;
+  const llama_lazy_mode(this.value);
+
+  static llama_lazy_mode fromValue(int value) => switch (value) {
+    0 => LLAMA_LAZY_MODE_OFF,
+    1 => LLAMA_LAZY_MODE_AUTO,
+    2 => LLAMA_LAZY_MODE_ON,
+    _ => throw ArgumentError('Unknown value for llama_lazy_mode: $value'),
+  };
+}
+
 enum llama_load_mode {
   LLAMA_LOAD_MODE_AUTO(-1),
   LLAMA_LOAD_MODE_NONE(0),
@@ -11081,6 +11144,12 @@ final class llama_model_params extends ffi.Struct {
   llama_load_mode get load_mode => llama_load_mode.fromValue(load_modeAsInt);
   set load_mode(llama_load_mode value) => load_modeAsInt = value.value;
 
+  @ffi.UnsignedInt()
+  external int lazy_modeAsInt;
+
+  llama_lazy_mode get lazy_mode => llama_lazy_mode.fromValue(lazy_modeAsInt);
+  set lazy_mode(llama_lazy_mode value) => lazy_modeAsInt = value.value;
+
   @ffi.Int32()
   external int main_gpu;
 
@@ -11118,6 +11187,7 @@ final class llama_model_params extends ffi.Struct {
     required int n_gpu_layers,
     required llama_split_mode split_mode,
     required llama_load_mode load_mode,
+    required llama_lazy_mode lazy_mode,
     required int main_gpu,
     required ffi.Pointer<ffi.Float> tensor_split,
     required llama_progress_callback progress_callback,
@@ -11135,6 +11205,7 @@ final class llama_model_params extends ffi.Struct {
     ..ref.n_gpu_layers = n_gpu_layers
     ..ref.split_mode = split_mode
     ..ref.load_mode = load_mode
+    ..ref.lazy_mode = lazy_mode
     ..ref.main_gpu = main_gpu
     ..ref.tensor_split = tensor_split
     ..ref.progress_callback = progress_callback
@@ -11200,6 +11271,9 @@ final class llama_model_quantize_params extends ffi.Struct {
 
   external ffi.Pointer<ffi.Int32> prune_layers;
 
+  @ffi.Size()
+  external int max_buf_size;
+
   static ffi.Pointer<llama_model_quantize_params> $allocate(
     ffi.Allocator $allocator, {
     required int nthread,
@@ -11216,6 +11290,7 @@ final class llama_model_quantize_params extends ffi.Struct {
     required ffi.Pointer<llama_model_kv_override> kv_overrides,
     required ffi.Pointer<llama_model_tensor_override> tt_overrides,
     required ffi.Pointer<ffi.Int32> prune_layers,
+    required int max_buf_size,
   }) => $allocator<llama_model_quantize_params>()
     ..ref.nthread = nthread
     ..ref.ftype = ftype
@@ -11230,7 +11305,8 @@ final class llama_model_quantize_params extends ffi.Struct {
     ..ref.imatrix = imatrix
     ..ref.kv_overrides = kv_overrides
     ..ref.tt_overrides = tt_overrides
-    ..ref.prune_layers = prune_layers;
+    ..ref.prune_layers = prune_layers
+    ..ref.max_buf_size = max_buf_size;
 }
 
 typedef llama_model_set_tensor_data_t =
@@ -12289,6 +12365,10 @@ enum mtmd_helper_gen_audio_outtype {
   };
 }
 
+final class mtmd_helper_init_opt extends ffi.Struct {
+  external mtmd_helper_video_init_params video_params;
+}
+
 typedef mtmd_helper_post_decode_callback =
     ffi.Pointer<ffi.NativeFunction<mtmd_helper_post_decode_callbackFunction>>;
 typedef mtmd_helper_post_decode_callbackFunction =
@@ -12367,6 +12447,20 @@ enum mtmd_input_chunk_type {
 }
 
 final class mtmd_input_chunks extends ffi.Opaque {}
+
+final class mtmd_input_part extends ffi.Struct {
+  external ffi.Pointer<mtmd_input_text> text;
+
+  external ffi.Pointer<mtmd_bitmap> bitmap;
+
+  static ffi.Pointer<mtmd_input_part> $allocate(
+    ffi.Allocator $allocator, {
+    required ffi.Pointer<mtmd_input_text> text,
+    required ffi.Pointer<mtmd_bitmap> bitmap,
+  }) => $allocator<mtmd_input_part>()
+    ..ref.text = text
+    ..ref.bitmap = bitmap;
+}
 
 final class mtmd_input_text extends ffi.Struct {
   external ffi.Pointer<ffi.Char> text;

--- a/lib/src/backends/llama_cpp/llama_cpp_service.dart
+++ b/lib/src/backends/llama_cpp/llama_cpp_service.dart
@@ -262,17 +262,21 @@ typedef _MtmdInputChunksInitNative = Pointer<mtmd_input_chunks> Function();
 typedef _MtmdInputChunksInitDart = Pointer<mtmd_input_chunks> Function();
 typedef _MtmdInputChunksFreeNative = Void Function(Pointer<mtmd_input_chunks>);
 typedef _MtmdInputChunksFreeDart = void Function(Pointer<mtmd_input_chunks>);
+typedef _MtmdHelperInitOptDefaultNative = mtmd_helper_init_opt Function();
+typedef _MtmdHelperInitOptDefaultDart = mtmd_helper_init_opt Function();
 typedef _MtmdHelperBitmapInitFromFileNative =
     mtmd_helper_bitmap_wrapper Function(
       Pointer<mtmd_context>,
       Pointer<Char>,
       Bool,
+      mtmd_helper_init_opt,
     );
 typedef _MtmdHelperBitmapInitFromFileDart =
     mtmd_helper_bitmap_wrapper Function(
       Pointer<mtmd_context>,
       Pointer<Char>,
       bool,
+      mtmd_helper_init_opt,
     );
 typedef _MtmdHelperBitmapInitFromBufNative =
     mtmd_helper_bitmap_wrapper Function(
@@ -280,6 +284,7 @@ typedef _MtmdHelperBitmapInitFromBufNative =
       Pointer<UnsignedChar>,
       Size,
       Bool,
+      mtmd_helper_init_opt,
     );
 typedef _MtmdHelperBitmapInitFromBufDart =
     mtmd_helper_bitmap_wrapper Function(
@@ -287,6 +292,7 @@ typedef _MtmdHelperBitmapInitFromBufDart =
       Pointer<UnsignedChar>,
       int,
       bool,
+      mtmd_helper_init_opt,
     );
 typedef _MtmdBitmapInitFromAudioNative =
     Pointer<mtmd_bitmap> Function(Size, Pointer<Float>);
@@ -6817,7 +6823,12 @@ class LlamaCppService {
   ) {
     if (!_mtmdPrimarySymbolsUnavailable) {
       try {
-        return mtmd_helper_bitmap_init_from_file(ctx, pathPtr, false).bitmap;
+        return mtmd_helper_bitmap_init_from_file(
+          ctx,
+          pathPtr,
+          false,
+          mtmd_helper_init_opt_default(),
+        ).bitmap;
       } on ArgumentError {
         _mtmdPrimarySymbolsUnavailable = true;
       }
@@ -6828,7 +6839,14 @@ class LlamaCppService {
         _mtmdUnavailableMessage('mtmd_helper_bitmap_init_from_file'),
       );
     }
-    return fallback.helperBitmapInitFromFile(ctx, pathPtr, false).bitmap;
+    return fallback
+        .helperBitmapInitFromFile(
+          ctx,
+          pathPtr,
+          false,
+          fallback.helperInitOptDefault(),
+        )
+        .bitmap;
   }
 
   Pointer<mtmd_bitmap> _mtmdHelperBitmapInitFromBuf(
@@ -6838,7 +6856,13 @@ class LlamaCppService {
   ) {
     if (!_mtmdPrimarySymbolsUnavailable) {
       try {
-        return mtmd_helper_bitmap_init_from_buf(ctx, data, size, false).bitmap;
+        return mtmd_helper_bitmap_init_from_buf(
+          ctx,
+          data,
+          size,
+          false,
+          mtmd_helper_init_opt_default(),
+        ).bitmap;
       } on ArgumentError {
         _mtmdPrimarySymbolsUnavailable = true;
       }
@@ -6849,7 +6873,15 @@ class LlamaCppService {
         _mtmdUnavailableMessage('mtmd_helper_bitmap_init_from_buf'),
       );
     }
-    return fallback.helperBitmapInitFromBuf(ctx, data, size, false).bitmap;
+    return fallback
+        .helperBitmapInitFromBuf(
+          ctx,
+          data,
+          size,
+          false,
+          fallback.helperInitOptDefault(),
+        )
+        .bitmap;
   }
 
   Pointer<mtmd_bitmap> _mtmdBitmapInitFromAudio(int n, Pointer<Float> samples) {
@@ -8118,6 +8150,7 @@ class _MtmdApi {
   final _MtmdFreeDart free;
   final _MtmdInputChunksInitDart inputChunksInit;
   final _MtmdInputChunksFreeDart inputChunksFree;
+  final _MtmdHelperInitOptDefaultDart helperInitOptDefault;
   final _MtmdHelperBitmapInitFromFileDart helperBitmapInitFromFile;
   final _MtmdHelperBitmapInitFromBufDart helperBitmapInitFromBuf;
   final _MtmdBitmapInitFromAudioDart bitmapInitFromAudio;
@@ -8137,6 +8170,7 @@ class _MtmdApi {
     required this.free,
     required this.inputChunksInit,
     required this.inputChunksFree,
+    required this.helperInitOptDefault,
     required this.helperBitmapInitFromFile,
     required this.helperBitmapInitFromBuf,
     required this.bitmapInitFromAudio,
@@ -8200,6 +8234,11 @@ class _MtmdApi {
               _MtmdInputChunksFreeNative,
               _MtmdInputChunksFreeDart
             >('mtmd_input_chunks_free'),
+        helperInitOptDefault: library
+            .lookupFunction<
+              _MtmdHelperInitOptDefaultNative,
+              _MtmdHelperInitOptDefaultDart
+            >('mtmd_helper_init_opt_default'),
         helperBitmapInitFromFile: library
             .lookupFunction<
               _MtmdHelperBitmapInitFromFileNative,

--- a/packages/llamadart_llama_cpp_flutter/CHANGELOG.md
+++ b/packages/llamadart_llama_cpp_flutter/CHANGELOG.md
@@ -1,4 +1,4 @@
-## Unreleased
+## 0.0.18
 
 * Updated Apple SwiftPM native pin to `leehack/llamadart-native@v0.4.0`.
 

--- a/packages/llamadart_llama_cpp_flutter/CHANGELOG.md
+++ b/packages/llamadart_llama_cpp_flutter/CHANGELOG.md
@@ -1,3 +1,7 @@
+## Unreleased
+
+* Updated Apple SwiftPM native pin to `leehack/llamadart-native@v0.4.0`.
+
 ## 0.0.17
 
 * Updated Apple SwiftPM native pin to `leehack/llamadart-native@v0.3.0`.

--- a/packages/llamadart_llama_cpp_flutter/README.md
+++ b/packages/llamadart_llama_cpp_flutter/README.md
@@ -7,10 +7,23 @@ Add this package to a Flutter iOS/macOS app when the app should link the
 prebuilt llama.cpp Apple XCFramework through SwiftPM instead of relying on the
 core package's native-assets fallback.
 
+**Unreleased coordinated upgrade:** companion `0.0.18` requires the matching
+llama.cpp v0.4.0 core bindings; it is not compatible with published core
+`0.8.22`. For published packages, keep core `0.8.22` with companion `0.0.17`.
+The development example below requires both path overrides to the same checkout.
+Publish companion `0.0.18` only with the matching next core release, and replace
+these temporary overrides/version constraints during that coordinated release.
+
 ```yaml
 dependencies:
   llamadart: ^0.8.22
   llamadart_llama_cpp_flutter: ^0.0.18
+
+dependency_overrides:
+  llamadart:
+    path: /path/to/llamadart
+  llamadart_llama_cpp_flutter:
+    path: /path/to/llamadart/packages/llamadart_llama_cpp_flutter
 ```
 
 This package has no runtime Dart API of its own. Import `package:llamadart`

--- a/packages/llamadart_llama_cpp_flutter/README.md
+++ b/packages/llamadart_llama_cpp_flutter/README.md
@@ -10,7 +10,7 @@ core package's native-assets fallback.
 ```yaml
 dependencies:
   llamadart: ^0.8.22
-  llamadart_llama_cpp_flutter: ^0.0.17
+  llamadart_llama_cpp_flutter: ^0.0.18
 ```
 
 This package has no runtime Dart API of its own. Import `package:llamadart`

--- a/packages/llamadart_llama_cpp_flutter/README.md
+++ b/packages/llamadart_llama_cpp_flutter/README.md
@@ -16,7 +16,7 @@ dependencies:
 This package has no runtime Dart API of its own. Import `package:llamadart`
 normally from the core package and use `LlamaBackend()` / `LlamaEngine` there.
 
-The Apple SwiftPM manifest pins `leehack/llamadart-native@v0.3.0`.
+The Apple SwiftPM manifest pins `leehack/llamadart-native@v0.4.0`.
 
 Source for this package lives in
 `packages/llamadart_llama_cpp_flutter` in the

--- a/packages/llamadart_llama_cpp_flutter/darwin/llamadart_llama_cpp_flutter/Package.swift
+++ b/packages/llamadart_llama_cpp_flutter/darwin/llamadart_llama_cpp_flutter/Package.swift
@@ -4,7 +4,7 @@ import PackageDescription
 
 let packageRoot = URL(fileURLWithPath: #filePath).deletingLastPathComponent()
 let artifactsRoot = packageRoot.appendingPathComponent("Artifacts")
-let llamaCppTag = "v0.3.0"
+let llamaCppTag = "v0.4.0"
 
 func localArtifactPath(_ name: String) -> String? {
     let path = artifactsRoot.appendingPathComponent(name).path
@@ -47,7 +47,7 @@ let package = Package(
             repository: "leehack/llamadart-native",
             artifactName: "llamadart-native-apple-xcframework-\(llamaCppTag).zip",
             tag: llamaCppTag,
-            checksum: "a3578c392294a9827c38379cf43cfd2ba578432b3f8878685a6bf0cd2d5b9d4a"
+            checksum: "9729e1839d383cfed6e21395cfa05655656f5b92465d461ab2ee44425eb6eb52"
         ),
         .target(
             name: "llamadart_llama_cpp_flutter",

--- a/packages/llamadart_llama_cpp_flutter/pubspec.yaml
+++ b/packages/llamadart_llama_cpp_flutter/pubspec.yaml
@@ -1,6 +1,6 @@
 name: llamadart_llama_cpp_flutter
 description: Flutter Apple SwiftPM runtime companion package for llamadart llama.cpp and GGUF support.
-version: 0.0.17
+version: 0.0.18
 repository: https://github.com/leehack/llamadart/tree/main/packages/llamadart_llama_cpp_flutter
 homepage: https://github.com/leehack/llamadart
 issue_tracker: https://github.com/leehack/llamadart/issues

--- a/scripts/fetch_webgpu_bridge_assets.sh
+++ b/scripts/fetch_webgpu_bridge_assets.sh
@@ -4,7 +4,7 @@ set -euo pipefail
 ROOT_DIR="$(git rev-parse --show-toplevel)"
 OUT_DIR="${WEBGPU_BRIDGE_OUT_DIR:-$ROOT_DIR/example/chat_app/web/webgpu_bridge}"
 ASSETS_REPO="${WEBGPU_BRIDGE_ASSETS_REPO:-leehack/llama-web-bridge-assets}"
-ASSETS_TAG="${WEBGPU_BRIDGE_ASSETS_TAG:-v0.1.41}"
+ASSETS_TAG="${WEBGPU_BRIDGE_ASSETS_TAG:-v0.1.43}"
 CDN_BASE="${WEBGPU_BRIDGE_CDN_BASE:-https://cdn.jsdelivr.net/gh/${ASSETS_REPO}@${ASSETS_TAG}}"
 PATCH_SAFARI_COMPAT="${WEBGPU_BRIDGE_PATCH_SAFARI_COMPAT:-1}"
 MIN_SAFARI_VERSION="${WEBGPU_BRIDGE_MIN_SAFARI_VERSION:-170400}"
@@ -21,7 +21,7 @@ if [[ "${1:-}" == "--help" || "${1:-}" == "-h" ]]; then
 Downloads prebuilt WebGPU bridge assets into the chat_app web directory.
 
 Default source:
-  https://cdn.jsdelivr.net/gh/leehack/llama-web-bridge-assets@v0.1.41
+  https://cdn.jsdelivr.net/gh/leehack/llama-web-bridge-assets@v0.1.43
 
 Environment variables:
   WEBGPU_BRIDGE_ASSETS_REPO   Asset repo in owner/repo format
@@ -35,7 +35,7 @@ Usage:
   ./scripts/fetch_webgpu_bridge_assets.sh
 
 Examples:
-  WEBGPU_BRIDGE_ASSETS_TAG=v0.1.41 ./scripts/fetch_webgpu_bridge_assets.sh
+  WEBGPU_BRIDGE_ASSETS_TAG=v0.1.43 ./scripts/fetch_webgpu_bridge_assets.sh
   WEBGPU_BRIDGE_ASSETS_REPO=acme/llama-web-bridge-assets WEBGPU_BRIDGE_ASSETS_TAG=v2 ./scripts/fetch_webgpu_bridge_assets.sh
 USAGE
   exit 0

--- a/test/integration/backends/llama_cpp/native_symbol_integration_test.dart
+++ b/test/integration/backends/llama_cpp/native_symbol_integration_test.dart
@@ -138,6 +138,7 @@ typedef _MtmdHelperBitmapInitFromBufNative =
       ffi.Pointer<ffi.UnsignedChar>,
       ffi.Size,
       ffi.Bool,
+      mtmd_helper_init_opt,
     );
 typedef _MtmdHelperBitmapInitFromBufDart =
     mtmd_helper_bitmap_wrapper Function(
@@ -145,6 +146,7 @@ typedef _MtmdHelperBitmapInitFromBufDart =
       ffi.Pointer<ffi.UnsignedChar>,
       int,
       bool,
+      mtmd_helper_init_opt,
     );
 typedef _MtmdBitmapFreeNative = ffi.Void Function(ffi.Pointer<mtmd_bitmap>);
 typedef _MtmdBitmapFreeDart = void Function(ffi.Pointer<mtmd_bitmap>);
@@ -402,6 +404,7 @@ String _sourceBracedDeclaration(String source, String marker) {
 void _expectBitmapHelperDecodesTransparentPng(
   _MtmdHelperBitmapInitFromBufDart helper,
   _MtmdBitmapFreeDart bitmapFree,
+  mtmd_helper_init_opt Function() defaultOptions,
 ) {
   final data = malloc<ffi.UnsignedChar>(_transparentPngBytes.length);
   ffi.Pointer<mtmd_bitmap> bitmap = ffi.nullptr;
@@ -416,6 +419,7 @@ void _expectBitmapHelperDecodesTransparentPng(
       data,
       _transparentPngBytes.length,
       false,
+      defaultOptions(),
     );
     bitmap = result.bitmap;
 
@@ -450,6 +454,19 @@ void main() {
         llama_model_default_params().load_mode,
         llama_load_mode.LLAMA_LOAD_MODE_AUTO,
       );
+    });
+
+    test('v0.4.0 by-value defaults match regenerated model layout', () {
+      final params = llama_model_default_params();
+      expect(params.lazy_mode, llama_lazy_mode.LLAMA_LAZY_MODE_AUTO);
+      expect(params.main_gpu, 0);
+      expect(params.vocab_only, isFalse);
+      expect(
+        llama_model_quantize_default_params().max_buf_size,
+        8 * 1024 * 1024 * 1024,
+      );
+      expect(LLAMA_SESSION_VERSION, 10);
+      expect(LLAMA_STATE_SEQ_VERSION, 3);
     });
 
     test('Verify speculative symbols are declared in generated bindings', () {
@@ -792,6 +809,7 @@ void main() {
       expect(fileNative, contains('Pointer<mtmd_context>,'));
       expect(fileNative, contains('Pointer<Char>,'));
       expect(fileNative, contains('Bool,'));
+      expect(fileNative, contains('mtmd_helper_init_opt,'));
       expect(fileNative, isNot(contains('Pointer<mtmd_bitmap> Function(')));
 
       final fileDart = _sourceSection(
@@ -803,6 +821,7 @@ void main() {
       expect(fileDart, contains('Pointer<mtmd_context>,'));
       expect(fileDart, contains('Pointer<Char>,'));
       expect(fileDart, contains('bool,'));
+      expect(fileDart, contains('mtmd_helper_init_opt,'));
 
       final bufNative = _sourceSection(
         serviceSource,
@@ -814,6 +833,7 @@ void main() {
       expect(bufNative, contains('Pointer<UnsignedChar>,'));
       expect(bufNative, contains('Size,'));
       expect(bufNative, contains('Bool,'));
+      expect(bufNative, contains('mtmd_helper_init_opt,'));
       expect(bufNative, isNot(contains('Pointer<mtmd_bitmap> Function(')));
 
       final bufDart = _sourceSection(
@@ -826,20 +846,54 @@ void main() {
       expect(bufDart, contains('Pointer<UnsignedChar>,'));
       expect(bufDart, contains('int,'));
       expect(bufDart, contains('bool,'));
+      expect(bufDart, contains('mtmd_helper_init_opt,'));
 
-      expect(
+      // Bind each assertion to its production function: deleting/bypassing one
+      // call must fail even when the other helper still passes defaults.
+      final fileBody = _sourceSection(
         serviceSource,
+        '  Pointer<mtmd_bitmap> _mtmdHelperBitmapInitFromFile(',
+        '  Pointer<mtmd_bitmap> _mtmdHelperBitmapInitFromBuf(',
+      ).replaceAll(RegExp(r'\s+'), '');
+      final bufBody = _sourceSection(
+        serviceSource,
+        '  Pointer<mtmd_bitmap> _mtmdHelperBitmapInitFromBuf(',
+        '  Pointer<mtmd_bitmap> _mtmdBitmapInitFromAudio(',
+      ).replaceAll(RegExp(r'\s+'), '');
+      expect(
+        fileBody,
         contains(
-          'mtmd_helper_bitmap_init_from_file(ctx, pathPtr, false).bitmap',
+          'returnmtmd_helper_bitmap_init_from_file(ctx,pathPtr,false,mtmd_helper_init_opt_default(),).bitmap;',
         ),
       );
       expect(
-        serviceSource,
+        fileBody,
         contains(
-          'mtmd_helper_bitmap_init_from_buf(ctx, data, size, false)'
-          '.bitmap',
+          'returnfallback.helperBitmapInitFromFile(ctx,pathPtr,false,fallback.helperInitOptDefault(),).bitmap;',
         ),
       );
+      expect(
+        bufBody,
+        contains(
+          'returnmtmd_helper_bitmap_init_from_buf(ctx,data,size,false,mtmd_helper_init_opt_default(),).bitmap;',
+        ),
+      );
+      expect(
+        bufBody,
+        contains(
+          'returnfallback.helperBitmapInitFromBuf(ctx,data,size,false,fallback.helperInitOptDefault(),).bitmap;',
+        ),
+      );
+      final fallback = serviceSource
+          .substring(serviceSource.indexOf('class _MtmdApi {'))
+          .replaceAll(RegExp(r'\s+'), '');
+      expect(
+        fallback,
+        contains(
+          "helperInitOptDefault:library.lookupFunction<_MtmdHelperInitOptDefaultNative,_MtmdHelperInitOptDefaultDart>('mtmd_helper_init_opt_default')",
+        ),
+      );
+      expect(fallback, contains('catch(_){returnnull;}'));
     });
 
     test('Verify mtmd bitmap helper ABI is callable', () {
@@ -849,9 +903,16 @@ void main() {
           fail('Expected a split mtmd fallback library for this platform.');
         }
         _expectBitmapHelperDecodesTransparentPng(
-          (ctx, data, len, placeholder) =>
-              mtmd_helper_bitmap_init_from_buf(ctx, data, len, placeholder),
+          (ctx, data, len, placeholder, options) =>
+              mtmd_helper_bitmap_init_from_buf(
+                ctx,
+                data,
+                len,
+                placeholder,
+                options,
+              ),
           (bitmap) => mtmd_bitmap_free(bitmap),
+          mtmd_helper_init_opt_default,
         );
         return;
       }
@@ -866,7 +927,16 @@ void main() {
           .lookupFunction<_MtmdBitmapFreeNative, _MtmdBitmapFreeDart>(
             'mtmd_bitmap_free',
           );
-      _expectBitmapHelperDecodesTransparentPng(helper, bitmapFree);
+      final defaultOptions = library
+          .lookupFunction<
+            mtmd_helper_init_opt Function(),
+            mtmd_helper_init_opt Function()
+          >('mtmd_helper_init_opt_default');
+      _expectBitmapHelperDecodesTransparentPng(
+        helper,
+        bitmapFree,
+        defaultOptions,
+      );
     });
 
     test('Verify b10514 mtmd symbols are resolvable', () {

--- a/test/integration/state_persistence_test.dart
+++ b/test/integration/state_persistence_test.dart
@@ -3,6 +3,7 @@
 library;
 
 import 'dart:io';
+import 'dart:typed_data';
 import 'package:test/test.dart';
 import 'package:llamadart/llamadart.dart';
 import '../test_helper.dart';
@@ -78,6 +79,30 @@ void main() async {
       () => engine.stateLoadFile(missingPath, tokenCapacity: 256),
       throwsA(isA<Exception>()),
     );
+  });
+
+  test('rejects v0.3.0 session headers and can reload a valid state', () async {
+    final tokens = await engine.tokenize('Once upon a time');
+    await engine
+        .generate(
+          'Once upon a time',
+          params: const GenerationParams(maxTokens: 2),
+        )
+        .drain<void>();
+    final validPath = '${tmpDir.path}/current-version.bin';
+    expect(await engine.stateSaveFile(validPath, tokens: tokens), isTrue);
+    final bytes = File(validPath).readAsBytesSync();
+    final header = ByteData.sublistView(bytes);
+    expect(header.getUint32(4, Endian.host), 10);
+    header.setUint32(4, 9, Endian.host);
+    final oldPath = '${tmpDir.path}/old-version.bin';
+    File(oldPath).writeAsBytesSync(bytes);
+    await expectLater(
+      engine.stateLoadFile(oldPath, tokenCapacity: 256),
+      throwsA(isA<LlamaException>()),
+    );
+    final restored = await engine.stateLoadFile(validPath, tokenCapacity: 256);
+    expect(restored.tokens, tokens);
   });
 
   test('rejects token capacity larger than context size', () async {

--- a/test/unit/tooling/check_webgpu_bridge_tag_test.dart
+++ b/test/unit/tooling/check_webgpu_bridge_tag_test.dart
@@ -83,21 +83,21 @@ const String _approvedManifestJson = '''
       "size_bytes": 113962
     },
     "llama_webgpu_core.wasm": {
-      "sha256": "85dee0979f80a41108351b3298c0e96fc79e92db602b2bd2ddbd652fb0f08e20",
-      "size_bytes": 8629961
+      "sha256": "223c695c85f792e507795ac49181cd2429efa7a71820ce2e0f8651fb5b09bc0c",
+      "size_bytes": 8841896
     },
     "llama_webgpu_core_mem64.js": {
       "sha256": "451ed2bfc99fc33e0de6b09eb96f03914a194c91bcd0bda968048c2d5efa7e2d",
       "size_bytes": 131045
     },
     "llama_webgpu_core_mem64.wasm": {
-      "sha256": "31de051ee7dfe8703a54c4ef91d68c59d9a08beb15eec5f0b26d4e344a6b57cd",
-      "size_bytes": 8845657
+      "sha256": "db7b615acb371f2334764bd8543eb7e5531c0f225497c7713ae866907d93d4e1",
+      "size_bytes": 9060973
     }
   },
   "assets_repository": "leehack/llama-web-bridge-assets",
-  "bridge_assets_tag": "v0.1.41",
-  "bridge_commit": "646037ac816c066d3f7d9e357139ca20800dc7ee",
+  "bridge_assets_tag": "v0.1.43",
+  "bridge_commit": "89178be67c3c84300bc1b129182bd5bc5a8e21fc",
   "bridge_repository": "leehack/llama-web-bridge",
   "capabilities": {
     "memory64": true,
@@ -144,27 +144,27 @@ const String _approvedManifestJson = '''
       "size_bytes": 113962
     },
     "llama_webgpu_core.wasm": {
-      "sha256": "85dee0979f80a41108351b3298c0e96fc79e92db602b2bd2ddbd652fb0f08e20",
-      "size_bytes": 8629961
+      "sha256": "223c695c85f792e507795ac49181cd2429efa7a71820ce2e0f8651fb5b09bc0c",
+      "size_bytes": 8841896
     },
     "llama_webgpu_core_mem64.js": {
       "sha256": "451ed2bfc99fc33e0de6b09eb96f03914a194c91bcd0bda968048c2d5efa7e2d",
       "size_bytes": 131045
     },
     "llama_webgpu_core_mem64.wasm": {
-      "sha256": "31de051ee7dfe8703a54c4ef91d68c59d9a08beb15eec5f0b26d4e344a6b57cd",
-      "size_bytes": 8845657
+      "sha256": "db7b615acb371f2334764bd8543eb7e5531c0f225497c7713ae866907d93d4e1",
+      "size_bytes": 9060973
     }
   },
-  "github_run_id": "33731854100",
-  "github_run_url": "https://github.com/leehack/llama-web-bridge/actions/runs/33731854100",
-  "llama_cpp_commit": "c1d0e7a004015f23bc0233470b747b596f29b264",
-  "llama_cpp_tag": "v0.3.0",
-  "native_commit": "28fca14873d4b4c531bef4425b261e2b911bdcce",
-  "native_manifest_sha256": "811fda999e70c3ad2716d1c196688dd38db62cf11a78044855ca94f71fabed45",
-  "native_release_tag": "v0.3.0",
+  "github_run_id": "34100775215",
+  "github_run_url": "https://github.com/leehack/llama-web-bridge/actions/runs/34100775215",
+  "llama_cpp_commit": "5266f24da75dc449bd56cbed7addb9c8e4a6a73e",
+  "llama_cpp_tag": "v0.4.0",
+  "native_commit": "236d369512eedbd564b5b1b839c2a6d0f9dd654e",
+  "native_manifest_sha256": "6187e6483eb03c86d79bb774e01ece71b201cb00561550bbc948b20d237b5cdc",
+  "native_release_tag": "v0.4.0",
   "native_repository": "leehack/llamadart-native",
-  "orchestrator_correlation_id": "auto-stable-v0.3.0-811fda999e70c3ad-build-eb5f166a4f9d118a",
+  "orchestrator_correlation_id": "auto-stable-v0.4.0-6187e6483eb03c86-build-89178be67c3c8430",
   "qualification_gates": {
     "multimodal": "passed",
     "speech_to_text": "required-automated-qualification",
@@ -173,9 +173,9 @@ const String _approvedManifestJson = '''
   },
   "release_channel": "stable",
   "release_rebuild": 0,
-  "release_tag": "v0.1.41",
+  "release_tag": "v0.1.43",
   "schema_version": 2,
-  "source_commit": "646037ac816c066d3f7d9e357139ca20800dc7ee",
+  "source_commit": "89178be67c3c84300bc1b129182bd5bc5a8e21fc",
   "source_repository": "leehack/llama-web-bridge",
   "unproven_capabilities": {
     "hardware_gpu_acceleration": "unavailable-on-hosted-runners",
@@ -184,9 +184,9 @@ const String _approvedManifestJson = '''
     "speaker_reference_fidelity": "unproven",
     "wasm32_text_to_speech": "unsupported"
   },
-  "upstream_commit": "c1d0e7a004015f23bc0233470b747b596f29b264",
+  "upstream_commit": "5266f24da75dc449bd56cbed7addb9c8e4a6a73e",
   "upstream_repository": "ggml-org/llama.cpp",
-  "upstream_tag": "v0.3.0"
+  "upstream_tag": "v0.4.0"
 }
 ''';
 
@@ -196,7 +196,7 @@ Future<List<String>> _verifyManifestJson(
 }) {
   final bytes = utf8.encode(manifestJson);
   return verifyManifest(
-    expectedTag: 'v0.1.41',
+    expectedTag: 'v0.1.43',
     expectedLlamaCppTag: bridgeLlamaCppTag,
     expectedLlamaCppCommit: bridgeLlamaCppCommit,
     expectedBridgeCommit: bridgeSourceCommit,
@@ -255,7 +255,7 @@ void main() {
         'website/docs/changelog/recent-releases.md',
       ]) {
         final current = _currentReleaseNotes(path);
-        expect(current, contains('`v0.1.41`'), reason: path);
+        expect(current, contains('`v0.1.43`'), reason: path);
         expect(current, contains(bridgeManifestSha256), reason: path);
         expect(
           current,
@@ -662,12 +662,12 @@ void main() {
 
     test('parity prose is accepted for matching upstream tags', () {
       final root = _fakeRuntimeRepo(
-        bridgeTag: 'v0.3.0',
-        nativeTag: 'v0.3.0',
+        bridgeTag: bridgeLlamaCppTag,
+        nativeTag: bridgeNativeReleaseTag,
         parityWording: true,
       );
 
-      expect(findBridgeRuntimeDrift(root, 'v0.3.0'), isEmpty);
+      expect(findBridgeRuntimeDrift(root, bridgeLlamaCppTag), isEmpty);
     });
 
     test('a doc naming a different bridge build is reported', () {
@@ -747,14 +747,14 @@ void main() {
         // bridgeNativeReleaseTag is a constant, so drive the mismatch from the
         // other side: a tree whose bridge and native pins agree on a family the
         // checked-in anchor does not belong to.
-        final root = _fakeRuntimeRepo(bridgeTag: 'v0.4.0', nativeTag: 'v0.4.0');
+        final root = _fakeRuntimeRepo(bridgeTag: 'v0.5.0', nativeTag: 'v0.5.0');
 
         expect(
-          findBridgeRuntimeDrift(root, 'v0.4.0'),
+          findBridgeRuntimeDrift(root, 'v0.5.0'),
           contains(
             contains(
               'bridgeNativeReleaseTag $bridgeNativeReleaseTag does not belong to '
-              'the recorded upstream llama.cpp release v0.4.0',
+              'the recorded upstream llama.cpp release v0.5.0',
             ),
           ),
         );
@@ -768,8 +768,8 @@ void main() {
     });
 
     test('immutable release identity stays pinned to the approved release', () {
-      expect(bridgeAssetsReleaseId, '381873266');
-      expect(bridgeAssetsTagCommit, 'dca41da58a689697f3b532f09da5aa1672e24e93');
+      expect(bridgeAssetsReleaseId, '384042112');
+      expect(bridgeAssetsTagCommit, '78be0c8c628cd8cbc6a1268b1a9758c3d6d052a6');
     });
 
     test('accepts equivalent CRLF documentation passages', () {

--- a/test/unit/tooling/safe_pr_head_update_test.dart
+++ b/test/unit/tooling/safe_pr_head_update_test.dart
@@ -10,6 +10,20 @@ import '../../../tool/git/safe_pr_head_update.dart';
 
 const zeroOid = '0000000000000000000000000000000000000000';
 
+bool isMaintainedMarkdown(String path) {
+  final parts = path.replaceAll('\\', '/').split('/');
+  return parts.last.endsWith('.md') &&
+      !parts.any(
+        const {
+          '.git',
+          '.dart_tool',
+          'node_modules',
+          'build',
+          '.docusaurus',
+        }.contains,
+      );
+}
+
 Future<ProcessResult> git(List<String> args, Directory cwd) {
   return Process.run('git', args, workingDirectory: cwd.path);
 }
@@ -1207,6 +1221,30 @@ void main() {
   });
 
   group('static repository writer contracts', () {
+    test(
+      'Markdown ownership excludes dependencies but retains maintained docs',
+      () {
+        for (final path in [
+          'README.md',
+          'doc/pr_branch_writer_inventory.md',
+          'website/docs/maintainers/release-workflow.md',
+          'website/versioned_docs/version-0.8.22/maintainers/release-workflow.md',
+        ]) {
+          expect(isMaintainedMarkdown(path), isTrue, reason: path);
+        }
+        for (final path in [
+          'website/node_modules/dependency/README.md',
+          r'website\node_modules\dependency\README.md',
+          'node_modules/dependency/README.md',
+          'example/chat_app/build/README.md',
+          'website/.docusaurus/README.md',
+          '.dart_tool/README.md',
+          '.git/README.md',
+        ]) {
+          expect(isMaintainedMarkdown(path), isFalse, reason: path);
+        }
+      },
+    );
     test('all executable and task sources exclude bypass writers', () {
       String repoPath(File file) {
         final normalized = file.path.replaceAll('\\', '/');
@@ -1294,14 +1332,9 @@ void main() {
       }
 
       final markdownFiles = Directory('.')
-          .listSync(recursive: true)
+          .listSync(recursive: true, followLinks: false)
           .whereType<File>()
-          .where((file) {
-            final path = repoPath(file);
-            return path.endsWith('.md') &&
-                !path.startsWith('.git/') &&
-                !path.contains('/.git/');
-          });
+          .where((file) => isMaintainedMarkdown(repoPath(file)));
       for (final file in markdownFiles) {
         final path = repoPath(file);
         final content = file.readAsStringSync();

--- a/tool/gguf_chat_features_smoke.dart
+++ b/tool/gguf_chat_features_smoke.dart
@@ -266,6 +266,26 @@ Future<void> main(List<String> args) async {
             maxTokens: 120,
           )
         : null;
+    final multimodalBytes = mmprojPath != null && imagePath != null
+        ? await _runScenario(
+            engine: engine,
+            name: 'multimodalBytes',
+            messages: [
+              LlamaChatMessage.withContent(
+                role: LlamaChatRole.user,
+                content: [
+                  const LlamaTextContent(
+                    'Describe this image in one short sentence.',
+                  ),
+                  LlamaImageContent(bytes: await File(imagePath).readAsBytes()),
+                ],
+              ),
+            ],
+            tools: const [],
+            enableThinking: false,
+            maxTokens: 120,
+          )
+        : null;
     _verifyNoThinking(noThinking);
     _verifyThinkingSeparation(thinking);
     _verifyNoThinking(toolCallNoThinking);
@@ -280,6 +300,10 @@ Future<void> main(List<String> args) async {
       _verifyHasOutput(multimodal);
       _verifyNoThinking(multimodal);
     }
+    if (multimodalBytes != null) {
+      _verifyHasOutput(multimodalBytes);
+      _verifyNoThinking(multimodalBytes);
+    }
     final result = {
       'backendName': backendName,
       'requestedBackend': backend.name,
@@ -291,6 +315,7 @@ Future<void> main(List<String> args) async {
       'toolCallWithThinkingBudget': toolCallWithThinkingBudget.toJson(),
       'toolCallWithZeroThinkingBudget': toolCallWithZeroThinkingBudget.toJson(),
       if (multimodal != null) 'multimodal': multimodal.toJson(),
+      if (multimodalBytes != null) 'multimodalBytes': multimodalBytes.toJson(),
     };
     print('RESULT gguf_chat_features ${jsonEncode(result)}');
   } finally {

--- a/tool/testing/check_webgpu_bridge_tag.dart
+++ b/tool/testing/check_webgpu_bridge_tag.dart
@@ -346,13 +346,13 @@ List<String> findCurrentReleaseNotesDrift(
 }
 
 /// The llama.cpp upstream release tag embedded in the pinned bridge assets.
-const String bridgeLlamaCppTag = 'v0.3.0';
+const String bridgeLlamaCppTag = 'v0.4.0';
 
 /// The exact upstream llama.cpp commit embedded in the pinned bridge assets.
-const String bridgeLlamaCppCommit = 'c1d0e7a004015f23bc0233470b747b596f29b264';
+const String bridgeLlamaCppCommit = '5266f24da75dc449bd56cbed7addb9c8e4a6a73e';
 
 /// The exact bridge source commit used to build the pinned bridge assets.
-const String bridgeSourceCommit = '646037ac816c066d3f7d9e357139ca20800dc7ee';
+const String bridgeSourceCommit = '89178be67c3c84300bc1b129182bd5bc5a8e21fc';
 
 /// Canonical repository identities recorded in the approved manifest.
 const String bridgeAssetsRepository = 'leehack/llama-web-bridge-assets';
@@ -361,17 +361,17 @@ const String bridgeUpstreamRepository = 'ggml-org/llama.cpp';
 const String bridgeNativeRepository = 'leehack/llamadart-native';
 
 /// The native release tag the pinned bridge assets were qualified against.
-const String bridgeNativeReleaseTag = 'v0.3.0';
+const String bridgeNativeReleaseTag = 'v0.4.0';
 
 /// The asset repository release that published the pinned bridge assets.
-const String bridgeAssetsReleaseId = '381873266';
+const String bridgeAssetsReleaseId = '384042112';
 
 /// The asset repository commit the pinned bridge asset tag points at.
-const String bridgeAssetsTagCommit = 'dca41da58a689697f3b532f09da5aa1672e24e93';
+const String bridgeAssetsTagCommit = '78be0c8c628cd8cbc6a1268b1a9758c3d6d052a6';
 
 /// SHA-256 hash of the exact approved published manifest.json.
 const String bridgeManifestSha256 =
-    'fe97604daabaad6aefa223a8637d5fd9dcac09dd4a61b2ef19cd6aabb39392b9';
+    '111eefc3588842cebfe665b363378edca34924764610263e1eda5280dfcfaa27';
 
 /// Where the native runtime's llama.cpp build is pinned.
 const String nativeLlamaCppTagPath = 'hook/build.dart';

--- a/tool/testing/run_local_e2e.dart
+++ b/tool/testing/run_local_e2e.dart
@@ -234,7 +234,7 @@ List<LocalE2eScenario> buildLocalE2eScenarios({String? projectRoot}) {
       name: 'gguf-chat-features-smoke',
       group: LocalE2eScenarioGroup.dartLocalOnly,
       description:
-          'Run real GGUF chat, thinking-budget/suppression, tool-call, and optional image smoke.',
+          'Run real GGUF chat, thinking-budget/suppression, tool-call, and optional image path/bytes smoke.',
       requiresDevice: false,
       stepsBuilder: (context) {
         final arguments = <String>['run', 'tool/gguf_chat_features_smoke.dart'];

--- a/website/docs/changelog/recent-releases.md
+++ b/website/docs/changelog/recent-releases.md
@@ -10,8 +10,13 @@ For canonical full release notes, use:
 ## Unreleased
 
 - Adopted native llama.cpp v0.4.0 with matching bindings and multimodal calls.
-  Saved native sessions from older runtimes must be regenerated; Web and LiteRT
-  runtime pins are unchanged.
+  Saved native sessions from older runtimes must be regenerated. Prepared Apple
+  companion `0.0.18` for the matching native runtime.
+
+- Aligned default WebGPU bridge assets to `v0.1.43` for Web/native
+  llama.cpp `v0.4.0@5266f24da75dc449bd56cbed7addb9c8e4a6a73e` parity.
+  Web `@litert-lm/core@0.15.0` and native LiteRT pins are unchanged. Immutable
+  manifest: `111eefc3588842cebfe665b363378edca34924764610263e1eda5280dfcfaa27`.
 
 ## 0.8.22
 

--- a/website/docs/changelog/recent-releases.md
+++ b/website/docs/changelog/recent-releases.md
@@ -7,6 +7,12 @@ For canonical full release notes, use:
 
 - [`CHANGELOG.md`](https://github.com/leehack/llamadart/blob/main/CHANGELOG.md)
 
+## Unreleased
+
+- Adopted native llama.cpp v0.4.0 with matching bindings and multimodal calls.
+  Saved native sessions from older runtimes must be regenerated; Web and LiteRT
+  runtime pins are unchanged.
+
 ## 0.8.22
 
 - Updated `llamadart_llama_cpp_flutter` to `0.0.17` with the

--- a/website/docs/getting-started/installation.md
+++ b/website/docs/getting-started/installation.md
@@ -79,7 +79,7 @@ hooks:
     llamadart:
       # Optional. Defaults to llamadart's tested native runtime pin.
       # Use a leehack/llamadart-native release tag when testing another build.
-      llamadart_native_tag: v0.3.0
+      llamadart_native_tag: v0.4.0
 
       # Optional. GitHub repository slug or github.com URL.
       llamadart_native_repository: leehack/llamadart-native
@@ -106,7 +106,7 @@ per-target module list.
 Native source overrides are for compatibility testing. They do not regenerate
 Dart FFI bindings or symbol lookups, so the selected binary still must be ABI-
 and symbol-compatible with the default
-`leehack/llamadart-native@v0.3.0` runtime.
+`leehack/llamadart-native@v0.4.0` runtime.
 
 Available native tags are published on the
 [`leehack/llamadart-native` releases page](https://github.com/leehack/llamadart-native/releases).
@@ -134,7 +134,7 @@ gh release list --repo leehack/llamadart-native --limit 20
 
 Before overriding, confirm the release includes the asset for your target. The
 hook downloads files named `llamadart-native-<bundle>-<tag>.tar.gz`, for example
-`llamadart-native-windows-x64-v0.3.0.tar.gz`.
+`llamadart-native-windows-x64-v0.4.0.tar.gz`.
 For local testing, `llamadart_native_path` may point directly at a bundle
 archive, at an extracted bundle directory, or at a directory containing
 `<tag>/<bundle>/`, `<bundle>/`, or the expected archive file.

--- a/website/docs/getting-started/installation.md
+++ b/website/docs/getting-started/installation.md
@@ -36,7 +36,7 @@ Package Manager, also add the runtime companion packages you need:
 ```yaml
 dependencies:
   llamadart: ^0.8.22
-  llamadart_llama_cpp_flutter: ^0.0.17 # GGUF / llama.cpp
+  llamadart_llama_cpp_flutter: ^0.0.18 # GGUF / llama.cpp
   llamadart_litert_lm_flutter: ^0.0.10 # Apple .litertlm / LiteRT-LM targets
 ```
 

--- a/website/docs/getting-started/installation.md
+++ b/website/docs/getting-started/installation.md
@@ -33,11 +33,24 @@ dependencies:
 For Flutter iOS/macOS apps that should link Apple XCFrameworks through Swift
 Package Manager, also add the runtime companion packages you need:
 
+**Unreleased coordinated upgrade:** companion `0.0.18` requires the matching
+llama.cpp v0.4.0 core bindings; it is not compatible with published core
+`0.8.22`. For published packages, keep core `0.8.22` with companion `0.0.17`.
+The development example below requires both path overrides to the same checkout.
+Publish companion `0.0.18` only with the matching next core release, and replace
+these temporary overrides/version constraints during that coordinated release.
+
 ```yaml
 dependencies:
   llamadart: ^0.8.22
   llamadart_llama_cpp_flutter: ^0.0.18 # GGUF / llama.cpp
   llamadart_litert_lm_flutter: ^0.0.10 # Apple .litertlm / LiteRT-LM targets
+
+dependency_overrides:
+  llamadart:
+    path: /path/to/llamadart
+  llamadart_llama_cpp_flutter:
+    path: /path/to/llamadart/packages/llamadart_llama_cpp_flutter
 ```
 
 The companion packages are published independently from the `packages/`

--- a/website/docs/guides/multimodal.md
+++ b/website/docs/guides/multimodal.md
@@ -98,8 +98,8 @@ on the loaded bridge's runtime capability report.
 
 Video is not currently consumable through the public Dart generation API.
 `LlamaVideoContent` makes an attempted path/byte request explicit, but
-generation rejects it with `LlamaUnsupportedException`. The published native
-`v0.3.0` archive exports upstream video helper symbols, but this release has
+generation rejects it with `LlamaUnsupportedException`. The pinned native
+`v0.4.0` archive exports upstream video helper symbols, but this release has
 not been qualified for end-to-end video input; symbol presence is not a
 capability check. A complete implementation still needs companion native builds
 with `LLAMA_SUBPROCESS`/`MTMD_VIDEO`, a cross-platform FFmpeg/ffprobe packaging

--- a/website/docs/guides/performance-tuning.md
+++ b/website/docs/guides/performance-tuning.md
@@ -148,7 +148,7 @@ Guidelines:
 - DSpark is an experimental, opt-in native llama.cpp external draft-model
   strategy. Use `SpeculativeDecodingConfig.draftDspark(draftModelPath: ...)`;
   it is never selected automatically, maps to upstream `draft-dspark`, requires
-  at least the `b10356-llamadart.1` wrapper fix; the package-pinned `v0.3.0`
+  at least the `b10356-llamadart.1` wrapper fix; the package-pinned `v0.4.0`
   runtime satisfies that ABI, supports speculators-format checkpoints, and
   adds LFM2 target/draft support. DSpark remains subject to
   target/draft/backend compatibility.

--- a/website/docs/guides/text-to-speech.md
+++ b/website/docs/guides/text-to-speech.md
@@ -172,13 +172,13 @@ memory-constrained mobile devices.
 - Web requires published bridge assets `v0.1.33+`, WebAssembly memory64 for the
   pinned roughly 1.48 GB model/projector pair, and a browser/device with enough
   memory. Older bridge assets fail capability discovery clearly.
-- The chat example pins `v0.1.41`, which retains the `v0.1.34` worker
+- The chat example pins `v0.1.43`, which retains the `v0.1.34` worker
   recovery. Eligible WebGPU errors and generic worker timeouts retry once on
   the main thread using cached model/projector bytes with CPU-only settings.
   The exact `worker request timeout` and `worker init timeout` errors preserve
   the original GPU offload settings on that retry. Already CPU-only models are
   not retried, and cancellation takes precedence over recovery. Other errors
-  propagate unchanged. See the [bridge recovery contract](https://github.com/leehack/llama-web-bridge/blob/646037ac816c066d3f7d9e357139ca20800dc7ee/docs/api.md#synthesizespeechoptions).
+  propagate unchanged. See the [bridge recovery contract](https://github.com/leehack/llama-web-bridge/blob/89178be67c3c84300bc1b129182bd5bc5a8e21fc/docs/api.md#synthesizespeechoptions).
   Recovery is slower and does not replace sufficient browser memory or
   validation of queue-watchdog timeouts on the target browser/device.
 - Web speaker references are selected-file bytes only; microphone speaker

--- a/website/docs/platforms/support-matrix.md
+++ b/website/docs/platforms/support-matrix.md
@@ -117,7 +117,7 @@ bundled:
 - `llama_cpp`: GGUF model support through llama.cpp.
 - `litert_lm`: `.litertlm` model support through LiteRT-LM.
 
-The `v0.3.0` native llama.cpp pin (llama.cpp `v0.3.0`) includes BailingMoE3 and
+The `v0.4.0` native llama.cpp pin retains BailingMoE3 and
 GraniteSWA/GraniteMoeSWA model loading and LFM2 target/draft support for
 DSpark speculative decoding. These architectures use the existing GGUF APIs;
 LFM2 DSpark uses `SpeculativeDecodingConfig.draftDspark(...)`. No
@@ -128,7 +128,7 @@ backend validation remains necessary before enabling DSpark in production.
 
 | Runtime path | Public video input | Current evidence |
 | --- | --- | --- |
-| Native llama.cpp / GGUF | Not consumable | The published `v0.3.0` archive exports upstream video helper symbols, but this release has not been qualified for end-to-end video input. The companion build does not opt into `LLAMA_SUBPROCESS`/`MTMD_VIDEO` or package FFmpeg/ffprobe; the public Dart path remains unsupported until matching native, packaging, and frame-lifecycle validation exists. |
+| Native llama.cpp / GGUF | Not consumable | The pinned `v0.4.0` archive exports upstream video helper symbols, but this release has not been qualified for end-to-end video input. The companion build does not opt into `LLAMA_SUBPROCESS`/`MTMD_VIDEO` or package FFmpeg/ffprobe; the public Dart path remains unsupported until matching native, packaging, and frame-lifecycle validation exists. |
 | Native LiteRT-LM | Not consumable | The public direct-media path accepts image/audio content only. |
 | WebGPU / Web LiteRT-LM | Not consumable | No validated public Dart video transport or frame-lifetime contract exists. |
 | Android / iOS | Not consumable | Explicitly unsupported pending native packaging and device validation. |

--- a/website/docs/platforms/support-matrix.md
+++ b/website/docs/platforms/support-matrix.md
@@ -8,7 +8,7 @@ backend-module configuration for
 `llamadart`.
 
 The native-assets hook currently pins `llamadart-native` tag
-`v0.3.0` and
+`v0.4.0` and
 `litert-lm-native` release `v0.16.0-native.2` (`hook/build.dart`). Apps can
 override the llama.cpp native GitHub source with
 `hooks.user_defines.llamadart.llamadart_native_tag` and
@@ -264,7 +264,7 @@ device/model bundle, use `cpu` or `gpu` for that artifact.
   a web load failure as a package bug. The [WebGPU Bridge](./webgpu-bridge)
   page has the browser-console probe and Flutter Web smoke-test path.
 
-## Current llama.cpp module availability by bundle (`v0.3.0`)
+## Current llama.cpp module availability by bundle (`v0.4.0`)
 
 | Bundle key | Available backend modules in bundle |
 | --- | --- |
@@ -312,7 +312,7 @@ hooks:
   user_defines:
     llamadart:
       # Optional. Defaults to llamadart's tested native runtime pin.
-      llamadart_native_tag: v0.3.0
+      llamadart_native_tag: v0.4.0
 
       # Optional. GitHub repository slug or github.com URL.
       llamadart_native_repository: leehack/llamadart-native

--- a/website/docs/platforms/webgpu-bridge.md
+++ b/website/docs/platforms/webgpu-bridge.md
@@ -146,13 +146,13 @@ development validation, and CDN-first loading for normal hosted deployments:
 1. On localhost: local asset first, then CDN fallback.
 2. On hosted deployments: CDN asset first, then local fallback.
 
-The example currently pins bridge assets to `v0.1.41`, with local vendored assets
-identified as `v0.1.41-local-v0.3.0`.
+The example currently pins bridge assets to `v0.1.43`, with local vendored assets
+identified as `v0.1.43-local-v0.4.0`.
 
 Fetch pinned local assets with:
 
 ```bash
-WEBGPU_BRIDGE_ASSETS_TAG=v0.1.41 ./scripts/fetch_webgpu_bridge_assets.sh
+WEBGPU_BRIDGE_ASSETS_TAG=v0.1.43 ./scripts/fetch_webgpu_bridge_assets.sh
 ```
 
 To verify the loaded runtime in a browser console, inspect:
@@ -201,13 +201,13 @@ cannot report success before the bridge exposes `prefetchModelToCache(...)`.
   physical playback, intelligibility, or speaker-reference fidelity. wasm32 TTS
   remains unsupported; use memory64.
 - `v0.1.39+` remains the compatibility floor for bridge asset capabilities.
-- The pinned `v0.1.41` bridge assets embed llama.cpp `v0.3.0`, matching the native runtime
-  (`v0.3.0`, both built from upstream `v0.3.0@c1d0e7a004015f23bc0233470b747b596f29b264`)
-  even though the bridge asset tag `v0.1.41` differs from the native runtime tag
-  `v0.3.0`. Pinned artifact provenance: release `381873266`, tag commit
-  `dca41da58a689697f3b532f09da5aa1672e24e93`, bridge source
-  `646037ac816c066d3f7d9e357139ca20800dc7ee`, manifest SHA-256
-  `fe97604daabaad6aefa223a8637d5fd9dcac09dd4a61b2ef19cd6aabb39392b9`. The
+- The pinned `v0.1.43` bridge assets embed llama.cpp `v0.4.0`, matching the native runtime
+  (`v0.4.0`, both built from upstream `v0.4.0@5266f24da75dc449bd56cbed7addb9c8e4a6a73e`)
+  even though the bridge asset tag `v0.1.43` differs from the native runtime tag
+  `v0.4.0`. Pinned artifact provenance: release `384042112`, tag commit
+  `78be0c8c628cd8cbc6a1268b1a9758c3d6d052a6`, bridge source
+  `89178be67c3c84300bc1b129182bd5bc5a8e21fc`, manifest SHA-256
+  `111eefc3588842cebfe665b363378edca34924764610263e1eda5280dfcfaa27`. The
   bridge assets provision an explicit 1 MiB stack for both wasm32 and memory64,
   preventing graph-parameter growth from overflowing Emscripten's 64 KiB
   default during memory64 Qwen3-ASR context construction.
@@ -341,7 +341,7 @@ You can override bridge asset source/version before loader startup:
 ```html
 <script>
   window.__llamadartBridgeAssetsRepo = 'leehack/llama-web-bridge-assets';
-  window.__llamadartBridgeAssetsTag = 'v0.1.41';
+  window.__llamadartBridgeAssetsTag = 'v0.1.43';
   // Custom assets stay speech-disabled unless the host has validated them:
   // window.__llamadartBridgeSpeechToTextSupported = true;
   // Prefer local runtime even off localhost:


### PR DESCRIPTION
## Summary
Adopt matching native and Web llama.cpp v0.4.0 runtimes, with regenerated native bindings, MTMD ABI updates, session migration tests, and Apple companion 0.0.18 preparation.

Closes #479 (pre-existing Markdown writer-audit contamination by installed website dependencies; narrowly fixed as a validation prerequisite).

## Production-readiness scope
- Native v0.4.0: published header/manifest/inventory/checksum validation, regenerated FFI model lazy-mode/quantization fields and MTMD options, matching primary and split-library file/buffer calls.
- Web assets v0.1.43: immutable release 384042112; tag commit `78be0c8c628cd8cbc6a1268b1a9758c3d6d052a6`; source `89178be67c3c84300bc1b129182bd5bc5a8e21fc`; upstream `v0.4.0@5266f24da75dc449bd56cbed7addb9c8e4a6a73e`.
- Exact manifest SHA-256 `111eefc3588842cebfe665b363378edca34924764610263e1eda5280dfcfaa27`; native manifest SHA-256 `6187e6483eb03c86d79bb774e01ece71b201cb00561550bbc948b20d237b5cdc`.
- Apple companion 0.0.18 metadata/SwiftPM pairing prepared; package NOT published. It requires the matching next core release with v0.4.0 FFI and must not publish alone. Current published core0.8.22 users must retain companion0.0.17; development snippets override both packages to the same checkout. Core version remains 0.8.22; this is not a core release-prep PR.
- Old native sessions (version 9) must be regenerated; version 10 save/load and old-version rejection followed by valid reload are tested.
- Web/native parity gates remain enforced. Frozen release notes preserved; only current Unreleased notes and maintained snippets updated.
- LiteRT native/Web pins, public video support, GPU qualification, and new lazy-loading APIs unchanged/out of scope.

## Publication prerequisite completed with user authorization
The failed automatic Web scan 34104915793 was retried, completed successfully, and dispatched publication 34117166273. That publication completed SUCCESS and produced immutable v0.1.43 using already-successful candidate 34100775215 and qualification 34102054173. The previous failure was a GitHub API timeout before credential exposure. No safeguards were bypassed or environment settings changed.

## Validation
- Targeted Web parity/provenance + companion metadata: 75/75 PASS. The five initial draft failures are fixed without relaxing those gates.
- Live `check_webgpu_bridge_tag.dart --verify-manifest`: PASS, including 17 consumer pins, v0.4.0 family parity, exact provenance and manifest bytes.
- Maintained Web fetch: PASS; seven artifact checksums verified.
- Consumer `chat-app-web-real-model-smoke`: PASS on local Chromium CPU/WASM worker with stories15M, pinned v0.1.43 staged in the deployable build; model load and nonempty generation, no page errors/request failures.
- Native ABI/state/inference: 25/25 PASS; strengthened symbol/call-site suite 16/16 PASS.
- Real Qwen3.5-0.8B Q4_K_M + F16 projector, macOS arm64 Metal: four tool-call variants PASS; public image file + bytes PASS. CPU stories15M baseline/external-draft output hashes match `2eed00e8`; pipeline evidence, not a speedup claim.
- Root analyzer, canonical formatting, final docs build/strict links, release-doc version verifier including --release-prep: PASS.
- Full VM after coordinated changes and #479 correction: **1,985 PASS / 77 fixture skips**, with website dependencies installed. The initial #479 failure is superseded by this passing rerun.
- Final-head Chrome: 925/925 PASS; exact-head hosted Chrome also SUCCESS.
- NVIDIA and older non-SVE Android physical devices unavailable; no passes claimed. No new Pixel test or physical playback/intelligibility claim in this PR.

## High-risk regression review
- Classification: high risk, artifact consumer/FFI/runtime routing.
- Exact head `451518d20590b9f75e95d7957649e856a082f802`; base `3ad853d286689046dec659938cdbb082b97ce00b`.
- Independent Astra `native_v040_independent_qa`: **PASS on exact final head**. Prior package-pairing finding corrected with explicit unreleased warning, safe published pairing, and mandatory same-checkout overrides. No remaining blocker in the independent bounded review; final hosted CI still required.
- Production deletion/bypass proof: individually scoped assertions for all four MTMD primary/fallback file/buffer calls and same-library defaults, real helper and public file/byte path tests, old-session negative+recovery test.
- #479 affects the test's filesystem ownership inventory, not runtime or publication authority. Maintained source/docs/versioned-doc checks remain; installed/generated dependency Markdown and symlink traversal are excluded with regressions.
- Known PR-caused P1 regressions: 0 known after the corrected full VM suite and independent Astra QA. Final live review threads: 0 total / 0 unresolved; refresh again before merge.
- Hosted CI: 15/15 populated exact-head checks SUCCESS, including [CI run 34118433659](https://github.com/leehack/llamadart/actions/runs/34118433659). GitHub reports CLEAN / MERGEABLE. Independent Astra QA PASS on the exact head. Remains DRAFT awaiting the separate merge decision. No merge or Dart package publication authorized/performed.
