### PR TITLE
test: preserve iOS ASR failure phase diagnostics

### DIFF
--- a/example/chat_app/integration_test/physical_ios_speech_e2e_test.dart
+++ b/example/chat_app/integration_test/physical_ios_speech_e2e_test.dart
@@ -17,6 +17,10 @@
 /// every path, digest, transcript, preset, and duration as a `--dart-define`.
 /// The optional `IOS_SPEECH_ROW` define selects one canonical row for a
 /// missing-row rerun; omit it or use `all` for the complete strict matrix.
+/// Failed Qwen3-ASR `RESULT` records include a content-free `phase` and short
+/// identifiers for validated artifact digests. Cleanup-only errors report
+/// `teardown`; cleanup never replaces a primary operation's failure phase.
+/// Error text remains fingerprinted, not a transcript or local file path.
 ///
 /// Each path define is either a safe absolute on-device path or an
 /// `@appcache/<relative>` reference. Installing onto a physical device rotates
@@ -219,20 +223,39 @@ void _emitAndValidateResults(
 void _recordPreflightFailure(
   List<SpeechE2ERowResult> results,
   Object error,
-  Iterable<String> rowIds,
-) {
+  Iterable<String> rowIds, {
+  PhysicalIosSpeechConfig? config,
+}) {
   for (final id in rowIds) {
+    final isQwen3Asr = id == 'llama_cpp_qwen3_asr';
     results.add(
       SpeechE2ERowResult(
         id: id,
         status: SpeechE2ERowStatus.fail,
         backend: unresolvedSpeechBackendForRow(id),
         duration: Duration.zero,
+        digestIdentifiers: isQwen3Asr && config != null
+            ? Qwen3AsrDiagnostics(
+                _qwen3AsrDigestIdentifiers(config),
+              ).digestIdentifiers
+            : const <String, String>{},
+        assertionSummary: isQwen3Asr
+            ? 'Failed during setup: ${safeSpeechErrorDiagnostic(error)}'
+            : '',
+        phase: isQwen3Asr ? PhysicalIosQwen3AsrPhase.setup : null,
         error: error,
       ),
     );
   }
 }
+
+Map<String, String> _qwen3AsrDigestIdentifiers(
+  PhysicalIosSpeechConfig config,
+) => <String, String>{
+  'model': config.qwen3AsrModelSha256,
+  'mmproj': config.qwen3AsrMmprojSha256,
+  'fixture': config.asrAudioSha256,
+};
 
 /// Loads a Qwen3 model plus its projector on explicit llama.cpp CPU.
 Future<LlamaEngine> _loadCpuEngine(
@@ -287,6 +310,7 @@ Future<String> _transcribeExact({
   required String audioPath,
   required String expectedTranscript,
   required String label,
+  void Function()? markCleanupPhase,
 }) async {
   final task = await awaitBounded(
     recognizer.transcribe(
@@ -347,6 +371,7 @@ Future<String> _transcribeExact({
       eventsClosed: eventsFuture,
       label: label,
     ),
+    markCleanupPhase: markCleanupPhase,
   );
   return fingerprint!;
 }
@@ -373,33 +398,6 @@ Future<void> _pushBoundedPcm(
       '$label.addPcm[$index]',
     );
     index++;
-  }
-}
-
-/// Runs one row, always recording a result and never aborting the harness.
-Future<void> _recordRow({
-  required String id,
-  required List<SpeechE2ERowResult> results,
-  required Future<SpeechE2ERowResult> Function(Stopwatch elapsed) body,
-}) async {
-  final stopwatch = Stopwatch()..start();
-  try {
-    final result = await body(stopwatch);
-    if (result.id != id) {
-      throw StateError('Speech row body returned a mismatched row id.');
-    }
-    results.add(result);
-  } catch (error) {
-    results.add(
-      SpeechE2ERowResult(
-        id: id,
-        status: classifySpeechRowFailure(error),
-        backend: unresolvedSpeechBackendForRow(id),
-        duration: stopwatch.elapsed,
-        error: error,
-        actionMarker: speechRowFailureMarker(error),
-      ),
-    );
   }
 }
 
@@ -432,22 +430,33 @@ void main() {
       return;
     }
 
+    PhysicalIosSpeechConfig? resolvedConfig;
     late final PhysicalIosSpeechConfig config;
     late final Map<String, PhysicalIosSpeechArtifactFailure> artifactFailures;
     try {
       // Resolution must precede every artifact read: a device install mints a
       // fresh data-container UUID, so `@appcache/` defines only name a real
       // file once bound to the runtime cache directory.
-      config = await canonicalizePhysicalIosSpeechFilesystemLayout(
-        await resolvePhysicalIosSpeechCachePaths(
-          PhysicalIosSpeechConfig.fromEnvironment(),
-        ),
+      final environmentConfig = PhysicalIosSpeechConfig.fromEnvironment();
+      resolvedConfig = environmentConfig;
+      final cacheResolvedConfig = await resolvePhysicalIosSpeechCachePaths(
+        environmentConfig,
       );
+      resolvedConfig = cacheResolvedConfig;
+      config = await canonicalizePhysicalIosSpeechFilesystemLayout(
+        cacheResolvedConfig,
+      );
+      resolvedConfig = config;
       artifactFailures = await config.validateArtifactsCollectingFailures(
         timeoutPerArtifact: _artifactHashTimeout,
       );
     } catch (error) {
-      _recordPreflightFailure(rowResults, error, selectedRowIds);
+      _recordPreflightFailure(
+        rowResults,
+        error,
+        selectedRowIds,
+        config: resolvedConfig,
+      );
       _emitAndValidateResults(rowResults, expectedIds: expectedRowIds);
       return;
     }
@@ -456,9 +465,15 @@ void main() {
     // ROW 1: llama.cpp Qwen3-ASR
     // =====================================================================
     if (selectedRowIds.contains('llama_cpp_qwen3_asr')) {
-      await _recordRow(
+      final diagnostics = Qwen3AsrDiagnostics(
+        _qwen3AsrDigestIdentifiers(config),
+      );
+      void setPhase(PhysicalIosQwen3AsrPhase phase) =>
+          diagnostics.phase = phase;
+      await recordSpeechRow(
         id: 'llama_cpp_qwen3_asr',
         results: rowResults,
+        diagnostics: diagnostics,
         body: (elapsed) async {
           requireValidSpeechArtifacts(artifactFailures, _row1ArtifactLabels);
           String? backendName;
@@ -517,13 +532,17 @@ void main() {
                 SpeechE2EBackendKind.llamaCppCpu,
               );
 
+              setPhase(PhysicalIosQwen3AsrPhase.fileTranscript);
               await _transcribeExact(
                 recognizer: recognizer,
                 audioPath: config.asrAudioPath,
                 expectedTranscript: config.asrExpectedTranscript,
                 label: 'row1.fixture',
+                markCleanupPhase: () =>
+                    setPhase(PhysicalIosQwen3AsrPhase.teardown),
               );
 
+              setPhase(PhysicalIosQwen3AsrPhase.cancellation);
               final cancelTask = await awaitBounded(
                 recognizer.transcribe(
                   SpeechToTextRequest(
@@ -572,10 +591,13 @@ void main() {
                   eventsClosed: cancelEventsFuture,
                   label: 'row1.cancel',
                 ),
+                markCleanupPhase: () =>
+                    setPhase(PhysicalIosQwen3AsrPhase.teardown),
               );
 
               // Physical microphone capture. The recorder is created outside the
               // capture try so a failing start() or stop() still disposes it.
+              setPhase(PhysicalIosQwen3AsrPhase.microphoneStart);
               final recorder = AudioRecordingService();
               String? micWavPath;
               await runWithSpeechCleanup(
@@ -591,6 +613,7 @@ void main() {
                     _cleanupTimeout,
                     'row1.mic.start',
                   );
+                  setPhase(PhysicalIosQwen3AsrPhase.microphoneCapture);
                   await Future<void>.delayed(
                     Duration(seconds: config.micDurationSeconds),
                   );
@@ -623,20 +646,27 @@ void main() {
                   expect(micInfo.sampleFrames, greaterThan(0));
                   expect(micInfo.durationSeconds, greaterThan(0.0));
 
+                  setPhase(PhysicalIosQwen3AsrPhase.microphoneTranscript);
                   await _transcribeExact(
                     recognizer: recognizer,
                     audioPath: capturedPath,
                     expectedTranscript: config.micExpectedTranscript,
                     label: 'row1.microphone',
+                    markCleanupPhase: () =>
+                        setPhase(PhysicalIosQwen3AsrPhase.teardown),
                   );
                 },
                 cleanup: () => _cleanupRecorder(recorder, micWavPath),
+                markCleanupPhase: () =>
+                    setPhase(PhysicalIosQwen3AsrPhase.teardown),
               );
             },
             cleanup: () => _disposeEngine(engine, 'row1.engine'),
+            markCleanupPhase: () => setPhase(PhysicalIosQwen3AsrPhase.teardown),
           );
 
           // Fresh engine over the same immutable paths proves unload/reload.
+          setPhase(PhysicalIosQwen3AsrPhase.reload);
           final reloadEngine = await _loadCpuEngine(
             config.qwen3AsrModelPath,
             config.qwen3AsrMmprojPath,
@@ -651,8 +681,11 @@ void main() {
               audioPath: config.asrAudioPath,
               expectedTranscript: config.asrExpectedTranscript,
               label: 'row1.reload.fixture',
+              markCleanupPhase: () =>
+                  setPhase(PhysicalIosQwen3AsrPhase.teardown),
             ),
             cleanup: () => _disposeEngine(reloadEngine, 'row1.reload'),
+            markCleanupPhase: () => setPhase(PhysicalIosQwen3AsrPhase.teardown),
           );
 
           final validatedBackendName = backendName;
@@ -664,11 +697,7 @@ void main() {
             status: SpeechE2ERowStatus.pass,
             backend: validatedBackendName,
             duration: elapsed.elapsed,
-            digestIdentifiers: {
-              'model': config.qwen3AsrModelSha256.substring(0, 8),
-              'mmproj': config.qwen3AsrMmprojSha256.substring(0, 8),
-              'fixture': config.asrAudioSha256.substring(0, 8),
-            },
+            digestIdentifiers: diagnostics.digestIdentifiers,
             assertionSummary:
                 'llama.cpp CPU with 0 GPU layers, caps verified, exact fixture '
                 'transcript, active cancellation, physical mic capture with '
@@ -683,7 +712,7 @@ void main() {
     // ROW 2: LiteRT-LM dedicated streaming ASR
     // =====================================================================
     if (selectedRowIds.contains('litert_lm_streaming_asr')) {
-      await _recordRow(
+      await recordSpeechRow(
         id: 'litert_lm_streaming_asr',
         results: rowResults,
         body: (elapsed) async {
@@ -969,7 +998,7 @@ void main() {
     // ROW 3: llama.cpp Qwen3-TTS
     // =====================================================================
     if (selectedRowIds.contains('llama_cpp_qwen3_tts')) {
-      await _recordRow(
+      await recordSpeechRow(
         id: 'llama_cpp_qwen3_tts',
         results: rowResults,
         body: (elapsed) async {
@@ -1383,7 +1412,7 @@ void main() {
     // ROW 4: LiteRT-LM TTS (expected unsupported)
     // =====================================================================
     if (selectedRowIds.contains('litert_lm_tts')) {
-      await _recordRow(
+      await recordSpeechRow(
         id: 'litert_lm_tts',
         results: rowResults,
         body: (elapsed) async {

--- a/example/chat_app/integration_test/support/physical_ios_speech_e2e_support.dart
+++ b/example/chat_app/integration_test/support/physical_ios_speech_e2e_support.dart
@@ -1712,17 +1712,31 @@ Future<List<T>> collectSpeechEvents<T>(Stream<T> events) {
 }
 
 /// Always runs [cleanup] and preserves a failure from [body] over cleanup.
+///
+/// When [markCleanupPhase] is provided, it runs only after [body] succeeds and
+/// before cleanup starts, so a body failure keeps its authoritative phase.
 Future<void> runWithSpeechCleanup({
   required Future<void> Function() body,
   required Future<void> Function() cleanup,
+  void Function()? markCleanupPhase,
 }) async {
   Object? firstError;
   StackTrace? firstStackTrace;
+  var bodySucceeded = false;
   try {
     await body();
+    bodySucceeded = true;
   } catch (error, stackTrace) {
     firstError = error;
     firstStackTrace = stackTrace;
+  }
+  if (bodySucceeded) {
+    try {
+      markCleanupPhase?.call();
+    } catch (error, stackTrace) {
+      firstError ??= error;
+      firstStackTrace ??= stackTrace;
+    }
   }
   try {
     await cleanup();
@@ -2275,6 +2289,78 @@ String? speechRowFailureMarker(Object error) {
   return null;
 }
 
+/// Stable, content-free phases for the strict llama.cpp Qwen3-ASR row.
+enum PhysicalIosQwen3AsrPhase {
+  setup('setup'),
+  fileTranscript('file_transcript'),
+  cancellation('cancellation'),
+  microphoneStart('microphone_start'),
+  microphoneCapture('microphone_capture'),
+  microphoneTranscript('microphone_transcript'),
+  reload('reload'),
+  teardown('teardown');
+
+  const PhysicalIosQwen3AsrPhase(this.marker);
+
+  /// Stable value emitted in physical-device result records and phase markers.
+  final String marker;
+}
+
+/// Content-free diagnostics for the strict Qwen3-ASR row.
+///
+/// Only validated SHA-256 values contribute identifiers; malformed setup
+/// metadata must neither leak into logs nor replace the original failure.
+class Qwen3AsrDiagnostics {
+  Qwen3AsrDiagnostics(Map<String, String> digests)
+    : digestIdentifiers = Map<String, String>.unmodifiable({
+        for (final key in const ['model', 'mmproj', 'fixture'])
+          if (RegExp(r'^[a-fA-F0-9]{64}$').hasMatch(digests[key] ?? ''))
+            key: digests[key]!.substring(0, 8).toLowerCase(),
+      });
+
+  final Map<String, String> digestIdentifiers;
+  PhysicalIosQwen3AsrPhase phase = PhysicalIosQwen3AsrPhase.setup;
+}
+
+/// Runs one row, preserving its failure and recording sanitized diagnostics.
+Future<void> recordSpeechRow({
+  required String id,
+  required List<SpeechE2ERowResult> results,
+  required Future<SpeechE2ERowResult> Function(Stopwatch elapsed) body,
+  Qwen3AsrDiagnostics? diagnostics,
+}) async {
+  final stopwatch = Stopwatch()..start();
+  try {
+    if (diagnostics != null && id != 'llama_cpp_qwen3_asr') {
+      throw ArgumentError('Qwen3-ASR diagnostics require the Qwen3-ASR row.');
+    }
+    final result = await body(stopwatch);
+    if (result.id != id) {
+      throw StateError('Speech row body returned a mismatched row id.');
+    }
+    results.add(result);
+  } catch (error) {
+    final phase = diagnostics?.phase;
+    results.add(
+      SpeechE2ERowResult(
+        id: id,
+        status: classifySpeechRowFailure(error),
+        backend: unresolvedSpeechBackendForRow(id),
+        duration: stopwatch.elapsed,
+        digestIdentifiers: diagnostics?.digestIdentifiers ?? const {},
+        assertionSummary: phase == null
+            ? ''
+            : 'Failed during ${phase.marker}: ${safeSpeechErrorDiagnostic(error)}',
+        phase: phase,
+        error: error,
+        actionMarker: speechRowFailureMarker(error),
+      ),
+    );
+  } finally {
+    stopwatch.stop();
+  }
+}
+
 /// A recorded row result with machine-readable serialization.
 class SpeechE2ERowResult {
   final String id;
@@ -2286,6 +2372,9 @@ class SpeechE2ERowResult {
   final Object? error;
   final String? actionMarker;
 
+  /// Optional content-free phase evidence for the strict Qwen3-ASR row.
+  final PhysicalIosQwen3AsrPhase? phase;
+
   SpeechE2ERowResult({
     required this.id,
     required this.status,
@@ -2295,6 +2384,7 @@ class SpeechE2ERowResult {
     this.assertionSummary = '',
     this.error,
     this.actionMarker,
+    this.phase,
   });
 
   /// Emits one JSON record so backend labels and errors containing spaces or
@@ -2302,6 +2392,7 @@ class SpeechE2ERowResult {
   String toResultLine() {
     final rawError = this.error;
     final error = rawError == null ? null : safeSpeechErrorDiagnostic(rawError);
+    final phase = this.phase?.marker;
     final record = <String, Object?>{
       'id': id,
       'status': status.name.toUpperCase(),
@@ -2309,6 +2400,7 @@ class SpeechE2ERowResult {
       'elapsedMs': duration.inMilliseconds,
       'digests': digestIdentifiers,
       'assertions': sanitizeSpeechDiagnostic(assertionSummary, maxLength: 400),
+      'phase': ?phase,
       'error': ?error,
       'action': ?actionMarker,
     };

--- a/example/chat_app/test/physical_ios_speech_e2e_support_test.dart
+++ b/example/chat_app/test/physical_ios_speech_e2e_support_test.dart
@@ -200,6 +200,175 @@ void main() {
     });
   });
 
+  group('Strict Qwen3-ASR harness wiring', () {
+    test('keeps phase evidence on the selected strict row only', () {
+      final source = File(
+        'integration_test/physical_ios_speech_e2e_test.dart',
+      ).readAsStringSync();
+      final row1Start = source.indexOf('// ROW 1: llama.cpp Qwen3-ASR');
+      final row2Start = source.indexOf(
+        '// ROW 2: LiteRT-LM dedicated streaming ASR',
+      );
+      expect(row1Start, greaterThanOrEqualTo(0));
+      expect(row2Start, greaterThan(row1Start));
+
+      final row1 = source.substring(row1Start, row2Start);
+      final laterRows = source.substring(row2Start);
+      expect(
+        row1,
+        contains("if (selectedRowIds.contains('llama_cpp_qwen3_asr'))"),
+      );
+      expect(row1, contains('await recordSpeechRow('));
+      expect(row1, contains('diagnostics: diagnostics,'));
+      expect(laterRows, isNot(contains('PhysicalIosQwen3AsrPhase.')));
+      expect(laterRows, isNot(contains('_recordQwen3AsrRow(')));
+
+      for (final phase in PhysicalIosQwen3AsrPhase.values.skip(1)) {
+        expect(row1, contains('PhysicalIosQwen3AsrPhase.${phase.name}'));
+      }
+      expect(RegExp(r'runWithSpeechCleanup\(').allMatches(row1), hasLength(4));
+      expect(RegExp(r'markCleanupPhase:').allMatches(row1), hasLength(7));
+      expect(RegExp(r'_transcribeExact\(').allMatches(row1), hasLength(3));
+      expect(row1, contains('gpuLayers == null || gpuLayers != 0'));
+      expect(row1, contains('requireStillActiveBeforeCancellation('));
+      expect(row1, contains('validatePcm16Wav('));
+      expect(
+        row1,
+        contains('expectedTranscript: config.micExpectedTranscript'),
+      );
+    });
+  });
+
+  group('Row diagnostic recording', () {
+    for (final phase in PhysicalIosQwen3AsrPhase.values) {
+      test('records ${phase.marker} without exposing original error', () async {
+        final diagnostics = Qwen3AsrDiagnostics({'model': 'A' * 64});
+        final results = <SpeechE2ERowResult>[];
+        final error = StateError('secret transcript /private/model.gguf');
+        await recordSpeechRow(
+          id: 'llama_cpp_qwen3_asr',
+          results: results,
+          diagnostics: diagnostics,
+          body: (_) async {
+            diagnostics.phase = phase;
+            throw error;
+          },
+        );
+        expect(results, hasLength(1));
+        expect(results.single.error, same(error));
+        final record = _decodeResultLine(results.single.toResultLine());
+        expect(record['phase'], phase.marker);
+        expect(record['status'], 'FAIL');
+        expect(record['digests'], {'model': 'aaaaaaaa'});
+        expect(record['assertions'], contains('Failed during ${phase.marker}'));
+        expect(results.single.toResultLine(), isNot(contains('secret')));
+        expect(results.single.toResultLine(), isNot(contains('/private/')));
+      });
+    }
+
+    test('malformed setup digests do not mask the original failure', () async {
+      final diagnostics = Qwen3AsrDiagnostics({
+        'model': '',
+        'mmproj': 'https://user:secret@example.test/model',
+        'fixture': 'a' * 63,
+        'untrusted-label': 'b' * 64,
+      });
+      final error = StateError('setup failure');
+      final results = <SpeechE2ERowResult>[];
+      await recordSpeechRow(
+        id: 'llama_cpp_qwen3_asr',
+        results: results,
+        diagnostics: diagnostics,
+        body: (_) async => throw error,
+      );
+      expect(results.single.error, same(error));
+      expect(results.single.digestIdentifiers, isEmpty);
+      expect(results.single.phase, PhysicalIosQwen3AsrPhase.setup);
+    });
+
+    test(
+      'nested cleanup preserves primary phase and runs every cleanup',
+      () async {
+        final diagnostics = Qwen3AsrDiagnostics({});
+        final results = <SpeechE2ERowResult>[];
+        final primary = StateError('transcript mismatch');
+        final cleanup = <String>[];
+        await recordSpeechRow(
+          id: 'llama_cpp_qwen3_asr',
+          results: results,
+          diagnostics: diagnostics,
+          body: (_) async {
+            diagnostics.phase = PhysicalIosQwen3AsrPhase.fileTranscript;
+            await runWithSpeechCleanup(
+              body: () => runWithSpeechCleanup(
+                body: () async => throw primary,
+                cleanup: () async {
+                  cleanup.add('task');
+                  throw StateError('task cleanup');
+                },
+                markCleanupPhase: () =>
+                    diagnostics.phase = PhysicalIosQwen3AsrPhase.teardown,
+              ),
+              cleanup: () async => cleanup.add('engine'),
+              markCleanupPhase: () =>
+                  diagnostics.phase = PhysicalIosQwen3AsrPhase.teardown,
+            );
+            throw StateError('unreachable');
+          },
+        );
+        expect(cleanup, ['task', 'engine']);
+        expect(results.single.error, same(primary));
+        expect(results.single.phase, PhysicalIosQwen3AsrPhase.fileTranscript);
+      },
+    );
+
+    test(
+      'other rows retain their existing success and failure shape',
+      () async {
+        final results = <SpeechE2ERowResult>[];
+        final pass = SpeechE2ERowResult(
+          id: 'litert_lm_streaming_asr',
+          status: SpeechE2ERowStatus.pass,
+          backend: 'test backend',
+          duration: Duration.zero,
+        );
+        await recordSpeechRow(
+          id: pass.id,
+          results: results,
+          body: (_) async => pass,
+        );
+        await recordSpeechRow(
+          id: pass.id,
+          results: results,
+          body: (_) async => throw StateError('failure'),
+        );
+        expect(results.first, same(pass));
+        expect(results.last.status, SpeechE2ERowStatus.fail);
+        expect(
+          _decodeResultLine(results.last.toResultLine()).containsKey('phase'),
+          isFalse,
+        );
+        expect(results.last.assertionSummary, isEmpty);
+      },
+    );
+
+    test('mismatched result remains a recorded failure', () async {
+      final results = <SpeechE2ERowResult>[];
+      await recordSpeechRow(
+        id: 'llama_cpp_qwen3_asr',
+        results: results,
+        body: (_) async => SpeechE2ERowResult(
+          id: 'wrong',
+          status: SpeechE2ERowStatus.pass,
+          backend: 'test',
+          duration: Duration.zero,
+        ),
+      );
+      expect(results.single.status, SpeechE2ERowStatus.fail);
+      expect(results.single.id, 'llama_cpp_qwen3_asr');
+    });
+  });
+
   group('PhysicalIosSpeechConfig', () {
     test('parses valid full configuration successfully', () {
       final config = PhysicalIosSpeechConfig.fromMap(_validEnv());
@@ -1401,6 +1570,59 @@ void main() {
         throwsA(isA<StateError>()),
       );
     });
+
+    test('cleanup phase never replaces a primary body failure phase', () async {
+      var phase = PhysicalIosQwen3AsrPhase.microphoneTranscript;
+      var cleanupRan = false;
+
+      await expectLater(
+        runWithSpeechCleanup(
+          body: () async => throw StateError('primary failure'),
+          cleanup: () async {
+            cleanupRan = true;
+            throw StateError('cleanup failure');
+          },
+          markCleanupPhase: () => phase = PhysicalIosQwen3AsrPhase.teardown,
+        ),
+        throwsA(
+          isA<StateError>().having(
+            (error) => error.message,
+            'message',
+            'primary failure',
+          ),
+        ),
+      );
+      expect(cleanupRan, isTrue);
+      expect(phase, PhysicalIosQwen3AsrPhase.microphoneTranscript);
+    });
+
+    test('attributes a cleanup-only failure to teardown', () async {
+      var phase = PhysicalIosQwen3AsrPhase.reload;
+
+      await expectLater(
+        runWithSpeechCleanup(
+          body: () async {},
+          cleanup: () async => throw StateError('cleanup failure'),
+          markCleanupPhase: () => phase = PhysicalIosQwen3AsrPhase.teardown,
+        ),
+        throwsA(isA<StateError>()),
+      );
+      expect(phase, PhysicalIosQwen3AsrPhase.teardown);
+    });
+
+    test('a phase-marker failure cannot skip cleanup', () async {
+      var cleanupRan = false;
+
+      await expectLater(
+        runWithSpeechCleanup(
+          body: () async {},
+          cleanup: () async => cleanupRan = true,
+          markCleanupPhase: () => throw StateError('marker failure'),
+        ),
+        throwsA(isA<StateError>()),
+      );
+      expect(cleanupRan, isTrue);
+    });
   });
 
   group('Streaming SHA-256 Verification', () {
@@ -1991,6 +2213,7 @@ void main() {
         decoded['assertions'],
         equals('verified caps, transcribed fixture, verified mic'),
       );
+      expect(decoded.containsKey('phase'), isFalse);
       expect(decoded.containsKey('error'), isFalse);
       expect(decoded.containsKey('action'), isFalse);
     });
@@ -2021,6 +2244,63 @@ void main() {
       expect(line, isNot(contains('/private/path')));
       expect(line, isNot(contains('access')));
       expect(decoded['action'], equals(microphonePermissionActionMarker));
+    });
+
+    test(
+      'serializes sanitized Qwen3-ASR phase, digests, and one error fingerprint',
+      () {
+        final error = StateError('private transcript and /private/model.gguf');
+        final diagnostic = safeSpeechErrorDiagnostic(error);
+        final row = SpeechE2ERowResult(
+          id: 'llama_cpp_qwen3_asr',
+          status: SpeechE2ERowStatus.fail,
+          backend: 'llama.cpp CPU',
+          duration: const Duration(milliseconds: 15832),
+          digestIdentifiers: {
+            'model': 'bca25981',
+            'mmproj': '41a342b5',
+            'fixture': '312ba074',
+          },
+          assertionSummary: 'Failed during microphone_transcript: $diagnostic',
+          phase: PhysicalIosQwen3AsrPhase.microphoneTranscript,
+          error: error,
+        );
+
+        final decoded = _decodeResultLine(row.toResultLine());
+        expect(decoded['id'], equals('llama_cpp_qwen3_asr'));
+        expect(decoded['status'], equals('FAIL'));
+        expect(decoded['backend'], equals('llama.cpp CPU'));
+        expect(decoded['elapsedMs'], equals(15832));
+        expect(
+          decoded['digests'],
+          equals({
+            'model': 'bca25981',
+            'mmproj': '41a342b5',
+            'fixture': '312ba074',
+          }),
+        );
+        expect(decoded['assertions'], endsWith(diagnostic));
+        expect(decoded['phase'], equals('microphone_transcript'));
+        expect(decoded['error'], equals(diagnostic));
+        expect(row.toResultLine(), isNot(contains('private')));
+        expect(row.toResultLine(), isNot(contains('/private/model.gguf')));
+      },
+    );
+
+    test('Qwen3-ASR phases are stable and content-free', () {
+      expect(
+        PhysicalIosQwen3AsrPhase.values.map((phase) => phase.marker),
+        equals(<String>[
+          'setup',
+          'file_transcript',
+          'cancellation',
+          'microphone_start',
+          'microphone_capture',
+          'microphone_transcript',
+          'reload',
+          'teardown',
+        ]),
+      );
     });
 
     test('validates strict summary counts on expected 3 PASS, 1 UNSUPPORTED', () {


### PR DESCRIPTION
## Scope
Closes #488.

Recover useful preserved iPad diagnostic work on current main. Qwen3-ASR failures now carry content-free setup/transcript/cancellation/microphone/reload/teardown phase evidence and validated short SHA-256 identifiers. Shared row recording preserves other-row behavior; cleanup cannot replace the primary failure or phase. Invalid setup metadata is omitted rather than logged. The original dirty worktree is untouched.

Runtime behavior, acceptance assertions, microphone requirements, dependency pins, release policy, and public APIs are unchanged. No model or physical-device run is claimed.

## Current-main refresh
Normal merge commit da8ac9bdd05c2af6ccb48a3311c0fee8cf265ceb integrates base 3d9e377745665a1ea35abd084f3c1b33ad7cbcdf after recovery #491 completed exact-main CI successfully. No rebase or force push. The PR diff remains exactly three harness/test files.

## Validation
- Actual local macOS Flutter 3.47.1 support test execution: PASS, all 123 physical_ios_speech_e2e_support_test.dart cases. The previous Apple hook blocker is fixed on main; no bypass is used.
- Dart 3.13.1 touched-file analyzer and canonical format: PASS. git diff --check: PASS.
- Behavioral regressions cover every phase, invalid digests, nested cleanup, preserved failure identity, row mismatch, and unchanged other-row results; static wiring complements behavior tests.
- Fresh independent Astra exact-head QA at da8ac9bdd05c2af6ccb48a3311c0fee8cf265ceb against 3d9e377745665a1ea35abd084f3c1b33ad7cbcdf: PASS, no blocking findings. Reviewed actual phase/cleanup/recording call sites and bounded privacy serialization. No further worthwhile cleanup or optimization identified.
- Current-head hosted CI: 13/13 populated checks SUCCESS, including Linux coverage/aggregate, native macOS/Windows, Chrome, docs/lint, Web Chat Contract real worker/GGUF smoke, companions, parity, advisory and preview. CI run: https://github.com/leehack/llamadart/actions/runs/34232011375 . Hosted macOS also passed the explicit fresh/warm/add/remove Flutter cache-transition integration.
- Final refresh: CLEAN/MERGEABLE, clean local/remote exact head, 0 behind / 2 ahead; zero unresolved review threads. Technically ready, deliberately remains draft pending maintainer decision.
- Current GraphQL review threads: 0 total / 0 unresolved. No automated approving review is claimed.

## Boundaries
No mark-ready, merge, publication, workflow dispatch, pin change, or physical device action. No known PR-caused P1 regression. This remains draft for maintainer consideration. The original dirty iPad worktree and preserved local changes are untouched.