### PR TITLE
fix(docs): expose published version navigation

### DIFF
--- a/website/docs/maintainers/docs-site.md
+++ b/website/docs/maintainers/docs-site.md
@@ -72,3 +72,7 @@ release-related merges.
 - Latest stable user-facing docs stay indexable, `/docs/next` plus archived
   versions are `noIndex`, and maintainer pages are listed under Help &
   Reference for contributors.
+- The navbar version dropdown switches between the current development docs
+  and every published version in `website/versions.json`. After a docs cut,
+  verify it opens the matching latest and archived installation pages without
+  changing their package pins or the latest-stable default route.

--- a/website/docusaurus.config.ts
+++ b/website/docusaurus.config.ts
@@ -154,6 +154,10 @@ const config: Config = {
       },
       items: [
         {
+          type: 'docsVersionDropdown',
+          position: 'left'
+        },
+        {
           type: 'docSidebar',
           sidebarId: 'docsSidebar',
           position: 'left',

--- a/website/test/docs_version_navigation.test.mjs
+++ b/website/test/docs_version_navigation.test.mjs
@@ -1,0 +1,26 @@
+import assert from 'node:assert/strict';
+import {readFileSync} from 'node:fs';
+import {fileURLToPath} from 'node:url';
+import test from 'node:test';
+import {loadSiteConfig} from '@docusaurus/core/lib/server/config.js';
+
+test('version navigation preserves all versions and the stable indexing policy', async () => {
+  const siteDir = fileURLToPath(new URL('..', import.meta.url));
+  const {siteConfig} = await loadSiteConfig({siteDir});
+  const selectors = siteConfig.themeConfig.navbar.items.filter(
+    (item) => item.type === 'docsVersionDropdown',
+  );
+  assert.equal(selectors.length, 1);
+  assert.equal(selectors[0].dropdownItemsBefore, undefined);
+  assert.equal(selectors[0].dropdownItemsAfter, undefined);
+  const [, options] = siteConfig.presets.find(([preset]) => preset === 'classic');
+  assert.equal(options.docs.lastVersion, undefined);
+  assert.equal(options.docs.onlyIncludeVersions, undefined);
+  const versions = JSON.parse(readFileSync(new URL('../versions.json', import.meta.url), 'utf8'));
+  assert.ok(versions.length > 1);
+  assert.notEqual(options.docs.versions[versions[0]]?.noIndex, true);
+  assert.equal(options.docs.versions.current.noIndex, true);
+  for (const version of versions.slice(1)) {
+    assert.equal(options.docs.versions[version].noIndex, true);
+  }
+});


### PR DESCRIPTION
## Summary

Closes #477.

Expose Docusaurus's standard docs version dropdown in the navbar. It includes development and published versions and preserves the current page across version selection where available. Document the matching release check and add a config-level regression test for one selector, full version inclusion and existing indexing policy.

Runtime behavior, package/runtime pins and historical versioned content are unchanged. Latest stable remains the default route; archived and development docs remain noindex.

## Validation

- Node20 clean npm ci, website tests 7/7, production Docusaurus build PASS.
- Generated installation pages for latest stable, archived 0.8.21 and next contain the dropdown with correct same-document cross-version links. Latest is indexable; archived/next retain noindex.
- git diff --check PASS.
- Independent Astra QA PASS on exact head `bda88a935f2b120569c91e784392cc401aff39c6`; independently inspected all 43 generated installation pages and their routing/indexing policy. Browser interaction was not separately exercised; standard component and rendered links were verified. Exact-head hosted CI pending; draft until all gates settle.

No release, publication, settings change or manual deployment.
