### PR TITLE
chore: prepare 0.8.23 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,8 +16,8 @@
   Web `@litert-lm/core@0.15.0` and native LiteRT pins are unchanged. Immutable
   manifest: `111eefc3588842cebfe665b363378edca34924764610263e1eda5280dfcfaa27`.
 
-* Known upstream limitation: llama.cpp v0.4.0 rejects grammars at the 2,000-rule
-  expansion boundary, such as `root ::= "a"{2000}`. The post-v0.4.0 upstream
+* Known upstream limitation: llama.cpp v0.4.0 can reject large grammar
+  repetitions, such as `root ::= "a"{2000}`. The post-v0.4.0 upstream
   correction is tracked in `llamadart-native#76` and is not part of this release.
 
 ## 0.8.22

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,16 +1,20 @@
-## Unreleased
+## 0.8.23
 
 * Updated the default llama.cpp native runtime pin to
   `leehack/llamadart-native@v0.4.0`, regenerated matching Dart FFI bindings, refreshed
   the `llamadart_llama_cpp_flutter` Apple SwiftPM checksum, and
   aligned current README/website native override docs. Updated multimodal calls
   for the matching ABI. Saved native sessions from older runtimes must be
-  regenerated. Prepared Apple companion `0.0.18` for the matching native runtime.
+  regenerated. Apple companion `0.0.18` supplies the matching native runtime.
 
 * Aligned the default WebGPU bridge assets to `v0.1.43` for Web/native
   llama.cpp `v0.4.0@5266f24da75dc449bd56cbed7addb9c8e4a6a73e` parity.
   Web `@litert-lm/core@0.15.0` and native LiteRT pins are unchanged. Immutable
   manifest: `111eefc3588842cebfe665b363378edca34924764610263e1eda5280dfcfaa27`.
+
+* Known upstream limitation: llama.cpp v0.4.0 rejects grammars at the 2,000-rule
+  expansion boundary, such as `root ::= "a"{2000}`. The post-v0.4.0 upstream
+  correction is tracked in `llamadart-native#76` and is not part of this release.
 
 ## 0.8.22
 

--- a/README.md
+++ b/README.md
@@ -55,30 +55,20 @@ For Dart or Flutter apps:
 
 ```yaml
 dependencies:
-  llamadart: ^0.8.22
+  llamadart: ^0.8.23
 ```
 
 Flutter iOS/macOS apps that should link Apple XCFrameworks through Swift
 Package Manager should also add the runtime companion packages they need:
 
-**Unreleased coordinated upgrade:** companion `0.0.18` requires the matching
-llama.cpp v0.4.0 core bindings; it is not compatible with published core
-`0.8.22`. For published packages, keep core `0.8.22` with companion `0.0.17`.
-The development example below requires both path overrides to the same checkout.
-Publish companion `0.0.18` only with the matching next core release, and replace
-these temporary overrides/version constraints during that coordinated release.
+Pair companion `0.0.18` with core `0.8.23` for matching llama.cpp v0.4.0
+bindings. Keep core `0.8.22` paired with companion `0.0.17`.
 
 ```yaml
 dependencies:
-  llamadart: ^0.8.22
+  llamadart: ^0.8.23
   llamadart_llama_cpp_flutter: ^0.0.18 # GGUF / llama.cpp
   llamadart_litert_lm_flutter: ^0.0.10 # Apple .litertlm / LiteRT-LM targets
-
-dependency_overrides:
-  llamadart:
-    path: /path/to/llamadart
-  llamadart_llama_cpp_flutter:
-    path: /path/to/llamadart/packages/llamadart_llama_cpp_flutter
 ```
 
 The LiteRT-LM companion manifest includes the complete iOS SwiftPM runtime

--- a/example/chat_app/pubspec.lock
+++ b/example/chat_app/pubspec.lock
@@ -413,7 +413,7 @@ packages:
       path: "../.."
       relative: true
     source: path
-    version: "0.8.22"
+    version: "0.8.23"
   llamadart_litert_lm_flutter:
     dependency: "direct main"
     description:

--- a/packages/llamadart_litert_lm_flutter/README.md
+++ b/packages/llamadart_litert_lm_flutter/README.md
@@ -15,7 +15,7 @@ also request an x86_64 Simulator slice must exclude x86_64 for LiteRT-LM builds.
 
 ```yaml
 dependencies:
-  llamadart: ^0.8.22
+  llamadart: ^0.8.23
   llamadart_litert_lm_flutter: ^0.0.10
 ```
 

--- a/packages/llamadart_llama_cpp_flutter/README.md
+++ b/packages/llamadart_llama_cpp_flutter/README.md
@@ -7,23 +7,13 @@ Add this package to a Flutter iOS/macOS app when the app should link the
 prebuilt llama.cpp Apple XCFramework through SwiftPM instead of relying on the
 core package's native-assets fallback.
 
-**Unreleased coordinated upgrade:** companion `0.0.18` requires the matching
-llama.cpp v0.4.0 core bindings; it is not compatible with published core
-`0.8.22`. For published packages, keep core `0.8.22` with companion `0.0.17`.
-The development example below requires both path overrides to the same checkout.
-Publish companion `0.0.18` only with the matching next core release, and replace
-these temporary overrides/version constraints during that coordinated release.
+Pair companion `0.0.18` with core `0.8.23` for matching llama.cpp v0.4.0
+bindings. Keep core `0.8.22` paired with companion `0.0.17`.
 
 ```yaml
 dependencies:
-  llamadart: ^0.8.22
+  llamadart: ^0.8.23
   llamadart_llama_cpp_flutter: ^0.0.18
-
-dependency_overrides:
-  llamadart:
-    path: /path/to/llamadart
-  llamadart_llama_cpp_flutter:
-    path: /path/to/llamadart/packages/llamadart_llama_cpp_flutter
 ```
 
 This package has no runtime Dart API of its own. Import `package:llamadart`

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: llamadart
 description: Dart and Flutter local LLM inference with llama.cpp GGUF and LiteRT-LM across native platforms and web.
-version: 0.8.22
+version: 0.8.23
 homepage: https://github.com/leehack/llamadart
 repository: https://github.com/leehack/llamadart
 issue_tracker: https://github.com/leehack/llamadart/issues

--- a/website/docs/changelog/recent-releases.md
+++ b/website/docs/changelog/recent-releases.md
@@ -7,16 +7,21 @@ For canonical full release notes, use:
 
 - [`CHANGELOG.md`](https://github.com/leehack/llamadart/blob/main/CHANGELOG.md)
 
-## Unreleased
+## 0.8.23
 
 - Adopted native llama.cpp v0.4.0 with matching bindings and multimodal calls.
-  Saved native sessions from older runtimes must be regenerated. Prepared Apple
-  companion `0.0.18` for the matching native runtime.
+  Saved native sessions from older runtimes must be regenerated. Apple companion
+  `0.0.18` supplies the matching native runtime.
 
 - Aligned default WebGPU bridge assets to `v0.1.43` for Web/native
   llama.cpp `v0.4.0@5266f24da75dc449bd56cbed7addb9c8e4a6a73e` parity.
   Web `@litert-lm/core@0.15.0` and native LiteRT pins are unchanged. Immutable
   manifest: `111eefc3588842cebfe665b363378edca34924764610263e1eda5280dfcfaa27`.
+
+- Known upstream limitation: llama.cpp v0.4.0 rejects grammars at the 2,000-rule
+  expansion boundary, such as `root ::= "a"{2000}`. The post-v0.4.0 correction is
+  tracked in [native #76](https://github.com/leehack/llamadart-native/issues/76)
+  and is not included in this release.
 
 ## 0.8.22
 

--- a/website/docs/changelog/recent-releases.md
+++ b/website/docs/changelog/recent-releases.md
@@ -22,8 +22,8 @@ For canonical full release notes, use:
   Web `@litert-lm/core@0.15.0` and native LiteRT pins are unchanged. Immutable
   manifest: `111eefc3588842cebfe665b363378edca34924764610263e1eda5280dfcfaa27`.
 
-- Known upstream limitation: llama.cpp v0.4.0 rejects grammars at the 2,000-rule
-  expansion boundary, such as `root ::= "a"{2000}`. The post-v0.4.0 correction is
+- Known upstream limitation: llama.cpp v0.4.0 can reject large grammar
+  repetitions, such as `root ::= "a"{2000}`. The post-v0.4.0 correction is
   tracked in [native #76](https://github.com/leehack/llamadart-native/issues/76)
   and is not included in this release.
 

--- a/website/docs/getting-started/installation.md
+++ b/website/docs/getting-started/installation.md
@@ -27,30 +27,20 @@ In Xcode, set `IPHONEOS_DEPLOYMENT_TARGET = 16.4` or
 
 ```yaml
 dependencies:
-  llamadart: ^0.8.22
+  llamadart: ^0.8.23
 ```
 
 For Flutter iOS/macOS apps that should link Apple XCFrameworks through Swift
 Package Manager, also add the runtime companion packages you need:
 
-**Unreleased coordinated upgrade:** companion `0.0.18` requires the matching
-llama.cpp v0.4.0 core bindings; it is not compatible with published core
-`0.8.22`. For published packages, keep core `0.8.22` with companion `0.0.17`.
-The development example below requires both path overrides to the same checkout.
-Publish companion `0.0.18` only with the matching next core release, and replace
-these temporary overrides/version constraints during that coordinated release.
+Pair companion `0.0.18` with core `0.8.23` for matching llama.cpp v0.4.0
+bindings. Keep core `0.8.22` paired with companion `0.0.17`.
 
 ```yaml
 dependencies:
-  llamadart: ^0.8.22
+  llamadart: ^0.8.23
   llamadart_llama_cpp_flutter: ^0.0.18 # GGUF / llama.cpp
   llamadart_litert_lm_flutter: ^0.0.10 # Apple .litertlm / LiteRT-LM targets
-
-dependency_overrides:
-  llamadart:
-    path: /path/to/llamadart
-  llamadart_llama_cpp_flutter:
-    path: /path/to/llamadart/packages/llamadart_llama_cpp_flutter
 ```
 
 The companion packages are published independently from the `packages/`


### PR DESCRIPTION
## Summary
Refreshed at `041e35b6ffc7dbe7dcc4a7722c3043044f1c2ffb` against `dee010e24f95a50f71830116087af6db3c6c7640`: merged #486 is integrated normally, with exact-head CAS protection and no force-push. The eight-file release diff and all runtime pins remain unchanged. Fresh independent Astra review, all local gates and all 15 exact-head hosted checks pass. Draft remains held only for explicit release approval.

Prerequisite [corrective PR #484](https://github.com/leehack/llamadart/pull/484) merged at `ccc2d35633e3ca6347a697f19fde4944e0a8dbd0`, closing [P1 #483](https://github.com/leehack/llamadart/issues/483), and is integrated here by a normal merge without force-push.

**Apple upgrade behavior:** existing app constraints `llamadart: ^0.8.22` with Apple companion `^0.0.17` can still resolve the new core patch while excluding companion `0.0.18`. The merged hook now verifies the actual resolved companion and maintained SwiftPM runtime manifest before symbol lookup. That mismatched pair fails the build with actionable upgrade guidance; it cannot silently link the old v0.3.0 framework to v0.4.0 bindings. Consumers must update the companion constraint to `^0.0.18` alongside core `^0.8.23`. The guard does not rewrite app constraints.

- Prepare core `0.8.23` with already-integrated native `v0.4.0` and Web assets `v0.1.43`; no runtime pin, binding, or implementation changes in this PR.
- Coordinate already-prepared Apple companion `0.0.18`, retain LiteRT companion `0.0.10`, and replace temporary development overrides with compatible package installation snippets.
- Move Unreleased notes into `0.8.23` and disclose the known upstream grammar boundary limitation.

## Production-readiness scope
This is a draft release-prep PR, not a publication action. **Merging this versioned release-prep branch authorizes automatic companion-first publication and the core release**, so it must not merge until the maintainer explicitly approves release.

| Component | Prepared version / unchanged source pin |
| --- | --- |
| Core | `0.8.23` |
| llama.cpp native and Apple SwiftPM | `llamadart-native@v0.4.0`, upstream `5266f24da75dc449bd56cbed7addb9c8e4a6a73e` |
| Apple llama.cpp companion | `0.0.18`, already prepared on main |
| Web assets | `v0.1.43`, manifest `111eefc3588842cebfe665b363378edca34924764610263e1eda5280dfcfaa27` |
| LiteRT native / companion | `v0.16.0-native.2` / `0.0.10`, unchanged |
| LiteRT Web | `@litert-lm/core@0.15.0`, unchanged |

The root-path chat example lock was regenerated by canonical pub resolution and changes only the core package version. Historical release docs are untouched. Core `0.8.22` must remain paired with Apple companion `0.0.17`; the new pair is core `0.8.23` + companion `0.0.18`.

## Known limitations and independent follow-ups
- [Native #76](https://github.com/leehack/llamadart-native/issues/76): published v0.4.0 rejects `root ::= "a"{2000}` at grammar sampler initialization; `{1999}` succeeds. The raw upstream fix is independent qualification work and is not included or mislabeled as a wrapper rebuild here.
- Older Android and NVIDIA/CUDA device coverage is explicitly unavailable and waived by the maintainer, not PASS.
- Existing unpatched image-size advisories remain tracked under [#454](https://github.com/leehack/llamadart/issues/454), with the existing documentation image guard unchanged. This PR does not claim a completely clean dependency audit.
- Modern Pixel 9 Pro / Android 17 / Tensor G4 full and compact CPU qualification PASS on published v0.4.0, seven measured 32-token generations each with stories15M. Native archive SHA-256 `756f4d3c4d020e2de4e26b029ebe9aad26073b4f14c425ce76d10e1c6922a73f`; full selected `android_armv9.0_1`, compact `android_armv8.0_1`. Device source `f43ada361ccde89ca1d2a0b57c10db87691b5a91` predates the Apple-only prebuild guard and release/docs changes; native artifact and generation code are unchanged. A disclosed six-line logging overlay identified the selected module without changing selection/inference; it was removed, and the original installed APK was restored without clearing user data. Independent Astra artifact/log/restoration audit passed. Durable evidence: `/private/tmp/llamadart-pixel-0907/handoff.md` and `independent-astra-audit.md`.
- Pixel's first full attempt was anomalously slow (median 9,351 ms) but completed. Two payload-identical full repeats returned normal medians 179/194 ms, alongside compact 175 ms. Cause remains unknown; the original observation is preserved and not called a proven regression or performance guarantee. This bounded modern CPU smoke does not establish full Android device-pool coverage.

## Validation
- PASS: latest prerequisite #486 exact-main CI [34163165448](https://github.com/leehack/llamadart/actions/runs/34163165448), including coverage aggregate; earlier Apple guard #484 post-merge CI/LiteRT smoke/HF deployment also passed.
- PASS: canonical Flutter `3.47.1` / Dart `3.13.1` workspace preparation, whole-workspace format and analysis.
- PASS: strict `verify_release_docs_versions.dart --release-prep` (core `0.8.23`, Apple `0.0.18`, LiteRT `0.0.10`, native `v0.4.0`).
- PASS: release-tier matrix inventory; Node 20 dependency installation, 7/7 website tests, production docs build and strict link validation.
- PASS on current integrated source: full serial VM 2,046 tests / 77 fixture-dependent skips; full Chrome 925/925; explicit release-doc companion-pin suite 24/24. No Dart or runtime production code changed in this release-prep diff.
- PASS: core `dart pub publish --dry-run`, 0 warnings, no publication.
- Expected publication ordering: pub.dev Apple `0.0.18` currently returns 404; LiteRT companion `0.0.10` returns 200. The existing post-merge workflow must publish Apple `0.0.18` before tagging the core; no publication was performed for this draft.
- Initial artifact download encountered HTTP 504; the exact published v0.4.0 macOS arm64 archive already verified in adoption was reused (SHA-256 `95e76865fb444f3187da47398cfab03a0af3ad46da6a9026e1d490401401355a`), without changing defaults or setting a local runtime override.

## Review gates
- High-risk classifier: `high-risk / artifactConsumer` (package/release metadata); release and high-risk matrix rows were inventoried. Production runtime/consumer implementation is unchanged; branch-deletion testing is N/A to this version/docs-only diff. Existing release-doc companion-pin regressions passed within the full VM suite.
- Exact head: `041e35b6ffc7dbe7dcc4a7722c3043044f1c2ffb`; current base `dee010e24f95a50f71830116087af6db3c6c7640`.
- Fresh independent Astra review PASS on exact head: identical eight-file release scope, unchanged merged guard/evaluator/workflows/pins, strict versions, publication ordering and current local command logs independently checked. Replacement CI [34163274481](https://github.com/leehack/llamadart/actions/runs/34163274481) SUCCESS; all 15 populated checks SUCCESS including coverage aggregate, LiteRT smokes, preview and non-required advisory. CLEAN/MERGEABLE; zero review threads. No GitHub automated review is present; independent Astra is separate evidence.
- The previously identified release-exposed Apple ABI blocker is corrected in merged #484 with positive/negative real-hook coverage and independent Astra review. Fresh integrated Astra review found zero known PR-caused P1 regressions. Existing upstream defects above are separately disclosed, not called fixed. The draft remains held for explicit release approval.
- [#485](https://github.com/leehack/llamadart/issues/485) is closed by merged #486. Fresh current-head evidence now satisfies the exact-Git-derived metadata-only route using the unchanged existing verifier/test honestly, without fabricated changed tests. The evaluator returns expected `unverifiedPrerequisites` / `externalPrerequisitesUnavailable` / exit 2: repository-local evidence is internally consistent, not authenticated operational attestation. As documented in `doc/high_risk_pre_merge_readiness.md`, external App/auditor/environment/ruleset enforcement is intentionally unconfigured and is **not a pending merge requirement**. Current readiness uses manual repository-local review and evidence. Adopting external enforcement would require a separately approved governance project; this release does not request or configure it.
- No merge, tag, release, workflow dispatch, publication, settings, or pin mutation occurred.
