### PR TITLE
fix: restore fresh Flutter Apple dependency scanning

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -409,6 +409,10 @@ jobs:
           LLAMADART_TEST_MODELS_DIR: ${{ github.workspace }}/.dart_tool/test_models
         run: dart test -p vm -j 1 --exclude-tags local-only
 
+      - name: Verify Flutter Apple companion cache transitions
+        if: runner.os == 'macOS'
+        run: dart test -p vm test/integration/apple_companion_flutter_cache_test.dart
+
   native-prompt-reuse-parity:
     name: Native Prompt Reuse Parity
     runs-on: ubuntu-latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -411,7 +411,7 @@ jobs:
 
       - name: Verify Flutter Apple companion cache transitions
         if: runner.os == 'macOS'
-        run: dart test -p vm test/integration/apple_companion_flutter_cache_test.dart
+        run: dart test -p vm --run-skipped test/integration/apple_companion_flutter_cache_test.dart
 
   native-prompt-reuse-parity:
     name: Native Prompt Reuse Parity

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## Unreleased
+
+* Fix fresh macOS Flutter test/build dependency scanning while retaining the
+  Apple companion ABI and local-override guards.
+
 ## 0.8.23
 
 * Fail Apple builds before native symbol lookup when the resolved llama.cpp

--- a/doc/testing_matrix.md
+++ b/doc/testing_matrix.md
@@ -126,13 +126,6 @@ Pick targeted rows based on the touched surface:
 | Change area | Matrix rows to consider |
 | --- | --- |
 | Native-assets hook, runtime pin, bundle layout | `native-hook-bundles`, `litert-lm-engine-smoke`, and relevant `platform` rows such as `android-arm64-device-smoke` |
-
-Apple companion hook changes also require
-`dart test -p vm test/integration/apple_companion_flutter_cache_test.dart` on
-macOS with the pinned Flutter SDK. This explicit `local-only` test runs in a
-temporary clone and exercises fresh/warm Flutter tests, rejects a newly added
-local `Artifacts` override, then verifies recovery after removal without
-clearing caches. The macOS CI native job runs it explicitly.
 | llama.cpp / GGUF generation, prompt reuse, context reuse | `native-prompt-reuse-parity`, `native-inference-benchmark`, `gguf-chat-features-smoke` |
 | Speculative decoding, bundled MTP, or n-gram drafting | `llama-cpp-speculative-benchmark`, `gemma4-mtp-smoke` |
 | Embedding API, `embedBatch`, or embedding throughput | `native-embedding-benchmark`, `native-embedding-sweep` |
@@ -149,6 +142,13 @@ clearing caches. The macOS CI native job runs it explicitly.
 | Chat-app live LiteRT-LM dictation | `litert-lm-asr-smoke`, `chat-app-live-speech-smoke` |
 | Chat-app Ask with voice | `gguf-audio-chat-smoke`, `litert-lm-chat-features-smoke`, `chat-app-voice-question-smoke` |
 | Example app, CLI, or server package | `examples-tests` |
+Apple companion hook changes also require
+`dart test -p vm --run-skipped test/integration/apple_companion_flutter_cache_test.dart` on
+macOS with the pinned Flutter SDK. This explicit `local-only` test runs in a
+temporary clone and exercises fresh/warm Flutter tests, rejects a newly added
+local `Artifacts` override, then verifies recovery after removal without
+clearing caches. The macOS CI native job runs it explicitly.
+
 
 The required `Web Chat Contract` check runs the chat app tests on VM and
 Chrome, validates the final Flutter Web artifact, exercises deterministic UI

--- a/doc/testing_matrix.md
+++ b/doc/testing_matrix.md
@@ -126,6 +126,13 @@ Pick targeted rows based on the touched surface:
 | Change area | Matrix rows to consider |
 | --- | --- |
 | Native-assets hook, runtime pin, bundle layout | `native-hook-bundles`, `litert-lm-engine-smoke`, and relevant `platform` rows such as `android-arm64-device-smoke` |
+
+Apple companion hook changes also require
+`dart test -p vm test/integration/apple_companion_flutter_cache_test.dart` on
+macOS with the pinned Flutter SDK. This explicit `local-only` test runs in a
+temporary clone and exercises fresh/warm Flutter tests, rejects a newly added
+local `Artifacts` override, then verifies recovery after removal without
+clearing caches. The macOS CI native job runs it explicitly.
 | llama.cpp / GGUF generation, prompt reuse, context reuse | `native-prompt-reuse-parity`, `native-inference-benchmark`, `gguf-chat-features-smoke` |
 | Speculative decoding, bundled MTP, or n-gram drafting | `llama-cpp-speculative-benchmark`, `gemma4-mtp-smoke` |
 | Embedding API, `embedBatch`, or embedding throughput | `native-embedding-benchmark`, `native-embedding-sweep` |

--- a/doc/testing_matrix.md
+++ b/doc/testing_matrix.md
@@ -142,13 +142,13 @@ Pick targeted rows based on the touched surface:
 | Chat-app live LiteRT-LM dictation | `litert-lm-asr-smoke`, `chat-app-live-speech-smoke` |
 | Chat-app Ask with voice | `gguf-audio-chat-smoke`, `litert-lm-chat-features-smoke`, `chat-app-voice-question-smoke` |
 | Example app, CLI, or server package | `examples-tests` |
+
 Apple companion hook changes also require
 `dart test -p vm --run-skipped test/integration/apple_companion_flutter_cache_test.dart` on
 macOS with the pinned Flutter SDK. This explicit `local-only` test runs in a
 temporary clone and exercises fresh/warm Flutter tests, rejects a newly added
 local `Artifacts` override, then verifies recovery after removal without
 clearing caches. The macOS CI native job runs it explicitly.
-
 
 The required `Web Chat Contract` check runs the chat app tests on VM and
 Chrome, validates the final Flutter Web artifact, exercises deterministic UI

--- a/hook/build.dart
+++ b/hook/build.dart
@@ -693,9 +693,10 @@ void _validateAppleLlamaCompanion(
     final artifacts = Directory(path.join(manifest.parent.path, 'Artifacts'));
     // The supported manifest can prefer local binaries over its remote pin.
     // Such binaries have no verified ABI contract and must not inherit trust
-    // from the tag string. Track the directory so local additions invalidate
-    // an otherwise cached successful hook result.
-    output.dependencies.add(artifacts.uri);
+    // from the tag string. Track the existing parent: directory dependencies
+    // hash child names, so adding/removing Artifacts invalidates a cached
+    // success without making Flutter enumerate a nonexistent directory.
+    output.dependencies.add(manifest.parent.uri);
     if (artifacts.existsSync()) {
       reject(
         'Local Artifacts overrides cannot establish framework ABI '

--- a/test/integration/apple_companion_flutter_cache_test.dart
+++ b/test/integration/apple_companion_flutter_cache_test.dart
@@ -1,0 +1,94 @@
+@TestOn('mac-os')
+@Tags(['local-only'])
+@Timeout(Duration(minutes: 10))
+library;
+
+import 'dart:convert';
+import 'dart:io';
+
+import 'package:path/path.dart' as path;
+import 'package:test/test.dart';
+
+// Exercise the real Flutter/native-assets cache, not only hook output metadata.
+// A fresh local clone keeps both tracked files and production caches untouched.
+void main() {
+  test('Flutter observes absent, added, and removed Apple overrides', () async {
+    final temporary = await Directory.systemTemp.createTemp(
+      'apple-hook-cache-',
+    );
+    addTearDown(() => temporary.delete(recursive: true));
+    final checkout = path.join(temporary.path, 'repo');
+    await _expectSuccess('git', [
+      'clone',
+      '--shared',
+      '--quiet',
+      Directory.current.path,
+      checkout,
+    ], Directory.current.path);
+    final app = path.join(checkout, 'example', 'chat_app');
+    final artifacts = Directory(
+      path.join(
+        checkout,
+        'packages',
+        'llamadart_llama_cpp_flutter',
+        'darwin',
+        'llamadart_llama_cpp_flutter',
+        'Artifacts',
+      ),
+    );
+    expect(artifacts.existsSync(), isFalse);
+    await _expectSuccess('flutter', ['pub', 'get'], app);
+    const testArguments = [
+      'test',
+      '--no-pub',
+      'test/physical_ios_speech_e2e_support_test.dart',
+    ];
+
+    // Fresh success must not register a missing directory for Flutter scanning.
+    await _expectSuccess('flutter', testArguments, app);
+    // Warm success proves the successful hook output is reusable.
+    await _expectSuccess('flutter', testArguments, app);
+    await artifacts.create();
+    final rejected = await _run('flutter', testArguments, app);
+    expect(rejected.exitCode, isNot(0), reason: rejected.output);
+    expect(
+      rejected.output,
+      contains('Local Artifacts overrides cannot establish'),
+    );
+    await artifacts.delete();
+    // Do not clear any cache: removal must recover through the same runner.
+    await _expectSuccess('flutter', testArguments, app);
+  });
+}
+
+Future<void> _expectSuccess(
+  String command,
+  List<String> arguments,
+  String cwd,
+) async {
+  final result = await _run(command, arguments, cwd);
+  expect(result.exitCode, 0, reason: result.output);
+}
+
+Future<({int exitCode, String output})> _run(
+  String command,
+  List<String> arguments,
+  String cwd,
+) async {
+  final process = await Process.start(
+    command,
+    arguments,
+    workingDirectory: cwd,
+  );
+  final stdout = process.stdout.transform(utf8.decoder).join();
+  final stderr = process.stderr.transform(utf8.decoder).join();
+  final int exitCode;
+  try {
+    exitCode = await process.exitCode.timeout(const Duration(minutes: 4));
+  } catch (_) {
+    process.kill(ProcessSignal.sigkill);
+    await process.exitCode;
+    rethrow;
+  }
+  return (exitCode: exitCode, output: '${await stdout}\n${await stderr}');
+}

--- a/test/unit/hook/build_hook_litert_lm_integration_test.dart
+++ b/test/unit/hook/build_hook_litert_lm_integration_test.dart
@@ -499,9 +499,21 @@ void main() {
             isTrue,
           );
           expect(
-            output.dependencies.any((uri) => uri.path.endsWith('/Artifacts/')),
+            output.dependencies.any(
+              (uri) =>
+                  uri.path.endsWith('/darwin/llamadart_llama_cpp_flutter/'),
+            ),
             isTrue,
           );
+          expect(
+            output.dependencies.any((uri) => uri.path.endsWith('/Artifacts/')),
+            isFalse,
+          );
+          for (final uri in output.dependencies.where(
+            (uri) => uri.path.endsWith('/'),
+          )) {
+            expect(Directory.fromUri(uri).existsSync(), isTrue);
+          }
         },
       );
     },

--- a/test/unit/tooling/check_webgpu_bridge_tag_test.dart
+++ b/test/unit/tooling/check_webgpu_bridge_tag_test.dart
@@ -365,6 +365,57 @@ void main() {
       );
     });
 
+    test(
+      'unrelated Unreleased notes retain the exact current released pin',
+      () {
+        final root = releaseNotesRepo('1.2.3');
+        for (final pin in releaseNotesPins) {
+          final file = File('${root.path}/${pin.path}');
+          file.writeAsStringSync(
+            '## Unreleased\n\n* Fix Apple dependency scanning.\n\n'
+            'WebGPU bridge assets are unchanged.\n\n${file.readAsStringSync()}',
+          );
+        }
+        expect(findCurrentReleaseNotesDrift(root, 'v9.9.9'), isEmpty);
+        expect(findCurrentReleaseNotesDrift(root, 'v8.8.8'), isNotEmpty);
+      },
+    );
+
+    test('pin-free Unreleased cannot borrow another historical version', () {
+      final root = releaseNotesRepo('1.0.0');
+      for (final pin in releaseNotesPins) {
+        final file = File('${root.path}/${pin.path}');
+        file.writeAsStringSync(
+          '## Unreleased\n\n* Apple fix.\n${file.readAsStringSync()}',
+        );
+      }
+      expect(findCurrentReleaseNotesDrift(root, 'v9.9.9'), hasLength(2));
+      for (final pin in releaseNotesPins) {
+        File(
+          '${root.path}/${pin.path}',
+        ).writeAsStringSync('## Unreleased\n\n* Apple fix.\n');
+      }
+      expect(findCurrentReleaseNotesDrift(root, 'v9.9.9'), hasLength(2));
+    });
+
+    for (final claim in [
+      'Aligned default WebGPU bridge assets to `v0.0.1`.',
+      'Moved WebGPU bridge assets to an invalid tag.',
+      'Aligned default WebGPU bridge assets to `v9.9.9`.\n- Moved WebGPU bridge assets to malformed.',
+      'Aligned default WebGPU bridge assets to `v9.9.9`.\n- Aligned default WebGPU bridge assets to `v9.9.9`.',
+    ]) {
+      test('Unreleased claim cannot hide behind released history: $claim', () {
+        final root = releaseNotesRepo('1.2.3');
+        for (final pin in releaseNotesPins) {
+          final file = File('${root.path}/${pin.path}');
+          file.writeAsStringSync(
+            '## Unreleased\n\n- $claim\n\n${file.readAsStringSync()}',
+          );
+        }
+        expect(findCurrentReleaseNotesDrift(root, 'v9.9.9'), hasLength(2));
+      });
+    }
+
     test('a heading naming another version is reported', () {
       expect(
         findCurrentReleaseNotesDrift(releaseNotesRepo('1.2.4'), 'v9.9.9'),

--- a/test/unit/tooling/check_webgpu_bridge_tag_test.dart
+++ b/test/unit/tooling/check_webgpu_bridge_tag_test.dart
@@ -408,8 +408,18 @@ void main() {
         final root = releaseNotesRepo('1.2.3');
         for (final pin in releaseNotesPins) {
           final file = File('${root.path}/${pin.path}');
+          final currentClaim = pin.path == 'CHANGELOG.md'
+              ? claim
+                    .replaceAll(
+                      'Aligned default WebGPU',
+                      'Aligned the default WebGPU',
+                    )
+                    .replaceAll('\n- ', '\n* ')
+              : claim;
+          final bullet = pin.path == 'CHANGELOG.md' ? '*' : '-';
           file.writeAsStringSync(
-            '## Unreleased\n\n- $claim\n\n${file.readAsStringSync()}',
+            '## Unreleased\n\n$bullet $currentClaim\n\n'
+            '${file.readAsStringSync()}',
           );
         }
         expect(findCurrentReleaseNotesDrift(root, 'v9.9.9'), hasLength(2));

--- a/tool/testing/check_webgpu_bridge_tag.dart
+++ b/tool/testing/check_webgpu_bridge_tag.dart
@@ -213,19 +213,32 @@ String readRootPackageVersion(Directory repoRoot) {
   return matches.single.group(1)!;
 }
 
-/// The body of the top `## ` section of [contents] when it is the current one.
+/// The current bridge-pin announcement section of [contents].
 ///
 /// Ordinary development leaves the top section headed `## Unreleased`; a
 /// release-prep change promotes that same section to `## $releaseVersion`.
-/// Returns null for any other heading, so a gate reading this never mistakes a
-/// frozen historical section for the current release notes.
+/// Pin-free Unreleased notes use only the immediately following exact current
+/// release. A recognizable (even malformed) pin bullet prevents fallback.
 String? currentReleaseNotesSection(String contents, String releaseVersion) {
   final match = _topReleaseNotesSection.firstMatch(contents);
   if (match == null) return null;
   final heading = match.namedGroup('heading');
   if (heading != 'Unreleased' && heading != releaseVersion) return null;
-  return match.namedGroup('body');
+  final body = match.namedGroup('body')!;
+  if (heading != 'Unreleased' || _bridgePinBullet.hasMatch(body)) return body;
+  final released = _topReleaseNotesSection.firstMatch(
+    contents.substring(match.end),
+  );
+  if (released?.namedGroup('heading') != releaseVersion) return null;
+  return released!.namedGroup('body');
 }
+
+// Ambiguous/reworded pin bullets must fail the exact canonical claim check,
+// not silently borrow a historical value. Ordinary prose is not a pin site.
+final RegExp _bridgePinBullet = RegExp(
+  r'^[*-]\s+[^\n]*(?:WebGPU bridge assets|default WebGPU)[^\n]*$',
+  multiLine: true,
+);
 
 /// Reads the tag every pin must quote.
 ///
@@ -328,6 +341,13 @@ List<String> findCurrentReleaseNotesDrift(
       continue;
     }
     final matches = pin.pattern.allMatches(section).toList();
+    if (matches.length == 1 &&
+        _bridgePinBullet.allMatches(section).length != 1) {
+      problems.add(
+        '${pin.path}: ambiguous or malformed additional bridge pin bullet',
+      );
+      continue;
+    }
     if (matches.length != 1) {
       problems.add(
         '${pin.path}: ${pin.pattern.pattern} matches ${matches.length} lines in '

--- a/website/docs/changelog/recent-releases.md
+++ b/website/docs/changelog/recent-releases.md
@@ -7,6 +7,11 @@ For canonical full release notes, use:
 
 - [`CHANGELOG.md`](https://github.com/leehack/llamadart/blob/main/CHANGELOG.md)
 
+## Unreleased
+
+- Fix fresh macOS Flutter test/build dependency scanning while retaining the
+  Apple companion ABI and local-override guards.
+
 ## 0.8.23
 
 - Fail Apple builds before native symbol lookup when the resolved llama.cpp


### PR DESCRIPTION
## Scope
Closes #490. Closes #492.

Repairs the merged PR #484 regression: its hook output registered a nonexistent Artifacts directory, causing Flutter 3.47.1 dependency scanning to fail before tests. Track the existing SwiftPM manifest parent instead; hooks_runner directory hashing observes child names, so adding/removing Artifacts invalidates cached success. Exact companion ABI validation and local-override rejection remain unchanged.

The new Unreleased note exposed the separate Web pin checker lifecycle defect #492. Pin-free Unreleased notes now use only the immediately following exact pubspec-version release section. Missing/mismatched sections and stale, malformed, or duplicate current pin claims fail closed. No historical notes were rewritten, and no native/Web/LiteRT pin changes.

## Exact-head validation
Head: d7ac6a739a975056fd2e7031d1bbbaefd54d0fc7. Base: 44ec6b262166beb266a63faa6526bab74919d0cf. Clean worktree, 0 behind / 5 ahead.

- Actual macOS Flutter 3.47.1 clone: fresh and warm test success, add empty Artifacts and fail the guard, remove it and succeed without clearing caches: PASS (16 seconds locally, also passed hosted macOS).
- Durable local-only integration is explicitly run with --run-skipped in the existing macOS native CI job.
- Hook suite: 34/34 PASS, including matching/mismatching ABI metadata and override rejection.
- Web pin checker: 57/57 PASS, including canonical root and website malformed/stale/duplicate claim fixtures.
- Full local VM: 2,052 PASS / 77 fixture-dependent skips.
- Canonical Flutter 3.47.1 workspace preparation, repository format (591 files, 0 changes), and full dart analyze: PASS.
- Release docs version check and offline Web pin/provenance gate: PASS.
- Hosted current-head checks: 14/14 SUCCESS, including Windows/macOS native, Linux VM+coverage aggregate, Chrome, Web Chat Contract real worker/GGUF smoke, docs, both companions, parity, LiteRT Linux/Windows and advisory.
- CI run: https://github.com/leehack/llamadart/actions/runs/34223963745
- Initial Windows attempt stopped in Flutter setup with curl exit 35 before dependency/test execution. One targeted same-head Windows-only rerun passed; no source change or publication dispatch was used to mask it.
- Fresh independent Astra audit: PASS on this exact head and base. Reviewed actual hook call sites, runner directory hashing, ABI/override guards, dedicated CI execution and checker fallback boundaries; independently reran checker 57/57. Zero blocking findings.
- GraphQL review threads: 0 total / 0 unresolved. No automated approving review is claimed.

## High-risk review
Artifact-consumer and regression-policy scope. Zero known PR-caused P1 regressions. Independent exact-head adversarial review and all populated checks are complete. Repository-local readiness is established; external status-publisher governance is unchanged and no configured attestation is claimed. PR remains draft pending maintainer decision.

## Preservation and boundaries
Original dirty iPad worktree and draft #489 untouched. No force push, mark-ready, merge, release, publication, workflow_dispatch, environment/settings, pin, or physical-device action. The only manual CI action was the targeted failed Windows job rerun described above.